### PR TITLE
[BE] Bump default protocol version of torch.save

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -20,7 +20,7 @@ import pickle
 import pathlib
 import torch._weights_only_unpickler as _weights_only_unpickler
 
-DEFAULT_PROTOCOL = 2
+DEFAULT_PROTOCOL = 5
 
 LONG_SIZE = struct.Struct('=l').size
 INT_SIZE = struct.Struct('=i').size


### PR DESCRIPTION
Fixes #97772 . Let's see what breaks when bump this protocol version.
