### PR TITLE
Add lint rule for std::round and replace with std::nearbyint

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -806,9 +806,7 @@ command = [
 [[linter]]
 code = 'ROUND'
 include_patterns = [
-    'c10/**',
-    'aten/**',
-    'torch/csrc/**',
+    'aten/src/ATen/native/**',
 ]
 command = [
     'python3',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -804,6 +804,27 @@ command = [
 ]
 
 [[linter]]
+code = 'ROUND'
+include_patterns = [
+    'c10/**',
+    'aten/**',
+    'torch/csrc/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=std::round',
+    '--linter-name=ROUND',
+    '--error-name=invalid round',
+    '--replace-pattern=s/std::round/std::nearbyint/',
+    """--error-description=\
+        Use of std::round is inconsistent with conventions and should be replaced with std::nearbyint\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+
+[[linter]]
 code = 'WORKFLOWSYNC'
 include_patterns = [
     '.github/workflows/pull.yml',


### PR DESCRIPTION
Avoid inconsistencies introduced by `std::round` such as that discovered in #97000.

`torch.round` has round to nearest even behavior, which is different from `std::round` but consistent with `std::nearbyint` with [`FE_TONEAREST`](https://en.cppreference.com/w/cpp/numeric/fenv/FE_round). There are [a few comments](https://github.com/search?q=repo%3Apytorch%2Fpytorch%20We%20do%20not%20use%20std%3A%3Around%20because&type=code) throughout the codebase saying we don't use `std::round` but we should lint for this. Added a lint rule for `aten/src/ATen/native/**`  

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #98435

