### PR TITLE
stepcurrent

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,7 @@ from _pytest.config import filename_arg
 from _pytest.config import Config
 from _pytest._code.code import ReprFileLocation
 from _pytest.python import Module
-from typing import Union
+from typing import Any, List, Union
 from typing import Optional
 from types import MethodType
 import xml.etree.ElementTree as ET
@@ -18,9 +18,24 @@ import sys
 # a lot of this file is copied from _pytest.junitxml and modified to get rerun info
 
 xml_key = StashKey["LogXMLReruns"]()
+STEPCURRENT_CACHE_DIR = "cache/stepcurrent"
 
 
 def pytest_addoption(parser: Parser) -> None:
+    group = parser.getgroup("general")
+    group.addoption(
+        "--scs",
+        action="store_true",
+        default=False,
+        dest="stepcurrent_skip",
+    )
+    group.addoption(
+        "--sc",
+        action="store_true",
+        default=False,
+        dest="stepcurrent",
+    )
+
     parser.addoption("--use-main-module", action='store_true')
     group = parser.getgroup("terminal reporting")
     group.addoption(
@@ -81,6 +96,8 @@ def pytest_configure(config: Config) -> None:
             config.getini("junit_log_passing_tests_reruns"),
         )
         config.pluginmanager.register(config.stash[xml_key])
+    if config.getoption("stepcurrent") or config.getoption("stepcurrent_skip"):
+        config.pluginmanager.register(StepcurrentPlugin(config), "stepcurrentplugin")
 
 
 def pytest_unconfigure(config: Config) -> None:
@@ -193,3 +210,54 @@ def pytest_report_teststatus(report, config):
         pluggy_result.force_result(
             (outcome, letter, f"{verbose} [{report.duration:.4f}s]")
         )
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    if not session.config.getoption("stepcurrent") and not session.config.getoption("stepcurrent_skip"):
+        assert session.config.cache is not None
+        session.config.cache.set(STEPCURRENT_CACHE_DIR, [])
+
+
+class StepcurrentPlugin:
+    # Modified fromo _pytest/stepwise.py in order to save the currently running
+    # test instead of the last failed test
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.report_status = ""
+        assert config.cache is not None
+        self.cache: pytest.Cache = config.cache
+        self.lastrun: Optional[str] = self.cache.get(STEPCURRENT_CACHE_DIR, None)
+        self.skip: bool = config.getoption("stepcurrent_skip")
+
+    def pytest_collection_modifyitems(self, config: Config, items: List[Any]) -> None:
+        if not self.lastrun:
+            self.report_status = "Cannot find last run test, not skipping"
+            return
+
+        # check all item nodes until we find a match on last run
+        failed_index = None
+        for index, item in enumerate(items):
+            if item.nodeid == self.lastrun:
+                failed_index = index
+                if self.skip:
+                    failed_index += 1
+                break
+
+        # If the previously failed test was not found among the test items,
+        # do not skip any tests.
+        if failed_index is None:
+            self.report_status = "previously run test not found, not skipping."
+        else:
+            self.report_status = f"skipping {failed_index} already run items."
+            deselected = items[:failed_index]
+            del items[:failed_index]
+            config.hook.pytest_deselected(items=deselected)
+
+    def pytest_report_collectionfinish(self) -> Optional[str]:
+        if self.config.getoption("verbose") >= 0 and self.report_status:
+            return f"stepcurrent: {self.report_status}"
+        return None
+
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        self.lastrun = report.nodeid
+        self.cache.set(STEPCURRENT_CACHE_DIR, self.lastrun)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -464,7 +464,6 @@ def run_test(
     extra_unittest_args=None,
     env=None,
 ) -> int:
-    cache_dir = tempfile.TemporaryDirectory()
     maybe_set_hip_visible_devies()
 
     unittest_args = options.additional_unittest_args.copy()
@@ -495,7 +494,7 @@ def run_test(
     # If using pytest, replace -f with equivalent -x
     if options.pytest:
         unittest_args.extend(
-            get_pytest_args(options, cache_dir.name, is_cpp_test=is_cpp_test)
+            get_pytest_args(options, test_file, is_cpp_test=is_cpp_test)
         )
         unittest_args = [arg if arg != "-f" else "-x" for arg in unittest_args]
 
@@ -576,7 +575,6 @@ def run_test(
 
     print_log_file(test_module, log_path, failed=(ret_code != 0))
     os.remove(log_path)
-    cache_dir.cleanup()
     return ret_code
 
 
@@ -896,7 +894,7 @@ def print_log_file(test: str, file_path: str, failed: bool) -> None:
         print_to_stderr("")
 
 
-def get_pytest_args(options, cache_dir, is_cpp_test=False):
+def get_pytest_args(options, stepcurrent_dir, is_cpp_test=False):
     if RERUN_DISABLED_TESTS:
         # When under rerun-disabled-tests mode, run the same tests multiple times to determine their
         # flakiness status. Default to 50 re-runs
@@ -907,15 +905,13 @@ def get_pytest_args(options, cache_dir, is_cpp_test=False):
     else:
         # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
         # failure
-        rerun_options = ["-x", "--reruns=2", "--sc"]
+        rerun_options = ["-x", "--reruns=2", f"--sc={stepcurrent_dir}"]
 
     pytest_args = [
         "-vv",
         "-rfEX",
         "-p",
         "no:xdist",
-        "-o",
-        f"cache_dir={cache_dir}",
     ]
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -494,7 +494,9 @@ def run_test(
     is_cpp_test = test_file.startswith(CPP_TEST_PREFIX)
     # If using pytest, replace -f with equivalent -x
     if options.pytest:
-        unittest_args.extend(get_pytest_args(options, cache_dir.name, is_cpp_test=is_cpp_test))
+        unittest_args.extend(
+            get_pytest_args(options, cache_dir.name, is_cpp_test=is_cpp_test)
+        )
         unittest_args = [arg if arg != "-f" else "-x" for arg in unittest_args]
 
     # TODO: These features are not available for C++ test yet
@@ -548,9 +550,8 @@ def run_test(
         and not RERUN_DISABLED_TESTS
         and isinstance(test_module, ShardedTest)
         and test_module.time is not None
-        and not options.continue_through_error
     )
-    timeout = 20 if should_file_rerun else None
+    timeout = THRESHOLD * 3 if should_file_rerun else None
     print_to_stderr("Executing {} ... [{}]".format(command, datetime.now()))
 
     with open(log_path, "w") as f:
@@ -561,11 +562,7 @@ def run_test(
             stderr=f,
             env=env,
             timeout=timeout,
-            retries=1
-            if should_file_rerun
-            else float("inf")
-            if options.continue_through_error
-            else 0,
+            retries=1 if should_file_rerun else 0,
         )
 
         # Pytest return code 5 means no test is collected. This is needed

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -906,7 +906,9 @@ def get_pytest_args(options, stepcurrent_key, is_cpp_test=False):
     else:
         # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
         # failure
-        rerun_options = ["-x", "--reruns=2", f"--sc={stepcurrent_key}"]
+        rerun_options = ["-x", "--reruns=2"]
+        if IS_CI:
+            rerun_options.append(f"--sc={stepcurrent_key}")
 
     pytest_args = [
         "-vv",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -23,6 +23,7 @@ import platform
 import random
 import re
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -582,6 +583,15 @@ def wait_for_process(p, timeout=None):
     except KeyboardInterrupt:
         # Give `p` a chance to handle KeyboardInterrupt. Without this,
         # `pytest` can't print errors it collected so far upon KeyboardInterrupt.
+        exit_status = p.wait(timeout=5)
+        if exit_status is not None:
+            return exit_status
+        else:
+            p.kill()
+            raise
+    except subprocess.TimeoutExpired:
+        # send SIGINT to give pytest a chance to make xml
+        p.send_signal(signal.SIGINT)
         exit_status = p.wait(timeout=5)
         if exit_status is not None:
             return exit_status


### PR DESCRIPTION
* add stepcurrent flag (--sc) based off the stepwise flag that saves the currently running test so that test running can resume from the last successful test after segfaults, takes in an argument for a key so that different test runs dont overwrite each other
* send sigint to process when timeout so that xml can be made

* add currently unused stepcurrent skip flag (--scs) based off stepwise skip flag that skips the failing test, was going to use if for the keep-going label but having trouble with CI