### PR TITLE
[inductor] Enable CSE on masked loads

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -986,9 +986,8 @@ class TritonKernel(Kernel):
 
         self._load_mask = mask
         try:
-            with self.swap_buffers(self.compute, self.compute):
-                # TODO(jansel): do we need a reshape here?
-                yield mask
+            # TODO(jansel): do we need a reshape here?
+            yield mask
         finally:
             self._load_mask = prior
 
@@ -1026,23 +1025,24 @@ class TritonKernel(Kernel):
             if V.graph.get_dtype(name) in (torch.float16, torch.bfloat16):
                 line += ".to(tl.float32)"
 
-        if (
+        if "tmp" in mask:
+            # Masked loads must come after the mask is computed
+            load_buffer = self.compute
+        elif (
             self.inside_reduction
             and not self.persistent_reduction
             and "rmask" not in mask
-            and "tmp" not in mask
             and not indirect_indexing
         ):
             # can lift a common load outside of reduction loop
             # One exception is when this is an indirect_load.
-            result_var = self.cse.generate(
-                self.body, line, append_broadcast=append_broadcast
-            )
+            load_buffer = self.body
         else:
-            result_var = self.cse.generate(
-                self.loads, line, append_broadcast=append_broadcast
-            )
+            load_buffer = self.loads
 
+        result_var = self.cse.generate(
+            load_buffer, line, append_broadcast=append_broadcast
+        )
         result_var.mask_vars = mask_vars
 
         if not self.inside_reduction or "rmask" not in mask:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98304
* __->__ #98303

Currently the `TritonKernel.mask_loads` context manager calls
`swap_buffers` which creates a new CSE context. So, code generated in
different mask contexts cannot be CSE'd even if their masks are the
same. This fixes the issue by not calling `swap_buffers` and instead
having `load` manually check if a `"tmp"` name appears in the mask
meaning the load needs to be generated in the compute buffer.

Currently, simple programs involving padding will result in duplcate
masked loads. e.g. the generated code for
```python
def forward():
    a = torch.nn.functional.pad(x, (0, 1))
    return a + a
```

contains the lines

```python
    tmp3 = tl.load(in_ptr0 + (x1 + tl.zeros([XBLOCK], tl.int32)), tmp2 & xmask, other=0)
    tmp4 = tl.where(tmp2, tmp3, 0.0)
    tmp5 = tl.load(in_ptr0 + (x1 + tl.zeros([XBLOCK], tl.int32)), tmp2 & xmask, other=0)
    tmp6 = tl.where(tmp2, tmp5, 0.0)
```

With this change, the duplicates are removed.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire