### PR TITLE
Automatically generate attributes and methods for custom backends.

### DIFF
--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -73,6 +73,11 @@ at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool
   return dst;
 }
 
+at::Tensor custom_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride, c10::optional<at::ScalarType> dtype_opt, c10::optional<at::Layout> layout_opt, c10::optional<at::Device> device_opt, c10::optional<bool> pin_memory_opt) {
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  auto dtype = c10::dtype_or_default(dtype_opt);
+  return  at::detail::empty_strided_generic(size, stride, &global_custom_alloc, private_use_ks, dtype);
+}
 
 // This macro does the heavy lifting.
 // With TORCH_LIBRARY_IMPL, you can register custom kernels for your backend.
@@ -88,6 +93,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", &custom_empty_symint);
   m.impl("fill_.Scalar", &custom_fill__scalar);
   m.impl("_copy_from", &custom__copy_from);
+  m.impl("empty_strided", &custom_empty_strided);
 }
 
 // This basic implementation doesn't bother dealing with different device indices

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -150,6 +150,18 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             test_tensor = torch.empty(4, 4, dtype=tt, device=device)
             self.assertTrue(test_tensor.type() == dt)
 
+        # check whether the attributes and methods of the corresponding custom backend are generated correctly
+        torch.utils.rename_privateuse1_backend('foo')
+        torch.utils.generate_methods_for_privateuse1_backend()
+        with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
+            torch.utils.generate_methods_for_privateuse1_backend()
+
+        x = torch.empty(4, 4)
+        self.assertFalse(x.is_foo)
+        x = x.foo()
+        self.assertTrue(x.is_foo)
+        self.assertTrue(hasattr(torch.nn.Module, 'foo'))
+
     def test_open_device_random(self):
         torch.utils.rename_privateuse1_backend('foo')
         with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
@@ -162,6 +174,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         with torch.random.fork_rng(device_type="foo"):
             pass
+
 
 if __name__ == "__main__":
     common.run_tests()

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -4,7 +4,7 @@ import sys
 from .throughput_benchmark import ThroughputBenchmark
 from ._crash_handler import enable_minidumps, disable_minidumps, enable_minidumps_on_exceptions
 from .cpp_backtrace import get_cpp_backtrace
-from .backend_registration import rename_privateuse1_backend
+from .backend_registration import rename_privateuse1_backend, generate_methods_for_privateuse1_backend
 
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -1,4 +1,8 @@
-from torch._C import _rename_privateuse1_backend
+import torch
+from torch._C import _rename_privateuse1_backend, _get_privateuse1_backend_name
+from typing import Union, Optional
+
+__all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend"]
 
 def rename_privateuse1_backend(backend_name: str) -> None:
     r"""
@@ -71,3 +75,61 @@ def rename_privateuse1_backend(backend_name: str) -> None:
         >>> a = torch.ones(2, device="foo")
         """
     return _rename_privateuse1_backend(backend_name)
+
+
+def _check_register_once(module, attr):
+    if hasattr(module, attr):
+        raise RuntimeError(f"The custom device module of {module} has already been registered with {attr}")
+
+
+def generate_methods_for_privateuse1_backend() -> None:
+    r"""
+    generate_methods_for_privateuse1_backend() -> None
+
+    Automatically generate attributes and methods for the custom backend after rename privateuse1 backend.
+
+    When you implement kernels for various torch operations, and register them to the PrivateUse1 dispatch key.
+    And call the function torch.rename_privateuse1_backend("foo") to rename your backend name.
+    At this point, you can easily register specific methods and attributes by calling this function.
+    Just like torch.Tensor.foo(), torch.Tensor.is_foo.
+
+    Note: We recommend you use generic functions (check devices are equal or to(device=)).
+    We provide these methods for convenience only and they will be "monkey patched" onto the objects
+    and so will not be properly typed.
+
+    Example::
+
+        >>> # xdoctest: +SKIP("failing")
+        >>> torch.utils.register_privateuse1_backend("foo")
+        >>> torch.utils.generate_for_privateuse1_backend()
+        # Then automatically generate backend-related attributes and methods.
+        >>> a = torch.tensor(2).foo()
+        >>> a.is_foo
+        >>> hasattr(torch.nn.Module, 'foo')
+        """
+    custom_backend_name = _get_privateuse1_backend_name()
+
+    @property  # type: ignore[misc]
+    def wrap_tensor_backend(self: torch.Tensor) -> bool:
+        return self.device.type == custom_backend_name
+
+    _check_register_once(torch.Tensor, f'is_{custom_backend_name}')
+    setattr(torch.Tensor, f'is_{custom_backend_name}', wrap_tensor_backend)
+
+    def wrap_tensor_to(self: torch.Tensor, device: Optional[Union[int, torch.device]] = 0) -> torch.Tensor:
+        if isinstance(device, torch.device):
+            if device.type == custom_backend_name:
+                return self.to(f'{custom_backend_name}:{device.index}')
+            else:
+                raise RuntimeError(f"Invalid device, must be {custom_backend_name} device")
+        return self.to(f'{custom_backend_name}:{device}')
+
+    _check_register_once(torch.Tensor, f'{custom_backend_name}')
+    setattr(torch.Tensor, f'{custom_backend_name}', wrap_tensor_to)
+
+    def wrap_module_to(self: torch.nn.modules.module.T,
+                       device: Optional[Union[int, torch.device]] = None) -> torch.nn.modules.module.T:
+        return self._apply(lambda t: getattr(t, f'{custom_backend_name}')(device))
+
+    _check_register_once(torch.nn.Module, f'{custom_backend_name}')
+    setattr(torch.nn.Module, f'{custom_backend_name}', wrap_module_to)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
#97593
A new extension mechanism has been added.
When the user registers a new backend, the corresponding methods and attributes can be automatically generated.
Do this code.
`torch.utils.rename_privateuse1_backend('foo')`
`torch.utils.generate_for_privateuse1_backend()`
Then, get the following methods and attributes.
`torch.Tensor.is_foo`
`torch.Tensor.foo()`
`torch.nn.Module.foo()`
