### PR TITLE
fix _slice_meta's shape calculation

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1,6 +1,5 @@
 import contextlib
 import itertools
-import math
 import operator
 import weakref
 from enum import Enum

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1523,7 +1523,7 @@ def _slice_meta(
 
     new_shape = []
     for x, y, z in zip(start_indices, limit_indices, _strides):
-        new_shape.append(math.floor((y - x) / z))
+        new_shape.append(1 + (y - x - 1) // z)
 
     new_strides = []
     for x, y in zip(a.stride(), _strides):


### PR DESCRIPTION
Fixes #98325.

This PR corrects the output shape calculation used in `_slice_meta` from:

```python
math.floor((end - start) / stride)
```

to

```python
1 + (end - start - 1) // stride
```