### PR TITLE
[functorch] typo in merge rule's github handle

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -370,7 +370,7 @@
   - '**functorch**'
   - '**pytree**'
   approved_by:
-  - kshiteej12345
+  - kshitij12345
   - srossross
   - chillee
   - zou3519


### PR DESCRIPTION
Github handle was spelled incorrectly.