### PR TITLE
[DTensor] Change Sharding algorithm to be in line with ``torch.chunk()``

### DIFF
--- a/test/distributed/_tensor/test_api.py
+++ b/test/distributed/_tensor/test_api.py
@@ -94,8 +94,8 @@ class DTensorAPITest(DTensorTestBase):
         for input_size, shard_dim in input_sizes_and_shard_dims:
             shard_spec = [Shard(shard_dim)]
             tensor_to_shard = torch.randn(input_size)
-            splitted_tensor_list = tensor_to_shard.tensor_split(
-                self.world_size, dim=shard_dim
+            splitted_tensor_list = list(
+                torch.chunk(tensor_to_shard, self.world_size, dim=shard_dim)
             )
             dist_tensor = distribute_tensor(tensor_to_shard, device_mesh, shard_spec)
             self.assertEqual(dist_tensor.size(), torch.Size(input_size))

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -190,7 +190,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 torch.chunk(tensor_to_split, self.world_size, dim=shard_dim)
             )
             for _ in range(self.world_size - len(tensor_splitted_list)):
-                tensor_splitted_list.append(torch.tensor([]), device=self.device_type)
+                tensor_splitted_list.append(torch.tensor([], device=self.device_type))
 
             padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,
@@ -246,7 +246,9 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             big_tensor = device_mesh.all_gather(
                 local_tensor, mesh_dim=0, gather_dim=shard_dim
             )
-            big_tensor_chunks = list(torch.chunk(big_tensor, device_mesh.size(), dim=shard_dim))
+            big_tensor_chunks = list(
+                torch.chunk(big_tensor, device_mesh.size(), dim=shard_dim)
+            )
             unpadded_list = [
                 shard_placement._unpad_tensor(big_tensor_chunks[i], pad_sizes[i])
                 if pad_sizes[i] > 0
@@ -293,7 +295,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 torch.chunk(tensor_to_split, self.world_size, dim=shard_dim)
             )
             for _ in range(self.world_size - len(tensor_splitted_list)):
-                tensor_splitted_list.append(torch.tensor([]), device=self.device_type)
+                tensor_splitted_list.append(torch.tensor([], device=self.device_type))
 
             padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -207,10 +207,17 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                     scattered_tensor, pad_sizes[my_rank]
                 )
 
-            self.assertEqual(
-                scattered_tensor.size(), tensor_splitted_list[my_rank].size()
-            )
-            self.assertEqual(scattered_tensor, tensor_splitted_list[my_rank])
+            if scattered_tensor.numel() == 0:
+                # We need to check numel() instead of size if a tensor is ([]) after unpadding,
+                # since the size could be ([0, 8]) after unpadding.
+                self.assertEqual(
+                    scattered_tensor.numel(), tensor_splitted_list[my_rank].numel()
+                )
+            else:
+                self.assertEqual(
+                    scattered_tensor.size(), tensor_splitted_list[my_rank].size()
+                )
+                self.assertEqual(scattered_tensor, tensor_splitted_list[my_rank])
 
     @with_comms
     def test_all_gather_1d(self):
@@ -318,13 +325,20 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                     scattered_tensor, pad_sizes[my_rank]
                 )
 
-            self.assertEqual(
-                scattered_tensor.size(), tensor_splitted_list[my_rank].size()
-            )
-            self.assertEqual(
-                scattered_tensor,
-                torch.ones_like(tensor_splitted_list[my_rank]) * res_num,
-            )
+            if scattered_tensor.numel() == 0:
+                # We need to check numel() instead of size if a tensor is ([]) after unpadding,
+                # since the size could be ([0, 8]) after unpadding.
+                self.assertEqual(
+                    scattered_tensor.numel(), tensor_splitted_list[my_rank].numel()
+                )
+            else:
+                self.assertEqual(
+                    scattered_tensor.size(), tensor_splitted_list[my_rank].size()
+                )
+                self.assertEqual(
+                    scattered_tensor,
+                    torch.ones_like(tensor_splitted_list[my_rank]) * res_num,
+                )
 
     @with_comms
     def test_all_gather_nd(self):

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -190,7 +190,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 torch.chunk(tensor_to_split, self.world_size, dim=shard_dim)
             )
             for _ in range(self.world_size - len(tensor_splitted_list)):
-                tensor_splitted_list.append(torch.tensor([], device=self.device_type))
+                tensor_splitted_list.append(torch.tensor([]), device=self.device_type)
 
             padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,
@@ -293,7 +293,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 torch.chunk(tensor_to_split, self.world_size, dim=shard_dim)
             )
             for _ in range(self.world_size - len(tensor_splitted_list)):
-                tensor_splitted_list.append(torch.tensor([], device=self.device_type))
+                tensor_splitted_list.append(torch.tensor([]), device=self.device_type)
 
             padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -166,7 +166,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             # make the random seed same across rank
             torch.manual_seed(0)
             global_tensor = torch.randn(scatter_tensor_shape, device=self.device_type)
-            splitted_list, _, _ = shard_placement._split_tensor(
+            splitted_list, _ = shard_placement._split_tensor(
                 global_tensor, mesh.size(), with_padding=True, contiguous=True
             )
             recv_tensor = torch.empty_like(splitted_list[mesh.get_rank()])
@@ -192,7 +192,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             for _ in range(self.world_size - len(tensor_splitted_list)):
                 tensor_splitted_list.append(torch.tensor([], device=self.device_type))
 
-            padded_tensor_list, _, pad_sizes = shard_placement._split_tensor(
+            padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,
                 device_mesh.size(),
                 with_padding=True,
@@ -236,7 +236,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 
         for shard_dim in range(tensor_to_split.ndim):
             shard_placement = Shard(shard_dim)
-            tensor_padded_list, pad_idx, pad_sizes = shard_placement._split_tensor(
+            tensor_padded_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_split,
                 device_mesh.size(),
                 with_padding=True,
@@ -291,7 +291,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             for _ in range(self.world_size - len(tensor_splitted_list)):
                 tensor_splitted_list.append(torch.tensor([], device=self.device_type))
 
-            padded_tensor_list, pad_idx, pad_sizes = shard_placement._split_tensor(
+            padded_tensor_list, pad_sizes = shard_placement._split_tensor(
                 tensor_to_scatter,
                 device_mesh.size(),
                 with_padding=True,

--- a/test/distributed/_tensor/test_redistribute.py
+++ b/test/distributed/_tensor/test_redistribute.py
@@ -91,7 +91,10 @@ class RedistributeTest(DTensorTestBase):
             local_replica = torch.randn(
                 input_size, device=self.device_type, requires_grad=True
             )
-            splitted_list = local_replica.tensor_split(self.world_size, shard_dim)
+            splitted_list = list(
+                torch.chunk(local_replica, self.world_size, dim=shard_dim)
+            )
+
             # make local tensor as the element of the corresponding chunked list
             local_tensor = splitted_list[self.rank]
             replica_tensor = distribute_tensor(local_replica, device_mesh, replica_spec)
@@ -180,6 +183,7 @@ class RedistributeTest(DTensorTestBase):
     def test_partial_to_shard(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         partial_spec = [_Partial()]
+        my_rank = device_mesh.get_rank()
 
         input_sizes_and_shard_dim = [
             ((self.world_size * 3, 3), 0),
@@ -198,9 +202,21 @@ class RedistributeTest(DTensorTestBase):
                 partial_local, device_mesh, partial_spec, run_check=False
             )
 
-            quot, rem = divmod(input_size[shard_dim], self.world_size)
+            full_chunk_size = (
+                input_size[shard_dim] + self.world_size - 1
+            ) // self.world_size
+            chunk_sizes = [
+                max(
+                    min(input_size[shard_dim], full_chunk_size * (idx + 1))
+                    - full_chunk_size * idx,
+                    0,
+                )
+                for idx in range(self.world_size)
+            ]
+
             local_shape = list(input_size)
-            local_shape[shard_dim] = quot + (1 if self.rank < rem else 0)
+            local_shape[shard_dim] = chunk_sizes[my_rank]
+
             # test partial to shard, trigger reduce_scatter
             scatter_shard_tensor = partial_tensor.redistribute(device_mesh, shard_spec)
             self.assertEqual(scatter_shard_tensor.size(), partial_tensor.size())

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
-from torch.distributed._tensor._utils import compute_local_shape
+from torch.distributed._tensor._utils import compute_local_offset, compute_local_shape
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Replicate, Shard
 
@@ -16,6 +16,31 @@ class UtilTest(DTensorTestBase):
     @property
     def world_size(self):
         return 8
+
+    @with_comms
+    def test_compute_local_offset_1d(self):
+        # mesh: 8 * 1
+        mesh_tensor = torch.arange(self.world_size)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        my_rank = device_mesh.get_rank()
+        size = torch.Size([10])
+
+        placement = [Shard(0)]
+        local_size = compute_local_shape(size, device_mesh, placement)
+        local_offset = compute_local_offset(size, device_mesh, placement)
+
+        tensor = torch.ones([10])
+        tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
+        # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
+        chunk_sizes = [
+            tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
+            for idx, tensor in enumerate(range(self.world_size))
+        ]
+
+        self.assertEqual(local_size[0], chunk_sizes[my_rank])
+        # offset for empty shard on the current dimension is equal to
+        # global tensor dim size on the current dimension.
+        self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
 
     @with_comms
     def test_compute_local_shape_2d(self):

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -38,7 +38,7 @@ class UtilTest(DTensorTestBase):
         ]
 
         self.assertEqual(local_size[0], chunk_sizes[my_rank])
-        # offset for empty shard on the current dimension is equal to
+        # Offset for empty shard on the current dimension is equal to
         # global tensor dim size on the current dimension.
         self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -113,9 +113,9 @@ class Shard(Placement):
             device = torch.device(
                 tensor.get_device() if torch.cuda.is_available() else "cpu"
             )
-            shard_size = list(reference_tensor.shape)
-            shard_size = [dim if dim >= self.dim else 0 for dim in shard_size]
-            return torch.zeros(shard_size, device=device)
+            tensor_size = list(reference_tensor.size())
+            tensor_size = [dim if dim >= self.dim else 0 for dim in tensor_size]  # type: ignore
+            return torch.zeros(tensor_size, device=device)
         else:
             pad = [0, 0] * (tensor.ndim - self.dim)
             pad[-1] = pad_size
@@ -174,7 +174,9 @@ class Shard(Placement):
         # Compute chunk size for each chunk on the dimension.
         chunk_sizes = [
             max(
-                min(size_on_dim, full_chunk_size * (idx + 1)) - full_chunk_size * idx, 0
+                min(size_on_dim, full_chunk_size * (idx + 1))
+                - full_chunk_size * idx,
+                0,
             )
             for idx in range(num_chunks)
         ]
@@ -272,7 +274,9 @@ class Shard(Placement):
         full_chunk_size = (size[self.dim] + num_chunks - 1) // num_chunks
         chunk_sizes = [
             max(
-                min(size[self.dim], full_chunk_size * (idx + 1)) - full_chunk_size * idx, 0
+                min(size[self.dim], full_chunk_size * (idx + 1))
+                - full_chunk_size * idx,
+                0,
             )
             for idx in range(num_chunks)
         ]
@@ -429,7 +433,9 @@ class DTensorSpec:
         # Caveat: we need to keep this in mind and sync hash and eq if we add more
         # fields to them,
         if self.tensor_meta is not None:
-            return hash((self.mesh, tuple(self.placements), self.tensor_meta.shape))
+            return hash(
+                (self.mesh, tuple(self.placements), self.tensor_meta.shape)
+            )
         else:
             return hash((self.mesh, tuple(self.placements)))
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -84,9 +84,7 @@ class Shard(Placement):
             shard_list = []
             for shard, pad_size in zip(tensor_list, pad_sizes):
                 # Fill the empty tensor with zeroes with padding.
-                if with_padding and pad_size == full_chunk_size:
-                    shard = self._pad_tensor(shard, pad_size)
-                elif with_padding and pad_size > 0:
+                if with_padding and pad_size > 0:
                     shard = self._pad_tensor(shard, pad_size)
                 shard = shard.contiguous() if contiguous else shard
                 shard_list.append(shard)
@@ -135,7 +133,7 @@ class Shard(Placement):
             size_on_dim >= num_chunks
         ), f"Size to be sharded on dim {self.dim} must be at least as large as the number of devices in that dimension {num_chunks}"
 
-        # compute the chunk size inline with ``torch.chunk``
+        # Compute the chunk size inline with ``torch.chunk``
         full_chunk_size = (size_on_dim + num_chunks - 1) // num_chunks
 
         # Compute chunk size for each chunk on the dimension.
@@ -177,7 +175,7 @@ class Shard(Placement):
         output = torch.empty_like(scatter_list[my_coordinate[mesh_dim]])
         mesh.scatter(output, scatter_list, mesh_dim=mesh_dim)
 
-        # Only unpad if the rank is part of the mesh and the local_tensor was padded on the dimension.
+        # Only unpad if the local_tensor was padded on the dimension.
         pad_size = pad_sizes[my_coordinate[mesh_dim]]
         if pad_size > 0:
             output = self._unpad_tensor(output, pad_size)
@@ -259,7 +257,7 @@ class Shard(Placement):
             gather_dim=self.dim,
         )
 
-        # unpad the tensor if the input tensor was padded
+        # Unpad the tensor if the input tensor was padded
         if is_padded:
             gathered_list = torch.chunk(result, num_chunks, dim=self.dim)
             gathered_list = [

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -101,7 +101,7 @@ class Shard(Placement):
                 shard_list.append(shard)
             return shard_list, idx_start_to_pad, pad_sizes
         else:
-            return shard_list, idx_start_to_pad, pad_sizes
+            return tensor_list, idx_start_to_pad, pad_sizes
 
     def _pad_tensor(
         self,
@@ -114,7 +114,7 @@ class Shard(Placement):
                 tensor.get_device() if torch.cuda.is_available() else "cpu"
             )
             tensor_size = list(reference_tensor.size())
-            tensor_size = [dim if dim >= self.dim else 0 for dim in tensor_size]  # type: ignore
+            tensor_size = [dim if dim >= self.dim else 0 for dim in tensor_size]  # type: ignore[attr-defined]
             return torch.zeros(tensor_size, device=device)
         else:
             pad = [0, 0] * (tensor.ndim - self.dim)
@@ -174,8 +174,7 @@ class Shard(Placement):
         # Compute chunk size for each chunk on the dimension.
         chunk_sizes = [
             max(
-                min(size_on_dim, full_chunk_size * (idx + 1))
-                - full_chunk_size * idx,
+                min(size_on_dim, full_chunk_size * (idx + 1)) - full_chunk_size * idx,
                 0,
             )
             for idx in range(num_chunks)
@@ -433,9 +432,7 @@ class DTensorSpec:
         # Caveat: we need to keep this in mind and sync hash and eq if we add more
         # fields to them,
         if self.tensor_meta is not None:
-            return hash(
-                (self.mesh, tuple(self.placements), self.tensor_meta.shape)
-            )
+            return hash((self.mesh, tuple(self.placements), self.tensor_meta.shape))
         else:
             return hash((self.mesh, tuple(self.placements)))
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -150,10 +150,9 @@ class Shard(Placement):
 
         local_offset_on_dim = -1
         if return_offset:
-            # QQ: what would be the offset of an empty shard? -1?
-            local_offset_on_dim = (
-                sum(chunk_sizes[:rank]) if local_shard_size != 0 else -1
-            )
+            # Return global tensor dim size of current dimension if for empty shard
+            # to represent the end of the corresponding tensor dim.
+            local_offset_on_dim = sum(chunk_sizes[:rank])
 
         return (local_shard_size, local_offset_on_dim)
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -180,6 +180,7 @@ class Shard(Placement):
         This function all_gather all shards and return a tensor that
         is replicated on the previously sharded mesh dimension
         """
+        # size: global_size
         my_coordinate = mesh.get_coordinate()
         num_chunks = mesh.size(dim=mesh_dim)
         # TODO: what should happen if rank is not in the mesh?

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -27,6 +27,9 @@ class Placement:
         return isinstance(self, _Partial)
 
 
+import torch.distributed as dist
+
+
 class Shard(Placement):
     # shard placement, shard on a dim
     def __init__(self, dim):
@@ -39,7 +42,7 @@ class Shard(Placement):
         *,
         with_padding: bool = True,
         contiguous: bool = True,
-    ) -> Tuple[List[torch.Tensor], int]:
+    ) -> Tuple[List[torch.Tensor], int, List[int]]:
         # NOTE: For with_padding option, we pad the tensor on each rank before calling
         # the collectives (i.e. scatter/all_gather, etc.). This is because for gloo
         # backend, it does not support uneven collectives, nccl supports some, but
@@ -54,37 +57,93 @@ class Shard(Placement):
             tensor.size(self.dim) >= num_chunks
         ), f"Tensors to be sharded on dim {self.dim} must be at least as large as "
         f"the number of devices in that dimension {num_chunks}"
-        # split tensor over dimension `dim` into n slices with padding if necessary
-        tensor_list = list(tensor.tensor_split(num_chunks, self.dim))
-        idx_start_to_pad = tensor.size(self.dim) % num_chunks
-        if with_padding or contiguous:
+
+        # chunk tensor over dimension `dim` into n slices with padding if necessary
+        tensor_list = list(
+            torch.chunk(tensor, num_chunks, dim=self.dim)
+        )
+        # compute the chunk size inline with ``torch.chunk``
+        full_chunk_size = (tensor.size(self.dim) + num_chunks - 1) // num_chunks
+
+        # Compute chunk size for each chunk for ``self.dim``
+        chunk_sizes = [
+            tensor_list[idx].size(self.dim) if idx < len(tensor_list) else 0
+            for idx in range(num_chunks)
+        ]
+        # Get idx start to pad
+        idx_start_to_pad = next(
+            (
+                idx
+                for idx, _ in enumerate(chunk_sizes)
+                if idx > 0 and chunk_sizes[idx] < chunk_sizes[idx - 1]
+            ),
+            -1,
+        )
+        # Compute pad size on each trunk
+        pad_sizes = [
+            full_chunk_size - chunk_size if idx >= idx_start_to_pad else 0
+            for idx, chunk_size in enumerate(chunk_sizes)
+        ]
+
+        # Fill empty trunk with empty tensor
+        num_empty_tensors = num_chunks - len(tensor_list)
+        device = torch.device(tensor.get_device() if torch.cuda.is_available() else "cpu")
+        empty_tensor = torch.tensor([], device=device)
+        for _ in range(num_empty_tensors):
+            tensor_list.append(empty_tensor)
+
+        if idx_start_to_pad != -1 and with_padding or contiguous:
             shard_list = []
-            for i, shard in enumerate(tensor_list):
-                if with_padding and idx_start_to_pad != 0 and i >= idx_start_to_pad:
-                    shard = self._pad_tensor(shard)
-                # input tensors are expected to be contiguous by the collective backend
+            for shard, pad_size in zip(tensor_list, pad_sizes):
+                # Fill the empty tensor with zeroes with padding.
+                if with_padding and pad_size == full_chunk_size:
+                    shard_shape = list(tensor_list[0].shape)
+                    shard_shape = [dim if dim >= self.dim else 0 for dim in shard_shape]
+                    shard = torch.zeros(
+                        shard_shape, device=device
+                    )
+                elif with_padding and pad_size > 0:
+                    shard = self._pad_tensor(shard, pad_size)
                 shard = shard.contiguous() if contiguous else shard
                 shard_list.append(shard)
-            return shard_list, idx_start_to_pad
+            return shard_list, idx_start_to_pad, pad_sizes
         else:
-            return tensor_list, idx_start_to_pad
+            return shard_list, idx_start_to_pad, pad_sizes
 
-    def _pad_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
-        # pad tensor by 1 on the shard dim
+    def _pad_tensor(
+        self,
+        tensor: torch.Tensor,
+        pad_size: int,
+    ) -> torch.Tensor:
         pad = [0, 0] * (tensor.ndim - self.dim)
-        pad[-1] = 1
+        pad[-1] = pad_size
         return torch.nn.functional.pad(tensor, pad)
 
-    def _unpad_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
-        # unpad tensor by 1 on the shard dim
-        return tensor.narrow(self.dim, start=0, length=tensor.size(self.dim) - 1)
+    def _unpad_tensor(
+        self,
+        tensor: torch.Tensor,
+        pad_size: int,
+    ) -> torch.Tensor:
+        tensor = tensor.narrow(
+            self.dim,
+            start=0,
+            length=tensor.size(self.dim) - pad_size,
+        )
+
+        # Explicitly return an empty tensor. Otherwise, even if the
+        # tensor is empty, the size won't be 0.
+        if tensor.numel() == 0:
+            device = torch.device(tensor.get_device() if torch.cuda.is_available() else "cpu")
+            return torch.tensor([], device=device)
+        else:
+            return tensor
 
     def _unpad_concat_tensor(
-        self, tensor: torch.Tensor, padding_idx: int, shard_count: int
+        self, tensor: torch.Tensor, padding_idx: int, pad_sizes: List[int], shard_count: int
     ) -> torch.Tensor:
         gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
         gathered_list = [
-            self._unpad_tensor(gathered_tensor) if i >= padding_idx else gathered_tensor
+            self._unpad_tensor(gathered_tensor) if pad_sizes[i] > 0 else gathered_tensor
             for i, gathered_tensor in enumerate(gathered_list)
         ]
         return torch.cat(gathered_list, dim=self.dim)
@@ -102,10 +161,37 @@ class Shard(Placement):
         assert (
             size_on_dim >= num_chunks
         ), f"Size to be sharded on dim {self.dim} must be at least as large as the number of devices in that dimension {num_chunks}"
-        split_size, pad_idx = divmod(size_on_dim, num_chunks)
-        local_shard_size = (
-            split_size + 1 if pad_idx != 0 and rank < pad_idx else split_size
+        
+        # compute the chunk size inline with ``torch.chunk``
+        full_chunk_size = (size_on_dim + num_chunks - 1) // num_chunks
+
+        # Compute chunk size for each chunk on the dimension.
+        chunk_sizes = [
+            max(min(size_on_dim, full_chunk_size * (idx + 1)) - full_chunk_size * idx, 0)
+            for idx in range(num_chunks)
+        ]
+        # Get idx start to pad
+        idx_start_to_pad = next(
+            (
+                idx
+                for idx, _ in enumerate(chunk_sizes)
+                if idx > 0 and chunk_sizes[idx] < chunk_sizes[idx - 1]
+            ),
+            -1,
         )
+        # Compute pad size on each trunk
+        pad_sizes = [
+            full_chunk_size - chunk_size if idx >= idx_start_to_pad else 0
+            for idx, chunk_size in enumerate(chunk_sizes)
+        ]
+
+        local_shard_size = chunk_sizes[rank]
+
+        
+        # split_size, pad_idx = divmod(size_on_dim, num_chunks)
+        # local_shard_size = (
+        #     split_size + 1 if pad_idx != 0 and rank < pad_idx else split_size
+        # )
         local_offset_on_dim = -1
         if return_offset:
             local_offset_on_dim = (
@@ -122,18 +208,25 @@ class Shard(Placement):
         """
         my_coordinate = mesh.get_coordinate()
         num_chunks = mesh.size(dim=mesh_dim)
+        print(f"my_coordinate:{my_coordinate}")
+        print(f"num_chunks:{num_chunks}")
+
         if my_coordinate is None:
             # if rank is not part of mesh, we simply return an empty tensor
             return tensor.new_empty(0, requires_grad=tensor.requires_grad)
 
-        scatter_list, pad_idx = self._split_tensor(
+        scatter_list, _, pad_sizes = self._split_tensor(
             tensor, num_chunks, with_padding=True, contiguous=True
         )
+        print(f"scatter_list:{scatter_list}")
+
         output = torch.empty_like(scatter_list[my_coordinate[mesh_dim]])
         mesh.scatter(output, scatter_list, mesh_dim=mesh_dim)
 
-        if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
-            output = self._unpad_tensor(output)
+        # Only unpad if the rank is part of the mesh and the local_tensor was padded on the dimension.
+        pad_size = pad_sizes[my_coordinate[mesh_dim]]
+        if pad_size > 0:
+            output = self._unpad_tensor(output, pad_size)
         return output
 
     def _reduce_shard_tensor(
@@ -153,11 +246,10 @@ class Shard(Placement):
         assert (
             my_coordinate is not None
         ), "Rank if not part of mesh"  # TODO: figure out behavior here
-
         pad_idx = 0
         if tensor.size(self.dim) % num_chunks != 0:
-            scattered_list, pad_idx = self._split_tensor(
-                tensor, num_chunks, with_padding=True, contiguous=False
+            scattered_list, _, pad_sizes = self._split_tensor(
+                tensor, num_chunks, with_padding=True, contiguous=True
             )
             tensor = torch.cat(scattered_list, dim=self.dim)
 
@@ -165,8 +257,9 @@ class Shard(Placement):
             tensor, op=reduce_op, mesh_dim=mesh_dim, scatter_dim=self.dim
         )
 
-        if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
-            output = self._unpad_tensor(output)
+        if pad_idx != 0:
+            pad_size = pad_sizes[my_coordinate[mesh_dim]]
+            output = self._unpad_tensor(output, pad_size)
         return output
 
     def _to_replicate_tensor(
@@ -180,30 +273,48 @@ class Shard(Placement):
         This function all_gather all shards and return a tensor that
         is replicated on the previously sharded mesh dimension
         """
-        # size: global_size
         my_coordinate = mesh.get_coordinate()
         num_chunks = mesh.size(dim=mesh_dim)
+
         # TODO: what should happen if rank is not in the mesh?
         # see issue https://github.com/pytorch/tau/pull/492
         assert (
             my_coordinate is not None
         ), "Rank if not part of mesh"  # TODO: figure out behavior here
         # check if it needs to pad input tensor before all_gather
-        pad_idx = size[self.dim] % num_chunks
-        if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
-            local_tensor = self._pad_tensor(local_tensor)
-        local_tensor = local_tensor.contiguous()
+        full_trunk_size = (size[self.dim] + num_chunks - 1) // num_chunks
+        chunks_sizes = []
+        for idx in range(num_chunks):
+            chunks_sizes.append(
+                max(
+                    min(size[self.dim], full_trunk_size * (idx + 1))
+                    - full_trunk_size * idx,
+                    0,
+                )
+            )
+        pad_sizes = [
+            full_trunk_size - chunk_size for chunk_size in chunks_sizes
+        ]
+        is_padded = not all(pad_size == 0 for pad_size in pad_sizes)
+
+        pad_size = pad_sizes[my_coordinate[mesh_dim]]
+        if pad_size > 0:
+            local_tensor = self._pad_tensor(local_tensor, pad_size).contiguous()
 
         result = mesh.all_gather(
             tensor=local_tensor,
             mesh_dim=mesh_dim,
             gather_dim=self.dim,
         )
-        if pad_idx != 0:
+
+        # unpad the tensor if the input tensor was padded
+        if is_padded:
             gathered_list = torch.chunk(result, num_chunks, dim=self.dim)
             gathered_list = [
-                self._unpad_tensor(gathered_tensor) if i >= pad_idx else gathered_tensor
-                for i, gathered_tensor in enumerate(gathered_list)
+                self._unpad_tensor(gathered_tensor, pad_size)  # type: ignore[misc]
+                if pad_size > 0
+                else gathered_tensor
+                for gathered_tensor, pad_size in zip(gathered_list, pad_sizes)
             ]
 
             result = torch.cat(gathered_list, dim=self.dim)
@@ -336,7 +447,9 @@ class DTensorSpec:
         # Caveat: we need to keep this in mind and sync hash and eq if we add more
         # fields to them,
         if self.tensor_meta is not None:
-            return hash((self.mesh, tuple(self.placements), self.tensor_meta.shape))
+            return hash(
+                (self.mesh, tuple(self.placements), self.tensor_meta.shape)
+            )
         else:
             return hash((self.mesh, tuple(self.placements)))
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -140,7 +140,9 @@ class Shard(Placement):
     ) -> torch.Tensor:
         gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
         gathered_list = [
-            self._unpad_tensor(gathered_tensor, pad_sizes[i]) if pad_sizes[i] > 0 else gathered_tensor
+            self._unpad_tensor(gathered_tensor, pad_sizes[i])
+            if pad_sizes[i] > 0
+            else gathered_tensor
             for i, gathered_tensor in enumerate(gathered_list)
         ]
         return torch.cat(gathered_list, dim=self.dim)

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -105,7 +105,9 @@ class Shard(Placement):
                 tensor.get_device() if torch.cuda.is_available() else "cpu"
             )
             tensor_size = list(reference_tensor.size())
-            tensor_size = [dim if dim >= self.dim else 0 for dim in tensor_size]  # type: ignore[attr-defined]
+            # print(f"before tensor_size: {tensor_size}")
+            # tensor_size = [dim if dim >= self.dim else 0 for dim in tensor_size]  # type: ignore[attr-defined]
+            # print(f"after tensor_size: {tensor_size}")
             return torch.zeros(tensor_size, device=device)
         else:
             pad = [0, 0] * (tensor.ndim - self.dim)
@@ -132,18 +134,6 @@ class Shard(Placement):
             return torch.tensor([], device=device)
         else:
             return tensor
-
-    def _unpad_concat_tensor(
-        self, tensor: torch.Tensor, pad_sizes: List[int], shard_count: int
-    ) -> torch.Tensor:
-        gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
-        gathered_list = [
-            self._unpad_tensor(gathered_tensor, pad_sizes[i])
-            if pad_sizes[i] > 0
-            else gathered_tensor
-            for i, gathered_tensor in enumerate(gathered_list)
-        ]
-        return torch.cat(gathered_list, dim=self.dim)
 
     def _local_shard_size_on_dim(
         self,

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -72,7 +72,7 @@ class Shard(Placement):
                 for idx, _ in enumerate(chunk_sizes)
                 if idx > 0 and chunk_sizes[idx] < chunk_sizes[idx - 1]
             ),
-            -1,
+            0,
         )
         # Compute pad size on each trunk
         pad_sizes = [
@@ -136,11 +136,11 @@ class Shard(Placement):
             return tensor
 
     def _unpad_concat_tensor(
-        self, tensor: torch.Tensor, padding_idx: int, pad_sizes: List[int], shard_count: int
+        self, tensor: torch.Tensor, pad_sizes: List[int], shard_count: int
     ) -> torch.Tensor:
         gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
         gathered_list = [
-            self._unpad_tensor(gathered_tensor) if pad_sizes[i] > 0 else gathered_tensor
+            self._unpad_tensor(gathered_tensor, pad_sizes[i]) if pad_sizes[i] > 0 else gathered_tensor
             for i, gathered_tensor in enumerate(gathered_list)
         ]
         return torch.cat(gathered_list, dim=self.dim)

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -125,7 +125,7 @@ def _redistribute_with_local_tensor(
                 )
             elif current.is_replicate():
                 # split the tensor and return the corresponding cloned local shard
-                shards, _, _ = target_placement._split_tensor(
+                shards, _ = target_placement._split_tensor(
                     local_tensor,
                     num_chunks,
                     with_padding=False,

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -125,7 +125,7 @@ def _redistribute_with_local_tensor(
                 )
             elif current.is_replicate():
                 # split the tensor and return the corresponding cloned local shard
-                shards, _ = target_placement._split_tensor(
+                shards, _, _ = target_placement._split_tensor(
                     local_tensor,
                     num_chunks,
                     with_padding=False,


### PR DESCRIPTION
As functional collective being updated, using tensor_split() as the underlying sharding algorithm would require padding and unpadding on multiple ranks. Therefore, we are changing the sharding algorithm to be in line with ``torch.chunk()`` to allow padding on the last two ranks in most of the scenarios. 