### PR TITLE
[BE] Fix `collect_env` for python-path-with-space

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -376,7 +376,7 @@ def get_pip_packages(run_lambda):
     """Returns `pip list` output. Note: will also find conda-installed pytorch
     and numpy packages."""
     # People generally have `pip` as `pip` or `pip3`
-    # But here it is incoved as `python -mpip`
+    # But here it is invoked as `python -mpip`
     def run_with_pip(pip):
         out = run_and_read_all(run_lambda, pip + ["list", "--format=freeze"])
         return "\n".join(

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -49,8 +49,9 @@ SystemEnv = namedtuple('SystemEnv', [
 
 def run(command):
     """Returns (return-code, stdout, stderr)"""
+    shell = True if type(command) is str else False
     p = subprocess.Popen(command, stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE, shell=True)
+                         stderr=subprocess.PIPE, shell=shell)
     raw_output, raw_err = p.communicate()
     rc = p.returncode
     if get_platform() == 'win32':
@@ -377,7 +378,7 @@ def get_pip_packages(run_lambda):
     # People generally have `pip` as `pip` or `pip3`
     # But here it is incoved as `python -mpip`
     def run_with_pip(pip):
-        out = run_and_read_all(run_lambda, "{} list --format=freeze".format(pip))
+        out = run_and_read_all(run_lambda, pip + ["list", "--format=freeze"])
         return "\n".join(
             line
             for line in out.splitlines()
@@ -394,7 +395,7 @@ def get_pip_packages(run_lambda):
         )
 
     pip_version = 'pip3' if sys.version[0] == '3' else 'pip'
-    out = run_with_pip(sys.executable + ' -mpip')
+    out = run_with_pip([sys.executable, '-mpip'])
 
     return pip_version, out
 


### PR DESCRIPTION
By invoking [`Popen`](https://docs.python.org/2.7/library/subprocess.html#popen-constructor) with list of command line arguments, rather than strings that would be parsed by shell.

Test plan:
```shell
% conda create -n py311 python=3.11
% cd ~/miniconda3/envs
% cp -a py311 py\ 311
% ./py\ 311/bin/python -mtorch.utils.collect_env
```

Fixes https://github.com/pytorch/pytorch/issues/98385
