### PR TITLE
[stronghold][bc-linter] correctly determine the base commit of the PR

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -55,7 +55,7 @@ jobs:
           git checkout --force ${{ github.event.pull_request.head.sha }}
 
           # Find the common ancestor commit (base commit) of the head and base branches of the pull request
-          base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}")
+          base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}" | tail -1)
           base=$(git rev-list "${base}"~1 2>/dev/null | head -1)
 
           # Iterate until a common ancestor is found
@@ -66,7 +66,7 @@ jobs:
             git fetch --no-tags --prune --no-recurse-submodules --deepen=10 origin ${{ github.event.pull_request.base.sha }}
 
             # Try to find the common ancestor commit (base commit) again
-            base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}")
+            base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}" | tail -1)
             base=$(git rev-list "${base}"~1 2>/dev/null | head -1)
 
             counter=$((counter + 1))

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -53,29 +53,31 @@ jobs:
           git fetch --no-tags --prune --no-recurse-submodules --depth=$((${{ github.event.pull_request.commits }} + 1)) origin ${{ github.event.pull_request.head.sha }}
           git fetch --no-tags --prune --no-recurse-submodules --depth=10 origin ${{ github.event.pull_request.base.sha }}
           git checkout --force ${{ github.event.pull_request.head.sha }}
-          
+
           # Find the common ancestor commit (base commit) of the head and base branches of the pull request
-          base=$(git rev-list $(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }})~1 2>/dev/null | head -1)
-          
+          base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}")
+          base=$(git rev-list "${base}"~1 2>/dev/null | head -1)
+
           # Iterate until a common ancestor is found
           counter=0
           while [[ -z $base ]] && [[ $counter -lt 128 ]]
           do
             # Fetch more commits from the base branch's history with a depth of 10
             git fetch --no-tags --prune --no-recurse-submodules --deepen=10 origin ${{ github.event.pull_request.base.sha }}
-            
+
             # Try to find the common ancestor commit (base commit) again
-            base=$(git rev-list $(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }})~1 2>/dev/null | head -1)
-          
+            base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}")
+            base=$(git rev-list "${base}"~1 2>/dev/null | head -1)
+
             counter=$((counter + 1))
           done
-          
+
           if [[ -z $base ]]; then
             echo "Failed to find PR base commit"
             exit 1
-          fi 
+          fi
 
-          echo "base=${base}" >> ${GITHUB_OUTPUT}
+          echo "base=${base}" >> "${GITHUB_OUTPUT}"
 
       - name: Check for suppression by label
         id: check_label

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -45,6 +45,38 @@ jobs:
           repository: pytorch/test-infra
           path: test-infra
 
+      - name: Fetching PR base commit
+        id: fetch_base_head
+        if: steps.check_user.outputs.allowed == 'true'
+        working-directory: pytorch
+        run: |
+          git fetch --no-tags --prune --no-recurse-submodules --depth=$((${{ github.event.pull_request.commits }} + 1)) origin ${{ github.event.pull_request.head.sha }}
+          git fetch --no-tags --prune --no-recurse-submodules --depth=10 origin ${{ github.event.pull_request.base.sha }}
+          git checkout --force ${{ github.event.pull_request.head.sha }}
+          
+          # Find the common ancestor commit (base commit) of the head and base branches of the pull request
+          base=$(git rev-list $(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }})~1 2>/dev/null | head -1)
+          
+          # Iterate until a common ancestor is found
+          counter=0
+          while [[ -z $base ]] && [[ $counter -lt 128 ]]
+          do
+            # Fetch more commits from the base branch's history with a depth of 10
+            git fetch --no-tags --prune --no-recurse-submodules --deepen=10 origin ${{ github.event.pull_request.base.sha }}
+            
+            # Try to find the common ancestor commit (base commit) again
+            base=$(git rev-list $(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }})~1 2>/dev/null | head -1)
+          
+            counter=$((counter + 1))
+          done
+          
+          if [[ -z $base ]]; then
+            echo "Failed to find PR base commit"
+            exit 1
+          fi 
+
+          echo "base=${base}" >> ${GITHUB_OUTPUT}
+
       - name: Check for suppression by label
         id: check_label
         if: contains(github.event.pull_request.labels.*.name, 'suppress-api-compatibility-check')
@@ -64,7 +96,7 @@ jobs:
           # When suppressed by label or #suppress-api-compatibility-check tag in the commit message
           # the job will not fail and will output notices instead of warnings.
           ../test-infra/tools/stronghold/bin/check-api-compatibility \
-              --base-commit=${{ github.event.pull_request.base.sha }} \
+              --base-commit=${{ steps.fetch_base_head.outputs.base }} \
               --head-commit=${{ github.event.pull_request.head.sha }} \
               ${{ steps.check_label.outputs.suppression }}
 

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -51,14 +51,10 @@ jobs:
         working-directory: pytorch
         run: |
           git fetch --no-tags --prune --no-recurse-submodules --depth=$((${{ github.event.pull_request.commits }} + 1)) origin ${{ github.event.pull_request.head.sha }}
-          git fetch --no-tags --prune --no-recurse-submodules --depth=10 origin ${{ github.event.pull_request.base.sha }}
           git checkout --force ${{ github.event.pull_request.head.sha }}
 
-          # Find the common ancestor commit (base commit) of the head and base branches of the pull request
-          base=$(git rev-list "${{ github.event.pull_request.head.sha }}" ^"${{ github.event.pull_request.base.sha }}" | tail -1)
-          base=$(git rev-list "${base}"~1 2>/dev/null | head -1)
-
           # Iterate until a common ancestor is found
+          base=""
           counter=0
           while [[ -z $base ]] && [[ $counter -lt 128 ]]
           do


### PR DESCRIPTION
Currently `${{ github.event.pull_request.base.sha }}` returns the HEAD of the base branch, which is different from **the base of the PR**.

See: 
https://github.com/github/docs/issues/431
https://github.com/orgs/community/discussions/39880

However, BC linter needs to know the base revision **of the PR**, as it looks at the changes **in the PR**.

This change is a workaround that determines the correct base of the PR. Hopefully in the future GH provides this information  in the event, and this workaround could be removed.