### PR TITLE
Support multiple separator characters, '/' and '\\', on Windows.

### DIFF
--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -8,8 +8,12 @@ namespace c10 {
 namespace detail {
 
 std::string StripBasename(const std::string& full_path) {
-  const char kSeparator = '/';
-  size_t pos = full_path.rfind(kSeparator);
+#ifdef _WIN32
+  const std::string separators("/\\");
+#else
+  const std::string separators("/");
+#endif
+  size_t pos = full_path.find_last_of(separators);
   if (pos != std::string::npos) {
     return full_path.substr(pos + 1, std::string::npos);
   } else {


### PR DESCRIPTION
On Windows, both '/' and '\\' can be used as a path separator, so `StripBasename` should handle them as path separators.

`StripBasename` is used in the `is_enabled` function in `torch\csrc\jit\jit_log.cpp`
Therefore, without this pull request, is_enabled does not work properly on Windows.

For more details, please refer to the issue #98145.

Fixes #98145
