### PR TITLE
[CUBLAS] Specify alignment for `cuBlasLt` `addmm`

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -105,15 +105,14 @@ static void _cublasAdjustLdLevel3(
   }
 }
 
-uint8_t _getAlignment(uintptr_t address) {
+uint32_t _getAlignment(uintptr_t address) {
   // alignment are in bytes
-  uint8_t alignment = 1;
-  for (; alignment < 32; alignment *= 2) {
-    if (address % (alignment * 2)) {
+  uint32_t alignment = 256;
+  for (; ; alignment /= 2) {
+    if (!(address % alignment)) {
       return alignment;
     }
   }
-  return alignment;
 }
 
 } // anonymous namespace
@@ -715,10 +714,10 @@ void gemm_and_bias(
       &workspaceSize,
       sizeof(workspaceSize)));
 
-  uint8_t a_alignment = _getAlignment(reinterpret_cast<uintptr_t>(mat1_ptr));
-  uint8_t b_alignment = _getAlignment(reinterpret_cast<uintptr_t>(mat2_ptr));
-  uint8_t c_alignment = _getAlignment(reinterpret_cast<uintptr_t>(result_ptr));
-  uint8_t d_alignment = _getAlignment(reinterpret_cast<uintptr_t>(bias));
+  uint32_t a_alignment = _getAlignment(reinterpret_cast<uintptr_t>(mat1_ptr));
+  uint32_t b_alignment = _getAlignment(reinterpret_cast<uintptr_t>(mat2_ptr));
+  uint32_t c_alignment = _getAlignment(reinterpret_cast<uintptr_t>(result_ptr));
+  uint32_t d_alignment = _getAlignment(reinterpret_cast<uintptr_t>(bias));
   TORCH_CUDABLAS_CHECK(cublasLtMatmulPreferenceSetAttribute(
       preference.descriptor(),
       CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES,

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -196,6 +196,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
                           (self_alignment == 2 &&
                            mat1_alignment == 2 &&
                            mat2_alignment == 2);
+      alignment_ok = true;
 
       useLtInterface = beta.toComplexDouble() == 1.0 && self.dim() == 1 &&
           result.dim() == 2 && self.sizes()[0] == mat2_sizes[1] &&

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -146,18 +146,6 @@ static bool getDisableAddmmCudaLt() {
     return false;
 }
 
-uint8_t getAlignment(const Tensor &t) {
-  // alignment are in bytes
-  uint8_t alignment = 1;
-  uintptr_t address = reinterpret_cast<uintptr_t>(t.const_data_ptr());
-  for (; alignment < 4; alignment *= 2) {
-    if (address % (alignment * 2)) {
-      return alignment;
-    }
-  }
-  return alignment;
-}
-
 Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, Activation activation=Activation::None) {
   // Make sure to keep addmm_cuda below in sync with this code; it
   // preflights a check to try to avoid actually needing to call
@@ -185,19 +173,6 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
     // leading dim >> rows when they are sliced from a large tensor
     // see fbcode/caffe2/test/test_linalg.py:test_corner_cases_of_cublasltmatmul
     if (!disable_addmm_cuda_lt) {
-      auto self_alignment = getAlignment(self);
-      auto mat1_alignment = getAlignment(mat1);
-      auto mat2_alignment = getAlignment(mat2);
-      // due to a heuristic bug, cuBlasLt requires all alignments > 2 or the same ( == 2)
-      // should we err on the side of caution and remove the second dispatch path?
-      bool alignment_ok = (self_alignment > 2 &&
-                           mat1_alignment > 2 &&
-                           mat2_alignment > 2) ||
-                          (self_alignment == 2 &&
-                           mat1_alignment == 2 &&
-                           mat2_alignment == 2);
-      alignment_ok = true;
-
       useLtInterface = beta.toComplexDouble() == 1.0 && self.dim() == 1 &&
           result.dim() == 2 && self.sizes()[0] == mat2_sizes[1] &&
           self.is_contiguous() &&
@@ -205,7 +180,6 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
            scalar_type == at::ScalarType::Float ||
            scalar_type == at::ScalarType::Half ||
            scalar_type == at::ScalarType::BFloat16) &&
-          alignment_ok &&
           mat2_sizes[0] > 1 && mat2_sizes[1] > 1 &&
           mat2_sizes[0] < 65535 * 32 && mat2_sizes[1] < 65535 * 32 &&
           mat1_sizes[0] < 65535 * 32 && mat1_sizes[1] < 65535 * 32 &&

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -106,13 +106,20 @@ class TestMatmulCuda(TestCase):
     def test_cublas_addmm_alignment(self):
         dtype = torch.half
         device = 'cuda'
-        A = torch.rand((5120 * 2560 + 1), requires_grad=True, dtype=dtype, device=device)
-        A = A[1:].reshape(5120, 2560)
-        # check that heuristic does not fail on 2-byte alignment
-        X = torch.rand((26, 1, 2560), requires_grad=True, dtype=dtype, device=device)
-        B = torch.rand((5120), requires_grad=True, dtype=dtype, device=device)
-        out = torch.nn.functional.linear(X, A, B)
-        self.assertEqual(out, torch.matmul(X, A.transpose(1, 0)) + B)
+        # perturb X, A, or B alignment
+        for idx in range(0, 3):
+            for offset in range(1, 3):
+                offsets = [0, 0, 0]
+                offsets[idx] = offset
+                x_offset, a_offset, b_offset = offsets
+                A = torch.rand((5120 * 2560 + a_offset), requires_grad=True, dtype=dtype, device=device)
+                A = A[a_offset:].reshape(5120, 2560)
+                X = torch.rand((26 * 2560 + x_offset), requires_grad=True, dtype=dtype, device=device)
+                X = X[x_offset:].reshape(26, 1, 2560)
+                B = torch.rand((5120 + b_offset), requires_grad=True, dtype=dtype, device=device)
+                B = B[b_offset:].reshape(5120)
+                out = torch.nn.functional.linear(X, A, B)
+                self.assertEqual(out, torch.matmul(X, A.transpose(1, 0)) + B)
 
     @onlyCUDA
     @unittest.skipIf(TEST_WITH_ROCM, "Only CUDA 11+ is supported")


### PR DESCRIPTION
Fixes the underlying issue previously addressed in #92201 by specifying minimum alignments explicitly to `cuBLAS` rather than relying on a handcrafted rule. ~~We're still investigating some potential failure modes on `sm80` and `sm90` but those would be real `cuBlasLt` heuristics bugs rather than being caused by underspecifying constraints to the heuristics.~~

According to the `cuBLAS` docs the default alignment is 256 bytes so that is the current maximum that is currently being checked: https://docs.nvidia.com/cuda/cublas/

CC @ptrblck @ngimel 

cc @csarofeen @ptrblck @xwang233