### PR TITLE
[spmd compile api] run gm_transforms before running the first iteration

### DIFF
--- a/torch/distributed/_spmd/api.py
+++ b/torch/distributed/_spmd/api.py
@@ -576,11 +576,11 @@ def compile(
             with torch.no_grad():
                 # N.B.: we don't need autograd as backward has already been
                 # captured in the graph.
-                output = compiled_obj.gm(*flat_inps)[0]
                 if first_iter and gm_transformation:
                     # TODO: SPMD should provid a default and configurable
                     # transformation.
                     compiled_obj.gm = gm_transformation(compiled_obj.gm)
+                output = compiled_obj.gm(*flat_inps)[0]
                 return output
 
         return wrapper


### PR DESCRIPTION
Summary: The non-transformed graph module contains functionalized optimizer which, in a memory constraint environment, needs to be defunctionalized (via fx transformation or lowering to Inductor) before running the first iteration. Otherwise OOM may occur.

Test Plan: Manually tested.

Reviewed By: mrshenli

Differential Revision: D44843942



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire