### PR TITLE
Revert "[spmd expansion] support torch.ops.aten.sym_numel (#98229)"

### DIFF
--- a/torch/distributed/_spmd/distribute.py
+++ b/torch/distributed/_spmd/distribute.py
@@ -492,14 +492,11 @@ def _convert_to_distributed(
                     return arg
 
             args = tree_map(_remap_arg, node.args)
-            if node.target == torch.ops.aten.sym_numel:
-                node_to_obj[node] = args[0].numel()
-            else:
-                assert (
-                    len(args) >= 2
-                ), f"Expected number of args for call function to be at least 2, found {len(args)} {node}"
-                # TODO(anj): Why do we assume this is only 2?
-                node_to_obj[node] = node.target(args[0], args[1])
+            assert (
+                len(args) >= 2
+            ), f"Expected number of args for call function to be at least 2, found {len(args)}"
+            # TODO(anj): Why do we assume this is only 2?
+            node_to_obj[node] = node.target(args[0], args[1])
         else:
             raise ValueError(f"Unrecognized node.op type {node.op}")
 


### PR DESCRIPTION
This reverts commit 4d13fcddeff01bc7d44f752173e8efecf25fcf9b.

Fixes diff train landing issue as the original diff was modified after the PR was merged in OSS. 
