### PR TITLE
[dynamo] Insert set_rng_state and get_rng_state in the fx graphs

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1070,14 +1070,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         before, after = opt_fn()
         self.assertTrue(same(before, after))
-        self.assertEqual(cnt.frame_count, 2)
-        self.assertEqual(cnt.op_count, 3)  # rand, rand
-        try:
-            graph, _ = torch._dynamo.export(fn)
-            # See https://github.com/pytorch/pytorch/pull/87490
-            self.fail("unexpected export success")
-        except torch._dynamo.exc.Unsupported:
-            pass
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 4)  # get_rng_state, rand, set_rng_state, rand
+        graph, _ = torch._dynamo.export(fn)
 
     def test_seq_append_list(self):
         x = torch.randn(4, 10)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -122,7 +122,6 @@ SKIP_DIRS = [
 
 FILENAME_ALLOWLIST = {
     torch.nn.Sequential.__init__.__code__.co_filename,
-    torch.set_rng_state.__code__.co_filename,
     torch._inductor.test_operators.__file__,
     # These are dynamo files!
     external_utils.__file__,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -379,7 +379,7 @@ class TorchVariable(VariableTracker):
             # GenerateStrateSource.
             device = "cpu" if self.value is torch.random.get_rng_state else "cuda"
             seed = (
-                torch.initial_seed() if device == "cuda" else torch.cuda.initial_seed()
+                torch.initial_seed() if device == "cpu" else torch.cuda.initial_seed()
             )
             source = GeneratorStateSource(device, seed)
 


### PR DESCRIPTION
This PR

* Ensures that we insert set_rng_state and get_rng_state in the Dynamo produced Fx graph
* Skips Dynamo tracing of torch/random.py and torch/cuda/random.py so that we don't see `default_generator` objects during Bytecode tracing.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @soumith @desertfire