### PR TITLE
Fix ddp static graph mode error when some outputs are not used

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1498,7 +1498,7 @@ class DistributedDataParallel(Module, Joinable):
 
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
-        if (self.find_unused_parameters and not self.static_graph) or (
+        if self.find_unused_parameters or (
             self.static_graph and self.num_iterations == 1
         ):
             state_dict = {

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8471,7 +8471,7 @@ class DistributedTest:
                 group_gloo,
             )
 
-        def _test_output_unused_in_loss(self, module_cls, static_graph):
+        def _test_output_unused_in_loss(self, module_cls, static_graph, gradient_as_bucket_view):
             model = module_cls()
             local_net = copy.deepcopy(model)
             net = torch.nn.parallel.DistributedDataParallel(
@@ -8479,6 +8479,7 @@ class DistributedTest:
                 device_ids=[self.rank],
                 find_unused_parameters=True,
                 static_graph=static_graph,
+                gradient_as_bucket_view=gradient_as_bucket_view,
             )
 
             # Tests that certain parameters not getting gradient since the
@@ -8575,8 +8576,10 @@ class DistributedTest:
         @skip_if_lt_x_gpu(2)
         def test_output_unused_in_loss_tuple_module(self):
             module_cls = UnusedParamTwoLinLayerNet
-            for static_graph in [True, False]:
-                self._test_output_unused_in_loss(module_cls, static_graph)
+            for static_graph, gradient_as_bucket_view in itertools.product(
+                [True, False], [True, False]
+            ):
+                self._test_output_unused_in_loss(module_cls, static_graph, gradient_as_bucket_view)
 
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],
@@ -8585,8 +8588,10 @@ class DistributedTest:
         @skip_if_lt_x_gpu(2)
         def test_output_unused_in_loss_dict_module(self):
             module_cls = DictOutputModule
-            for static_graph in [True, False]:
-                self._test_output_unused_in_loss(module_cls, static_graph)
+            for static_graph, gradient_as_bucket_view in itertools.product(
+                [True, False], [True, False]
+            ):
+                self._test_output_unused_in_loss(module_cls, static_graph, gradient_as_bucket_view)
 
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8471,13 +8471,14 @@ class DistributedTest:
                 group_gloo,
             )
 
-        def _test_output_unused_in_loss(self, module_cls, gradient_as_bucket_view):
+        def _test_output_unused_in_loss(self, module_cls, static_graph):
             model = module_cls()
             local_net = copy.deepcopy(model)
             net = torch.nn.parallel.DistributedDataParallel(
                 copy.deepcopy(model).cuda(self.rank),
                 device_ids=[self.rank],
                 find_unused_parameters=True,
+                static_graph=static_graph,
             )
 
             # Tests that certain parameters not getting gradient since the
@@ -8574,8 +8575,8 @@ class DistributedTest:
         @skip_if_lt_x_gpu(2)
         def test_output_unused_in_loss_tuple_module(self):
             module_cls = UnusedParamTwoLinLayerNet
-            for grad_as_bucket_view in [True, False]:
-                self._test_output_unused_in_loss(module_cls, grad_as_bucket_view)
+            for static_graph in [True, False]:
+                self._test_output_unused_in_loss(module_cls, static_graph)
 
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],
@@ -8584,8 +8585,8 @@ class DistributedTest:
         @skip_if_lt_x_gpu(2)
         def test_output_unused_in_loss_dict_module(self):
             module_cls = DictOutputModule
-            for grad_as_bucket_view in [True, False]:
-                self._test_output_unused_in_loss(module_cls, grad_as_bucket_view)
+            for static_graph in [True, False]:
+                self._test_output_unused_in_loss(module_cls, static_graph)
 
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],


### PR DESCRIPTION
Fixes #97030

In static mode, those outputs without backward will stuck the reducer logic, use `_DDPSink` logic to handle the case.

Since static graph mode will omit `find_unused_parameters` argument, use `find_unused_parameters=True, static_graph=True` to specify this case.