### PR TITLE
[c10d] delete lengths offset checks

### DIFF
--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -477,10 +477,6 @@ size_t computeLengthsAndOffsets(
   size_t offset = 0;
   for(const auto i : c10::irange(group_size)) {
     size_t length = tensors[i].numel();
-    TORCH_INTERNAL_ASSERT(
-        length <= std::numeric_limits<int>::max() &&
-            offset <= std::numeric_limits<int>::max(),
-        "Length or offset larger than INT_MAX not supported");
     (*lengths)[i] = length;
     (*offsets)[i] = offset;
     offset += length;

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -460,12 +460,9 @@ size_t computeLengthsAndOffsets(
   }
   for(const auto i : c10::irange(group_size)) {
     size_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
-    TORCH_INTERNAL_ASSERT(
-        length <= std::numeric_limits<int>::max() &&
-            offset <= std::numeric_limits<int>::max(),
-        "Length or offset larger than INT_MAX not supported");
     (*lengths)[i] = length;
     (*offsets)[i] = offset;
+    // TODO: see if we should add overflow protection for offset
     offset += length;
   }
   return offset;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98368

According to @kwen2501, NCCL supports up to size_t send counts, so
PGNCCL shouldn't restrict it

A follow up is to think about whether we should add overflow protection
of offset