### PR TITLE
Added allowed_workflows to pytorch probot

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -12,3 +12,9 @@ ciflow_push_tags:
 - ciflow/periodic
 - ciflow/trunk
 - ciflow/unstable
+allowed_workflows:
+- lint
+- pull
+- trunk
+- linux-binary
+- windows-binary


### PR DESCRIPTION
Added allowed_workflows to pytorch probot. This is a follow up PR [regarding the retry bot](https://github.com/pytorch/test-infra/pull/3942/files#diff-ee5e4f1e1fa962c6f62e5dcebde6e0bab573e74474601bf5749ccb668fd9c900R14-R16).