### PR TITLE
Allow discontiguous NestedTensors to empty_like

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -14,6 +14,7 @@ namespace at {
 namespace native {
 struct NestedTensorImpl;
 inline bool nested_tensor_impl_is_contiguous(const NestedTensorImpl* nt);
+int64_t get_numel_from_nested_size_tensor(const at::Tensor& tensor);
 
 struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   explicit NestedTensorImpl(

--- a/aten/src/ATen/native/nested/NestedTensorFactories.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.cpp
@@ -13,22 +13,19 @@ TensorOptions verify_empty_parameters(
     c10::optional<Device> device,
     c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TensorOptions options_ =
-      TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
-          pin_memory);
+  TensorOptions options_ = TensorOptions()
+                               .dtype(dtype)
+                               .layout(layout)
+                               .device(device)
+                               .pinned_memory(pin_memory)
+                               .memory_format(optional_memory_format);
 
-  TORCH_CHECK(
-      !(options_.has_memory_format() && optional_memory_format.has_value()),
-      "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-      "the redundant setter.");
-  TensorOptions options = self.options().merge_in(options_).merge_memory_format(
-      optional_memory_format);
-
+  TensorOptions options = self.options().merge_in(options_);
   auto memory_format =
       options_.memory_format_opt().value_or(MemoryFormat::Preserve);
   TORCH_CHECK(
-      memory_format == MemoryFormat::Preserve,
-      "empty_like_nested only supports memory format Preserve, but got ",
+      memory_format == MemoryFormat::Preserve || memory_format == MemoryFormat::Contiguous,
+      "empty_like_nested only supports memory format Preserve or Contiguous, but got ",
       memory_format,
       " instead.");
 
@@ -50,12 +47,24 @@ Tensor empty_like_nested(
   auto self_nt = get_nested_tensor_impl(self);
   // Since we clone sizes, strides, and offsets it should be safe to use
   // get_unsafe_storage_as_tensor for the call to empty like.
-  Tensor new_buffer = at::empty_like(self_nt->get_unsafe_storage_as_tensor(), options);
+  auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Preserve);
+  if (memory_format == MemoryFormat::Contiguous) {
+    Tensor new_buffer = at::empty_like(
+        self_nt->get_unsafe_storage_as_tensor(), options);
+    auto nested_size = self_nt->get_nested_sizes().clone();
+    auto tensor = wrap_buffer(new_buffer, nested_size);
+    return tensor;
+  }
+  // The fall through path must be Preserve
+  TORCH_CHECK(
+      memory_format == MemoryFormat::Preserve,
+      "memory format option is only supported by strided tensors");
+  Tensor new_buffer =
+      at::empty_like(self_nt->get_unsafe_storage_as_tensor(), options);
   auto nested_size = self_nt->get_nested_sizes().clone();
   auto nested_strides = self_nt->get_nested_strides().clone();
   auto offsets = self_nt->get_storage_offsets().clone();
-  auto tensor = detail::make_tensor_base<NestedTensorImpl>(
-      new_buffer, nested_size, nested_strides, offsets);
+  auto tensor = wrap_buffer(new_buffer, nested_size, nested_strides, offsets);
   return tensor;
 }
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2036,8 +2036,8 @@ class TestNestedTensorDeviceType(TestCase):
         nt_cont, nt_noncont = random_nt_noncontiguous_pair((2, 3, 6, 7))
         nt_empty = torch.empty_like(nt_cont)
         assert nt_cont.is_same_size(nt_empty)
-        with self.assertRaisesRegex(RuntimeError, "empty_like only supports contiguous memory format for Nested Tensors"):
-            nt_empty = torch.empty_like(nt_noncont)
+        nt_empty_non_contig = torch.empty_like(nt_noncont)
+        assert nt_noncont.is_same_size(nt_empty_non_contig)
 
 
 class TestNestedTensorAutograd(TestCase):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2032,13 +2032,27 @@ class TestNestedTensorDeviceType(TestCase):
         nt_empty_req_grad = torch.empty_like(nt, requires_grad=True)
         self.assertEqual(nt_empty_req_grad.requires_grad, True)
 
-        # Test noncontiguous tensor fails to copy
+        # Test noncontiguous tensor does not fail to copy
         nt_cont, nt_noncont = random_nt_noncontiguous_pair((2, 3, 6, 7))
         nt_empty = torch.empty_like(nt_cont)
         assert nt_cont.is_same_size(nt_empty)
         nt_empty_non_contig = torch.empty_like(nt_noncont)
         assert nt_noncont.is_same_size(nt_empty_non_contig)
 
+        # Test the contiguous memory format option
+        nt_empty_contig = torch.empty_like(nt_cont, memory_format=torch.contiguous_format)
+        assert nt_cont.is_same_size(nt_empty_contig)
+        assert nt_empty_contig.is_contiguous()
+
+        nt_empty_non_contig = torch.empty_like(nt_noncont, memory_format=torch.contiguous_format)
+        assert nt_noncont.is_same_size(nt_empty_non_contig)
+        assert nt_empty_non_contig.is_contiguous()
+
+        # Test other memory formats fail
+        self.assertRaises(RuntimeError, lambda: torch.empty_like(nt_cont, memory_format=torch.channels_last))
+        self.assertRaises(RuntimeError, lambda: torch.empty_like(nt_noncont, memory_format=torch.channels_last))
+        self.assertRaises(RuntimeError, lambda: torch.empty_like(nt_cont, memory_format=torch.channels_last_3d))
+        self.assertRaises(RuntimeError, lambda: torch.empty_like(nt_noncont, memory_format=torch.channels_last_3d))
 
 class TestNestedTensorAutograd(TestCase):
     # Note [Gradcheck args check_batched_grad=False] the common_utils testing version of gradcheck


### PR DESCRIPTION
# Summary
Preivously we disallowd dis-contiguous NTs to passed into to empty_like. This was done out of an abundance of caution, :think:. However it should be safe to create an empty NT for dis-contiguous NTs. Empty like does account for offsets, strides, and sizes in construction of the result and therefore this should be safe.

cc @cpuhrsch @jbschlosser @bhosmer