### PR TITLE
Back out "Disable dynamo tracing torchrec.distributed (#97824)"

### DIFF
--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -145,10 +145,7 @@ def add(import_name: str):
     if isinstance(import_name, types.ModuleType):
         return add(import_name.__name__)
     assert isinstance(import_name, str)
-    try:
-        module_spec = importlib.util.find_spec(import_name)
-    except Exception:
-        return
+    module_spec = importlib.util.find_spec(import_name)
     if not module_spec:
         return
     origin = module_spec.origin
@@ -191,7 +188,6 @@ for _name in (
     "tensorflow",
     "tensorrt",
     "torch2trt",
-    "torchrec.distributed",
     "tqdm",
     "tree",
     "tvm",


### PR DESCRIPTION
Summary:
This diff is at least the proximate cause for a large increase in memory consumption in FAIM workflows. See:
- https://fb.workplace.com/groups/fluent2.users/permalink/3338250533108824/
- https://fburl.com/sevmanager/sfjs06ov

Test Plan:
Failing flow: f426720454

Successful flow (D44633264 backed out): f427830256

Reviewed By: yanboliang

Differential Revision: D44978317



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire