### PR TITLE
Fix fused_8bit_rowwise_conversion_ops_test

### DIFF
--- a/caffe2/python/fused_8bit_rowwise_conversion_ops_test.py
+++ b/caffe2/python/fused_8bit_rowwise_conversion_ops_test.py
@@ -63,6 +63,8 @@ def fused_rowwise_8bit_quantize_dequantize_reference(data):
 class TestFused8BitRowwiseQuantizationConversion(hu.HypothesisTestCase):
     @given(input_data=hu.tensor(min_dim=1, max_dim=3, max_value=33))
     def test_quantize_op(self, input_data):
+        input_data[input_data == -0.0] = 0.0
+
         quantize = core.CreateOperator(
             'FloatToFused8BitRowwiseQuantized',
             ['input_data'],


### PR DESCRIPTION
Summary:
This test tests an operator that quantizes and serializes a float array.
Among the data serialized, one element is the bias, i.e. the minimum value in the array.

The test may fail when the array contains both +0.0 and -0.0, while all other elements are positive.
(this happens quite frequently with a hypothesis version >= 6.17.4, due to [this issue](https://github.com/HypothesisWorks/hypothesis/issues/3606))
Depending on the exact settings of SIMD (single instruction, multiple data), the elements of the array may be visited in different orders while running the operator and while calculating the reference.
Because +0.0 and -0.0 compare equal, the minimum value may be either +0.0 or -0.0.
Nevertheless, the serialized forms of these two values differ in the sign bit, and can make the test fail because it's conducting an exact match on the serialized result.

To avoid this failure, I'm adding a line to replace all -0.0 with +0.0 in the input array.

Test Plan:
Run this with both hypothesis < 6.17.4 and >= 6.17.4:
```
buck2 test mode/opt caffe2/caffe2/python:fused_8bit_rowwise_conversion_ops_test - test_quantize_op
```

Differential Revision: D44617022



cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel