### PR TITLE
remove //c10:headers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -314,7 +314,7 @@ cc_library(
         "aten/src",
     ],
     deps = [
-        "//c10:headers",
+        "//c10",
     ],
 )
 
@@ -383,7 +383,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":aten_headers",
-        "//c10:headers",
+        "//c10",
         "@cuda",
         "@cuda//:cuda_driver",
         "@cuda//:nvrtc",
@@ -1262,7 +1262,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_core_macros",
-        "//c10:headers",
+        "//c10",
         "//caffe2/proto:caffe2_pb",
     ],
 )
@@ -1579,7 +1579,7 @@ cc_library(
     deps = [
         ":aten_headers",
         ":caffe2_headers",
-        "//c10:headers",
+        "//c10",
         "@com_github_google_flatbuffers//:flatbuffers",
         "@local_config_python//:python_headers",
         "@onnx",

--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -28,25 +28,3 @@ config_setting(
     name = "using_glog",
     flag_values = {":use_glog": "true"},
 )
-
-cc_library(
-    name = "headers",
-    hdrs = [
-        "//c10/core:headers",
-        "//c10/cuda:headers",
-        "//c10/mobile:headers",
-        "//c10/util:headers",
-    ],
-    deps = [
-        "//c10/core:alignment",
-        "//c10/cuda:Macros",
-        "//c10/macros:macros",
-    ] + select({
-        ":using_gflags": ["@com_github_gflags_gflags//:gflags"],
-        "//conditions:default": [],
-    }) + select({
-        ":using_glog": ["@com_github_glog//:glog"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98418
* #98417
* __->__ #98420

The c10 library is light enough that there's not really much benefit
to being very unbazel-y and providing an incomplete library that lacks
the source files.

Differential Revision: [D44713077](https://our.internmc.facebook.com/intern/diff/D44713077/)