### PR TITLE
add deterministic impl for scatter and scatter_reduction sum/mean mode

### DIFF
--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -475,6 +475,8 @@ void gather_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim, c
 }
 
 void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  // When indices are not unique, the behavior is non-deterministic
+  globalContext().alertNotDeterministic("scatter_cuda_");
   cuda_scatter_gather_base_kernel<>()(
     self, dim, index, src,
     "scatter_cuda_", tensor_assign);
@@ -497,6 +499,9 @@ void scatter_add_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& inde
 
 void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                const Tensor& src, const ReductionType& reduce) {
+  // See Note [Writing Nondeterministic Operations]
+  // Nondeterministic because of atomicAdd/AtomicMul usage
+  globalContext().alertNotDeterministic("scatter_reduce_cuda_kernel");
   switch (reduce) {
   case ReductionType::SUM :
     cuda_scatter_gather_base_kernel<true, false>()(self, dim, index, src,
@@ -513,13 +518,14 @@ void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Ten
 
 void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                     const Tensor& src, const ReductionType& reduce) {
-  globalContext().alertNotDeterministic("scatter_reduce_cuda");
   switch (reduce) {
   case ReductionType::SUM :
+    globalContext().alertNotDeterministic("scatter_reduce_cuda_sum_");
     cuda_scatter_gather_base_kernel<true, false>()(self, dim, index, src,
             "scatter_reduce_cuda_sum_", reduce_add);
     break;
   case ReductionType::PROD :
+    globalContext().alertNotDeterministic("scatter_reduce_cuda_prod_");
     cuda_scatter_gather_base_kernel<true, false>()(self, dim, index, src,
             "scatter_reduce_cuda_prod_", reduce_multiply);
     break;
@@ -532,6 +538,7 @@ void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const
             "scatter_reduce_cuda_amin_", reduce_minimum);
     break;
   case ReductionType::MEAN :
+    globalContext().alertNotDeterministic("scatter_reduce_cuda_mean_");
     cuda_scatter_gather_base_kernel<true, false>()(self, dim, index, src,
             "scatter_reduce_cuda_mean_", reduce_mean);
     break;

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -164,8 +164,10 @@ class TestScatterGather(TestCase):
 
     @dtypes(torch.float16, torch.float32, torch.complex64)
     def test_scatter_(self, device, dtype):
-        self._test_scatter_base(torch.Tensor.scatter_, device=device, dtype=dtype,
-                                is_scalar=False, reduction=None)
+        for deterministic in [False, True]:
+            with DeterministicGuard(deterministic):
+                self._test_scatter_base(torch.Tensor.scatter_, device=device, dtype=dtype,
+                                        is_scalar=False, reduction=None)
 
     @dtypes(torch.float16, torch.float32, torch.complex64)
     def test_scatter__scalar(self, device, dtype):
@@ -207,9 +209,11 @@ class TestScatterGather(TestCase):
     @dtypes(*get_all_dtypes(include_half=True, include_bfloat16=True, include_bool=False))
     def test_scatter_reduce_sum(self, device, dtype):
         for include_self in (True, False):
-            self._test_scatter_base(torch.Tensor.scatter_reduce_, device=device, dtype=dtype,
-                                    is_scalar=False, reduction='sum', unique_indices=False,
-                                    include_self=include_self)
+            for deterministic in [False, True]:
+                with DeterministicGuard(deterministic):
+                    self._test_scatter_base(torch.Tensor.scatter_reduce_, device=device, dtype=dtype,
+                                            is_scalar=False, reduction='sum', unique_indices=False,
+                                            include_self=include_self)
 
     @dtypes(*get_all_dtypes(include_half=True, include_bfloat16=True))
     @dtypesIfCUDA(*get_all_dtypes(include_half=True, include_bfloat16=True, include_complex=False, include_bool=False))
@@ -223,9 +227,11 @@ class TestScatterGather(TestCase):
     @dtypesIfCUDA(*get_all_dtypes(include_half=True, include_bfloat16=True, include_complex=False, include_bool=False))
     def test_scatter_reduce_mean(self, device, dtype):
         for include_self in (True, False):
-            self._test_scatter_base(torch.Tensor.scatter_reduce_, device=device, dtype=dtype,
-                                    is_scalar=False, reduction='mean', unique_indices=False,
-                                    include_self=include_self)
+            for deterministic in [False, True]:
+                with DeterministicGuard(deterministic):
+                    self._test_scatter_base(torch.Tensor.scatter_reduce_, device=device, dtype=dtype,
+                                            is_scalar=False, reduction='mean', unique_indices=False,
+                                            include_self=include_self)
 
     @dtypes(*get_all_dtypes(include_half=True, include_bfloat16=True, include_complex=False))
     @dtypesIfCUDA(*get_all_dtypes(include_half=True, include_bfloat16=True, include_complex=False, include_bool=False))

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -691,6 +691,8 @@ def use_deterministic_algorithms(mode, *, warn_only=False):
         * :func:`torch.index_select` when attempting to differentiate a CUDA tensor
         * :func:`torch.repeat_interleave` when attempting to differentiate a CUDA tensor
         * :func:`torch.Tensor.index_copy` when called on a CPU or CUDA tensor
+        * :func:`torch.Tensor.scatter` when `src` type is Tensor and called on CUDA tensor
+        * :func:`torch.Tensor.scatter_reduce` when ``reduce='sum'`` or ``reduce='mean'`` and called on CUDA tensor
 
     The following normally-nondeterministic operations will throw a
     :class:`RuntimeError` when ``mode=True``:
@@ -731,6 +733,7 @@ def use_deterministic_algorithms(mode, *, warn_only=False):
         * :func:`torch.median` with indices output when called on a CUDA tensor
         * :func:`torch.nn.functional.grid_sample` when attempting to differentiate a CUDA tensor
         * :func:`torch.cumsum` when called on a CUDA tensor when dtype is floating point or complex
+        * :func:`torch.Tensor.scatter_reduce` when ``reduce='prod'`` and called on CUDA tensor
 
     A handful of CUDA operations are nondeterministic if the CUDA version is
     10.2 or greater, unless the environment variable ``CUBLAS_WORKSPACE_CONFIG=:4096:8``


### PR DESCRIPTION
using the existing deterministic implementation via `index_put` which has a deterministic implementation based on sorting indices. 

With the `accumulate` arg in `index_put`, this can work for both scatter and scatter_reduce with sum/mean reduction mode.


cc @mruberry @kurtamohler