### PR TITLE
[torch package][easy] Make all the save/load tests use buffers

### DIFF
--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -3,10 +3,9 @@
 import pickle
 from io import BytesIO
 from textwrap import dedent
-from unittest import skipIf
 
 from torch.package import PackageExporter, PackageImporter, sys_importer
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import run_tests
 
 try:
     from .common import PackageTestCase
@@ -22,28 +21,21 @@ packaging_directory = Path(__file__).parent
 class TestSaveLoad(PackageTestCase):
     """Core save_* and loading API tests."""
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
     def test_saving_source(self):
-        filename = self.temp()
-        with PackageExporter(filename) as he:
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
             he.save_source_file("foo", str(packaging_directory / "module_a.py"))
             he.save_source_file("foodir", str(packaging_directory / "package_a"))
-        hi = PackageImporter(filename)
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
         foo = hi.import_module("foo")
         s = hi.import_module("foodir.subpackage")
         self.assertEqual(foo.result, "module_a")
         self.assertEqual(s.result, "package_a.subpackage")
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
     def test_saving_string(self):
-        filename = self.temp()
-        with PackageExporter(filename) as he:
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
             src = dedent(
                 """\
                 import math
@@ -51,7 +43,8 @@ class TestSaveLoad(PackageTestCase):
                 """
             )
             he.save_source_string("my_mod", src)
-        hi = PackageImporter(filename)
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
         m = hi.import_module("math")
         import math
 
@@ -59,19 +52,16 @@ class TestSaveLoad(PackageTestCase):
         my_mod = hi.import_module("my_mod")
         self.assertIs(my_mod.math, math)
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
     def test_save_module(self):
-        filename = self.temp()
-        with PackageExporter(filename) as he:
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
             import module_a
             import package_a
 
             he.save_module(module_a.__name__)
             he.save_module(package_a.__name__)
-        hi = PackageImporter(filename)
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
         module_a_i = hi.import_module("module_a")
         self.assertEqual(module_a_i.result, "module_a")
         self.assertIsNot(module_a, module_a_i)
@@ -135,21 +125,18 @@ class TestSaveLoad(PackageTestCase):
         self.assertEqual(package_a_i.result, "package_a")
         self.assertIsNot(package_a_i, package_a)
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
     def test_pickle(self):
         import package_a.subpackage
 
         obj = package_a.subpackage.PackageASubpackageObject()
         obj2 = package_a.PackageAObject(obj)
 
-        filename = self.temp()
-        with PackageExporter(filename) as he:
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
             he.intern("**")
             he.save_pickle("obj", "obj.pkl", obj2)
-        hi = PackageImporter(filename)
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
 
         # check we got dependencies
         sp = hi.import_module("package_a.subpackage")
@@ -185,10 +172,6 @@ class TestSaveLoad(PackageTestCase):
         self.assertEqual(len(unpickled_container), 1)
         self.assertEqual(container[0](), unpickled_container[0]())
 
-    @skipIf(
-        IS_FBCODE or IS_SANDCASTLE,
-        "Tests that use temporary files are disabled in fbcode",
-    )
     def test_exporting_mismatched_code(self):
         """
         If an object with the same qualified name is loaded from different
@@ -199,20 +182,22 @@ class TestSaveLoad(PackageTestCase):
 
         obj = package_a.subpackage.PackageASubpackageObject()
         obj2 = package_a.PackageAObject(obj)
-        f1 = self.temp()
-        with PackageExporter(f1) as pe:
+
+        b1 = BytesIO()
+        with PackageExporter(b1) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj2)
 
-        importer1 = PackageImporter(f1)
+        b1.seek(0)
+        importer1 = PackageImporter(b1)
         loaded1 = importer1.load_pickle("obj", "obj.pkl")
-        importer2 = PackageImporter(f1)
+
+        b1.seek(0)
+        importer2 = PackageImporter(b1)
         loaded2 = importer2.load_pickle("obj", "obj.pkl")
 
-        f2 = self.temp()
-
         def make_exporter():
-            pe = PackageExporter(f2, importer=[importer1, sys_importer])
+            pe = PackageExporter(BytesIO(), importer=[importer1, sys_importer])
             # Ensure that the importer finds the 'PackageAObject' defined in 'importer1' first.
             return pe
 


### PR DESCRIPTION
Summary:
Make it a bit easier to run the tests anywhere/avoid skipping the tests by using buffers instead of temporary files.
[Er, still figuring out how the sync tooling works, I'll send this against github once the first diff is landed]

Test Plan: buck2 test

Reviewed By: fluckydog232

Differential Revision: D44818261

