### PR TITLE
Make dynamo enable_nnmodule_hooks=False by default

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1344,8 +1344,6 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             backend=cc,
         )(outer_func)
 
-        # m = TestModule()
-        # handle = m.register_forward_hook(forward_hook)
         failure_reason = None
         self.assertEqual(compiled_func(inp), outer_func(inp))
         self.assertEqual(compiled_func(inp).item(), 15)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -198,6 +198,12 @@ optimize_ddp = True
 # Whether to skip guarding on FSDP-managed modules
 skip_fsdp_guards = True
 
+# By default, Dynamo traces nn.Module.forward instead of .__call__, bypassing
+# all forward/backward hooks as if they don't exist.  Enabling hook support
+# traces .__call__ instead.  This adds additional overhead due to guarding
+# on hook-related data structures in every nn module.
+enable_nnmodule_hooks = False
+
 # Make dynamo skip guarding on hooks on nn modules
 # Note: unsafe: if your model actually has hooks and you remove them, or doesn't and  you add them,
 # dynamo will not notice and will execute whichever version you first compiled.

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -99,7 +99,10 @@ class OptimizedModule(torch.nn.Module):
         super().__setattr__(name, value)
 
     def __call__(self, *args, **kwargs):
-        return self.dynamo_ctx(self._orig_mod.__call__)(*args, **kwargs)
+        if config.enable_nnmodule_hooks:
+            return self.dynamo_ctx(self._orig_mod.__call__)(*args, **kwargs)
+        else:
+            return self.dynamo_ctx(self._orig_mod.forward)(*args, **kwargs)
 
     def forward(self, *args, **kwargs):
         log.warning(

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -122,6 +122,13 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         ), f"expected FunctionType found {typestr(fn)} {fn}"
         # unpack @torch._dynamo.optimize()(fn) wrapped function
         fn = inspect.getattr_static(fn, "_torchdynamo_inline", fn)
+        if istype(fn, types.MethodType):
+            # when we record the original fn, it may be a bound method such as .forward
+            # however, NNModuleVariable.call_function special-cases .forward to be called
+            # as a function with [self] added to args.  Need to mirror that here.
+            # TODO: see if NNModuleVariable.call_function can just use UserMethodVariable instead
+            fn = fn.__func__
+
         # unpack torch.jit.script_if_tracing
         if inspect.getattr_static(fn, "__script_if_tracing_wrapper", False):
             fn = inspect.getattr_static(fn, "__original_fn", fn)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -262,12 +262,12 @@ class NNModuleVariable(VariableTracker):
                 else:
                     fn = mod.__call__
                     fn_source = AttrSource(self.source, "__call__")
-                if istype(mod.__call__, types.MethodType):
+                if istype(fn, types.MethodType):
                     fn = fn.__func__
                     fn_source = AttrSource(fn_source, "__func__")
                     args = [self] + args
                 else:
-                    assert istype(mod.__call__, types.FunctionType)
+                    assert istype(fn, types.FunctionType)
 
                 options["source"] = fn_source
                 return tx.inline_user_function_return(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98253
* #97184
* __->__ #98223

Previously, hook support was enabled globally and not configurable.

Since guard overhead due to hooks is significant (and some hook related
features are missing or WIP), and hooks used less often than not used,
it makes more sense to disable by default at least for now.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire