### PR TITLE
[dynamo] Add kwarg constructor for `call_dict`

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -612,6 +612,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         return d1["a"] + d2["c"] + 1
 
     @make_test
+    def test_call_dict6(x):
+        return dict(x=x+1)
+
+    @make_test
     def test_min_max(a, b):
         c = a + b
         a = a.sum()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8,7 +8,6 @@ import contextlib
 import copy
 import inspect
 import itertools
-import logging
 import random
 import unittest
 import weakref

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2626,20 +2626,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertTrue(same(ref, res))
 
-    def test_call_dict_kwargs(self):
-        class Foo(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.a = torch.randn(4)
-
-            def forward(self, x):
-                outputs = torch.sin(x) + torch.cos(self.a)
-                return dict(x=x, outputs=outputs)
-
-        with self.assertNoLogs(logger="torch._dynamo", level=logging.WARNING):
-            foo = torch.compile(Foo())
-            foo(torch.randn(4))
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -805,8 +805,10 @@ class BuiltinVariable(VariableTracker):
         else:
             raise AssertionError("call_dict_helper with illegal arg")
 
-    def call_dict(self, tx, obj=None):
+    def call_dict(self, tx, obj=None, **kwargs):
         if self.is_supported_call_dict_arg(tx, obj):
+            if kwargs:
+                return self.call_dict_helper(tx, dict, variables.ConstDictVariable(kwargs, dict))
             return self.call_dict_helper(tx, dict, obj)
 
     def call_zip(self, tx, *args):


### PR DESCRIPTION
Fixes #96459

Tested on the simple repro in the issue but not sure if there's some nuance around `ConstDictVariable` that I have to consider for more complex cases.

Added a test in `test/dynamo/test_repros.py` that checks to ensure no warnings are emitted for the simple case. Ideally this would only check for the specific `incorrect arg count` warning that prompted the original issue, but the code for that is ugly since it probably requires using `assertNoLogs` in a try/catch to check if we have logs at all and then `assertLogs` to check the logs themselves.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire