### PR TITLE
Change the stepweight decay to avoid precision loss around 1

### DIFF
--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -385,7 +385,7 @@ def _single_tensor_adamw(
         step_t += 1
 
         # Perform stepweight decay
-        param.mul_(1 - lr * weight_decay)
+        param.sub_(param * lr * weight_decay)
 
         # Decay the first and second moment running average coefficient
         exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)


### PR DESCRIPTION
The updated step weight decay is more XLA friendly in that it avoids computation graph change when the value of lr*weight_decay is too small (e.g. <=1e-9). In the original version, the value 1-lr*weight_decay would become 1 and trigger XLA special constant tensor optimization, resulting in a graph change. 