### PR TITLE
[DCP] Rewrite read slicing to use a wrapper.

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -456,7 +456,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 save_dict = {
                     "sharded": sharded_tensor.rand(save_spec, tensor_size),
                     "replicated": torch.rand(
-                        tensor_size, device=f"cpu:{self.rank}"
+                        tensor_size, device="cpu"
                     ),
                 }
 

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -384,7 +384,7 @@ class _ReaderView(io.IOBase):
         return self.base_stream.seekable()
 
     def readinto(self, b):
-        return self.base_stream.readinto(b)
+        return self.base_stream.readinto(b)  # type: ignore[attr-defined]
 
     def read(self, size=-1):
         return self.base_stream.read(size)

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -369,10 +369,7 @@ class _ReaderView(io.IOBase):
         elif __whence == os.SEEK_END:
             __whence = os.SEEK_SET
             __offset = (self.offset + self.len) - __offset
-        try:
-            return self.base_stream.seek(__offset, __whence)
-        except BaseException as ex:
-            raise ex
+        return self.base_stream.seek(__offset, __whence)
 
     def tell(self) -> int:
         return self.base_stream.tell() - self.offset

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -1,3 +1,5 @@
+import os
+import io
 from typing import (
     List,
     Callable,
@@ -352,3 +354,41 @@ def _element_wise_add(a: Sequence[int], b: Sequence[int]) -> List[int]:
 
 def _element_wise_sub(a: Sequence[int], b: Sequence[int]) -> List[int]:
     return [i_a - i_b for i_a, i_b in zip(a, b)]
+
+class _ReaderView(io.IOBase):
+    def __init__(self, base_stream: io.IOBase, offset: int, len: int):
+        super().__init__()
+        self.offset = offset
+        self.len = len
+        self.base_stream = base_stream
+        self.seek(0)
+
+    def seek(self, __offset: int, __whence: int = os.SEEK_SET) -> int:
+        if __whence == os.SEEK_SET:
+            __offset = self.offset + __offset
+        elif __whence == os.SEEK_END:
+            __whence = os.SEEK_SET
+            __offset = (self.offset + self.len) - __offset
+        try:
+            return self.base_stream.seek(__offset, __whence)
+        except BaseException as ex:
+            raise ex
+
+    def tell(self) -> int:
+        return self.base_stream.tell() - self.offset
+
+    def readable(self) -> bool:
+        return self.base_stream.readable()
+
+    def seekable(self) -> bool:
+        return self.base_stream.seekable()
+
+    def readinto(self, b):
+        return self.base_stream.readinto(b)
+
+    def read(self, size=-1):
+        return self.base_stream.read(size)
+
+def _create_file_view(file: io.IOBase, offset: int, length: int) -> io.IOBase:
+    # FIXME (kumpera) torch.load fails if we wrap with io.BufferedReader
+    return _ReaderView(file, offset, length)


### PR DESCRIPTION
Moved SlicedBufferedReader to utils and renamed to _ReaderView.

It no longer depends on file handles and is a pure wrapper. This makes it general enought to handle non io stream objects like fsspec's.

Should help with #98386