### PR TITLE
docs: Linking ResNeXt PyTorch Hub Pipeline

### DIFF
--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -50,12 +50,13 @@ Pipe APIs in PyTorch
 Skip connections
 ^^^^^^^^^^^^^^^^
 
-Certain models like `ResNeXt <https://pytorch.org/hub/pytorch_vision_resnext/>`__ are not completely sequential and have skip
-connections between layers. Naively implementing as part of pipeline
-parallelism would imply that we need to copy outputs for certain layers through
-multiple GPUs till we eventually reach the GPU where the layer for the skip
-connection resides. To avoid this copy overhead, we provide APIs below to stash
-and pop Tensors in different layers of the model.
+Certain models like `ResNeXt <https://pytorch.org/hub/pytorch_vision_resnext/>`__
+are not completely sequential and have skip connections between layers.
+Naively implementing as part of pipeline parallelism would imply that
+we need to copy outputs for certain layers through multiple GPUs till
+we eventually reach the GPU where the layer for the skip connection resides.
+To avoid this copy overhead, we provide APIs below to stash and pop Tensors
+in different layers of the model.
 
 .. autofunction:: torch.distributed.pipeline.sync.skip.skippable.skippable
 .. autoclass:: torch.distributed.pipeline.sync.skip.skippable.stash

--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -50,7 +50,7 @@ Pipe APIs in PyTorch
 Skip connections
 ^^^^^^^^^^^^^^^^
 
-Certain models like ResNeXt are not completely sequential and have skip
+Certain models like `ResNeXt <https://pytorch.org/hub/pytorch_vision_resnext/>`__ are not completely sequential and have skip
 connections between layers. Naively implementing as part of pipeline
 parallelism would imply that we need to copy outputs for certain layers through
 multiple GPUs till we eventually reach the GPU where the layer for the skip


### PR DESCRIPTION
Introducing ResNeXt model as link to PyTorch Hub see Skip connections section.
Handle issue in #98690.