### PR TITLE
[MPS] Add higher order derivatives warning to max_pool2d

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -359,6 +359,10 @@ Tensor mps_max_pool2d(const Tensor& input,
                       IntArrayRef padding,
                       IntArrayRef dilation,
                       bool ceil_mode) {
+  TORCH_WARN_ONCE("max_pool2d with `return_indices=False` on MPS is not infinitely differentiable.",
+                  " If you want to calculate higher order derivatives, e.g. second order,",
+                  " set `return_indices=True`.");
+
   Tensor output = at::empty({0}, input.options(), MemoryFormat::Contiguous);
   mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -359,10 +359,6 @@ Tensor mps_max_pool2d(const Tensor& input,
                       IntArrayRef padding,
                       IntArrayRef dilation,
                       bool ceil_mode) {
-  TORCH_WARN_ONCE("max_pool2d with `return_indices=False` on MPS is not infinitely differentiable.",
-                  " If you want to calculate higher order derivatives, e.g. second order,",
-                  " set `return_indices=True`.");
-
   Tensor output = at::empty({0}, input.options(), MemoryFormat::Contiguous);
   mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2354,6 +2354,7 @@
   # is True:
   result: leaky_relu_backward(grad_output_t, self_p, negative_slope, self_is_result)
 
+# This derivative is mps-only, and `max_pool2d_double_backward` just raises an error.
 - name: max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   grad_output: max_pool2d_double_backward()
   self: zeros_like(self)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2354,9 +2354,9 @@
   # is True:
   result: leaky_relu_backward(grad_output_t, self_p, negative_slope, self_is_result)
 
-# This derivative is mps-only, and `max_pool2d_double_backward` just raises an error.
+# This derivative is mps-only, and `error_for_max_pool2d_double_backward` just raises an error.
 - name: max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
-  grad_output: max_pool2d_double_backward()
+  grad_output: error_for_max_pool2d_double_backward()
   self: zeros_like(self)
   result: auto_linear
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2354,6 +2354,11 @@
   # is True:
   result: leaky_relu_backward(grad_output_t, self_p, negative_slope, self_is_result)
 
+- name: max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
+  grad_output: max_pool2d_double_backward()
+  self: zeros_like(self)
+  result: auto_linear
+
 - name: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2)
   self: zeros_like(self)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1972,6 +1972,15 @@ Tensor max_pool_double_backward(
   }
 }
 
+Tensor max_pool2d_double_backward() {
+  TORCH_CHECK(
+      false,
+      "max_pool2d with `return_indices=False` is not infinitely differentiable.",
+      " If you want to calculate higher order derivatives, e.g. second order,",
+      " set `return_indices=True`.");
+  return Tensor();
+}
+
 Tensor glu_double_backward(
     const Tensor& grad,
     const Tensor& grad_output,

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1972,7 +1972,7 @@ Tensor max_pool_double_backward(
   }
 }
 
-Tensor max_pool2d_double_backward() {
+Tensor error_for_max_pool2d_double_backward() { // This is mps-only.
   TORCH_CHECK(
       false,
       "max_pool2d with `return_indices=False` is not infinitely differentiable.",

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -407,6 +407,7 @@ at::Tensor max_pool_double_backward(
     const at::Tensor& grad,
     const at::Tensor& indices,
     int dim);
+at::Tensor max_pool2d_double_backward();
 at::Tensor glu_double_backward(
     const at::Tensor& grad,
     const at::Tensor& grad_output,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -407,7 +407,7 @@ at::Tensor max_pool_double_backward(
     const at::Tensor& grad,
     const at::Tensor& indices,
     int dim);
-at::Tensor max_pool2d_double_backward();
+at::Tensor error_for_max_pool2d_double_backward();
 at::Tensor glu_double_backward(
     const at::Tensor& grad,
     const at::Tensor& grad_output,


### PR DESCRIPTION
The higher order derivatives calculations of `max_pool2d` require indices provided, but `mps_max_pool2d` kernel doesn't calculate it. If we calculate indices during back propagations afterwards, that would be expensive and unnecessary since users can directly call `max_pool2d` with `return_indices=True`, which calculates `indices` along.

This PR adds a warning for it.