### PR TITLE
torch.library.Library.impl: add missing param in docstring example

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -78,11 +78,10 @@ class Library:
                           the dispatch key that the library was created with.
 
         Example::
-            >>> # xdoctest: +SKIP
             >>> my_lib = Library("aten", "IMPL")
             >>> def div_cpu(self, other):
             >>>     return self * (1 / other)
-            >>> my_lib.impl("div.Tensor", "CPU")
+            >>> my_lib.impl("div.Tensor", div_cpu, "CPU")
         '''
         if not callable(fn):
             raise TypeError("Input function is required to be a callable but found type {}".format(type(fn)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #98619

previously this was missing the callable
```
            >>> my_lib = Library("aten", "IMPL")
            >>> def div_cpu(self, other):
            >>>     return self * (1 / other)
            >>> my_lib.impl("div.Tensor", "CPU")
            #                            ^ missing `div_cpu` here
```