### PR TITLE
add generic func to get function defined in custom device module

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -152,6 +152,8 @@ class TestCppExtensionOpenRgistration(common.TestCase):
                 torch.utils.rename_privateuse1_backend('xxx')
             # register foo module, torch.foo
             torch._register_device_module('foo', DummyModule)
+            self.assertTrue(torch.utils.get_custom_mod_func("device_count")() == 1)
+            self.assertTrue(torch.utils.get_custom_mod_func("func_name") is None)
             # default set for_tensor and for_module are True, so only set for_storage is True
             torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
             # generator tensor and module can be registered only once
@@ -186,7 +188,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         def test_open_device_random():
             with torch.random.fork_rng(device_type="foo"):
                 pass
-                
+
         def test_open_device_tensor():
             device = self.module.custom_device()
             # check whether print tensor.type() meets the expectation
@@ -423,9 +425,6 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_open_device_storage_type()
         test_open_device_faketensor()
 
-        self.assertTrue(torch.utils.custom_device_name == "foo")
-        self.assertTrue(torch.utils.get_custom_mod_func("device_count")() == 1)
-        self.assertTrue(torch.utils.get_custom_mod_func("func_name") is None)
 
 if __name__ == "__main__":
     common.run_tests()

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -152,8 +152,8 @@ class TestCppExtensionOpenRgistration(common.TestCase):
                 torch.utils.rename_privateuse1_backend('xxx')
             # register foo module, torch.foo
             torch._register_device_module('foo', DummyModule)
-            self.assertTrue(torch.utils.get_custom_mod_func("device_count")() == 1)
-            self.assertTrue(torch.utils.get_custom_mod_func("func_name") is None)
+            self.assertTrue(torch.utils.backend_registration._get_custom_mod_func("device_count")() == 1)
+            self.assertTrue(torch.utils.backend_registration._get_custom_mod_func("func_name") is None)
             # default set for_tensor and for_module are True, so only set for_storage is True
             torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
             # generator tensor and module can be registered only once

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -153,7 +153,8 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             # register foo module, torch.foo
             torch._register_device_module('foo', DummyModule)
             self.assertTrue(torch.utils.backend_registration._get_custom_mod_func("device_count")() == 1)
-            self.assertTrue(torch.utils.backend_registration._get_custom_mod_func("func_name") is None)
+            with self.assertRaisesRegex(RuntimeError, "Try to call torch.foo"):
+                torch.utils.backend_registration._get_custom_mod_func("func_name_")
             # default set for_tensor and for_module are True, so only set for_storage is True
             torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
             # generator tensor and module can be registered only once

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -186,7 +186,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         def test_open_device_random():
             with torch.random.fork_rng(device_type="foo"):
                 pass
-
+                
         def test_open_device_tensor():
             device = self.module.custom_device()
             # check whether print tensor.type() meets the expectation
@@ -423,6 +423,9 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_open_device_storage_type()
         test_open_device_faketensor()
 
+        self.assertTrue(torch.utils.custom_device_name == "foo")
+        self.assertTrue(torch.utils.get_custom_mod_func("device_count")() == 1)
+        self.assertTrue(torch.utils.get_custom_mod_func("func_name") is None)
 
 if __name__ == "__main__":
     common.run_tests()

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -4,8 +4,8 @@ import torch
 from .throughput_benchmark import ThroughputBenchmark
 from ._crash_handler import enable_minidumps, disable_minidumps, enable_minidumps_on_exceptions
 from .cpp_backtrace import get_cpp_backtrace
-from .backend_registration import (rename_privateuse1_backend, get_custom_mod_func,
-                                   generate_methods_for_privateuse1_backend)
+from .backend_registration import (rename_privateuse1_backend, generate_methods_for_privateuse1_backend,
+                                   get_custom_mod_func)
 
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -4,7 +4,8 @@ import torch
 from .throughput_benchmark import ThroughputBenchmark
 from ._crash_handler import enable_minidumps, disable_minidumps, enable_minidumps_on_exceptions
 from .cpp_backtrace import get_cpp_backtrace
-from .backend_registration import rename_privateuse1_backend, generate_methods_for_privateuse1_backend
+from .backend_registration import (rename_privateuse1_backend, get_custom_mod_func,
+                                   generate_methods_for_privateuse1_backend)
 
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -4,8 +4,7 @@ import torch
 from .throughput_benchmark import ThroughputBenchmark
 from ._crash_handler import enable_minidumps, disable_minidumps, enable_minidumps_on_exceptions
 from .cpp_backtrace import get_cpp_backtrace
-from .backend_registration import (rename_privateuse1_backend, generate_methods_for_privateuse1_backend,
-                                   get_custom_mod_func)
+from .backend_registration import rename_privateuse1_backend, generate_methods_for_privateuse1_backend
 
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -3,8 +3,7 @@ import torch
 from torch._C import _rename_privateuse1_backend, _get_privateuse1_backend_name
 from typing import List, Optional, Union
 
-__all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend",
-           "get_custom_mod_func"]
+__all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend"]
 
 # TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
 # renamed-backend name for `privateuse1`, but the func will cause an
@@ -302,7 +301,7 @@ def generate_methods_for_privateuse1_backend(for_tensor: bool = True, for_module
     if for_storage:
         _generate_storage_methods_for_privateuse1_backend(custom_backend_name, unsupported_dtype)
 
-def get_custom_mod_func(func_name: str):
+def _get_custom_mod_func(func_name: str):
     r"""
     Return the func named `func_name` defined in custom device module. If not defined,
     return `None`. And the func is registered with `torch.utils.rename_privateuse1_backend('foo')`
@@ -320,10 +319,10 @@ def get_custom_mod_func(func_name: str):
                 ....
         torch.utils.rename_privateuse1_backend("foo")
         torch._register_device_module("foo", DummyfooModule)
-        foo_is_available_func = torch.utils.get_custom_mod_func("is_available")
+        foo_is_available_func = torch.utils.backend_registration._get_custom_mod_func("is_available")
         if foo_is_available_func:
             foo_is_available = foo_is_available_func()
-        func_ = torch.utils.get_custom_mod_func("func_name")
+        func_ = torch.utils.backend_registration._get_custom_mod_func("func_name")
         if func_:
             result = func_(*args, **kwargs)
     Attention: This func is only used for custom device.

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -3,8 +3,8 @@ import torch
 from torch._C import _rename_privateuse1_backend, _get_privateuse1_backend_name
 from typing import List, Optional, Union
 
-__all__ = ["rename_privateuse1_backend", "get_custom_mod_func",
-           "generate_methods_for_privateuse1_backend"]
+__all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend",
+           "get_custom_mod_func"]
 
 # TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
 # renamed-backend name for `privateuse1`, but the func will cause an
@@ -304,7 +304,7 @@ def generate_methods_for_privateuse1_backend(for_tensor: bool = True, for_module
 
 def get_custom_mod_func(func_name: str):
     r"""
-    Return the func named `_func_name_` defined in custom device module. If not defined,
+    Return the func named `func_name` defined in custom device module. If not defined,
     return `None`. And the func is registered with `torch.utils.rename_privateuse1_backend('foo')`
     and `torch._register_device_module('foo', BackendModule)`.
     If the custom device module or the func is not defined, it will give warning or error message.
@@ -320,14 +320,13 @@ def get_custom_mod_func(func_name: str):
                 ....
         torch.utils.rename_privateuse1_backend("foo")
         torch._register_device_module("foo", DummyfooModule)
-        foo_is_available_func = get_custom_mod_func("is_available")
+        foo_is_available_func = torch.utils.get_custom_mod_func("is_available")
         if foo_is_available_func:
             foo_is_available = foo_is_available_func()
-        func_ = get_custom_mod_func("func_name")
+        func_ = torch.utils.get_custom_mod_func("func_name")
         if func_:
             result = func_(*args, **kwargs)
-        # raise error/warning, you must have define func named `device_count` in `DummyfooModule` module
-        run_custom_device_mod_func("device_count")
+    Attention: This func is only used for custom device.
     """
     assert isinstance(func_name, str), f"func_name must be `str`, but got `{type(func_name)}`."
     backend_name = _get_privateuse1_backend_name()


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Now for the custom device, we use `getattr` and `setattr` to run the func defined in custom device module in some files, such as `AMP`, `random`, `DDP` and so on. So I want to add a generic func to get these funcs more friendly, could you take a look? @bdhirsh @albanD 

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5