### PR TITLE
[dynamo] Fix bug with torch._dynamo.skip

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1,0 +1,163 @@
+# Owner(s): ["module: dynamo"]
+import os
+import unittest.mock as mock
+from unittest.mock import patch
+
+import torch
+
+import torch._dynamo.test_case
+import torch._dynamo.testing
+
+
+class DecoratorTests(torch._dynamo.test_case.TestCase):
+    def test_skip(self):
+        def fn2(x):
+            return x.sin()
+
+        @torch._dynamo.skip
+        def fn1(x):
+            x = x.sigmoid()
+            return fn2(x.cos())
+
+        def fn(x):
+            return fn1(x.tan())
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        opt_fn(torch.randn(4))
+        self.assertEqual(cnts.frame_count, 2)
+
+    @patch.object(torch._dynamo.config, "suppress_errors", True)
+    def test_nested_disable_decorator(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch._dynamo.disable()
+        def fn1(x):
+            return torch.sin(x) * 10
+
+        @torch._dynamo.optimize(cnts)
+        def fn2(x):
+            x = x + 1
+            x = x + 1
+            x = fn1(x)  # graph break
+            x = x + 1
+            x = x + 1
+            return x
+
+        @torch._dynamo.optimize(cnts, nopython=True)
+        def fn3(x):
+            return fn2(x)
+
+        fn2(torch.randn(4, 5))
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 4)
+
+        try:
+            fn3(torch.randn(4, 5))
+            self.assertFalse(True)
+        except torch._dynamo.exc.Unsupported as e:
+            self.assertIn("call torch._dynamo.disable() wrapped function", str(e))
+
+    def test_disable_optimize(self):
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch._dynamo.optimize(cnt, disable=True)
+        def f1(x):
+            return x + 1
+
+        f1(torch.ones(6))
+        self.assertEqual(cnt.frame_count, 0)
+
+        @torch._dynamo.optimize(cnt, disable=True)
+        def f2(x):
+            return x + 1
+
+        f2(torch.ones(6))
+        self.assertEqual(cnt.frame_count, 0)
+
+        with patch.dict(os.environ, {"TORCHDYNAMO_DISABLE": "1"}):
+
+            @torch._dynamo.optimize(cnt)
+            def f3(x):
+                return x + 1
+
+            f3(torch.ones(6))
+        self.assertEqual(cnt.frame_count, 0)
+
+    def test_torch_guards_stack_frame_register_inlining_disable(self):
+        y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
+        x = torch.tensor([0.5, 0.5])
+
+        class encoder(torch.nn.Module):
+            def __init__(self, y):
+                super().__init__()
+                self.register_parameter("param", y)
+
+            @torch._dynamo.disable
+            def helper(self, x, y):
+                return x * y
+
+            def forward(self, a, *args):
+                x = a + a
+                return self.helper(x, self.param)
+
+        e = encoder(y)
+
+        seen_frames = []
+        import contextlib
+
+        @contextlib.contextmanager
+        def global_context_capture_fn(frame_summary):
+            seen_frames.append(frame_summary)
+            yield
+
+        with mock.patch(
+            "torch._guards.TracingContext.current_frame",
+            side_effect=global_context_capture_fn,
+        ):
+            torch._dynamo.optimize("eager")(e)(x)
+
+        self.assertEqual(len(seen_frames), 0)
+
+    def test_torch_guards_stack_frame_register_inlining_partially_disable(self):
+        y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
+        x = torch.tensor([0.5, 0.5])
+
+        class encoder(torch.nn.Module):
+            def __init__(self, y):
+                super().__init__()
+                self.register_parameter("param", y)
+
+            @torch._dynamo.disable
+            def helper_disabled(self, x, y):
+                return x * y
+
+            def helper(self, x, y):
+                return x * y
+
+            def forward(self, a, *args):
+                x = a + a
+                return self.helper(x, self.param) + self.helper_disabled(x, self.param)
+
+        e = encoder(y)
+
+        seen_frames = []
+        import contextlib
+
+        @contextlib.contextmanager
+        def global_context_capture_fn(frame_summary):
+            seen_frames.append(frame_summary)
+            yield
+
+        with mock.patch(
+            "torch._guards.TracingContext.current_frame",
+            side_effect=global_context_capture_fn,
+        ):
+            torch._dynamo.optimize("eager")(e)(x)
+
+        self.assertEqual(len(seen_frames), 1)
+        self.assertEqual(seen_frames[0].name, "forward")
+        self.assertEqual(
+            seen_frames[0].line,
+            "return self.helper(x, self.param) + self.helper_disabled(x, self.param)",
+        )

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1697,37 +1697,6 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         torch._dynamo.run()(fn2)(torch.randn(4))
         self.assertEqual(cnts2.frame_count, 0)
 
-    @patch.object(torch._dynamo.config, "suppress_errors", True)
-    def test_nested_disable_decorator(self):
-        cnts = torch._dynamo.testing.CompileCounter()
-
-        @torch._dynamo.disable()
-        def fn1(x):
-            return torch.sin(x) * 10
-
-        @torch._dynamo.optimize(cnts)
-        def fn2(x):
-            x = x + 1
-            x = x + 1
-            x = fn1(x)  # graph break
-            x = x + 1
-            x = x + 1
-            return x
-
-        @torch._dynamo.optimize(cnts, nopython=True)
-        def fn3(x):
-            return fn2(x)
-
-        fn2(torch.randn(4, 5))
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 4)
-
-        try:
-            fn3(torch.randn(4, 5))
-            self.assertFalse(True)
-        except torch._dynamo.exc.Unsupported as e:
-            self.assertIn("call torch._dynamo.disable() wrapped function", str(e))
-
     def test_graph_break(self):
         cnts = torch._dynamo.testing.CompileCounter()
 
@@ -3354,32 +3323,6 @@ def fn():
         res = opt_fn(x, y)
         self.assertTrue(same(ref, res))
 
-    def test_disable_optimize(self):
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch._dynamo.optimize(cnt, disable=True)
-        def f1(x):
-            return x + 1
-
-        f1(torch.ones(6))
-        self.assertEqual(cnt.frame_count, 0)
-
-        @torch._dynamo.optimize(cnt, disable=True)
-        def f2(x):
-            return x + 1
-
-        f2(torch.ones(6))
-        self.assertEqual(cnt.frame_count, 0)
-
-        with patch.dict(os.environ, {"TORCHDYNAMO_DISABLE": "1"}):
-
-            @torch._dynamo.optimize(cnt)
-            def f3(x):
-                return x + 1
-
-            f3(torch.ones(6))
-        self.assertEqual(cnt.frame_count, 0)
-
     @patch.object(torch._dynamo.config, "print_graph_breaks", True)
     def test_duplicate_graph_break_warning(self):
         @torch._dynamo.optimize("eager")
@@ -4784,84 +4727,6 @@ def fn():
         model.training_step = compiled_model.dynamo_ctx(model.training_step)
 
         model.training_step()
-
-    def test_torch_guards_stack_frame_register_inlining_disable(self):
-        y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
-        x = torch.tensor([0.5, 0.5])
-
-        class encoder(torch.nn.Module):
-            def __init__(self, y):
-                super().__init__()
-                self.register_parameter("param", y)
-
-            @torch._dynamo.disable
-            def helper(self, x, y):
-                return x * y
-
-            def forward(self, a, *args):
-                x = a + a
-                return self.helper(x, self.param)
-
-        e = encoder(y)
-
-        seen_frames = []
-        import contextlib
-
-        @contextlib.contextmanager
-        def global_context_capture_fn(frame_summary):
-            seen_frames.append(frame_summary)
-            yield
-
-        with mock.patch(
-            "torch._guards.TracingContext.current_frame",
-            side_effect=global_context_capture_fn,
-        ):
-            torch._dynamo.optimize("eager")(e)(x)
-
-        self.assertEqual(len(seen_frames), 0)
-
-    def test_torch_guards_stack_frame_register_inlining_partially_disable(self):
-        y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
-        x = torch.tensor([0.5, 0.5])
-
-        class encoder(torch.nn.Module):
-            def __init__(self, y):
-                super().__init__()
-                self.register_parameter("param", y)
-
-            @torch._dynamo.disable
-            def helper_disabled(self, x, y):
-                return x * y
-
-            def helper(self, x, y):
-                return x * y
-
-            def forward(self, a, *args):
-                x = a + a
-                return self.helper(x, self.param) + self.helper_disabled(x, self.param)
-
-        e = encoder(y)
-
-        seen_frames = []
-        import contextlib
-
-        @contextlib.contextmanager
-        def global_context_capture_fn(frame_summary):
-            seen_frames.append(frame_summary)
-            yield
-
-        with mock.patch(
-            "torch._guards.TracingContext.current_frame",
-            side_effect=global_context_capture_fn,
-        ):
-            torch._dynamo.optimize("eager")(e)(x)
-
-        self.assertEqual(len(seen_frames), 1)
-        self.assertEqual(seen_frames[0].name, "forward")
-        self.assertEqual(
-            seen_frames[0].line,
-            "return self.helper(x, self.param) + self.helper_disabled(x, self.param)",
-        )
 
     def test_torch_guards_stack_frame_register_inlining(self):
         x = torch.tensor([0.5, 0.5])

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2016,7 +2016,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 f"inline in skipfiles: {func.fn.__qualname__}  | {func.get_name()} {func.get_filename()}"
             )
 
-        if inspect.getattr_static(func.get_function(), "_torchdynamo_disable", False):
+        if isinstance(func, UserFunctionVariable) and inspect.getattr_static(
+            func.get_function(), "_torchdynamo_disable", False
+        ):
             unimplemented(
                 f"call torch._dynamo.skip() wrapped function {func.get_function()}"
             )

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2016,6 +2016,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 f"inline in skipfiles: {func.fn.__qualname__}  | {func.get_name()} {func.get_filename()}"
             )
 
+        if inspect.getattr_static(func.get_function(), "_torchdynamo_disable", False):
+            unimplemented(
+                f"call torch._dynamo.skip() wrapped function {func.get_function()}"
+            )
+
     @staticmethod
     def inline_call_(
         parent, func: VariableTracker, args: List[VariableTracker], kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98862


Summary
* Fixed an issue with `skip`
* Also removed some tests from test_misc.py and moved them to test_decorators.py as test_misc.py is becoming a dumping ground.


~~~

# Code - fn1 was not getting skipped earlier
def fn2(x):
    return x.sin()

@torch._dynamo.skip
def fn1(x):
    x = x.sigmoid()
    return fn2(x.cos())

def fn(x):
    return fn1(x.tan())


# Extracted graph
def forward(self, L_x_ : torch.Tensor):
    l_x_ = L_x_
    tan = l_x_.tan();  l_x_ = None
    return (tan,)


def forward(self, L_x_ : torch.Tensor):
    l_x_ = L_x_
    sin = l_x_.sin();  l_x_ = None
    return (sin,)
~~~


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire