### PR TITLE
Making fsdp device-agnostic for custom-backend which  implement cuda-semantics

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -87,7 +87,7 @@ class _UninitializedDeviceHandle(_FSDPDeviceHandle):
         pass
 
     def __getattribute__(self, __name: str) -> Any:
-        raise RuntimeError("Try to use an uninitialized device handle.")
+        raise RuntimeError("Trying to use an uninitialized device handle.")
 
 
 class _FSDPState(_State):

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -26,7 +26,7 @@ import torch.nn as nn
 from torch.distributed.algorithms._comm_hooks import default_hooks
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp._common_utils import (
-    _FSDPDeviceHandler,
+    _FSDPDeviceHandle,
     _FSDPState,
     _get_module_fsdp_state,
     _is_fsdp_flattened,
@@ -429,7 +429,7 @@ def _init_param_handle_from_module(
         device_from_device_id,
         state.rank,
     )
-    state.device_handler = _FSDPDeviceHandler.from_device(state.compute_device)
+    state._device_handle = _FSDPDeviceHandle.from_device(state.compute_device)
 
     managed_params = list(_get_orig_params(fully_sharded_module, state._ignored_params))
     if sync_module_states:
@@ -514,7 +514,7 @@ def _init_param_handles_from_module(
                 device_from_device_id,
                 state.rank,
             )
-            state.device_handler = _FSDPDeviceHandler.from_device(state.compute_device)
+            state._device_handle = _FSDPDeviceHandle.from_device(state.compute_device)
         if sync_module_states:
             _sync_module_states(params, buffers, state.process_group)
         _init_param_handle_from_params(state, params, fully_sharded_module)
@@ -881,9 +881,9 @@ def _get_compute_device(
     rank: int,
 ) -> torch.device:
     """
-    Determines and returns this FSDP instance's compute device. If specified
-    device by 'device_id', then returns that device. Otherwise, If the module
-    is already on a non-CPU device, then the compute device is that non-CPU
+    Determines and returns this FSDP instance's compute device. If a device is
+    specified by ``device_id``, then returns that device. Otherwise, If the
+    module is already on a non-CPU device, then the compute device is that non-CPU
     device. If the module is on CPU, then the compute device is the current
     device.
 

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -212,7 +212,7 @@ def _communicate_optim_state(
             dist.all_gather_into_tensor(
                 tensor_buffer, value, group=fsdp_state.process_group
             )
-            torch.cuda.synchronize()
+            fsdp_state.device_handler.synchronize()
             unpadded_numel = cast(
                 nn.Parameter, flat_param._unpadded_unsharded_size
             ).numel()
@@ -278,7 +278,7 @@ def _unflatten_communicated_optim_state(
                     optim_state,
                     fsdp_state.rank,
                     fsdp_state.world_size,
-                    torch.cuda.device_count(),
+                    fsdp_state.device_handler.device_count(),
                     fsdp_state.process_group,
                 )
             unflat_state_param[state_name] = optim_state
@@ -1602,7 +1602,7 @@ def _gather_orig_param_state(
                 value,
                 fsdp_state.rank,
                 fsdp_state.world_size,
-                torch.cuda.device_count(),
+                fsdp_state.device_handler.device_count(),
                 fsdp_state.process_group,
             )
         value = value.cpu()

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -212,7 +212,7 @@ def _communicate_optim_state(
             dist.all_gather_into_tensor(
                 tensor_buffer, value, group=fsdp_state.process_group
             )
-            fsdp_state.device_handler.synchronize()
+            fsdp_state._device_handle.synchronize()
             unpadded_numel = cast(
                 nn.Parameter, flat_param._unpadded_unsharded_size
             ).numel()
@@ -278,7 +278,7 @@ def _unflatten_communicated_optim_state(
                     optim_state,
                     fsdp_state.rank,
                     fsdp_state.world_size,
-                    fsdp_state.device_handler.device_count(),
+                    fsdp_state._device_handle.device_count(),
                     fsdp_state.process_group,
                 )
             unflat_state_param[state_name] = optim_state
@@ -1602,7 +1602,7 @@ def _gather_orig_param_state(
                 value,
                 fsdp_state.rank,
                 fsdp_state.world_size,
-                fsdp_state.device_handler.device_count(),
+                fsdp_state._device_handle.device_count(),
                 fsdp_state.process_group,
             )
         value = value.cpu()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -161,7 +161,7 @@ def _lazy_init(
     """
     if state._is_root is not None:
         return  # no-op: already lazily initialized
-    if not torch.cuda.is_available():
+    if not state.device_handler.is_available():
         # Allow the FSDP constructor to run even without CUDA but check this
         # once we start real execution
         raise RuntimeError("FSDP does not support CPU only execution")
@@ -277,20 +277,20 @@ def _init_streams(
     data transfers. The streams should be shared across FSDP instances.
     """
     assert state._is_root
-    assert torch.cuda.is_available()
+    assert state.device_handler.is_available()
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._streams["unshard"] = torch.cuda.Stream()
+    state._streams["unshard"] = state.device_handler.Stream()
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
-    state._streams["post_backward"] = torch.cuda.Stream()
+    state._streams["post_backward"] = state.device_handler.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._streams["pre_unshard"] = torch.cuda.Stream()
+    state._streams["pre_unshard"] = state.device_handler.Stream()
     # Default stream for computation
-    state._streams["default"] = torch.cuda.current_stream()
+    state._streams["default"] = state.device_handler.current_stream()
     state._stream_to_name = {
-        torch.cuda.current_stream(): "default",
+        state.device_handler.current_stream(): "default",
         state._streams["unshard"]: "unshard",
         state._streams["pre_unshard"]: "pre_unshard",
         state._streams["post_backward"]: "post_backward",
@@ -315,7 +315,7 @@ def _unshard(
     if not handles:
         return
     any_ran_pre_unshard = False
-    with torch.cuda.stream(pre_unshard_stream):
+    with state.device_handler.stream(pre_unshard_stream):
         for handle in handles:
             ran_pre_unshard = handle.pre_unshard()
             any_ran_pre_unshard = any_ran_pre_unshard or ran_pre_unshard
@@ -325,7 +325,7 @@ def _unshard(
         event = state._free_event_queue.dequeue_if_needed()
         if event:
             event.synchronize()
-    with torch.cuda.stream(unshard_stream):
+    with state.device_handler.stream(unshard_stream):
         for handle in handles:
             handle.unshard()
             handle.post_unshard()
@@ -355,7 +355,7 @@ def _reshard(
     ):
         handle.reshard(free_unsharded_flat_param)
         if state.limit_all_gathers and free_unsharded_flat_param:
-            free_event = torch.cuda.Event()
+            free_event = state.device_handler.Event()
             free_event.record()
             state._free_event_queue.enqueue(free_event)
         handle.post_reshard()
@@ -444,7 +444,7 @@ def _pre_forward_unshard(
             state, handles, state._streams["unshard"], state._streams["pre_unshard"]
         )
     state._needs_pre_forward_unshard[handles_key] = False
-    torch.cuda.current_stream().wait_stream(state._streams["unshard"])
+    state.device_handler.current_stream().wait_stream(state._streams["unshard"])
     _prefetch_handles(state, handles_key, _PrefetchMode.FORWARD)
 
 
@@ -581,7 +581,7 @@ def _root_pre_forward(
             for handles_key in handles_keys:
                 state._needs_pre_forward_unshard[handles_key] = True
         _wait_for_computation_stream(
-            torch.cuda.current_stream(),
+            state.device_handler.current_stream(),
             state._streams["unshard"],
             state._streams["pre_unshard"],
         )
@@ -694,7 +694,7 @@ def _pre_backward_hook(
                     state._streams["unshard"],
                     state._streams["pre_unshard"],
                 )
-            torch.cuda.current_stream().wait_stream(state._streams["unshard"])
+            state.device_handler.current_stream().wait_stream(state._streams["unshard"])
 
         # Set this to `False` to ensure that a mistargeted prefetch does not
         # actually unshard these handles
@@ -762,9 +762,11 @@ def _post_backward_hook(
 
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
-        state._streams["post_backward"].wait_stream(torch.cuda.current_stream())
+        state._streams["post_backward"].wait_stream(
+            state.device_handler.current_stream()
+        )
 
-        with torch.cuda.stream(state._streams["post_backward"]):
+        with state.device_handler.stream(state._streams["post_backward"]):
             autograd_computed_grad = flat_param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
@@ -911,7 +913,9 @@ def _cast_grad_to_param_dtype(
         # caching allocator; for the sharded strategies, the gradient is
         # produced in the post-backward stream, so this `record_stream()`
         # should be a no-op
-        _no_dispatch_record_stream(low_prec_grad_data, torch.cuda.current_stream())
+        _no_dispatch_record_stream(
+            low_prec_grad_data, state.device_handler.current_stream()
+        )
 
 
 def _check_comm_hook(
@@ -965,12 +969,14 @@ def _post_backward_final_callback(
     root_state = state
 
     if root_state._sync_gradients:
-        torch.cuda.current_stream().wait_stream(root_state._streams["post_backward"])
+        state.device_handler.current_stream().wait_stream(
+            root_state._streams["post_backward"]
+        )
         if root_state.cpu_offload.offload_params:
             # Wait for non-blocking GPU -> CPU sharded gradient copies from the
             # post-backward hooks to finish explicitly since CPU gradients do
             # not automatically synchronize with the GPU
-            torch.cuda.current_stream().synchronize()
+            state.device_handler.current_stream().synchronize()
     root_state._exec_order_data.next_iter()
 
     for fsdp_state in state._all_fsdp_states:

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -161,7 +161,7 @@ def _lazy_init(
     """
     if state._is_root is not None:
         return  # no-op: already lazily initialized
-    if not state.device_handler.is_available():
+    if not state._device_handle.is_available():
         # Allow the FSDP constructor to run even without CUDA but check this
         # once we start real execution
         raise RuntimeError("FSDP does not support CPU only execution")
@@ -277,20 +277,20 @@ def _init_streams(
     data transfers. The streams should be shared across FSDP instances.
     """
     assert state._is_root
-    assert state.device_handler.is_available()
+    assert state._device_handle.is_available()
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._streams["unshard"] = state.device_handler.Stream()
+    state._streams["unshard"] = state._device_handle.Stream()
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
-    state._streams["post_backward"] = state.device_handler.Stream()
+    state._streams["post_backward"] = state._device_handle.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._streams["pre_unshard"] = state.device_handler.Stream()
+    state._streams["pre_unshard"] = state._device_handle.Stream()
     # Default stream for computation
-    state._streams["default"] = state.device_handler.current_stream()
+    state._streams["default"] = state._device_handle.current_stream()
     state._stream_to_name = {
-        state.device_handler.current_stream(): "default",
+        state._device_handle.current_stream(): "default",
         state._streams["unshard"]: "unshard",
         state._streams["pre_unshard"]: "pre_unshard",
         state._streams["post_backward"]: "post_backward",
@@ -315,7 +315,7 @@ def _unshard(
     if not handles:
         return
     any_ran_pre_unshard = False
-    with state.device_handler.stream(pre_unshard_stream):
+    with state._device_handle.stream(pre_unshard_stream):
         for handle in handles:
             ran_pre_unshard = handle.pre_unshard()
             any_ran_pre_unshard = any_ran_pre_unshard or ran_pre_unshard
@@ -325,7 +325,7 @@ def _unshard(
         event = state._free_event_queue.dequeue_if_needed()
         if event:
             event.synchronize()
-    with state.device_handler.stream(unshard_stream):
+    with state._device_handle.stream(unshard_stream):
         for handle in handles:
             handle.unshard()
             handle.post_unshard()
@@ -355,7 +355,7 @@ def _reshard(
     ):
         handle.reshard(free_unsharded_flat_param)
         if state.limit_all_gathers and free_unsharded_flat_param:
-            free_event = state.device_handler.Event()
+            free_event = state._device_handle.Event()
             free_event.record()
             state._free_event_queue.enqueue(free_event)
         handle.post_reshard()
@@ -444,7 +444,7 @@ def _pre_forward_unshard(
             state, handles, state._streams["unshard"], state._streams["pre_unshard"]
         )
     state._needs_pre_forward_unshard[handles_key] = False
-    state.device_handler.current_stream().wait_stream(state._streams["unshard"])
+    state._device_handle.current_stream().wait_stream(state._streams["unshard"])
     _prefetch_handles(state, handles_key, _PrefetchMode.FORWARD)
 
 
@@ -581,7 +581,7 @@ def _root_pre_forward(
             for handles_key in handles_keys:
                 state._needs_pre_forward_unshard[handles_key] = True
         _wait_for_computation_stream(
-            state.device_handler.current_stream(),
+            state._device_handle.current_stream(),
             state._streams["unshard"],
             state._streams["pre_unshard"],
         )
@@ -694,7 +694,7 @@ def _pre_backward_hook(
                     state._streams["unshard"],
                     state._streams["pre_unshard"],
                 )
-            state.device_handler.current_stream().wait_stream(state._streams["unshard"])
+            state._device_handle.current_stream().wait_stream(state._streams["unshard"])
 
         # Set this to `False` to ensure that a mistargeted prefetch does not
         # actually unshard these handles
@@ -763,10 +763,10 @@ def _post_backward_hook(
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
         state._streams["post_backward"].wait_stream(
-            state.device_handler.current_stream()
+            state._device_handle.current_stream()
         )
 
-        with state.device_handler.stream(state._streams["post_backward"]):
+        with state._device_handle.stream(state._streams["post_backward"]):
             autograd_computed_grad = flat_param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
@@ -914,7 +914,7 @@ def _cast_grad_to_param_dtype(
         # produced in the post-backward stream, so this `record_stream()`
         # should be a no-op
         _no_dispatch_record_stream(
-            low_prec_grad_data, state.device_handler.current_stream()
+            low_prec_grad_data, state._device_handle.current_stream()
         )
 
 
@@ -969,14 +969,14 @@ def _post_backward_final_callback(
     root_state = state
 
     if root_state._sync_gradients:
-        state.device_handler.current_stream().wait_stream(
+        state._device_handle.current_stream().wait_stream(
             root_state._streams["post_backward"]
         )
         if root_state.cpu_offload.offload_params:
             # Wait for non-blocking GPU -> CPU sharded gradient copies from the
             # post-backward hooks to finish explicitly since CPU gradients do
             # not automatically synchronize with the GPU
-            state.device_handler.current_stream().synchronize()
+            state._device_handle.current_stream().synchronize()
     root_state._exec_order_data.next_iter()
 
     for fsdp_state in state._all_fsdp_states:

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -122,8 +122,8 @@ def _common_pre_state_dict_hook(
     fsdp_state: _FSDPState,
 ) -> None:
     """Performs the pre-state_dict tasks shared by all state_dict types."""
-    if fsdp_state.device_handler.is_available():
-        fsdp_state.device_handler.synchronize()
+    if fsdp_state._device_handle.is_available():
+        fsdp_state._device_handle.synchronize()
     # TODO: need to check if this is always correct for composable FSDP.
     _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
@@ -513,7 +513,7 @@ def _sharded_post_state_dict_hook(
             tensor=param,
             rank=fsdp_state.rank,
             world_size=fsdp_state.world_size,
-            num_devices_per_node=fsdp_state.device_handler.device_count(),
+            num_devices_per_node=fsdp_state._device_handle.device_count(),
             pg=fsdp_state.process_group,
         )
         if fsdp_state._state_dict_config.offload_to_cpu:
@@ -702,8 +702,8 @@ def _pre_load_state_dict_hook(
         StateDictType.SHARDED_STATE_DICT: _sharded_pre_load_state_dict_hook,
     }
     # Code that is common for all state_dict impls
-    if fsdp_state.device_handler.is_available():
-        fsdp_state.device_handler.synchronize()
+    if fsdp_state._device_handle.is_available():
+        fsdp_state._device_handle.synchronize()
     # Dispatch into state_dict specific implementation of pre-hook.
     _pre_load_state_dict_hook_fn[fsdp_state._state_dict_type](
         module, fsdp_state, state_dict, prefix

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -171,7 +171,7 @@ def _unshard_fsdp_state_params(
     _validate_unshard_params_args(
         state, writeback, rank0_only, offload_to_cpu, with_grads
     )
-    torch.cuda.synchronize()
+    state.device_handler.synchronize()
     # If handles are shared by other module(s), the handle may be already unsharded.
     handles = [
         handle
@@ -194,7 +194,7 @@ def _unshard_fsdp_state_params(
     free_unsharded_flat_params = [handle.needs_unshard() for handle in handles]
     # No need to call `wait_stream()` since we unshard in the computation
     # stream directly
-    computation_stream = torch.cuda.current_stream()
+    computation_stream = state.device_handler.current_stream()
     _unshard(state, handles, computation_stream, computation_stream)
     if with_grads:
         _unshard_grads(handles)

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -171,7 +171,7 @@ def _unshard_fsdp_state_params(
     _validate_unshard_params_args(
         state, writeback, rank0_only, offload_to_cpu, with_grads
     )
-    state.device_handler.synchronize()
+    state._device_handle.synchronize()
     # If handles are shared by other module(s), the handle may be already unsharded.
     handles = [
         handle
@@ -194,7 +194,7 @@ def _unshard_fsdp_state_params(
     free_unsharded_flat_params = [handle.needs_unshard() for handle in handles]
     # No need to call `wait_stream()` since we unshard in the computation
     # stream directly
-    computation_stream = state.device_handler.current_stream()
+    computation_stream = state._device_handle.current_stream()
     _unshard(state, handles, computation_stream, computation_stream)
     if with_grads:
         _unshard_grads(handles)

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -436,7 +436,7 @@ class FlatParamHandle:
         align_addresses = use_orig_params
         self._init_get_unflat_views_fn(align_addresses)
         self.device = device
-        self._device_handler: Optional[_FSDPDeviceHandler] = None
+        self.device_handler = _FSDPDeviceHandler.from_device(self.device)
         self.process_group = process_group
         self.rank = process_group.rank()
         self.world_size = process_group.size()
@@ -466,14 +466,6 @@ class FlatParamHandle:
             params, fully_sharded_module, self._aligned_numel, use_orig_params  # type: ignore[arg-type]
         )
         self._use_unsharded_views(as_params=False)
-
-    @property
-    def device_handler(self) -> _FSDPDeviceHandler:
-        if self._device_handler is not None:
-            return self._device_handler
-
-        self._device_handler = _FSDPDeviceHandler.from_device(self.device)
-        return self._device_handler
 
     def _init_setattr_fns(self):
         use_unsafe_setattr = os.environ.get(_FSDP_USE_UNSAFE_SETATTR, "") == "1"

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -29,7 +29,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.distributed._tensor import DTensor
 from torch.distributed.fsdp._common_utils import (
-    _FSDPDeviceHandler,
+    _FSDPDeviceHandle,
     _named_parameters_with_duplicates,
     _set_fsdp_flattened,
     HandleTrainingState,
@@ -436,7 +436,7 @@ class FlatParamHandle:
         align_addresses = use_orig_params
         self._init_get_unflat_views_fn(align_addresses)
         self.device = device
-        self.device_handler = _FSDPDeviceHandler.from_device(self.device)
+        self._device_handle = _FSDPDeviceHandle.from_device(self.device)
         self.process_group = process_group
         self.rank = process_group.rank()
         self.world_size = process_group.size()
@@ -1294,7 +1294,7 @@ class FlatParamHandle:
         # default stream suffices since the default stream waits for the
         # unshard stream.
         _no_dispatch_record_stream(
-            self.flat_param._mp_shard, self.device_handler.current_stream()  # type: ignore[attr-defined]
+            self.flat_param._mp_shard, self._device_handle.current_stream()  # type: ignore[attr-defined]
         )
         _free_storage(self.flat_param._mp_shard)  # type: ignore[attr-defined]
 
@@ -1566,7 +1566,7 @@ class FlatParamHandle:
         self._check_on_compute_device(unsharded_flat_param)
         # Do not free the memory until all ops in the current stream finish
         _no_dispatch_record_stream(
-            unsharded_flat_param, self.device_handler.current_stream()
+            unsharded_flat_param, self._device_handle.current_stream()
         )
         _free_storage(unsharded_flat_param)
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -29,6 +29,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.distributed._tensor import DTensor
 from torch.distributed.fsdp._common_utils import (
+    _FSDPDeviceHandler,
     _named_parameters_with_duplicates,
     _set_fsdp_flattened,
     HandleTrainingState,
@@ -435,6 +436,7 @@ class FlatParamHandle:
         align_addresses = use_orig_params
         self._init_get_unflat_views_fn(align_addresses)
         self.device = device
+        self._device_handler: Optional[_FSDPDeviceHandler] = None
         self.process_group = process_group
         self.rank = process_group.rank()
         self.world_size = process_group.size()
@@ -464,6 +466,14 @@ class FlatParamHandle:
             params, fully_sharded_module, self._aligned_numel, use_orig_params  # type: ignore[arg-type]
         )
         self._use_unsharded_views(as_params=False)
+
+    @property
+    def device_handler(self) -> _FSDPDeviceHandler:
+        if self._device_handler is not None:
+            return self._device_handler
+
+        self._device_handler = _FSDPDeviceHandler.from_device(self.device)
+        return self._device_handler
 
     def _init_setattr_fns(self):
         use_unsafe_setattr = os.environ.get(_FSDP_USE_UNSAFE_SETATTR, "") == "1"
@@ -1292,7 +1302,7 @@ class FlatParamHandle:
         # default stream suffices since the default stream waits for the
         # unshard stream.
         _no_dispatch_record_stream(
-            self.flat_param._mp_shard, torch.cuda.current_stream()  # type: ignore[attr-defined]
+            self.flat_param._mp_shard, self.device_handler.current_stream()  # type: ignore[attr-defined]
         )
         _free_storage(self.flat_param._mp_shard)  # type: ignore[attr-defined]
 
@@ -1563,7 +1573,9 @@ class FlatParamHandle:
         self._check_storage_allocated(unsharded_flat_param)
         self._check_on_compute_device(unsharded_flat_param)
         # Do not free the memory until all ops in the current stream finish
-        _no_dispatch_record_stream(unsharded_flat_param, torch.cuda.current_stream())
+        _no_dispatch_record_stream(
+            unsharded_flat_param, self.device_handler.current_stream()
+        )
         _free_storage(unsharded_flat_param)
 
     def _use_sharded_flat_param(self) -> None:


### PR DESCRIPTION
Custom backend implementation based on privateuse1 with semantics identical to CUDA (CUDA is so popular), named for example 'my_device', and registered as the same module name torch.my_device.

This PR aims to satisfy the constraints of such a backend, which can be directly integrated into the current FSDP implementation.

The main issues addressed are:

#### 1. Device decision for FSDP wrapping of Modules without Parameters

Users typically organize FSDP code as follows:
```python
m = Module().to('my_device:0')
fsdp_m = FSDP(m)
```
or like this:
```python
m = Module()
fsdp_m = FSDP(m, device_id=torch.device('my_device', 0))
```
If the model has Parameters, everything works fine because FSDP will prioritize the device where the Parameters are located. However, for Modules without Parameters, the to() call has no side effects, and FSDP will assume the current CUDA device, which prevents the use of devices other than the current CUDA device for Modules without Parameters. Therefore, when FSDP is called with a device_id argument, this configuration takes top priority.

#### 2. Abstraction of a cuda-like device

Now, in addition to compute_device, _FSDPState includes a device_handler member. In fact, this device_handler is now just a reference to either torch.cuda or torch.my_device. From now on, code that works based on _FSDPState should use state.device_handler to operate streams create, wait or sync, just like using torch.cuda previously.