### PR TITLE
[BuildSpeed] Limit `Logcumsumexp` complex to OSS builds only

### DIFF
--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -102,7 +102,11 @@ __host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::comple
 }
 
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
+#if defined(FBCODE_CAFFE2)
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+#else
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+#endif
       ScalarType::Half, ScalarType::BFloat16,
       self.scalar_type(), "logcumsumexp_cuda",
       [&]() {

--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -102,12 +102,13 @@ __host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::comple
 }
 
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
+// Compile time for CUDA-11.4 is 3x slower than with CUDA-11.6+, specifically for complex numbers
 #if defined(FBCODE_CAFFE2)
-  AT_DISPATCH_FLOATING_TYPES_AND2(
+#define _LCME_DISPATCH AT_DISPATCH_FLOATING_TYPES_AND2
 #else
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+#define _LCME_DISPATCH AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2
 #endif
-      ScalarType::Half, ScalarType::BFloat16,
+  _LCME_DISPATCH(ScalarType::Half, ScalarType::BFloat16,
       self.scalar_type(), "logcumsumexp_cuda",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;


### PR DESCRIPTION
As it takes ridiculous amount of time to build with complex times on CUDA-11.4.

Build speeds for a single gpu architecture (`sm_80`) on 3Ghz 8275CL Intel Xeon:
- 143 sec to compile for all dtypes using CUDA-11.6
- 351 sec to compile for all dtypes using CUDA-11.4
- 24 sec to compile for only floating dtypes using CUDA-11.6
- 52 sec to compile for only floating dtypes using CUDA-11.4

Tweak code a bit to make it compilable with MSVC, which is having trouble with nested preprocessor directives.