### PR TITLE
[fix] Disable EMA if ema_alpha is set to None

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -670,8 +670,8 @@ class AdagradOptimizer(Optimizer):
 
     def _process_ema_options(self, ema_options):
         logger.info(f"ema_options: {str(ema_options)}")
-        self.ema_enabled = True if ema_options and "ema_alpha" in ema_options else False
-        self.ema_teacher_enabled = True if ema_options and "ema_teacher_alpha" in ema_options else False
+        self.ema_enabled = ema_options and ema_options.get("ema_alpha", None) is not None
+        self.ema_teacher_enabled = ema_options and ema_options.get("ema_teacher_alpha", None) is not None
         self.param2ema_teacher_param = {}
         if self.ema_enabled or self.ema_teacher_enabled:
             self.ema_start = ema_options.get("ema_start", None)


### PR DESCRIPTION
Summary: changing the condition to enable ema updates in training, and disable it if the "ema_alpha" value is None

Test Plan: f427638974

Differential Revision: D44937126

