### PR TITLE
[Sparse] Raise exception when expand is called on sparse tensor

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1107,7 +1107,7 @@ Tensor expand(const Tensor& self, c10::IntArrayRef size, bool /*unused*/) {
            "): the number of sizes provided (", size.size(), ") ",
            "must be greater or equal to the number of dimensions in the tensor (",
            self.dim(), ")");
-  TORCH_CHECK(!self.is_sparse() && !self.is_sparse_csr(), 
+  TORCH_CHECK(!self.is_sparse() && !at::sparse_csr::is_sparse_compressed(self),
             "expand is unsupported for ", self.layout(), " tensors");
 
   auto expandedSizesAndStrides = inferExpandGeometry_dimvector(self.sizes(), self.strides(), size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1107,6 +1107,8 @@ Tensor expand(const Tensor& self, c10::IntArrayRef size, bool /*unused*/) {
            "): the number of sizes provided (", size.size(), ") ",
            "must be greater or equal to the number of dimensions in the tensor (",
            self.dim(), ")");
+  TORCH_CHECK(!self.is_sparse() && !self.is_sparse_csr(), 
+            "expand is unsupported for ", self.layout(), " tensors");
 
   auto expandedSizesAndStrides = inferExpandGeometry_dimvector(self.sizes(), self.strides(), size);
 


### PR DESCRIPTION
It's already not working, but this makes error message a bit more readable. I.e. it turns:
```
% python -c "import torch;x=torch.eye(3).to_sparse().expand(3,3)" 
```

from
```
NotImplementedError: Could not run 'aten::as_strided' with arguments from the 'SparseCPU' backend.
```
to
```
RuntimeError: Expand is unsupported for Sparse tensors.
```



cc @alexsamardzic @nikitaved @pearu @cpuhrsch @amjames @bhosmer