### PR TITLE
[inductor] [cpp] fix error for node with scalar input

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3082,6 +3082,15 @@ class CommonTemplate:
             (torch.randn([16, 16]),),
         )
 
+    def test_fill3(self):
+        def fn(x):
+            return aten.fill_.Scalar(x, 8)
+
+        self.common(
+            fn,
+            (torch.randint(0, 999, size=[], dtype=torch.int64),),
+        )
+
     def test_pow1(self):
         def fn(x):
             return [aten.pow(x, e) for e in range(-8, 9)]

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -490,7 +490,7 @@ class GraphLowering(torch.fx.Interpreter):
                 dense = torch._prims_common.is_non_overlapping_and_dense(n.meta["val"])
                 # requiring a stride order for a non-dense output wouldn't
                 # recreate the same strides, and would fail with view, defer for now.
-                if dense and len(strides):
+                if dense:
                     result = ir.ExternKernel.require_stride_order(
                         result, ir.get_stride_order(strides)
                     )


### PR DESCRIPTION
In the case of running a node with scalar input, the cpp output code would return an undefined buffer.


Here gives an example of the operator `aten.fill_.Scalar`:

#### Output_code before fixing
```
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_root/hw/chwr6vy6e6sd25sfh42qtywkuf2emodexm2aomp3lbrcxwznfwyi.h"
extern "C" void kernel(long* out_ptr0)
{
   {
       auto tmp0 = static_cast<long>(8);
       out_ptr0[0] = tmp0;
   }
}
''')

async_compile.wait(globals())
del async_compile

def call(args):
   arg0_1, = args
   args.clear()
   kernel_cpp_0(c_void_p(arg0_1.data_ptr()))
   del arg0_1
   return (buf0, )

def benchmark_compiled_module():
   from torch._dynamo.testing import rand_strided
   from torch._inductor.utils import print_performance
   arg0_1 = rand_strided((), (), device='cpu', dtype=torch.int64)
   print_performance(lambda: call([arg0_1]))
```

#### Output_code after fixing
```
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_root/hw/chwr6vy6e6sd25sfh42qtywkuf2emodexm2aomp3lbrcxwznfwyi.h"
extern "C" void kernel(long* out_ptr0,
                       long* out_ptr1)
{
    {
        auto tmp0 = static_cast<long>(8);
        out_ptr0[static_cast<long>(0)] = tmp0;
        out_ptr1[static_cast<long>(0)] = tmp0;
    }
}
''')

async_compile.wait(globals())
del async_compile

def call(args):
    arg0_1, = args
    args.clear()
    buf0 = empty_strided((), (), device='cpu', dtype=torch.int64)
    kernel_cpp_0(c_void_p(buf0.data_ptr()), c_void_p(arg0_1.data_ptr()))
    del arg0_1
    return (buf0, )

def benchmark_compiled_module():
    from torch._dynamo.testing import rand_strided
    from torch._inductor.utils import print_performance
    arg0_1 = rand_strided((), (), device='cpu', dtype=torch.int64)
    print_performance(lambda: call([arg0_1]))

```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire