### PR TITLE
Clarify the saving of intermediates in the "extending torch.func" docs (#98020)

### DIFF
--- a/docs/source/notes/extending.func.rst
+++ b/docs/source/notes/extending.func.rst
@@ -37,8 +37,13 @@ Only the latter is supported with function transforms:
   (by calling ``ctx.save_for_backward(*tensors)``), or save non-Tensors
   (by assigning them to the ``ctx`` object).
 
-Any intermediates that need to be saved must be returned as an output from
-:meth:`~Function.forward`.
+Because :meth:`~Function.setup_context` accepts only ``inputs`` and ``output``,
+the only quantities that can be saved are either objects (such as Tensors) in
+the inputs or outputs or quantities (like ``Tensor.shape``) derived from them.
+If you wish to save a non-input intermediate activation from
+:meth:`Function.forward` for backward, then you'll need to return it as an
+output from :meth:`~Function.forward` so that it gets passed to
+:meth:`~Function.setup_context`.
 
 Depending on the transform,
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/97260

We got some feedback that the page reads like "in order to save an input for backward, you must return it as an output of the autograd.Function.forward".

Doing so actually raises an error (on master and as of 2.1), but results in an ambiguous situation on 2.0.0. To avoid more users running into this, we clarify the documentation so it doesn't read like the above and clearly mentions that you can save things from the inputs or outputs.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/98020 Approved by: https://github.com/soulitzer, https://github.com/kshitij12345

Fixes #ISSUE_NUMBER
