### PR TITLE
[PyTorch] Don't do extra numel() check in TensorImpl::data()

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1541,12 +1541,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // Computing an offset into an empty tensor would be UB, since an empty
     // tensor's storage will be nullptr, and adding a nonzero offset to nullptr
     // is UB.  So we skip the offset computation in this case.
-    if (is_empty()) {
+    char* const data = static_cast<char*>(storage_.data());
+    if (data == nullptr) {
       return nullptr;
     }
-    return static_cast<void*>(
-        static_cast<char*>(storage_.data()) +
-        data_type_.itemsize() * storage_offset_);
+    return static_cast<void*>(data + data_type_.itemsize() * storage_offset_);
   }
 
   /**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98090

`is_empty()` checks `numel() == 0`, but we don't need to access `numel_` at all (or the policy that `numel()` checks) in our happy path -- we just need the data pointer from `storage_`. Let's do the check we need to do using only the data we strictly need, rather than adding instructions loading other pieces of data.

Differential Revision: [D44586464](https://our.internmc.facebook.com/intern/diff/D44586464/)