### PR TITLE
[CI] Mark sebotnet33ts_256 as nondeterministic

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -80,6 +80,11 @@ SKIP_TRAIN = {
     "eca_halonext26ts",
 }
 
+NONDETERMINISTIC = {
+    # https://github.com/pytorch/pytorch/issues/94066
+    "sebotnet33ts_256",
+}
+
 MAX_BATCH_SIZE_FOR_ACCURACY_CHECK = {
     "cait_m36_384": 4,
 }

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -136,6 +136,7 @@ REQUIRE_COSINE_TOLERACE = {
 
 # non-deterministic output / cant check correctness
 NONDETERMINISTIC = {
+    # https://github.com/pytorch/pytorch/issues/98355
     "mobilenet_v3_large",
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98356

Summary: The goal is make sure the new dashboard doesn't give noisy
alert on this test.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx