### PR TITLE
[bazel] Move torch/csrc/distributed/c10d/quantization/quantization_gpu.cu

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -790,7 +790,51 @@ test_bazel() {
 
     tools/bazel test --config=cpu-only --test_timeout=480 --test_output=all --test_tag_filters=-gpu-required --test_filter=-*CUDA :all_tests
   else
-    tools/bazel test //c10/test:core_tests //c10/test:typeid_test //c10/test:util_base_tests
+    tools/bazel test \
+      //:any_test \
+      //:autograd_test \
+      //:dataloader_test \
+      //:dispatch_test \
+      //:enum_test \
+      //:expanding_array_test \
+      //:fft_test \
+      //:functional_test \
+      //:grad_mode_test \
+      //:inference_mode_test \
+      //:init_test \
+      //:jit_test \
+      //:memory_test \
+      //:meta_tensor_test \
+      //:misc_test \
+      //:moduledict_test \
+      //:modulelist_test \
+      //:modules_test \
+      //:namespace_test \
+      //:nested_test \
+      //:nn_utils_test \
+      //:operations_test \
+      //:ordered_dict_test \
+      //:parallel_benchmark_test \
+      //:parameterdict_test \
+      //:parameterlist_test \
+      //:sequential_test \
+      //:serialize_test \
+      //:special_test \
+      //:static_test \
+      //:support_test \
+      //:tensor_flatten_test \
+      //:tensor_indexing_test \
+      //:tensor_options_cuda_test \
+      //:tensor_options_test \
+      //:tensor_test \
+      //:torch_dist_autograd_test \
+      //:torch_include_test \
+      //:transformer_test \
+      //c10/cuda/test:test \
+      //c10/test:core_tests \
+      //c10/test:typeid_test \
+      //c10/test:util/ssize_test \
+      //c10/test:util_base_tests
   fi
 }
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1460,6 +1460,11 @@ cc_library(
 
 cu_library(
     name = "caffe2_cuda",
+    # one may think that `quantization_gpu.cu` could be a separate kernel,
+    # however that leads to de-registration problem that's described in
+    # https://github.com/pytorch/pytorch/issues/79236
+    # To solve it we add it into the `caffe2_cuda`,
+    # this is also aligned with the CMake build.
     srcs = [":caffe2_cu_srcs"] + ["torch/csrc/distributed/c10d/quantization/quantization_gpu.cu"],
     copts = CAFFE2_COPTS + torch_cuda_half_options,
     visibility = ["//visibility:public"],
@@ -1607,12 +1612,6 @@ TORCH_COPTS = COMMON_COPTS + [
     "-fno-trapping-math",
 ]
 
-cu_library(
-    name = "torch_distributed_cuda",
-    srcs = ["torch/csrc/distributed/c10d/quantization/quantization_gpu.cu"],
-    deps = [":torch_headers"],
-)
-
 torch_sources = {
     k: ""
     for k in (
@@ -1647,7 +1646,6 @@ cc_library(
         "//caffe2/proto:torch_cc_proto",
         "@kineto",
     ] + if_cuda([
-        # ":torch_distributed_cuda",
         "@cuda//:nvToolsExt",
         "@cutlass",
     ]),

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1460,7 +1460,7 @@ cc_library(
 
 cu_library(
     name = "caffe2_cuda",
-    srcs = [":caffe2_cu_srcs"],
+    srcs = [":caffe2_cu_srcs"] + ["torch/csrc/distributed/c10d/quantization/quantization_gpu.cu"],
     copts = CAFFE2_COPTS + torch_cuda_half_options,
     visibility = ["//visibility:public"],
     deps = [
@@ -1647,7 +1647,7 @@ cc_library(
         "//caffe2/proto:torch_cc_proto",
         "@kineto",
     ] + if_cuda([
-        ":torch_distributed_cuda",
+        # ":torch_distributed_cuda",
         "@cuda//:nvToolsExt",
         "@cutlass",
     ]),


### PR DESCRIPTION
Fixes #79236

Avoid kernel de-registration problems in bazel by virtue of having a single cuda kernel lib.

Test plan: cherry-picked on a branch where we run all GPU tests and verified that this fixes majority of the tests.
https://github.com/pytorch/pytorch/actions/runs/4593347787/jobs/8111184857?pr=96202