### PR TITLE
Implement `is_causal` API for `Transformer`

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2761,18 +2761,18 @@ aot_autograd_module_failures = set({
                                 # of a tracing tensor with aten._local_scalar_dense.default -
                                 # erroring out! It's likely that this is caused by data-dependent
                                 # control flow or similar.
-    torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input
+    torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.eq compares a mask input
                                   # to a causal mask tensor, to see if Boolean is_causal should be set
                                   # for TrnasformerEncoder layers, MHA and sdp custom kernels
-    torch.nn.Transformer,  # DataDependentOutputException: aten.equal compares a mask input
+    torch.nn.Transformer,  # DataDependentOutputException: aten.eq compares a mask input
                            # to a causal mask tensor, to see if Boolean is_causal should be set
                            # for TransformerEncoder layers, MHA and sdp custom kernels
                            # (this bubbles up to Transformer)
 })
 
 symbolic_aot_autograd_module_failures = {
-    torch.nn.Transformer,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
-    torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
+    torch.nn.Transformer,  # DataDependentOutputException: aten.eq compares a mask input to a mask producing a bool
+    torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.eq compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
     torch.nn.CrossEntropyLoss,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2764,6 +2764,9 @@ aot_autograd_module_failures = set({
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.eq compares a mask input
                                   # to a causal mask tensor, to see if Boolean is_causal should be set
                                   # for TrnasformerEncoder layers, MHA and sdp custom kernels
+    torch.nn.TransformerDecoder,  # DataDependentOutputException: aten.eq compares a mask input
+                                  # to a causal mask tensor, to see if Boolean is_causal should be set
+                                  # for TrnasformerDecoder layers, MHA and sdp custom kernels
     torch.nn.Transformer,  # DataDependentOutputException: aten.eq compares a mask input
                            # to a causal mask tensor, to see if Boolean is_causal should be set
                            # for TransformerEncoder layers, MHA and sdp custom kernels
@@ -2773,6 +2776,7 @@ aot_autograd_module_failures = set({
 symbolic_aot_autograd_module_failures = {
     torch.nn.Transformer,  # DataDependentOutputException: aten.eq compares a mask input to a mask producing a bool
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.eq compares a mask input to a mask producing a bool
+    torch.nn.TransformerDecoder,  # DataDependentOutputException: aten.eq compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
     torch.nn.CrossEntropyLoss,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3795,7 +3795,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         encoder_input_shape = correct_encoder_input_shape
         decoder_input_shape = correct_decoder_input_shape
         wrong_src_mask_size = seq_len + 1
-        test(encoder_input_shape, decoder_input_shape, src_mask_len=wrong_src_mask_size)
+        test(encoder_input_shape, decoder_input_shape,
+             src_mask_len=wrong_src_mask_size, raises=True)
 
         # Incorrect tgt_mask
         encoder_input_shape = correct_encoder_input_shape

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3689,7 +3689,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                  src_mask_len=None, tgt_mask_len=None, memory_mask_size=None,
                  src_key_padding_mask_size=None, tgt_key_padding_mask_size=None,
                  memory_key_padding_mask_size=None,
-                 raises=False):
+                 # We set these as `False` by default so that tests are
+                 # forced to consider the attention masks. Otherwise
+                 # shapes may be ignored because a causal mask is
+                 # assumed. Obviously ignoring mask arguments is not
+                 # desired for argument checking tests.
+                 src_is_causal=False, tgt_is_causal=False,
+                 memory_is_causal=False, raises=False):
             encoder_input = torch.randn(encoder_input_shape)
             decoder_input = torch.randn(decoder_input_shape)
             model = getattr(nn, model_name)(d_model, nhead, num_encoder_layers,
@@ -3733,7 +3739,10 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                           memory_mask=memory_task,
                           src_key_padding_mask=src_key_padding_mask,
                           tgt_key_padding_mask=tgt_key_padding_mask,
-                          memory_key_padding_mask=memory_key_padding_mask)
+                          memory_key_padding_mask=memory_key_padding_mask,
+                          src_is_causal=src_is_causal,
+                          tgt_is_causal=tgt_is_causal,
+                          memory_is_causal=memory_is_causal)
             else:
                 model(encoder_input, decoder_input,
                       src_mask=src_mask,
@@ -3741,7 +3750,10 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                       memory_mask=memory_task,
                       src_key_padding_mask=src_key_padding_mask,
                       tgt_key_padding_mask=tgt_key_padding_mask,
-                      memory_key_padding_mask=memory_key_padding_mask)
+                      memory_key_padding_mask=memory_key_padding_mask,
+                      src_is_causal=src_is_causal,
+                      tgt_is_causal=tgt_is_causal,
+                      memory_is_causal=memory_is_causal)
 
 
         correct_encoder_input_shape = (seq_len, bsz, d_model)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1077,6 +1077,9 @@ class MultiheadAttention(Module):
             corresponding position is not allowed to attend. For a float mask, the mask values will be added to
             the attention weight.
             If both attn_mask and key_padding_mask are supplied, their types should match.
+        average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
+            heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
+            effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
         is_causal: If specified, applies a causal mask as attention mask.
             Default: ``False``.
             Warning:
@@ -1084,9 +1087,6 @@ class MultiheadAttention(Module):
             causal mask. Providing incorrect hints can result in
             incorrect execution, including forward and backward
             compatibility.
-        average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
-            heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
-            effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
 
     Outputs:
         - **attn_output** - Attention outputs of shape :math:`(L, E)` when input is unbatched,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -841,6 +841,6 @@ def _detect_is_causal_mask(mask: Optional[Tensor], is_causal: Optional[bool]) ->
 
         # Do not use `torch.equal` so we handle batched masks by
         # broadcasting the comparison.
-        make_causal = (mask == causal_comparison).all()
+        make_causal = bool((mask == causal_comparison).all())
 
     return make_causal

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -174,7 +174,7 @@ class Transformer(Module):
         return output
 
     @staticmethod
-    def generate_square_subsequent_mask(sz: int, device='cpu') -> Tensor:
+    def generate_square_subsequent_mask(sz: int, device=None) -> Tensor:
         r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
             Unmasked positions are filled with float(0.0).
         """

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -231,6 +231,7 @@ class TransformerEncoder(Module):
         Args:
             src: the sequence to the encoder (required).
             mask: the mask for the src sequence (optional).
+            src_key_padding_mask: the mask for the src keys per batch (optional).
             is_causal: If specified, applies a causal mask as mask.
                 Default: ``False``.
                 Warning:
@@ -238,7 +239,6 @@ class TransformerEncoder(Module):
                 causal mask. Providing incorrect hints can result in
                 incorrect execution, including forward and backward
                 compatibility.
-            src_key_padding_mask: the mask for the src keys per batch (optional).
 
         Shape:
             see the docs in Transformer class.
@@ -536,6 +536,7 @@ class TransformerEncoderLayer(Module):
         Args:
             src: the sequence to the encoder layer (required).
             src_mask: the mask for the src sequence (optional).
+            src_key_padding_mask: the mask for the src keys per batch (optional).
             is_causal: If specified, applies a causal mask as src mask.
                 Default: ``False``.
                 Warning:
@@ -543,7 +544,6 @@ class TransformerEncoderLayer(Module):
                 causal mask. Providing incorrect hints can result in
                 incorrect execution, including forward and backward
                 compatibility.
-            src_key_padding_mask: the mask for the src keys per batch (optional).
 
         Shape:
             see the docs in Transformer class.
@@ -768,6 +768,7 @@ class TransformerDecoderLayer(Module):
                 ``memory_mask`` is the causal mask. Providing incorrect
                 hints can result in incorrect execution, including
                 forward and backward compatibility.
+
         Shape:
             see the docs in Transformer class.
         """

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -85,7 +85,8 @@ class Transformer(Module):
 
     def forward(self, src: Tensor, tgt: Tensor, src_mask: Optional[Tensor] = None, tgt_mask: Optional[Tensor] = None,
                 memory_mask: Optional[Tensor] = None, src_key_padding_mask: Optional[Tensor] = None,
-                tgt_key_padding_mask: Optional[Tensor] = None, memory_key_padding_mask: Optional[Tensor] = None) -> Tensor:
+                tgt_key_padding_mask: Optional[Tensor] = None, memory_key_padding_mask: Optional[Tensor] = None,
+                src_is_causal: bool = False, tgt_is_causal: bool = False, memory_is_causal: bool = False) -> Tensor:
         r"""Take in and process masked source/target sequences.
 
         Args:
@@ -97,6 +98,28 @@ class Transformer(Module):
             src_key_padding_mask: the Tensor mask for src keys per batch (optional).
             tgt_key_padding_mask: the Tensor mask for tgt keys per batch (optional).
             memory_key_padding_mask: the Tensor mask for memory keys per batch (optional).
+            src_is_causal: If specified, applies a causal mask as tgt mask.
+                Default: ``False``.
+                Warning:
+                ``src_is_causal`` provides a hint that ``src_mask`` is
+                the causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
+            tgt_is_causal: If specified, applies a causal mask as tgt mask.
+                Default: ``False``.
+                Warning:
+                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
+                the causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
+            memory_is_causal: If specified, applies a causal mask as
+                memory mask.
+                Default: ``False``.
+                Warning:
+                ``memory_is_causal`` provides a hint that
+                ``memory_mask`` is the causal mask. Providing incorrect
+                hints can result in incorrect execution, including
+                forward and backward compatibility.
 
         Shape:
             - src: :math:`(S, E)` for unbatched input, :math:`(S, N, E)` if `batch_first=False` or
@@ -142,10 +165,12 @@ class Transformer(Module):
         if src.size(-1) != self.d_model or tgt.size(-1) != self.d_model:
             raise RuntimeError("the feature number of src and tgt must be equal to d_model")
 
-        memory = self.encoder(src, mask=src_mask, src_key_padding_mask=src_key_padding_mask)
+        memory = self.encoder(src, mask=src_mask, src_key_padding_mask=src_key_padding_mask,
+                              is_causal=src_is_causal)
         output = self.decoder(tgt, memory, tgt_mask=tgt_mask, memory_mask=memory_mask,
                               tgt_key_padding_mask=tgt_key_padding_mask,
-                              memory_key_padding_mask=memory_key_padding_mask)
+                              memory_key_padding_mask=memory_key_padding_mask,
+                              tgt_is_causal=tgt_is_causal, memory_is_causal=memory_is_causal)
         return output
 
     @staticmethod

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -174,11 +174,14 @@ class Transformer(Module):
         return output
 
     @staticmethod
-    def generate_square_subsequent_mask(sz: int, device=None) -> Tensor:
+    def generate_square_subsequent_mask(sz: int, device=None, dtype=None) -> Tensor:
         r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
             Unmasked positions are filled with float(0.0).
         """
-        return torch.triu(torch.full((sz, sz), float('-inf'), device=device), diagonal=1)
+        return torch.triu(
+            torch.full((sz, sz), float('-inf'), device=device, dtype=dtype),
+            diagonal=1,
+        )
 
     def _reset_parameters(self):
         r"""Initiate parameters in the transformer model."""

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -178,7 +178,11 @@ class Transformer(Module):
         return output
 
     @staticmethod
-    def generate_square_subsequent_mask(sz: int, device=None, dtype=None) -> Tensor:
+    def generate_square_subsequent_mask(
+            sz: int,
+            device: Optional[torch.device] = None,
+            dtype: Optional[torch.dtype] = None,
+    ) -> Tensor:
         r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
             Unmasked positions are filled with float(0.0).
         """

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -331,14 +331,13 @@ class TransformerEncoder(Module):
         # Prevent type refinement
         make_causal = (is_causal is True)
 
-        if is_causal is None:
-            if mask is not None:
-                sz = mask.size(0)
-                causal_comparison = Transformer.generate_square_subsequent_mask(
-                    sz, device=mask.device, dtype=mask.dtype)
+        if is_causal is None and mask is not None:
+            sz = mask.size(0)
+            causal_comparison = Transformer.generate_square_subsequent_mask(
+                sz, device=mask.device, dtype=mask.dtype)
 
-                if torch.equal(mask, causal_comparison):
-                    make_causal = True
+            if torch.equal(mask, causal_comparison):
+                make_causal = True
 
         is_causal = make_causal
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -334,9 +334,8 @@ class TransformerEncoder(Module):
         if is_causal is None:
             if mask is not None:
                 sz = mask.size(0)
-                causal_comparison = torch.triu(
-                    torch.ones(sz, sz, device=mask.device) * float('-inf'), diagonal=1
-                ).to(mask.dtype)
+                causal_comparison = Transformer.generate_square_subsequent_mask(
+                    sz, device=mask.device, dtype=mask.dtype)
 
                 if torch.equal(mask, causal_comparison):
                     make_causal = True

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -336,8 +336,7 @@ class TransformerEncoder(Module):
             causal_comparison = Transformer.generate_square_subsequent_mask(
                 sz, device=mask.device, dtype=mask.dtype)
 
-            if torch.equal(mask, causal_comparison):
-                make_causal = True
+            make_causal = torch.equal(mask, causal_comparison)
 
         is_causal = make_causal
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -368,7 +368,7 @@ class TransformerDecoder(Module):
 
     def forward(self, tgt: Tensor, memory: Tensor, tgt_mask: Optional[Tensor] = None,
                 memory_mask: Optional[Tensor] = None, tgt_key_padding_mask: Optional[Tensor] = None,
-                memory_key_padding_mask: Optional[Tensor] = None, tgt_is_causal: bool = False,
+                memory_key_padding_mask: Optional[Tensor] = None, tgt_is_causal: Optional[bool] = None,
                 memory_is_causal: bool = False) -> Tensor:
         r"""Pass the inputs (and mask) through the decoder layer in turn.
 
@@ -380,7 +380,7 @@ class TransformerDecoder(Module):
             tgt_key_padding_mask: the mask for the tgt keys per batch (optional).
             memory_key_padding_mask: the mask for the memory keys per batch (optional).
             tgt_is_causal: If specified, applies a causal mask as tgt mask.
-                Default: ``False``.
+                Default: ``None``; try to detect a causal mask.
                 Warning:
                 ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
                 the causal mask. Providing incorrect hints can result in
@@ -399,6 +399,8 @@ class TransformerDecoder(Module):
             see the docs in Transformer class.
         """
         output = tgt
+
+        tgt_is_causal = _detect_is_causal_mask(tgt_mask, tgt_is_causal)
 
         for mod in self.layers:
             output = mod(output, memory, tgt_mask=tgt_mask,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -233,7 +233,7 @@ class TransformerEncoder(Module):
             mask: the mask for the src sequence (optional).
             src_key_padding_mask: the mask for the src keys per batch (optional).
             is_causal: If specified, applies a causal mask as mask.
-                Default: ``False``.
+                Default: ``None``; try to detect a causal mask.
                 Warning:
                 ``is_causal`` provides a hint that ``mask`` is the
                 causal mask. Providing incorrect hints can result in

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -203,9 +203,13 @@ class TransformerEncoder(Module):
         Args:
             src: the sequence to the encoder (required).
             mask: the mask for the src sequence (optional).
-            is_causal: If specified, applies a causal mask as mask (optional)
-                and ignores attn_mask for computing scaled dot product attention.
+            is_causal: If specified, applies a causal mask as mask.
                 Default: ``False``.
+                Warning:
+                ``is_causal`` provides a hint that ``mask`` is the
+                causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
             src_key_padding_mask: the mask for the src keys per batch (optional).
 
         Shape:
@@ -361,9 +365,20 @@ class TransformerDecoder(Module):
             tgt_key_padding_mask: the mask for the tgt keys per batch (optional).
             memory_key_padding_mask: the mask for the memory keys per batch (optional).
             tgt_is_causal: If specified, applies a causal mask as tgt mask.
-                Mutually exclusive with providing tgt_mask. Default: ``False``.
-            memory_is_causal: If specified, applies a causal mask as memory mask.
-                Mutually exclusive with providing memory_mask. Default: ``False``.
+                Default: ``False``.
+                Warning:
+                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
+                the causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
+            memory_is_causal: If specified, applies a causal mask as
+                memory mask.
+                Default: ``False``.
+                Warning:
+                ``memory_is_causal`` provides a hint that
+                ``memory_mask`` is the causal mask. Providing incorrect
+                hints can result in incorrect execution, including
+                forward and backward compatibility.
 
         Shape:
             see the docs in Transformer class.
@@ -493,8 +508,13 @@ class TransformerEncoderLayer(Module):
         Args:
             src: the sequence to the encoder layer (required).
             src_mask: the mask for the src sequence (optional).
-            is_causal: If specified, applies a causal mask as src_mask.
-              Default: ``False``.
+            is_causal: If specified, applies a causal mask as src mask.
+                Default: ``False``.
+                Warning:
+                ``is_causal`` provides a hint that ``src_mask`` is the
+                causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
             src_key_padding_mask: the mask for the src keys per batch (optional).
 
         Shape:
@@ -706,9 +726,20 @@ class TransformerDecoderLayer(Module):
             tgt_key_padding_mask: the mask for the tgt keys per batch (optional).
             memory_key_padding_mask: the mask for the memory keys per batch (optional).
             tgt_is_causal: If specified, applies a causal mask as tgt mask.
-                Mutually exclusive with providing tgt_mask. Default: ``False``.
-            memory_is_causal: If specified, applies a causal mask as memory mask.
-                Mutually exclusive with providing memory_mask. Default: ``False``.
+                Default: ``False``.
+                Warning:
+                ``tgt_is_causal`` provides a hint that ``tgt_mask`` is
+                the causal mask. Providing incorrect hints can result in
+                incorrect execution, including forward and backward
+                compatibility.
+            memory_is_causal: If specified, applies a causal mask as
+                memory mask.
+                Default: ``False``.
+                Warning:
+                ``memory_is_causal`` provides a hint that
+                ``memory_mask`` is the causal mask. Providing incorrect
+                hints can result in incorrect execution, including
+                forward and backward compatibility.
         Shape:
             see the docs in Transformer class.
         """


### PR DESCRIPTION
Adjust documentation according to #97214 and implement `is_causal` API for `Transformer`.
As discussed in #97166.