### PR TITLE
Fix typos under caffe2/operators directory 

### DIFF
--- a/caffe2/operators/async_net_barrier_op.cc
+++ b/caffe2/operators/async_net_barrier_op.cc
@@ -33,7 +33,7 @@ OPERATOR_SCHEMA(AsyncNetBarrier)
     .DeviceInferenceFunction(asyncBarrierOpDevInfer)
     .SetDoc(R"DOC(
 This is a pretty much no-op operator, since it's only purposes is make sure that
-async_scheduling will schedule certian operations earlier than others.
+async_scheduling will schedule certain operations earlier than others.
 
 Exaple where this operator can work well - mixture of data-parallel and model-
 parallel training, where one wants to force that all copies are started before

--- a/caffe2/operators/async_net_barrier_op.h
+++ b/caffe2/operators/async_net_barrier_op.h
@@ -15,7 +15,7 @@ class AsyncNetBarrierOp : public Operator<Context> {
 
   bool RunOnDevice() override {
     // This is a pretty much no-op operator, since it's only purposes is make
-    // sure that async_scheduling will schedule certian operations earlier than
+    // sure that async_scheduling will schedule certain operations earlier than
     // others.
     //
     // Exaple where this operator can work well - mixture of data-parallel and

--- a/caffe2/operators/batch_bucketize_op.cc
+++ b/caffe2/operators/batch_bucketize_op.cc
@@ -117,7 +117,7 @@ after running this operator.
         "Flatten tensor, dimension has to match the sum of lengths")
     .Output(
         0,
-        "bucktized_feat",
+        "bucketized_feat",
         "2-D dense tensor, with 1st dim = float_features.dim(0), 2nd dim = size(indices)"
         "in the arg list, the tensor is of the same data type as `feature`.");
 

--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -52,7 +52,7 @@ Transform proposal bounding boxes to target bounding box using bounding box
         "If proposals from multiple images in a batch are present, they "
         "should be grouped sequentially and in incremental order."
         "For rotated boxes, this would have an additional angle (in degrees) "
-        "in the format [<optionaal_batch_id>, ctr_x, ctr_y, w, h, angle].")
+        "in the format [<optional_batch_id>, ctr_x, ctr_y, w, h, angle].")
     .Input(
         1,
         "deltas",

--- a/caffe2/operators/bisect_percentile_op.cc
+++ b/caffe2/operators/bisect_percentile_op.cc
@@ -15,7 +15,7 @@ OPERATOR_SCHEMA(BisectPercentile)
 
     For each feature, we also need additional information regarding the feature
     value distribution.
-    There are several vectors to keep data to percentile mappping information
+    There are several vectors to keep data to percentile mapping information
     as arguments (context):
     1. feature raw values (R)
     2. feature percentile mapping (P)

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -262,7 +262,7 @@ returned boxes.
 )DOC")
     .Arg("score_thresh", "(float) TEST.SCORE_THRESH")
     .Arg("nms", "(float) TEST.NMS")
-    .Arg("detections_per_im", "(int) TEST.DEECTIONS_PER_IM")
+    .Arg("detections_per_im", "(int) TEST.DETECTIONS_PER_IM")
     .Arg("soft_nms_enabled", "(bool) TEST.SOFT_NMS.ENABLED")
     .Arg("soft_nms_method", "(string) TEST.SOFT_NMS.METHOD")
     .Arg("soft_nms_sigma", "(float) TEST.SOFT_NMS.SIGMA")
@@ -280,7 +280,7 @@ returned boxes.
         "boxes",
         "Bounding box for each class, size (count, num_classes * 4). "
         "For rotated boxes, this would have an additional angle (in degrees) "
-        "in the format [<optionaal_batch_id>, ctr_x, ctr_y, w, h, angle]. "
+        "in the format [<optional_batch_id>, ctr_x, ctr_y, w, h, angle]. "
         "Size: (count, num_classes * 5).")
     .Input(
         2,

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -46,7 +46,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       ConvTransposeUnpoolBase<Context>::GetOutputSize(X, C);
   auto* Y = Output(0, Y_dims, at::dtype<T>());
   if (X.numel() == 0) {
-    VLOG(2) << "Number of elements is 0 in ConvTrasposeOp";
+    VLOG(2) << "Number of elements is 0 in ConvTransposeOp";
     return true;
   }
 
@@ -200,7 +200,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       ConvTransposeUnpoolBase<Context>::GetOutputSize(X, C);
   auto* Y = Output(0, Y_dims, at::dtype<T>());
   if (X.numel() == 0) {
-    VLOG(2) << "Number of elements is 0 in ConvTrasposeOp";
+    VLOG(2) << "Number of elements is 0 in ConvTransposeOp";
     return true;
   }
 
@@ -361,7 +361,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   math::Set<T, Context>(filter.numel(), T(0), dfilter_data, &context_);
 
   if (X.numel() == 0) {
-    VLOG(2) << "Number of elements is 0 in ConvTrasposeOp";
+    VLOG(2) << "Number of elements is 0 in ConvTransposeOp";
     if (dbias_data != nullptr) {
       math::Set<T, Context>(C, T(0), dbias_data, &context_);
     }
@@ -526,7 +526,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   math::Set<T, Context>(filter.numel(), T(0), dfilter_data, &context_);
 
   if (X.numel() == 0) {
-    VLOG(2) << "Number of elements is 0 in ConvTrasposeOp";
+    VLOG(2) << "Number of elements is 0 in ConvTransposeOp";
     if (dbias_data != nullptr) {
       math::Set<T, Context>(C, T(0), dbias_data, &context_);
     }

--- a/caffe2/operators/conv_transpose_op_mobile.h
+++ b/caffe2/operators/conv_transpose_op_mobile.h
@@ -31,7 +31,7 @@ class ConvTransposeMobileOp final : public ConvTransposeUnpoolBase<Context> {
   bool RunOnDeviceWithOrderNHWC() override;
 
  private:
-  // We store a numThreasds per-worker  tiles of Y, and numThreads per-worker
+  // We store a numThreads per-worker  tiles of Y, and numThreads per-worker
   // threadBuffer for the gemm output, laid out in that order.
   Tensor threadBuffer_{CPU};
 

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -552,7 +552,7 @@ bool ConvTransposeMobileOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   Tensor* Y = Output(0, sizes, at::dtype<T>());
 
   if (X.numel() == 0) {
-    VLOG(2) << "Number of elements is 0 in ConvTrasposeOp";
+    VLOG(2) << "Number of elements is 0 in ConvTransposeOp";
     return true;
   }
 

--- a/caffe2/operators/crf_viterbi_op.cc
+++ b/caffe2/operators/crf_viterbi_op.cc
@@ -82,7 +82,7 @@ class ViterbiPathOp : public Operator<CPUContext> {
 
     CAFFE_ENFORCE(
         predictions.dim() == 2 && transitions.dim() == 2,
-        "Predictions and transitions hould 2D matrices");
+        "Predictions and transitions hold 2D matrices");
 
     CAFFE_ENFORCE(
         predictions.size(1) == transitions.size(0),

--- a/caffe2/operators/data_couple.cc
+++ b/caffe2/operators/data_couple.cc
@@ -8,7 +8,7 @@ OPERATOR_SCHEMA(DataCouple)
     .SetDoc(R"DOC(
 
 A one to one operator that takes an arbitrary number of input and output blobs
-such that each input blob is inplace with it's matching output blob. It then proceedes
+such that each input blob is inplace with it's matching output blob. It then proceeds
 to do nothing with each of these operators. This serves two purposes. It can make it
 appear as if a blob has been written to, as well as can tie together different blobs
 in a data dependency

--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -1030,7 +1030,7 @@ class CollectTensorOp final : public Operator<Context> {
         CAFFE_ENFORCE(
             // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
             tensorVector->size() == numToCollect_,
-            "TensorVecotor size = ",
+            "TensorVector size = ",
             tensorVector->size(),
             " is different from numToCollect = ",
             numToCollect_);

--- a/caffe2/operators/dataset_ops.h
+++ b/caffe2/operators/dataset_ops.h
@@ -92,7 +92,7 @@ class TreeCursor {
 
 /**
  * Simple wrapper class allowing an easy traversal of the tensors representing
- * the hirerarchical structure.
+ * the hierarchical structure.
  */
 class TreeWalker {
  public:

--- a/caffe2/operators/fused_rowwise_random_quantization_ops.cc
+++ b/caffe2/operators/fused_rowwise_random_quantization_ops.cc
@@ -29,7 +29,7 @@ bool FloatToFusedRandRowwiseQuantizedOp<Context>::RunOnDevice() {
   // quantized data in one byte, the last buckets of some bytes may have
   // unused bits. There are totally tail buckets are unused.
   // We encode *bitwidth* and *tail* at the beginning of
-  // each row, following by 32-bit floating data respresenting min and max.
+  // each row, following by 32-bit floating data representing min and max.
   // | bitwidth | tail | min | max | ... int8 data ... |
   // |    1B    |  1B  |  4B |  4B | ...output_data....|
   // In output_data: the b-th bucket of the i-th byte stores

--- a/caffe2/operators/gather_ranges_to_dense_op.cc
+++ b/caffe2/operators/gather_ranges_to_dense_op.cc
@@ -72,7 +72,7 @@ are sorted by the corresponding KEY.
         "min_observation",
         "The number of observations needed before deciding that the ratio of "
         "mismatched ranges is alarming, also determines whether an info "
-        "sumarizing the empty and mismatch ratio will be printed at the end.")
+        "summarizing the empty and mismatch ratio will be printed at the end.")
     .Arg(
         "max_mismatched_ratio",
         "An error is raised when ratio of mismatched ranges exceeds this.")

--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -128,7 +128,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
           continue;
         }
         if (rangeLength != lengths_[j]) {
-          // Range lengths missmatch for output #, will be filled with zeros
+          // Range lengths mismatch for output #, will be filled with zeros
           // Note, empty ranges are not counted as mismatched because empty
           // are more common and more tolerable.
           mismatchedRanges_[j]++;
@@ -227,7 +227,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
   vector<set<int>> mismatchedLengths_;
   // To avoid false alarm due to insufficient sample (e.g., first batch being
   // mismatched and causing 100% to be mismatched), use a threshold to ensure
-  // enough samples are gathered before decideding whether there is an alarm or
+  // enough samples are gathered before deciding whether there is an alarm or
   // not.
   int64_t minObservation_ = 0;
   float maxMismatchedRatio_ = 0;

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -81,7 +81,7 @@ ERMatXf ComputeAllAnchors(
         ConstEigenVectorMap<float>(shift_zero.data(), shift_zero.size());
   }
 
-  // Broacast anchors over shifts to enumerate all anchors at all positions
+  // Broadcast anchors over shifts to enumerate all anchors at all positions
   // in the (H, W) grid:
   //   - add A anchors of shape (1, A, box_dim) to
   //   - K shifts of shape (K, 1, box_dim) to get
@@ -370,7 +370,7 @@ OPERATOR_SCHEMA(GenerateProposals)
     .NumInputs(4)
     .NumOutputs(2)
     .SetDoc(R"DOC(
-Generate bounding box proposals for Faster RCNN. The propoasls are generated for
+Generate bounding box proposals for Faster RCNN. The proposals are generated for
 a list of images based on image score 'score', bounding box regression result
 'deltas' as well as predefined bounding box shapes 'anchors'. Greedy
 non-maximum suppression is applied to generate the final bounding boxes.

--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -27,7 +27,7 @@ const float PI = 3.14159265358979323846;
 // weights: weights [wx, wy, ww, wh] for the deltas
 // bbox_xform_clip: minimum bounding box width and height in log-space after
 //     transofmration
-// correct_transform_coords: Correct bounding box transform coordates. Set to
+// correct_transform_coords: Correct bounding box transform coordinates. Set to
 //     true to match the detectron code, set to false for backward compatibility
 // return: pixel coordinates of the bounding boxes
 //     size (M, 4), format [x1; y1; x2; y2]

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -242,7 +242,7 @@ int rotated_rect_intersection_pts(
   rect1.get_vertices(pts1);
   rect2.get_vertices(pts2);
 
-  // Specical case of rect1 == rect2
+  // Special case of rect1 == rect2
   bool same = true;
 
   for (const auto i : c10::irange(4)) {

--- a/caffe2/operators/h_softmax_op.cc
+++ b/caffe2/operators/h_softmax_op.cc
@@ -484,7 +484,7 @@ bool HuffmanTreeHierarchyOp<T, Context>::RunOnDevice() {
     nodes.push(node);
   };
 
-  // Main loop for buttom up huffman tree construction.
+  // Main loop for bottom up huffman tree construction.
   while (!nodes.empty()) {
     auto lNode = get_next_node();
     if (!nodes.empty()) {
@@ -626,7 +626,7 @@ search tree.
     .Arg(
         "tree",
         "Serialized TreeProto string containing a tree "
-        "including all intermidate nodes and leafs. All nodes must have names "
+        "including all intermediate nodes and leafs. All nodes must have names "
         "for correct outputs")
     .Arg(
         "beam",

--- a/caffe2/operators/heatmap_max_keypoint_op.cc
+++ b/caffe2/operators/heatmap_max_keypoint_op.cc
@@ -98,7 +98,7 @@ bool HeatmapMaxKeypointOp<float, CPUContext>::RunOnDevice() {
       ERArrXXf fmax = ERArrXXf::Zero(3, 3);
 
       // initialize fmax values of local 3x3 grid
-      // when 3x3 grid going out-of-bound, mirrowing around center
+      // when 3x3 grid going out-of-bound, mirroring around center
       for (int y = -1; y <= 1; y++) {
         for (int x = -1; x <= 1; x++) {
           int xx = x - 2 * (x + maxX >= heatmap_size) + 2 * (x + maxX < 0);

--- a/caffe2/operators/integral_image_op.cc
+++ b/caffe2/operators/integral_image_op.cc
@@ -17,7 +17,7 @@ template <>
 bool IntegralImageOp<float, CPUContext>::RunOnDevice() {
   const auto& X = Input(0);
 
-  CAFFE_ENFORCE_EQ(X.dim(), 4, "Only supports 4D tensors for the momement");
+  CAFFE_ENFORCE_EQ(X.dim(), 4, "Only supports 4D tensors for the moment");
 
   vector<int64_t> out_shape(X.sizes().vec());
   out_shape[2] += 1; // H + 1 output size

--- a/caffe2/operators/integral_image_op.cu
+++ b/caffe2/operators/integral_image_op.cu
@@ -120,7 +120,7 @@ template <>
 bool IntegralImageOp<float, CUDAContext>::RunOnDevice() {
   auto& X = Input(0);
 
-  CAFFE_ENFORCE(X.dim() == 4, "Only supports 4D tensors for the momement");
+  CAFFE_ENFORCE(X.dim() == 4, "Only supports 4D tensors for the moment");
 
   // Input is (N, C, H, W)
   // Output is (N, C, H + 1, W + 1)

--- a/caffe2/operators/last_n_window_collector.cc
+++ b/caffe2/operators/last_n_window_collector.cc
@@ -171,7 +171,7 @@ OPERATOR_SCHEMA(LastNWindowCollector)
     })
     .SetDoc(R"DOC(
 Collect the last N rows from input data. The purpose is to keep track of data
-accross batches, so for example suppose the LastNWindowCollector is called
+across batches, so for example suppose the LastNWindowCollector is called
 successively with the following input data
 
   [1, 2, 3, 4]

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -307,7 +307,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
       const vector<int64_t>& ind_slice,
       int bs,
       int idx) {
-    // implement the functinality index_select(core, 1, ind_slice)
+    // implement the functionality index_select(core, 1, ind_slice)
     auto num_of_elements = ranks[idx] * factor_j[idx] * ranks[idx + 1];
     for (const auto i : c10::irange(bs)) {
       memcpy(
@@ -495,7 +495,7 @@ class TTSparseLengthsSumGradientOp final : public Operator<Context> {
   ~TTSparseLengthsSumGradientOp() {}
 };
 
-// implement the graident op for TTLengthSumGradient op
+// implement the gradient op for TTLengthSumGradient op
 template <typename T, class Context>
 bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   const auto& core0 = Input(0);
@@ -646,7 +646,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
       &context_);
 
   // =======================================================
-  // Calcuate dCore1_data:
+  // Calculate dCore1_data:
   // 1) Transpose core1_out_grad and multiply with core0_out
   // 2) Transpose the result and then add to dCore1_data
   vector<vector<T>> dCore1_data_slice_grad(
@@ -688,7 +688,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
         sizeof(T) * num_of_elements);
   }
 
-  // Calcuate core0_out_grad
+  // Calculate core0_out_grad
   vector<vector<T>> core0_out_grad(
       bs, vector<T>(core0_out_shape[1] * core0_out_shape[2], 0));
 

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -394,7 +394,7 @@ class CheckpointOp final : public Operator<Context> {
     CAFFE_ENFORCE_GT(every_, 0, "Checkpoint interval should be positive.");
     if (every_ == 1) {
       // Just issue a warning, but it's totally legal so we don't do anything.
-      LOG(WARNING) << "It seems that we are checkpointting every iteration. "
+      LOG(WARNING) << "It seems that we are checkpointing every iteration. "
                    << "Is that intended?";
     }
     save_op_def_.set_type("Save");

--- a/caffe2/operators/lpnorm_op.cc
+++ b/caffe2/operators/lpnorm_op.cc
@@ -152,7 +152,7 @@ supports l1 and l2 norm) determined by the argument p.
     .Arg("p", "Order of the norm in p-norm")
     .Arg(
         "average",
-        "whehther we calculate norm or averaged_norm."
+        "whether we calculate norm or averaged_norm."
         "The Lp_averaged_norm(x) is defined as"
         "Lp_averaged_normgradient(x) = LpNormGradient(x) / size(x)");
 

--- a/caffe2/operators/negate_gradient_op.cc
+++ b/caffe2/operators/negate_gradient_op.cc
@@ -8,7 +8,7 @@ OPERATOR_SCHEMA(NegateGradient)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
     .SetDoc(R"DOC(
-NegagteGradient operator in forward pass simply copies input to the
+NegateGradient operator in forward pass simply copies input to the
 output, and in backward pass, flips the sign of the output gradient
 )DOC");
 

--- a/caffe2/operators/prefetch_op.h
+++ b/caffe2/operators/prefetch_op.h
@@ -37,7 +37,7 @@ class PrefetchOperator : public OperatorBase {
 
   virtual ~PrefetchOperator() noexcept {
     CHECK(finalize_ || !prefetch_thread_.get())
-        << "YOU MADE A PROGRAMING ERROR: derived class of PrefetchOperator "
+        << "YOU MADE A PROGRAMMING ERROR: derived class of PrefetchOperator "
            "should call Finalize() in its destructor so the prefetching "
            "thread is joined. ";
   }

--- a/caffe2/operators/quantized/int8_roi_align_op.cc
+++ b/caffe2/operators/quantized/int8_roi_align_op.cc
@@ -40,6 +40,6 @@ Region of Interest (RoI) align operation as used in Mask R-CNN.
         "Y",
         "4D Int8 Tensor output of shape (R, C, pooled_h, pooled_w). "
         "The r-th batch element "
-        "is a pooled feature map cooresponding to the r-th RoI.");
+        "is a pooled feature map corresponding to the r-th RoI.");
 
 } // namespace caffe2

--- a/caffe2/operators/quantized/int8_roi_align_op.h
+++ b/caffe2/operators/quantized/int8_roi_align_op.h
@@ -110,7 +110,7 @@ void pre_calc_for_bilinear_interpolate(
           uint8_t w3 = static_cast<uint8_t>(Round(ly * hx * w_multiplier));
           uint8_t w4 = static_cast<uint8_t>(Round(ly * lx * w_multiplier));
 
-          // save weights and indeces
+          // save weights and indices
           PreCalc pc;
           pc.pos1 = y_low * width + x_low;
           pc.pos2 = y_low * width + x_high;
@@ -203,8 +203,8 @@ void ROIAlignForward(
     int Y_shift;
     QuantizeMultiplierSmallerThanOne(real_multiplier, &Y_multiplier, &Y_shift);
 
-    // we want to precalculate indeces and weights shared by all chanels,
-    // this is the key point of optimiation
+    // we want to precalculate indices and weights shared by all channels,
+    // this is the key point of optimization
     std::vector<PreCalc> pre_calc(
         roi_bin_grid_h * roi_bin_grid_w * pooled_width * pooled_height);
     pre_calc_for_bilinear_interpolate(

--- a/caffe2/operators/rnn/recurrent_network_executor.h
+++ b/caffe2/operators/rnn/recurrent_network_executor.h
@@ -79,7 +79,7 @@ class RecurrentNetworkExecutorBase {
       const std::vector<std::unique_ptr<ObserverBase<OperatorBase>>>&
           observers_list) {
     if (timestep_ops_template_.size() == 0) {
-      // Firsrt invocation -- compute dependencies
+      // Firrt invocation -- compute dependencies
       CalculateInternalDependencies();
 
       // Label ops based on whether they contain reference to the timestep
@@ -134,7 +134,7 @@ class RecurrentNetworkExecutorBase {
         // For ops that have the timestep blob as an input we need to
         // create a new operator definition with the timestep-specific
         // timestep blob. This is required to avoid race conditions when
-        // multiple timesteps execute in paralle.
+        // multiple timesteps execute in parallel.
         if (rnn_op.has_timestep_blob) {
           OperatorDef op_copy = step_net_def_.op(rnn_op.order);
 
@@ -216,7 +216,7 @@ class RecurrentNetworkExecutorBase {
   }
 
   // Return all outbound dependencies of an op. Special case for
-  // rnn dependencies, that are set in recurent_network_op.
+  // rnn dependencies, that are set in recurrent_network_op.
   std::vector<string> op_deps(int i) {
     std::vector<string> outs;
     auto& opdef = step_net_def_.op(i);

--- a/caffe2/operators/rnn/recurrent_network_op.cc
+++ b/caffe2/operators/rnn/recurrent_network_op.cc
@@ -177,7 +177,7 @@ void AddApplyLinkOps(
     // to add control_input to that op
     for (auto& op : *netdef->mutable_op()) {
       if (HasInput(op, link.internal)) {
-        // First appears as an input, no need to do antyhing
+        // First appears as an input, no need to do anything
         continue;
       }
       if (HasOutput(op, link.internal)) {

--- a/caffe2/operators/rnn/recurrent_network_op.h
+++ b/caffe2/operators/rnn/recurrent_network_op.h
@@ -626,7 +626,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
   }
 
   void AddParamGradientAccumulationOps(const OperatorDef& operator_def) {
-    // If a user passes in param_grads mapping, we can copy dirrectly
+    // If a user passes in param_grads mapping, we can copy directly
     // form a blob where backward cell net written data to.
     // This becomes handy in a case where gradient from the cell net
     // is an internal blob of the backward cell. This happens, for example,

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -292,7 +292,7 @@ Region of Interest (RoI) align operation as used in Mask R-CNN.
         0,
         "Y",
         "4D output of shape (R, C, pooled_h, pooled_w). The r-th batch element "
-        "is a pooled feature map cooresponding to the r-th RoI.");
+        "is a pooled feature map corresponding to the r-th RoI.");
 
 template <typename T>
 using RoIAlignCPUOp = caffe2::RoIAlignOp<T, CPUContext>;

--- a/caffe2/operators/roi_align_rotated_op.cc
+++ b/caffe2/operators/roi_align_rotated_op.cc
@@ -309,7 +309,7 @@ C10_EXPORT bool RoIAlignRotatedOp<float, CPUContext>::RunOnDevice() {
     } else if (order_ == StorageOrder::NHWC) {
       sizes = {0, pooled_height_, pooled_width_, X.dim32(3)};
     }
-    // Output tensor is inititalized with proper sizes and data type
+    // Output tensor is initialized with proper sizes and data type
     Output(0, sizes, at::dtype<float>());
     return true;
   }
@@ -408,7 +408,7 @@ Based on https://arxiv.org/abs/1703.01086.
         0,
         "Y",
         "4D output of shape (R, C, pooled_h, pooled_w). The r-th batch element "
-        "is a pooled feature map cooresponding to the r-th RoI.");
+        "is a pooled feature map corresponding to the r-th RoI.");
 
 } // namespace caffe2
 

--- a/caffe2/operators/segment_reduction_op.h
+++ b/caffe2/operators/segment_reduction_op.h
@@ -225,7 +225,7 @@ i.e. `SEGMENT_IDS[-1]+1`. Other dimensions are inherited from the input tensor.
         0,
         "OUTPUT",
         "Aggregated tensor with the first dimension of K and the "
-        "other dimentsions inherited from DATA");
+        "other dimensions inherited from DATA");
   }
   using ForwardOp = AbstractSortedSegmentRangeOp<
       T,
@@ -1370,7 +1370,7 @@ tensor.
  *   P+1: INDICES - 1-D vector with indices to look up in DATA. Should have the
  *                  same dimension as LENGTHS
  *   # P+1 if SparseFused == false:
- *   P+1 or P+2: LENGTHS - lengths on indecies vector
+ *   P+1 or P+2: LENGTHS - lengths on indices vector
  *
  * Output:
  *   Tensor with first dimension of K, where K = len(LENGTHS). Rest

--- a/caffe2/operators/sparse_dropout_with_replacement_op.cc
+++ b/caffe2/operators/sparse_dropout_with_replacement_op.cc
@@ -70,7 +70,7 @@ OPERATOR_SCHEMA(SparseDropoutWithReplacement)
     .SetDoc(R"DOC(
 
 `SparseDropoutWithReplacement` takes a 1-d input tensor and a lengths tensor.
-Values in the Lengths tensor represent how many input elements consitute each
+Values in the Lengths tensor represent how many input elements constitute each
 example in a given batch.  The set of input values for an example will be
 replaced with the single dropout value with probability given by the `ratio`
 argument.

--- a/caffe2/operators/sparse_itemwise_dropout_with_replacement_op.cc
+++ b/caffe2/operators/sparse_itemwise_dropout_with_replacement_op.cc
@@ -64,7 +64,7 @@ OPERATOR_SCHEMA(SparseItemwiseDropoutWithReplacement)
     .SetDoc(R"DOC(
 
 `SparseItemwiseDropoutWithReplacement` takes a 1-d input tensor and a lengths tensor.
-Values in the Lengths tensor represent how many input elements consitute each
+Values in the Lengths tensor represent how many input elements constitute each
 example in a given batch.  The each input value in the tensor of an example can be
 replaced with the replacement value with probability given by the `ratio`
 argument.

--- a/caffe2/operators/spatial_batch_norm_op.h
+++ b/caffe2/operators/spatial_batch_norm_op.h
@@ -112,7 +112,7 @@ class SpatialBNOp : public Operator<Context> {
       if (mean.numel() != C) {
         running_mean = Output(RUNNING_MEAN, {C}, at::dtype<T>());
         C10_LOG_EVERY_MS(WARNING, 1000)
-            << "[Depreacated] Running mean is not initialized in "
+            << "[Deprecated] Running mean is not initialized in "
                "SpatialBatchNorm Op";
         math::Set<T, Context>(
             C, T(0), running_mean->template mutable_data<T>(), &context_);

--- a/caffe2/operators/stats_put_ops.h
+++ b/caffe2/operators/stats_put_ops.h
@@ -87,7 +87,7 @@ struct TemplatePutOp : public Operator<CPUContext> {
     Checks if given number of is NaN, while being permissive with different
     implementations of the standard libraries between operating systems.
 
-    Uses the preperties of NaN, defined by IEEE.
+    Uses the properties of NaN, defined by IEEE.
     https://www.gnu.org/software/libc/manual/html_node/Infinity-and-NaN.html
     */
     return input != input;

--- a/caffe2/operators/utility_ops.cc
+++ b/caffe2/operators/utility_ops.cc
@@ -490,7 +490,7 @@ OPERATOR_SCHEMA(GatherRanges)
 Given DATA tensor of rank 1, and RANGES tensor of rank 3, gather
 corresponding ranges into a 1-D tensor OUTPUT.
 
-RANGES dimentions description:
+RANGES dimensions description:
 1: represents list of examples within a batch
 2: represents list features
 3: two values which are start and length or a range (to be applied on DATA)


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.cc` and `.h` files under `caffe2/operators` directory
