### PR TITLE
Bring the fix to flaky missing libzstd on MacOS M1 to its build job

### DIFF
--- a/.ci/pytorch/macos-build.sh
+++ b/.ci/pytorch/macos-build.sh
@@ -72,6 +72,8 @@ build_lite_interpreter() {
     "${CPP_BUILD}/caffe2/build/bin/test_lite_interpreter_runtime"
 }
 
+print_cmake_info
+
 if [[ ${BUILD_ENVIRONMENT} = *arm64* ]]; then
   if [[ $(uname -m) == "arm64" ]]; then
     compile_arm64

--- a/.ci/pytorch/macos-common.sh
+++ b/.ci/pytorch/macos-common.sh
@@ -12,3 +12,22 @@ sysctl -a | grep machdep.cpu
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
+
+print_cmake_info() {
+  CMAKE_EXEC=$(which cmake)
+  echo "$CMAKE_EXEC"
+
+  CONDA_INSTALLATION_DIR=$(dirname "$CMAKE_EXEC")
+  # Print all libraries under cmake rpath for debugging
+  ls -la "$CONDA_INSTALLATION_DIR/../lib"
+
+  export CMAKE_EXEC
+  # Explicitly add conda env lib folder to cmake rpath to address the flaky issue
+  # where cmake dependencies couldn't be found. This seems to point to how conda
+  # links $CMAKE_EXEC to its package cache when cloning a new environment
+  install_name_tool -add_rpath @executable_path/../lib "${CMAKE_EXEC}" || true
+  # Adding the rpath will invalidate cmake signature, so signing it again here
+  # to trust the executable. EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
+  # with an exit code 137 otherwise
+  codesign -f -s - "${CMAKE_EXEC}" || true
+}

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -82,25 +82,6 @@ test_libtorch() {
   fi
 }
 
-print_cmake_info() {
-  CMAKE_EXEC=$(which cmake)
-  echo "$CMAKE_EXEC"
-
-  CONDA_INSTALLATION_DIR=$(dirname "$CMAKE_EXEC")
-  # Print all libraries under cmake rpath for debugging
-  ls -la "$CONDA_INSTALLATION_DIR/../lib"
-
-  export CMAKE_EXEC
-  # Explicitly add conda env lib folder to cmake rpath to address the flaky issue
-  # where cmake dependencies couldn't be found. This seems to point to how conda
-  # links $CMAKE_EXEC to its package cache when cloning a new environment
-  install_name_tool -add_rpath @executable_path/../lib "${CMAKE_EXEC}" || true
-  # Adding the rpath will invalidate cmake signature, so signing it again here
-  # to trust the executable. EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
-  # with an exit code 137 otherwise
-  codesign -f -s - "${CMAKE_EXEC}" || true
-}
-
 test_custom_backend() {
   print_cmake_info
 


### PR DESCRIPTION
I did this fix https://github.com/pytorch/pytorch/pull/92737 a while back on MacOS M1 test job and haven't seen this flaky issue [Library not loaded: @rpath/libzstd.1.dylib](https://hud.pytorch.org/failure/Library%20not%20loaded%3A%20%40rpath%2Flibzstd.1.dylib) there again.  Recently, we start to build on M1 runners, and the flaky failure starts to show up there too, i.e. https://github.com/pytorch/pytorch/actions/runs/4599605256/jobs/8125180118.  So I'm bringing the same fix to MacOS M1 build job.

