### PR TITLE
[ROCm] add skipCUDAIfVersionLessThan to unskip test_jiterator for ROCm

### DIFF
--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -8,7 +8,7 @@ from itertools import product
 from torch.testing._internal.common_utils import TestCase, parametrize, run_tests, TEST_CUDA, NoTest
 from torch.testing._internal.common_dtype import all_types_and_complex_and
 from torch.testing._internal.common_device_type import (
-    skipCUDAIfRocm, skipCUDAIf, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
+    skipCUDAIfRocm, skipCUDAIfVersionLessThan, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
 from torch.testing._internal.common_cuda import _get_torch_cuda_version
 
 if not TEST_CUDA:
@@ -40,10 +40,10 @@ class TestPythonJiterator(TestCase):
 
         self.assertEqual(expected, result)
 
-    @skipCUDAIfRocm
     # See https://github.com/pytorch/pytorch/pull/76394#issuecomment-1118018287 for details
-    @skipCUDAIf(_get_torch_cuda_version() < (11, 6), "On cuda 11.3, nvrtcCompileProgram is taking too long to "
-                "compile jiterator generated kernels for non-contiguous input that requires dynamic-casting.")
+    # On cuda 11.3, nvrtcCompileProgram is taking too long to
+    # compile jiterator generated kernels for non-contiguous input that requires dynamic-casting.
+    @skipCUDAIfVersionLessThan((11, 6))
     @parametrize("shape_strides", [
         (([3, 3], [1, 3]), ([3, 1], [1, 3])),  # non-contiguous
     ])

--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -8,8 +8,7 @@ from itertools import product
 from torch.testing._internal.common_utils import TestCase, parametrize, run_tests, TEST_CUDA, NoTest
 from torch.testing._internal.common_dtype import all_types_and_complex_and
 from torch.testing._internal.common_device_type import (
-    skipCUDAIfRocm, skipCUDAIfVersionLessThan, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
-from torch.testing._internal.common_cuda import _get_torch_cuda_version
+    skipCUDAIfVersionLessThan, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
 
 if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1280,10 +1280,26 @@ def skipCUDAVersionIn(versions : List[Tuple[int, int]] = None):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
             version = _get_torch_cuda_version()
-            if version == (0, 0):  # cpu
+            if version == (0, 0):  # cpu or rocm
                 return fn(self, *args, **kwargs)
             if version in (versions or []):
                 reason = "test skipped for CUDA version {0}".format(version)
+                raise unittest.SkipTest(reason)
+            return fn(self, *args, **kwargs)
+
+        return wrap_fn
+    return dec_fn
+
+# Skips a test for CUDA versions less than specified, given in the form of [major, minor].
+def skipCUDAIfVersionLessThan(versions : Tuple[int, int] = None):
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            version = _get_torch_cuda_version()
+            if version == (0, 0):  # cpu or rocm
+                return fn(self, *args, **kwargs)
+            if version < versions:
+                reason = "test skipped for CUDA versions < {0}".format(version)
                 raise unittest.SkipTest(reason)
             return fn(self, *args, **kwargs)
 


### PR DESCRIPTION
This unskips 121 tests that the decorator `@skipCUDAIf(_get_torch_cuda_version() < (11, 6))` was unintentionally skipping for ROCm.  Other decorators such as `skipCUDAVersionIn` will only activate for the CUDA device, not the CPU or ROCm-as-CUDA.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport