### PR TITLE
fix max_pool / avg_pool corner case when ceil_mode is on

### DIFF
--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -52,6 +52,9 @@ static inline T pooling_output_shape_pad_lr(
         if ((outputSize - 1) * stride >= inputSize + pad_l) {
           --outputSize;
         }
+        // output size may be < 1 when kernel size > input size
+        // here, output size under ceil mode is forced to be >= 1
+        outputSize = std::max(outputSize, (int64_t)1);
     }
     return outputSize;
 }


### PR DESCRIPTION
Fixes #88464
Fixes #95116

This PR fixes a corner case for max_pool / avg_pool. When ceil_mode is on, the output size should at least be 1 to ensure that every element in the input tensor is covered by a sliding window.

According to the formula of output shape, there are cases where output size is 0 or negative when kernel size > input size. Hence, we force the output size to be >=1 to produce a valid output.

[maxpool1d](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html)
<img width="403" alt="image" src="https://user-images.githubusercontent.com/23010269/230301611-d5aaec69-0f77-44ae-b68e-11865c684d49.png">

[avgpool1d](https://pytorch.org/docs/stable/generated/torch.nn.AvgPool1d.html)
<img width="351" alt="image" src="https://user-images.githubusercontent.com/23010269/230298076-51169ecb-e6c2-40e7-8112-5a8952ca5cc3.png">


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10