### PR TITLE
Return zero_point from determine_qparams as a int64

### DIFF
--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -580,7 +580,7 @@ def determine_qparams(
                 [float(zero_point)], dtype=zero_point.dtype, device=device
             )
 
-    return scale, zero_point
+    return scale, zero_point.to(torch.int64)
 
 def _get_num_pos_args(f: Callable) -> int:
     """ Get number of positional args for a function


### PR DESCRIPTION
Summary:
In some cases, zero_point is returned as an int tensor. We want it to be a long.

This fixes a failed assertion in Executorch op_choose_qparams:
https://www.internalfb.com/code/fbsource/[4609e7dbbf2e]/fbcode/executorch/kernels/quantized/cpu/op_choose_qparams.cpp?lines=49-52

Test Plan: CI

Reviewed By: jerryzh168

Differential Revision: D44764070

