### PR TITLE
[ONNX] Export Relu6 without using Relu

### DIFF
--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -179,7 +179,6 @@ def clamp_max(g: jit_utils.GraphContext, self, max):
 @_onnx_symbolic("aten::relu6")
 @_beartype.beartype
 def relu6(g: jit_utils.GraphContext, input):
-    relu_ = opset9._op_with_optional_float_cast(g, "Relu", input, opset_before=14)
     scalar_type = _type_utils.JitScalarType.from_value(
         input, _type_utils.JitScalarType.FLOAT
     )
@@ -191,7 +190,7 @@ def relu6(g: jit_utils.GraphContext, input):
         "Constant",
         value_t=torch.tensor(6, dtype=scalar_type.dtype()),
     )
-    return clamp(g, relu_, min_val, max_val)
+    return clamp(g, input, min_val, max_val)
 
 
 @_onnx_symbolic("aten::select")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1359,8 +1359,7 @@ def relu(g: jit_utils.GraphContext, input):
 @symbolic_helper.quantized_args(True)
 @_beartype.beartype
 def relu6(g: jit_utils.GraphContext, input):
-    relu = _op_with_optional_float_cast(g, "Relu", input, opset_before=14)
-    return clamp_max(g, relu, 6)
+    return clamp(g, input, 0, 6)
 
 
 @_onnx_symbolic("aten::ceil")


### PR DESCRIPTION
The clamp operator used in the export of Relu6 already clamps the input value in between 0 and 6. There's no need to first perform a Relu on the input tensor.

