### PR TITLE
[FSDP] Do not use unsharded flat parameter if prefetching

### DIFF
--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -195,7 +195,7 @@ def _unshard_fsdp_state_params(
     # No need to call `wait_stream()` since we unshard in the computation
     # stream directly
     computation_stream = torch.cuda.current_stream()
-    _unshard(state, handles, computation_stream, computation_stream)
+    _unshard(state, handles, computation_stream, computation_stream, False)
     if with_grads:
         _unshard_grads(handles)
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1092,12 +1092,13 @@ class FlatParamHandle:
         # Invariant: `_mp_shard` is always on the compute device.
         flat_param.data = flat_param._mp_shard  # type: ignore[attr-defined]
 
-    def unshard(self):
+    def unshard(self, is_prefetch: bool):
         """
         Runs the unshard logic. This includes all-gathering the flat parameter
-        and switching to using the unsharded flat parameter. If the handle does
-        not need unsharding, then this only switches to using the unsharded
-        flat parameter. For ``NO_SHARD``, this is a no-op.
+        and switching to using the unsharded flat parameter (if not
+        prefetching). If the handle does not need unsharding, then this only
+        switches to using the unsharded flat parameter. For ``NO_SHARD``, this
+        only switches between tensor and parameter unsharded views as needed.
 
         If FSDP is in :meth:`summon_full_params` and the handle uses parameter
         mixed precision, then the parameter is forced to full precision.
@@ -1114,7 +1115,10 @@ class FlatParamHandle:
             return
         unsharded_flat_param = self._alloc_padded_unsharded_flat_param()
         padded_unsharded_flat_param = self._all_gather_flat_param(unsharded_flat_param)
-        self._use_unsharded_flat_param(padded_unsharded_flat_param)
+        # Only switch to using the unsharded flat parameter if not prefetching
+        # to avoid doubly incurring the CPU overhead of using unsharded views
+        if not is_prefetch:
+            self._use_unsharded_flat_param(padded_unsharded_flat_param)
 
     def needs_unshard(self) -> bool:
         """Returns if the handle's flat parameter needs to be unsharded."""

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1103,7 +1103,11 @@ class FlatParamHandle:
         If FSDP is in :meth:`summon_full_params` and the handle uses parameter
         mixed precision, then the parameter is forced to full precision.
         """
+        # Only switch to using the unsharded flat parameter if not prefetching
+        # to avoid doubly incurring the CPU overhead of using unsharded views
         if not self.needs_unshard():
+            if is_prefetch:
+                return
             # Even when not needing an unshard, we should switch to using
             # the unsharded flat parameter
             unsharded_flat_param = (
@@ -1115,8 +1119,6 @@ class FlatParamHandle:
             return
         unsharded_flat_param = self._alloc_padded_unsharded_flat_param()
         padded_unsharded_flat_param = self._all_gather_flat_param(unsharded_flat_param)
-        # Only switch to using the unsharded flat parameter if not prefetching
-        # to avoid doubly incurring the CPU overhead of using unsharded views
         if not is_prefetch:
             self._use_unsharded_flat_param(padded_unsharded_flat_param)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98242
* #98221
* #97981
* #97980
* #97979
* #97796
* #97667
* #97666
* #97665
* #97664
* #97663
* #97662
* #97661

- This undoes https://github.com/pytorch/pytorch/pull/97981 due to a minor concern: The unshard logic (namely the `_use_unsharded_flat_parameter()` -> `_use_unsharded_views()` logic) for a handle depends on its own training state, not on that of the handle that prefetched it. Therefore, we actually want the handle itself to run `_use_unsharded_flat_parameter()`, not the handle that is prefetching. Otherwise, the handle could still be in `IDLE` but is being prefetched from another handle in `BACKWARD_PRE`, in which case the original handle does not correctly use the logic as if it were in `BACKWARD_PRE`.
- Instead, we only run the `_use_unsharded_flat_parameter()` when the handle itself is running `unshard()`, which we differentiate using the `is_prefetch: bool` flag.

In progress... this is broken currently.