### PR TITLE
fix the use of incomplete vector<T> for C++20 compatibilities (#93978)

### DIFF
--- a/aten/src/ATen/core/List.cpp
+++ b/aten/src/ATen/core/List.cpp
@@ -12,5 +12,9 @@ bool operator==(const ListImpl& lhs, const ListImpl& rhs) {
           rhs.list.cbegin(),
           _fastEqualsForContainer);
 }
+
+ListImpl::ListImpl(list_type list_, TypePtr elementType_)
+  : list(std::move(list_))
+  , elementType(std::move(elementType_)) {}
 } // namespace detail
 } // namespace c10

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -24,9 +24,7 @@ namespace detail {
 struct ListImpl final : public c10::intrusive_ptr_target {
   using list_type = std::vector<IValue>;
 
-  explicit ListImpl(list_type list_, TypePtr elementType_)
-  : list(std::move(list_))
-  , elementType(std::move(elementType_)) {}
+  explicit TORCH_API ListImpl(list_type list_, TypePtr elementType_);
 
   list_type list;
 
@@ -480,9 +478,7 @@ namespace impl {
 // (maybe except for some internal prim ops).
 using GenericList = List<IValue>;
 
-inline const IValue* ptr_to_first_element(const GenericList& list) {
-  return &list.impl_->list[0];
-}
+const IValue* ptr_to_first_element(const GenericList& list);
 
 }
 }

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -349,4 +349,12 @@ template <class T>
 void List<T>::unsafeSetElementType(TypePtr t) {
   impl_->elementType = std::move(t);
 }
+
+namespace impl {
+
+inline const IValue* ptr_to_first_element(const GenericList& list) {
+  return &list.impl_->list[0];
+}
+
+}
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -747,6 +747,9 @@ size_t StaticModule::prepareStaticNodeInfos(
   return node_idx - node_start;
 }
 
+BlockInfo::BlockInfo(uint32_t input_idx, Block& block)
+    : input_idx_(input_idx), block_(block) {}
+
 void BlockInfo::set_nodes(
     std::vector<StaticNodeInfo> nodes,
     const FastMap<Node*, bool>& node_has_out_variant) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -272,8 +272,7 @@ using SROperator = std::function<void(ProcessedNode*)>;
 //   planner.
 class BlockInfo {
  public:
-  BlockInfo(uint32_t input_idx, Block& block)
-      : input_idx_(input_idx), block_(block) {}
+  BlockInfo(uint32_t input_idx, Block& block);
 
   void set_nodes(
       std::vector<StaticNodeInfo> nodes,
@@ -283,9 +282,7 @@ class BlockInfo {
     return nodes_;
   }
 
-  size_t num_nodes() const {
-    return nodes_.size();
-  }
+  size_t num_nodes() const;
 
   size_t num_inputs() const {
     return block_.inputs().size();
@@ -851,6 +848,10 @@ class TORCH_API StaticNodeInfo {
   ProcessedNodeInputs inputs_;
   uint16_t outputs_offset_;
 };
+
+inline size_t BlockInfo::num_nodes() const {
+  return nodes_.size();
+}
 
 /*
   ProcessedNodeMetadata class wraps the possible metadata


### PR DESCRIPTION
Avoid referring to std::vector<T> members and constructor/desctructors when T is incomplete.

Referring to incomplete members is [not legal](https://timsong-cpp.github.io/cppwp/n4868/vector#overview-4) according to the C++ standard.

Non-noexcept constructors need access to members' destructors. As of C++20, std::vector's destructor is constexpr and so forcefully requires a complete type for the vector's elements.

These issues cause build errors in newer toolchains under c++20 mode.

Fix them by moving code that needs complete types to a different place where the type is already defined. Pull Request resolved: https://github.com/pytorch/pytorch/pull/93978 Approved by: https://github.com/Skylion007

Fixes #ISSUE_NUMBER
