### PR TITLE
rewrite at::vec::*::convert_to_int_of_same_size

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -14,6 +14,8 @@
 // See https://github.com/pytorch/pytorch/issues/37577 for an instance
 // of this bug in the past.
 
+#include <array>
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <functional>
@@ -957,16 +959,17 @@ inline Vectorized<dst_t> cast(const Vectorized<src_t>& src) {
   return CastImpl<dst_t, src_t>::apply(src);
 }
 
-template <typename T>
-inline Vectorized<int_same_size_t<T>> convert_to_int_of_same_size(const Vectorized<T>& src) {
+template <typename T, typename IntType = int_same_size_t<T>>
+inline Vectorized<IntType> convert_to_int_of_same_size(const Vectorized<T>& src) {
+  static_assert(sizeof(T) == sizeof(IntType));
   static constexpr int size = Vectorized<T>::size();
-  T src_arr[size];
-  src.store(static_cast<void*>(src_arr));
-  int_same_size_t<T> buffer[size];
-  for (const auto i : c10::irange(size)) {
-    buffer[i] = static_cast<int_same_size_t<T>>(src_arr[i]);
-  }
-  return Vectorized<int_same_size_t<T>>::loadu(static_cast<void*>(buffer));
+
+  std::array<T, size> src_arr;
+  src.store(static_cast<void*>(src_arr.data()));
+  std::array<IntType, size> buffer;
+  std::transform(src_arr.cbegin(), src_arr.cend(), buffer.begin(),
+                 [](const T& x) { return static_cast<IntType>(x); });
+  return Vectorized<IntType>::loadu(static_cast<const void*>(buffer.data()));
 }
 
 // Example inputs for AVX512:

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -511,8 +511,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     auto sw = n * e;
     auto se = n * w;
 
-    auto i_x_w = convert_to_int_of_same_size<scalar_t>(x_w);
-    auto i_y_n = convert_to_int_of_same_size<scalar_t>(y_n);
+    auto i_x_w = convert_to_int_of_same_size(x_w);
+    auto i_y_n = convert_to_int_of_same_size(y_n);
     auto i_x_e = i_x_w + iVec(1);
     auto i_y_s = i_y_n + iVec(1);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98411
* __->__ #98429

This was failing to compile with unrelated changes in the
windows-binary-libtorch-release build job. This rewrite seems to avoid
that problem.

For an example failure, see:
https://hud.pytorch.org/pytorch/pytorch/commit/144d5268a1ee55a348c36bb6f02b881cc67d5173

Differential Revision: [D44717809](https://our.internmc.facebook.com/intern/diff/D44717809/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10