### PR TITLE
[Easy] Fix lint error on DTensor math_ops.py

### DIFF
--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -11,7 +11,7 @@ from torch.distributed._tensor.ops.utils import (
     normalize_dims,
     register_prop_rule,
 )
-from torch.distributed._tensor.placement_types import DTensorSpec, _Partial
+from torch.distributed._tensor.placement_types import _Partial, DTensorSpec
 
 
 aten = torch.ops.aten


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98170

This lint error is caused by conflicts betwee #97996 and #98148
