### PR TITLE
[CI] Mark vision_maskrcnn as NONDETERMINISTIC

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -138,6 +138,7 @@ REQUIRE_COSINE_TOLERACE = {
 NONDETERMINISTIC = {
     # https://github.com/pytorch/pytorch/issues/98355
     "mobilenet_v3_large",
+    "vision_maskrcnn",  # eager variant
 }
 
 # These benchmarks took >600s on an i9-11900K CPU


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98570

Summary: vision_maskrcnn fails eager checking, so mark it as
NONDETERMINISTIC to reduce noise on the dashboard.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx