### PR TITLE
[Dynamo] Support skip fbcode modules

### DIFF
--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -150,6 +150,15 @@ if HAS_PRIMS_REFS:
 
 SKIP_DIRS_RE = None
 
+is_fbcode = importlib.import_module("torch._inductor.config").is_fbcode()
+# Skip fbcode dirs(including torch.package dirs) containing
+# one of the following strings.
+FBCODE_SKIP_DIRS = {
+    "torchrec/distributed",
+    "torchrec/fb/distributed",
+}
+FBCODE_SKIP_DIRS_RE = re.compile(f".*({'|'.join(map(re.escape, FBCODE_SKIP_DIRS))})")
+
 
 def _recompile_re():
     global SKIP_DIRS_RE
@@ -182,6 +191,8 @@ def check(filename, allow_torch=False):
         return False
     if allow_torch and is_torch(filename):
         return False
+    if is_fbcode and bool(FBCODE_SKIP_DIRS_RE.match(filename)):
+        return True
     return bool(SKIP_DIRS_RE.match(filename))
 
 

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -151,11 +151,12 @@ if HAS_PRIMS_REFS:
 SKIP_DIRS_RE = None
 
 is_fbcode = importlib.import_module("torch._inductor.config").is_fbcode()
-# Skip fbcode dirs(including torch.package dirs) containing
+# Skip fbcode paths(including torch.package paths) containing
 # one of the following strings.
 FBCODE_SKIP_DIRS = {
     "torchrec/distributed",
     "torchrec/fb/distributed",
+    "caffe2/torch/fb/sparsenn/pooled_embeddings_modules.py",
 }
 FBCODE_SKIP_DIRS_RE = re.compile(f".*({'|'.join(map(re.escape, FBCODE_SKIP_DIRS))})")
 


### PR DESCRIPTION
Fix Meta internal use case:
* We are going to skip tracing ```torchrec.distributed```, however, in fbcode, the structure is a bit different from OSS torchrec.
* Meta internally uses ```torch.package```, so we should support skip tracing files like ```<torch_package_0>.torchrec/distributed/...```.
* We put the logic behind a flag ```is_fbcode``` to avoid misuse.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire