### PR TITLE
[inductor][cpp] fix mul for uint8

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -115,6 +115,19 @@ class CPUReproTests(TestCase):
         compiled_out = opt_fn(p0, p1)
         assert same(real_out, compiled_out)
 
+    def test_pow_cos(self):
+        # https://github.com/pytorch/pytorch/issues/98149
+        def fn(x):
+            t = x.pow(5)
+            return torch.cos(t)
+
+        x = torch.tensor([4], dtype=torch.uint8)
+        opt_fn = torch._dynamo.optimize("inductor")(fn)
+        opt_fn(x)
+        real_out = fn(x)
+        compiled_out = opt_fn(x)
+        assert same(real_out, compiled_out)
+
     def test_reduce_with_masked(self):
         # https://github.com/pytorch/pytorch/issues/96484
         def fn(a, b):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -624,6 +624,10 @@ class CppOverrides(OpOverrides):
     """Map element-wise ops to C++"""
 
     @staticmethod
+    def mul(a, b):
+        return f"decltype({a})({a} * {b})"
+
+    @staticmethod
     def to_dtype(x, dtype):
         assert dtype in DTYPE_TO_CPP, f"{dtype} missing from {__name__}.DTYPE_TO_CPP"
         return f"static_cast<{DTYPE_TO_CPP[dtype]}>({x})"


### PR DESCRIPTION
Fixes #98149

The type of `mul`'s output is not inconsistent with its input. This PR fixes the type of `mul`'s output.

Here is the output code for the newly added test case `pow+cos`. `tmp4` is 1024 before fixing and 0 after fixing.
#### Before fixing
```
auto tmp0 = in_ptr0[static_cast<long>(0)];     // tmp0 is unsigned_char
auto tmp1 = tmp0 * tmp0;                       // tmp1 is int
auto tmp2 = tmp1 * tmp1;                       // tmp2 is int
auto tmp3 = tmp2 * tmp0;                       // tmp3 is int
auto tmp4 = static_cast<float>(tmp3);          // tmp4 is float
auto tmp5 = std::cos(tmp4);
out_ptr0[static_cast<long>(0)] = tmp5;
```

#### After fixing
```
auto tmp0 = in_ptr0[static_cast<long>(0)];     // tmp0 is unsigned_char
auto tmp1 = decltype(tmp0)(tmp0 * tmp0);       // tmp1 is unsigned_char
auto tmp2 = decltype(tmp1)(tmp1 * tmp1);       // tmp2 is unsigned_char
auto tmp3 = decltype(tmp2)(tmp2 * tmp0);       // tmp3 is unsigned_char
auto tmp4 = static_cast<float>(tmp3);          // tmp4 is float
auto tmp5 = std::cos(tmp4);
out_ptr0[static_cast<long>(0)] = tmp5;
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire