### PR TITLE
Cleanup collectives and inductor backend.

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3919,7 +3919,6 @@ try:
         result = ir.AllReduceCoalesced.create(input, reduce_op, tag, ranks, group_size)
         return list(map(TensorBox.create, result))
 
-
 except ImportError:
     log.info(
         "Inductor support for distributed collectives depends on building torch.distributed"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -213,7 +213,7 @@ class BaseSchedulerNode:
                 # o what have i done.  lets make this an api
                 or (
                     isinstance(self, ExternKernelSchedulerNode)
-                    and isinstance(self.node, (ir.AllReduce, ir.ForceInPlace))
+                    and isinstance(self.node, ir.InPlaceHint)
                 )
             )
             and config.inplace_buffers
@@ -333,9 +333,7 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
             # (would this have been fixed if I tracked mutations properly above?)
             return False
 
-        if not isinstance(
-            self.node, (torch._inductor.ir.AllReduce, torch._inductor.ir.ForceInPlace)
-        ):
+        if not isinstance(self.node, torch._inductor.ir.InPlaceHint):
             # TODO make this a property of the IR
             return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Rename ForceInplace to InPlaceHint and use it with all collectives.
Unify codegen of AllReduceCoallesced with others.

Fix the wait behavior of all_reduce_coallesced so that you only need to
wait on a single tensor even when code-gen'ing. This requires ref-counting
the wait cleanup to ensure it won't trigger a wait too soon.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire