### PR TITLE
Add a unit test for negative torch.arange() incorrect numerical behavior with dynamic shapes

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7396,11 +7396,16 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 nheads = 16
                 start = math.log2(0.5)
                 end = math.log2(1 / (2**8))
-                scales = 2 ** torch.arange(
-                    start,
-                    end + 1e-6 * np.sign(end - start),
-                    (end - start) / (nheads - 1),
-                ).view(1, nheads, 1, 1).cuda()
+                scales = (
+                    2
+                    ** torch.arange(
+                        start,
+                        end + 1e-6 * np.sign(end - start),
+                        (end - start) / (nheads - 1),
+                    )
+                    .view(1, nheads, 1, 1)
+                    .cuda()
+                )
                 q_pos = torch.arange(dec_in.size(1), dtype=torch.long).cuda()
                 k_pos = torch.arange(dec_in.size(1), dtype=torch.long).cuda()
                 rel_pos = k_pos[None, :] - q_pos[:, None]
@@ -7410,15 +7415,15 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
                 dec_mask = dec_mask + dec_bias[0]
 
-                emb = nn.Embedding(1024, 256)
+                emb = nn.Embedding(1024, 256, device="cuda")
                 out = emb(dec_in)
 
                 dec_layer = nn.TransformerDecoderLayer(
-                    256, 16, 512, batch_first=True, norm_first=True
+                    256, 16, 512, batch_first=True, norm_first=True, device="cuda"
                 )
                 out = dec_layer(out, enc_out, tgt_mask=dec_mask)
 
-                head = nn.Linear(256, 1024)
+                head = nn.Linear(256, 1024, device="cuda")
                 return head(out)
 
             enc_out = torch.rand(1, 512, 256)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7387,6 +7387,9 @@ if HAS_CUDA and not TEST_WITH_ASAN:
         @torch._dynamo.config.patch(dynamic_shapes=True)
         def test_negative_arange_dynamic_shapes(self):
             # Repro from alibi relative encodings
+            def sign(x):
+                return (x > 0) - (x < 0)
+
             def fn(enc_out, dec_in):
                 padmask = dec_in == 0
                 dec_mask = padmask.unsqueeze(-1) == padmask.unsqueeze(-2)
@@ -7400,7 +7403,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                     2
                     ** torch.arange(
                         start,
-                        end + 1e-6 * np.sign(end - start),
+                        end + 1e-6 * sign(end - start),
                         (end - start) / (nheads - 1),
                     )
                     .view(1, nheads, 1, 1)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5772,6 +5772,46 @@ class CommonTemplate:
             [x],
         )
 
+    @torch._dynamo.config.patch(dynamic_shapes=True)
+    def test_negative_arange_dynamic_shapes(self):
+        # Repro from alibi relative encodings
+        def fn(enc_out, dec_in):
+            padmask = dec_in == 0
+            dec_mask = padmask.unsqueeze(-1) == padmask.unsqueeze(-2)
+            dec_mask = dec_mask.to(dtype=torch.float32)
+            dec_mask = dec_mask.tril(diagonal=0)
+            
+            nheads = 16
+            start = math.log2(0.5)
+            end = math.log2(1 / (2**8))
+            scales = 2 ** torch.arange(start, end + 1e-6 * np.sign(end - start), (end - start) / (nheads - 1)).view(1, nheads, 1, 1)
+            q_pos = torch.arange(dec_in.size(1), dtype=torch.long)
+            k_pos = torch.arange(dec_in.size(1), dtype=torch.long)
+            rel_pos = k_pos[None, :] - q_pos[:, None]
+            values = rel_pos.abs().neg().unsqueeze(0).unsqueeze(0)
+            dec_bias = values * scales
+            dec_bias.tril_(diagonal=0)
+
+            dec_mask = dec_mask + dec_bias[0]
+
+            emb = nn.Embedding(1024, 256)
+            out = emb(dec_in)
+
+            dec_layer = nn.TransformerDecoderLayer(256, 16, 512, batch_first=True, norm_first=True)
+            out = dec_layer(out, enc_out, tgt_mask=dec_mask)
+
+            head = nn.Linear(256, 1024)
+            return head(out)
+
+        enc_out = torch.rand(1, 512, 256)
+        dec_inputs = [torch.randint(0, 512, (1, i), dtype=torch.long) for i in range(8)]
+        for dec_inp in dec_inputs:
+            self.common(
+                fn,
+                [enc_out, dec_inp],
+            )
+
+
     @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
     def test_in_out_buffer(self):
         def fn(x, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7397,11 +7397,15 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                     start = math.log2(0.5)
                     end = math.log2(1 / (2**8))
 
-                    self.scales = 2 ** torch.arange(
-                        start,
-                        end + 1e-6 * sign(end - start),
-                        (end - start) / (nheads - 1),
-                    ).view(1, nheads, 1, 1)
+                    self.register_buffer(
+                        "scales",
+                        2
+                        ** torch.arange(
+                            start,
+                            end + 1e-6 * sign(end - start),
+                            (end - start) / (nheads - 1),
+                        ).view(1, nheads, 1, 1),
+                    )
                     self.emb = nn.Embedding(1024, 256)
                     self.dec_layer = nn.TransformerDecoderLayer(
                         256, 16, 512, batch_first=True, norm_first=True

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5780,11 +5780,13 @@ class CommonTemplate:
             dec_mask = padmask.unsqueeze(-1) == padmask.unsqueeze(-2)
             dec_mask = dec_mask.to(dtype=torch.float32)
             dec_mask = dec_mask.tril(diagonal=0)
-            
+
             nheads = 16
             start = math.log2(0.5)
             end = math.log2(1 / (2**8))
-            scales = 2 ** torch.arange(start, end + 1e-6 * np.sign(end - start), (end - start) / (nheads - 1)).view(1, nheads, 1, 1)
+            scales = 2 ** torch.arange(
+                start, end + 1e-6 * np.sign(end - start), (end - start) / (nheads - 1)
+            ).view(1, nheads, 1, 1)
             q_pos = torch.arange(dec_in.size(1), dtype=torch.long)
             k_pos = torch.arange(dec_in.size(1), dtype=torch.long)
             rel_pos = k_pos[None, :] - q_pos[:, None]
@@ -5797,20 +5799,23 @@ class CommonTemplate:
             emb = nn.Embedding(1024, 256)
             out = emb(dec_in)
 
-            dec_layer = nn.TransformerDecoderLayer(256, 16, 512, batch_first=True, norm_first=True)
+            dec_layer = nn.TransformerDecoderLayer(
+                256, 16, 512, batch_first=True, norm_first=True
+            )
             out = dec_layer(out, enc_out, tgt_mask=dec_mask)
 
             head = nn.Linear(256, 1024)
             return head(out)
 
         enc_out = torch.rand(1, 512, 256)
-        dec_inputs = [torch.randint(0, 512, (1, i+1), dtype=torch.long) for i in range(8)]
+        dec_inputs = [
+            torch.randint(0, 512, (1, i + 1), dtype=torch.long) for i in range(8)
+        ]
         for dec_inp in dec_inputs:
             self.common(
                 fn,
                 [enc_out, dec_inp],
             )
-
 
     @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
     def test_in_out_buffer(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5804,7 +5804,7 @@ class CommonTemplate:
             return head(out)
 
         enc_out = torch.rand(1, 512, 256)
-        dec_inputs = [torch.randint(0, 512, (1, i), dtype=torch.long) for i in range(8)]
+        dec_inputs = [torch.randint(0, 512, (1, i+1), dtype=torch.long) for i in range(8)]
         for dec_inp in dec_inputs:
             self.common(
                 fn,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7391,7 +7391,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 padmask = dec_in == 0
                 dec_mask = padmask.unsqueeze(-1) == padmask.unsqueeze(-2)
                 dec_mask = dec_mask.to(dtype=torch.float32)
-                dec_mask = dec_mask.tril(diagonal=0)
+                dec_mask = dec_mask.tril(diagonal=0).cuda()
 
                 nheads = 16
                 start = math.log2(0.5)
@@ -7400,9 +7400,9 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                     start,
                     end + 1e-6 * np.sign(end - start),
                     (end - start) / (nheads - 1),
-                ).view(1, nheads, 1, 1)
-                q_pos = torch.arange(dec_in.size(1), dtype=torch.long)
-                k_pos = torch.arange(dec_in.size(1), dtype=torch.long)
+                ).view(1, nheads, 1, 1).cuda()
+                q_pos = torch.arange(dec_in.size(1), dtype=torch.long).cuda()
+                k_pos = torch.arange(dec_in.size(1), dtype=torch.long).cuda()
                 rel_pos = k_pos[None, :] - q_pos[:, None]
                 values = rel_pos.abs().neg().unsqueeze(0).unsqueeze(0)
                 dec_bias = values * scales


### PR DESCRIPTION
This unit test is for the fix in #97777 for issue #96971

cc: @ezyang 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire