### PR TITLE
DDP forward support custom stream accelerated copy.

### DIFF
--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -62,14 +62,18 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
             if not use_side_stream_for_tensor_copies:
                 return (obj.to(target_device),)
             else:
-                # Perform CPU -> GPU copies in a background stream. This code is
+                # If the custom module is not registered to torch, stream is not used for acceleration
+                device_mod = getattr(torch, device.type, None)
+                if device.type == "cpu" or device_mod is None:
+                    return (obj.to(target_device),)
+                # Perform CPU -> target_device copies in a background stream. This code is
                 # motivated from similar logic in torch/nn/parallel/_functions.py
-                stream = _get_stream(target_device.index)
-                with torch.cuda.stream(stream):
-                    output = obj.to(target_device.index)
+                stream = _get_stream(target_device)
+                with device_mod.stream(stream):
+                    output = obj.to(target_device)
                 # synchronize with the copy stream
                 with torch.cuda.device(target_device.index):
-                    current_stream = torch.cuda.current_stream()
+                    current_stream = device_mod.current_stream()
                     # Sync the current stream with the copy stream
                     current_stream.wait_stream(stream)
                     # Ensure tensor memory is not reused until work on

--- a/torch/nn/parallel/_functions.py
+++ b/torch/nn/parallel/_functions.py
@@ -92,7 +92,7 @@ class Scatter(Function):
         streams = None
         if torch.cuda.is_available() and ctx.input_device == -1:
             # Perform CPU to GPU copies in a background stream
-            streams = [_get_stream(device) for device in target_gpus]
+            streams = [_get_stream(torch.device("cuda", device)) for device in target_gpus]
         outputs = comm.scatter(input, target_gpus, chunk_sizes, ctx.dim, streams)
         # Synchronize with the copy stream
         if streams is not None:
@@ -109,16 +109,18 @@ class Scatter(Function):
 
 
 # background streams used for copying
-_streams: Optional[List[Optional[torch.cuda.Stream]]] = None
+_streams: Optional[List[Optional[torch.Stream]]] = None
 
-
-def _get_stream(device: int):
-    """Gets a background stream for copying between CPU and GPU"""
+def _get_stream(device: torch.device):
+    """Gets a background stream for copying between CPU and target device"""
     global _streams
-    if device == -1:
+    if device.type == "cpu":
+        return None
+    device_mod = getattr(torch, device.type, None)
+    if device_mod is None:
         return None
     if _streams is None:
-        _streams = [None] * torch.cuda.device_count()
-    if _streams[device] is None:
-        _streams[device] = torch.cuda.Stream(device)
-    return _streams[device]
+        _streams = [None] * device_mod.device_count()
+    if _streams[device.index] is None:
+        _streams[device.index] = device_mod.Stream(device.index)
+    return _streams[device.index]


### PR DESCRIPTION
At present, DDP forward uses `_get_stream` to get a stream,which is cudaStream.
If the custom module already registered to torch, I can use `getattr` to get it and it's stream. Then, the custom stream is used to copy the tensor.