### PR TITLE
Disable inductor/test_minifier on ASAN

### DIFF
--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -7,7 +7,7 @@ import torch
 import torch._dynamo
 import torch._inductor.utils
 from torch._dynamo.test_minifier_common import MinifierTestBase
-from torch.testing._internal.common_utils import IS_JETSON, IS_MACOS
+from torch.testing._internal.common_utils import IS_JETSON, IS_MACOS, TEST_WITH_ASAN
 
 _HAS_TRITON = torch._inductor.utils.has_triton()
 requires_cuda = functools.partial(unittest.skipIf, not _HAS_TRITON, "requires cuda")
@@ -44,6 +44,7 @@ def triton_accuracy_error(x):
 """
 
 
+@unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
 class MinifierTests(MinifierTestBase):
     @classmethod
     def setUpClass(cls):
@@ -324,6 +325,7 @@ inner(torch.randn(20, 20).to("cpu"))
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    # skip CI tests on mac since CPU inductor does not seem to work due to C++ compile errors
-    if not IS_MACOS:
+    # Skip CI tests on mac since CPU inductor does not seem to work due to C++ compile errors,
+    # also skip on ASAN due to https://github.com/pytorch/pytorch/issues/98262
+    if not IS_MACOS and not TEST_WITH_ASAN:
         run_tests()

--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -44,7 +44,6 @@ def triton_accuracy_error(x):
 """
 
 
-@unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
 class MinifierTests(MinifierTestBase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This is to mitigate the timeout issue on ASAN https://github.com/pytorch/pytorch/issues/98262.  This test is slow on ASAN and it seems to cause problem to correctly compute the number of shards needed to run it.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire