### PR TITLE
[fx] Fix trivial replacement case

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -384,7 +384,12 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        matches = subgraph_rewriter.replace_pattern_with_filters(traced, pattern, replacement, [])
+
+        # There should be no replacement nodes since we did not add any new
+        # nodes in the graph
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(len(matches[0].replacements), 0)
 
         traced.graph.lint()
 

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -301,6 +301,9 @@ def _replace_pattern(
         replacement_nodes = []
 
         def get_replacement_nodes(curr_node: Node):
+            if curr_node in match.placeholder_nodes:
+                return
+
             nonlocal replacement_nodes
             for arg in curr_node.args:
                 if isinstance(arg, Node):


### PR DESCRIPTION
Stops the recursion early if we encounter a previous placeholder node.