### PR TITLE
[spmd expansion] support torch.ops.aten.sym_numel

### DIFF
--- a/torch/distributed/_spmd/distribute.py
+++ b/torch/distributed/_spmd/distribute.py
@@ -492,11 +492,14 @@ def _convert_to_distributed(
                     return arg
 
             args = tree_map(_remap_arg, node.args)
-            assert (
-                len(args) >= 2
-            ), f"Expected number of args for call function to be at least 2, found {len(args)}"
-            # TODO(anj): Why do we assume this is only 2?
-            node_to_obj[node] = node.target(args[0], args[1])
+            if node.target == torch.ops.aten.sym_numel:
+                node_to_obj[node] = args[0].numel()
+            else:
+                assert (
+                    len(args) >= 2
+                ), f"Expected number of args for call function to be at least 2, found {len(args)} {node}"
+                # TODO(anj): Why do we assume this is only 2?
+                node_to_obj[node] = node.target(args[0], args[1])
         else:
             raise ValueError(f"Unrecognized node.op type {node.op}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98392
* #98391
* #98390
* #98389
* __->__ #98388

The current logic assumes non-overload ops takes two arguments however torch.ops.aten.sym_numel takes one.