### PR TITLE
[MPS] Handle deserialization more permissively

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10378,6 +10378,17 @@ class TestNoRegression(TestCase):
             self.assertEqual(x, x2)
             self.assertEqual(x2.device.type, "cpu")
 
+        # Ensures that `mps:0` Tensors can be loaded on mps
+        with tempfile.NamedTemporaryFile() as f:
+            x = torch.rand(2, device="mps:0")
+            torch.save(x, f)
+
+            f.seek(0)
+            x2 = torch.load(f, map_location="mps:0")
+
+            self.assertEqual(x, x2)
+            self.assertEqual(x2.device.type, "mps")
+
 
 MPS_DTYPES = get_all_dtypes()
 for t in [torch.double, torch.cdouble, torch.cfloat, torch.bfloat16]:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -199,7 +199,7 @@ def _cuda_deserialize(obj, location):
 
 
 def _mps_deserialize(obj, location):
-    if location == 'mps':
+    if location.startswith('mps'):
         return obj.mps()
 
 


### PR DESCRIPTION
MPS deserialization should handle `mps:0`.
It is generated from some codes like the following

```python
torch.rand(size=(3, 4)).to("mps")
```