### PR TITLE
[Easy] Reuse `source` variable in `wrap_tensor`

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -766,16 +766,16 @@ class VariableBuilder:
             return self.tx.output.register_attr_or_module(
                 value,
                 self.name,
-                source=self.get_source(),
+                source=source,
                 # Guards are done inside register_attr_or_module
                 # guards=self.make_guards(GuardBuilder.TENSOR_MATCH),
             )
 
-        if is_constant_source(self.get_source()):
+        if is_constant_source(source):
             return self.tx.output.register_attr_or_module(
                 value,
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
-                source=self.get_source(),
+                source=source,
                 # Guards are added inside register_attr_or_module
             )
 
@@ -802,9 +802,9 @@ class VariableBuilder:
             assert type(value) in (torch.Tensor, torch.nn.Parameter)
             ignore_subclass = False
 
-        is_duplicate_tensor = self.get_source() in self.tx.output.input_source_to_var
+        is_duplicate_tensor = source in self.tx.output.input_source_to_var
         if is_duplicate_tensor:
-            return self.tx.output.input_source_to_var[self.get_source()]
+            return self.tx.output.input_source_to_var[source]
 
         tensor_proxy = self.tx.output.create_graph_input(
             re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(value)
@@ -816,9 +816,9 @@ class VariableBuilder:
             guards=self.make_guards(GuardBuilder.TENSOR_MATCH),
             should_specialize=self.tensor_should_specialize(),
             ignore_subclass=ignore_subclass,
-            source=self.get_source(),
+            source=source,
         )
-        self.tx.output.input_source_to_var[self.get_source()] = tensor_variable
+        self.tx.output.input_source_to_var[source] = tensor_variable
         assert "tensor_dict" not in tensor_proxy.node.meta
         tensor_proxy.node.meta["tensor_dict"] = value.__dict__.copy()
 
@@ -829,9 +829,7 @@ class VariableBuilder:
         if isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor):
             fake_tensor_value = example_value
 
-        self.tx.output.add_grapharg(
-            GraphArg(self.get_source(), value, False, fake_tensor_value)
-        )
+        self.tx.output.add_grapharg(GraphArg(source, value, False, fake_tensor_value))
 
         if type(value) in config.traceable_tensor_subclasses:
             subclass_torch_function__func = value.__torch_function__.__func__
@@ -841,7 +839,7 @@ class VariableBuilder:
             # on the default inherited from torch.Tensor
             return TensorWithTFOverrideVariable(
                 tensor_variable,
-                self.get_source(),
+                source,
                 subclass_torch_function__func,
                 subclass_type,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98845
* #98775

https://github.com/pytorch/pytorch/blob/2fab2893aa7b255127e0b92560585d9ecf6dc506/torch/_dynamo/variables/builder.py#L759-L760
We already save `source = self.get_source()` to begin `wrap_tensor()`. Since the source should be fixed at `VariableBuilder` construction time, we should be okay to reuse the `source` variable instead of calling `get_source()` every time.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire