### PR TITLE
Update ROCm skip decorators

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1207,7 +1207,7 @@ class TestCuda(TestCase):
             c2p.put(sync_func(self, TestCuda.FIFTY_MIL_CYCLES))
 
     # Skip the test for ROCm as per https://github.com/pytorch/pytorch/issues/53190
-    @skipIfRocm
+    @skipIfRocm(msg="flakey on ROCm https://github.com/pytorch/pytorch/issues/53190")
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     def test_stream_event_nogil(self):
         for sync_func in [TestCuda._stream_synchronize,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10818,7 +10818,7 @@ class TestNNDeviceType(NNTestCase):
             gradcheck(ctc_after_softmax, [x])
 
     @onlyCUDA
-    @skipCUDAIfRocm
+    @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
     @skipCUDAIfCudnnVersionLessThan(7600)
     def test_ctc_loss_cudnn(self, device):
         batch_size = 16

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1250,19 +1250,11 @@ def skipCUDAIfNoMagmaAndNoCusolver(fn):
         return skipCUDAIfNoMagma(fn)
 
 # Skips a test on CUDA when using ROCm.
-def skipCUDAIfRocm(msg="test doesn't currently work on the ROCm stack"):
-
+def skipCUDAIfRocm(*args, msg="test doesn't currently work on the ROCm stack"):
     def dec_fn(fn):
-        @wraps(fn)
-        def wrap_fn(self, *args, **kwargs):
-            if TEST_WITH_ROCM:
-                if self.device_type == 'cuda':
-                    raise unittest.SkipTest(f"skipCUDAIfRocm: {msg}")
-
-            return fn(self, *args, **kwargs)
-
-        return wrap_fn
-    return dec_fn
+        reason = f"skipCUDAIfRocm: {msg}"
+        return skipCUDAIf(TEST_WITH_ROCM, reason=reason)(fn)
+    return dec_fn(args[0]) if args else dec_fn
 
 # Skips a test on CUDA when not using ROCm.
 def skipCUDAIfNotRocm(fn):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -204,6 +204,8 @@ except ImportError:
 #         Skips the test if the device is a CPU device and MKL is not installed
 #     - @skipCUDAIfNoMagma
 #         Skips the test if the device is a CUDA device and MAGMA is not installed
+#     - @skipCUDAOpIfRocm
+#         Skips the op test if the device is a CUDA device and ROCm is being used
 #     - @skipCUDAIfRocm
 #         Skips the test if the device is a CUDA device and ROCm is being used
 
@@ -1251,18 +1253,13 @@ def skipCUDAIfNoMagmaAndNoCusolver(fn):
 
 # Skips a test on CUDA when using ROCm.
 def skipCUDAIfRocm(msg="test doesn't currently work on the ROCm stack"):
+    def decorator(fn):
+        return skipCUDAIf(TEST_WITH_ROCM, f"skipCUDAIfRocm: {msg}")(fn)
+    return decorator
 
-    def dec_fn(fn):
-        @wraps(fn)
-        def wrap_fn(self, *args, **kwargs):
-            if TEST_WITH_ROCM:
-                if self.device_type == 'cuda':
-                    raise unittest.SkipTest(f"skipCUDAIfRocm: {msg}")
-
-            return fn(self, *args, **kwargs)
-
-        return wrap_fn
-    return dec_fn
+# Skips a test on CUDA opinfo test when using ROCm 
+def skipCUDAOpIfRocm(fn):
+    return skipCUDAIf(TEST_WITH_ROCM, "skipCUDAOpIfRocm: test doesn't currently work on the ROCm stack")(fn)
 
 # Skips a test on CUDA when not using ROCm.
 def skipCUDAIfNotRocm(fn):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1250,8 +1250,19 @@ def skipCUDAIfNoMagmaAndNoCusolver(fn):
         return skipCUDAIfNoMagma(fn)
 
 # Skips a test on CUDA when using ROCm.
-def skipCUDAIfRocm(fn):
-    return skipCUDAIf(TEST_WITH_ROCM, "test doesn't currently work on the ROCm stack")(fn)
+def skipCUDAIfRocm(msg="test doesn't currently work on the ROCm stack"):
+
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            if TEST_WITH_ROCM:
+                if self.device_type == 'cuda':
+                    raise unittest.SkipTest(f"skipCUDAIfRocm: {msg}")
+
+            return fn(self, *args, **kwargs)
+
+        return wrap_fn
+    return dec_fn
 
 # Skips a test on CUDA when not using ROCm.
 def skipCUDAIfNotRocm(fn):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1143,15 +1143,17 @@ def skipRocmIfTorchDynamo(msg="test doesn't currently work with dynamo on the RO
 
     return decorator
 
-def skipIfRocm(msg="test doesn't currently work on the ROCm stack"):
+def skipIfRocm(*args, msg="test doesn't currently work on the ROCm stack"):
     def dec_fn(fn):
+        reason = f"skipIfRocm: {msg}"
         @wraps(fn)
-        def wrap_fn(self, *args, **kwargs):
+        def wrapper(*args, **kwargs):
             if TEST_WITH_ROCM:
-                raise unittest.SkipTest(f"skipIfRocm: {msg}")
-            return fn(self, *args, **kwargs)
-        return wrap_fn
-    return dec_fn
+                raise unittest.SkipTest(reason)
+            else:
+                return fn(*args, **kwargs)
+        return wrapper
+    return dec_fn(args[0]) if args else dec_fn
 
 def skipIfMps(fn):
     @wraps(fn)

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIfNoCusolver,
     skipCUDAIfNoMagma,
     skipCUDAIfNoMagmaAndNoCusolver,
-    skipCUDAOpIfRocm,
+    skipCUDAIfRocm,
     tol,
     toleranceOverride,
 )
@@ -1543,7 +1543,7 @@ op_db: List[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_ldl_factor,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAOpIfRocm],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAIfRocm],
     ),
     OpInfo(
         "linalg.ldl_factor_ex",
@@ -1551,7 +1551,7 @@ op_db: List[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_ldl_factor,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAOpIfRocm],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAIfRocm],
     ),
     OpInfo(
         "linalg.ldl_solve",
@@ -1564,7 +1564,7 @@ op_db: List[OpInfo] = [
                 _get_torch_cuda_version() < (11, 4), "not available before CUDA 11.3.1"
             ),
             skipCUDAIfNoCusolver,
-            skipCUDAOpIfRocm,
+            skipCUDAIfRocm,
             skipCPUIfNoLapack,
         ],
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIfNoCusolver,
     skipCUDAIfNoMagma,
     skipCUDAIfNoMagmaAndNoCusolver,
-    skipCUDAIfRocm,
+    skipCUDAOpIfRocm,
     tol,
     toleranceOverride,
 )
@@ -1543,7 +1543,7 @@ op_db: List[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_ldl_factor,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAIfRocm],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAOpIfRocm],
     ),
     OpInfo(
         "linalg.ldl_factor_ex",
@@ -1551,7 +1551,7 @@ op_db: List[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_ldl_factor,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAIfRocm],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, skipCUDAOpIfRocm],
     ),
     OpInfo(
         "linalg.ldl_solve",
@@ -1564,7 +1564,7 @@ op_db: List[OpInfo] = [
                 _get_torch_cuda_version() < (11, 4), "not available before CUDA 11.3.1"
             ),
             skipCUDAIfNoCusolver,
-            skipCUDAIfRocm,
+            skipCUDAOpIfRocm,
             skipCPUIfNoLapack,
         ],
     ),


### PR DESCRIPTION
- msg tag added to skipIfRocm skipCUDAIfRocm

- Added ROCm specific dynamo/inductor skips for PyT2.0


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang