### PR TITLE
Compare `len(fw_derivatives)` with 0 w/o using `not`

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1013,7 +1013,7 @@ def emit_body(
             f"ERROR: derivative ignored for {name} -- specified an autograd function without derivative"
         )
 
-    if requires_derivative and not len(fw_derivatives) == 0:
+    if requires_derivative and len(fw_derivatives) > 0:
         assert sum(len(derivative.var_names) for derivative in fw_derivatives) == len(
             differentiable_outputs
         ), (


### PR DESCRIPTION
`fw_derivatives` is a list as in the permlink so we can make use of the fact that the empty list is evaluated as `False` but from I prefer `len(some_list) > 0` thanks to its clarity and implication that the variable is a container.

https://github.com/pytorch/pytorch/blob/53c9bc8c68f05fee2421ef00c2f852f4cd322693/tools/autograd/gen_variable_type.py#L942