### PR TITLE
Index expanded dims before checking memory overlap

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -237,10 +237,6 @@ class CPUReproTests(TestCase):
         self.assertFalse(complex_memory_overlap(unsqueezed))
         self.assertFalse(complex_memory_overlap(unsqueezed.permute(1, 2, 0)))
 
-        expanded = unsqueezed.expand(-1, 2, -1)
-        self.assertTrue(complex_memory_overlap(expanded))
-        self.assertTrue(complex_memory_overlap(expanded.permute(1, 2, 0)))
-
         gathered = dense.index_select(0, torch.IntTensor([1, 0, 1]))
         self.assertFalse(complex_memory_overlap(gathered))
         self.assertFalse(complex_memory_overlap(gathered.t()))

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -388,9 +388,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertEqual(self.num_checkpoints(), 2)
 
         def test_expanded_inputs(self):
-            x = torch.empty_strided([4, 512], [0, 1], device="cuda")
-            for i in range(4):
-                x[i].random_(0, 1)
+            x = torch.rand(1, 512, device="cuda").expand(4, 512)
 
             def foo(x):
                 return x + 4 + torch.ones([4, 512], device="cuda")

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -387,6 +387,21 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             # and then again to record it
             self.assertEqual(self.num_checkpoints(), 2)
 
+        def test_expanded_inputs(self):
+            x = torch.empty_strided([4, 512], [0, 1], device="cuda")
+            for i in range(4):
+                x[i].random_(0, 1)
+
+            def foo(x):
+                return x + 4 + torch.ones([4, 512], device="cuda")
+
+            foo_opt = torch.compile()(foo)
+
+            for _ in range(3):
+                self.assertEqual(foo_opt(x), foo(x))
+
+            self.assertFalse(self.get_manager().new_graph_id().id == 0)
+
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_tensor_dies_between_checkpoint(self):
             def foo(args):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -83,6 +83,7 @@ def index_expanded_dims(t, expanded_dims):
 def complex_memory_overlap(t):
     # if torch._debug_has_internal_overlap thinks this tensor potentially has
     # memory overlap internally, let's dig deeper to find out whether it's true.
+    t = index_expanded_dims(t, get_expanded_dims(t))
     if torch._debug_has_internal_overlap(t) != 0:
         strides = t.stride()
         sizes = t.shape
@@ -404,6 +405,13 @@ def static_input(x):
     return torch.as_strided(buffer, x.size(), x.stride())
 
 
+def index_expanded_dims_and_copy_(dst, src, expanded_dims):
+    "Index into expanded dimensions of both dst and src then copy_"
+    dst = index_expanded_dims(dst, expanded_dims)
+    src = index_expanded_dims(src, expanded_dims)
+    dst.copy_(src)
+
+
 def cudagraphify_impl(model, inputs, static_input_idxs=()):
     """
     Assumes inputs[static_input_idxs[i]] are always the same memory address
@@ -411,17 +419,22 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
     static_input_idxs = remove_unaligned_input_idxs(inputs, static_input_idxs)
 
     assert isinstance(inputs, (list, tuple))
-    static_inputs = [
-        static_input(x).copy_(x.detach())
-        if idx not in static_input_idxs
-        else x.detach()
-        for idx, x in enumerate(inputs)
-    ]
 
     inps_expanded_dims = [
         get_expanded_dims(x) if idx not in static_input_idxs else []
         for idx, x in enumerate(inputs)
     ]
+
+    # allocate static tensor inputs
+    static_inputs = [
+        static_input(x) if idx not in static_input_idxs else x.detach()
+        for idx, x in enumerate(inputs)
+    ]
+
+    # copy over input values for fresh allocations
+    for idx, (x, expanded_dims) in enumerate(zip(inputs, expanded_dims)):
+        if idx not in static_input_idxs:
+            index_expanded_dims_and_copy_(static_inputs[idx], x, expanded_dims)
 
     # warmup
     torch.cuda.synchronize()
@@ -454,9 +467,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
                     # TODO - could make one single op of multiple slices
                     # and avoid dispatch.
                     # Could also pre-index the `dst` tensors
-                    dst = index_expanded_dims(dst, expanded_dims)
-                    src = index_expanded_dims(src, expanded_dims)
-                    dst.copy_(src)
+                    index_expanded_dims_and_copy_(dst, src, expanded_dims)
             new_inputs.clear()
             graph.replay()
             return static_outputs
@@ -468,9 +479,10 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
 
         def run(new_inputs):
             for idx in copy_indices:
-                src = index_expanded_dims(static_inputs[idx], inps_expanded_dims[idx])
-                dst = index_expanded_dims(new_inputs[idx], inps_expanded_dims[idx])
-                dst.copy_(src)
+                expanded_dims = inps_expanded_dims[idx]
+                index_expanded_dims_and_copy_(
+                    static_inputs[idx], new_inputs[idx], expanded_dims
+                )
             new_inputs.clear()
             graph.replay()
             return static_outputs

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -432,7 +432,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
     ]
 
     # copy over input values for fresh allocations
-    for idx, (x, expanded_dims) in enumerate(zip(inputs, expanded_dims)):
+    for idx, (x, expanded_dims) in enumerate(zip(inputs, inps_expanded_dims)):
         if idx not in static_input_idxs:
             index_expanded_dims_and_copy_(static_inputs[idx], x, expanded_dims)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98656
* #98616

As the comment for `get_expanded_dims` says:

```
# copy_ fails when trying to write to tensors with memory overlap,
# for expanded dimensions (a dimension which used to have size 1 -> ?)
# we can select one element from that dimension and write to it
# to achieve writing to all values of that dimension of the input tensor
```

We were doing this for the copy, for not for checking if we could copy. Update it so we index then check for memory overlap. This covers all of the `complex_striding` warnings I observed in TB.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire