### PR TITLE
dynamic range constraint API

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2147,6 +2147,47 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             torch._dynamo.export(my_dyn_fn, x, y, z, constraints=constraints)
 
     @config.patch(dynamic_shapes=True)
+    def test_export_dynamic_dim_raise_on_compound_range_constraint(self):
+        x = torch.ones(6, 4, 4)
+        with self.assertRaisesRegex(TypeError, "Cannot determine truth value"):
+            4 < dynamic_dim(x, 0) <= 6
+
+    @config.patch(dynamic_shapes=True)
+    def test_export_dynamic_dim_range_constraint(self):
+        x = torch.ones(6, 4, 4)
+        constraints = [
+            4 < dynamic_dim(x, 0),
+            dynamic_dim(x, 0) <= 6,
+        ]
+
+        def foo(x):
+            if x.shape[0] > 3:  # ok
+                return x.sin()
+            return x.cos()
+
+        torch._dynamo.export(
+            foo,
+            x,
+            constraints=constraints,
+            aten_graph=True,
+            tracing_mode="symbolic",
+        )
+
+        def bar(x):
+            if x.shape[0] > 5:  # error
+                return x.sin()
+            return x.cos()
+
+        with self.assertRaises(ConstraintViolationError):
+            torch._dynamo.export(
+                bar,
+                x,
+                constraints=constraints,
+                aten_graph=True,
+                tracing_mode="symbolic",
+            )
+
+    @config.patch(dynamic_shapes=True)
     def test_list_contains(self):
         def func(x):
             assert x.size(-1) in [4, 5, 6], "bad"

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -620,7 +620,12 @@ class Constraint:
 
     def _clone_with_range(self, lower=2, upper=sympy.oo):
         lower, upper = builtins.max(lower, self._lower), builtins.min(upper, self._upper)
-        return Constraint(self.w_tensor, self.t_id, self.dim, StrictMinMaxConstraint(ValueRanges(lower=lower, upper=upper)))
+        return Constraint(
+            self.w_tensor,
+            self.t_id,
+            self.dim,
+            StrictMinMaxConstraint(ValueRanges(lower=lower, upper=upper))
+        )
 
     def __ge__(self, lower):
         return self._clone_with_range(lower=lower)
@@ -642,7 +647,7 @@ class Constraint:
         raise TypeError(
             f"Cannot determine truth value of Constraint. "
             "If you are trying to combine Constraints with logical connectives, "
-            "split it into multiple Constraints instead."
+            "you can specify them separately instead."
         )
 
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -60,6 +60,12 @@ always_optimize_code_objects = utils.ExactWeakKeyDictionary()
 null_context = contextlib.nullcontext
 
 
+from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
+from torch.utils._sympy.value_ranges import ValueRanges
+import builtins
+import sympy
+
+
 # See https://github.com/python/typing/pull/240
 class Unset(Enum):
     token = 0
@@ -596,9 +602,48 @@ class Constraint:
     # TODO: We don't need t_id; we can get it off of w_tensor
     t_id: int
     dim: int
-    constraint_range: Optional[
-        torch.fx.experimental.symbolic_shapes.StrictMinMaxConstraint
-    ]
+    constraint_range: Optional[StrictMinMaxConstraint]
+
+    @property
+    def _lower(self):
+        if self.constraint_range is None:
+            return 2
+        else:
+            return self.constraint_range.vr.lower
+
+    @property
+    def _upper(self):
+        if self.constraint_range is None:
+            return sympy.oo
+        else:
+            return self.constraint_range.vr.upper
+
+    def _clone_with_range(self, lower=2, upper=sympy.oo):
+        lower, upper = builtins.max(lower, self._lower), builtins.min(upper, self._upper)
+        return Constraint(self.w_tensor, self.t_id, self.dim, StrictMinMaxConstraint(ValueRanges(lower=lower, upper=upper)))
+
+    def __ge__(self, lower):
+        return self._clone_with_range(lower=lower)
+
+    def __gt__(self, lower):
+        return self._clone_with_range(lower=lower+1)
+
+    def __le__(self, upper):
+        return self._clone_with_range(upper=upper)
+
+    def __lt__(self, upper):
+        return self._clone_with_range(upper=upper-1)
+
+    def __bool__(self):
+        # NOTE(avik): We do not support compound expressions like a <= x <= b.
+        # This is because Python implicitly desugars them into bool(a <= x) and bool(x <= b),
+        # and moreover, enforces that any overload of __bool__ must return True or False.
+        # FWIW, sympy also raises TypeError in this case.
+        raise TypeError(
+            f"Cannot determine truth value of Constraint. "
+            "If you are trying to combine Constraints with logical connectives, "
+            "split it into multiple Constraints instead."
+        )
 
 
 def export(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1168,20 +1168,10 @@ def wrap_to_fake_tensor_and_record(
             for constraint in tx.output.export_constraints:
                 if constraint.t_id == t_id:
                     if constraint.dim in dim2constraint:
-                        other_cr = dim2constraint[constraint.dim]
-                        cr = constraint.constraint_range
-                        if other_cr is None:
-                            dim2constraint[constraint.dim] = cr
-                        elif cr is not None:
-                            from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
-                            from torch.utils._sympy.value_ranges import ValueRanges
-                            import builtins
-                            dim2constraint[constraint.dim] = StrictMinMaxConstraint(
-                                ValueRanges(
-                                    builtins.max(cr.vr.lower, other_cr.vr.lower),
-                                    builtins.min(cr.vr.upper, other_cr.vr.upper),
-                                )
-                            )
+                        from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
+                        dim2constraint[constraint.dim] = StrictMinMaxConstraint(
+                            constraint.constraint_range.vr & dim2constraint[constraint.dim].vr
+                        )
                     else:
                         dim2constraint[constraint.dim] = constraint.constraint_range
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2256,7 +2256,6 @@ class ShapeEnv:
                 current_loc = TracingContext.get().loc_in_frame
                 # current_loc describes a line in the current frame
                 user_stack = ''.join(traceback.format_list([*frame_summaries, current_loc]))
-                guard = ShapeGuard(expr, user_stack)
                 expr = LoggingShapeGuardPrinter(self.var_to_sources).doprint(expr)
                 log.warning(f"Adding shape guard {expr} at \n{user_stack}")
             log.debug("SHAPE GUARD", stack_info=True)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1737,7 +1737,7 @@ class ShapeEnv:
         # TODO: Make this more efficient by binding all the size/stride/offsets
         # to locals before performing tests on them.
 
-        from torch._dynamo.source import TensorPropertySource, TensorProperty
+        from torch._dynamo.source import TensorPropertySource, TensorProperty, NegateSource
 
         # Actual codegen must be delayed as we don't necessarily know what
         # the symbol mapping is
@@ -1903,7 +1903,7 @@ class ShapeEnv:
                         if not (c_vr.lower == r.lower and c_vr.upper == r.upper):
                             record_constraint_violation(lambda: (
                                 f"Could not validate constraint {c.render(sources[0])} as "
-                                f"we actually inferred the valid range to be [{vr.lower}, {vr.upper}]."
+                                f"we actually inferred the valid range to be [{r.lower}, {r.upper}]."
                                 "This is actually supposed to be impossible to "
                                 "trigger right now as we do not refine ranges; maybe you called "
                                 "constrain_range manually, or we forgot to update this error message? "
@@ -2256,6 +2256,7 @@ class ShapeEnv:
                 current_loc = TracingContext.get().loc_in_frame
                 # current_loc describes a line in the current frame
                 user_stack = ''.join(traceback.format_list([*frame_summaries, current_loc]))
+                guard = ShapeGuard(expr, user_stack)
                 expr = LoggingShapeGuardPrinter(self.var_to_sources).doprint(expr)
                 log.warning(f"Adding shape guard {expr} at \n{user_stack}")
             log.debug("SHAPE GUARD", stack_info=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98779

This diff adds the ability to specify range constraints on dynamic dimensions. (Previously we only supported declaring a dynamic dimension, which gets the default range `[2, sympy.oo]`.)

One point worth calling out: our initial design called for compound expressions like `lower <= dynamic_dim(x, d) <= upper`. However this seems difficult to support, because of a combination of desugaring and overloading semantics for such compound expressions in Python. Rather than silently doing the wrong thing, we explicitly error in this case and recommend users to specify multiple constraints, which is supported.

Differential Revision: [D44847318](https://our.internmc.facebook.com/intern/diff/D44847318/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire