### PR TITLE
[RFC] Allow elastic agent to fail fast

### DIFF
--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -903,7 +903,6 @@ class SimpleElasticAgent(ElasticAgent):
                 else:
                     self._stop_workers(self._worker_group)
                     self._worker_group.state = WorkerState.FAILED
-                    self._exit_barrier()
                     return run_result
             elif state == WorkerState.HEALTHY:
                 # membership changes do not count as retries


### PR DESCRIPTION
Summary: Today, on a segfault on a single trainer , we end up keeping the gpu on all ranks blocked for 5 minutes due to elastic agents barrier timeouts

Test Plan: Rely on existing test to validate . Looking to get some feedback on adding UTs

Differential Revision: D44929488

