### PR TITLE
Log PT2 compile to Scuba

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Set
 import torch
 import torch._logging
 from torch._guards import tracing
+from torch._utils_internal import signpost_event
 from torch.fx.experimental.symbolic_shapes import ConstraintViolationError
 from torch.fx.graph_module import _forward_from_src as original_forward_from_src
 
@@ -295,6 +296,17 @@ def convert_frame_assert(
         global initial_deterministic_algorithms_state
         initial_deterministic_algorithms_state = (
             torch.are_deterministic_algorithms_enabled()
+        )
+
+        signpost_event(
+            "dynamo",
+            "_convert_frame_assert._compile",
+            {
+                "co_name": code.co_name,
+                "co_filename": code.co_filename,
+                "co_firstlineno": code.co_firstlineno,
+                "cache_size": cache_size,
+            },
         )
 
         return _compile(

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -1,6 +1,10 @@
+import logging
 import os
 import sys
 import tempfile
+from typing import Any, Dict
+
+log = logging.getLogger(__name__)
 
 
 # this arbitrary-looking assortment of functionality is provided here
@@ -40,6 +44,23 @@ def prepare_multiprocessing_environment(path: str) -> None:
 
 def resolve_library_path(path: str) -> str:
     return os.path.realpath(path)
+
+
+# Meta only, see
+# https://www.internalfb.com/intern/wiki/ML_Workflow_Observability/User_Guides/Adding_instrumentation_to_your_code/
+#
+# This will cause an event to get logged to Scuba via the signposts API.  You
+# can view samples on the API at https://fburl.com/scuba/workflow_signpost/zh9wmpqs
+# we log to subsystem "torch", and the category and name you provide here.
+# Each of the arguments translate into a Scuba column.  We're still figuring
+# out local conventions in PyTorch, but category should be something like
+# "dynamo" or "inductor", and name should be a specific string describing what
+# kind of event happened.
+#
+# Killswitch is at
+# https://www.internalfb.com/intern/justknobs/?name=pytorch%2Fsignpost#event
+def signpost_event(category: str, name: str, parameters: Dict[str, Any]):
+    log.info("%s %s: %r", category, name, parameters)
 
 
 TEST_MASTER_ADDR = "127.0.0.1"


### PR DESCRIPTION
Summary:
Modeled off of https://www.internalfb.com/code/fbsource/[5f363eaeab1b5d620b9df83ba0de65adfd96771b]/fbcode/caffe2/torch/fb/trainer/profilers/gpu_mem_signpost.py?lines=106-115

I didn't use the Scuba integration in torch/_inductor/fb/logging.py to avoid
having to make a new Scuba table; probably should do this.

Test Plan:
```
buck2 test //caffe2/test:test_dynamo
```

Differential Revision: D44850903



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire