### PR TITLE
Remove redundant `found_inf` recompute from `_step_supports_amp_unscaling` path

### DIFF
--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -336,6 +336,8 @@ class GradScaler:
             # and `found_inf` to the passed optimizer so that the optimizer can utilize those
             # to skip the parameter updates or unscale gradients before updating parameters in
             # the fused kernel, e.g. `FusedAdamMathFunctor`.
+            # In this behavior, `GradScaler._check_inf_per_device` is called if `OptState.READY`,
+            # while the method is expected to be called by users side, i.e. their optimizers.
             kwargs_ = kwargs
             has_grad_scaler_kwarg = "grad_scaler" in inspect.signature(optimizer.step).parameters
             if has_grad_scaler_kwarg:
@@ -346,11 +348,13 @@ class GradScaler:
                     FutureWarning)
                 kwargs_.update({"grad_scaler": self})
             else:
+                if optimizer_state["stage"] is OptState.READY:
+                    self._check_inf_per_device(optimizer)
                 scaler = self._get_scale_async()
                 found_inf = cast(
                     torch.Tensor,
                     sum([
-                        t.to(scaler.device, non_blocking=True) for t in self._check_inf_per_device(optimizer).values()
+                        t.to(scaler.device, non_blocking=True) for t in optimizer_state["found_inf_per_device"].values()
                     ])
                 )
                 optimizer.grad_scale = None if optimizer_state["stage"] == OptState.UNSCALED else scaler


### PR DESCRIPTION
following https://github.com/pytorch/pytorch/pull/97415#issuecomment-1499787115.

Rel: https://github.com/pytorch/pytorch/pull/98613

cc @vincentqb @jbschlosser @albanD @janeyx99 @mcarilli @ptrblck @leslie-fang-intel @jgong5 @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire