### PR TITLE
Fix complex variable notation for division operator to be consistent.

### DIFF
--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -268,7 +268,7 @@ struct alignas(sizeof(T) * 2) complex {
         real_ = a / abs_c;
         imag_ = b / abs_d;
       } else {
-        auto rat = c / d;
+        auto rat = d / c;
         auto scl = 1.0 / (c + d * rat);
         real_ = (a + b * rat) * scl;
         imag_ = (b - a * rat) * scl;

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -248,36 +248,36 @@ struct alignas(sizeof(T) * 2) complex {
       __ubsan_ignore_float_divide_by_zero__ {
     // (a + bi) / (c + di) = (ac + bd)/(c^2 + d^2) + (bc - ad)/(c^2 + d^2) i
     // the calculation below follows numpy's complex division
-    T ar = real_;
-    T ai = imag_;
-    U br = rhs.real();
-    U bi = rhs.imag();
+    T a = real_;
+    T b = imag_;
+    U c = rhs.real();
+    U d = rhs.imag();
 
 #if defined(__GNUC__) && !defined(__clang__)
     // std::abs is already constexpr by gcc
-    auto abs_br = std::abs(br);
-    auto abs_bi = std::abs(bi);
+    auto abs_c = std::abs(c);
+    auto abs_d = std::abs(d);
 #else
-    auto abs_br = br < 0 ? -br : br;
-    auto abs_bi = bi < 0 ? -bi : bi;
+    auto abs_c = c < 0 ? -c : c;
+    auto abs_d = d < 0 ? -d : d;
 #endif
 
-    if (abs_br >= abs_bi) {
-      if (abs_br == 0 && abs_bi == 0) {
+    if (abs_c >= abs_d) {
+      if (abs_c == 0 && abs_d == 0) {
         /* divide by zeros should yield a complex inf or nan */
-        real_ = ar / abs_br;
-        imag_ = ai / abs_bi;
+        real_ = a / abs_c;
+        imag_ = b / abs_d;
       } else {
-        auto rat = bi / br;
-        auto scl = 1.0 / (br + bi * rat);
-        real_ = (ar + ai * rat) * scl;
-        imag_ = (ai - ar * rat) * scl;
+        auto rat = c / d;
+        auto scl = 1.0 / (c + d * rat);
+        real_ = (a + b * rat) * scl;
+        imag_ = (b - a * rat) * scl;
       }
     } else {
-      auto rat = br / bi;
-      auto scl = 1.0 / (bi + br * rat);
-      real_ = (ar * rat + ai) * scl;
-      imag_ = (ai * rat - ar) * scl;
+      auto rat = c / d;
+      auto scl = 1.0 / (d + c * rat);
+      real_ = (a * rat + b) * scl;
+      imag_ = (b * rat - a) * scl;
     }
     return *this;
   }


### PR DESCRIPTION
A readability improvement: changes notation in complex division to match comments `(a + bi)/(c + di)` for `constexpr FORCE_INLINE_APPLE complex<T>& operator/=(const complex<U>& rhs)`