### PR TITLE
Move android-emulator-build-test to periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -280,3 +280,12 @@ jobs:
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
+
+  android-emulator-build-test:
+    name: android-emulator-build-test
+    uses: ./.github/workflows/_run_android_tests.yml
+    with:
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
+        ]}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -201,12 +201,3 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
-  android-emulator-build-test:
-    name: android-emulator-build-test
-    uses: ./.github/workflows/_run_android_tests.yml
-    with:
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
-        ]}


### PR DESCRIPTION
Per internal discussion, this test is only to verify open source Android build, and it's not critical to run it on every commit.