### PR TITLE
Further improve symbolic shapes logging

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -4051,7 +4051,7 @@ def fn():
             root_tx=None,
             export=False,
             export_constraints=None,
-            frame_state={'_id': 0},
+            frame_state={"_id": 0},
         )
         # Contrived property so as not to have it be None
         graph.nn_modules = {}

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -4051,7 +4051,7 @@ def fn():
             root_tx=None,
             export=False,
             export_constraints=None,
-            frame_state=None,
+            frame_state={'_id': 0},
         )
         # Contrived property so as not to have it be None
         graph.nn_modules = {}

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -206,6 +206,9 @@ def exception_handler(e, code, frame=None):
         log.error(format_error_msg(e, code, record_filename, frame))
 
 
+FRAME_COUNTER = 0
+
+
 def convert_frame_assert(
     compiler_fn: CompilerFn,
     one_graph: bool = True,
@@ -219,6 +222,11 @@ def convert_frame_assert(
         frame: types.FrameType, cache_size: int, hooks: Hooks, frame_state
     ):
         increment_frame()
+        global FRAME_COUNTER
+        if '_id' not in frame_state:
+            frame_state['_id'] = FRAME_COUNTER
+            FRAME_COUNTER += 1
+
         code = frame.f_code
 
         if code in input_codes and (

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -223,8 +223,8 @@ def convert_frame_assert(
     ):
         increment_frame()
         global FRAME_COUNTER
-        if '_id' not in frame_state:
-            frame_state['_id'] = FRAME_COUNTER
+        if "_id" not in frame_state:
+            frame_state["_id"] = FRAME_COUNTER
             FRAME_COUNTER += 1
 
         code = frame.f_code

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -213,7 +213,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
             shape_env=ShapeEnv(
                 allow_scalar_outputs=config.capture_scalar_outputs,
                 allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
-                frame_id=frame_state['_id'],
+                frame_id=frame_state["_id"],
             )
             if config.dynamic_shapes
             else None,

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -213,6 +213,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
             shape_env=ShapeEnv(
                 allow_scalar_outputs=config.capture_scalar_outputs,
                 allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
+                frame_id=frame_state['_id'],
             )
             if config.dynamic_shapes
             else None,

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1392,7 +1392,7 @@ class ShapeEnvLoggerAdapter(logging.LoggerAdapter):
         return '%s: %s' % (self.extra['envid'], msg), kwargs
 
 
-ENV_ID = 0
+ENV_COUNTER = collections.Counter()
 
 
 class ShapeEnv:
@@ -1419,6 +1419,8 @@ class ShapeEnv:
         # When True, assume input sizes which have the same size are
         # symbolically equal.
         duck_shape=True,
+        # For debugging
+        frame_id=None,
     ):
         # Not directly used by ShapeEnv; indirectly used by FakeTensor
         self.allow_scalar_outputs = allow_scalar_outputs
@@ -1449,9 +1451,13 @@ class ShapeEnv:
         self.assume_static_by_default = assume_static_by_default
         self.specialize_zero_one = specialize_zero_one
         self.duck_shape = duck_shape
-        global ENV_ID
-        self.log = ShapeEnvLoggerAdapter(log, {'envid': ENV_ID})
-        ENV_ID += 1
+        per_frame_id = ENV_COUNTER[frame_id]
+        ENV_COUNTER[frame_id] += 1
+        if frame_id is None:
+            env_id = per_frame_id
+        else:
+            env_id = f"{frame_id}.{per_frame_id}"
+        self.log = ShapeEnvLoggerAdapter(log, {'envid': env_id})
         self.log.info("create_env")
 
     def _suppress_guards_tls(self):
@@ -1696,6 +1702,8 @@ class ShapeEnv:
         constraint_inputs: Optional[InputList[Union[DimConstraint, Optional[DimList[DimConstraint]]]]] = None,
         _simplified=False
     ) -> List[str]:
+        self.log.info("produce_guards")
+
         assert len(placeholders) == len(sources)
 
         # Expand optional inputs, or verify invariants are upheld
@@ -2297,14 +2305,14 @@ class ShapeEnv:
         Given an expression, evaluates it, adding guards if necessary
         """
         if len(orig_expr.free_symbols) == 0:
-            self.log.debug("evaluate_expr %s [trivial]", orig_expr)
+            self.log.debug("eval %s [trivial]", orig_expr)
             return orig_expr
 
         expr = orig_expr
 
         static_expr = self._maybe_evaluate_static(expr)
         if static_expr is not None:
-            self.log.debug("evaluate_expr %s == %s [statically known]", orig_expr, static_expr)
+            self.log.debug("eval %s == %s [statically known]", orig_expr, static_expr)
             return static_expr
 
         if not (expr.free_symbols <= self.var_to_val.keys()):
@@ -2372,7 +2380,7 @@ class ShapeEnv:
                         ''.join(traceback.format_list(user_tb))
                     )
                 self.log.info(
-                    "evaluate_expr %s [guard added]%s (%s)%s",
+                    "eval %s [guard added]%s (%s)%s",
                     g,
                     maybe_user_loc,
                     format_frame(frame),
@@ -2380,7 +2388,7 @@ class ShapeEnv:
                     stack_info=is_debug,
                 )
         else:
-            self.log.debug("evaluate_expr %s [guard suppressed]", g)
+            self.log.debug("eval %s [guard suppressed]", g)
 
         return concrete_val
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99159

* Introduce a frame counter which lets us uniquely identify frames.
  This makes it easier to tell if you are recompiling the same frame
* Shorten evaluate_expr to eval for more visual distinctiveness

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire