### PR TITLE
Fix typos under torch/distributed directory

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -305,7 +305,7 @@ def reduce_scatter_tensor(
 ):
     """
     Reduces the tensor data across all machines in such a way that all get
-    the final result, then scatter the results to correponding ranks.
+    the final result, then scatter the results to corresponding ranks.
 
     Note that it currently only supports scatter_dim = 0.
 

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
@@ -107,7 +107,7 @@ def _handle_col_wise_sharding_base(
         col_dim: dim of result tensor after the operation.
         input: tensor to be applied op on.
         world_size: number of ranks.
-        weight: shareded weight tensor.
+        weight: sharded weight tensor.
         local_shard: col-wise sharded weight tensor.
         pg: process group.
         gathered_inputs: list of inputs from all ranks. If specified, we
@@ -170,7 +170,7 @@ def _result_distribute_with_col_rearrange(results, input, world_size, weight, pg
             We need to distribute them back to their original ranks.
         input: tensor to be applied op to.
         world_size: number of ranks.
-        weight: shareded weight tensor.
+        weight: sharded weight tensor.
         pg: process group.
 
     Return: column rearranged result.

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
@@ -405,7 +405,7 @@ def _handle_row_wise_sharding(
     )
 
     op = ReduceOp.SUM if mode != "max" else ReduceOp.MAX
-    # TODO: Make the result a PartialTensor and move the the logic below there.
+    # TODO: Make the result a PartialTensor and move the logic below there.
     local_shards = result.chunk(pg.size())
     result = reduce_scatter(
         torch.empty_like(local_shards[0]),

--- a/torch/distributed/_spmd/api.py
+++ b/torch/distributed/_spmd/api.py
@@ -75,7 +75,7 @@ class Override(ABC):
     This is useful when any part of the model is not traceable or if you prefer
     to not trace it due to any reason. More specifically, users can implement
     :meth:`torch.distributed._spmd.Override.replacement` to replace an original
-    submodule with the return new submodule. The new submodule contrains
+    submodule with the return new submodule. The new submodule contains
     operations that users preferred to be traced, which simply be a dummy
     placeholder operator. After tracing, users can implement
     :meth:`torch.distributed._spmd.Override.transform` to transform the traced
@@ -101,7 +101,7 @@ class Override(ABC):
     @abstractmethod
     def transform(self, gm: fx.GraphModule, schema_map: Dict[str, Schema]) -> fx.Graph:
         r"""
-        Given a DTensor-expanded graph and shardig schema for every node,
+        Given a DTensor-expanded graph and sharding schema for every node,
         conduct additional transformation for the sub-graph from the :class:`nn.Module`
         returned by :meth:`torch.distributed._spmd.Override.replacement` if
         necessary.

--- a/torch/distributed/_spmd/distribute.py
+++ b/torch/distributed/_spmd/distribute.py
@@ -446,7 +446,7 @@ def _convert_to_distributed(
         if node.op == OP.PLACEHOLDER:
             assert i < len(
                 inps
-            ), f"got more placeholer nodes ({i + 1}) than inputs ({len(inps)})"
+            ), f"got more placeholder nodes ({i + 1}) than inputs ({len(inps)})"
 
             # our example inputs are local shards. Create DTensors from them.
             node_to_obj[node] = DTensor.from_local(

--- a/torch/distributed/_spmd/iter_graph_module.py
+++ b/torch/distributed/_spmd/iter_graph_module.py
@@ -24,7 +24,7 @@ class IterGraph(fx.Graph):
     IterGraph subclass fx.Graph to override the necessary APIs that will be used
     when constructing a optimization, e.g., communication fusion. IterGraph also
     provides APIs that originally belong to fx.Node and all these APIs will have
-    ``node_`` prefix. For example, ``IterGraph.node_prepend`` is the equivalance
+    ``node_`` prefix. For example, ``IterGraph.node_prepend`` is the equivalence
     of ``fx.Node.prepend``. Note that all the optimizations must be constructed
     using these APIs.
     """
@@ -111,12 +111,12 @@ class IterGraph(fx.Graph):
         looks similar to SESE graph.
 
         1. Only one node has inputs/args from the external nodes (not in subgraph).
-        2. Only one node has a user from the the external nodes and the user must
+        2. Only one node has a user from the external nodes and the user must
            be output. The output condition is not strictly enforced due to the
            testing purpose.
 
         SESE graph is very restrict and is not applicable for all optimizations.
-        But this gives a good start point to explor cross-iteration optimizations.
+        But this gives a good start point to explore cross-iteration optimizations.
         """
         all_nodes: Set[fx.Node] = set(subgraph)
         for i, node in enumerate(subgraph):
@@ -127,7 +127,7 @@ class IterGraph(fx.Graph):
                     return False
             if i == len(subgraph) - 1:
                 # TODO: the only user must be the output. Otherwise, we don't
-                # know how to move this subgraph. We currently do not stricly
+                # know how to move this subgraph. We currently do not strictly
                 # force this attribute because some test code create fake output.
                 if len(node.users) > 1:
                     return False
@@ -176,7 +176,7 @@ class IterGraph(fx.Graph):
             )
 
         # The main graph must be the last one to be modified. Otherwise, the
-        # mapping may change and hence intorduce incorrect mapping for setup
+        # mapping may change and hence introduce incorrect mapping for setup
         # and cleanup graphs.
 
         # For the setup graph, no additional input is needed but additional
@@ -188,7 +188,7 @@ class IterGraph(fx.Graph):
 
         # For the cleanup graph, additional input is required to get the output
         # from the last iteration -- main graph. Additional nodes are also
-        # needed to perform the action moved from the last itertion.
+        # needed to perform the action moved from the last iteration.
         new_input_node = self.cleanup_graph.placeholder(nodes[0].name + "_input")
         target_cleanup_node = self._lookup_node(target_node, self.cleanup_graph)
         assert target_cleanup_node is not None, "The target_cleanup_node is None."
@@ -449,7 +449,7 @@ class IterGraph(fx.Graph):
 
     def functionalize_optim(self) -> None:
         # IterGraph can only support full graph (fwd+bwd+optim). As optimizer
-        # is not a functional call (it is inplace op), this mehod adds the of
+        # is not a functional call (it is inplace op), this method adds the of
         # the optimizer call. This method has strong assumption of the optimizer
         # and may not always be working. This method is intended be a temporary
         # solution only.

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -150,7 +150,7 @@ class DeviceMesh(object):
             ), f"Default PG backend: {world_backend} not supporting CUDA!"
             if not default_initialized:
                 # automatically set the current cuda device base on num of gpu devices available in each host
-                # NOTE: This device selection would only work for homogenous hardware.
+                # NOTE: This device selection would only work for homogeneous hardware.
                 torch.cuda.set_device(get_rank() % torch.cuda.device_count())
         else:
             raise RuntimeError(

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -84,7 +84,7 @@ class OpSchema:
             with NO non-DTensor positional arguments (i.e. int/float/tuple, etc)
             mainly used by sharding propagation to propagate the output spec
         """
-        # filter out non-relavant values from args schema to get a clean spec list
+        # filter out non-relevant values from args schema to get a clean spec list
         # this would mainly be used by sharding propagation rules
         return tuple(item for item in self.args_schema if isinstance(item, DTensorSpec))
 

--- a/torch/distributed/_tensor/ops/common_rules.py
+++ b/torch/distributed/_tensor/ops/common_rules.py
@@ -121,7 +121,7 @@ def einop_rule(
             if sum_dim not in pending_sums_counter:
                 seen_shardings[sum_dim] = "+"
             # update pending sum counter for pending sum mesh
-            # dimension with the occurance from each input
+            # dimension with the occurrence from each input
             pending_sums_counter[sum_dim] = pending_sums_counter.get(sum_dim, 0) + 1
 
         for idx, (dim, mesh_dim) in enumerate(zip(input_dim, input_spec.dim_map)):

--- a/torch/distributed/_tensor/ops/view_ops.py
+++ b/torch/distributed/_tensor/ops/view_ops.py
@@ -525,7 +525,7 @@ def propagate_shape_and_sharding(
             _, in_dim = get_dim_size(cmd.input_dim)
             out_size = cmd.group_shape[cmd.split_id]
             if cmd.split_id == 0 and in_dim is not None:
-                # we need to check that the input dimension is divisble
+                # we need to check that the input dimension is divisible
                 # by the size of the submesh we're sharding it on
                 # NOTE: it would be possible to shard the same input dimension
                 # on more than one mesh dimension. In that case, the dimension

--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -262,7 +262,7 @@ def apply_activation_checkpointing(
         checkpoint_wrapper_fn (Optional[Callable[nn.Module]])
             A ``Callable`` which will wrap modules
         check_fn (Optional[Callable[nn.Module, nn.Module]])
-            A lambda function which will be passed each child submoule of ``model`` and returns
+            A lambda function which will be passed each child submodule of ``model`` and returns
             ``True`` or ``False`` depending on whether the submodule should be wrapped.
     Returns: None (`model` is modified inplace)
     """

--- a/torch/distributed/checkpoint/_nested_dict.py
+++ b/torch/distributed/checkpoint/_nested_dict.py
@@ -31,7 +31,7 @@ def flatten_state_dict(
     Flatten ``state_dict`` made of nested dicts and lists into a top level dictionary.
     Use ``unflatten_state_dict`` to revert this process.
     Returns:
-        A tuple with the flaten state_dict and a mapping from original to new state_dict.
+        A tuple with the flatten state_dict and a mapping from original to new state_dict.
     N.B. The new keys are derived from the object paths, joined by dot.
         For example: ``{ 'a': {'b':...}}`` results in the key `a.b`.
     """

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -181,7 +181,7 @@ class SavePlanner(abc.ABC):
     @abc.abstractmethod
     def set_up_planner(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
         """
-        Intialize this planner to save ``state_dict``.
+        Initialize this planner to save ``state_dict``.
 
         Implementations should save those values as they won't be provided lated in the save process.
 
@@ -230,7 +230,7 @@ class SavePlanner(abc.ABC):
 
         Called on each rank multiple times, at least once per WriteItem in the final SavePlan.
 
-        This method should be idepotent and thread-save. StorageWriter implementations
+        This method should be idempotent and thread-save. StorageWriter implementations
         are free to call it as frequently as they need.
 
         Any transformation that allocates memory should be lazily done when his method

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -38,7 +38,7 @@ def save_state_dict(
         call `save_state_dict` and that all data in state_dict belong to it.
 
     .. note::
-        This function can be used to save a state_dict with an intialized process
+        This function can be used to save a state_dict with an initialized process
         group by passing ``no_dist=True``. This can be used to produce a checkpoint
         that can consumed by load_state_dict is a SPMD fashion.
 

--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -122,7 +122,7 @@ class StorageWriter(abc.ABC):
         Writes the metadata and marks the current checkpoint as successful.
 
         The actual format/schema used for serializing `metadata` is an
-        implemetation detail. The only requirement is that it's recoverable
+        implementation detail. The only requirement is that it's recoverable
         in to the same object graph.
 
         Args:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -342,7 +342,7 @@ class _World:
     Container class for c10d process group state.
     This is used during registration and lookup of PG state.
 
-    .. warning:: This is an experimental API inteded to expose the inner workings
+    .. warning:: This is an experimental API intended to expose the inner workings
        of c10d and is subject to change..
     """
     def __init__(self):
@@ -1096,7 +1096,7 @@ def _new_process_group_helper(
         # Set sequence numbers for gloo and nccl backends.
         if backend_str in [Backend.GLOO, Backend.NCCL]:
             backend_class._set_sequence_number_for_group()
-        # If the type is a sublcass of ProcessGroup then return this process group immediately
+        # If the type is a subclass of ProcessGroup then return this process group immediately
         # TODO: This defaults to the old behavior for PythonProcessGroups which overwrites the
         # ProcessGroup instance
         if issubclass(type(backend_class), ProcessGroup):

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -44,7 +44,7 @@ class WorkerSpec:
     """
     Contains blueprint information about a particular type of worker.
     For a given role, there must only exist a single worker spec.
-    Worker spec is expected to be homogenous across all nodes (machine),
+    Worker spec is expected to be homogeneous across all nodes (machine),
     that is each node runs the same number of workers for a particular spec.
 
     Args:
@@ -764,7 +764,7 @@ class SimpleElasticAgent(ElasticAgent):
         elif failure or worker.global_rank in result.return_values:
             return result.state.value
         else:
-            raise ValueError(f"Unknow worker: {worker.global_rank}")
+            raise ValueError(f"Unknown worker: {worker.global_rank}")
 
     def _construct_event(
         self,

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -110,7 +110,7 @@ class ErrorHandler:
         with open(rootcause_error_file, "r") as fp:
             rootcause_error = json.load(fp)
             # Override error code since the child process cannot capture the error code if it
-            # is terminated by singals like SIGSEGV.
+            # is terminated by signals like SIGSEGV.
             if error_code:
                 self.override_error_code_in_rootcause_data(rootcause_error_file, rootcause_error, error_code)
             log.debug(

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -697,7 +697,7 @@ class EtcdRendezvous:
                     # rendezvous version as dead (but only if it hadn't changed)
                     log.info("Keep-alive key %s is not renewed.", key)
                     log.info(
-                        "Rendevous version %s is incomplete. ",
+                        "Rendezvous version %s is incomplete. ",
                         expected_version
                     )
                     log.info("Attempting to destroy it.")

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -462,7 +462,7 @@ def _init_param_handles_from_module(
     # reverse topological sort order. This avoids increasing peak GPU memory
     # usage when the unsharded model exists on CPU or meta device.
     # NOTE: This order differs from that followed by the wrapper path when
-    # using auto wrapping, which also represents a valid reverse toplogical
+    # using auto wrapping, which also represents a valid reverse topological
     # sort order, but the difference does not matter.
     materialized_module = False
     for fully_sharded_module, (params, buffers) in reversed(

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1943,7 +1943,7 @@ class FlatParamHandle:
                         flat_param_grad.untyped_storage().data_ptr()
                     )
         # TODO: If we want to handle shared parameters, we need to re-generate
-        # the shared parameter data structures in case shardness changed.
+        # the shared parameter data structures in case sharedness changed.
         for i, (
             param_name,
             module,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1943,7 +1943,7 @@ class FlatParamHandle:
                         flat_param_grad.untyped_storage().data_ptr()
                     )
         # TODO: If we want to handle shared parameters, we need to re-generate
-        # the shared parameter data structures in case sharedness changed.
+        # the shared parameter data structures in case shardness changed.
         for i, (
             param_name,
             module,

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -138,7 +138,7 @@ def _get_entrypoint_name(
     entrypoint: Union[Callable, str, None], args: List[Any]
 ) -> str:
     """Retrieve entrypoint name with the rule:
-    1. If entrypoint is a function, use ``entrypont.__qualname__``.
+    1. If entrypoint is a function, use ``entrypoint.__qualname__``.
     2. If entrypoint is a string, check its value:
         2.1 if entrypoint equals to ``sys.executable`` (like "python"), use the first element from ``args``
             which does not start with hifen letter (for example, "-u" will be skipped).

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -745,7 +745,7 @@ def _recursive_script_module_receiver(
     recursive_script_module_serialized,
 ):
     """
-    Deserializes a RecursiveScirptModule that does not contain a script RemoteModule.
+    Deserializes a RecursiveScriptModule that does not contain a script RemoteModule.
     """
     f = io.BytesIO(recursive_script_module_serialized)
     m = torch.jit.load(f)
@@ -754,7 +754,7 @@ def _recursive_script_module_receiver(
 
 def _recursive_script_module_reducer(recursive_script_module):
     """
-    Serializes a RecursiveScirptModule that does not contain a script RemoteModule,
+    Serializes a RecursiveScriptModule that does not contain a script RemoteModule,
     and raises an error otherwise.
     """
     if hasattr(recursive_script_module._c, "module_rref"):

--- a/torch/distributed/nn/jit/templates/remote_module_template.py
+++ b/torch/distributed/nn/jit/templates/remote_module_template.py
@@ -55,7 +55,7 @@ _generated_methods = [
 """
 
 # This template may cause typing error (the mismatch between ``Tuple[()]`` and ``Tuple[Any]``)
-# even if the code is only used for instaniation but not execution.
+# even if the code is only used for instantiation but not execution.
 # Therefore, only include handling moving CPU tensors to a cuda device if necessary.
 # TODO: Merge these two templates together in the future once TorchScript syntax is improved.
 _REMOTE_FORWARD_TEMPLATE_ENABLE_MOVING_CPU_TENSORS_TO_CUDA = """

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -418,7 +418,7 @@ class Pipe(Module):
 
         It's worth to cache CUDA streams although PyTorch already manages a
         pool of pre-allocated CUDA streams, because it may reduce GPU memory
-        fragementation when the number of micro-batches is small.
+        fragmentation when the number of micro-batches is small.
 
         """
         if not self._copy_streams:

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -483,7 +483,7 @@ except TypeError:
 # This is for the fact that pybind11 generates the parameter
 # `self` as type `rpc.PyRRef`, so a `:inherited-members:`
 # under `.. autoclass:: RRef` does not work.
-# we have to do the following process to replacee `rpc.PyRRef` with `rpc.RRef`.
+# we have to do the following process to replace `rpc.PyRRef` with `rpc.RRef`.
 #
 def method_factory(method_name, docstring):
     def method(self, *args, **kwargs):

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -651,7 +651,7 @@ def determine_local_world_size(nproc_per_node: str):
 
         log.info(
             f"Using nproc_per_node={nproc_per_node},"
-            f" seting to {num_proc} since the instance "
+            f" setting to {num_proc} since the instance "
             f"has {os.cpu_count()} {device_type}"
         )
         return num_proc


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/distributed` directory
