### PR TITLE
Change daily aggregates upload job to use sum and occurence counter instead of averages

### DIFF
--- a/tools/stats/upload_test_stat_aggregates.py
+++ b/tools/stats/upload_test_stat_aggregates.py
@@ -52,7 +52,7 @@ def get_test_stat_aggregates(date: datetime.date) -> Any:
     ]
     api_response = rs.QueryLambdas.execute_query_lambda(
         query_lambda=lambda_function_name,
-        version="865e3748f31e9b59",
+        version="71062190c39485ac",
         parameters=query_parameters,
     )
     for i in range(len(api_response["results"])):

--- a/tools/stats/upload_test_stat_aggregates.py
+++ b/tools/stats/upload_test_stat_aggregates.py
@@ -52,7 +52,7 @@ def get_test_stat_aggregates(date: datetime.date) -> Any:
     ]
     api_response = rs.QueryLambdas.execute_query_lambda(
         query_lambda=lambda_function_name,
-        version="71062190c39485ac",
+        version="d1e2d7f3f3ef2e5e",
         parameters=query_parameters,
     )
     for i in range(len(api_response["results"])):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98359


We used to keep track of the average of stats, however, when we munge the data to find interesting insights this makes things difficult (ie. finding total test time for an oncall). The pin is updated such that we keep track of the sum instead as well as an "occurrences" field such that the average can be rederived from sum/occurrences. 
