### PR TITLE
Skip testing distributed backend if the backend (UCC, NCCL, Gloo) is not available

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -14,7 +14,7 @@ from itertools import groupby
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_gloo_available():
+if not c10d.is_available() or not c10d.is_gloo_available():
     print("c10d GLOO not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -14,8 +14,8 @@ from itertools import groupby
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_available():
-    print("c10d not available, skipping tests", file=sys.stderr)
+if not c10d.is_gloo_available():
+    print("c10d GLOO not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
 import test_c10d_common

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -16,8 +16,8 @@ from unittest import mock
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_available():
-    print("c10d not available, skipping tests", file=sys.stderr)
+if not c10d.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
 import test_c10d_common

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -16,7 +16,7 @@ from unittest import mock
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_nccl_available():
+if not c10d.is_available() or not c10d.is_nccl_available():
     print("c10d NCCL not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -13,8 +13,8 @@ from functools import reduce
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_available():
-    print("c10d not available, skipping tests", file=sys.stderr)
+if not c10d.is_ucc_available():
+    print("c10d UCC not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
 import test_c10d_common
@@ -36,7 +36,6 @@ from torch.testing._internal.common_distributed import (
     verify_ddp_error_logged,
 )
 from torch.testing._internal.common_utils import (
-    TEST_WITH_ROCM,
     TestCase,
     run_tests,
     retry_on_connect_failures,
@@ -1051,5 +1050,4 @@ if __name__ == "__main__":
         not torch.cuda._initialized
     ), "test_distributed must not have initialized CUDA context on main process"
 
-    if not TEST_WITH_ROCM:
-        run_tests()
+    run_tests()

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -13,7 +13,7 @@ from functools import reduce
 import torch
 import torch.distributed as c10d
 
-if not c10d.is_ucc_available():
+if not c10d.is_available() or not c10d.is_ucc_available():
     print("c10d UCC not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_distributed import (
     verify_ddp_error_logged,
 )
 from torch.testing._internal.common_utils import (
+    TEST_WITH_ROCM,
     TestCase,
     run_tests,
     retry_on_connect_failures,
@@ -1050,4 +1051,5 @@ if __name__ == "__main__":
         not torch.cuda._initialized
     ), "test_distributed must not have initialized CUDA context on main process"
 
-    run_tests()
+    if not TEST_WITH_ROCM:
+        run_tests()


### PR DESCRIPTION
After the recent change on https://github.com/pytorch/pytorch/pull/88110 to add a new c10d test for UCC backend, the test starts to fail on ROCm distributed job.  I guess ROCm doesn't support that backend yet, so I go ahead and disable the test there.  Please let me know if the support on ROCm is coming, I will close this PR accordingly.  But it's now failing in ROCm trunk with `AssertionError: Unknown c10d backend type UCC`, for example https://hud.pytorch.org/pytorch/pytorch/commit/4adba70cc6fa273f210a94a82b337bbddffc3c1d

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport