### PR TITLE
[AOTAutograd] Fix is-duplicate check in de-dup guard logic

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -596,10 +596,11 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
                 .run(GUARDS_FILE.getvalue())
             self.assertTrue(same(correct_outputs, outputs))
 
-    def test_fsdp_dup_tensors(self):
+    def test_fsdp_dup_tensors_same_source(self):
         """
-        Tests that parameters and buffers are de-duplicated, meaning that they
-        each only passed once as a graph input.
+        Tests that FSDP-managed modules' parameters and buffers with the same
+        source are de-duplicated, meaning that they are each only passed once
+        as a graph input.
         """
         class DuplicateModule(nn.Module):
             def __init__(self) -> None:
@@ -612,18 +613,9 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 # Use `_param` and `_buf` each twice in this compiled forward
                 # to exercise if they are de-duplicated by TorchDynamo
-                z = self._add_buf(x)
-                z += self._mul_buf(self._buf)
+                z = x + self._buf + self._buf
                 z += self._param + self._param
                 return z
-
-            def _add_buf(self, z: torch.Tensor) -> torch.Tensor:
-                z += self._buf
-                return z
-
-            def _mul_buf(self, buf: torch.Tensor):
-                buf.mul_(2)
-                return buf + buf
 
         model = DuplicateModule()
         fsdp_model = FSDP(copy.deepcopy(model), use_orig_params=True)
@@ -632,6 +624,50 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
         local_out = model(inp)
         fsdp_out = fsdp_model(inp)
         self.assertEqual(local_out, fsdp_out)
+
+    def test_fsdp_dup_tensors_diff_source(self):
+        """
+        Tests that FSDP-managed modules' parameters and buffers with different
+        source do not result in incorrect AOTAutograd de-dup guards like
+        ``a is b``, where ``a`` and ``b`` are certainly not the same. We check
+        this by checking for per-invocation recompiles.
+        """
+        class BufModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer(
+                    "_buf", torch.randn((3,), requires_grad=False, device="cuda")
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + self._buf
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self._param = nn.Parameter(torch.randn((1,), device="cuda"))
+                self._buf_module = BufModule()
+                # Share the buffer, meaning same tensor but different source
+                self.register_buffer("_buf", self._buf_module._buf)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                # Use the same buffer tensor twice in the compiled forward,
+                # including a data mutation to trigger de-dup logic
+                self._buf.mul_(2)
+                z = x + self._buf
+                z = self._buf_module(z)
+                z += self._param
+                return z
+
+        fsdp_model = FSDP(Model(), use_orig_params=True)
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        fsdp_model = torch._dynamo.optimize(cnt)(fsdp_model)
+        inp = torch.randn((2, 3), device="cuda")
+        for _ in range(3):
+            fsdp_model(inp)
+        # Check for no recompiles (if there were incorrect de-dup guards, then
+        # the frame count would be equal to the number of forward calls)
+        self.assertEqual(cnt.frame_count, 1)
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1855,31 +1855,34 @@ def aot_wrapper_dedupe(
     # This is done via (respectively):
     #
     #   seen_args = {a: 0, b: 1, c: 2}
-    #   add_dupe_map = {  # how to get args from the deduped list
-    #       0: 0,
-    #       1: 1,
-    #       2: 0,
-    #       3: 2,
-    #   }
+    #   enumerate(add_dupe_map) = [  # how to get args from the deduped list
+    #       (0, 0),
+    #       (1, 1),
+    #       (2, 0),
+    #       (3, 2),
+    #   ]
     #   keep_arg_mask = [True, True, False, True]
 
     seen_args = {}
     keep_arg_mask = []
-    add_dupe_map = {}
+    # Implicitly map duped arg position (list index) to de-duped arg position
+    add_dupe_map: List[int] = []
     duped_arg_len = len(flat_args)
 
     j = 0  # index into deduped_flat_args
     for i, t in enumerate(flat_args):
         if t in seen_args:
             keep_arg_mask.append(False)
-            add_dupe_map[i] = seen_args[t]
+            add_dupe_map.append(seen_args[t])
             continue
         keep_arg_mask.append(True)
         seen_args[t] = j
-        add_dupe_map[i] = j
+        add_dupe_map.append(j)
         j += 1
-
-    unique_args = j
+    num_unique_args = j
+    assert len(add_dupe_map) == duped_arg_len, (
+        f"Expects add_dupe_map to have length {duped_arg_len} but got {len(add_dupe_map)}"
+    )
 
     # NB: Hot path, avoid set lookups here
     # TODO: Can avoid the zip here too, probably
@@ -1895,15 +1898,22 @@ def aot_wrapper_dedupe(
     updated_fw_metadata = remove_dupe_metadata(fw_metadata, keep_arg_mask)
 
     tracing_context = TracingContext.get()
+    unique_arg_count = 0
     if tracing_context and aot_config.aot_autograd_arg_pos_to_source:
         # TODO(voz): This structure is 1:1, we could consider an alternate structure like
         # kept_pos:[dupe_arg_pos], however, add_dupe_map is 1:1 so we would need a new structure there,
         # which feels like needless complexity for a tiny bit of efficiency at this point.
-        for dupe_arg_pos, kept_pos in add_dupe_map.items():
-            if dupe_arg_pos != kept_pos:
+        for dupe_arg_pos, kept_pos in enumerate(add_dupe_map):
+            is_dupe_arg = kept_pos < unique_arg_count
+            if is_dupe_arg:
                 dupe_arg_source = aot_config.aot_autograd_arg_pos_to_source[dupe_arg_pos]
                 kept_arg_source = aot_config.aot_autograd_arg_pos_to_source[kept_pos]
                 tracing_context.guards_context.aotautograd_guards.append(DuplicateInputs(kept_arg_source, dupe_arg_source))
+            else:
+                unique_arg_count += 1
+        assert unique_arg_count == num_unique_args, (
+            f"Expects unique_arg_count to be {num_unique_args} but got {unique_arg_count}"
+        )
 
     @wraps(flat_fn)
     def wrapped_flat_fn(*args):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #98932
* #98845
* #98775

**Context**
The existing check to see if an arg is duped is `if dupe_arg_pos != kept_pos:`. However, this incorrectly considers every arg after a true duped arg to also be a duped arg.

Consider `flat_args = [a, b, b, c]`, where indices `1` and `2` are duped.
- `add_dupe_map = {0: 0, 1: 1, 2: 1, 3: 2}`
- For `dupe_arg_pos=2, kept_pos=1`, `2 != 1`, so the check correctly identifies the second `b` to be a duped arg.
- For `dupe_arg_pos=3, kept_pos=2`, `3 != 2`, so the check incorrectly identifies the `c` to be a duped arg.

Indeed, if there were more args like `[a, b, b, c, d, e, ...]`, every arg after the second `b` will be considered a duped arg since its `kept_pos` will always be 1 lower than its `dupe_arg_pos`.

**Overview**
This PR changes `add_dupe_map` to be implemented as a `List[int]`, where the list index implicitly represents the `dupe_arg_pos` and the list element represents the `kept_pos`. We use a list to have stable in-order iteration and because we know the keys to be in `{0, 1, ..., len(flat_args) - 1}`.

With `add_dupe_map` as a list, the `is_dupe_arg` condition is whether the entry in `add_dupe_map` shows a new not-yet-seen index in the iteration. One way to do this is to count the number of unique args so far and compare against that.

This closes https://github.com/pytorch/pytorch/issues/98883, where now the guards change from
```
GUARDS ___guarded_code.valid
and ___check_type_id(L['self'], 93996836333040)
and ___check_obj_id(L['self'], 140119034997536)
and not ___are_deterministic_algorithms_enabled()
and ___check_tensors(L['x'])
and L['self']._buf is L['self']._buf_module._buf
and L['self']._buf_module._buf is L['self']._param
```
to without the final incorrect `L['self']._buf_module._buf is L['self']._param` guard.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire