### PR TITLE
[dynamo] Raise exception on incorrect usage of disallow_in_graph

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -7,9 +7,80 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch._dynamo.exc import IncorrectUsage
+
+
+def my_custom_function(x):
+    return x + 1
 
 
 class DecoratorTests(torch._dynamo.test_case.TestCase):
+    def test_disallow_in_graph(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch._dynamo.optimize(cnts)
+        def fn(a):
+            x = torch.add(a, 1)
+            x = torch.add(x, 1)
+            x = torch.sub(x, 1)
+            x = torch.add(x, 1)
+            x = torch.add(x, 1)
+            return x
+
+        torch._dynamo.disallow_in_graph(torch.sub)
+        fn(torch.randn(10))
+        torch._dynamo.allow_in_graph(torch.sub)
+
+        # check for graph break on sub
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 4)
+
+    def test_allow_in_graph(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch._dynamo.optimize(cnts)
+        def fn(a):
+            x = torch.add(a, 1)
+            x = torch.add(x, 1)
+            x = my_custom_function(x)
+            x = torch.add(x, 1)
+            x = torch.add(x, 1)
+            return x
+
+        torch._dynamo.allow_in_graph(my_custom_function)
+        fn(torch.randn(10))
+        torch._dynamo.disallow_in_graph(my_custom_function)
+
+        # check for no graph break
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 5)
+
+    def test_incorrect_usage_disallow_in_graph(self):
+        with self.assertRaises(IncorrectUsage):
+
+            @torch._dynamo.disallow_in_graph
+            def fn1(x):
+                return x.cos()
+
+    def test_graph_break(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch._dynamo.optimize(cnts)
+        def fn(x):
+            x = torch.cos(x)
+            x = torch.cos(x)
+            torch._dynamo.graph_break()
+            x = torch.cos(x)
+            x = torch.cos(x)
+            torch._dynamo.graph_break()
+            x = torch.cos(x)
+            x = torch.cos(x)
+            return x
+
+        fn(torch.randn(4, 5))
+        self.assertEqual(cnts.frame_count, 3)
+        self.assertEqual(cnts.op_count, 6)
+
     def test_skip(self):
         def fn2(x):
             return x.sin()

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -14,6 +14,7 @@ from .eval_frame import (
     run,
     skip,
 )
+from .exc import IncorrectUsage
 from .external_utils import is_compiling
 from .utils import compilation_metrics, guard_failures, orig_code_map, reset_frame_count
 
@@ -84,6 +85,23 @@ def allow_in_graph(fn):
     return fn
 
 
+def _disallow_in_graph_helper(throw_if_not_allowed):
+    def inner(fn):
+        if isinstance(fn, (list, tuple)):
+            return [disallow_in_graph(x) for x in fn]
+        assert callable(fn), "disallow_in_graph expects a callable"
+        if throw_if_not_allowed and not allowed_functions.is_allowed(fn):
+            raise IncorrectUsage(
+                "disallow_in_graph is expected to be used on an already allowed callable (like torch.* ops). "
+                "Allowed callables means callables that TorchDynamo puts as-is in the extracted graph."
+            )
+        allowed_functions._allowed_function_ids.remove(id(fn))
+        allowed_functions._disallowed_function_ids.add(id(fn))
+        return fn
+
+    return inner
+
+
 def disallow_in_graph(fn):
     """
     Customize which functions TorchDynamo will exclude in the generated
@@ -104,15 +122,10 @@ def disallow_in_graph(fn):
     Will break the graph on `torch.sub`, and give two graphs each with a
     single `torch.add()` op.
     """
-    if isinstance(fn, (list, tuple)):
-        return [disallow_in_graph(x) for x in fn]
-    assert callable(fn), "disallow_in_graph expects a callable"
-    allowed_functions._allowed_function_ids.remove(id(fn))
-    allowed_functions._disallowed_function_ids.add(id(fn))
-    return fn
+    return _disallow_in_graph_helper(throw_if_not_allowed=True)(fn)
 
 
-@disallow_in_graph
+@_disallow_in_graph_helper(throw_if_not_allowed=False)
 def graph_break():
     """Force a graph break"""
     pass

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -97,6 +97,10 @@ class UserError(Unsupported):
         self.error_type = error_type
 
 
+class IncorrectUsage(Exception):
+    pass
+
+
 def unimplemented(msg: str):
     assert msg != os.environ.get("BREAK", False)
     raise Unsupported(msg)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #98899
* __->__ #98892
* #98862

Summary - 
`disallow_in_graph` is mostly useful for backends. Suppose, your backend does not support `torch.abs()`. So, you can use `disallow_in_graph` to do a graph break. 

The assumption in the above statement is that `disallow_in_graph` is called on an `allowed` callable. `allowed` in Dynamo language refers to a callable that is put as-is in the Dynamo graph. 

Therefore, if one uses `disallow_in_graph` on some non-torch non-allowed function, we want to raise an exception to tell user that they probably want something else.
* If they want to disable Dynamo - they should use torch._dynamo.disable
* If they wanted to stop inlining - they should use torch._dynamo.graph_break. However this is not a decorator. So, we need to provide another API. But, the question - who would want to do this?

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire