### PR TITLE
Support >4GB strings in the TorchScript model

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -264,9 +264,15 @@ void Pickler::pushBinGet(uint32_t memo_id) {
 
 // unmemoized encoding of a string
 void Pickler::pushStringImpl(const std::string& string) {
-  push<PickleOpCode>(PickleOpCode::BINUNICODE);
-  push<uint32_t>(to_le32(string.size()));
-  pushBytes(string);
+  if (string.size() <= UINT_MAX) {
+    push<PickleOpCode>(PickleOpCode::BINUNICODE);
+    push<uint32_t>(to_le32(string.size()));
+    pushBytes(string);
+  } else {
+    push<PickleOpCode>(PickleOpCode::BINUNICODE8);
+    push<int64_t>(to_le64(string.size()));
+    pushBytes(string);
+  }
 }
 
 void Pickler::pushString(const std::string& string) {

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -349,6 +349,10 @@ PickleOpCode Unpickler::readInstruction() {
       uint32_t length = from_le32(read<uint32_t>());
       stack_.emplace_back(readBytes(length));
     } break;
+    case PickleOpCode::BINUNICODE8: {
+      int64_t length = from_le64(read<int64_t>());
+      stack_.emplace_back(readBytes(length));
+    } break;
     case PickleOpCode::BINFLOAT:
       stack_.emplace_back(readFloat());
       break;


### PR DESCRIPTION
Summary: The support of BINUNICODE8 is missing. So adding it. So we can support attributes > 4GB. For example, for very large model, we save the lowered model in the EngineHolder using a string attribute.

Test Plan: buck2 test mode/opt //caffe2/test:jit -- --exact 'caffe2/test:jit - test_save_load_large_string_attribute (jit.test_save_load.TestSaveLoad)'

Differential Revision: D44905770

