### PR TITLE
export comm func for custom device

### DIFF
--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -107,7 +107,7 @@ class TORCH_API CommHookInterface {
 namespace detail {
 // This helper function is called both by CppCommHookInterface below and inside
 // reducer.
- at::Tensor parseCppCommHookResult(const c10::IValue& result);
+ TORCH_API at::Tensor parseCppCommHookResult(const c10::IValue& result);
 } // namespace detail
 
 // This CppCommHook interface only requires implementing runHook method that


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
export the func named `parseCppCommHookResult` used for custom device ddp.
