### PR TITLE
[dynamo] Remove _dynamo.skip and fold it in _dynamo.disable

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -85,7 +85,7 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         def fn2(x):
             return x.sin()
 
-        @torch._dynamo.skip
+        @torch._dynamo.disable(recursive=False)
         def fn1(x):
             x = x.sigmoid()
             return fn2(x.cos())

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1414,7 +1414,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
     @torch._dynamo.config.patch("suppress_errors", True)
     def test_guard_fail_tensor_bool(self):
-        @torch._dynamo.skip
+        @torch._dynamo.disable(recursive=False)
         def fn():
             condition_shape = (5, 5)
             dtypes = (torch.bool,)
@@ -2400,7 +2400,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         # dynamo eval frame handler is active), as that will cause the
         # generator to become exhausted and trigger the throw_flag == TRUE
         # case.
-        @torch._dynamo.skip
+        @torch._dynamo.disable(recursive=False)
         def f(x):
             generator_box.clear()
             return g(x)

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -12,7 +12,6 @@ from .eval_frame import (
     OptimizedModule,
     reset_code,
     run,
-    skip,
 )
 from .exc import IncorrectUsage
 from .external_utils import is_compiling
@@ -34,7 +33,6 @@ __all__ = [
     "replay",
     "disable",
     "reset",
-    "skip",
     "OptimizedModule",
     "is_compiling",
     "register_backend",

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -970,17 +970,21 @@ def disable(fn=None, recursive=True):
             return DisableContext()(fn)
         return DisableContext()
     else:
-        if fn is None:
+        return skip(fn)
 
-            def inner(new_fn):
-                return disable(fn=new_fn, recursive=False)
 
-            return inner
-        fn = innermost_fn(fn)
-        assert callable(fn)
-        skip_code(fn.__code__)
-        fn._torchdynamo_disable = True
-        return fn
+def skip(fn=None):
+    """
+    Skip frames associated with the function code, but still process recursively
+    invoked frames
+    """
+    if fn is None:
+        return skip
+    fn = innermost_fn(fn)
+    assert callable(fn)
+    skip_code(fn.__code__)
+    fn._torchdynamo_disable = True
+    return fn
 
 
 class TorchPatcher:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2020,7 +2020,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             func.get_function(), "_torchdynamo_disable", False
         ):
             unimplemented(
-                f"call torch._dynamo.skip() wrapped function {func.get_function()}"
+                f"call torch._dynamo.disable() wrapped function {func.get_function()}"
             )
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98899
* #98892
* #98862

Summary
There is confusion between`_dynamo.skip` and `_dynamo.disable`. This removes the `_dynamo.skip` API. The functionality is still available via `_dynamo.disable(recursive=False)`

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire