### PR TITLE
remove no-op C10_DISABLE_NUMA preprocessor flag

### DIFF
--- a/c10/BUCK.oss
+++ b/c10/BUCK.oss
@@ -36,7 +36,6 @@ cxx_library(
         '-DC10_USING_CUSTOM_GENERATED_MACROS',
         '-DC10_USE_GLOG',
         '-DC10_USE_MINIMAL_GLOG',
-        '-DC10_DISABLE_NUMA',
         '-DC10_MOBILE',
         '-fexceptions',
         '-Wno-global-constructors'

--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -101,7 +101,6 @@ def define_ovrsource_targets():
 
     common_c10_cmake_defines = [
         ("#cmakedefine C10_BUILD_SHARED_LIBS", ""),
-        ("#cmakedefine C10_DISABLE_NUMA", ""),
         ("#cmakedefine C10_USE_NUMA", ""),
         ("#cmakedefine C10_USE_MSVC_STATIC_RUNTIME", ""),
     ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98243

Nothing reads this, so setting it does nothing.

Differential Revision: [D44642070](https://our.internmc.facebook.com/intern/diff/D44642070/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D44642070/)!