### PR TITLE
Back out "[core][pruning][be] rename BaseSparsifier to BasePruner (#98747)"

### DIFF
--- a/test/ao/sparsity/test_composability.py
+++ b/test/ao/sparsity/test_composability.py
@@ -22,7 +22,7 @@ sparse_defaults = {
     "zeros_per_block": 4,
 }
 
-def _get_model_and_pruner_and_sparse_config(qconfig=None):
+def _get_model_and_sparsifier_and_sparse_config(qconfig=None):
     model = nn.Sequential(
         nn.Linear(4, 4),  # 0
         nn.ReLU(),
@@ -37,7 +37,7 @@ def _get_model_and_pruner_and_sparse_config(qconfig=None):
         model[4].qconfig = qconfig
         model[5].qconfig = qconfig
 
-    pruner = pruning.WeightNormPruner(**sparse_defaults)
+    sparsifier = pruning.WeightNormSparsifier(**sparse_defaults)
 
     sparse_config = [
         {
@@ -48,7 +48,7 @@ def _get_model_and_pruner_and_sparse_config(qconfig=None):
         },
         {"tensor_fqn": "0.weight"},
     ]
-    return model, pruner, sparse_config
+    return model, sparsifier, sparse_config
 
 def _squash_mask_calibrate_and_convert(model, sparsifier, input):
     sparsifier.step()
@@ -71,7 +71,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config(tq.get_default_qconfig("fbgemm"))
+        ) = _get_model_and_sparsifier_and_sparse_config(tq.get_default_qconfig("fbgemm"))
 
         tq.prepare(mod, inplace=True)
         sparsifier.prepare(mod, config=sparse_config)
@@ -100,7 +100,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config(tq.get_default_qconfig("fbgemm"))
+        ) = _get_model_and_sparsifier_and_sparse_config(tq.get_default_qconfig("fbgemm"))
 
         sparsifier.prepare(mod, config=sparse_config)
         tq.prepare(mod, inplace=True)
@@ -131,7 +131,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config(tq.get_default_qconfig("fbgemm"))
+        ) = _get_model_and_sparsifier_and_sparse_config(tq.get_default_qconfig("fbgemm"))
 
         sparsifier.prepare(mod, config=sparse_config)
         tq.prepare(mod, inplace=True)
@@ -169,7 +169,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config(tq.get_default_qconfig("fbgemm"))
+        ) = _get_model_and_sparsifier_and_sparse_config(tq.get_default_qconfig("fbgemm"))
         sparsifier.prepare(mod, config=sparse_config)
         tq.fuse_modules(mod, [["5", "6"]], inplace=True)
         mod[5].qconfig = tq.get_default_qconfig("fbgemm")
@@ -198,7 +198,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             _,
-        ) = _get_model_and_pruner_and_sparse_config(tq.get_default_qconfig("fbgemm"))
+        ) = _get_model_and_sparsifier_and_sparse_config(tq.get_default_qconfig("fbgemm"))
         tq.fuse_modules(mod, [["5", "6"]], inplace=True)
 
         # its absolutely broken by fusion but will still work if you put the correct fqn in
@@ -250,7 +250,7 @@ class TestComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config(
+        ) = _get_model_and_sparsifier_and_sparse_config(
             tq.get_default_qat_qconfig("fbgemm")
         )
         sparsifier.prepare(mod, config=sparse_config)
@@ -275,7 +275,7 @@ class TestComposability(TestCase):
 
     # This tests whether performing qat prepare before sparse prepare causes issues.
     def test_qat_prep_before_s_prep(self):
-        mod, sparsifier, _ = _get_model_and_pruner_and_sparse_config(
+        mod, sparsifier, _ = _get_model_and_sparsifier_and_sparse_config(
             tq.get_default_qat_qconfig("fbgemm")
         )
         tq.prepare_qat(mod, inplace=True)
@@ -337,7 +337,7 @@ class TestFxComposability(TestCase):
             mod,
             sparsifier,
             _,
-        ) = _get_model_and_pruner_and_sparse_config()
+        ) = _get_model_and_sparsifier_and_sparse_config()
 
         example = torch.randn(1, 4, 4, 4)
         qconfig = tq.get_default_qconfig("fbgemm")
@@ -396,7 +396,7 @@ class TestFxComposability(TestCase):
             mod,
             sparsifier,
             _,
-        ) = _get_model_and_pruner_and_sparse_config()
+        ) = _get_model_and_sparsifier_and_sparse_config()
 
         example = torch.randn(1, 4, 4, 4)
         qconfig = tq.get_default_qconfig("fbgemm")
@@ -455,7 +455,7 @@ class TestFxComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config()
+        ) = _get_model_and_sparsifier_and_sparse_config()
         sparsifier.prepare(mod, config=sparse_config)
 
         example = torch.randn(1, 4, 4, 4)
@@ -500,7 +500,7 @@ class TestFxComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config()
+        ) = _get_model_and_sparsifier_and_sparse_config()
         sparsifier.prepare(mod, config=sparse_config)
 
         example = torch.randn(1, 4, 4, 4)
@@ -546,7 +546,7 @@ class TestFxComposability(TestCase):
             mod,
             sparsifier,
             sparse_config,
-        ) = _get_model_and_pruner_and_sparse_config()
+        ) = _get_model_and_sparsifier_and_sparse_config()
         sparsifier.prepare(mod, config=sparse_config)
 
         example = torch.randn(1, 4, 4, 4)

--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -3,7 +3,7 @@
 
 from torch import nn
 
-from torch.ao.pruning import WeightNormPruner
+from torch.ao.pruning import WeightNormSparsifier
 from torch.ao.pruning import BaseScheduler, LambdaSL, CubicSL
 
 from torch.testing._internal.common_utils import TestCase
@@ -24,33 +24,33 @@ class TestScheduler(TestCase):
         model = nn.Sequential(
             nn.Linear(16, 16)
         )
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        scheduler = ImplementedScheduler(pruner)
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        scheduler = ImplementedScheduler(sparsifier)
 
-        assert scheduler.sparsifier is pruner
+        assert scheduler.sparsifier is sparsifier
         assert scheduler._step_count == 1
-        assert scheduler.base_sl == [pruner.groups[0]['sparsity_level']]
+        assert scheduler.base_sl == [sparsifier.groups[0]['sparsity_level']]
 
     def test_order_of_steps(self):
         """Checks if the warning is thrown if the scheduler step is called
-        before the pruner step"""
+        before the sparsifier step"""
 
         model = nn.Sequential(
             nn.Linear(16, 16)
         )
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        scheduler = ImplementedScheduler(pruner)
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        scheduler = ImplementedScheduler(sparsifier)
 
-        # Pruner step is not called
+        # Sparsifier step is not called
         with self.assertWarns(UserWarning):
             scheduler.step()
 
         # Correct order has no warnings
         # Note: This will trigger if other warnings are present.
         with warnings.catch_warnings(record=True) as w:
-            pruner.step()
+            sparsifier.step()
             scheduler.step()
             # Make sure there is no warning related to the base_scheduler
             for warning in w:
@@ -62,27 +62,27 @@ class TestScheduler(TestCase):
         model = nn.Sequential(
             nn.Linear(16, 16)
         )
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        assert pruner.groups[0]['sparsity_level'] == 0.5
-        scheduler = ImplementedScheduler(pruner)
-        assert pruner.groups[0]['sparsity_level'] == 0.5
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        assert sparsifier.groups[0]['sparsity_level'] == 0.5
+        scheduler = ImplementedScheduler(sparsifier)
+        assert sparsifier.groups[0]['sparsity_level'] == 0.5
 
-        pruner.step()
+        sparsifier.step()
         scheduler.step()
-        assert pruner.groups[0]['sparsity_level'] == 0.25
+        assert sparsifier.groups[0]['sparsity_level'] == 0.25
 
     def test_lambda_scheduler(self):
         model = nn.Sequential(
             nn.Linear(16, 16)
         )
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        assert pruner.groups[0]['sparsity_level'] == 0.5
-        scheduler = LambdaSL(pruner, lambda epoch: epoch * 10)
-        assert pruner.groups[0]['sparsity_level'] == 0.0  # Epoch 0
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        assert sparsifier.groups[0]['sparsity_level'] == 0.5
+        scheduler = LambdaSL(sparsifier, lambda epoch: epoch * 10)
+        assert sparsifier.groups[0]['sparsity_level'] == 0.0  # Epoch 0
         scheduler.step()
-        assert pruner.groups[0]['sparsity_level'] == 5.0  # Epoch 1
+        assert sparsifier.groups[0]['sparsity_level'] == 5.0  # Epoch 1
 
 
 class TestCubicScheduler(TestCase):
@@ -104,8 +104,8 @@ class TestCubicScheduler(TestCase):
         return model
 
     def _make_scheduler(self, model, **kwargs):
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=self.model_sparse_config)
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=self.model_sparse_config)
 
         scheduler_args = {
             'init_sl': self.initial_sparsity,
@@ -113,20 +113,20 @@ class TestCubicScheduler(TestCase):
         }
         scheduler_args.update(kwargs)
 
-        scheduler = CubicSL(pruner, **scheduler_args)
-        return pruner, scheduler
+        scheduler = CubicSL(sparsifier, **scheduler_args)
+        return sparsifier, scheduler
 
     @staticmethod
-    def _get_sparsity_levels(pruner, precision=32):
-        r"""Gets the current levels of sparsity in a pruner."""
-        return [round(group['sparsity_level'], precision) for group in pruner.groups]
+    def _get_sparsity_levels(sparsifier, precision=32):
+        r"""Gets the current levels of sparsity in a sparsifier."""
+        return [round(group['sparsity_level'], precision) for group in sparsifier.groups]
 
     def test_constructor(self):
         model = self._make_model()
-        pruner, scheduler = self._make_scheduler(model=model, initially_zero=True)
+        sparsifier, scheduler = self._make_scheduler(model=model, initially_zero=True)
         self.assertIs(
-            scheduler.sparsifier, pruner,
-            msg="pruner is not properly attached")
+            scheduler.sparsifier, sparsifier,
+            msg="Sparsifier is not properly attached")
         self.assertEqual(
             scheduler._step_count, 1,
             msg="Scheduler is initialized with incorrect step count")
@@ -136,21 +136,21 @@ class TestCubicScheduler(TestCase):
 
         # Value before t_0 is 0
         self.assertEqual(
-            self._get_sparsity_levels(pruner), scheduler._make_sure_a_list(0.0),
-            msg="Pruner is not reset correctly after attaching to the Scheduler")
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(0.0),
+            msg="Sparsifier is not reset correctly after attaching to the Scheduler")
 
         # Value before t_0 is s_0
         model = self._make_model()
-        pruner, scheduler = self._make_scheduler(model=model, initially_zero=False)
+        sparsifier, scheduler = self._make_scheduler(model=model, initially_zero=False)
         self.assertEqual(
-            self._get_sparsity_levels(pruner),
+            self._get_sparsity_levels(sparsifier),
             scheduler._make_sure_a_list(self.initial_sparsity),
-            msg="Pruner is not reset correctly after attaching to the Scheduler")
+            msg="Sparsifier is not reset correctly after attaching to the Scheduler")
 
     def test_step(self):
         # For n=5, dt=2, there will be totally 10 steps between s_0 and s_f, starting from t_0
         model = self._make_model()
-        pruner, scheduler = self._make_scheduler(
+        sparsifier, scheduler = self._make_scheduler(
             model=model, initially_zero=True, init_t=3, delta_t=2, total_t=5)
 
         scheduler.step()
@@ -158,17 +158,17 @@ class TestCubicScheduler(TestCase):
         self.assertEqual(scheduler._step_count, 3, msg="Scheduler step_count is expected to increment")
         # Value before t_0 is supposed to be 0
         self.assertEqual(
-            self._get_sparsity_levels(pruner), scheduler._make_sure_a_list(0.0),
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(0.0),
             msg="Scheduler step updating the sparsity level before t_0")
 
         scheduler.step()  # Step = 3  =>  sparsity = initial_sparsity
         self.assertEqual(
-            self._get_sparsity_levels(pruner), scheduler._make_sure_a_list(self.initial_sparsity),
-            msg="Pruner is not reset to initial sparsity at the first step")
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(self.initial_sparsity),
+            msg="Sparsifier is not reset to initial sparsity at the first step")
 
         scheduler.step()  # Step = 4  =>  sparsity ~ [0.3, 0.2]
         self.assertEqual(
-            self._get_sparsity_levels(pruner, 1), [0.3, 0.2],
+            self._get_sparsity_levels(sparsifier, 1), [0.3, 0.2],
             msg="Sparsity level is not set correctly after the first step")
 
         current_step = scheduler._step_count - scheduler.init_t[0] - 1
@@ -176,5 +176,5 @@ class TestCubicScheduler(TestCase):
         for _ in range(more_steps_needed):  # More steps needed to final sparsity level
             scheduler.step()
         self.assertEqual(
-            self._get_sparsity_levels(pruner), self.sorted_sparse_levels,
+            self._get_sparsity_levels(sparsifier), self.sorted_sparse_levels,
             msg="Sparsity level is not reaching the target level afer delta_t * n steps ")

--- a/test/ao/sparsity/test_sparsifier.py
+++ b/test/ao/sparsity/test_sparsifier.py
@@ -7,52 +7,52 @@ import re
 
 import torch
 from torch import nn
-from torch.ao.pruning import BasePruner, WeightNormPruner, NearlyDiagonalPruner, FakeSparsity
+from torch.ao.pruning import BaseSparsifier, WeightNormSparsifier, FakeSparsity, NearlyDiagonalSparsifier
 from torch.nn.utils.parametrize import is_parametrized
 
 from torch.testing._internal.common_utils import TestCase
-from torch.testing._internal.common_pruning import SimpleLinear, MockSparseLinear, ImplementedPruner
+from torch.testing._internal.common_pruning import SimpleLinear, MockSparseLinear, ImplementedSparsifier
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 
 
-class TestBasePruner(TestCase):
+class TestBaseSparsifier(TestCase):
     def test_constructor(self):
         # Cannot instantiate the abstract base
-        self.assertRaises(TypeError, BasePruner)
+        self.assertRaises(TypeError, BaseSparsifier)
         # Can instantiate the model with no configs
         model = SimpleLinear()
-        pruner = ImplementedPruner(test=3)
-        pruner.prepare(model, config=None)
-        assert len(pruner.groups) == 5
-        pruner.step()
+        sparsifier = ImplementedSparsifier(test=3)
+        sparsifier.prepare(model, config=None)
+        assert len(sparsifier.groups) == 5
+        sparsifier.step()
         # Can instantiate the model with configs
-        pruner = ImplementedPruner(test=3)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
-        assert len(pruner.groups) == 1
-        assert pruner.groups[0]['tensor_fqn'] == 'linear1.weight'
-        assert 'test' in pruner.groups[0]
-        assert pruner.groups[0]['test'] == 3
+        sparsifier = ImplementedSparsifier(test=3)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
+        assert len(sparsifier.groups) == 1
+        assert sparsifier.groups[0]['tensor_fqn'] == 'linear1.weight'
+        assert 'test' in sparsifier.groups[0]
+        assert sparsifier.groups[0]['test'] == 3
 
     def test_prepare_config(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(test=3)
+        sparsifier = ImplementedSparsifier(test=3)
         # Make sure there are no parametrizations before `prepare`
         assert not hasattr(model.seq[0], 'parametrizations')
         assert not hasattr(model.linear1, 'parametrizations')
         assert not hasattr(model.linear2, 'parametrizations')
-        pruner.prepare(model, config=[
+        sparsifier.prepare(model, config=[
             {'tensor_fqn': 'seq.0.weight', 'test': 42},
             # No 'linear1' to make sure it will be skipped in the sparsification
             {'tensor_fqn': 'linear2.weight'}
         ])
-        assert len(pruner.groups) == 2
+        assert len(sparsifier.groups) == 2
         # Check if default argument is not assigned if explicit
-        assert pruner.groups[0]['tensor_fqn'] == 'seq.0.weight'
-        assert pruner.groups[0]['test'] == 42
+        assert sparsifier.groups[0]['tensor_fqn'] == 'seq.0.weight'
+        assert sparsifier.groups[0]['test'] == 42
         # Check if FQN and module are pointing to the same location
-        assert pruner.groups[1]['tensor_fqn'] == 'linear2.weight'
-        assert pruner.groups[1]['module'] == model.linear2
+        assert sparsifier.groups[1]['tensor_fqn'] == 'linear2.weight'
+        assert sparsifier.groups[1]['module'] == model.linear2
         # Check if parameterizations are attached
         assert hasattr(model.seq[0], 'parametrizations')
         assert not hasattr(model.linear1, 'parametrizations')
@@ -60,22 +60,22 @@ class TestBasePruner(TestCase):
 
     def test_step(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(test=3)
-        pruner.enable_mask_update = True
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
-        pruner.step()
+        sparsifier = ImplementedSparsifier(test=3)
+        sparsifier.enable_mask_update = True
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
+        sparsifier.step()
         assert torch.all(model.linear1.parametrizations.weight[0].mask[0] == 0)
 
     def test_state_dict(self):
         step_count = 3
         model0 = SimpleLinear()
-        pruner0 = ImplementedPruner(test=3)
-        pruner0.prepare(model0, [{'tensor_fqn': 'linear1.weight'}])
+        sparsifier0 = ImplementedSparsifier(test=3)
+        sparsifier0.prepare(model0, [{'tensor_fqn': 'linear1.weight'}])
         mask = model0.linear1.parametrizations['weight'][0].mask
         mask.data = torch.arange(mask.shape[0] * mask.shape[1]).reshape(mask.shape)
         for step in range(step_count):
-            pruner0.step()
-        state_dict = pruner0.state_dict()
+            sparsifier0.step()
+        state_dict = sparsifier0.state_dict()
 
         # Check the expected keys in the state_dict
         assert 'state' in state_dict
@@ -88,30 +88,30 @@ class TestBasePruner(TestCase):
 
         # Check loading static_dict creates an equivalent model
         model1 = SimpleLinear()
-        pruner1 = ImplementedPruner()
-        pruner1.prepare(model1, None)
+        sparsifier1 = ImplementedSparsifier()
+        sparsifier1.prepare(model1, None)
 
-        assert pruner0.state != pruner1.state
+        assert sparsifier0.state != sparsifier1.state
 
         # Make sure the masks are different in the beginning
-        for mg in pruner0.groups:
+        for mg in sparsifier0.groups:
             if mg['tensor_fqn'] == 'linear1.weight':
                 mask0 = mg['module'].parametrizations.weight[0].mask
-        for mg in pruner1.groups:
+        for mg in sparsifier1.groups:
             if mg['tensor_fqn'] == 'linear1.weight':
                 mask1 = mg['module'].parametrizations.weight[0].mask
         self.assertNotEqual(mask0, mask1)
 
-        pruner1.load_state_dict(state_dict)
+        sparsifier1.load_state_dict(state_dict)
 
         # Make sure the states are loaded, and are correct
-        assert pruner0.state == pruner1.state
+        assert sparsifier0.state == sparsifier1.state
 
         # Make sure the masks (and all dicts) are the same after loading
-        assert len(pruner0.groups) == len(pruner1.groups)
-        for idx in range(len(pruner0.groups)):
-            mg0 = pruner0.groups[idx]
-            mg1 = pruner1.groups[idx]
+        assert len(sparsifier0.groups) == len(sparsifier1.groups)
+        for idx in range(len(sparsifier0.groups)):
+            mg0 = sparsifier0.groups[idx]
+            mg1 = sparsifier1.groups[idx]
             for key in mg0.keys():
                 assert key in mg1
                 if key == 'module':
@@ -126,9 +126,9 @@ class TestBasePruner(TestCase):
 
     def test_convert(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(test=3)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
-        new_model = pruner.convert(model, mapping={nn.Linear: MockSparseLinear}, inplace=False)
+        sparsifier = ImplementedSparsifier(test=3)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
+        new_model = sparsifier.convert(model, mapping={nn.Linear: MockSparseLinear}, inplace=False)
 
         assert isinstance(new_model.linear1, MockSparseLinear)
         assert isinstance(new_model.seq[0], nn.Linear)
@@ -138,21 +138,21 @@ class TestBasePruner(TestCase):
 
     def test_mask_squash(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(test=3)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
+        sparsifier = ImplementedSparsifier(test=3)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}])
         assert hasattr(model.linear1.parametrizations.weight[0], 'mask')
         assert is_parametrized(model.linear1, 'weight')
         assert not is_parametrized(model.seq[0], 'weight')
 
-        pruner.squash_mask()
+        sparsifier.squash_mask()
         assert not is_parametrized(model.seq[0], 'weight')
         assert not is_parametrized(model.linear1, 'weight')
 
     def test_mask_squash_with_params1(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(foo=3, bar=2, baz=1)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
-        pruner.squash_mask(
+        sparsifier = ImplementedSparsifier(foo=3, bar=2, baz=1)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
+        sparsifier.squash_mask(
             params_to_keep_per_layer={
                 'linear1': ('foo', 'bar'),
                 'seq.0': ('baz',)
@@ -170,9 +170,9 @@ class TestBasePruner(TestCase):
 
     def test_mask_squash_with_params2(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(foo=3, bar=2, baz=1)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
-        pruner.squash_mask(params_to_keep=('foo', 'bar'))
+        sparsifier = ImplementedSparsifier(foo=3, bar=2, baz=1)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
+        sparsifier.squash_mask(params_to_keep=('foo', 'bar'))
         assert not is_parametrized(model.seq[0], 'weight')
         assert not is_parametrized(model.linear1, 'weight')
         assert hasattr(model.seq[0], 'sparse_params')
@@ -186,9 +186,9 @@ class TestBasePruner(TestCase):
 
     def test_mask_squash_with_params3(self):
         model = SimpleLinear()
-        pruner = ImplementedPruner(foo=3, bar=2, baz=1)
-        pruner.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
-        pruner.squash_mask(
+        sparsifier = ImplementedSparsifier(foo=3, bar=2, baz=1)
+        sparsifier.prepare(model, [{'tensor_fqn': 'linear1.weight'}, {'tensor_fqn': 'seq.0.weight'}])
+        sparsifier.squash_mask(
             params_to_keep=('foo', 'bar'),
             params_to_keep_per_layer={'seq.0': ('baz',)})
         assert not is_parametrized(model.seq[0], 'weight')
@@ -203,28 +203,28 @@ class TestBasePruner(TestCase):
         assert model.linear1.sparse_params.get('baz', None) is None
 
 
-class TestWeightNormPruner(TestCase):
+class TestWeightNormSparsifier(TestCase):
     def test_constructor(self):
         model = SimpleLinear()
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        for g in pruner.groups:
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        for g in sparsifier.groups:
             assert isinstance(g['module'], nn.Linear)
             # The groups are unordered
             assert g['module_fqn'] in ('seq.0', 'seq.1', 'seq.2', 'linear1', 'linear2')
 
     def test_step(self):
         model = SimpleLinear()
-        pruner = WeightNormPruner(sparsity_level=0.5)
-        pruner.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
-        for g in pruner.groups:
+        sparsifier = WeightNormSparsifier(sparsity_level=0.5)
+        sparsifier.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
+        for g in sparsifier.groups:
             # Before step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) == 0  # checking sparsity level is 0
-        pruner.enable_mask_update = True
-        pruner.step()
+        sparsifier.enable_mask_update = True
+        sparsifier.step()
         self.assertAlmostEqual(model.linear1.parametrizations['weight'][0].mask.mean().item(), 0.5, places=2)
-        for g in pruner.groups:
+        for g in sparsifier.groups:
             # After step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) > 0  # checking sparsity level has increased
@@ -232,24 +232,24 @@ class TestWeightNormPruner(TestCase):
         iters_before_collapse = 1000
         for _ in range(iters_before_collapse):
             model.linear1.weight.data = torch.randn(model.linear1.weight.shape)
-            pruner.step()
-        for g in pruner.groups:
+            sparsifier.step()
+        for g in sparsifier.groups:
             # After step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) > 0  # checking sparsity level did not collapse
 
     def test_step_2_of_4(self):
         model = SimpleLinear()
-        pruner = WeightNormPruner(sparsity_level=1.0,
-                                  sparse_block_shape=(1, 4),
-                                  zeros_per_block=2)
-        pruner.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
-        pruner.step()
+        sparsifier = WeightNormSparsifier(sparsity_level=1.0,
+                                          sparse_block_shape=(1, 4),
+                                          zeros_per_block=2)
+        sparsifier.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
+        sparsifier.step()
         # make sure the sparsity level is approximately 50%
         mask = model.linear1.parametrizations['weight'][0].mask.to(torch.float)  # mean works on float only
         self.assertAlmostEqual(mask.mean().item(), 0.5, places=2)
         # Make sure each block has exactly 50% zeros
-        module = pruner.groups[0]['module']
+        module = sparsifier.groups[0]['module']
         mask = module.parametrizations['weight'][0].mask
         for row in mask:
             for idx in range(0, len(row), 4):
@@ -260,9 +260,9 @@ class TestWeightNormPruner(TestCase):
 
     def test_prepare(self):
         model = SimpleLinear()
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        for g in pruner.groups:
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        for g in sparsifier.groups:
             module = g['module']
             # Check mask exists
             assert hasattr(module.parametrizations['weight'][0], 'mask')
@@ -272,10 +272,10 @@ class TestWeightNormPruner(TestCase):
 
     def test_mask_squash(self):
         model = SimpleLinear()
-        pruner = WeightNormPruner()
-        pruner.prepare(model, config=None)
-        pruner.squash_mask()
-        for g in pruner.groups:
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=None)
+        sparsifier.squash_mask()
+        for g in sparsifier.groups:
             module = g['module']
             assert not is_parametrized(module, 'weight')
             assert not hasattr(module, 'mask')
@@ -290,7 +290,7 @@ class TestWeightNormPruner(TestCase):
                                                     zeros_per_blocks))
         # Create a config and model with all the testcases
         model = nn.Sequential()
-        pruner = WeightNormPruner()
+        sparsifier = WeightNormSparsifier()
 
         sparsity_per_layer_config = []
         p = re.compile(r'[-\.\s]')
@@ -312,9 +312,9 @@ class TestWeightNormPruner(TestCase):
             }
             sparsity_per_layer_config.append(config)
 
-        pruner.prepare(model, sparsity_per_layer_config)
-        pruner.step()
-        pruner.squash_mask()
+        sparsifier.prepare(model, sparsity_per_layer_config)
+        sparsifier.step()
+        sparsifier.squash_mask()
         model.eval()
 
         for sl, sbs, zpb in testcases[1]:
@@ -335,33 +335,33 @@ class TestWeightNormPruner(TestCase):
                 assert sparse_mask.mean() == true_sl
 
 
-class TestNearlyDiagonalPruner(TestCase):
+class TestNearlyDiagonalSparsifier(TestCase):
     def test_constructor(self):
         model = SimpleLinear()
-        pruner = NearlyDiagonalPruner(nearliness=1)
-        pruner.prepare(model, config=None)
-        for g in pruner.groups:
+        sparsifier = NearlyDiagonalSparsifier(nearliness=1)
+        sparsifier.prepare(model, config=None)
+        for g in sparsifier.groups:
             assert isinstance(g['module'], nn.Linear)
             # The groups are unordered
             assert g['module_fqn'] in ('seq.0', 'seq.1', 'seq.2', 'linear1', 'linear2')
 
     def test_step(self):
         model = SimpleLinear()
-        pruner = NearlyDiagonalPruner(nearliness=1)
-        pruner.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
+        sparsifier = NearlyDiagonalSparsifier(nearliness=1)
+        sparsifier.prepare(model, config=[{'tensor_fqn': 'linear1.weight'}])
 
-        for g in pruner.groups:
+        for g in sparsifier.groups:
             # Before step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) == 0  # checking sparsity level is 0
 
-        pruner.enable_mask_update = True
-        pruner.step()
+        sparsifier.enable_mask_update = True
+        sparsifier.step()
         mask = module.parametrizations['weight'][0].mask
         height, width = mask.shape
         assert torch.all(mask == torch.eye(height, width))
 
-        for g in pruner.groups:
+        for g in sparsifier.groups:
             # After step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) > 0  # checking sparsity level has increased
@@ -370,17 +370,17 @@ class TestNearlyDiagonalPruner(TestCase):
         iters_before_collapse = 1000
         for _ in range(iters_before_collapse):
             model.linear1.weight.data = torch.randn(model.linear1.weight.shape)
-            pruner.step()
-        for g in pruner.groups:
+            sparsifier.step()
+        for g in sparsifier.groups:
             # After step
             module = g['module']
             assert (1.0 - module.parametrizations['weight'][0].mask.mean()) > 0  # checking sparsity level did not collapse
 
     def test_prepare(self):
         model = SimpleLinear()
-        pruner = NearlyDiagonalPruner(nearliness=1)
-        pruner.prepare(model, config=None)
-        for g in pruner.groups:
+        sparsifier = NearlyDiagonalSparsifier(nearliness=1)
+        sparsifier.prepare(model, config=None)
+        for g in sparsifier.groups:
             module = g['module']
             # Check mask exists
             assert hasattr(module.parametrizations['weight'][0], 'mask')
@@ -390,11 +390,11 @@ class TestNearlyDiagonalPruner(TestCase):
 
     def test_mask_squash(self):
         model = SimpleLinear()
-        pruner = NearlyDiagonalPruner(nearliness=1)
-        pruner.prepare(model, config=None)
-        pruner.step()
-        pruner.squash_mask()
-        for g in pruner.groups:
+        sparsifier = NearlyDiagonalSparsifier(nearliness=1)
+        sparsifier.prepare(model, config=None)
+        sparsifier.step()
+        sparsifier.squash_mask()
+        for g in sparsifier.groups:
             module = g['module']
             assert not is_parametrized(module, 'weight')
             assert not hasattr(module, 'mask')
@@ -409,7 +409,7 @@ class TestNearlyDiagonalPruner(TestCase):
 
         p = re.compile(r'[-\.\s]')
         for nearliness in nearliness_levels:
-            pruner = NearlyDiagonalPruner(nearliness=1)
+            sparsifier = NearlyDiagonalSparsifier(nearliness=1)
             layer_name = f'{nearliness}'
             layer_name = p.sub('_', layer_name)
 
@@ -422,14 +422,14 @@ class TestNearlyDiagonalPruner(TestCase):
                 'nearliness': nearliness
             }
 
-            pruner.prepare(model, [config])
+            sparsifier.prepare(model, [config])
             # should raise a ValueError when nearliness arg is illegal
             if (nearliness > 0 and nearliness % 2 == 0) or (nearliness // 2 >= min(width, height)):
                 with self.assertRaises(ValueError):
-                    pruner.step()
+                    sparsifier.step()
             else:
-                pruner.step()
-                pruner.squash_mask()
+                sparsifier.step()
+                sparsifier.squash_mask()
                 model.eval()
 
                 layer = getattr(model, layer_name)

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -11,9 +11,9 @@ from ao.sparsity.test_kernels import TestQuantizedSparseLayers  # noqa: F401
 from ao.sparsity.test_parametrization import TestFakeSparsity  # noqa: F401
 
 # Sparsifier
-from ao.sparsity.test_sparsifier import TestBasePruner  # noqa: F401
-from ao.sparsity.test_sparsifier import TestNearlyDiagonalPruner  # noqa: F401
-from ao.sparsity.test_sparsifier import TestWeightNormPruner  # noqa: F401
+from ao.sparsity.test_sparsifier import TestBaseSparsifier  # noqa: F401
+from ao.sparsity.test_sparsifier import TestWeightNormSparsifier  # noqa: F401
+from ao.sparsity.test_sparsifier import TestNearlyDiagonalSparsifier  # noqa: F401
 
 # Structured Pruning
 from ao.sparsity.test_structured_sparsifier import TestBaseStructuredSparsifier  # noqa: F401

--- a/torch/ao/pruning/__init__.py
+++ b/torch/ao/pruning/__init__.py
@@ -3,9 +3,9 @@ from ._mappings import get_dynamic_sparse_quantized_mapping
 from ._mappings import get_static_sparse_quantized_mapping
 
 # Sparsifier
-from .sparsifier.base_pruner import BasePruner
-from .sparsifier.weight_norm_pruner import WeightNormPruner
-from .sparsifier.nearly_diagonal_pruner import NearlyDiagonalPruner
+from .sparsifier.base_sparsifier import BaseSparsifier
+from .sparsifier.weight_norm_sparsifier import WeightNormSparsifier
+from .sparsifier.nearly_diagonal_sparsifier import NearlyDiagonalSparsifier
 
 # Scheduler
 from .scheduler.base_scheduler import BaseScheduler

--- a/torch/ao/pruning/_experimental/data_sparsifier/base_data_sparsifier.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/base_data_sparsifier.py
@@ -1,7 +1,7 @@
 import abc
 import torch
 from typing import Optional, Tuple, List, Any, Dict
-from ...sparsifier.base_pruner import BasePruner
+from ...sparsifier import base_sparsifier
 from collections import defaultdict
 from torch import nn
 import copy
@@ -32,7 +32,7 @@ class _Container(nn.Module):
     pass
 
 
-class BaseDataSparsifier(BasePruner):
+class BaseDataSparsifier(base_sparsifier.BaseSparsifier):
     r"""
     Base Data Sparsifier class for all Data sparsifiers.
     The abstract class accepts raw torch tensors / embedding / embedding bags (refer to SUPPORTED_TYPES above)

--- a/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
+++ b/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
@@ -7,7 +7,7 @@ from torch.fx import symbolic_trace
 from torch.nn.utils import parametrize
 from typing import Type, Set, Dict, Callable, Tuple, Optional, Union
 
-from torch.ao.pruning import BasePruner
+from torch.ao.pruning import BaseSparsifier
 from .parametrization import FakeStructuredSparsity, BiasHook, module_contains_param
 from .match_utils import apply_match, MatchAllNode
 from .prune_functions import (
@@ -203,7 +203,7 @@ def _get_default_structured_pruning_patterns() -> Dict[
     return patterns
 
 
-class BaseStructuredSparsifier(BasePruner):
+class BaseStructuredSparsifier(BaseSparsifier):
     r"""Base class for structured pruning.
 
     Abstract methods that need to be implemented:

--- a/torch/ao/pruning/scheduler/base_scheduler.py
+++ b/torch/ao/pruning/scheduler/base_scheduler.py
@@ -1,5 +1,5 @@
 
-from torch.ao.pruning import BasePruner
+from torch.ao.pruning import BaseSparsifier
 
 from functools import wraps
 import warnings
@@ -12,8 +12,8 @@ class BaseScheduler:
     def __init__(self, sparsifier, last_epoch=-1, verbose=False):
 
         # Attach sparsifier
-        if not isinstance(sparsifier, BasePruner):
-            raise TypeError('{} is not an instance of torch.ao.pruning.BasePruner'.format(
+        if not isinstance(sparsifier, BaseSparsifier):
+            raise TypeError('{} is not an instance of torch.ao.pruning.BaseSparsifier'.format(
                 type(sparsifier).__name__))
         self.sparsifier = sparsifier
 

--- a/torch/ao/pruning/scheduler/cubic_scheduler.py
+++ b/torch/ao/pruning/scheduler/cubic_scheduler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import warnings
-from .base_scheduler import BaseScheduler
 
+from .base_scheduler import BaseScheduler
 
 __all__ = ["CubicSL"]
 
@@ -24,7 +24,7 @@ class CubicSL(BaseScheduler):
     happens. By default,
 
     Args:
-        sparsifier (BasePruner): Wrapped pruner.
+        sparsifier (BaseSparsifier): Wrapped sparsifier.
         init_sl (int, list): Initial level of sparsity
         init_t (int, list): Initial step, when pruning starts
         delta_t (int, list): Pruning frequency

--- a/torch/ao/pruning/scheduler/lambda_scheduler.py
+++ b/torch/ao/pruning/scheduler/lambda_scheduler.py
@@ -8,7 +8,7 @@ class LambdaSL(BaseScheduler):
     """Sets the sparsity level of each parameter group to the final sl
     times a given function. When last_epoch=-1, sets initial sl as zero.
     Args:
-        pruner (BasePruner): Wrapped pruner.
+        sparsifier (BaseSparsifier): Wrapped sparsifier.
         sl_lambda (function or list): A function which computes a multiplicative
             factor given an integer parameter epoch, or a list of such
             functions, one for each group in sparsifier.param_groups.

--- a/torch/ao/pruning/sparsifier/base_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/base_sparsifier.py
@@ -16,16 +16,18 @@ from .utils import (
     module_to_fqn,
 )
 
-__all__ = ["BasePruner"]
+__all__ = ["BaseSparsifier"]
 
 SUPPORTED_MODULES = {nn.Linear}
 
 KEYS_NOT_IN_STATE_DICT = ["module", "module_fqn", "tensor_name"]
 
+__all__ = ["BaseSparsifier"]
+
 
 # TODO update desc with new config args
-class BasePruner(abc.ABC):
-    r"""Base class for all pruners.
+class BaseSparsifier(abc.ABC):
+    r"""Base class for all sparsifiers.
 
     Abstract methods that need to be implemented:
 
@@ -43,11 +45,11 @@ class BasePruner(abc.ABC):
 
     Example::
 
-        >>> # xdoctest: +SKIP("Can't instantiate abstract class BasePruner with abstract method update_mask")
+        >>> # xdoctest: +SKIP("Can't instantiate abstract class BaseSparsifier with abstract method update_mask")
         >>> config = [{'tensor_fqn': 'layer1.weight', 'tensor_fqn': 'linear2.weight2', 'sparsity_level': 0.5}]
         >>> defaults = {'sparsity_level': 0.7}
         >>> # model.layer1.weight will have `sparsity_level` = 0.7 (getting default)
-        >>> pruner = BasePruner(config, defaults)
+        >>> sparsifier = BaseSparsifier(config, defaults)
     """
 
     def __init__(self, defaults: Optional[Dict[str, Any]] = None):
@@ -243,12 +245,12 @@ class BasePruner(abc.ABC):
         Examples:
             >>> # xdoctest: +SKIP("locals are undefined")
             >>> # Don't save any sparse params
-            >>> pruner.squash_mask()
+            >>> sparsifier.squash_mask()
             >>> hasattr(model.submodule1, 'sparse_params')
             False
 
             >>> # Keep sparse params per layer
-            >>> pruner.squash_mask(
+            >>> sparsifier.squash_mask(
             ...     params_to_keep_per_layer={
             ...         'submodule1.linear1': ('foo', 'bar'),
             ...         'submodule2.linear42': ('baz',)
@@ -259,7 +261,7 @@ class BasePruner(abc.ABC):
             {'baz': 0.1}
 
             >>> # Keep sparse params for all layers
-            >>> pruner.squash_mask(params_to_keep=('foo', 'bar'))
+            >>> sparsifier.squash_mask(params_to_keep=('foo', 'bar'))
             >>> print(model.submodule1.linear1.sparse_params)
             {'foo': 42, 'bar': 24}
             >>> print(model.submodule2.linear42.sparse_params)
@@ -267,7 +269,7 @@ class BasePruner(abc.ABC):
 
             >>> # Keep some sparse params for all layers, and specific ones for
             >>> # some other layers
-            >>> pruner.squash_mask(
+            >>> sparsifier.squash_mask(
             ...     params_to_keep=('foo', 'bar'),
             ...     params_to_keep_per_layer={
             ...         'submodule2.linear42': ('baz',)

--- a/torch/ao/pruning/sparsifier/nearly_diagonal_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/nearly_diagonal_sparsifier.py
@@ -1,11 +1,12 @@
 import torch
 
-from . import base_pruner
+from . import base_sparsifier
 
-class NearlyDiagonalPruner(base_pruner.BasePruner):
-    r"""Nearly Diagonal Pruner
 
-    This pruner creates a nearly diagonal mask to be applied to the weight matrix.
+class NearlyDiagonalSparsifier(base_sparsifier.BaseSparsifier):
+    r"""Nearly Diagonal Sparsifier
+
+    This sparsifier creates a nearly diagonal mask to be applied to the weight matrix.
     Nearly Diagonal Matrix is a matrix that contains non-zero elements near the diagonal and the rest are zero.
     An example of a nearly diagonal matrix with degree (or nearliness) 3 and 5 are follows respectively.
     1 1 0 0       1 1 1 0
@@ -14,7 +15,7 @@ class NearlyDiagonalPruner(base_pruner.BasePruner):
     0 0 1 1       0 1 1 1
     Note that a nearly diagonal matrix with degree 1 is just a matrix with main diagonal populated
 
-    This pruner is controlled by one variable:
+    This sparsifier is controlled by one variable:
     1. `nearliness` defines the number of non-zero diagonal lines that are closest to the main diagonal.
         Currently - supports only odd number
 

--- a/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
@@ -4,23 +4,23 @@ from typing import Callable, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 
-from .base_pruner import BasePruner
+from .base_sparsifier import BaseSparsifier
 
-__all__ = ["WeightNormPruner"]
+__all__ = ["WeightNormSparsifier"]
 
 def _flat_idx_to_2d(idx, shape):
     rows = idx // shape[1]
     cols = idx % shape[1]
     return rows, cols
 
-class WeightNormPruner(BasePruner):
-    r"""Weight-Norm Pruner
+class WeightNormSparsifier(BaseSparsifier):
+    r"""Weight-Norm Sparsifier
 
-    This pruner computes the norm of every sparse block and "zeroes-out" the
+    This sparsifier computes the norm of every sparse block and "zeroes-out" the
     ones with the lowest norm. The level of sparsity defines how many of the
     blocks is removed.
 
-    This pruner is controlled by three variables:
+    This sparsifier is controlled by three variables:
     1. `sparsity_level` defines the number of *sparse blocks* that are zeroed-out
     2. `sparse_block_shape` defines the shape of the sparse blocks. Note that
         the sparse blocks originate at the zero-index of the tensor.
@@ -46,7 +46,7 @@ class WeightNormPruner(BasePruner):
         channels, while the `block_COLS` would refer to the input channels.
 
     Note::
-        All arguments to the WeightNormPruner constructor are "default"
+        All arguments to the WeightNormSparsifier constructor are "default"
         arguments and could be overriden by the configuration provided in the
         `prepare` step.
     """

--- a/torch/testing/_internal/common_pruning.py
+++ b/torch/testing/_internal/common_pruning.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Owner(s): ["module: unknown"]
 
-from torch.ao.pruning import BasePruner
+from torch.ao.pruning import BaseSparsifier
 import torch
 import torch.nn.functional as F
 from torch import nn
 
-class ImplementedPruner(BasePruner):
+class ImplementedSparsifier(BaseSparsifier):
     def __init__(self, **kwargs):
         super().__init__(defaults=kwargs)
 


### PR DESCRIPTION
Summary: Back out D44856390 since renaming the type breaks backwards compatibility of existing models used in integration tests and likely in prod as well.

Test Plan:
buck2 run //aiplatform/modelstore/model_generation/integration_tests:cogwheel_igr_tab_offline_and_recurring_model_generation_v1_api_test-launcher -- --build-fbpkg --run-disabled --run-harness-in-tupperware

Now fails with an OOM: https://www.internalfb.com/servicelab/experiment/100000000259121/trial/100000000331723/run

It was failing with an import error without this revert.

Differential Revision: D44991351

