### PR TITLE
Fix _like meta registrations

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -379,15 +379,6 @@ struct RandomFromToStub {
   }
 };
 
-template<typename RNG>
-struct RandomFromToMeta {
-  // No-op!
-  void operator()(TensorIteratorBase& iter, uint64_t range, int64_t from, c10::optional<Generator> gen) {
-  }
-  void operator()(TensorIteratorBase& iter, c10::optional<Generator> gen) {
-  }
-};
-
 Tensor& random_(Tensor& self, int64_t from, optional<int64_t> to, c10::optional<Generator> gen) {
   return at::native::templates::random_from_to_impl<RandomFromToStub, Generator>(self, from, to, std::move(gen));
 }
@@ -402,11 +393,13 @@ Tensor& random_meta_(Tensor& self, c10::optional<Generator> gen) {
 }
 
 Tensor& random_meta_(Tensor& self, int64_t from, optional<int64_t> to, c10::optional<Generator> gen) {
-  return at::native::templates::random_from_to_impl<RandomFromToMeta, Generator>(self, from, to, std::move(gen));
+  // No error checking yay
+  return self;
 }
 
 Tensor& random_meta_(Tensor& self, int64_t to, c10::optional<Generator> gen) {
-  return random_meta_(self, 0, to, std::move(gen));
+  // No error checking yay
+  return self;
 }
 
 // ====================================================================================================================

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1996,7 +1996,7 @@ def uniform(
 @register_decomposition(aten.uniform_)
 def uniform_(self, low=0, high=1, generator=None):
     assert generator is None
-    return self.copy_((high - low) * torch.rand_like(self) + low)
+    return self.copy_(uniform(self, low, high))
 
 
 # aten/src/ATen/native/UpSample.cpp compute_output_size

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2023,20 +2023,6 @@ def full(size, fill_value, *args, **kwargs):
     return torch.empty(size, *args, **kwargs)
 
 
-@register_meta(
-    [
-        aten.randint_like.default,
-        aten.randint_like.low_dtype,
-        aten.randn_like.default,
-        aten.rand_like.default,
-        aten.full_like.default,
-        aten.ones_like.default,
-    ]
-)
-def meta_like(self, *args, **kwargs):
-    return aten.empty_like.default(self, **kwargs)
-
-
 # zeros_like is special cased to work for sparse
 @register_meta(aten.zeros_like.default)
 def zeros_like(
@@ -2070,7 +2056,7 @@ def zeros_like(
 
         res._coalesced_(True)
         return res
-    return aten.empty_like.default(
+    res = aten.empty_like.default(
         self,
         dtype=dtype,
         layout=layout,
@@ -2078,6 +2064,9 @@ def zeros_like(
         pin_memory=pin_memory,
         memory_format=memory_format,
     )
+    # device can be not "meta"
+    res.fill_(0)
+    return res
 
 
 @register_meta(aten.select.int)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5394,7 +5394,15 @@ def log_normal(self, mean=1, std=2, generator=None):
 def normal(self, mean=0, std=1, generator=None):
     assert generator is None
     utils.check(std >= 0, lambda: f"normal expects std >= 0.0, but found std {std}")
-    return std * torch.randn_like(self) + mean
+    normal_samples = prims.normal(
+        self.shape,
+        mean=0.,
+        std=1.,
+        dtype=self.dtype,
+        device=self.device,
+        requires_grad=False
+    )
+    return std * normal_samples + mean
 
 
 # inplace

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5396,11 +5396,11 @@ def normal(self, mean=0, std=1, generator=None):
     utils.check(std >= 0, lambda: f"normal expects std >= 0.0, but found std {std}")
     normal_samples = prims.normal(
         self.shape,
-        mean=0.,
-        std=1.,
+        mean=0.0,
+        std=1.0,
         dtype=self.dtype,
         device=self.device,
-        requires_grad=False
+        requires_grad=False,
     )
     return std * normal_samples + mean
 


### PR DESCRIPTION
The meta implementation for these _like function is wrong whenever device != "meta" (it doesn't fill the memory!).
zeros_like is special due to sparse and is fixed directly by always filling it with zeros.
Every other one is CompositeExplicit implementation, I went with removing their meta registration and tweaking code to avoid infinite recursions.
I can do the same as zeros_like (and add the proper filling for each) but that would duplicate the c++ logic and make the meta registrations non trivial. I can do it if you prefer to removal.


test_meta works fine with these fixes, relying on CI to see if other tests are breaking as well.