### PR TITLE
[Add] storage support for custom backend.

### DIFF
--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -46,6 +46,8 @@ at::DeprecatedTypeProperties* get_type_properties(
     backend = at::Backend::MPS;
   } else if (device_type == at::DeviceType::Meta) {
     backend = at::Backend::Undefined;
+  } else if (device_type == at::DeviceType::PrivateUse1) {
+    backend = at::Backend::PrivateUse1;
   } else {
     TORCH_CHECK(false, "Invalid device for storage: ", device_type);
   }

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -112,6 +112,8 @@ static PyObject* THPStorage_pynew(
       allocator = c10::GetAllocator(device.type());
     } else if (device.type() == at::DeviceType::Meta) {
       allocator = c10::GetAllocator(device.type());
+    } else if (device.type() == at::DeviceType::PrivateUse1) {
+      allocator = c10::GetAllocator(device.type());
     } else {
       TORCH_CHECK(
           false,


### PR DESCRIPTION
Currently storage only considers partial backend. We want storage to create on custom backend by key PrivateUse1.
@ezyang Could you review my changes?