### PR TITLE
[TEST] update NVIDIA driver in CI to 525.105.17

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -32,7 +32,7 @@ if ! command -v aws >/dev/null; then
 fi
 
 if [ -n "${USE_CUDA_DOCKER_RUNTIME:-}" ]; then
-  DRIVER_FN="NVIDIA-Linux-x86_64-515.76.run"
+  DRIVER_FN="NVIDIA-Linux-x86_64-525.105.17.run"
   wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
   sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
   nvidia-smi


### PR DESCRIPTION
Updates the NVIDIA driver to `525.105.17` (the current Datacenter driver) for CUDA 12.x

CC @malfet @atalman 