### PR TITLE
[llvm-17][ORC] Fix for move most ORC APIs to ExecutorAddr, introduce ExecutorSymbolDef.

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -114,7 +114,11 @@ static void registerIntrinsics(
   using namespace llvm::orc;
 
   auto entry = [&](const char* name, auto ptr) -> SymbolMap::value_type {
+#if LLVM_VERSION_MAJOR >= 17
+    return {Mangle(name), {ExecutorAddr(toAddress(ptr)), JITSymbolFlags::None}};
+#else
     return {Mangle(name), {toAddress(ptr), JITSymbolFlags::None}};
+#endif
   };
 
   SymbolMap symbols;


### PR DESCRIPTION
Summary:
Due to change in upstream there are multiple builds that fail to build with llvm-17.
https://github.com/llvm/llvm-project/commit/8b1771bd9f304be39d4dcbdcccedb6d3bcd18200
Added a llvm version check.

Test Plan: local testing on failing build with trunk/llvm-12

Reviewed By: zhuhan0

Differential Revision: D44851324



cc @EikanWang @jgong5