### PR TITLE
[EdgeML] Switch from BZL to BUCK for model resource testing

### DIFF
--- a/pt_ops.bzl
+++ b/pt_ops.bzl
@@ -58,7 +58,7 @@ def pt_operator_library(
             rule_name = name,
             model_name = model_name,
             dep_graph_yaml = "none" if IS_OSS else "$(location fbsource//xplat/caffe2:pytorch_op_deps)/fb/pytorch_op_deps.yaml ",
-            models_yaml = "none" if IS_OSS else "$(location fbsource//xplat/pytorch_models:all_mobile_model_configs)/build/all_mobile_model_configs.yaml ",
+            models_yaml = "none" if IS_OSS else "$(location fbsource//xplat/pytorch_models/build:all_mobile_model_configs)/all_mobile_model_configs.yaml ",
             optionally_root_ops = "--root_ops " + (",".join(ops)) if len(ops) > 0 else "",
             optionally_training_root_ops = "--training_root_ops " + (",".join(ops)) if len(ops) > 0 and train else "",
             optionally_model_versions = "--model_versions " + (",".join(model_versions)) if model_versions != None else "",


### PR DESCRIPTION
Summary:
See [this post](https://fb.workplace.com/groups/devinfra.capacity.eng/permalink/1200060064273920/) for context and specifically [this solution](https://fb.workplace.com/groups/devinfra.capacity.eng/posts/1200060064273920/?comment_id=1200166060929987&reply_comment_id=1200177124262214) which this diff implements.

The gist is that updating `bzl` file is *very* expensive for diff time testing and triggers many flaky tests when attempting to land a model update from EdgeML.  The purpose of these bzl files (from what I can tell) is to unit test models via a CXX resources map.  Since it's only used for CXX resource generation, this can be accomplished via generating `fb_xplat_cxx_library` BUCK target instead.  This required shuffling around some existing BUCK files due to buck rules around file ownership.

Since the EdgeML process already generates code to begin with, this is straightforward to do by just changing the code from generating bzl files to now generate a BUCK file and change the existing targets to use it thus we can now delete the old bzl files.

Test Plan:
Run the model gen script.

```
buck2 run mode/opt caffe2/torch/fb/mobile/cli:cli -- --concat_all_model_configs
```

Sanity test the new BUCK target.

```
buck2 build xplat/pytorch_models/build:test_resources
```

Run the model unit tests and confirm they still work.

```
buck2 run xplat/caffe2:for_each_prod_ptl_model_test
```

CI/CD for the rest.

I expect some flaky test given the `bzl` file deletion which triggers off a ton of unrelated tests.

Differential Revision: D44699671

