### PR TITLE
Use the same python version in MacOS workflows and add more debug messages

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -25,6 +25,7 @@ setup_test_python() {
   # using the address associated with the loopback interface.
   export GLOO_SOCKET_IFNAME=lo0
   echo "Ninja version: $(ninja --version)"
+  echo "Python version: $(python --version)"
 
   # Increase default limit on open file handles from 256 to 1024
   ulimit -n 1024
@@ -45,9 +46,6 @@ test_python_shard() {
   fi
 
   setup_test_python
-
-  which python
-  python --version
 
   time python test/run_test.py --verbose --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS"
 

--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -46,6 +46,9 @@ test_python_shard() {
 
   setup_test_python
 
+  which python
+  python --version
+
   time python test/run_test.py --verbose --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS"
 
   assert_git_not_dirty

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -21,3 +21,4 @@ sympy==1.11.1
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0
+sympy==1.11.1

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,24 +113,6 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      - name: Install misc macOS dependencies
-        if: ${{ runner.arch == 'ARM64' }}
-        uses: nick-fields/retry@v2.8.2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 90
-          command: |
-            # Install dependencies
-            brew install libomp
-            brew link --force libomp
-
-            # TODO: The latest Rosetta version is required to run the current sccache
-            # binary for MacOS. We should get this fixed with a native sccache for M1
-            # Without this, the build job would fail with bad CPU type in executable
-            # error. This is only needed on M1
-            softwareupdate --install-rosetta --agree-to-license
-
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@v2.8.2
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -27,7 +27,7 @@ on:
         description: |
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
-      python_version:
+      python-version:
         required: false
         type: string
         default: "3.8"
@@ -99,7 +99,7 @@ jobs:
         if: inputs.environment-file == ''
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
@@ -109,7 +109,7 @@ jobs:
         if: inputs.environment-file != ''
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ inputs.python-version }}
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,8 +113,8 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      # TODO: Move this to a setup-mac action
       - name: Install misc macOS dependencies
+        if: ${{ runner.arch == 'ARM64' }}
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5
@@ -128,7 +128,7 @@ jobs:
             # TODO: The latest Rosetta version is required to run the current sccache
             # binary for MacOS. We should get this fixed with a native sccache for M1
             # Without this, the build job would fail with bad CPU type in executable
-            # error
+            # error. This is only needed on M1
             softwareupdate --install-rosetta --agree-to-license
 
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,7 +113,8 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      - name: Install macOS homebrew dependencies
+      # TODO: Move this to a setup-mac action
+      - name: Install misc macOS dependencies
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5
@@ -123,6 +124,12 @@ jobs:
             # Install dependencies
             brew install libomp
             brew link --force libomp
+
+            # TODO: The latest Rosetta version is required to run the current sccache
+            # binary for MacOS. We should get this fixed with a native sccache for M1
+            # Without this, the build job would fail with bad CPU type in executable
+            # error
+            softwareupdate --install-rosetta --agree-to-license
 
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@v2.8.2

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -120,11 +120,10 @@ jobs:
               echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"
             else
-              echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
-              echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
               # The runner has access to the S3 bucket via IAM profile without the need
               # for any credential
-              echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "${GITHUB_ENV}"
+              echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
+              echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
             fi
 
             sudo chmod +x "${LOCAL_PATH}/sccache"

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,9 +113,9 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      - name: Install sccache (only for non-forked PRs)
+      - name: Install sccache (only for non-forked PRs, or pushes to trunk)
         uses: nick-fields/retry@v2.8.2
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,25 +113,31 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      - name: Install sccache (only for non-forked PRs, and pushes to trunk)
+      - name: Install sccache (only for non-forked PRs)
         uses: nick-fields/retry@v2.8.2
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 90
           command: |
+            set -ex
+
+            LOCAL_PATH="/usr/local/bin"
+            sudo curl --retry 3 --retry-all-errors "https://s3.amazonaws.com/ossci-macos/sccache/sccache-v0.4.1-${RUNNER_ARCH}" --output "${LOCAL_PATH}/sccache"
+
             if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
-              sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v0.4.0-pre.7 --output /usr/local/bin/sccache
               echo "ACTIONS_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
               echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"
             else
-              sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
               echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
               echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
             fi
-            sudo chmod +x /usr/local/bin/sccache
+
+            sudo chmod +x "${LOCAL_PATH}/sccache"
+            # This is needed so that later build script could find sccache (which sccache)
+            echo "${LOCAL_PATH}" >> $GITHUB_PATH
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -133,6 +133,9 @@ jobs:
             else
               echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
               echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
+              # The runner has access to the S3 bucket via IAM profile without the need
+              # for any credential
+              echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "${GITHUB_ENV}"
             fi
 
             sudo chmod +x "${LOCAL_PATH}/sccache"

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -112,8 +112,24 @@ jobs:
           command: |
             set -ex
 
+            DOWNLOAD_SCCACHE=0
+            SCCACHE_VERSION="0.4.1"
             LOCAL_PATH="/usr/local/bin"
-            sudo curl --retry 3 --retry-all-errors "https://s3.amazonaws.com/ossci-macos/sccache/sccache-v0.4.1-${RUNNER_ARCH}" --output "${LOCAL_PATH}/sccache"
+
+            if [ ! -f "${LOCAL_PATH}/sccache" ]; then
+              DOWNLOAD_SCCACHE=1
+            else
+              LOCAL_VERSION=$("${LOCAL_PATH}/sccache" --version | cut -d" " -f2)
+
+              if [ "${LOCAL_VERSION}" != "${SCCACHE_VERSION}" ]; then
+                DOWNLOAD_SCCACHE=1
+              fi
+            fi
+
+            if [ "${DOWNLOAD_SCCACHE}" == "1" ]; then
+              sudo curl --retry 3 --retry-all-errors "https://s3.amazonaws.com/ossci-macos/sccache/sccache-v0.4.1-${RUNNER_ARCH}" --output "${LOCAL_PATH}/sccache"
+              sudo chmod +x "${LOCAL_PATH}/sccache"
+            fi
 
             if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
               echo "ACTIONS_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
@@ -126,7 +142,6 @@ jobs:
               echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
             fi
 
-            sudo chmod +x "${LOCAL_PATH}/sccache"
             # This is needed so that later build script could find sccache (which sccache)
             echo "${LOCAL_PATH}" >> $GITHUB_PATH
 

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -113,7 +113,7 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
-      - name: Install sccache (only for non-forked PRs, or pushes to trunk)
+      - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@v2.8.2
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -58,23 +58,12 @@ on:
         value: ${{ jobs.build.outputs.build-outcome }}
         description: The outcome of the build step. This is used to influence test filtering logic later on.
 
-    secrets:
-      MACOS_SCCACHE_S3_ACCESS_KEY_ID:
-        required: true
-        description: Access key for S3 bucket for macOS sccache.
-      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY:
-        required: true
-        description: Secret for S3 bucket for macOS sccache.
-
 jobs:
   build:
     # Don't run on forked repos.
     if: github.repository_owner == 'pytorch'
     runs-on: ${{ inputs.runner-type }}
     env:
-      # For sccache access (only on non-forked PRs)
-      AWS_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
       SCCACHE_USE_GHA: ${{ inputs.sccache-use-gha }}  # this is placed here instead of the sccache step to appease actionlint
     outputs:

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -83,20 +83,6 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      # This is copied from the main macos test workflow. It was missed in the earlier fix because macos M1
-      # runners are shared and not ephemeral, so the issue wasn't manifested if the runners with the fix were
-      # used
-      - name: Install macOS homebrew dependencies
-        uses: nick-fields/retry@v2.8.2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 90
-          command: |
-            # Install dependencies
-            brew install libomp
-            brew link --force libomp
-
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -77,8 +77,10 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      # TODO: Move this to a setup-mac action
-      - name: Install misc macOS dependencies
+      # This is copied from the main macos test workflow. It was missed in the earlier fix because macos M1
+      # runners are shared and not ephemeral, so the issue wasn't manifested if the runners with the fix were
+      # used
+      - name: Install macOS homebrew dependencies
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -14,6 +14,12 @@ on:
         description: |
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
+      python-version:
+        required: false
+        type: string
+        default: "3.8"
+        description: |
+          The python version to be used. Will be 3.8 by default
       test-matrix:
         required: true
         type: string
@@ -92,9 +98,9 @@ jobs:
             brew link --force libomp
 
       - name: Setup miniconda
-        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
@@ -117,11 +123,11 @@ jobs:
             export PATH="$CONDA_ENV/bin":$PATH
           fi
 
-          # DEBUG
-          ${CONDA_RUN} python3 --version
-          ${CONDA_RUN} which python
-          ${CONDA_RUN} which python3
-          echo "${PATH}"
+          # Print out some information about the test environment
+          ${CONDA_RUN} which python3 || true
+          ${CONDA_RUN} python3 --version || true
+          ${CONDA_RUN} which python || true
+          ${CONDA_RUN} python --version || true
 
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -92,7 +92,7 @@ jobs:
             brew link --force libomp
 
       - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
         with:
           python-version: 3.9
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -116,6 +116,12 @@ jobs:
             # Use binaries under conda environment
             export PATH="$CONDA_ENV/bin":$PATH
           fi
+
+          # DEBUG
+          ${CONDA_RUN} python3 --version
+          ${CONDA_RUN} which python
+          ${CONDA_RUN} which python3
+          echo "${PATH}"
 
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -77,10 +77,8 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      # This is copied from the main macos test workflow. It was missed in the earlier fix because macos M1
-      # runners are shared and not ephemeral, so the issue wasn't manifested if the runners with the fix were
-      # used
-      - name: Install macOS homebrew dependencies
+      # TODO: Move this to a setup-mac action
+      - name: Install misc macOS dependencies
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -110,10 +110,12 @@ jobs:
           fi
 
           # Print out some information about the test environment
-          ${CONDA_RUN} which python3 || true
-          ${CONDA_RUN} python3 --version || true
-          ${CONDA_RUN} which python || true
-          ${CONDA_RUN} python --version || true
+          which conda
+          conda --version
+          ${CONDA_RUN} which python3
+          ${CONDA_RUN} python3 --version
+          ${CONDA_RUN} which python
+          ${CONDA_RUN} python --version
 
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -129,6 +129,7 @@ jobs:
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
+      # TODO: Move this to a setup-mac action
       - name: Install misc macOS dependencies
         uses: nick-fields/retry@v2.8.2
         with:
@@ -139,12 +140,6 @@ jobs:
             # Install dependencies
             brew install libomp
             brew link --force libomp
-
-            # TODO: The latest Rosetta version is required to run the current sccache
-            # binary for MacOS. We should get this fixed with a native sccache for M1
-            # Without this, the build job would fail with bad CPU type in executable
-            # error
-            softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -126,17 +126,6 @@ jobs:
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install macOS homebrew dependencies
-        uses: nick-fields/retry@v2.8.2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 90
-          command: |
-            # Install dependencies
-            brew install libomp
-            brew link --force libomp
-
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -129,8 +129,7 @@ jobs:
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
-      # TODO: Move this to a setup-mac action
-      - name: Install misc macOS dependencies
+      - name: Install macOS homebrew dependencies
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Setup miniconda (x86, py3.8)
         if: ${{ runner.arch == 'X64' }}
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
         with:
           python-version: 3.8
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Setup miniconda (arm64, py3.9)
         if: ${{ runner.arch == 'ARM64' }}
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
         with:
           python-version: 3.9
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -184,6 +184,12 @@ jobs:
             # Use binaries under conda environment
             export PATH="$CONDA_ENV/bin":$PATH
           fi
+
+          # DEBUG
+          ${CONDA_RUN} python3 --version
+          ${CONDA_RUN} which python
+          ${CONDA_RUN} which python3
+          echo "${PATH}"
 
           ${CONDA_RUN} python3 -mpip install --no-index --no-deps $(echo dist/*.whl)
           ${CONDA_RUN} .ci/pytorch/macos-test.sh

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -18,6 +18,12 @@ on:
         description: |
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
+      python-version:
+        required: false
+        type: string
+        default: "3.8"
+        description: |
+          The python version to be used. Will be 3.8 by default
       arch:
         required: true
         type: string
@@ -106,19 +112,10 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Setup miniconda (x86, py3.8)
-        if: ${{ runner.arch == 'X64' }}
-        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: 3.8
-          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
-          pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
-
-      - name: Setup miniconda (arm64, py3.9)
-        if: ${{ runner.arch == 'ARM64' }}
-        uses: huydhn/test-infra/.github/actions/setup-miniconda@debug-macos-flaky-deps
-        with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
           pip-requirements-file: .github/requirements/pip-requirements-${{ runner.os }}.txt
 
@@ -165,6 +162,9 @@ jobs:
           PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
         run: |
+          # shellcheck disable=SC1090
+          set -ex
+
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
           # sanitize the input commit message and PR body here:
@@ -185,11 +185,11 @@ jobs:
             export PATH="$CONDA_ENV/bin":$PATH
           fi
 
-          # DEBUG
-          ${CONDA_RUN} python3 --version
-          ${CONDA_RUN} which python
-          ${CONDA_RUN} which python3
-          echo "${PATH}"
+          # Print out some information about the test environment
+          ${CONDA_RUN} which python3 || true
+          ${CONDA_RUN} python3 --version || true
+          ${CONDA_RUN} which python || true
+          ${CONDA_RUN} python --version || true
 
           ${CONDA_RUN} python3 -mpip install --no-index --no-deps $(echo dist/*.whl)
           ${CONDA_RUN} .ci/pytorch/macos-test.sh

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -129,7 +129,7 @@ jobs:
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install macOS homebrew dependencies
+      - name: Install misc macOS dependencies
         uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 5
@@ -139,6 +139,12 @@ jobs:
             # Install dependencies
             brew install libomp
             brew link --force libomp
+
+            # TODO: The latest Rosetta version is required to run the current sccache
+            # binary for MacOS. We should get this fixed with a native sccache for M1
+            # Without this, the build job would fail with bad CPU type in executable
+            # error
+            softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -35,13 +35,6 @@ on:
         default: 270
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID:
-        required: true
-        description: access key id for test stats upload
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY:
-        required: true
-        description: secret acess key for test stats upload
 
 jobs:
   # This needs to be run right before the test starts so that it can gather the

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -168,10 +168,12 @@ jobs:
           fi
 
           # Print out some information about the test environment
-          ${CONDA_RUN} which python3 || true
-          ${CONDA_RUN} python3 --version || true
-          ${CONDA_RUN} which python || true
-          ${CONDA_RUN} python --version || true
+          which conda
+          conda --version
+          ${CONDA_RUN} which python3
+          ${CONDA_RUN} python3 --version
+          ${CONDA_RUN} which python
+          ${CONDA_RUN} python --version
 
           ${CONDA_RUN} python3 -mpip install --no-index --no-deps $(echo dist/*.whl)
           ${CONDA_RUN} .ci/pytorch/macos-test.sh

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -40,6 +40,8 @@ jobs:
     with:
       sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
 
   macos-13-py3-arm64-mps-test:
@@ -48,5 +50,7 @@ jobs:
     needs: macos-12-py3-arm64-build
     with:
       build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
       runs-on: macos-m1-13

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -20,7 +20,7 @@ jobs:
       runner-type: macos-m1-12
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
-      python_version: 3.9.12
+      python-version: 3.9.12
       # We need to set the environment file here instead of trying to detect it automatically because
       # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
       # is needed when building PyTorch MacOS arm64 from x86-64

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -29,9 +29,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-    secrets:
-      MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
-      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-arm64-mps-test:
     name: macos-12-py3-arm64-mps

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -223,9 +223,6 @@ jobs:
           { config: "default", shard: 3, num_shards: 4, runner: "macos-12" },
           { config: "default", shard: 4, num_shards: 4, runner: "macos-12" },
         ]}
-    secrets:
-      MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
-      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-x86-64-test:
     name: macos-12-py3-x86-64
@@ -235,9 +232,6 @@ jobs:
       build-environment: macos-12-py3-x86-64
       test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
       arch: x86_64
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
   macos-12-py3-x86-64-lite-interpreter-build-test:
     name: macos-12-py3-x86-64-lite-interpreter
@@ -252,9 +246,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "macos-12" },
         ]}
-    secrets:
-      MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
-      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   android-emulator-build-test:
     name: android-emulator-build-test

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -109,7 +109,7 @@ jobs:
       runner-type: macos-m1-12
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
-      python_version: 3.9.12
+      python-version: 3.9.12
       # We need to set the environment file here instead of trying to detect it automatically because
       # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
       # is needed when building PyTorch MacOS arm64 from x86-64
@@ -132,6 +132,8 @@ jobs:
     with:
       sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -145,6 +145,8 @@ jobs:
     needs: macos-12-py3-arm64-build
     with:
       build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
       arch: arm64
     secrets:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -120,9 +120,6 @@ jobs:
           { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-12" },
           { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-12" },
         ]}
-    secrets:
-      MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
-      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-arm64-mps-test:
     name: macos-12-py3-arm64-mps
@@ -149,9 +146,6 @@ jobs:
       python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
       arch: arm64
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
   win-vs2019-cuda11_7-py3-build:
     name: win-vs2019-cuda11.7-py3


### PR DESCRIPTION
After https://github.com/fairinternal/pytorch-gha-infra/pull/139 (https://github.com/fairinternal/pytorch-gha-infra/actions/runs/4683157903/jobs/8297905750), the flaky issue on MacOS points to sccache setup.  There are several issues there:
  * sccache is downloaded to `/usr/local/bin/sccache`.  Surprisingly, the build script doesn't find it in some cases (probably the new runners), for example https://github.com/pytorch/pytorch/actions/runs/4681216666/jobs/8293519052 has `which sccache` returns nothing despite that the binary is there.  In such case, `/usr/local/bin` is not in GitHub path.
  * Once sccache is used.  We need to use the correct sccache binary arch.  Using sccache for x86-64 on M1 would end up with a x86-64 torch binary, i.e. https://hud.pytorch.org/pytorch/pytorch/commit/01e011b07c9ad2447f3061e33ec757f0c23cec6f
  * We don't need to set the AWS secret key on MacOS runner anymore.  The AWS M1 runner has access to S3 cache via its IAM profile while GitHub x86-64 runner uses GitHub cache https://github.com/pytorch/pytorch/pull/96142

Other minor changes:
* The same python version is used in both MacOS build and test jobs.  This is set by the workflow via `python-version` parameter
* Add some debug information about the python version is used to run the test