### PR TITLE
Add parentheses to `FloorDiv`.

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -744,7 +744,7 @@ class FloorDiv(sympy.Function):
     def _sympystr(self, printer):
         base = printer.parenthesize(self.base, self.precedence)
         divisor = printer.parenthesize(self.divisor, self.precedence)
-        return f"{base}//{divisor}"
+        return f"({base}//{divisor})"
 
     # SymPy assumptions based on argument types.
     def _eval_is_real(self):


### PR DESCRIPTION
[SymPy incorrectly prints](https://github.com/sympy/sympy/issues/25026) multiplications that:
- Have a negative term; and
- Have a custom operation of smaller precedence than `Mul` (except for `Add` -- which is expanded)

I have observed this behavior when running `maml` with dynamic shapes (errors out on `master`, though). There was, for example, the following guard:

```python
# vars[12].size()[2] == 2
# vars[0].size()[2] == 3
# x.size()[2] == 28

vars[12].size()[2] ** 2 - \
    2 * vars[12].size()[2] * \
    (-vars[0].size()[2] + (-vars[0].size()[2] + (x.size()[2] - vars[0].size()[2]) // 2 + 1) // 2 + 1) // 2
```

Which translates into:

```python
>>> 2 ** 2 - 2 * 2 * (-3 + (-3 + (28 - 3) // 2 + 1) // 2 + 1) // 2
>>> 2 ** 2 - 2 * 2 * (-3 + (-3 + 25 // 2 + 1) // 2 + 1) // 2
>>> 2 ** 2 - 2 * 2 * (-3 + 10 // 2 + 1) // 2
>>> 2 ** 2 - 2 * 2 * 3 // 2
>>> 4 - 2 * 2 * 3 // 2  # floordiv and mul have same precedence in Python
>>> -2
```

Now, placing the parentheses correctly (this PR), we get:

```python
>>> 4 - 2 * 2 * (3 // 2)
>>> 0
```
