### PR TITLE
Enable replicated embedding in SPMD for NLP models

### DIFF
--- a/torch/distributed/_tensor/ops/embedding_ops.py
+++ b/torch/distributed/_tensor/ops/embedding_ops.py
@@ -3,7 +3,7 @@
 
 import torch
 
-from torch.distributed._tensor.api import DTensorSpec, Replicate
+from torch.distributed._tensor.api import _Partial, DTensorSpec, Replicate, Shard
 from torch.distributed._tensor.op_schema import OpSchema, OutputSharding
 from torch.distributed._tensor.ops.utils import register_prop_rule
 
@@ -17,6 +17,15 @@ def embedding_rules(op_schema: OpSchema) -> OutputSharding:
     if any(placement.is_shard(0) for placement in weight_spec.placements):
         raise NotImplementedError(
             "DTensor does not support row-wise sharded embedding operation yet!"
+        )
+
+    if all(
+        placement.is_replicate() for placement in weight_spec.placements
+    ) and inp_spec.placements == [Shard(0)]:
+        # Embedding table is replicated, input ids are sharded along batch
+        # dimension. Output lookups should match input sharding spec in this case.
+        return OutputSharding(
+            output_spec=DTensorSpec(mesh=inp_spec.mesh, placements=inp_spec.placements)
         )
 
     if all(placement.is_replicate() for placement in inp_spec.placements):
@@ -51,3 +60,23 @@ def embedding_renorm_rules(op_schema: OpSchema) -> OutputSharding:
     raise NotImplementedError(
         "DTensor does not support sharded embedding operation with max_norm yet!"
     )
+
+
+@register_prop_rule(aten.embedding_dense_backward.default)
+def embedding_dense_backward_rules(op_schema: OpSchema) -> OutputSharding:
+    grad_output, indices = op_schema.args_schema[:2]
+    assert isinstance(grad_output, DTensorSpec)
+    assert isinstance(indices, DTensorSpec)
+    if grad_output.placements == indices.placements:
+        # The embedding table is replicated, and input/oupput activations are
+        # sharded. In this case, gradients for the embedding table should be
+        # Partial.
+        return OutputSharding(
+            output_spec=DTensorSpec(mesh=indices.mesh, placements=[_Partial()])
+        )
+    else:
+        raise NotImplementedError(
+            "Unsupported embedding dense backward schema:\n"
+            f"grad_output - {grad_output}\n"
+            f"indices - {indices}"
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98687
* __->__ #98686

For models like NanoGPT, embeddings are replicated and input ids
are sharded. In this case, output lookups should be sharded to
match ids.