### PR TITLE
avoid warning in irange for unsigned types

### DIFF
--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <c10/util/Exception.h>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <algorithm>
 #include <iterator>
@@ -51,7 +52,7 @@ struct integer_iterator {
       // end`. To handle `c10::irange(n)` where n < 0 (which should be
       // empty), we just make `begin != end` fail whenever `end` is
       // negative.
-      return other.value < 0 || value == other.value;
+      return is_negative(other.value) || value == other.value;
     } else {
       return value == other.value;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97973

Unsigned types should not be compared to be less than zero.

Differential Revision: [D44538384](https://our.internmc.facebook.com/intern/diff/D44538384/)