### PR TITLE
[BE] Use `Literal` from `typing`

### DIFF
--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -1,9 +1,7 @@
 import itertools
 import textwrap
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
-
-from typing_extensions import Literal  # Python 3.8+
+from typing import List, Literal, Optional, Tuple, Union
 
 import torchgen.api.cpp as cpp
 import torchgen.api.meta as meta

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
@@ -19,7 +20,6 @@ from typing import (
 )
 
 import yaml
-from typing_extensions import Literal  # Python 3.8+
 
 import torchgen.api.dispatcher as dispatcher
 import torchgen.api.meta as meta

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -16,6 +16,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     NoReturn,
     Optional,
     Sequence,
@@ -24,8 +25,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
-from typing_extensions import Literal  # Python 3.8+
 
 from torchgen.code_template import CodeTemplate
 


### PR DESCRIPTION
Since PyTorch is Python-3.8+ compatible framework

