### PR TITLE
Change dynamo cache limit to avoid excessive recompilation

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -40,8 +40,11 @@ minimum_call_count = 1
 # turn on/off DCE pass
 dead_code_elimination = True
 
-# disable (for a function) when cache reaches this size
-cache_size_limit = 64
+# Try recompiling a particular function (or frame) this many times
+# (due to changing input shapes or other guard failures)
+# and then use eager execution for any subsequent new inputs that do not
+# match already compiled versions.
+cache_size_limit = 3
 
 # whether or not to specialize on int inputs.  This only has an effect with
 # dynamic_shapes; when dynamic_shapes is False, we ALWAYS specialize on int


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98337

Why limit to 3? 64 is too big, 1 may be too small.

Open to consider any value between 1 and 3...

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @soumith @desertfire