### PR TITLE
[spmd expansion] speed up expansion by ~5x

### DIFF
--- a/torch/distributed/_spmd/distribute.py
+++ b/torch/distributed/_spmd/distribute.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from enum import auto, Enum
 from functools import partial
-from typing import cast, Dict, List, Optional, Sequence, Set, Tuple
+from typing import cast, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 import torch.fx as fx
@@ -18,7 +18,7 @@ from torch.distributed._spmd.experimental_ops import *  # noqa: F401, F403
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed._tensor.dispatch import (
     _CURRENT_DECOMPOSITION_TABLE,
-    operator_dispatch,
+    _operator_dispatch,
 )
 from torch.distributed._tensor.placement_types import _Partial, Placement
 from torch.distributed._tensor.redistribute import _redistribute_with_local_tensor
@@ -120,10 +120,36 @@ def _update_specs_for_redistribute(args, target_schema, redistribute):
     return specs, unflattened_args
 
 
+# When no tensor redistribution is required, we only need to update non-tensor args
+# of the node according to op_schema and avoid building a GraphModule just for the
+# node.
+def _update_node_from_op_schema(node: torch.fx.Node, op_schema: OpSchema) -> None:
+    flat_args, args_tree_spec = tree_flatten(node.args)
+    flat_args_schema, _ = tree_flatten(op_schema.args_schema)
+
+    def is_sym_int_or_int(arg: Union[int, torch.fx.Node]) -> bool:
+        if isinstance(arg, torch.fx.Node):
+            return arg.target in [
+                torch.ops.aten.sym_size,
+                torch.ops.aten.sym_numel,
+                torch.ops.aten.sym_stride,
+            ]
+        return isinstance(arg, int)
+
+    assert len(flat_args) == len(flat_args_schema)
+    for i, (arg, arg_schema) in enumerate(zip(flat_args, flat_args_schema)):
+        if is_sym_int_or_int(arg) and isinstance(arg_schema, int):
+            flat_args[i] = arg_schema
+
+    args = tree_unflatten(flat_args, args_tree_spec)
+    for idx, arg in enumerate(args):
+        node.update_arg(idx, arg)
+    return None
+
+
 def _get_dtensor_dispatch_graph(
-    node: fx.Node,
-    node_to_obj: Dict[fx.Node, object],
-) -> fx.GraphModule:
+    node: fx.Node, node_to_obj: Dict[fx.Node, object], force_make_fx: bool = False
+) -> Optional[fx.GraphModule]:
     def _remap_arg(arg: object) -> object:
         if isinstance(arg, torch.fx.Node):
             obj = node_to_obj[arg]
@@ -144,7 +170,7 @@ def _get_dtensor_dispatch_graph(
         op_overload = cast(torch._ops.OpOverload, node.target)
 
         # run dispatch once to get the real DTensor output.
-        out = operator_dispatch(
+        out, op_schema, output_sharding = _operator_dispatch(
             op_overload,
             args,
             kwargs,  # kwargs in this set of tests are all constants
@@ -152,16 +178,15 @@ def _get_dtensor_dispatch_graph(
         )
         node_to_obj[node] = out
 
-        op_schema = DTensor._propagator.prepare_op_schema(op_overload, args, kwargs)
-        # get DTensor specs for inputs and outputs
-        output_sharding = DTensor._propagator.propagate_op_sharding(
-            op_overload,
-            op_schema,
-        )
-
         assert output_sharding.schema_suggestions is not None
         target_schema = output_sharding.schema_suggestions[0]
         redistribute = target_schema is not op_schema
+
+        # If no redistribution is needed, we don't need to replace
+        # the original node.
+        if not redistribute:
+            _update_node_from_op_schema(node, target_schema)
+            return None
 
         # TODO: this is broken when kwargs contains tensors
         # or if a non-tensor kwarg was modified by the sharding propagation
@@ -223,7 +248,10 @@ def _build_dummy_add_graph(
         zero, dt.device_mesh, [Replicate()], run_check=False
     )
 
-    traced_dispatch = _get_dtensor_dispatch_graph(call_functions[0], node_to_obj)
+    traced_dispatch = _get_dtensor_dispatch_graph(
+        call_functions[0], node_to_obj, force_make_fx=True
+    )
+    assert traced_dispatch is not None
 
     # TODO(anj): This depends on the call function node -> actual DTensor output
     # mapping that we want to avoid for SPMD expansion
@@ -458,7 +486,9 @@ def _convert_to_distributed(
             )
 
         elif isinstance(node.target, torch._ops.OpOverload):
-            node_replacements[node] = _get_dtensor_dispatch_graph(node, node_to_obj)
+            replacement = _get_dtensor_dispatch_graph(node, node_to_obj)
+            if replacement is not None:
+                node_replacements[node] = replacement
         elif node.op == OP.OUTPUT:
             if not _allow_partial:
                 # Returns an expanded dummy add node that ensures


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98392
* #98391
* #98390
* __->__ #98389
* #98388

According to profiling, the top two expensive operations in spmd expansion are propagate_op_sharding and make_fx (for every dispatcher op node). This PR makes the following changes to speed up spmd expansion:
- We are unneccessarily doing propagate_op_sharding twice for every op. Remove one.
- When no tensor redistribution is required, we only need to update non-tensor args of the node according to op_schema and avoid building a GraphModule just for the node.

On a DDP use cases + foreach Adam, this change speeds up spmd expansion by ~5x (~10 min -> ~2 min).