### PR TITLE
Remove MERGE_IN_PROGRESS when exiting merge

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2037,7 +2037,8 @@ def main() -> None:
             )
         else:
             print("Missing comment ID or PR number, couldn't upload to Rockset")
-    pr.remove_label(MERGE_IN_PROGRESS_LABEL)
+    finally:
+        pr.remove_label(MERGE_IN_PROGRESS_LABEL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I.e. do it in finally section
This should take care of cases like https://github.com/pytorch/pytorch/pull/97645#issuecomment-1500490754

