### PR TITLE
optimize the AMP func name in custom_device_mod

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -785,19 +785,19 @@ class DummyXPUModule:
         return True
 
     @staticmethod
-    def is_autocast_foo_enabled():
+    def is_autocast_enabled():
         return True
 
     @staticmethod
-    def get_autocast_foo_dtype():
+    def get_autocast_dtype():
         return torch.float16
 
     @staticmethod
-    def set_autocast_foo_enabled(enable):
+    def set_autocast_enabled(enable):
         pass
 
     @staticmethod
-    def set_autocast_foo_dtype(dtype):
+    def set_autocast_dtype(dtype):
         pass
 
     @staticmethod

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -24,17 +24,17 @@ def rename_privateuse1_backend(backend_name: str) -> None:
     (1) get_amp_supported_dtype() -> List[torch.dtype]
         get the supported dtypes on your `foo` device in AMP, maybe the `foo` device supports one more dtype.
 
-    (2) is_autocast_foo_enabled() -> bool
+    (2) is_autocast_enabled() -> bool
         check the AMP is enabled or not on your `foo` device.
 
-    (3) get_autocast_foo_dtype() -> torch.dtype
-        get the supported dtype on your `foo` device in AMP, which is set by `set_autocast_foo_dtype` or the
+    (3) get_autocast_dtype() -> torch.dtype
+        get the supported dtype on your `foo` device in AMP, which is set by `set_autocast_dtype` or the
         default dtype, and the default dtype is `torch.float16`.
 
-    (4) set_autocast_foo_enabled(bool) -> None
+    (4) set_autocast_enabled(bool) -> None
         enable the AMP or not on your `foo` device.
 
-    (5) set_autocast_foo_dtype(dtype) -> None
+    (5) set_autocast_dtype(dtype) -> None
         set the supported dtype on your `foo` device in AMP, and the dtype be contained in the dtypes got
         from `get_amp_supported_dtype`.
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1、optimize the func name of AMP in custom device module，use `torch.foo.set_autocast_enable` instead of `torch.foo.set_autocast_foo_enable`.
2、In AMP with custom device，use `custom_device_mod.set_autocast_enable` instead of `getattr(custom_device_mod,  "set_autocast_enable"`, because we have check that `custom_device_mod` hasattr `set_autocast_enable` before.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5