### PR TITLE
Turn off cudagraph trees 

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -200,7 +200,7 @@ class triton:
     cudagraphs = False
 
     # Use cudagraph trees for memory pooling if `cudagraphs` is True
-    cudagraph_trees = not is_fbcode()
+    cudagraph_trees = False
 
     # assertions not on the fast path, steady state
     slow_path_cudagraph_asserts = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98709

There were some recent failures on master, and I think it's fair to defer on turning it on till we get a bit of the Tensor construction overhead down because that shows up a lot in the TB benchmarks.

There may ultimately be an unavoidable tradeoff between memory and performance to some extent but we can get the overhead numbers down a bit first. 

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire