### PR TITLE
Unbreak torch.compile on macos

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -202,15 +202,13 @@ class NormalizeIRTests(torch._dynamo.test_case.TestCase):
 
 class MPSNotSupportedTest(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.backends.mps.is_available(), "requires mps")
-    def test_default_mps_to_aot_eager(self):
+    def test_mps_not_supported(self):
         model = Seq().to("mps")
         example_input = torch.randn(1, 10).to("mps")
-
-        # Not sure yet if there's a better way to test this
-        a = torch.compile(model, backend="inductor")(example_input)
-        torch._dynamo.reset()
-        b = torch.compile(model, backend="aot_eager")(example_input)
-        self.assertTrue(torch.equal(a, b))
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.compile(model, backend="inductor")(example_input),
+        )
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -917,7 +917,6 @@ class WrapperModule(torch.nn.Module):
         return self.m()
 
 
-@unittest.skipIf(torch.backends.mps.is_available(), "not applicable to mps")
 class DefaultsTests(torch._dynamo.test_case.TestCase):
     def test_func_default_tensor_args(self):
         """

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -37,7 +37,6 @@ from torch._dynamo.testing import (
 )
 from torch._dynamo.utils import ifdyn, ifunspec
 from torch.nn import functional as F
-from torch.testing._internal.common_utils import IS_MACOS
 
 
 _orig_module_call = torch.nn.Module.__call__
@@ -2283,7 +2282,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         opt_mod(*args)
 
     @skipIfPy311
-    @unittest.skipIf(IS_MACOS, "need to debug mac issue")
     def test_pointless_graph_removal(self):
         cnt = torch._dynamo.testing.CompileCounter()
 
@@ -2821,10 +2819,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(
             dict(counters["graph_break"]), {"autograd.Function with requires_grad": 1}
         )
-        if not IS_MACOS:
-            # TODO(jansel): I have no idea why these are failing on mac...
-            self.assertEqual(cnt.op_count, 6)
-            self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 6)
+        self.assertEqual(cnt.frame_count, 1)
         cnt.clear()
         counters.clear()
 

--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -14,7 +14,6 @@ def dummy_fn(x):
     return torch.sigmoid(x + math.pi) / 10.0
 
 
-@unittest.skipIf(torch.backends.mps.is_available(), "default to aot_eager")
 class TestInductorConfig(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1590,8 +1590,6 @@ def compile(model: Optional[Callable] = None, *,
     import torch._dynamo
     if mode is not None and options is not None:
         raise RuntimeError("Either mode or options can be specified, but both can't be specified at the same time.")
-    if torch.backends.mps.is_available():
-        backend = "aot_eager"
     if mode is None and options is None:
         mode = "default"
     if backend == "inductor":

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1150,7 +1150,7 @@ class Scheduler:
             from .codegen.cpp import CppScheduling
 
             return CppScheduling(self)
-        else:
+        elif device.type == "cuda":
             if not has_triton():
                 device_props = torch.cuda.get_device_properties(device)
                 if device_props.major < 7:
@@ -1164,6 +1164,8 @@ class Scheduler:
             from .codegen.triton import TritonScheduling
 
             return TritonScheduling(self)
+        else:
+            raise RuntimeError(f"Unsupported device type: {device.type}")
 
     def get_backend(self, device: torch.device):
         if device not in self.backends:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99119


It seems like #96980 made torch.compile() completely ignore the `backend=` arg on macos rendering the entire API useless even if the user wasn't using mps tensors.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire