### PR TITLE
[docs] nn.functional.embedding: Note expected discrepancy between numerical and analytical gradients 

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2138,6 +2138,11 @@ def embedding(
 
     See :class:`torch.nn.Embedding` for more details.
 
+    .. warning::
+        To ensure correct gradients during backward, make sure the entries in the :attr:`weight`
+        matrix at the row specified by :attr:`padding_idx` are all zeroes. Alternatively, use
+        :class:`torch.nn.Embedding`, which initializes the appropriate weights automatically.
+
     Args:
         input (LongTensor): Tensor containing indices into the embedding matrix
         weight (Tensor): The embedding matrix with number of rows equal to the maximum possible index + 1,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2138,10 +2138,15 @@ def embedding(
 
     See :class:`torch.nn.Embedding` for more details.
 
-    .. warning::
-        To ensure correct gradients during backward, make sure the entries in the :attr:`weight`
-        matrix at the row specified by :attr:`padding_idx` are all zeroes. Alternatively, use
-        :class:`torch.nn.Embedding`, which initializes the appropriate weights automatically.
+    .. note::
+        Note that the analytical gradients of this function with respect to
+        entries in :attr:`weight` at the row specified by :attr:`padding_idx`
+        are expected to differ from the numerical ones.
+
+    .. note::
+        Note that `:class:`torch.nn.Embedding` differs from this function in
+        that it initializes the row of :attr:`weight` specified by
+        :attr:`padding_idx` to all zeros on construction.
 
     Args:
         input (LongTensor): Tensor containing indices into the embedding matrix


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99745
* __->__ #99181
* 

Fixes https://github.com/pytorch/pytorch/issues/93950