### PR TITLE
Update _linux-test.yml

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
-        if: !contains(matrix.runner, 'gcp')
+        if: !contains(matrix.runner, 'gcp-a100')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        if: contains(matrix.runner, 'gcp-a100')
+        if: ${{ !contains(matrix.runner, 'gcp-a100') }}
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
-        if: !contains(matrix.runner, 'a100')
+        if: !contains(matrix.runner, 'gcp-a100')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
-        if: !contains(matrix.runner, 'gcp-a100')
+        if: !contains(matrix.runner, 'gcp')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,8 +71,8 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
-        if: !contains(matrix.runner, 'gcp')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        if: !contains(matrix.runner, 'gcp-a100')
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
-        if: contains(matrix.runner, 'a100')
+        if: !contains(matrix.runner, 'a100')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        if: !contains(matrix.runner, 'gcp-a100')
+        if: contains(matrix.runner, 'gcp-a100')
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -71,6 +71,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Setup SSH (Click me for login details)
+        if: contains(matrix.runner, 'a100')
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        if: ${{ !contains(matrix.runner, 'gcp-a100') }}
+        if: ${{ !contains(matrix.runner, 'gcp.a100') }}
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |


### PR DESCRIPTION
Skip "setup-ssh" for now for a100 runners from GCP as it frequently encounter issues like "connect ETIMEDOUT 173.231.16.75:443" Every day about 10 occurrences

Examples for just today so far: 
2023-04-04T15:07:50.916331Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4609056040/jobs/8146321650
-- | -- | --
2023-04-04T15:03:56.914692Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4609010125/jobs/8146217819
2023-04-04T14:39:58.004717Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4608784966/jobs/8145641764
2023-04-04T14:19:28.854825Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4608561116/jobs/8145147916
2023-04-04T06:15:39.241848Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4604422106/jobs/8135687673
2023-04-04T06:10:21.056131Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4604406947/jobs/8135611094
2023-04-04T05:34:50.908482Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4604198332/jobs/8135201048
2023-04-04T03:04:36.628201Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4603162241/jobs/8133620905
2023-04-04T01:49:27.119830Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4600897505/jobs/8132760483
2023-04-04T01:18:06.141437Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4602745871/jobs/8132387930
2023-04-04T00:38:30.610770Z | inductor | https://github.com/pytorch/pytorch/actions/runs/4602537869/jobs/8131938265


