### PR TITLE
fix link to torch dynamo FAQ page

### DIFF
--- a/docs/source/compile/get-started.rst
+++ b/docs/source/compile/get-started.rst
@@ -159,6 +159,6 @@ Here is a few examples of existing methods and their limitations:
 -  ``torch._dynamo`` works out of the box and produces partial graphs.
    It still has the option of producing a single graph with
    ``nopython=True`` which are needed for `some
-   situations <https://pytorch.org/docs/stable/dynamo/faq.html#do-i-still-need-to-export-whole-graphs>`__
+   situations <https://pytorch.org/docs/stable/compile/faq.html#do-i-still-need-to-export-whole-graphs>`__
    but allows a smoother transition where partial graphs can be
    optimized without code modification

--- a/docs/source/compile/get-started.rst
+++ b/docs/source/compile/get-started.rst
@@ -159,6 +159,6 @@ Here is a few examples of existing methods and their limitations:
 -  ``torch._dynamo`` works out of the box and produces partial graphs.
    It still has the option of producing a single graph with
    ``nopython=True`` which are needed for `some
-   situations <./documentation/FAQ.md#do-i-still-need-to-export-whole-graphs>`__
+   situations <https://pytorch.org/docs/stable/dynamo/faq.html#do-i-still-need-to-export-whole-graphs>`__
    but allows a smoother transition where partial graphs can be
    optimized without code modification


### PR DESCRIPTION
The [documentation page](https://github.com/pytorch/pytorch/blob/master/docs/source/compile/get-started.rst#Existing-Backends) has a broken link (for torch dynamo FAQ) that directs a user to a dead end page. The PR fixes the link and directs the user to PyTorch documentation with the appropriate header