### PR TITLE
Guard color diagnostics opts by compiler type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,8 +862,15 @@ if(NOT MSVC)
   append_cxx_flag_if_supported("-Qunused-arguments" CMAKE_CXX_FLAGS)
 
   if(${USE_COLORIZE_OUTPUT})
-    append_cxx_flag_if_supported("-fcolor-diagnostics" CMAKE_CXX_FLAGS)
-    append_cxx_flag_if_supported("-fdiagnostics-color=always" CMAKE_CXX_FLAGS)
+    # Why compiler checks are necessary even when `try_compile` is used
+    # Because of the bug in ccache that can incorrectly identify `-fcolor-diagnostics`
+    # As supported by GCC, see https://github.com/ccache/ccache/issues/740 (for older ccache)
+    # and https://github.com/ccache/ccache/issues/1275 (for newer ones)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      append_cxx_flag_if_supported("-fdiagnostics-color=always" CMAKE_CXX_FLAGS)
+    else()
+      append_cxx_flag_if_supported("-fcolor-diagnostics" CMAKE_CXX_FLAGS)
+    endif()
   endif()
 
   append_cxx_flag_if_supported("-faligned-new" CMAKE_CXX_FLAGS)


### PR DESCRIPTION
On Linux system where `/usr/bin/c++` is not a symlink to either `g++` or `clang++`, `try_compile` can still incorrectly identify `gcc` as supporting `-fcolor-diagnostics` flag.

Rather than introducing a super complex condition (i.e. `USE_CCACHE` and `LINUX` ...) just guard the checks specific to compiler identifier.

See https://github.com/ccache/ccache/issues/1275

Fixes https://github.com/pytorch/pytorch/issues/83500
