### PR TITLE
Add the DistributedDataParallel types that were lost when distributed.pyi was removed

### DIFF
--- a/torch/nn/parallel/_common_types.py
+++ b/torch/nn/parallel/_common_types.py
@@ -1,0 +1,6 @@
+from typing import Sequence, Union
+
+from torch import device
+
+_device_t = Union[int, device]
+_devices_t = Sequence[_device_t]


### PR DESCRIPTION
The file `torch/nn/parallel/distributed.pyi` was removed in https://github.com/pytorch/pytorch/pull/88701. I am not sure about the reason for the removal, but some effort was invested in adding type annotations to the `DistributedDataParallel` class and it is unfortunate that these were lost. This pull request adds them to `torch/nn/parallel/distributed.py`.