### PR TITLE
[aibench] Fix the broken opbench test test_run_all_op_benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
+++ b/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
@@ -33,7 +33,7 @@ class WeightNormSparsifierBenchmark(op_bench.TorchBenchmarkBase):
         model.register_buffer("weight", weight)
 
         sparse_config = [{"tensor_fqn": "weight"}]
-        self.sparsifier = pruning.WeightNormSparsifier(
+        self.sparsifier = pruning.sparsifier.weight_norm_sparsifier.WeightNormSparsifier(
             sparsity_level=SL,
             sparse_block_shape=SBS,
             zeros_per_block=ZPB,


### PR DESCRIPTION
Summary:
D44856390 renames all Sparsifier to Pruner.

Fixes the broken test failure: https://www.internalfb.com/intern/test/281475061355211?ref_report_id=0

Test Plan:
```
buck2 test mode/opt //aibench/api:opbench_api_tests -- --exact 'aibench/api:opbench_api_tests - test_run_all_op_benchmarks (aibench.api.opbench.tests.test_opbench.TestOpBench)' --run-disabled
watchman fresh instance event, clearing cache
Buck UI: https://www.internalfb.com/buck2/daf61536-c8d5-4ac5-8f13-c9e4364569bf
Test UI: https://www.internalfb.com/intern/testinfra/testrun/844425230707536
RE: reSessionID-ef756b03-ea25-4a51-99ad-295ce39f3f41  Up: 1.6 MiB  Down: 63 MiB
Jobs completed: 171812. Time elapsed: 263.0s. Cache hits: 50%. Commands: 393 (cached: 198, remote: 195, local: 0)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. 0 builds failed
```

Differential Revision: D45021913

