### PR TITLE
Update InternalMatch in subgraph_rewriter after repeated replacements

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -93,6 +93,7 @@ class TestSubgraphRewriter(JitTestCase):
         class M(torch.nn.Module):
             def forward(self, x):
                 val = torch.neg(x)
+                val = torch.add(val, val)
                 return torch.add(val, val)
 
         def pattern(x):
@@ -115,9 +116,9 @@ class TestSubgraphRewriter(JitTestCase):
 
         ref_output = comparison_fn(x)
         test_output = traced.forward(x)
-        one_replacement = len(matches) == 1 and len(matches[0].replacements) == 0
+        no_replacements = len(matches) == 2 and len(matches[1].replacements) == 0
         self.assertEqual(ref_output, test_output)
-        self.assertTrue(one_replacement)
+        self.assertTrue(no_replacements)
 
     def test_subgraph_rewriter_single_pattern_match(self):
         class M(torch.nn.Module):

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -271,7 +271,7 @@ def _replace_pattern(
             if isinstance(gn, Node):
                 val_map[rn] = match_changed_node.get(gn, gn)
                 if gn != val_map[rn]:
-                        # Update match.placeholder_nodes and match.nodes_map with the node that replaced gn
+                    # Update match.placeholder_nodes and match.nodes_map with the node that replaced gn
                     gn_ind = match.placeholder_nodes.index(gn)
                     match.placeholder_nodes[gn_ind] = match_changed_node[gn]
                     map_key = list(match.nodes_map.keys())[list(match.nodes_map.values()).index(gn)]

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -270,7 +270,8 @@ def _replace_pattern(
         for rn, gn in zip(replacement_placeholders, match.placeholder_nodes):
             if isinstance(gn, Node):
                 val_map[rn] = match_changed_node.get(gn, gn)
-                if gn in match.placeholder_nodes and gn in match_changed_node:
+                if gn != val_map[rn]:
+                        # Update match.placeholder_nodes and match.nodes_map with the node that replaced gn
                     gn_ind = match.placeholder_nodes.index(gn)
                     match.placeholder_nodes[gn_ind] = match_changed_node[gn]
                     map_key = list(match.nodes_map.keys())[list(match.nodes_map.values()).index(gn)]

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -270,6 +270,11 @@ def _replace_pattern(
         for rn, gn in zip(replacement_placeholders, match.placeholder_nodes):
             if isinstance(gn, Node):
                 val_map[rn] = match_changed_node.get(gn, gn)
+                if gn in match.placeholder_nodes and gn in match_changed_node:
+                    gn_ind = match.placeholder_nodes.index(gn)
+                    match.placeholder_nodes[gn_ind] = match_changed_node[gn]
+                    map_key = list(match.nodes_map.keys())[list(match.nodes_map.values()).index(gn)]
+                    match.nodes_map[map_key] = match_changed_node[gn]
             else:
                 val_map[rn] = gn
 


### PR DESCRIPTION
Fixes #98974 

When `torch.fx.subgraph_rewriter._replace_pattern` is used to remove nodes from a graph, if there are two adjacent matches then after the first removal, the nodes in `InternalMatch.nodes_map` and `placeholder_nodes` become outdated because they contain nodes that were just removed from the graph.

This fix is to update the `match.nodes_map` and `match.placeholder_nodes` using the node changes stored in `match_changed_node`.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10