### PR TITLE
fix load_sharded_optimizer_state_dict error on multi node

### DIFF
--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -20,7 +20,7 @@ from torch.distributed.checkpoint.metadata import (
     MetadataIndex,
     STATE_DICT_TYPE,
     TensorStorageMetadata,
-    ChunkStorageMetadata
+    ChunkStorageMetadata,
 )
 from torch.distributed.checkpoint.planner_helpers import (
     create_read_items_for_chunk_list,
@@ -170,8 +170,12 @@ class _ReaderWithOffset(DefaultLoadPlanner):
             original_shard = obj.local_shards()[0]
             local_chunks = [
                 ChunkStorageMetadata(
-                    offsets=torch.Size(_element_wise_add(original_shard.metadata.shard_offsets, offset)),
-                    sizes=torch.Size(original_shard.metadata.shard_sizes)
+                    offsets=torch.Size(
+                        _element_wise_add(
+                            original_shard.metadata.shard_offsets, offset
+                        )
+                    ),
+                    sizes=torch.Size(original_shard.metadata.shard_sizes),
                 )
             ]
 
@@ -256,7 +260,8 @@ def load_sharded_optimizer_state_dict(
         sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:{i}/cuda:{i}" for i in range(dist.get_world_size())
+                f"rank:{i}/cuda:{i % torch.cuda.device_count()}"
+                for i in range(dist.get_world_size())
             ],
         )
     else:


### PR DESCRIPTION
Fixes #95892 

This PR fixes the placement error in ChunkShardingSpec when training with multi nodes. 'rank:{global_rank}/cuda:{local_rank}' should be used but 'rank:{global_rank}/cuda:{global_rank}' is used so this would result in a CUDA error: invalid device ordinal. 
