### PR TITLE
[fx] Subgraph rewriter matching on attributes

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -863,3 +863,33 @@ class TestSubgraphRewriter(JitTestCase):
 def forward(self, x):
     _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(x, [3, 4], [1, 2]);  x = None
     return _reshape_alias_copy_default_1""")  # noqa: B950
+
+    def test_replacement_with_attrs(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.tensor([1])
+                self.b = torch.tensor([2])
+
+            def forward(self, x):
+                return x + self.a - self.b
+
+        class Pattern(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.tensor([1])
+
+            def forward(self, x):
+                return x + self.a
+
+        class Replacement(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.c = torch.tensor([3])
+
+            def forward(self, x):
+                return x - self.c
+
+        traced = symbolic_trace(M())
+        matches = subgraph_rewriter.replace_pattern(traced, Pattern(), Replacement())
+        self.assertEqual(len(matches), 1)

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -6,7 +6,7 @@ from ._compatibility import compatibility
 
 import copy
 from dataclasses import dataclass
-from typing import Callable, Dict, List, NamedTuple, Optional, Set, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Union
 import torch
 
 __all__ = ['Match', 'replace_pattern', 'replace_pattern_with_filters', "ReplacedPatterns"]
@@ -28,48 +28,47 @@ class ReplacedPatterns:
     # List of nodes that were added into the graph
     replacements: List[Node]
 
-def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
+def _replace_attributes(gm: GraphModule, replacement: torch.nn.Module) -> None:
     gm.delete_all_unused_submodules()
 
     if isinstance(replacement, GraphModule):
         replacement.graph.lint()
 
-    def try_get_submodule(mod: torch.nn.Module, target: str) -> Optional[torch.nn.Module]:
-        try:
-            mod_match = mod.get_submodule(target)
-            return mod_match
-        except AttributeError:
-            return None
+    def try_get_attr(gm: torch.nn.Module, target: str) -> Optional[Any]:
+        module_path, _, attr_name = target.rpartition(".")
+        mod: torch.nn.Module = gm.get_submodule(module_path)
+        attr = getattr(mod, attr_name, None)
+        return attr
 
     for node in gm.graph.nodes:
         if node.op == "call_module" or node.op == "get_attr":
 
-            gm_submod = try_get_submodule(gm, node.target)
+            gm_attr = try_get_attr(gm, node.target)
+            replacement_attr = try_get_attr(replacement, node.target)
 
-            replacement_submod = try_get_submodule(replacement, node.target)
-
-            # CASE 1: This target already exists as a submodule in our
+            # CASE 1: This target already exists as an attribute in our
             # result GraphModule. Whether or not it exists in
             # `replacement`, the existing submodule takes precedence.
-            if gm_submod is not None:
+            if gm_attr is not None:
                 continue
 
-            # CASE 2: The target exists as a submodule in `replacement`
+            # CASE 2: The target exists as an attribute in `replacement`
             # only, so we need to copy it over.
-            elif replacement_submod is not None:
-                new_submod = copy.deepcopy(getattr(replacement, node.target))
-                gm.add_submodule(node.target, new_submod)
+            elif replacement_attr is not None:
+                new_attr = copy.deepcopy(replacement_attr)
+                if isinstance(replacement_attr, torch.nn.Module):
+                    gm.add_submodule(node.target, new_attr)
+                else:
+                    setattr(gm, node.target, new_attr)
 
-            # CASE 3: The target doesn't exist as a submodule in `gm`
+            # CASE 3: The target doesn't exist as an attribute in `gm`
             # or `replacement`
             else:
                 raise RuntimeError("Attempted to create a \"", node.op,
                                    "\" node during subgraph rewriting "
                                    f"with target {node.target}, but "
-                                   "the referenced submodule does not "
-                                   "exist in either the original "
-                                   "GraphModule `gm` or the replacement"
-                                   " GraphModule `replacement`")
+                                   "the referenced attribute does not "
+                                   "exist in the replacement GraphModule")
 
     gm.graph.lint()
 
@@ -298,7 +297,7 @@ def _replace_pattern(
             copied_returning_nodes = (copied_returning_nodes, )
 
         # Get a list of nodes that have been replaced into the graph
-        replacement_nodes = []
+        replacement_nodes: List[Node] = []
 
         def get_replacement_nodes(curr_node: Node):
             nonlocal replacement_nodes
@@ -338,6 +337,6 @@ def _replace_pattern(
     # If `replacement` was an nn.Module, we'll need to make sure that
     # all the submodules have been copied over correctly
     if isinstance(replacement, torch.nn.Module):
-        _replace_submodules(gm, replacement)
+        _replace_attributes(gm, replacement)
 
     return match_and_replacements


### PR DESCRIPTION
Fixes #68534

Similar to how submodules are added, if there already exists an attribute with the same name in `gm` as in `replacement`, the attribute value in `gm` will take precedence.