### PR TITLE
Support `getattr` for ConstantVariable when compiling with Dynamo

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1075,6 +1075,16 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch._dynamo.optimize(cnts)(fn)
         self.assertTrue(same(opt_fn(mod, x), fn(mod, x)))
 
+    def test_constant_getattr(self):
+        # https://github.com/pytorch/pytorch/issues/97480
+        def fn():
+            return getattr(None, 'arg', 3)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        optimized_fn = torch._dynamo.optimize(cnt)(fn)
+        res = optimized_fn()
+        self.assertTrue(same(res, 3))
+
     def test_user_property(self):
         class MyConfig:
             @property

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1078,7 +1078,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
     def test_constant_getattr(self):
         # https://github.com/pytorch/pytorch/issues/97480
         def fn():
-            return getattr(None, 'arg', 3)
+            return getattr(None, "arg", 3)
 
         cnt = torch._dynamo.testing.CompileCounter()
         optimized_fn = torch._dynamo.optimize(cnt)(fn)

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -135,6 +135,11 @@ class ConstantVariable(VariableTracker):
 
         unimplemented(f"const method call {typestr(self.value)}.{name}")
 
+    def call_hasattr(self, tx, name: str) -> "VariableTracker":
+        options = VariableTracker.propagate(self)
+        result = hasattr(self.value, name)
+        return variables.ConstantVariable(result, **options)
+
 
 class EnumVariable(VariableTracker):
     def __init__(self, value, **kwargs):

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -136,9 +136,8 @@ class ConstantVariable(VariableTracker):
         unimplemented(f"const method call {typestr(self.value)}.{name}")
 
     def call_hasattr(self, tx, name: str) -> "VariableTracker":
-        options = VariableTracker.propagate(self)
         result = hasattr(self.value, name)
-        return variables.ConstantVariable(result, **options)
+        return variables.ConstantVariable(result).add_options(self)
 
 
 class EnumVariable(VariableTracker):


### PR DESCRIPTION
This PR enables `getattr` on ConstantVariable by implementing its `call_hasattr` function.

Fixes #97480


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire