### PR TITLE
Add custom backend case for storage and automatically generate storage attributes.

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -39,10 +39,6 @@ class DummyModule(object):
         return 1
 
     @staticmethod
-    def current_device() -> int:
-        return 0
-
-    @staticmethod
     def get_rng_state(device: Union[int, str, torch.device] = 'foo') -> torch.Tensor:
         # create a tensor using our custom device object.
         return torch.empty(4, 4, device="foo")
@@ -184,8 +180,6 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         # check UntypedStorage
         z2 = y.untyped_storage()
         self.assertFalse(z2.is_foo)
-        # check case if Module has current_device
-        torch._register_device_module('foo', DummyModule)
         z2 = z2.foo()
         self.assertFalse(self.module.custom_add_called())
         self.assertTrue(z2.is_foo)

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -12,6 +12,7 @@ import torch
 import torch.utils.cpp_extension
 from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 
+
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
 TEST_CUDNN = False
 TEST_ROCM = torch.cuda.is_available() and torch.version.hip is not None and ROCM_HOME is not None
@@ -36,6 +37,10 @@ class DummyModule(object):
     @staticmethod
     def device_count() -> int:
         return 1
+
+    @staticmethod
+    def current_device() -> int:
+        return 0
 
     @staticmethod
     def get_rng_state(device: Union[int, str, torch.device] = 'foo') -> torch.Tensor:
@@ -179,6 +184,8 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         # check UntypedStorage
         z2 = y.untyped_storage()
         self.assertFalse(z2.is_foo)
+        # check case if Module has current_device
+        torch._register_device_module('foo', DummyModule)
         z2 = z2.foo()
         self.assertFalse(self.module.custom_add_called())
         self.assertTrue(z2.is_foo)

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -12,7 +12,6 @@ import torch
 import torch.utils.cpp_extension
 from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 
-
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
 TEST_CUDNN = False
 TEST_ROCM = torch.cuda.is_available() and torch.version.hip is not None and ROCM_HOME is not None
@@ -161,6 +160,28 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         x = x.foo()
         self.assertTrue(x.is_foo)
         self.assertTrue(hasattr(torch.nn.Module, 'foo'))
+
+        # check whether the attributes and methods for storage of the corresponding custom backend are generated correctly
+        torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)
+
+        x = torch.empty(4, 4)
+        # check TypedStorage
+        z1 = x.storage()
+        self.assertFalse(z1.is_foo)
+        z1 = z1.foo()
+        self.assertFalse(self.module.custom_add_called())
+        self.assertTrue(z1.is_foo)
+        with self.assertRaisesRegex(RuntimeError, "Invalid device"):
+            z1.foo(torch.device("cpu"))
+        z1 = z1.cpu()
+
+        y = torch.empty(4, 4)
+        # check UntypedStorage
+        z2 = y.untyped_storage()
+        self.assertFalse(z2.is_foo)
+        z2 = z2.foo()
+        self.assertFalse(self.module.custom_add_called())
+        self.assertTrue(z2.is_foo)
 
     def test_open_device_random(self):
         torch.utils.rename_privateuse1_backend('foo')

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 
 __all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend"]
 
-
 def rename_privateuse1_backend(backend_name: str) -> None:
     r"""
     rename_privateuse1_backend(backend_name) -> None
@@ -225,7 +224,8 @@ def _generate_storage_methods_for_privateuse1_backend(custom_backend_name: str,
                               device=None, non_blocking=False, **kwargs) -> torch.storage.TypedStorage:
         torch.storage._warn_typed_storage_removal()
         if unsupported_dtype and self.dtype in unsupported_dtype:
-            raise RuntimeError(f"Cannot create {custom_backend_name} storage as {self.dtype} dtype is not supported by this backend")
+            raise RuntimeError(f"Cannot create {custom_backend_name} storage "
+                               f"as {self.dtype} dtype is not supported by this backend")
         custom_backend_storage: torch.UntypedStorage = getattr(
             self._untyped_storage, custom_backend_name)(device, non_blocking, **kwargs)
         return self._new_wrapped_storage(custom_backend_storage)

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -129,7 +129,7 @@ def _generate_tensor_methods_for_privateuse1_backend(custom_backend_name: str) -
             **kwargs (dict): For compatibility, may contain the key ``memory_format`` argument.
         """
         device_idx = _normalization_device(custom_backend_name, device)
-        return self.to(torch.device(f'{custom_backend_name}:{device_idx}'), non_blocking, **kwargs)
+        return self.to(device=torch.device(f'{custom_backend_name}:{device_idx}'), non_blocking=non_blocking, **kwargs)
 
     _check_register_once(torch.Tensor, custom_backend_name)
     setattr(torch.Tensor, custom_backend_name, wrap_tensor_to)


### PR DESCRIPTION
Currently storage only considers partial backend. We want storage to create on custom backend by key PrivateUse1.
It also provides an easy automatic generation of storage-related attributes.
When the user registers a new backend, the corresponding methods and attributes can be automatically generated.
Do this code.
`torch.utils.rename_privateuse1_backend('foo')`
`torch.utils.generate_storage_for_privateuse1_backend()`
Then, get the following methods and attributes.
`torch.TypedStorage.is_foo`
`torch.TypedStorage.foo()`
`torch.UntypedStorage.is_foo`
`torch.UntypedStorage.foo()`


cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh