### PR TITLE
make gemv calls data_ptr_correct

### DIFF
--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -42,7 +42,7 @@ TORCH_META_FUNC(addmv)(const Tensor &self, const Tensor &mat, const Tensor &vec,
 namespace native {
 
 template<typename scalar_t>
-void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t lda, scalar_t *x, int64_t incx, scalar_t beta, scalar_t *y, int64_t incy);
+void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, const scalar_t *a, int64_t lda, const scalar_t *x, int64_t incx, scalar_t beta, scalar_t *y, int64_t incy);
 
 template<typename scalar_t>
 scalar_t dot_impl(int64_t n, scalar_t *x, int64_t incx, scalar_t *y, int64_t incy);
@@ -92,17 +92,17 @@ TORCH_IMPL_FUNC(addmv_out_cpu)(const Tensor &self, const Tensor &mat, const Tens
         auto beta = beta_.to<scalar_t>();
         auto alpha = alpha_.to<scalar_t>();
         if (mat.stride(0) == 1 && lda_cond(mat.size(0), mat.size(1), mat.stride(1))) {
-          gemv<scalar_t>('n', mat.size(0), mat.size(1), alpha, mat.data_ptr<scalar_t>(), mat.stride(1),
-              vec.data_ptr<scalar_t>(), vec.stride(0), beta, result.data_ptr<scalar_t>(), r_stride);
+          gemv<scalar_t>('n', mat.size(0), mat.size(1), alpha, mat.const_data_ptr<scalar_t>(), mat.stride(1),
+              vec.const_data_ptr<scalar_t>(), vec.stride(0), beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
         else if (mat.stride(1) == 1 && lda_cond(mat.size(1), mat.size(0), mat.stride(0))) {
-          gemv<scalar_t>('t', mat.size(1), mat.size(0), alpha, mat.data_ptr<scalar_t>(), mat.stride(0),
-              vec.data_ptr<scalar_t>(), vec.stride(0), beta, result.data_ptr<scalar_t>(), r_stride);
+          gemv<scalar_t>('t', mat.size(1), mat.size(0), alpha, mat.const_data_ptr<scalar_t>(), mat.stride(0),
+              vec.const_data_ptr<scalar_t>(), vec.stride(0), beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
         else {
           Tensor cmat = mat.contiguous();
-          gemv<scalar_t>('t', mat.size(1), mat.size(0), alpha, cmat.data_ptr<scalar_t>(), cmat.stride(0),
-              vec.data_ptr<scalar_t>(), vec.stride(0), beta, result.data_ptr<scalar_t>(), r_stride);
+          gemv<scalar_t>('t', mat.size(1), mat.size(0), alpha, cmat.const_data_ptr<scalar_t>(), cmat.stride(0),
+              vec.const_data_ptr<scalar_t>(), vec.stride(0), beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
       });
     }

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -653,19 +653,19 @@ TORCH_IMPL_FUNC(addmv_out_cuda)(const Tensor &self, const Tensor &mat, const Ten
         auto alpha = alpha_.to<scalar_t>();
         if (mat.stride(0) == 1 && mat.stride(1) >= std::max<int64_t>(1, mat.size(0))) {
           at::cuda::blas::gemv<scalar_t>('n',
-            mat.size(0), mat.size(1), alpha, mat.data_ptr<scalar_t>(), mat.stride(1), vec_contiguous.data_ptr<scalar_t>(),
-            vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
+            mat.size(0), mat.size(1), alpha, mat.const_data_ptr<scalar_t>(), mat.stride(1), vec_contiguous.const_data_ptr<scalar_t>(),
+            vec_stride, beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
         else if (mat.stride(1) == 1 && mat.stride(0) >= std::max<int64_t>(1, mat.size(1))) {
           at::cuda::blas::gemv<scalar_t>('t',
-            mat.size(1), mat.size(0), alpha, mat.data_ptr<scalar_t>(), mat.stride(0),
-            vec_contiguous.data_ptr<scalar_t>(), vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
+            mat.size(1), mat.size(0), alpha, mat.const_data_ptr<scalar_t>(), mat.stride(0),
+            vec_contiguous.const_data_ptr<scalar_t>(), vec_stride, beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
         else {
           Tensor cmat = mat.contiguous();
           at::cuda::blas::gemv<scalar_t>('t',
-              mat.size(1), mat.size(0), alpha, cmat.data_ptr<scalar_t>(), cmat.stride(0),
-              vec_contiguous.data_ptr<scalar_t>(), vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
+              mat.size(1), mat.size(0), alpha, cmat.const_data_ptr<scalar_t>(), cmat.stride(0),
+              vec_contiguous.const_data_ptr<scalar_t>(), vec_stride, beta, result.mutable_data_ptr<scalar_t>(), r_stride);
         }
       });
     }

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -232,18 +232,18 @@ void slow_conv_dilated_all_cuda_template(
   /* MSVC does not like #ifdef-s inside the CPP macro
      AT_DISPATCH_FLOATING_TYPES_AND_HALF. So, we define the code
      branching outside the CPP macro: */
-#define CALCULATE_GRAD_BIAS                          \
-  at::cuda::blas::gemv<scalar_t>(                    \
-      /*trans=*/'t',                                 \
-      /*    m=*/output_vsize,                        \
-      /*    n=*/nOutputPlane,                        \
-      /*alpha=*/static_cast<scalar_t>(1),            \
-      /*    A=*/grad_output_n.data_ptr<scalar_t>(),  \
-      /*  lda=*/output_vsize,                        \
-      /*    x=*/ones.data_ptr<scalar_t>(),           \
-      /* incx=*/1,                                   \
-      /* beta=*/static_cast<scalar_t>(1),            \
-      /*    y=*/grad_bias.data_ptr<scalar_t>(),      \
+#define CALCULATE_GRAD_BIAS                                \
+  at::cuda::blas::gemv<scalar_t>(                          \
+      /*trans=*/'t',                                       \
+      /*    m=*/output_vsize,                              \
+      /*    n=*/nOutputPlane,                              \
+      /*alpha=*/static_cast<scalar_t>(1),                  \
+      /*    A=*/grad_output_n.const_data_ptr<scalar_t>(),  \
+      /*  lda=*/output_vsize,                              \
+      /*    x=*/ones.const_data_ptr<scalar_t>(),           \
+      /* incx=*/1,                                         \
+      /* beta=*/static_cast<scalar_t>(1),                  \
+      /*    y=*/grad_bias.mutable_data_ptr<scalar_t>(),    \
       /* incy=*/1)
 #else
 #define CALCULATE_GRAD_BIAS grad_bias += grad_output_n.sum(dims)


### PR DESCRIPTION
make gemv calls data_ptr_correct

Summary:
The following link for dgemv, for example, shows that all arguments
except for `y` are exclusively input arguments.
https://netlib.org/lapack/explore-html/d7/d15/group__double__blas__level2_gadd421a107a488d524859b4a64c1901a9.html

Test Plan: Rely on CI.
