### PR TITLE
Correctly update _has_global_hooks when global hooks are registered

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -305,9 +305,9 @@ def register_module_full_backward_pre_hook(
             ``handle.remove()``
 
     """
-    _update_has_global_hooks()
     handle = hooks.RemovableHandle(_global_backward_pre_hooks)
     _global_backward_pre_hooks[handle.id] = hook
+    _update_has_global_hooks()
     return handle
 
 
@@ -356,6 +356,7 @@ def register_module_full_backward_hook(
 
     handle = hooks.RemovableHandle(_global_backward_hooks)
     _global_backward_hooks[handle.id] = hook
+    _update_has_global_hooks()
     return handle
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98859
* #98854
* #96923
* #96866
* #96862
* #96783
* #90105

