### PR TITLE
Add check for same dtype in tensordot implementation

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -726,6 +726,7 @@ Tensor bilinear(const Tensor& input1, const Tensor& input2, const Tensor& weight
 // in the two dimension lists
 Tensor tensordot(const Tensor& input1, const Tensor& input2, IntArrayRef dims1, IntArrayRef dims2) {
   TORCH_CHECK(dims1.size() == dims2.size(), "both dimension lists should have same length");
+  TORCH_CHECK(input1.scalar_type() == input2.scalar_type(), "both inputs should have same dtype");
   int64_t csize = 1;  // total size of the contracted dimensions
   Tensor t1 = input1;
   Tensor t2 = input2;


### PR DESCRIPTION
Fixes #77517

I believe[ the first bullet point in this comment](https://github.com/pytorch/pytorch/issues/77517#issuecomment-1129233539) from the linked issue is no longer a concern, but please let me know if I'm incorrect here. 


cc @jianyuh @nikitaved @pearu @mruberry @walterddr @IvanYashchuk @xwang233 @Lezcano