### PR TITLE
Reduce overhead in CUDAGraph Trees

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -658,7 +658,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 return torch.sin(y) * torch.nn.functional.dropout(x, p=0.4)
 
             inp = torch.rand([4, 4], requires_grad=True, device="cuda")
-            # print("Input ID", id(inp))
             out = foo(inp)
             out.sum().backward()
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -43,6 +43,10 @@ requires_multigpu = functools.partial(
 )
 
 
+def cdata(t):
+    return t.untyped_storage()._cdata
+
+
 class TestCase(TorchTestCase):
     @classmethod
     def setUpClass(cls):
@@ -127,13 +131,15 @@ if HAS_CUDA and not TEST_WITH_ASAN:
         def get_root_children(self):
             return [root.num_descendants() for root in self.get_roots()]
 
-        def cudagraphify_impl(self, *args, **kwargs):
+        def cudagraphify_impl(
+            self, *args, is_inference=True, is_backward=False, **kwargs
+        ):
             return tree_cudagraphify_impl(
                 *args,
                 **kwargs,
                 device_index=self.device_idx,
-                is_backward=False,
-                is_inference=True,
+                is_inference=is_inference,
+                is_backward=is_backward,
             )
 
         @staticmethod
@@ -418,7 +424,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertEqual(all_live_block_count(), 0)
 
         def test_aliased_storage_single_weakref(self):
-            @torch.compile
+            @torch.compile(mode="reduce-overhead")
             def foo(x):
                 x = x * 20
                 x_alias = x[0]
@@ -446,6 +452,78 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                     )
 
             self.assertFalse(self.get_manager().new_graph_id().id == 0)
+
+        def test_aliasing_static_ref(self):
+            class Mod(torch.nn.Linear):
+                def forward(self, x):
+                    return self.weight.T @ x, self.weight.T, self.weight[0:4]
+
+            m = Mod(10, 10).cuda()
+
+            @torch.compile(mode="reduce-overhead")
+            def foo(mod, x):
+                return mod(x)
+
+            @torch.compile(mode="reduce-overhead")
+            def foo2(x):
+                return x[2:]
+
+            x = torch.rand([10, 10], device="cuda", requires_grad=True)
+            param_c = cdata(m.weight)
+            for _ in range(3):
+                # print("Runnng foo")
+                out1, alias_1, alias_2 = foo(m, x)
+                self.assertEqual(len({param_c, cdata(alias_1), cdata(alias_2)}), 1)
+
+                # print("Runnng foo2")
+                out2 = foo2(out1)
+                out2.sum().backward()
+                self.assertEqual(cdata(out1), cdata(out2))
+
+        def test_aliased_static_parameter(self):
+            inp = torch.rand([20, 20], device="cuda")
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                return (x[0],)
+
+            foo_cg = self.cudagraphify_impl(foo, [inp], (0,))
+
+            for _ in range(3):
+                out = foo_cg([inp])[0]
+                self.assertEqual(cdata(inp), cdata(out))
+
+        def test_alias_of_earlier_graph(self):
+            inp = torch.rand([20, 20], device="cuda")
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                out = x + x
+                return (out, out[1:])
+
+            foo_cg = foo
+            # foo_cg = self.cudagraphify_impl(foo, [inp], (0,), is_inference=False)
+
+            def foo2(args):
+                x = args[0]
+                args.clear()
+                return x[1:]
+
+            foo2_cg = foo2
+
+            # out = foo([inp])[0]
+
+            # foo2_cg = self.cudagraphify_impl(foo2, [out], is_inference=False)
+
+            for _ in range(1):
+                out1, out2 = foo_cg([inp])
+                self.assertEqual(cdata(out1), cdata(out2))
+
+                out3 = foo2_cg([out1])
+                self.assertEqual(cdata(out3), cdata(out1))
+                del out1, out2, out3
 
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_aliased_output_checkpoint(self):
@@ -580,7 +658,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 return torch.sin(y) * torch.nn.functional.dropout(x, p=0.4)
 
             inp = torch.rand([4, 4], requires_grad=True, device="cuda")
-            print("Input ID", id(inp))
+            # print("Input ID", id(inp))
             out = foo(inp)
             out.sum().backward()
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -494,37 +494,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 out = foo_cg([inp])[0]
                 self.assertEqual(cdata(inp), cdata(out))
 
-        def test_alias_of_earlier_graph(self):
-            inp = torch.rand([20, 20], device="cuda")
-
-            def foo(args):
-                x = args[0]
-                args.clear()
-                out = x + x
-                return (out, out[1:])
-
-            foo_cg = foo
-            # foo_cg = self.cudagraphify_impl(foo, [inp], (0,), is_inference=False)
-
-            def foo2(args):
-                x = args[0]
-                args.clear()
-                return x[1:]
-
-            foo2_cg = foo2
-
-            # out = foo([inp])[0]
-
-            # foo2_cg = self.cudagraphify_impl(foo2, [out], is_inference=False)
-
-            for _ in range(1):
-                out1, out2 = foo_cg([inp])
-                self.assertEqual(cdata(out1), cdata(out2))
-
-                out3 = foo2_cg([out1])
-                self.assertEqual(cdata(out3), cdata(out1))
-                del out1, out2, out3
-
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_aliased_output_checkpoint(self):
             def foo(args):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -321,7 +321,7 @@ def is_live(weak_ref):
 
 class StorageWeakRefWrapper:
     """
-    Wrapper around a storage weak ref.
+    Wrapper around a storage weak ref. Will deallocate it upon expiration if invoked.
     """
 
     __slots__ = ["ref", "_data_ptr"]
@@ -345,7 +345,11 @@ class StorageWeakRefWrapper:
         return instance
 
     def __call__(self) -> Optional[StorageWeakRefPointer]:
+        if self.ref is None:
+            return None
+
         if self.ref.expired():
+            self.ref = None
             return None
 
         return self.ref.cdata
@@ -355,7 +359,7 @@ class StorageWeakRefWrapper:
         return self._data_ptr
 
     def __repr__(self):
-        if self.ref.expired():
+        if self.ref is None or self.ref.expired():
             return f"StorageWeakRefWrapper to {self.data_ptr()}; dead"
         else:
             return f"StorageWeakRefWrapper to {self.data_ptr()}; alive"

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -694,9 +694,6 @@ class CUDAGraphNode:
         )
         self.outputs_metadata: OutputList[Optional[Dict[str, Any]]] = []
 
-        # # self.output_persistent_storage : OutputList[Optional[UntypedStorage]] = []
-        # self.output_persistent_storage = []
-
         # As with inputs, we do not want to keep the outputs permanently alive because that would prevent
         # their memory being reclaimed in subsequent cuda graph recordings. We record the tensor metadata
         # needed to reconstruct instead.

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -2,6 +2,14 @@
 #include <ATen/cuda/CUDAConfig.h>
 #include <c10/util/UniqueVoidPtr.h>
 #include <unordered_set>
+#include <c10/core/Device.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/util/Optional.h>
+#include <ATen/core/TensorBody.h>
+#include <ATen/EmptyTensor.h>
+#include <pybind11/pytypes.h>
+#include <torch/csrc/utils/python_arg_parser.h>
+
 #if AT_CUDNN_ENABLED()
 
 #include <ATen/native/cudnn/Macros.h>
@@ -884,6 +892,20 @@ static void registerCudaDeviceProperties(PyObject* module) {
       });
 }
 
+
+inline at::ScalarType scalartype(PyObject* obj) {
+  if (obj == (PyObject*)&PyFloat_Type) {
+    return at::ScalarType::Double;
+  }
+  if (obj == (PyObject*)&PyBool_Type) {
+    return at::ScalarType::Bool;
+  }
+  if (obj == (PyObject*)&PyLong_Type) {
+    return at::ScalarType::Long;
+  }
+  return reinterpret_cast<THPDtype*>(obj)->scalar_type;
+}
+
 // We choose to ignore certain blocks that are currently allocated
 // when we set the pool to its checkpoint. For those blocks, we need
 // to swap out the deleter function of their corresponding blocks
@@ -1058,6 +1080,114 @@ static void registerCudaPluggableAllocator(PyObject* module) {
     auto data_ptr = storage_impl->data_ptr().get();
     return (storage_impl->data_ptr().get_deleter() == alloc->raw_deleter());
   });
+
+  m.def("_Tensor_Weak_Ref", [](at::Tensor t) {
+    size_t ptr = reinterpret_cast<size_t>(c10::raw::intrusive_ptr::make_weak(t.unsafeGetTensorImpl()));
+    return ptr;
+  });
+
+
+  m.def("_Storage_Test", [](c10::Storage s) {
+    return s.nbytes();
+  });
+
+
+  m.def("_Tensor_New_With_Ptr", [](size_t ptr) {
+    // auto t_ptr = reinterpret_cast<c10::TensorImpl*>(ptr);
+    // auto tensor_impl = c10::intrusive_ptr<at::TensorImpl, at::UndefinedTensorImpl>::reclaim(t_ptr);
+    // if (true && tensor_impl.get() != at::UndefinedTensorImpl::singleton()) {
+    //   c10::raw::intrusive_ptr::incref(tensor_impl.get());
+    // }
+    // return at::Tensor(std::move(tensor_impl));
+    auto t_ptr = reinterpret_cast<c10::TensorImpl*>(ptr);
+    auto t_lock = c10::raw::weak_intrusive_ptr::lock(t_ptr);
+    TORCH_CHECK(t_lock);
+    auto tensor = c10::intrusive_ptr<at::TensorImpl>::reclaim(t_lock);
+    return at::Tensor(tensor);
+  });
+
+  m.def("_Tensor_Free_Ref", [](size_t ptr) {
+    auto t_ptr = reinterpret_cast<c10::TensorImpl*>(ptr);
+    c10::raw::weak_intrusive_ptr::decref(t_ptr);
+  });
+
+  m.def("_Tensor_Expired", [](size_t ptr) {
+    auto t_ptr = reinterpret_cast<c10::TensorImpl*>(ptr);
+    return c10::raw::weak_intrusive_ptr::use_count(t_ptr) == 0;
+  });
+
+    // const std::vector<c10::optional<c10::Storage>>& storages,
+    // const std::vector<c10::optional<py::dict>>& metadatas) {
+
+
+  m.def("_map_Storage_Refs", [](
+    const py::sequence& outputs,
+    const py::list& outputs_persistent_storage,
+    py::list output_refs,
+    py::list output_data_ptrs) {
+
+      TORCH_CHECK(outputs.size() == outputs_persistent_storage.size());
+
+      for (size_t i = 0, end = outputs.size(); i < end; ++i) {
+        if (!outputs_persistent_storage[i].is_none() || outputs[i].is_none()) {
+          output_refs.append(py::none());
+          output_data_ptrs.append(py::none());
+          continue;
+        }
+
+        auto t = outputs[i].cast<at::Tensor>();
+        c10::StorageImpl* storage = t.storage().unsafeGetStorageImpl();
+        auto weak = c10::raw::intrusive_ptr::make_weak(storage);
+        output_refs.append(reinterpret_cast<size_t>(weak));
+        output_data_ptrs.append(reinterpret_cast<size_t>(storage->data_ptr().get()));
+      }
+  });
+
+
+
+  m.def("_construct_Tensors_From_Storage_and_Metadata", [](
+    const py::list& storages,
+    const py::list& metadatas,
+    py::list& outputs) {
+
+      TORCH_CHECK(storages.size() == metadatas.size());
+      for (size_t i = 0, end = storages.size(); i < end; ++i) {
+          const auto& maybe_metadata = metadatas[i];
+
+          if (maybe_metadata.is_none()) {
+              outputs.append(py::none());
+              continue;
+          }
+
+          const py::dict& metadata = maybe_metadata.cast<py::dict>();
+          c10::Storage s;
+          if (storages[i].is_none()) {
+            s = c10::Storage(
+              c10::Storage::use_byte_size_t(),
+              metadata["nbytes"].cast<int64_t>(),
+              at::DataPtr(reinterpret_cast<void*>(metadata["data_ptr"].cast<size_t>()),
+              metadata["device"].cast<c10::Device>())
+            );
+          } else if (py::isinstance<py::int_>(storages[i])) {
+            s = outputs[storages[i].cast<int64_t>()].cast<at::Tensor>().storage();
+          } else {
+            s = storages[i].cast<c10::Storage>();
+          }
+
+          auto dtype_arg = metadata["dtype"].ptr();
+          auto meta = scalarTypeToTypeMeta(scalartype(dtype_arg));
+
+          constexpr c10::DispatchKeySet cuda_dks(c10::DispatchKey::CUDA);
+          at::Tensor tensor = at::detail::make_tensor_base<c10::TensorImpl>(
+            std::move(s), cuda_dks, meta
+          );
+
+          tensor.unsafeGetTensorImpl()->set_sizes_and_strides(metadata["size"].cast<std::vector<int64_t>>(), metadata["stride"].cast<std::vector<int64_t>>());
+          tensor.unsafeGetTensorImpl()->set_storage_offset(metadata["storage_offset"].cast<int64_t>());
+          outputs.append(std::move(tensor));
+      }
+  });
+
 
   m.def(
       "_cuda_beginAllocateCurrentStreamToPool",

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -4,7 +4,6 @@
 #include <ATen/cuda/CUDAConfig.h>
 #include <c10/core/Device.h>
 #include <c10/core/TensorImpl.h>
-#include <c10/util/Optional.h>
 #include <c10/util/UniqueVoidPtr.h>
 #include <pybind11/pytypes.h>
 #include <torch/csrc/utils/python_arg_parser.h>
@@ -892,19 +891,6 @@ static void registerCudaDeviceProperties(PyObject* module) {
       });
 }
 
-inline at::ScalarType scalartype(PyObject* obj) {
-  if (obj == (PyObject*)&PyFloat_Type) {
-    return at::ScalarType::Double;
-  }
-  if (obj == (PyObject*)&PyBool_Type) {
-    return at::ScalarType::Bool;
-  }
-  if (obj == (PyObject*)&PyLong_Type) {
-    return at::ScalarType::Long;
-  }
-  return reinterpret_cast<THPDtype*>(obj)->scalar_type;
-}
-
 // We choose to ignore certain blocks that are currently allocated
 // when we set the pool to its checkpoint. For those blocks, we need
 // to swap out the deleter function of their corresponding blocks
@@ -1138,7 +1124,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           }
 
           auto dtype_arg = metadata["dtype"].ptr();
-          auto meta = scalarTypeToTypeMeta(scalartype(dtype_arg));
+          auto meta = scalarTypeToTypeMeta(toScalarType(dtype_arg));
 
           constexpr c10::DispatchKeySet cuda_dks(c10::DispatchKey::CUDA);
           at::Tensor tensor = at::detail::make_tensor_base<c10::TensorImpl>(

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1,5 +1,4 @@
 #include <ATen/ATen.h>
-#include <ATen/EmptyTensor.h>
 #include <ATen/core/TensorBody.h>
 #include <ATen/cuda/CUDAConfig.h>
 #include <c10/core/Device.h>

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -700,14 +700,7 @@ inline at::ScalarType PythonArgs::scalartypeWithDefault(
   return scalartype(i);
 }
 
-inline at::ScalarType PythonArgs::scalartype(int i) {
-  if (!args[i]) {
-    auto scalartype = signature.params[i].default_scalartype;
-    return (scalartype == at::ScalarType::Undefined)
-        ? torch::tensors::get_default_scalar_type()
-        : scalartype;
-  }
-  PyObject* obj = args[i];
+inline at::ScalarType toScalarType(PyObject* obj) {
   if (obj == (PyObject*)&PyFloat_Type) {
     return at::ScalarType::Double;
   }
@@ -718,6 +711,17 @@ inline at::ScalarType PythonArgs::scalartype(int i) {
     return at::ScalarType::Long;
   }
   return reinterpret_cast<THPDtype*>(obj)->scalar_type;
+}
+
+inline at::ScalarType PythonArgs::scalartype(int i) {
+  if (!args[i]) {
+    auto scalartype = signature.params[i].default_scalartype;
+    return (scalartype == at::ScalarType::Undefined)
+        ? torch::tensors::get_default_scalar_type()
+        : scalartype;
+  }
+  PyObject* obj = args[i];
+  return toScalarType(obj);
 }
 
 inline c10::optional<at::ScalarType> PythonArgs::scalartypeOptional(int i) {

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -18,9 +18,6 @@ try:
 except ImportError:
     pass
 
-# Save a direct reference to _free_weak_ref because the `torch` module
-# might be cleared during Python shutdown before this module is cleared.
-_free_weak_ref = torch.Storage._free_weak_ref
 
 class StorageWeakRef:
     r"""A weak reference to a Storage.
@@ -28,22 +25,26 @@ class StorageWeakRef:
     The cdata member is a Python number containing the integer representation of
     the Storage pointer."""
 
-    __slots__ = ["cdata"]
+    __slots__ = ["cdata", "_free_weak_ref"]
 
     def __init__(self, storage):
         self.cdata = storage._weak_ref()
+        # Save a direct reference to _free_weak_ref because the `torch` module
+        # might be cleared during Python shutdown before this module is cleared.
+        self._free_weak_ref = torch.Storage._free_weak_ref  # type: ignore[attr-defined]
 
     @classmethod
     def from_weakref(cls, cdata):
         instance = cls.__new__(cls)
         instance.cdata = cdata
+        instance._free_weak_ref = torch.Storage._free_weak_ref  # type: ignore[attr-defined]
         return instance
 
     def expired(self):
         return torch.Storage._expired(self.cdata)  # type: ignore[attr-defined]
 
     def __del__(self):
-        _free_weak_ref(self.cdata)
+        self._free_weak_ref(self.cdata)
 
     def __hash__(self):
         return self.cdata

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -18,6 +18,9 @@ try:
 except ImportError:
     pass
 
+# Save a direct reference to _free_weak_ref because the `torch` module
+# might be cleared during Python shutdown before this module is cleared.
+_free_weak_ref = torch.Storage._free_weak_ref
 
 class StorageWeakRef:
     r"""A weak reference to a Storage.
@@ -25,17 +28,22 @@ class StorageWeakRef:
     The cdata member is a Python number containing the integer representation of
     the Storage pointer."""
 
+    __slots__ = ["cdata"]
+
     def __init__(self, storage):
         self.cdata = storage._weak_ref()
-        # Save a direct reference to _free_weak_ref because the `torch` module
-        # might be cleared during Python shutdown before this module is cleared.
-        self._free_weak_ref = torch.Storage._free_weak_ref  # type: ignore[attr-defined]
+
+    @classmethod
+    def from_weakref(cls, cdata):
+        instance = cls.__new__(cls)
+        instance.cdata = cdata
+        return instance
 
     def expired(self):
         return torch.Storage._expired(self.cdata)  # type: ignore[attr-defined]
 
     def __del__(self):
-        self._free_weak_ref(self.cdata)
+        _free_weak_ref(self.cdata)
 
     def __hash__(self):
         return self.cdata


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98341
* __->__ #98529
* #98254
* #97440
* #98112

Significantly reduces overhead of constructing Tensors and Storages and checking Storage Liveness. Removes the regression for HF models that I tested and removes 75% of overhead of the extremely overhead bound resnet50 training we have in torchbench. (.91x base commit, 1.02x torchinductor default, 1.16x this PR, 1.25 previous cudagraphs impl). 

This PR takes care of all of the lower hanging fruit. 

- Computes storage aliasing at record time instead of during at runtime. We no longer need to use a runtime storage cache, and can instead index directly into the existing alias if there is one, or construct a new Storage

- Moves the heavyweight C++ calls into a batch - getting storage weakrefs and constructing tensors

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire