### PR TITLE
Adds 3D attn_mask support to merge_masks() for Multihead Attention fast path

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -167,19 +167,19 @@ class TestTransformers(NNTestCase):
 
 
             if attn_mask_dim == 2:
-                attn_mask = torch.randn(L, L).to(device) > 0
+                attn_mask = torch.randn(L, L, device=device) > 0
             elif attn_mask_dim == 3:
-                attn_mask = torch.randn(B * H, L, L).to(device) > 0
+                attn_mask = torch.randn(B * H, L, L, device=device) > 0
             elif attn_mask_dim is None:
                 attn_mask = None
 
             if key_padding_mask_dim == 2:
-                key_padding_mask = torch.randn(B, L).to(device) > 0
+                key_padding_mask = torch.randn(B, L, device=device) > 0
             elif key_padding_mask_dim is None:
                 key_padding_mask = None
 
-            mha = nn.MultiheadAttention(D, H, batch_first=True).to(device)
-            X = torch.randn(B, L, D).to(device)
+            mha = nn.MultiheadAttention(D, H, batch_first=True, device=device)
+            X = torch.randn(B, L, D, device=device)
 
             mha.train()  # disable fast path
             out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -35,8 +35,6 @@ from torch.testing._internal.common_cuda import TEST_CUDA, SM80OrLater, PLATFORM
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
 
-TEST_CUDA = False
-
 @contextlib.contextmanager
 def use_deterministic_algorithims(mode: bool, warn_only: bool):
     r"""

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -182,9 +182,9 @@ class TestTransformers(NNTestCase):
             X = torch.randn(B, L, D).to(device)
 
             mha.train()  # disable fast path
-            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)  # works
+            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)
             mha.eval()  # enable fast path
-            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)  # previously crashed (fixed)
+            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)
 
     @parametrize("device", device_list)
     @parametrize("nhead", [1, 4, 8])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, SM80OrLater, PLATFORM
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
 
+TEST_CUDA = False
 
 @contextlib.contextmanager
 def use_deterministic_algorithims(mode: bool, warn_only: bool):
@@ -155,6 +156,37 @@ class TestTransformers(NNTestCase):
                 test_eval_bool = encoder(test, src_key_padding_mask=pad_mask)
                 l1_bool = nn.L1Loss()(test_train_bool[:, 0:2, :], test_eval_bool[:, 0:2, :]).item()
                 self.assertTrue(l1_bool < 1e-4, "Eval/Train difference in pad_mask BOOL")
+
+    @parametrize("device", device_list)
+    @parametrize("attn_mask_dim", [2, 3, None])
+    @parametrize("key_padding_mask_dim", [2, None])
+    def test_multiheadattention_fastpath_attn_mask(self, device, attn_mask_dim, key_padding_mask_dim):
+        with torch.no_grad():
+            B = 2
+            L = 4
+            D = 8
+            H = 4
+
+
+            if attn_mask_dim == 2:
+                attn_mask = torch.randn(L, L).to(device) > 0
+            elif attn_mask_dim == 3:
+                attn_mask = torch.randn(B * H, L, L).to(device) > 0
+            elif attn_mask_dim is None:
+                attn_mask = None
+
+            if key_padding_mask_dim == 2:
+                key_padding_mask = torch.randn(B, L).to(device) > 0
+            elif key_padding_mask_dim is None:
+                key_padding_mask = None
+
+            mha = nn.MultiheadAttention(D, H, batch_first=True).to(device)
+            X = torch.randn(B, L, D).to(device)
+
+            mha.train()  # disable fast path
+            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)  # works
+            mha.eval()  # enable fast path
+            out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)  # previously crashed (fixed)
 
     @parametrize("device", device_list)
     @parametrize("nhead", [1, 4, 8])

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1258,20 +1258,27 @@ class MultiheadAttention(Module):
         mask_type: Optional[int] = None
         merged_mask: Optional[Tensor] = None
 
-        if attn_mask is not None:
-            mask_type = 0
-            merged_mask = attn_mask
         if key_padding_mask is not None:
             mask_type = 1
             merged_mask = key_padding_mask
-        if (attn_mask is not None) and (key_padding_mask is not None):
+
+        if attn_mask is not None:
             # In this branch query can't be a nested tensor, so it has a shape
             batch_size, seq_len, _ = query.shape
             mask_type = 2
-            key_padding_mask_expanded = key_padding_mask.view(batch_size, 1, 1, seq_len) \
-                                                        .expand(-1, self.num_heads, -1, -1)
-            attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
-            merged_mask = attn_mask_expanded + key_padding_mask_expanded
+
+            # Always expands attn_mask to 4D
+            if attn_mask.dim() == 3:
+                attn_mask_expanded = attn_mask.view(batch_size, -1, seq_len, seq_len)
+            elif attn_mask.dim() == 2:
+                attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
+
+            merged_mask = attn_mask_expanded
+            if key_padding_mask is not None:
+                key_padding_mask_expanded = key_padding_mask.view(batch_size, 1, 1, seq_len).expand(-1, self.num_heads, -1, -1)
+                merged_mask = attn_mask_expanded + key_padding_mask_expanded
+
+        # no attn_mask and no key_padding_mask, returns None, None
         return merged_mask, mask_type
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1270,7 +1270,7 @@ class MultiheadAttention(Module):
             # Always expands attn_mask to 4D
             if attn_mask.dim() == 3:
                 attn_mask_expanded = attn_mask.view(batch_size, -1, seq_len, seq_len)
-            else: # attn_mask.dim() == 2:
+            else:  # attn_mask.dim() == 2:
                 attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
             merged_mask = attn_mask_expanded
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1270,7 +1270,7 @@ class MultiheadAttention(Module):
             # Always expands attn_mask to 4D
             if attn_mask.dim() == 3:
                 attn_mask_expanded = attn_mask.view(batch_size, -1, seq_len, seq_len)
-            elif attn_mask.dim() == 2:
+            else: # attn_mask.dim() == 2:
                 attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
             merged_mask = attn_mask_expanded
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1272,8 +1272,8 @@ class MultiheadAttention(Module):
                 attn_mask_expanded = attn_mask.view(batch_size, -1, seq_len, seq_len)
             elif attn_mask.dim() == 2:
                 attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
-
             merged_mask = attn_mask_expanded
+
             if key_padding_mask is not None:
                 key_padding_mask_expanded = key_padding_mask.view(batch_size, 1, 1, seq_len).expand(-1, self.num_heads, -1, -1)
                 merged_mask = attn_mask_expanded + key_padding_mask_expanded


### PR DESCRIPTION
Fixes #97409

Adds support for 3D attn_mask by always expanding attn_mask to 4D as per https://github.com/pytorch/pytorch/pull/98375#issuecomment-1499504721

cc @jbschlosser  @bnehoran  @cpuhrsch  @erichan1 
