### PR TITLE
[vmap] Fix index_select support when dim is negative (#97916)

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -836,6 +836,7 @@ Tensor get_expanded_index(const Tensor& index, IntArrayRef self_size, int64_t di
   if (index.dim() == 0) {
     return index.expand(self_size);
   }
+  dim = maybe_wrap_dim(dim, self_size.size());
 
   // setup new_index_shape as [BS, 1, ..., idx_size, ..., 1]
   // to reshape index_

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4443,7 +4443,7 @@ def sample_inputs_index(op_info, device, dtype, requires_grad, reference=False, 
         args = []
 
         # dim. We handle the scalar case
-        dim = 1 if t.ndim == 2 else 0
+        dim = -1 if t.ndim == 2 else 0
         args.append(dim)
 
         idx = make_idx(t.shape[dim] if t.ndim != 0 else 1)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/96854

Previously, this would segfault (via indexing -2 into a SmallVector). This PR fixes it so that we wrap negative dimensions.

Test Plan:
- changed the index_select OpInfo to use dim=-1 instead of dim=1, because it's much more common that the negative dimension doesn't work instead of the positive one.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/97916
Approved by: https://github.com/ngimel, https://github.com/janeyx99

Fixes #ISSUE_NUMBER
