### PR TITLE
Fix the bug of comm headers.

### DIFF
--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -107,7 +107,7 @@ class TORCH_API CommHookInterface {
 namespace detail {
 // This helper function is called both by CppCommHookInterface below and inside
 // reducer.
- at::Tensor parseCppCommHookResult(const c10::IValue& result);
+TORCH_API at::Tensor parseCppCommHookResult(const c10::IValue& result);
 } // namespace detail
 
 // This CppCommHook interface only requires implementing runHook method that


### PR DESCRIPTION
`comm.hpp` is  exposed to the developer under `torch/include/torch/csrc/distributed/c10d/`.
But when I use it, the following error occurs : `undefined symbol:xxx`. So I want it can expose to developer.

![image](https://user-images.githubusercontent.com/37650440/230697500-ec095103-3566-4415-88df-17491f01846e.png)
