### PR TITLE
Support Modules with custom __getitem__ method through fallback

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -274,13 +274,7 @@ class ModuleList(torch.nn.Module):
             ]
         )
 
-    def __getitem__(self, idx: int):
-        return self.layers[idx]
-
     def forward(self, x):
-        for i in range(len(self.layers)):
-            x = self[i](x)
-
         for i in range(len(self.layers)):
             x = self.layers[i](x)
 
@@ -302,7 +296,47 @@ class ModuleList(torch.nn.Module):
         return x
 
 
+class CustomGetItemModuleList(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [
+                torch.nn.Linear(10, 10),
+                torch.nn.ReLU(),
+                torch.nn.Linear(10, 10),
+                torch.nn.ReLU(),
+            ]
+        )
+
+    def __getitem__(self, idx: int):
+        return self.layers[idx]
+
+    def __len__(self) -> int:
+        return len(self.layers)
+
+    def forward(self, x):
+        for i in range(len(self)):
+            x = self[i](x)
+
+        return x
+
+
 class ModuleDict(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleDict(
+            {
+                "0": torch.nn.Linear(10, 10),
+            }
+        )
+
+    def forward(self, x):
+        # TODO(future PR): handle more logic
+        x = self.layers["0"](x)
+        return x
+
+
+class CustomGetItemModuleDict(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.layers = torch.nn.ModuleDict(
@@ -315,9 +349,7 @@ class ModuleDict(torch.nn.Module):
         return self.layers[key]
 
     def forward(self, x):
-        # TODO(future PR): handle more logic
         x = self["0"](x)
-        x = self.layers["0"](x)
         return x
 
 
@@ -769,7 +801,9 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
     test_cfgmod = make_test(CfgModule())
     test_stringmember = make_test(StringMember())
     test_modulelist = make_test(ModuleList())
+    test_modulelist = make_test(CustomGetItemModuleList())
     test_moduledict = make_test(ModuleDict())
+    test_moduledict = make_test(CustomGetItemModuleDict())
     test_super1 = make_test(SuperModule())
     test_super2 = make_test(SuperModule2())
     test_super_class_method = make_test(SuperChildCallsClassMethod())

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -274,7 +274,13 @@ class ModuleList(torch.nn.Module):
             ]
         )
 
+    def __getitem__(self, idx: int):
+        return self.layers[idx]
+
     def forward(self, x):
+        for i in range(len(self.layers)):
+            x = self[i](x)
+
         for i in range(len(self.layers)):
             x = self.layers[i](x)
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -305,10 +305,22 @@ class ModuleDict(torch.nn.Module):
             }
         )
 
+    def __getitem__(self, key: str) -> torch.nn.Module:
+        return self.layers[key]
+
     def forward(self, x):
         # TODO(future PR): handle more logic
         x = self.layers["0"](x)
         return x
+
+
+class ModuleWithCustomModuleDict(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dict = ModuleDict()
+        
+    def forward(self, x):
+        return self.dict["0"](x)
 
 
 class TensorList(torch.nn.Module):
@@ -760,6 +772,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
     test_stringmember = make_test(StringMember())
     test_modulelist = make_test(ModuleList())
     test_moduledict = make_test(ModuleDict())
+    test_custom_moduledict = make_test(ModuleWithCustomModuleDict())
     test_super1 = make_test(SuperModule())
     test_super2 = make_test(SuperModule2())
     test_super_class_method = make_test(SuperChildCallsClassMethod())

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -305,36 +305,14 @@ class ModuleDict(torch.nn.Module):
             }
         )
 
+    def __getitem__(self, key: str) -> torch.nn.Module:
+        return self.layers[key]
+
     def forward(self, x):
         # TODO(future PR): handle more logic
+        x = self["0"](x)
         x = self.layers["0"](x)
         return x
-
-
-class ModuleDictWithCustomGetItem(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.layers = torch.nn.ModuleDict(
-            {
-                "__0": torch.nn.Linear(10, 10),
-            }
-        )
-
-    def __getitem__(self, key: str) -> torch.nn.Module:
-        return self.layers["__" + key]
-
-    def forward(self, x):
-        x = self["0"](x)
-        return x
-
-
-class ModuleWithCustomModuleDict(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.dict = ModuleDictWithCustomGetItem()
-
-    def forward(self, x):
-        return self.dict["0"](x)
 
 
 class TensorList(torch.nn.Module):
@@ -786,7 +764,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
     test_stringmember = make_test(StringMember())
     test_modulelist = make_test(ModuleList())
     test_moduledict = make_test(ModuleDict())
-    test_custom_moduledict = make_test(ModuleWithCustomModuleDict())
     test_super1 = make_test(SuperModule())
     test_super2 = make_test(SuperModule2())
     test_super_class_method = make_test(SuperChildCallsClassMethod())

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -309,7 +309,8 @@ class ModuleDict(torch.nn.Module):
         # TODO(future PR): handle more logic
         x = self.layers["0"](x)
         return x
-    
+
+
 class ModuleDictWithCustomGetItem(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -331,7 +332,7 @@ class ModuleWithCustomModuleDict(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.dict = ModuleDictWithCustomGetItem()
-        
+
     def forward(self, x):
         return self.dict["0"](x)
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -305,19 +305,32 @@ class ModuleDict(torch.nn.Module):
             }
         )
 
-    def __getitem__(self, key: str) -> torch.nn.Module:
-        return self.layers[key]
-
     def forward(self, x):
         # TODO(future PR): handle more logic
         x = self.layers["0"](x)
+        return x
+    
+class ModuleDictWithCustomGetItem(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleDict(
+            {
+                "__0": torch.nn.Linear(10, 10),
+            }
+        )
+
+    def __getitem__(self, key: str) -> torch.nn.Module:
+        return self.layers["__" + key]
+
+    def forward(self, x):
+        x = self["0"](x)
         return x
 
 
 class ModuleWithCustomModuleDict(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.dict = ModuleDict()
+        self.dict = ModuleDictWithCustomGetItem()
         
     def forward(self, x):
         return self.dict["0"](x)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -272,16 +272,6 @@ class NNModuleVariable(VariableTracker):
                     kwargs,
                 )
 
-    def _custom_getitem_fallback(self, module, tx, name, options, key):
-        getitem_fn = getattr(module, name).__func__
-
-        if not isinstance(getitem_fn, types.FunctionType):
-            unimplemented("torch.nn.Module with a non-function custom __getitem__")
-
-        return variables.UserMethodVariable(getitem_fn, self, **options).call_function(
-            tx, [key], {}
-        )
-
     def call_method(
         self,
         tx,
@@ -475,7 +465,7 @@ class NNModuleVariable(VariableTracker):
             if type(module).__getitem__ not in inline_supported:
                 assert isinstance(args[0], variables.ConstantVariable), typestr(args[0])
                 key = args[0].as_python_constant()
-                assert isinstance(key, str)
+                assert isinstance(key, (str, int))
                 fn = getattr(module, name).__func__
 
                 assert isinstance(fn, types.FunctionType)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -455,14 +455,14 @@ class NNModuleVariable(VariableTracker):
             )
         elif name == "__getitem__":
             assert not kwargs and len(args) == 1
-            inline_supported = (
+            builtin_supported = (
                 torch.nn.ModuleDict.__getitem__,
                 torch.nn.ModuleList.__getitem__,
                 torch.nn.ParameterList.__getitem__,
                 torch.nn.Sequential.__getitem__,
             )
 
-            if type(module).__getitem__ not in inline_supported:
+            if type(module).__getitem__ not in builtin_supported:
                 assert isinstance(args[0], variables.ConstantVariable), typestr(args[0])
                 key = args[0].as_python_constant()
                 assert isinstance(key, (str, int))

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -276,12 +276,12 @@ class NNModuleVariable(VariableTracker):
         getitem_fn = getattr(module, name).__func__
 
         if not isinstance(getitem_fn, types.FunctionType):
-            unimplemented(f"torch.nn.Module with a non-function custom __getitem__")
-            
+            unimplemented("torch.nn.Module with a non-function custom __getitem__")
+
         return variables.UserMethodVariable(getitem_fn, self, **options).call_function(
             tx, [key], {}
         )
-                    
+
     def call_method(
         self,
         tx,
@@ -471,14 +471,14 @@ class NNModuleVariable(VariableTracker):
                 torch.nn.ParameterList.__getitem__,
                 torch.nn.Sequential.__getitem__,
             )
-            
+
             if type(module).__getitem__ not in inline_supported:
                 assert isinstance(args[0], variables.ConstantVariable), typestr(args[0])
                 key = args[0].as_python_constant()
                 assert isinstance(key, str)
                 # Try fallback to custom __getitem__
                 return self._custom_getitem_fallback(module, tx, name, options, args[0])
-            
+
             assert self.source
 
             if isinstance(args[0], SliceVariable):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -476,8 +476,16 @@ class NNModuleVariable(VariableTracker):
                 assert isinstance(args[0], variables.ConstantVariable), typestr(args[0])
                 key = args[0].as_python_constant()
                 assert isinstance(key, str)
-                # Try fallback to custom __getitem__
-                return self._custom_getitem_fallback(module, tx, name, options, args[0])
+                fn = getattr(module, name).__func__
+
+                assert isinstance(fn, types.FunctionType)
+
+                src = AttrSource(AttrSource(self.source, name), "__func__")
+                return tx.inline_user_function_return(
+                    variables.UserFunctionVariable(fn, source=src, **options),
+                    [self] + list(args),
+                    kwargs,
+                )
 
             assert self.source
 


### PR DESCRIPTION
This PR allows to torch.compile torch.nn.Module with custom __getitem__ methods but falling back to Python.

Fixes #97720

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire @yanboliang 
