### PR TITLE
Don't specialize when indexing by SymInt

### DIFF
--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -379,6 +379,19 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
         # just one graph now rather than 10
         self.assertEqual(cnt_dynamic.frame_count, 1)
 
+    @patch("torch._dynamo.config.dynamic_shapes", True)
+    @patch("torch._dynamo.config.assume_static_by_default", False)
+    def test_dynamic_getitem(self):
+        def fn(a, b):
+            return a[b.size(0) - 1]
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnt)(fn)
+        for i in range(3, 12):
+            opt_fn(torch.randn(i), torch.randn(i))
+        # just one graph
+        self.assertEqual(cnt.frame_count, 1)
+
     def test_dynamic_kwarg(self):
         def fn(a, b):
             return a - b * 10

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -479,13 +479,15 @@ class BuiltinVariable(VariableTracker):
                     # Work around weird bug in hf_T5
                     fn, args = operator.add, [args[1], args[0]]
 
-                if self.fn is operator.getitem and isinstance(
-                    args[1], SymNodeVariable
-                ):
+                if self.fn is operator.getitem and isinstance(args[1], SymNodeVariable):
                     # Standard indexing will force specialization due to
                     # __index__.  Rewrite as a regular torch op which will
                     # trace fine
-                    fn, args = torch.select, [args[0], variables.ConstantVariable(0), args[1]]
+                    fn, args = torch.select, [
+                        args[0],
+                        variables.ConstantVariable(0),
+                        args[1],
+                    ]
 
                 proxy = tx.output.create_proxy(
                     "call_function",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -479,6 +479,14 @@ class BuiltinVariable(VariableTracker):
                     # Work around weird bug in hf_T5
                     fn, args = operator.add, [args[1], args[0]]
 
+                if self.fn is operator.getitem and isinstance(
+                    args[1], SymNodeVariable
+                ):
+                    # Standard indexing will force specialization due to
+                    # __index__.  Rewrite as a regular torch op which will
+                    # trace fine
+                    fn, args = torch.select, [args[0], variables.ConstantVariable(0), args[1]]
+
                 proxy = tx.output.create_proxy(
                     "call_function",
                     fn,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99123

Fixes https://github.com/pytorch/pytorch/issues/99091

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire