### PR TITLE
Don't apply _Py_OPCODE twice

### DIFF
--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1427,7 +1427,7 @@ PyTypeObject Tensor::Type = {
 // dim() --------------------
 
 bool relevant_op(_Py_CODEUNIT c) {
-    switch(_Py_OPCODE(c)) {
+    switch(c) {
         case STORE_NAME:
         case STORE_GLOBAL:
         case STORE_FAST:


### PR DESCRIPTION
It's already applied in PyInstDecoder::opcode.
Applying it twice returns incorrect result on big endian systems.

This change fixes 14 tests in test/functorch/test_dims.py on big endian systems.