### PR TITLE
[POC][pt2] Add canonicalizers to simplify expressions w/o decomposing

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 from collections import defaultdict
-from functools import wraps
+from functools import wraps, lru_cache
 from itertools import chain
 from typing import Callable, Dict, Sequence, Union
 
@@ -8,6 +8,8 @@ import torch
 import torch.library
 from torch._ops import OpOverload, OpOverloadPacket
 from torch.utils._pytree import tree_map
+from torch._decomp.utils import _add_op_to_registry
+from torch._decomp.canonicalizers import canonicalizer_registry
 
 __all__ = [
     "decomposition_table",
@@ -26,32 +28,6 @@ global_decomposition_table: Dict[str, Dict[OpOverload, Callable]] = defaultdict(
 decomposition_table = global_decomposition_table["post_autograd"]
 pre_autograd_decomposition_table = global_decomposition_table["pre_autograd"]
 meta_table = global_decomposition_table["meta"]
-
-
-def _add_op_to_registry(registry, op, fn):
-    """
-    This is an internal API for adding an op to the decomposition table.
-
-    If op is OpOverload, it will be added to the registry directly.
-    If op is OpOverloadPacket, all the valid op_overloads in the packet will be added to the registry.
-    """
-    overloads = []
-    if isinstance(op, OpOverload):
-        overloads.append(op)
-    else:
-        assert isinstance(op, OpOverloadPacket)
-        for ol in op.overloads():
-            overloads.append(getattr(op, ol))
-
-    for op_overload in overloads:
-        if op_overload in registry:
-            raise RuntimeError(f"duplicate registrations for {op_overload}")
-
-        # TorchScript dumps a bunch of extra nonsense overloads
-        # which don't have corresponding dispatcher entries, we need
-        # to filter those out, e.g aten.add.float_int
-        if torch._C._dispatch_has_kernel(op_overload.name()):
-            registry[op_overload] = fn
 
 
 def register_decomposition(aten_op, registry=None, *, type="post_autograd"):
@@ -151,17 +127,35 @@ def get_decompositions(
     """
     assert type in {"post_autograd", "pre_autograd", "meta"}
 
-    registry = global_decomposition_table[type]
+    decomp_registry = global_decomposition_table[type]
     packets_to_overloads = defaultdict(list)
     for opo in registry:
         packets_to_overloads[opo.overloadpacket].append(opo)
+
+    def canonical_decomp(overload):
+        # Merge canonicalizer and decomposition
+        decomp = decomp_registry.get(overload, None)
+        canonicalizer = canonicalizer_registry.get(overload, None)
+
+        if canonicalizer is None:
+            return decomp
+        if decomp is None:
+            return canonicalizer
+
+        def joint_decomp(*args, **kwargs):
+            canonical = canonicalizer(*args, **kwargs)
+            if canonical is not NotImplemented:
+                return canonical
+            return decomp(*args, **kwargs)
+
     decompositions = {}
     for op in aten_ops:
         if isinstance(op, OpOverloadPacket) and op in packets_to_overloads:
             for op_overload in packets_to_overloads[op]:
-                decompositions[op_overload] = registry[op_overload]
+                decompositions[op_overload] = canonical_decomp(op_overload)
         elif isinstance(op, OpOverload) and op in registry:
-            decompositions[op] = registry[op]
+            decompositions[op] = canonical_decomp(op)
+
     return decompositions
 
 
@@ -174,155 +168,161 @@ import torch._refs
 # excluding decompositions that results in prim ops
 # Resulting opset of decomposition is core aten ops
 def core_aten_decompositions() -> Dict[OpOverload, Callable]:
-    aten = torch.ops.aten
-    return get_decompositions(
-        [
-            aten._adaptive_avg_pool2d_backward,
-            aten.addcdiv,
-            aten.addcdiv_,
-            aten.addcmul,
-            aten.addcmul_,
-            aten.addr,
-            aten.aminmax,
-            aten.avg_pool2d_backward,
-            aten.binary_cross_entropy,
-            aten.binary_cross_entropy_backward,
-            aten.binary_cross_entropy_with_logits,
-            aten.bucketize,
-            aten.celu,
-            aten.col2im,
-            aten.cudnn_batch_norm,
-            aten.cudnn_batch_norm_backward,
-            aten.detach,
-            aten.diag_embed,
-            aten.diagonal,
-            aten.dot,
-            aten.elu,
-            aten.elu_backward,
-            aten._embedding_bag,
-            aten.embedding_dense_backward,
-            aten.expand_as,
-            aten.eye,
-            aten.fill,
-            aten.frac,
-            aten._fused_moving_avg_obs_fq_helper,
-            aten.gelu,
-            aten.gelu_backward,
-            aten.glu_backward,
-            aten.grid_sampler_2d,
-            aten.hardshrink,
-            aten.hardshrink_backward,
-            aten.hardsigmoid,
-            aten.hardsigmoid_backward,
-            aten.hardswish,
-            aten.hardswish_,
-            aten.hardswish_backward,
-            aten.hardtanh,
-            aten.hardtanh_,
-            aten.hardtanh_backward,
-            aten.heaviside,
-            aten.huber_loss,
-            aten.huber_loss_backward,
-            aten.im2col,
-            aten.index_add,
-            aten.index_add_,
-            aten.index_copy,
-            aten.index_copy_,
-            aten.index_fill,
-            aten.index_fill_,
-            aten.index_select,
-            aten.isneginf,
-            aten.isposinf,
-            aten.l1_loss,
-            aten.leaky_relu,
-            aten.leaky_relu_,
-            aten.leaky_relu_backward,
-            aten.lerp,
-            aten.linspace,
-            aten.logaddexp,
-            aten.logit,
-            aten.logit_backward,
-            aten.log_sigmoid_backward,
-            aten.log_sigmoid_forward,
-            aten._log_softmax,
-            aten._log_softmax_backward_data,
-            aten.logspace,
-            aten.logsumexp.default,
-            aten.masked_fill,
-            aten.masked_fill_,
-            aten.max_pool2d_with_indices_backward,
-            aten.mish,
-            aten.mse_loss,
-            aten.mse_loss_backward,
-            aten.mv,
-            aten.mvlgamma,
-            aten.nansum,
-            aten.nan_to_num,
-            aten.narrow,
-            aten.native_batch_norm,
-            aten.native_batch_norm_backward,
-            aten._native_batch_norm_legit,
-            aten._native_batch_norm_legit_functional,
-            aten._native_batch_norm_legit_no_training,
-            aten.native_dropout_backward,
-            aten.native_group_norm,
-            aten.native_group_norm_backward,
-            aten.native_layer_norm,
-            aten.native_layer_norm_backward,
-            aten.new_empty,
-            aten.new_full,
-            aten.new_ones,
-            aten.new_zeros,
-            aten.nll_loss_backward,
-            aten.nll_loss_forward,
-            aten.norm,
-            aten.ones,
-            aten.ones_like,
-            aten._prelu_kernel,
-            aten._prelu_kernel_backward,
-            aten._reshape_alias,
-            aten.rot90,
-            aten.rsub.Scalar,
-            aten.rsub.Tensor,
-            aten.select_backward,
-            aten.select_scatter,
-            aten.sgn,
-            aten.sigmoid_backward,
-            aten.silu,
-            aten.silu_,
-            aten.silu_backward,
-            aten.sinc,
-            aten.slice_backward,
-            aten.soft_margin_loss,
-            aten.soft_margin_loss_backward,
-            aten._softmax,
-            aten._softmax_backward_data,
-            aten.softplus,
-            aten.softplus_backward,
-            aten.softshrink,
-            aten.softshrink_backward,
-            aten.special_entr,
-            aten.special_log_ndtr,
-            aten.special_xlog1py,
-            aten.stack,
-            aten.t,
-            aten.tanh_backward,
-            aten.threshold,
-            aten.threshold_backward,
-            aten.trace,
-            aten.transpose.int,
-            aten.tril.default,
-            aten.triu.default,
-            aten.unfold,
-            aten.unfold_backward,
-            aten.unfold_copy,
-            aten.upsample_bilinear2d,
-            aten.upsample_bilinear2d.vec,
-            aten.upsample_nearest2d_backward,
-            aten.xlogy,
-            aten.zero,
-            aten.zero_,
-            aten.zeros,
-            aten.zeros_like,
-        ]
-    )
+    # Canonicalizers never call prims
+    decompositions = canonicalizer_registry.clone()
+    # Select only decompositions not using prims
+    decompositions.update(get_decompositions(_get_core_decomposition_ops()))
+    return decompositions
+
+
+@lru_cache(None)
+def _get_core_decomposition_ops():
+    return [
+        aten._adaptive_avg_pool2d_backward,
+        aten.addcdiv,
+        aten.addcdiv_,
+        aten.addcmul,
+        aten.addcmul_,
+        aten.addr,
+        aten.aminmax,
+        aten.avg_pool2d_backward,
+        aten.binary_cross_entropy,
+        aten.binary_cross_entropy_backward,
+        aten.binary_cross_entropy_with_logits,
+        aten.bucketize,
+        aten.celu,
+        aten.col2im,
+        aten.cudnn_batch_norm,
+        aten.cudnn_batch_norm_backward,
+        aten.detach,
+        aten.diag_embed,
+        aten.diagonal,
+        aten.dot,
+        aten.elu,
+        aten.elu_backward,
+        aten._embedding_bag,
+        aten.embedding_dense_backward,
+        aten.expand_as,
+        aten.eye,
+        aten.fill,
+        aten.frac,
+        aten._fused_moving_avg_obs_fq_helper,
+        aten.gelu,
+        aten.gelu_backward,
+        aten.glu_backward,
+        aten.grid_sampler_2d,
+        aten.hardshrink,
+        aten.hardshrink_backward,
+        aten.hardsigmoid,
+        aten.hardsigmoid_backward,
+        aten.hardswish,
+        aten.hardswish_,
+        aten.hardswish_backward,
+        aten.hardtanh,
+        aten.hardtanh_,
+        aten.hardtanh_backward,
+        aten.heaviside,
+        aten.huber_loss,
+        aten.huber_loss_backward,
+        aten.im2col,
+        aten.index_add,
+        aten.index_add_,
+        aten.index_copy,
+        aten.index_copy_,
+        aten.index_fill,
+        aten.index_fill_,
+        aten.index_select,
+        aten.isneginf,
+        aten.isposinf,
+        aten.l1_loss,
+        aten.leaky_relu,
+        aten.leaky_relu_,
+        aten.leaky_relu_backward,
+        aten.lerp,
+        aten.linspace,
+        aten.logaddexp,
+        aten.logit,
+        aten.logit_backward,
+        aten.log_sigmoid_backward,
+        aten.log_sigmoid_forward,
+        aten._log_softmax,
+        aten._log_softmax_backward_data,
+        aten.logspace,
+        aten.logsumexp.default,
+        aten.masked_fill,
+        aten.masked_fill_,
+        aten.max_pool2d_with_indices_backward,
+        aten.mish,
+        aten.mse_loss,
+        aten.mse_loss_backward,
+        aten.mv,
+        aten.mvlgamma,
+        aten.nansum,
+        aten.nan_to_num,
+        aten.narrow,
+        aten.native_batch_norm,
+        aten.native_batch_norm_backward,
+        aten._native_batch_norm_legit,
+        aten._native_batch_norm_legit_functional,
+        aten._native_batch_norm_legit_no_training,
+        aten.native_dropout_backward,
+        aten.native_group_norm,
+        aten.native_group_norm_backward,
+        aten.native_layer_norm,
+        aten.native_layer_norm_backward,
+        aten.new_empty,
+        aten.new_full,
+        aten.new_ones,
+        aten.new_zeros,
+        aten.nll_loss_backward,
+        aten.nll_loss_forward,
+        aten.norm,
+        aten.ones,
+        aten.ones_like,
+        aten._prelu_kernel,
+        aten._prelu_kernel_backward,
+        aten._reshape_alias,
+        aten.rot90,
+        aten.rsub.Scalar,
+        aten.rsub.Tensor,
+        aten.select_backward,
+        aten.select_scatter,
+        aten.sgn,
+        aten.sigmoid_backward,
+        aten.silu,
+        aten.silu_,
+        aten.silu_backward,
+        aten.sinc,
+        aten.slice_backward,
+        aten.soft_margin_loss,
+        aten.soft_margin_loss_backward,
+        aten._softmax,
+        aten._softmax_backward_data,
+        aten.softplus,
+        aten.softplus_backward,
+        aten.softshrink,
+        aten.softshrink_backward,
+        aten.special_entr,
+        aten.special_log_ndtr,
+        aten.special_xlog1py,
+        aten.stack,
+        aten.t,
+        aten.tanh_backward,
+        aten.threshold,
+        aten.threshold_backward,
+        aten.trace,
+        aten.transpose.int,
+        aten.tril.default,
+        aten.triu.default,
+        aten.unfold,
+        aten.unfold_backward,
+        aten.unfold_copy,
+        aten.upsample_bilinear2d,
+        aten.upsample_bilinear2d.vec,
+        aten.upsample_nearest2d_backward,
+        aten.xlogy,
+        aten.zero,
+        aten.zero_,
+        aten.zeros,
+        aten.zeros_like,
+    ]

--- a/torch/_decomp/canonicalizers.py
+++ b/torch/_decomp/canonicalizers.py
@@ -1,0 +1,82 @@
+from typing import Sequence
+
+import torch
+from torch._decomp.utils import _add_op_to_registry
+import torch._prims_common as utils
+from torch._prims_common import TensorOrNumberLikeType, Number, TensorLikeType
+
+
+aten = torch._ops.ops.aten
+canonicalizer_registry = {}
+
+# A canonicalizer rewrites high level operations in a more "canonical" way. e.g.
+#   torch.mul(x, 1) -> x.clone()
+#   torch.pow(2, x) -> torch.exp2(x)
+#
+# Unlike a decomposition, canonicalizers are additionally required to:
+#   1. use similar high-level operations, not many lower level operations
+#   2. only call torch and aten functions, never prims
+#   3. produce valid gradients when run before AOTAutograd
+
+
+def register_canonicalizer(aten_ops):
+    if not isinstance(aten_ops, Sequence):
+        aten_ops = (aten_ops,)
+
+    def inner(fn):
+        global canonicalizer_registry
+
+        for op in aten_ops:
+            _add_op_to_registry(canonicalizer_registry, op, fn)
+
+        return fn
+
+    return inner
+
+
+@register_canonicalizer(aten.pow)
+def pow(
+    a: TensorOrNumberLikeType,
+    b: TensorOrNumberLikeType,
+) -> TensorLikeType:
+
+    if isinstance(b, Number):
+        assert isinstance(a, TensorLikeType)
+        if b == 1.0:
+            return a.clone()
+        elif b == 2.0:
+            return a * a
+        elif b == 0.5:
+            return torch.sqrt(a)
+
+    if isinstance(a, Number):
+        if a == 1.0:
+            return torch.fill(b, True)
+        if a == 2.0 and (
+            utils.is_float_dtype(b.dtype) or utils.is_complex_dtype(b.dtype)
+        ):
+            return torch.exp2(b)
+
+    return NotImplemented
+
+
+@register_canonicalizer(aten.cat.default)
+def cat(tensors, dim=0):
+    if len(tensors) == 1:
+        memory_format = utils.suggest_memory_format(t)
+        return tensors[0].clone(memory_format=memory_format)
+    return NotImplemented
+
+
+@register_canonicalizer(aten.ceil.default)
+def ceil(x):
+    if utils.is_integer_dtype(x):
+        return x.clone()
+    return NotImplemented
+
+
+@register_canonicalizer(aten.isnan)
+def isnan(x):
+    if utils.is_integer_dtype(x):
+        return torch.full_like(x, False, dtype=torch.bool)
+    return NotImplemented

--- a/torch/_decomp/utils.py
+++ b/torch/_decomp/utils.py
@@ -1,6 +1,7 @@
 import torch
 from torch._ops import OpOverload, OpOverloadPacket
 
+
 def _add_op_to_registry(registry, op, fn):
     """
     This is an internal API for adding an op to the decomposition table.

--- a/torch/_decomp/utils.py
+++ b/torch/_decomp/utils.py
@@ -1,0 +1,27 @@
+import torch
+from torch._ops import OpOverload, OpOverloadPacket
+
+def _add_op_to_registry(registry, op, fn):
+    """
+    This is an internal API for adding an op to the decomposition table.
+
+    If op is OpOverload, it will be added to the registry directly.
+    If op is OpOverloadPacket, all the valid op_overloads in the packet will be added to the registry.
+    """
+    overloads = []
+    if isinstance(op, OpOverload):
+        overloads.append(op)
+    else:
+        assert isinstance(op, OpOverloadPacket)
+        for ol in op.overloads():
+            overloads.append(getattr(op, ol))
+
+    for op_overload in overloads:
+        if op_overload in registry:
+            raise RuntimeError(f"duplicate registrations for {op_overload}")
+
+        # TorchScript dumps a bunch of extra nonsense overloads
+        # which don't have corresponding dispatcher entries, we need
+        # to filter those out, e.g aten.add.float_int
+        if torch._C._dispatch_has_kernel(op_overload.name()):
+            registry[op_overload] = fn

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -377,13 +377,6 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     return self + result
 
 
-@register_decomposition([aten.cat.default])
-def cat(tensors, dim=0):
-    if len(tensors) == 1:
-        return tensors[0].clone()
-    return NotImplemented
-
-
 @register_decomposition([aten.conj_physical])
 def conj_physical(self):
     assert not self.is_complex(), "TODO: implement this"

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1122,7 +1122,7 @@ def float_power(
     b = _maybe_convert_to_dtype(b, dtype)
 
     a, b = _maybe_broadcast(a, b)
-    return torch.pow(a, b)
+    return pow(a, b)
 
 
 # >>> a = torch.tensor(-0.2500, dtype=torch.float64)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1092,23 +1092,6 @@ def pow(
     a: Union[TensorLikeType, NumberType],
     b: Union[TensorLikeType, NumberType],
 ) -> TensorLikeType:
-    assert isinstance(a, TensorLikeType) or isinstance(b, TensorLikeType)
-
-    if isinstance(b, Number):
-        if b == 1.0:
-            return a.clone()  # type: ignore[return-value,union-attr]
-        elif b == 2.0:
-            return a * a  # type: ignore[return-value]
-        elif b == 0.5:
-            return torch.sqrt(a)  # type: ignore[arg-type]
-    elif isinstance(a, Number):
-        if a == 1.0:
-            return torch.fill(b, True)
-        if a == 2.0 and (
-            utils.is_float_dtype(b.dtype) or utils.is_complex_dtype(b.dtype)
-        ):
-            return torch.exp2(b)
-
     return prims.pow(a, b)
 
 
@@ -1139,7 +1122,7 @@ def float_power(
     b = _maybe_convert_to_dtype(b, dtype)
 
     a, b = _maybe_broadcast(a, b)
-    return pow(a, b)
+    return torch.pow(a, b)
 
 
 # >>> a = torch.tensor(-0.2500, dtype=torch.float64)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99003

Currently decompositions serve a somewhat dual purpose. They either lower to
more primitive operators, or they inspect the arguments and specialize the
decomposition to a single simpler operator.

For example, `pow` specializes `pow(2, x)` into `exp2(x)` and `isinf`
short-circuits on integers to `zeros_like`.

These simplifications are great, but inductor can't always use them because they
are coupled to decomposition into prims. This either leads to duplication between
the decomposition and the lowering, or else one just gets forgotten.

This PR proposes adding a new registry for "canonicalizers" which only do
specialization and not decomposition. This means you can choose to use the
canonicalizer + decomposition, or just the canonicalizer on its own.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @aakhundov @soumith @anijain2305 @desertfire