### PR TITLE
[torch/fx] add torch/utils/_stats.py to stack frame skiplist

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -201,7 +201,8 @@ class TracerBase:
                     'torch/utils/_python_dispatch.py',
                     'torch/_prims_common/wrappers.py',
                     'torch/_refs/__init__.py',
-                    'torch/_refs/nn/functional/__init__.py'
+                    'torch/_refs/nn/functional/__init__.py',
+                    'torch/utils/_stats.py',
                     ]
         while frame:
             frame = frame.f_back


### PR DESCRIPTION
We added some @count decorators to stuff that show up now

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e503e8</samp>

Ignore `torch/utils/_stats.py` when tracing user frame in `torch.fx.proxy`. This avoids false source attribution for some profiling and debugging functions.
