### PR TITLE
inductor: fix the issue of cat missing dim argument for sink_cat_after_pointwise

### DIFF
--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -50,6 +50,9 @@ class TestFxFusion(TestCase):
         def test_arg(x, y):
             return torch.cat([x, y], -1).view(-1).view(128).tanh()
 
+        def test_arg2(x, y):
+            return torch.cat([x, y]).view(-1).view(128).tanh()
+
         def test_kwarg2(x, y):
             return torch.cat(tensors=[x, y], dim=0).tanh()
 
@@ -61,7 +64,7 @@ class TestFxFusion(TestCase):
             torch.randn(8, 8),
             torch.randn(8, 8),
         ]
-        for f in [test_kwarg, test_arg, test_kwarg2, test_kwarg3]:
+        for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3]:
             traced = trace_func(f, inputs)
             self.assertTrue(torch.allclose(f(*inputs), traced(*inputs)))
             self.assertEqual(count_call_method(traced, "tanh"), 2)

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -284,7 +284,7 @@ def sink_cat_after_pointwise(module: torch.fx.GraphModule) -> torch.fx.GraphModu
         if user and is_pointwise_unary(user):
             with g.inserting_before(node):
 
-                def cat_args(tensors, dim):
+                def cat_args(tensors, dim=0):
                     return tensors, dim
 
                 tensors, dim = cat_args(*node.args, **node.kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98901

Fix #98850 which reports an error when a cat doesn't give a dim value.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire