### PR TITLE
[kineto] add SOFT_ASSERT when logging metdata

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -119,7 +119,7 @@ struct MetadataBase {
   }
 
   void addMetadata(const std::string& key, const std::string& value) {
-    if (kineto_activity_ && !value.empty() && value != "\"\"") {
+    if (SOFT_ASSERT(hasKinetoActivity()) && !value.empty() && value != "\"\"") {
       torch::profiler::impl::kineto::addMetadata(kineto_activity_, key, value);
     }
   }


### PR DESCRIPTION
Summary: having a valid `kineto_activity_` before logging metadata is a crucial invariant worthy of asserts

Test Plan:
## Test with D44362040

Verify that we get SOFT_ASSERT logs before and after the diff

## Log
```
W0329 11:29:34.269824 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.270107 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.270385 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.270653 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.270941 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.271199 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.271476 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.271724 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.272003 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.272280 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.272553 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.272822 718148 profiler_kineto.cpp:122] Warning:  (function operator())
W0329 11:29:34.273092 718148 profiler_kineto.cpp:122] Warning:  (function operator())
```

Reviewed By: aaronenyeshi

Differential Revision: D44513152

