### PR TITLE
Skip gat, gcn and sage for TorchBench CUDA test

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -76,10 +76,7 @@ CI_SKIP = collections.defaultdict(list)
 CI_SKIP[CI("eager", training=False)] = [
     # TorchBench
     "DALLE2_pytorch",  # AttributeError: text_encodings
-    "gat",  # only works on CPU
-    "gcn",  # only works on CPU
     "llama",  # does not support complex32
-    "sage",  # only works on CPU
     # TypeError: pad_center() takes 1 positional argument but 2 were given
     "tacotron2",
     # torchrec_dlrm requires gcc-11, https://github.com/pytorch/benchmark/pull/1427
@@ -1097,6 +1094,10 @@ class BenchmarkRunner:
 
     @property
     def skip_models(self):
+        return set()
+
+    @property
+    def skip_models_for_cuda(self):
         return set()
 
     @property
@@ -2151,6 +2152,8 @@ def run(runner, args, original_dir=None):
 
     if args.devices == ["cpu"]:
         runner.skip_models.update(runner.very_slow_models)
+    elif args.devices == ["cuda"]:
+        runner.skip_models.update(runner.skip_models_for_cuda)
 
     if args.inductor or args.inductor_settings:
         runner.skip_models.update(runner.failing_torchinductor_models)

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -75,6 +75,12 @@ SKIP = {
     "fambench_xlmr",
 }
 
+SKIP_FOR_CUDA = {
+    "gat",  # only works on CPU
+    "gcn",  # only works on CPU
+    "sage",  # only works on CPU
+}
+
 # Additional models that are skipped in training
 SKIP_TRAIN = {
     # not designed for training
@@ -206,6 +212,10 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         return SKIP
 
     @property
+    def skip_models_for_cuda(self):
+        return SKIP_FOR_CUDA
+
+    @property
     def slow_models(self):
         return SLOW_BENCHMARKS
 
@@ -325,7 +335,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
                 not re.search("|".join(args.filter), model_name, re.I)
                 or re.search("|".join(args.exclude), model_name, re.I)
                 or model_name in args.exclude_exact
-                or model_name in SKIP
+                or model_name in self.skip_models
             ):
                 continue
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98244

Summary: The three models only support CPU for now.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx