### PR TITLE
torch.hub: add safe weights_only option to load_state_dict_from_url

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -109,6 +109,10 @@ class TestHub(TestCase):
         self.assertTrue(os.path.exists(expected_file_path))
         self.assertEqual(sum_of_state_dict(loaded_state), SUM_OF_HUB_EXAMPLE)
 
+        # with safe weight_only
+        loaded_state = hub.load_state_dict_from_url(TORCHHUB_EXAMPLE_RELEASE_URL, weights_only=True)
+        self.assertEqual(sum_of_state_dict(loaded_state), SUM_OF_HUB_EXAMPLE)
+
     @retry(Exception, tries=3)
     def test_load_legacy_zip_checkpoint(self):
         with warnings.catch_warnings(record=True) as ws:


### PR DESCRIPTION
This adds a `weights_only` option to torch.hub.load_state_dict_from_url which is helpful for loading pretrained models from potentially untrusted sources.

Ex: https://github.com/d4l3k/torchdrive/blob/main/torchdrive/models/simple_bev.py#L618-L621

See https://github.com/pytorch/pytorch/pull/86812 for more info on weights_only

Test plan:

```
pytest test/test_hub.py
```

cc @nairbv @NicolasHug @vmoens @jdsgomes