### PR TITLE
Rearrange the fields in at::OperandInfo to reduce padding.

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -132,6 +132,10 @@ struct TORCH_API OperandInfo {
 
   C10_ALWAYS_INLINE ~OperandInfo() = default;
 
+  /// The data pointer. This may be different from tensor->data_ptr() if the
+  /// iterator is split.
+  void* data = nullptr;
+
   /// Stride after broadcasting. The stride is in bytes, not number of elements.
   StrideVector stride_bytes;
 
@@ -159,10 +163,6 @@ struct TORCH_API OperandInfo {
   TensorOptions options() const {
     return TensorOptions(target_dtype).device(device);
   }
-
-  /// The data pointer. This may be different from tensor->data_ptr() if the
-  /// iterator is split.
-  void* data = nullptr;
 
   bool is_output = false;
 


### PR DESCRIPTION
Summary:
Rearrange the fields in at::OperandInfo to reduce padding.

The current class layout is {64,3,1,1,8,1,1,1,16,16,8,8}. Moving the 5th
element in the class allows the small bytes/bools to be packed together.

This class is frequently read from places like the stack trace below, so
compacting the class could speed things up.

c10/util/MaybeOwned.h:198 operator*
aten/src/ATen/TensorIterator.h:187 tensor_base
aten/src/ATen/TensorIterator.h:322 tensor_base
aten/src/ATen/TensorIterator.cpp:1194 compute_mem_overlaps
aten/src/ATen/TensorIterator.cpp:1475 build

Test Plan: Rely on unit tests.

Differential Revision: D44559604

