### PR TITLE
use libcusolver_lapack_static.a for CUDA>=12

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -452,7 +452,7 @@ if(USE_CUDA AND NOT USE_ROCM)
      elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 12)
        list(APPEND ATen_CUDA_DEPENDENCY_LIBS
          CUDA::cusolver_static
-	 ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
+         ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
        )
      endif()
    endif()

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -444,10 +444,17 @@ if(USE_CUDA AND NOT USE_ROCM)
       CUDA::cufft_static_nocallback
     )
    if(NOT BUILD_LAZY_CUDA_LINALG)
-     list(APPEND ATen_CUDA_DEPENDENCY_LIBS
-       CUDA::cusolver_static
-       ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
-     )
+     if(CUDA_VERSION_MAJOR LESS_EQUAL 11)
+       list(APPEND ATen_CUDA_DEPENDENCY_LIBS
+         CUDA::cusolver_static
+         ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
+       )
+     elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 12)
+       list(APPEND ATen_CUDA_DEPENDENCY_LIBS
+         CUDA::cusolver_static
+	 ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
+       )
+     endif()
    endif()
   else()
     list(APPEND ATen_CUDA_DEPENDENCY_LIBS

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -972,13 +972,13 @@ elseif(USE_CUDA)
       if(CUDA_VERSION_MAJOR LESS_EQUAL 11)
         target_link_libraries(torch_cuda_linalg PRIVATE
             CUDA::cusolver_static
-	    ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
+            ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
         )
       elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 12)
         target_link_libraries(torch_cuda_linalg PRIVATE
             CUDA::cusolver_static
-	    ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
-	)
+            ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
+        )
       endif()
     else()
       target_link_libraries(torch_cuda_linalg PRIVATE

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -969,10 +969,17 @@ elseif(USE_CUDA)
       target_link_libraries(torch_cuda_linalg PRIVATE caffe2::mkl)
     endif()
     if($ENV{ATEN_STATIC_CUDA})
-      target_link_libraries(torch_cuda_linalg PRIVATE
-          CUDA::cusolver_static
-          ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
-      )
+      if(CUDA_VERSION_MAJOR LESS_EQUAL 11)
+        target_link_libraries(torch_cuda_linalg PRIVATE
+            CUDA::cusolver_static
+	    ${CUDAToolkit_LIBRARY_DIR}/liblapack_static.a     # needed for libcusolver_static
+        )
+      elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 12)
+        target_link_libraries(torch_cuda_linalg PRIVATE
+            CUDA::cusolver_static
+	    ${CUDAToolkit_LIBRARY_DIR}/libcusolver_lapack_static.a     # needed for libcusolver_static
+	)
+      endif()
     else()
       target_link_libraries(torch_cuda_linalg PRIVATE
           CUDA::cusolver


### PR DESCRIPTION
Needed for https://github.com/pytorch/builder/pull/1374 to enable nightly CUDA12.1 builds.

From the cuSOLVER release notes (https://docs.nvidia.com/cuda/cusolver/index.html#link-third-party-lapack-library):
> The `liblapack_static.a` library is deprecated and will be removed in the next major release. Use the `libcusolver_lapack_static.a` instead.

Note that "next major release" corresponds to CUDA 12, not 13.
The fix was verified locally on an H100 using https://github.com/pytorch/builder/pull/1374 and pip wheels were properly built:
```
>>> torch.version.cuda
'12.1'
>>> torch.backends.cudnn.version()
8801
>>> conv =nn.Conv2d(3, 3, 3).cuda()
>>> x = torch.randn(1, 3, 224, 224).cuda()
>>> out = conv(x)
>>> out.sum()
tensor(5386.9219, device='cuda:0', grad_fn=<SumBackward0>)
```

CC @malfet @atalman @ngimel 