### PR TITLE
convert to mutable_data_ptr data_ptr calls immediately after at::empty()

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -146,7 +146,7 @@ inline at::Tensor construct_offsets(const at::Tensor& sizes) {
   }
   int64_t ntensors = sizes.size(0), orig_dim = sizes.size(1);
   auto offsets = at::empty({ntensors}, sizes.options());
-  int64_t *offsets_ptr = offsets.data_ptr<int64_t>();
+  int64_t *offsets_ptr = offsets.mutable_data_ptr<int64_t>();
   // nesting scalars has easy offsets
   if (orig_dim == 0) {
     std::iota(offsets_ptr, offsets_ptr + ntensors, 0);

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -170,7 +170,7 @@ void apply_linalg_eig(Tensor& values, Tensor& vectors, Tensor& input, Tensor& in
   if (input.is_complex()) {
     ScalarType real_dtype = toRealValueType(input.scalar_type());
     rwork = at::empty({lda * 2}, input.options().dtype(real_dtype));
-    rwork_data = rwork.data_ptr<value_t>();
+    rwork_data = rwork.mutable_data_ptr<value_t>();
   }
 
   // call lapackEig once to get the optimal size for work data
@@ -180,7 +180,7 @@ void apply_linalg_eig(Tensor& values, Tensor& vectors, Tensor& input, Tensor& in
 
   int lwork = std::max<int>(1, static_cast<int>(real_impl<scalar_t, value_t>(work_query)));
   Tensor work = at::empty({lwork}, input.dtype());
-  auto work_data = work.data_ptr<scalar_t>();
+  auto work_data = work.mutable_data_ptr<scalar_t>();
 
   for (const auto i : c10::irange(batch_size)) {
     scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
@@ -259,18 +259,18 @@ void apply_lapack_eigh(const Tensor& values, const Tensor& vectors, const Tensor
 
   lwork = std::max<int>(1, real_impl<scalar_t, value_t>(lwork_query));
   Tensor work = at::empty({lwork}, vectors.options());
-  auto work_data = work.data_ptr<scalar_t>();
+  auto work_data = work.mutable_data_ptr<scalar_t>();
 
   liwork = std::max<int>(1, iwork_query);
   Tensor iwork = at::empty({liwork}, vectors.options().dtype(at::kInt));
-  auto iwork_data = iwork.data_ptr<int>();
+  auto iwork_data = iwork.mutable_data_ptr<int>();
 
   Tensor rwork;
   value_t* rwork_data = nullptr;
   if (vectors.is_complex()) {
     lrwork = std::max<int>(1, rwork_query);
     rwork = at::empty({lrwork}, values.options());
-    rwork_data = rwork.data_ptr<value_t>();
+    rwork_data = rwork.mutable_data_ptr<value_t>();
   }
 
   // Now call lapackSyevd for each matrix in the batched input
@@ -524,7 +524,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
   int* jpvt_data = nullptr;
   if (driver_t::Gelsy == driver_type) {
     jpvt = at::empty({std::max<int64_t>(1, n)}, A.options().dtype(at::kInt));
-    jpvt_data = jpvt.data_ptr<int>();
+    jpvt_data = jpvt.mutable_data_ptr<int>();
   }
 
   // Run once the driver, first to get the optimal workspace size
@@ -546,7 +546,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
 
   lwork = std::max<int>(1, real_impl<scalar_t, value_t>(work_opt));
   Tensor work = at::empty({lwork}, A.options());
-  scalar_t* work_data = work.data_ptr<scalar_t>();
+  scalar_t* work_data = work.mutable_data_ptr<scalar_t>();
 
   // 'rwork' only used for complex inputs and 'gelsy', 'gelsd' and 'gelss' drivers
   Tensor rwork;
@@ -565,7 +565,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
         rwork_len = std::max<int64_t>(1, rwork_opt);
     }
     rwork = at::empty({rwork_len}, A.options().dtype(c10::toRealValueType(A.scalar_type())));
-    rwork_data = rwork.data_ptr<value_t>();
+    rwork_data = rwork.mutable_data_ptr<value_t>();
   }
 
   // 'iwork' workspace array is relevant only for 'gelsd'
@@ -573,7 +573,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
   int* iwork_data;
   if (driver_t::Gelsd == driver_type) {
     iwork = at::empty({std::max<int>(1, iwork_opt)}, A.options().dtype(at::kInt));
-    iwork_data = iwork.data_ptr<int>();
+    iwork_data = iwork.mutable_data_ptr<int>();
   }
 
   at::native::batch_iterator_with_broadcasting<scalar_t>(A, B,
@@ -784,7 +784,7 @@ void apply_ldl_factor(
   using value_t = typename c10::scalar_value_type<scalar_t>::type;
   int lwork = std::max<int>(1, real_impl<scalar_t, value_t>(wkopt));
   Tensor work = at::empty({lwork}, A.dtype());
-  auto work_data = work.data_ptr<scalar_t>();
+  auto work_data = work.mutable_data_ptr<scalar_t>();
 
   for (const auto i : c10::irange(batch_size)) {
     scalar_t* a_working_ptr = &a_data[i * a_stride];

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -331,7 +331,7 @@ index_select_add(
     auto numel = add_indices.numel();
 
     Tensor src_fp32 = at::empty({ddim}, src.options().dtype(at::kFloat));
-    auto* src_data_fp32 = src_fp32.data_ptr<float>();
+    auto* src_data_fp32 = src_fp32.mutable_data_ptr<float>();
 
     // Initialize the intermediate output buffer to be 0.
     Tensor output_fp32 =
@@ -604,7 +604,7 @@ index_select_scale_add(
     }
 
     Tensor scale_fp32 = at::empty(scale.sizes(), scale.options().dtype(at::kFloat));
-    auto* scale_data_fp32 = scale_fp32.data_ptr<float>();
+    auto* scale_data_fp32 = scale_fp32.mutable_data_ptr<float>();
 
 #if defined(USE_FBGEMM)
     bool isbf16 = std::is_same<data_t, at::Half>::value ? false : true;

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -61,7 +61,7 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
   std::vector<at::Tensor> steps;
   steps.reserve(batch_size);
   at::Tensor batch_sizes_t = at::empty(lengths[0], _lengths.options());
-  int64_t * batch_sizes = batch_sizes_t.data_ptr<int64_t>();
+  int64_t * batch_sizes = batch_sizes_t.mutable_data_ptr<int64_t>();
 
   std::vector<int64_t> step_shape; // == [-1, *input.shape[2:]]
   {
@@ -169,7 +169,7 @@ std::tuple<Tensor, Tensor> _pad_packed_sequence(const Tensor& data, const Tensor
   std::vector<int64_t> tmp_view_size = std::move(output_size); // == [-1, -1, *var_data.size()[1:]]
 
   at::Tensor lengths_t = at::empty(max_batch_size, batch_sizes_t.options());
-  int64_t * lengths = lengths_t.data_ptr<int64_t>() + max_batch_size - 1;
+  int64_t * lengths = lengths_t.mutable_data_ptr<int64_t>() + max_batch_size - 1;
   int64_t data_offset = 0;
   int64_t prev_batch_size = max_batch_size;
   int64_t prev_i = 0;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -2125,7 +2125,7 @@ Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims){
     thread_count_nonzero[0] += thread_count_nonzero[i];
   }
   auto out = at::empty({}, self.options().dtype(kLong));
-  *out.data_ptr<int64_t>() = thread_count_nonzero[0];
+  *out.mutable_data_ptr<int64_t>() = thread_count_nonzero[0];
   return out;
 }
 

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -57,7 +57,7 @@ Tensor unique_elements(const scalar_t* begin, const scalar_t* end,
 
   // Write the output tensor
   Tensor output = at::empty({static_cast<int64_t>(set.size())}, options);
-  scalar_t *output_data = output.data_ptr<scalar_t>();
+  scalar_t *output_data = output.mutable_data_ptr<scalar_t>();
   std::copy(set.begin(), set.end(), output_data);
   if (sorted) {
     std::sort(output_data, output_data + set.size());
@@ -84,7 +84,7 @@ Tensor unique_elements(const bool* begin, const bool* end,
   // Write the output tensor
   int64_t num_elem = seen[false] + seen[true];
   Tensor output = at::empty({num_elem}, options);
-  bool *output_data = output.data_ptr<bool>();
+  bool *output_data = output.mutable_data_ptr<bool>();
 
   if (seen[false]) {
     *output_data++ = false;

--- a/aten/src/ATen/native/cpu/SpmmReduceKernel.cpp
+++ b/aten/src/ATen/native/cpu/SpmmReduceKernel.cpp
@@ -262,7 +262,7 @@ void spmm_reduce_backward_input_arg_kernel_impl(
   int64_t M = grad_out.size(0);
   int64_t K = grad_out.size(1);
   auto grad = at::empty({M, K}, grad_out.options());
-  scalar_t* grad_data = grad.data_ptr<scalar_t>();
+  scalar_t* grad_data = grad.mutable_data_ptr<scalar_t>();
 
   at::parallel_for(0, M, 1, [&](int64_t begin, int64_t end) {
     for (const auto m : c10::irange(begin, end)) {
@@ -344,7 +344,7 @@ void spmm_reduce_backward_other_arg_kernel_impl(
   int64_t M = grad_out.size(0);
   int64_t K = grad_out.size(1);
   auto grad = at::empty({M, K}, grad_out.options());
-  scalar_t* grad_data = grad.data_ptr<scalar_t>();
+  scalar_t* grad_data = grad.mutable_data_ptr<scalar_t>();
 
   at::parallel_for(0, M, 1, [&](int64_t begin, int64_t end) {
     for (const auto m : c10::irange(begin, end)) {

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -81,7 +81,7 @@ void batch_norm_cpu_contiguous_impl(Tensor& output, const Tensor& input,
 
   Tensor alpha = at::empty({n_channel}, input.options());
   Tensor beta = at::empty({n_channel}, input.options());
-  scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
+  scalar_t* alpha_data = alpha.mutable_data_ptr<scalar_t>();
   scalar_t* beta_data = beta.data_ptr<scalar_t>();
 
   batch_norm_cpu_collect_linear_and_constant_terms<scalar_t, scalar_t>(
@@ -132,7 +132,7 @@ void batch_norm_cpu_channels_last_impl(Tensor& output, const Tensor& input,
 
   Tensor alpha = at::empty({n_channel}, input.options());
   Tensor beta = at::empty({n_channel}, input.options());
-  scalar_t* alpha_data = alpha.data_ptr<scalar_t>();
+  scalar_t* alpha_data = alpha.mutable_data_ptr<scalar_t>();
   scalar_t* beta_data = beta.data_ptr<scalar_t>();
 
   batch_norm_cpu_collect_linear_and_constant_terms<scalar_t, scalar_t>(
@@ -608,7 +608,7 @@ void batch_norm_cpu_contiguous_impl<BFloat16>(Tensor& output, const Tensor& inpu
   // use float as acc type
   Tensor alpha = at::empty({n_channel}, input.options().dtype(kFloat));
   Tensor beta = at::empty({n_channel}, input.options().dtype(kFloat));
-  float* alpha_data = alpha.data_ptr<float>();
+  float* alpha_data = alpha.mutable_data_ptr<float>();
   float* beta_data = beta.data_ptr<float>();
 
   const bool mixed_type = is_mixed_type(input, weight, bias, save_mean, save_invstd, running_mean, running_var);
@@ -671,7 +671,7 @@ void batch_norm_cpu_channels_last_impl<BFloat16>(Tensor& output, const Tensor& i
 
   Tensor alpha = at::empty({n_channel}, input.options().dtype(kFloat));
   Tensor beta = at::empty({n_channel}, input.options().dtype(kFloat));
-  float* alpha_data = alpha.data_ptr<float>();
+  float* alpha_data = alpha.mutable_data_ptr<float>();
   float* beta_data = beta.data_ptr<float>();
 
   const bool mixed_type = is_mixed_type(input, weight, bias, save_mean, save_invstd, running_mean, running_var);

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -327,7 +327,7 @@ void GroupNormKernelImplChannelsLastInternal(
     //
     // for each plain of HxW, scale and bias is calculated only once
     Tensor buffer = at::empty({N * G, 2 * D}, X.options().dtype(c10::CppTypeToScalarType<T_ACC>::value));
-    T_ACC* buffer_data = buffer.data_ptr<T_ACC>();
+    T_ACC* buffer_data = buffer.mutable_data_ptr<T_ACC>();
 
     at::parallel_for(0, N * G, 1, [&](int64_t begin, int64_t end) {
       int64_t n{0}, g{0};

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -301,7 +301,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
   // prepare cufft for execution
   CUFFT_CHECK(cufftSetStream(plan, at::cuda::getCurrentCUDAStream()));
   auto workspace = at::empty({ config->workspace_size() }, at::device(at::kCUDA).dtype(at::kByte));
-  CUFFT_CHECK(cufftSetWorkArea(plan, workspace.data_ptr()));
+  CUFFT_CHECK(cufftSetWorkArea(plan, workspace.mutable_data_ptr()));
 
   // execute transform plan
   exec_cufft_plan(*config, input.data_ptr(), out.data_ptr(), forward);

--- a/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
@@ -98,7 +98,7 @@ matmul_nested_helper(
       ndims = self_sizes[0].size();
   std::vector<int64_t> batch_sizes(ntensors, 1);
   Tensor sizemat = at::empty({ntensors, ndims}, sizemat_op);
-  int64_t* sizemat_ptr = sizemat.data_ptr<int64_t>();
+  int64_t* sizemat_ptr = sizemat.mutable_data_ptr<int64_t>();
   int64_t numel = 0;
   for (int64_t i = 0; i < ntensors; i++) {
     const IntArrayRef& self_size = self_sizes[i],
@@ -160,21 +160,21 @@ Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
 
   // viewed metadata for self
   auto self_new_sizes = at::empty({N * n_heads, 2}, opt);
-  int64_t* self_new_sizes_ptr = self_new_sizes.data_ptr<int64_t>();
+  int64_t* self_new_sizes_ptr = self_new_sizes.mutable_data_ptr<int64_t>();
 
   auto self_new_strides = at::empty({N * n_heads, 2}, opt);
-  int64_t* self_new_strides_ptr = self_new_strides.data_ptr<int64_t>();
+  int64_t* self_new_strides_ptr = self_new_strides.mutable_data_ptr<int64_t>();
   auto self_new_offsets = at::empty({N * n_heads}, opt);
-  int64_t *self_new_offsets_ptr = self_new_offsets.data_ptr<int64_t>();
+  int64_t *self_new_offsets_ptr = self_new_offsets.mutable_data_ptr<int64_t>();
 
   // viewed metadata for mat2
   auto mat2_new_sizes = at::empty({N * n_heads, 2}, opt2);
-  int64_t* mat2_new_sizes_ptr = mat2_new_sizes.data_ptr<int64_t>();
+  int64_t* mat2_new_sizes_ptr = mat2_new_sizes.mutable_data_ptr<int64_t>();
 
   auto mat2_new_strides = at::empty({N * n_heads, 2}, opt2);
-  int64_t* mat2_new_strides_ptr = mat2_new_strides.data_ptr<int64_t>();
+  int64_t* mat2_new_strides_ptr = mat2_new_strides.mutable_data_ptr<int64_t>();
   auto mat2_new_offsets = at::empty({N * n_heads}, opt);
-  int64_t *mat2_new_offsets_ptr = mat2_new_offsets.data_ptr<int64_t>();
+  int64_t *mat2_new_offsets_ptr = mat2_new_offsets.mutable_data_ptr<int64_t>();
 
   for (int64_t i = 0; i < N; i++) {
     const IntArrayRef& self_size_i = self_sizes[i];
@@ -220,7 +220,7 @@ Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
   auto out_new_sizes = at::empty({N, 3}, opt);
   auto out_new_strides = at::empty({N, 3}, opt);
   auto out_new_offsets = at::empty({N}, opt);
-  int64_t *out_new_offsets_ptr = out_new_offsets.data_ptr<int64_t>();
+  int64_t *out_new_offsets_ptr = out_new_offsets.mutable_data_ptr<int64_t>();
 
   int64_t* out_new_sizes_ptr = out_new_sizes.data_ptr<int64_t>();
   int64_t* out_new_strides_ptr = out_new_strides.data_ptr<int64_t>();

--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
@@ -196,7 +196,7 @@ Tensor NestedTensor_batch_offsets_from_size_tensor(
     int64_t extra_elements) {
   int64_t* const sizes_ptr = sizes.data_ptr<int64_t>();
   Tensor offsets = at::empty({1 + sizes.size(0) + extra_elements}, at::kInt);
-  int32_t* const offsets_ptr = offsets.data_ptr<int32_t>();
+  int32_t* const offsets_ptr = offsets.mutable_data_ptr<int32_t>();
   offsets_ptr[0] = 0;
   const auto sizes_size_1 = sizes.size(1);
   const auto sizes_size_0 = sizes.size(0);

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -122,7 +122,7 @@ Tensor batch_offsets_from_efficient_size(const Tensor& ef_sizes) {
   int64_t* nt_sizes_ptr = ef_sizes.data_ptr<int64_t>();
   int64_t ef_sizes_size_0 = ef_sizes.sizes()[0];
   Tensor offsets = at::empty({1 + ef_sizes_size_0}, at::kLong);
-  int64_t* offsets_ptr = offsets.data_ptr<int64_t>();
+  int64_t* offsets_ptr = offsets.mutable_data_ptr<int64_t>();
   offsets_ptr[0] = 0;
   int64_t ef_sizes_size_1 = ef_sizes.sizes()[1];
   for (const auto i : c10::irange(ef_sizes_size_0)) {

--- a/aten/src/ATen/native/quantized/cpu/Normalization.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Normalization.cpp
@@ -88,7 +88,7 @@ Tensor q_batch_norm1d_impl(
 
   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  float* alpha_data = alpha.data_ptr<float>();
+  float* alpha_data = alpha.mutable_data_ptr<float>();
   float* beta_data = beta.data_ptr<float>();
 
   const float* mean_data = mean.template data_ptr<float>();
@@ -197,7 +197,7 @@ Tensor q_batch_norm2d_impl(
 
   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  float* alpha_data = alpha.data_ptr<float>();
+  float* alpha_data = alpha.mutable_data_ptr<float>();
   float* beta_data = beta.data_ptr<float>();
 
   const float* mean_data = mean.template data_ptr<float>();
@@ -293,7 +293,7 @@ Tensor q_batch_norm3d_impl(
 
   Tensor alpha = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   Tensor beta = at::empty_like(mean, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  float* alpha_data = alpha.data_ptr<float>();
+  float* alpha_data = alpha.mutable_data_ptr<float>();
   float* beta_data = beta.data_ptr<float>();
 
   const float* mean_data = mean.template data_ptr<float>();

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2998,7 +2998,7 @@ void quantized_groupnorm_nhwc_kernel(
 
     // Buffer for x and x^2
     Tensor buffer = at::empty({M, 2 * channels_per_group}, X.options().dtype(at::kFloat));
-    float* buffer_data = buffer.data_ptr<float>();
+    float* buffer_data = buffer.mutable_data_ptr<float>();
 
     // We can parallel in the following 2 impls:
     //
@@ -3090,11 +3090,11 @@ void quantized_groupnorm_nhwc_kernel(
       // To avoid thread conflict, we use a temp buffer of {T, Bs, 2*C}
       int num_threads = at::get_num_threads();
       Tensor buffer = at::empty({num_threads, Bs, 2 * C}, X.options().dtype(at::kFloat)).zero_();
-      float* buffer_data = buffer.data_ptr<float>();
+      float* buffer_data = buffer.mutable_data_ptr<float>();
       Tensor mean = at::empty(M, X.options().dtype(at::kFloat));
-      float* mean_data = mean.data_ptr<float>();
+      float* mean_data = mean.mutable_data_ptr<float>();
       Tensor rstd = at::empty(M, X.options().dtype(at::kFloat));
-      float* rstd_data = rstd.data_ptr<float>();
+      float* rstd_data = rstd.mutable_data_ptr<float>();
 
       // Step 1: Accumulate on C dimension
       at::parallel_for(0, Bs * HxW, 1, [&](int64_t begin, int64_t end) {

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -292,7 +292,7 @@ TEST_F(atest, atest) {
     int isgone = 0;
     {
       auto base = at::empty({1, 2, 3}, TensorOptions(kCUDA));
-      auto f2 = from_blob(base.data_ptr(), {1, 2, 3}, [&](void*) { isgone++; });
+      auto f2 = from_blob(base.mutable_data_ptr(), {1, 2, 3}, [&](void*) { isgone++; });
     }
     ASSERT_EQ(isgone, 1);
 

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -156,7 +156,7 @@ TEST(TestQTensor, QuantizePerChannel4d) {
   int ch_axis = 1;
   // create 4d tensor where each H x W image is a range(0, H*W)
   Tensor tensor = at::empty({1, C, H, W}, at::device(at::kCPU).dtype(kFloat));
-  auto* tensor_data = tensor.data_ptr<float>();
+  auto* tensor_data = tensor.mutable_data_ptr<float>();
   for (int c = 0, i = 0; c < C; ++c) {
     for (int e = 0; e < H * W; ++e, ++i) {
       tensor_data[i] = e;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98734

The tensor is uninitialized in this case, so it is highly likely to be
written before it will be read. Furthermore, because it is a new
tensor, there's no harm in getting mutable access to it: there's no
lazy copy that would be materialized.

This was automatically generated with a regular expression.

Differential Revision: [D44831830](https://our.internmc.facebook.com/intern/diff/D44831830/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10