### PR TITLE
Dynamo support for _maybe_wrap_tensor

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -453,6 +453,13 @@ class TorchVariable(VariableTracker):
             return TorchVariable(torch.add, **options).call_function(
                 tx, [args[0], result], {}
             )
+        elif self.value == torch.distributed._functional_collectives._maybe_wrap_tensor:
+            # this function will wrap with AsyncTensor during eager, but does nothing other
+            # than trace a 'wait_tensor' call under tracing.
+            assert len(args) == 1, "expected single input tensor for wait_tensor()"
+            return TorchVariable(torch._C._nn.wait_tensor, **options).call_function(
+                tx, args, {}
+            )
         else:
             any_symints_or_symfloats = any(
                 [isinstance(x, SymNodeVariable) for x in args]

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -64,6 +64,10 @@ As a wise man said once: Don't cross the streams (https://www.youtube.com/watch?
 data_ptr_to_work = dict()
 work_version = 0
 
+def _maybe_wrap_tensor(self):
+    # Mockup while waiting for https://github.com/pytorch/pytorch/pull/98001
+    pass
+
 def _register_tensor_work(tensor, work):
     # Note: called directly by inductor codegen currently
     global data_ptr_to_work


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98005

Mockup for now, will add test and rebase on https://github.com/pytorch/pytorch/pull/98001 after landing.

One issue with this approach may be if we want to move the wait outside the dynamo graph, or move it across graph-breaks.  We could experiment with ways to kill the wait_tensor in our graph and construct an AsyncTensor wrapper to pass onward to the eager code or the subsequent graph.  But.. this sounds tricky.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx