### PR TITLE
[FSDP] Add skip writeback check gated by env var

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -75,6 +75,14 @@ or a submodule chosen by the provided wrapping policy.
 # special cases such as for high CPU overhead or for intentionally bypassing
 # checks in the overrides, we may use 'unsafe'.
 _FSDP_USE_UNSAFE_SETATTR = "FSDP_USE_UNSAFE_SETATTR"
+# Environment variable toggling whether to check for parameter/gradient
+# writeback (i.e. for the user changing any FSDP-managed module's parameters
+# after FSDP initialization, whether the storage or the variable itself)
+# We should check by default since it prevents silent correctness errors, but
+# since such changes are atypical, we may want to skip the check to save CPU
+# overhead, especially since the check happens pre-forward and pre-backward
+# each iteration.
+_FSDP_SKIP_WRITEBACK_CHECK = "FSDP_SKIP_WRITEBACK_CHECK"
 
 
 # Some value to set padding in tensors to for debuggability
@@ -412,6 +420,16 @@ class FlatParamHandle:
                 f"Cannot construct a {self.__class__.__name__} with an empty parameter list"
             )
         self._init_setattr_fns()
+        self._skip_writeback_check = (
+            os.environ.get(_FSDP_SKIP_WRITEBACK_CHECK, "") == "1"
+        )
+        if self._skip_writeback_check:
+            _warn_skip_writeback_check(
+                log,
+                f"Since {_FSDP_SKIP_WRITEBACK_CHECK}=1, FSDP will not check "
+                "for parameter or gradient writeback. Changing parameter or "
+                "gradient storages may lead to silent correctness errors.",
+            )
         align_addresses = use_orig_params
         self._init_get_unflat_views_fn(align_addresses)
         self.device = device
@@ -1057,7 +1075,7 @@ class FlatParamHandle:
         matches the dtype of the expected unsharded parameter.
         """
         ret = False
-        if self._use_orig_params:
+        if self._use_orig_params and not self._skip_writeback_check:
             ret = self._writeback_orig_params()
         if (
             self.uses_sharded_strategy
@@ -2383,6 +2401,13 @@ def _construct_padding_tensor(
         )
         * _FLAT_PARAM_PADDING_VALUE
     )
+
+
+# Use `lru_cache(1)` to only log the warning once (assuming the fixed warning
+# messasge is passed in)
+@functools.lru_cache(1)
+def _warn_skip_writeback_check(log: logging.Logger, warning: str):
+    log.warning(warning)
 
 
 # A handles key represents the group of `FlatParamHandle`s involved in a given

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -76,12 +76,11 @@ or a submodule chosen by the provided wrapping policy.
 # checks in the overrides, we may use 'unsafe'.
 _FSDP_USE_UNSAFE_SETATTR = "FSDP_USE_UNSAFE_SETATTR"
 # Environment variable toggling whether to check for parameter/gradient
-# writeback (i.e. for the user changing any FSDP-managed module's parameters
-# after FSDP initialization, whether the storage or the variable itself)
+# writeback in case their storages change after FSDP initialization
 # We should check by default since it prevents silent correctness errors, but
 # since such changes are atypical, we may want to skip the check to save CPU
-# overhead, especially since the check happens pre-forward and pre-backward
-# each iteration.
+# overhead, especially since the check happens in the pre-forward and
+# pre-backward each iteration.
 _FSDP_SKIP_WRITEBACK_CHECK = "FSDP_SKIP_WRITEBACK_CHECK"
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98332
* #98320
* #98319
* __->__ #98300
* #98299
* #98250
* #98249
* #98221

This adds the option to skip the `_writeback_orig_params()` function that checks for parameter and gradient writeback in case storages changed, gated by an env var `FSDP_SKIP_WRITEBACK_CHECK`.

As described in the code comment, this writeback check is important for detecting a failure mode of FSDP `use_orig_params=True`. However, because the failure mode is an atypical case and performing the check incurs nontrivial CPU overhead each iteration, we add this option to skip the check altogether.

<details>
<summary>(Before) Pre-backward hook: 1.044 ms</summary>

![Screenshot 2023-04-04 at 9 05 53 AM](https://user-images.githubusercontent.com/31054793/229800917-9580ce6b-3721-469a-9212-f0cbfd8cbb52.png)

</details>

<details>
<summary>(After) Pre-backward hook: 0.500 ms</summary>

![Screenshot 2023-04-04 at 9 34 57 AM](https://user-images.githubusercontent.com/31054793/229810916-b16295d5-7da7-42c4-9168-04edeebe045c.png)

</details>