### PR TITLE
[MPS] Add `random_` overload

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -6,6 +6,7 @@
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <type_traits>
 
 namespace at::native {
 namespace mps {
@@ -316,16 +317,16 @@ Tensor& random_mps_(Tensor& self, int64_t from, c10::optional<int64_t> to_opt, c
           });
     } else if (isIntegralType(input_dtype, /*includeBool=*/true)) {
       AT_DISPATCH_INTEGRAL_TYPES_AND(at::ScalarType::Bool, input_dtype, "random_from_to_range_calc", [&] {
-        if (std::is_same<scalar_t, bool>::value) {
-          to = static_cast<int64_t>(true);
+        if constexpr (std::is_same_v<scalar_t, int64_t>) {
+          to = std::numeric_limits<int64_t>::max();
         } else {
-          to = static_cast<int64_t>(std::numeric_limits<scalar_t>::max());
+          to = static_cast<uint64_t>(std::numeric_limits<scalar_t>::max()) + 1;
         }
       });
     } else {
       TORCH_CHECK(false, "random_mps_ handles only integral, floating-point and boolean types");
     }
-    templates::check_from_to_in_range(from, to, self.dtype());
+    templates::check_from_to_in_range(from, to - 1, self.dtype());
   } else {
     // [std::numeric_limits<int64_t>::lowest(), std::numeric_limits<int64_t>::max()]
     // range = 2^64
@@ -340,6 +341,10 @@ Tensor& random_mps_(Tensor& self, int64_t from, c10::optional<int64_t> to_opt, c
 
 Tensor& random_mps_(Tensor& self, int64_t to, c10::optional<Generator> gen) {
   return random_mps_(self, 0, to, gen);
+}
+
+Tensor& random_mps_(Tensor& self, c10::optional<Generator> gen) {
+  return random_mps_(self, 0, c10::nullopt, gen);
 }
 
 // Exponential distribution

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -6,7 +6,6 @@
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <type_traits>
 
 namespace at::native {
 namespace mps {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8123,6 +8123,7 @@
   variants: method
   dispatch:
     CPU, CUDA: random_
+    MPS: random_mps_
     Meta: random_meta_
   autogen: random, random.out
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7174,7 +7174,7 @@ class TestNLLLoss(TestCaseMPS):
         self.assertTrue(current_alloc_after > current_alloc_before)
         self.assertTrue(driver_alloc_after > driver_alloc_before)
 
-    # Test random_.to and random_.from
+    # Test random_, random_.to and random_.from
     def test_random(self):
         def helper(shape, low, high, dtype=torch.int32):
 
@@ -7182,14 +7182,20 @@ class TestNLLLoss(TestCaseMPS):
 
             # We can't check reliably the mean and std.
             # Just make sure we don't return constant values
-            self.assertNotEqual(mps_out.to('cpu').float().mean(), 0.)
-            self.assertNotEqual(mps_out.to('cpu').float().std(), 0.)
+            self.assertNotEqual(mps_out.float().mean().item(), 0.)
+            self.assertNotEqual(mps_out.float().std().item(), 0.)
 
         helper([100, 100], 0, 10)
         helper([100, 100], 23, 89)
         helper([100, 100], 23, 89, dtype=torch.float32)
         helper([100, 100], 23, 89, dtype=torch.int64)
         helper([100, 100], 0, 2, dtype=torch.bool)
+
+        # Test random_
+        for dtype in [torch.bool, torch.int8, torch.uint8, torch.int32, torch.float16, torch.float32]:
+            x = torch.empty(10, 10, dtype=dtype, device='mps')
+            x.random_()
+            self.assertNotEqual(x.abs().max().item(), 0)
 
     # Test exponential
     def test_exponential(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7195,7 +7195,7 @@ class TestNLLLoss(TestCaseMPS):
         for dtype in [torch.bool, torch.int8, torch.uint8, torch.int32, torch.float16, torch.float32]:
             x = torch.empty(10, 10, dtype=dtype, device='mps')
             x.random_()
-            self.assertNotEqual(x.abs().max().item(), 0)
+            self.assertNotEqual(x.max().item(), 0)
 
     # Test exponential
     def test_exponential(self):


### PR DESCRIPTION
That simply calls `torch.random_(from=0, to=None)`

Also, fix optional upper bound calculation for all `dtypes` but int64:
As one can see from https://pytorch.org/docs/stable/generated/torch.Tensor.random_.html
`from` boundary is inclusive, but `to` is exclusive, i.e. if `to` is
omitted for `torch.int8` dtype, it should be set to `128` and to `2`
for torch.bool.

Add test for `torch.random_`

Fixes https://github.com/pytorch/pytorch/issues/98118
