### PR TITLE
Skip dtensor ops on CPU-only runner due to flaky timeout

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -713,4 +713,7 @@ instantiate_device_type_tests(TestDTensorOps, globals(), only_for=(DEVICE_TYPE,)
 
 
 if __name__ == "__main__":
-    run_tests()
+    # NB: CPU dtensor ops test frequently timeout https://github.com/pytorch/pytorch/issues/98816
+    # so running it only on CUDA
+    if torch.cuda.is_available():
+        run_tests()


### PR DESCRIPTION
`distributed/_tensor/test_dtensor_ops` is still flaky in trunk with a curious timeout issue, for example https://hud.pytorch.org/pytorch/pytorch/commit/ce4df4cc596aa10534ac6d54912f960238264dfd.  It seems that the test just hang without any failure.  The root cause is unclear.  On the other hang, https://github.com/pytorch/pytorch/issues/98816 might offer a solution for this.  Anyway, I'm disable the test on CPU for now while the investigation is being done.

The test is still being run on CUDA-available runner because it's not flaky there.