### PR TITLE
Inductor CPU and CUDA test template need to inherit from TorchTestCase

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -29,11 +29,11 @@ RUN_CPU = HAS_CPU and not torch.backends.mps.is_available() and not IS_MACOS
 RUN_CUDA = HAS_CUDA and not TEST_WITH_ASAN
 
 
-class CppWrapperTemplate:
+class CppWrapperTemplate(TorchTestCase):
     pass
 
 
-class CudaWrapperTemplate:
+class CudaWrapperTemplate(TorchTestCase):
     pass
 
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -519,7 +519,7 @@ class SweepInputs2:
                 cls.gen_template(name1, name2)
 
 
-class CommonTemplate:
+class CommonTemplate(TorchTestCase):
     def test_bool(self):
         def fn(a, b):
             return (

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -519,7 +519,7 @@ class SweepInputs2:
                 cls.gen_template(name1, name2)
 
 
-class CommonTemplate(TorchTestCase):
+class CommonTemplate:
     def test_bool(self):
         def fn(a, b):
             return (

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2271,7 +2271,6 @@ class TestCase(expecttest.TestCase):
             self._run_with_retry(result=result, num_runs_left=0, report_only=report_only,
                                  num_red=num_red, num_green=num_green + 1)
 
-
     def run(self, result=None):
         with contextlib.ExitStack() as stack:
             if TEST_WITH_CROSSREF:


### PR DESCRIPTION
Otherwise, some testing functionality such as checking for slow test would fail. 
 For example, https://hud.pytorch.org/pytorch/pytorch/commit/5bcbb9bca714ebf105c407390d5fe293876d8634 fails with the following error `'CpuTests' object has no attribute 'runTest'`

### Testing

Add `"test_linear_packed_cpu_dynamic_shapes_cpp_wrapper (__main__.DynamicShapesCppWrapperCpuTests)": 66.40046428571428` as an example into `test/.pytorch-slow-tests.json` and run `PYTORCH_TEST_SKIP_FAST=1 pytest --verbose -s inductor/test_torchinductor_dynamic_shapes.py -k test_linear_packed_cpu_dynamic_shapes_cpp_wrapper` without any failure.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire