### PR TITLE
Add REPO_ROOT to front of PYTHONPATH

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -34,7 +34,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 try:
     # using tools/ to optimize test run.
-    sys.path.append(str(REPO_ROOT))
+    sys.path.insert(0, str(REPO_ROOT))
     from tools.stats.export_test_times import TEST_TIMES_FILE
     from tools.testing.test_selections import (
         calculate_shards,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99173

This will make us prefer our tools/ folder over any other
tools folder that may be setup.py develop'ed (in my case,
it was torchtext/tools)

Signed-off-by: Edward Z. Yang <ezyang@meta.com>