### PR TITLE
set num_warps to at least 4

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -447,6 +447,7 @@ def triton_config(size_hints, x, y=None, z=None, num_stages=1) -> Config:
     # want at least 4 warps if there's enough elements per thread
     # given that this is a rare situation, don't expect this to affect perf
     # in general
+    # see https://github.com/pytorch/pytorch/pull/97950
     num_warps = max(num_warps, 4) if conditional_product(x, y, z) >= 128 else num_warps
     xnumel = size_hints[0]
     ynumel = size_hints[1] if y else None

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -442,6 +442,12 @@ def triton_config(size_hints, x, y=None, z=None, num_stages=1) -> Config:
     if z:
         cfg["ZBLOCK"] = z
     num_warps = next_power_of_2(min(max(conditional_product(x, y, z) // 256, 1), 8))
+    # we are going to arrive at 2 warps only if bs was too small due to
+    # numel being too small. However to workaround some ptx bugs we still
+    # want at least 4 warps if there's enough elements per thread
+    # given that this is a rare situation, don't expect this to affect perf
+    # in general
+    num_warps = max(num_warps, 4) if conditional_product(x, y, z) >= 128 else num_warps
     xnumel = size_hints[0]
     ynumel = size_hints[1] if y else None
     znumel = size_hints[2] if z else None


### PR DESCRIPTION
To avoid IMAs in https://gist.github.com/ngimel/25e81c996d9c8c652d97e33cc9c7d5f4
This is not a general fix (e.g. if inputs were a bit larger, num_warps would naturally be 4, and we could still have spills and hit ptxas bugs), but will do for now. 
Longer term, we should check spills in kernels we generate and recompile with more warps if there are spills. 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire