### PR TITLE
[pt2][inductor] hardcode autotuning names

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -101,7 +101,7 @@ def tuned_bmm(mat1, mat2, *, layout=None):
                 )
             )
 
-    return autotune_select_algorithm(choices, [mat1, mat2], layout)
+    return autotune_select_algorithm("bmm", choices, [mat1, mat2], layout)
 
 
 # Don't register this since it is slower than decomposing it
@@ -123,4 +123,4 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 )
             )
 
-    return autotune_select_algorithm(choices, [inp, mat1, mat2], layout)
+    return autotune_select_algorithm("baddbmm", choices, [inp, mat1, mat2], layout)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -383,7 +383,7 @@ def convolution(
                 )
             )
 
-    return autotune_select_algorithm(choices, args, layout)
+    return autotune_select_algorithm("convolution", choices, args, layout)
 
 
 @register_lowering(aten._convolution)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -115,7 +115,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
                 )
             )
 
-    return autotune_select_algorithm(choices, [mat1, mat2], layout)
+    return autotune_select_algorithm("mm", choices, [mat1, mat2], layout)
 
 
 @register_lowering(aten._int_mm)
@@ -135,7 +135,7 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
                     **mm_options(config, k, layout),
                 )
             )
-    return autotune_select_algorithm(choices, [mat1, mat2], layout)
+    return autotune_select_algorithm("int_mm", choices, [mat1, mat2], layout)
 
 
 @register_lowering(aten.addmm)
@@ -143,7 +143,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp_expanded = mm_args(mat1, mat2, inp, layout=layout)
     if not use_triton_template(layout):
         choices = [aten_addmm.bind((inp, mat1, mat2), layout, alpha=alpha, beta=beta)]
-        return autotune_select_algorithm(choices, [inp, mat1, mat2], layout)
+        return autotune_select_algorithm("addmm", choices, [inp, mat1, mat2], layout)
 
     choices = [
         aten_addmm.bind((inp_expanded, mat1, mat2), layout, alpha=alpha, beta=beta)
@@ -168,4 +168,6 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
             )
         )
 
-    return autotune_select_algorithm(choices, [inp_expanded, mat1, mat2], layout)
+    return autotune_select_algorithm(
+        "addmm", choices, [inp_expanded, mat1, mat2], layout
+    )

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -168,4 +168,6 @@ def tuned_mm_plus_mm(mat1, mat2, mat3, mat4, *, layout=None):
                     )
                 )
 
-    return autotune_select_algorithm(choices, [mat1, mat2, mat3, mat4], layout)
+    return autotune_select_algorithm(
+        "mm_plus_mm", choices, [mat1, mat2, mat3, mat4], layout
+    )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -649,7 +649,7 @@ class ErrorFromChoice(RuntimeError):
 
 
 class AlgorithmSelectorCache(PersistentCache):
-    def __call__(self, choices: List[ChoiceCaller], input_nodes, layout):
+    def __call__(self, name, choices: List[ChoiceCaller], input_nodes, layout):
         # TODO(nmacchioni): remove once CI tests are fixed
         choices = [choice for choice in choices if choice is not None]
         assert len(choices) > 0, "no choices to select"
@@ -700,7 +700,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
         if make_benchmark_fn.cache_info().currsize:
             counters["inductor"]["select_algorithm_autotune"] += 1
-            self.log_results(choices[0].name, input_nodes, timings, autotune_elapse)
+            self.log_results(name, input_nodes, timings, autotune_elapse)
         return builtins.min(timings, key=timings.__getitem__).output_node()
 
     @classmethod


### PR DESCRIPTION
Summary: switch to hardcoded autotuning names, we want consistency incase the default choice changes

Test Plan: CI

Differential Revision: D44643318



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire