### PR TITLE
Add slow workflow to upload test stats workflow

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -2,7 +2,7 @@ name: Upload test stats
 
 on:
   workflow_run:
-    workflows: [pull, trunk, periodic, inductor, unstable]
+    workflows: [pull, trunk, periodic, inductor, unstable, slow]
     types:
       - completed
 


### PR DESCRIPTION
I wonder if it would be better to write an exclusion list instead