### PR TITLE
Add alias to generate a uniform distribution + test

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1580,6 +1580,14 @@ class TestDistributions(DistributionsTestCase):
         low.grad.zero_()
         high.grad.zero_()
 
+        # check uniform alias 
+        rand = uniform(0, 1, low.size())
+        torch.set_rng_state(state)
+        u = Uniform(low, high).rsample()
+        u.backward(torch.ones_like(u))
+        self.assertEqual(low.grad, 1 - rand)
+        self.assertEqual(high.grad, rand)
+
         self._check_forward_ad(lambda x: x.uniform_())
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn.functional as F
 from typing import Dict, Any
 from torch.overrides import is_tensor_like
+from torch.types import _int, _float
 
 euler_constant = 0.57721566490153286060  # Euler Mascheroni Constant
 
@@ -155,3 +156,13 @@ def vec_to_tril_matrix(vec, diag=0):
     tril_mask = arange < arange.view(-1, 1) + (diag + 1)
     mat[..., tril_mask] = vec
     return mat
+
+def uniform(low: _float, high: _float, *size: _int) -> torch.Tensor:
+    """
+    Returns a tensor filled with numbers sampled from a uniform random distribution
+    Args:
+        low (float): Lower bound of the distribution.
+        high (float): Upper bound of the distribution.
+        *size (int): Sequence of integers that defines the shape of the Tensor. Can be a variable number or a list.
+    """
+    return torch.empty(size).uniform_(low, high)


### PR DESCRIPTION
Fixes issue https://github.com/pytorch/pytorch/issues/67321
Superseded PR: https://github.com/pytorch/pytorch/pull/84718

Added alias uniform(low, high, size) for creating a tensor of uniform distribution.

cc @kit1980 
