### PR TITLE
[better_engineering][multiplatform] Repalce host_info() check with select for default_compiler_flags

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -43,11 +43,12 @@ default_compiler_flags = [
     # nvrtc library which we load canonically anyway
     "-DUSE_DIRECT_NVRTC",
     "-DUSE_RUY_QMATMUL",
-] + ([] if native.host_info().os.is_windows else [
+] + select({
     # XNNPACK depends on an updated version of pthreadpool interface, whose implementation
     # includes <pthread.h> - a header not available on Windows.
-    "-DUSE_XNNPACK",
-]) + (["-O1"] if native.read_config("fbcode", "build_mode_test_label", "") == "dev-nosan" else [])
+    "DEFAULT": ["-DUSE_XNNPACK"],
+    "ovr_config//os:windows": [],
+}) + (["-O1"] if native.read_config("fbcode", "build_mode_test_label", "") == "dev-nosan" else [])
 
 compiler_specific_flags = {
     "clang": [


### PR DESCRIPTION
Summary: Same as title

Test Plan: CI

Differential Revision: D44667769

