### PR TITLE
[inductor] Support IndexPutFallback in cpp_wrapper

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1611,6 +1611,9 @@ def parse_args(args=None):
     )
     parser.add_argument("--cosine", action="store_true", help="use cosine similarity")
     parser.add_argument(
+        "--cpp-wrapper", action="store_true", help="turn on cpp/cuda wrapper codegen"
+    )
+    parser.add_argument(
         "--ci", action="store_true", help="Flag to tell that its a CI run"
     )
     parser.add_argument(
@@ -2251,6 +2254,7 @@ def run(runner, args, original_dir=None):
         )
         inductor_config.split_reductions = not args.disable_split_reductions
         inductor_config.triton.divisible_by_16 = not args.disable_divisible_by_16
+        inductor_config.cpp_wrapper = args.cpp_wrapper
 
     runner.setup_amp()
 

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -80,6 +80,7 @@ if RUN_CPU:
         BaseTest("test_bmm1"),
         BaseTest("test_bmm2"),
         BaseTest("test_cat"),  # alias
+        BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_int_div", "", test_cpu_repro.CPUReproTests()),
         BaseTest("test_linear1"),
         BaseTest("test_linear2"),
@@ -114,6 +115,7 @@ if RUN_CUDA:
         BaseTest("test_bmm2"),
         BaseTest("test_cat"),  # alias
         BaseTest("test_convolution1"),
+        BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_linear1"),
         BaseTest("test_linear2"),
         BaseTest("test_linear_packed"),

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -198,6 +198,8 @@ class WrapperCodeGen(CodeGen):
         self.need_seed = False
         self.declare = ""
         self.ending = ""
+        self.open_bracket = "["
+        self.closed_bracket = "]"
         self.comment = "#"
         self.namespace = ""
         self.none_str = "None"
@@ -328,7 +330,9 @@ class WrapperCodeGen(CodeGen):
         return
 
     def generate_extern_kernel_alloc(self, output_name, kernel, args):
-        self.writeline(f"{output_name} = {kernel}({', '.join(args)})")
+        self.writeline(
+            f"{self.declare}{output_name} = {kernel}({', '.join(args)}){self.ending}"
+        )
 
     def generate_extern_kernel_out(self, output_view, codegen_reference, args, kernel):
         if output_view:
@@ -563,7 +567,7 @@ class WrapperCodeGen(CodeGen):
         self.header.splice(f"\n\n{metadata_comment}{name} = {kernel}")
 
     def wrap_kernel_call(self, name, call_args):
-        return "{}({})".format(name, ", ".join(call_args))
+        return f"{name}({', '.join(call_args)}){self.ending}"
 
     def generate_profiler_mark_wrapper_call(self, stack):
         self.wrapper_call.writeline("from torch.profiler import record_function")
@@ -710,6 +714,8 @@ class CppWrapperCodeGen(WrapperCodeGen):
         super().__init__()
         self.declare = "auto "
         self.ending = ";"
+        self.open_bracket = "{"
+        self.closed_bracket = "}"
         self.comment = "//"
         self.namespace = "at::"
         self.none_str = "at::Tensor()"
@@ -742,10 +748,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
                 '''
                 """
             )
-
-    @cache_on_self
-    def get_output_refs(self):
-        return [x.codegen_reference() for x in V.graph.graph_outputs]
 
     def mark_output_type(self):
         # mark output type to unwrap tensor back to python scalar
@@ -804,9 +806,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
     def define_kernel(self, name: str, kernel: str, kernel_path: str = None):
         self.header.splice(f"\n{kernel}\n")
-
-    def wrap_kernel_call(self, name, call_args):
-        return f"{name}({', '.join(call_args)});"
 
     def generate_return(self, output_refs):
         self.wrapper_call.writeline(f"return {{{', '.join(output_refs)}}};\n}}")
@@ -871,9 +870,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
             """
         )
 
-    def generate_extern_kernel_alloc(self, output_name, kernel, args):
-        self.writeline(f"auto {output_name} = {kernel}({', '.join(args)});")
-
     def generate_extern_kernel_out(self, output_view, codegen_reference, args, kernel):
         if output_view:
             output_as_strided = f"{output_view.codegen_reference()}"
@@ -883,7 +879,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
             args.insert(0, output_name)
         else:
             args.insert(0, f"{codegen_reference}")
-        self.writeline(f"{kernel}({', '.join(args)});")
+        self.writeline(self.wrap_kernel_call(kernel, args))
 
     def codegen_sizevar(self, x: Expr) -> str:
         from .cpp import cexpr
@@ -956,7 +952,8 @@ class CppWrapperCodeGen(WrapperCodeGen):
         elif isinstance(s, str):
             return f'"{s}"'
         elif isinstance(s, (List, Tuple)):
-            return self.codegen_shape_tuple(s)
+            vals = ", ".join(list(map(self.val_to_str, s)))
+            return f"{{{vals}}}"
         else:
             return repr(s)
 
@@ -979,12 +976,12 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
             #include <c10/util/Exception.h>
             #include <c10/cuda/CUDAGuard.h>
 
-            #define AT_CUDA_DRIVER_CHECK_OVERRIDE(EXPR)                                     \
-            do {                                                                            \
-                CUresult __err = EXPR;                                                      \
-                if (__err != CUDA_SUCCESS) {                                                \
-                    AT_ERROR("CUDA driver error: ", static_cast<int>(__err));               \
-                }                                                                           \
+            #define AT_CUDA_DRIVER_CHECK_OVERRIDE(EXPR)                         \\
+            do {                                                                \\
+                CUresult __err = EXPR;                                          \\
+                if (__err != CUDA_SUCCESS) {                                    \\
+                    AT_ERROR("CUDA driver error: ", static_cast<int>(__err));   \\
+                }                                                               \\
             } while (0)
 
             static inline CUfunction loadKernel(const std::string &filePath,

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -248,7 +248,6 @@ class GraphLowering(torch.fx.Interpreter):
 
     def disable_cpp_wrapper(self, cond):
         self.cpp_wrapper = False
-        assert not self.aot_mode, "AOT compilation failed"
         log.debug("Set cpp_wrapper to False due to %s", cond)
 
     def register_buffer(self, buffer: ir.ComputedBuffer):
@@ -603,6 +602,9 @@ class GraphLowering(torch.fx.Interpreter):
             cuda = device == "cuda"
             self.check_cpp_wrapper(cuda)
             # Re-check self.cpp_wrapper because it might be disabled due to failed checking
+            if cuda:
+                assert self.cpp_wrapper, "CudaWrapperCodeGen hit unsupported case"
+
             if self.cpp_wrapper:
                 self.wrapper_code = (
                     CudaWrapperCodeGen() if cuda else CppWrapperCodeGen()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2683,31 +2683,28 @@ class ExternKernel(InputsKernel):
     def apply_constraint(self):
         pass
 
+    def codegen_const_args(self):
+        return map(V.graph.wrapper_code.val_to_str, self.constant_args)
+
     def codegen_args(self):
         args = [x.codegen_reference() for x in self.inputs]
-        args.extend(
-            map(
-                V.graph.wrapper_code.val_to_str,
-                self.constant_args,
-            )
-        )
+        args.extend(self.codegen_const_args())
         return args
 
     def codegen_kwargs(self):
         kwargs = []
         if self.kwargs:
             if V.graph.cpp_wrapper:
-                if self.kwargs:
-                    # TODO: use native_functions.yaml as the ground truth
-                    assert (
-                        self.ordered_kwargs_for_cpp_kernel
-                    ), "ordered_kwargs_for_cpp_kernel has to be provided"
-                    for arg_name in self.ordered_kwargs_for_cpp_kernel:
-                        assert arg_name in self.kwargs, (
-                            "arg %s not found in self.kwargs" % arg_name
-                        )
-                        v = self.kwargs.get(arg_name)
-                        kwargs.append(V.graph.wrapper_code.val_to_str(v))
+                # TODO: use native_functions.yaml as the ground truth
+                assert (
+                    self.ordered_kwargs_for_cpp_kernel
+                ), "ordered_kwargs_for_cpp_kernel has to be provided"
+                for arg_name in self.ordered_kwargs_for_cpp_kernel:
+                    assert arg_name in self.kwargs, (
+                        "arg %s not found in self.kwargs" % arg_name
+                    )
+                    v = self.kwargs.get(arg_name)
+                    kwargs.append(V.graph.wrapper_code.val_to_str(v))
             else:
                 kwargs = [
                     f"{k}={V.graph.wrapper_code.val_to_str(v)}"
@@ -2929,8 +2926,6 @@ class IndexPutFallback(ExternKernel):
     This needs to be a custom class to handle mutation and indices properly
     """
 
-    kernel = "aten.index_put_"
-
     def codegen(self, wrapper):
         (x, values, *valid_indices) = [t.codegen_reference() for t in self.inputs]
         indices = []
@@ -2939,10 +2934,11 @@ class IndexPutFallback(ExternKernel):
             if self.indices[i] is not None:
                 indices.append(next(iter_valid_indices))
             else:
-                indices.append("None")
-        wrapper.writeline(
-            f"{self.kernel}({x}, [{','.join(indices)}], {values}, {repr(self.constant_args[0])})"
-        )
+                indices.append(V.graph.wrapper_code.none_str)
+
+        indices = f"{V.graph.wrapper_code.open_bracket}{', '.join(indices)}{V.graph.wrapper_code.closed_bracket}"
+        args = [x, indices, values, *self.codegen_const_args()]
+        wrapper.writeline(wrapper.wrap_kernel_call(self.kernel, args))
 
     def should_allocate(self):
         return False
@@ -2958,6 +2954,7 @@ class IndexPutFallback(ExternKernel):
             [accumulate],
         )
         self.name = V.graph.register_buffer(self)
+        self.kernel = "at::index_put_" if V.graph.cpp_wrapper else "aten.index_put_"
 
 
 class DeviceCopy(ExternKernelOut):


### PR DESCRIPTION
Summary:
1) Make the fallback index_put generate the right cpp code in cpp_wapper
2) Add a --cpp-wrapper option to common.py

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10