### PR TITLE
Adding MPS support for 3D convolutions

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -49,6 +49,10 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
 
+
+
+#endif
+
 - (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
                                     weightsTensor:(MPSGraphTensor * _Nonnull) weights
                                        descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
@@ -66,9 +70,6 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
                                            forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
                                                                    name:(NSString * _Nullable) name;
 
-
-
-#endif
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor
                                                 axis:(NSInteger)axis

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -1,7 +1,39 @@
 #pragma once
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
+@interface unsupported_MPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
+
+
+@property (readwrite, nonatomic) NSUInteger strideInX;
+@property (readwrite, nonatomic) NSUInteger strideInY;
+@property (readwrite, nonatomic) NSUInteger strideInZ;
+@property (readwrite, nonatomic) NSUInteger dilationRateInX;
+@property (readwrite, nonatomic) NSUInteger dilationRateInY;
+@property (readwrite, nonatomic) NSUInteger dilationRateInZ;
+
+@property (readwrite, nonatomic) NSUInteger paddingLeft;
+@property (readwrite, nonatomic) NSUInteger paddingRight;
+@property (readwrite, nonatomic) NSUInteger paddingTop;
+@property (readwrite, nonatomic) NSUInteger paddingBottom;
+@property (readwrite, nonatomic) NSUInteger paddingFront;
+@property (readwrite, nonatomic) NSUInteger paddingBack;
+
+@property (readwrite, nonatomic) MPSGraphPaddingStyle paddingStyle;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout dataLayout;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout weightsLayout;
+
+@property (readwrite, nonatomic) NSUInteger groups;
+
+@end
 // TODO: Remove me when moved to MacOS 13
+#if !defined(__MAC_13_0) && \
+    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
+
+@compatibility_alias MPSGraphConvolution3DOpDescriptor unsupported_MPSGraphConvolution3DOpDescriptor;
+
+
+#endif
+
 @interface MPSGraph (VenturaOps)
 
 #if !defined(__MAC_13_0) && \
@@ -16,6 +48,28 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToEven       =  4L,
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
+
+
+
+- (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
+                                    weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                       descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
+                                                      name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DDataGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                          weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                                            outputShape:(MPSShape * _Nonnull) outputShape
+                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                   name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DWeightsGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                            sourceTensor:(MPSGraphTensor * _Nonnull) source
+                                                            outputShape:(MPSShape * _Nonnull) outputShape
+                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                   name:(NSString * _Nullable) name;
+
+
+
 #endif
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -25,12 +25,12 @@
 @property (readwrite, nonatomic) NSUInteger groups;
 
 @end
+
 // TODO: Remove me when moved to MacOS 13
 #if !defined(__MAC_13_0) && \
     (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
 
 @compatibility_alias MPSGraphConvolution3DOpDescriptor unsupported_MPSGraphConvolution3DOpDescriptor;
-
 
 #endif
 
@@ -48,8 +48,6 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToEven       =  4L,
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
-
-
 
 - (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
                                     weightsTensor:(MPSGraphTensor * _Nonnull) weights

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -3,8 +3,59 @@
 #include <ATen/native/ConvUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at::native {
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 
+#if !defined(__MAC_13_0) && \
+    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
+
+@implementation MPSGraphConvolution3DOpDescriptor
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    return self;
+}
+
+@end
+
+#endif
+
+namespace at::native {
+// Create 3D convolution descriptor
+void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
+                    NSUInteger strideInX,
+                    NSUInteger strideInY,
+                    NSUInteger strideInZ,
+                    NSUInteger dilationRateInX,
+                    NSUInteger dilationRateInY,
+                    NSUInteger dilationRateInZ,
+                    NSUInteger paddingHorizontal,
+                    NSUInteger paddingVertical,
+                    NSUInteger paddingDepth,
+                    NSUInteger groups) {
+  descriptor_.strideInX = strideInX;
+  descriptor_.strideInY = strideInY;
+  descriptor_.strideInZ = strideInZ;
+  descriptor_.dilationRateInX = dilationRateInX;
+  descriptor_.dilationRateInY = dilationRateInY;
+  descriptor_.dilationRateInZ = dilationRateInZ;
+
+  // TODO: Program the padding style
+  descriptor_.paddingStyle = MPSGraphPaddingStyleExplicit;
+
+  descriptor_.paddingLeft = paddingHorizontal;
+  descriptor_.paddingRight = paddingHorizontal;
+  descriptor_.paddingTop = paddingVertical;
+  descriptor_.paddingBottom = paddingVertical;
+  descriptor_.paddingFront = paddingDepth;
+  descriptor_.paddingBack = paddingDepth;
+     
+  // PyTorch always uses NCDHW memory layout for 3D tensors
+  descriptor_.dataLayout = (MPSGraphTensorNamedDataLayout)7L;//MPSGraphTensorNamedDataLayoutNCDHW;
+      
+  // PyTorch always uses OIDHW memory layout for 3D weights
+  descriptor_.weightsLayout = (MPSGraphTensorNamedDataLayout)9L;//MPSGraphTensorNamedDataLayoutOIDHW;
+
+  descriptor_.groups = groups; //not yet tested in Xcode/C++
+}
 void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor* descriptor_,
                               NSUInteger strideInX,
                               NSUInteger strideInY,
@@ -70,10 +121,14 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
                              IntArrayRef dilation,
                              int64_t groups,
                              c10::optional<IntArrayRef> input_shape) {
-  TORCH_CHECK(input_t.dim() < 5, "Conv3D is not supported on MPS");
+  const bool is_macOS_13_0_or_newer = is_macos_13_or_newer();
+
+  TORCH_CHECK(((input_t.dim() < 5)|is_macOS_13_0_or_newer), "Conv3D is only supported on MPS for MacOS_13_2 or newer");
+  bool is3DConv = input_t.dim() == 5;
+
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");
 
-  using namespace at::native::mps;
+  namespace native_mps = at::native::mps;
   CheckedFrom c = "mps_convolution";
   TensorArg input{input_t, "input", 1}, weight{weight_t, "weight", 2};
   checkAllSameType(c, {input, weight});
@@ -105,13 +160,15 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public MPSCachedGraph {
+  struct CachedGraph : public native_mps::MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* biasTensor_ = nil;
     MPSGraphTensor* weightTensor_ = nil;
     MPSGraphTensor* outputTensor_ = nil;
   };
+
+  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   auto stream = at::mps::getCurrentMPSStream();
 
@@ -139,85 +196,129 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
       bias_shape_key = "nobias";
     }
 
-    string key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
+    string key;
+    if (is3DConv){
+        key = "mps_3d_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" + to_string(dilation[0]) + ":" + to_string(dilation[1]) +
+        ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" + to_string(padding[2]) + ":" +
+        to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
+        to_string(bias_defined) + ":" + bias_shape_key;
+          
+    } else {
+        key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
         ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
         to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
         to_string(bias_defined) + ":" + bias_shape_key;
+    }
+    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
     MPSShape* inputShape = mps::getMPSShape(input_t, memory_format);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-      MPSShape* weightShape = mps::getMPSShape(weight_t);
-      bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
-                              weightShape.count >= 4 && !is_channels_last);
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 memory_format,
+    if (!cachedGraph) {
+      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
+        CachedGraph* newCachedGraph = nil;
+
+        @autoreleasepool {
+          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
+
+          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+            MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ =
+                [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+          MPSShape* weightShape = mps::getMPSShape(weight_t);
+          bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
+                                  weightShape.count >= 4 && !is_channels_last);
+          
+            if (is3DConv){
+                fill_conv3d_desc(conv3dDescriptor_,
+                                 stride[2],stride[1],stride[0],
+                                 dilation[2],dilation[1],dilation[0],
+                                 padding[2],padding[1],padding[0],
                                  groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       memory_format,
-                       groups);
-      }
+                
+            } else {
+                if (isDepthwiseConv) {
+                    fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                             stride[1],
+                                             stride[0],
+                                             dilation[1],
+                                             dilation[0],
+                                             padding[1],
+                                             padding[0],
+                                             memory_format,
+                                             groups);
+                } else {
+                    fill_conv_desc(conv2dDescriptor_,
+                                   stride[1],
+                                   stride[0],
+                                   dilation[1],
+                                   dilation[0],
+                                   padding[1],
+                                   padding[0],
+                                   memory_format,
+                                   groups);
+                }
+            }
 
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input_t), inputShape);
-      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
+          MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(
+              mpsGraph, native_mps::getMPSScalarType(input_t.scalar_type()), inputShape);
+          MPSGraphTensor* weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
-      MPSGraphTensor* biasTensor = nil;
-      if (bias_defined) {
-        biasTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(bias_opt.value()));
-      }
+            MPSGraphTensor* biasTensor = nil;
+            MPSGraphTensor* outputTensor;
+            if(is3DConv){
+                outputTensor = [mpsGraph convolution3DWithSourceTensor:inputTensor
+                                                         weightsTensor:weightTensor
+                                                            descriptor:conv3dDescriptor_
+                                                                  name:nil];
+                
+            } else {
+                if (bias_defined) {
+                    biasTensor =
+                    native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(bias_opt.value()));
+                }
+                
+                if (isDepthwiseConv) {
+                    MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                            dimension:-3
+                                                                        withDimension:-4
+                                                                                 name:nil];
+                    outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
+                                                                      weightsTensor:weightTransposeTensor
+                                                                         descriptor:depthWiseConv3dDescriptor_
+                                                                               name:nil];
+                } else {
+                    outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
+                                                             weightsTensor:weightTensor
+                                                                descriptor:conv2dDescriptor_
+                                                                      name:nil];
+                }
+            }
 
-      MPSGraphTensor* outputTensor;
-      if (isDepthwiseConv) {
-        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                dimension:-3
-                                                            withDimension:-4
-                                                                     name:nil];
-        outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
-                                                          weightsTensor:weightTransposeTensor
-                                                             descriptor:depthWiseConv3dDescriptor_
-                                                                   name:nil];
-      } else {
-        outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
-                                                 weightsTensor:weightTensor
-                                                    descriptor:conv2dDescriptor_
-                                                          name:nil];
-      }
+          if (is_channels_last) {
+            outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
+          }
 
-      if (is_channels_last) {
-        outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
-      }
+          if (bias_defined) {
+            outputTensor = [mpsGraph additionWithPrimaryTensor:outputTensor secondaryTensor:biasTensor name:nil];
+          }
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->weightTensor_ = weightTensor;
+          newCachedGraph->biasTensor_ = biasTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
+        }
+        return newCachedGraph;
+      });
+      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
+    }
 
-      if (bias_defined) {
-        outputTensor = [mpsGraph additionWithPrimaryTensor:outputTensor secondaryTensor:biasTensor name:nil];
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->weightTensor_ = weightTensor;
-      newCachedGraph->biasTensor_ = biasTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, inputShape);
-    auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
-    auto biasPlaceholder = Placeholder();
+    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, inputShape);
+    auto weightsPlaceholder = native_mps::Placeholder(cachedGraph->weightTensor_, weight_t);
+    auto biasPlaceholder = native_mps::Placeholder();
     // Reshape the bias to be broadcastable with output of conv2d
     if (bias_defined)
-      biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, *output);
+      biasPlaceholder =
+          native_mps::Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
+    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, *output);
 
     NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =
         [[[NSMutableDictionary alloc] initWithCapacity:3] autorelease];
@@ -230,7 +331,7 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return *output;
@@ -254,8 +355,10 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                       IntArrayRef dilation,
                                       int64_t groups,
                                       bool bias_defined) {
-  using namespace at::native::mps;
+  namespace native_mps = at::native::mps;
   using namespace mps;
+  bool is3DConv = grad_output_t.dim() == 5;
+
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_input";
   TensorArg grad_output{grad_output_t, "grad_output", 1}, weight{weight_t, "weight", 2};
@@ -270,12 +373,14 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
   convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public MPSCachedGraph {
+  struct CachedGraph : public native_mps::MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
     MPSGraphTensor* weightTensor_ = nil;
     MPSGraphTensor* gradInputTensor_ = nil;
   };
+
+  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   // Add backward with input
   @autoreleasepool {
@@ -296,75 +401,116 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
     MPSShape* gradOutputShape = getMPSShape(grad_output_t, memory_format);
     MPSShape* mps_input_shape = getMPSShape(input_size);
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
-    string key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+    string key;
+    if(is3DConv){
+        key = "mps_3d_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +  ":" + to_string(stride[2]) +
+        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
+        to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
+        getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
+        
+    } else {
+        key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
         getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
+    }
+    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    
+    if (!cachedGraph) {
+      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
+        CachedGraph* newCachedGraph = nil;
 
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        @autoreleasepool {
+          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-      MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
-      // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
-      bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
-                              weightOutputShape.count >= 4 && !is_channels_last);
+          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+          MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
 
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 at::MemoryFormat::Contiguous,
+          MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
+          // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
+          bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
+                                  weightOutputShape.count >= 4 && !is_channels_last);
+
+            if(is3DConv) {
+                fill_conv3d_desc(conv3dDescriptor_,
+                                 stride[2],stride[1],stride[0],
+                                 dilation[2],dilation[1],dilation[0],
+                                 padding[2],padding[1],padding[0],
                                  groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       at::MemoryFormat::Contiguous,
-                       groups);
-      }
+            } else {
+                if (isDepthwiseConv) {
+                    fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                             stride[1],
+                                             stride[0],
+                                             dilation[1],
+                                             dilation[0],
+                                             padding[1],
+                                             padding[0],
+                                             at::MemoryFormat::Contiguous,
+                                             groups);
+                } else {
+                    
+                    fill_conv_desc(conv2dDescriptor_,
+                                   stride[1],
+                                   stride[0],
+                                   dilation[1],
+                                   dilation[0],
+                                   padding[1],
+                                   padding[0],
+                                   at::MemoryFormat::Contiguous,
+                                   groups);
+                }
+            }
 
-      MPSGraphTensor* gradOutputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
-      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
+          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(
+              mpsGraph, native_mps::getMPSScalarType(grad_output_t.scalar_type()), gradOutputShape);
+          MPSGraphTensor* weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
-      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-      if (is_channels_last) {
-        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-      }
-      MPSGraphTensor* gradInputTensor;
-      if (isDepthwiseConv) {
-        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                dimension:-3
-                                                            withDimension:-4
-                                                                     name:nil];
-        gradInputTensor =
-            [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                     weightsTensor:weightTransposeTensor
-                                                                       outputShape:mps_input_shape
-                                                                        descriptor:depthWiseConv3dDescriptor_
-                                                                              name:nil];
-      } else {
-        gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                          weightsTensor:weightTensor
-                                                                            outputShape:mps_input_shape
-                                                           forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                   name:nil];
-      }
+          MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
+          if (is_channels_last) {
+            gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
+          }
+          MPSGraphTensor* gradInputTensor;
+            if (is3DConv){
+                gradInputTensor = [mpsGraph convolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                                  weightsTensor:weightTensor
+                                                                                    outputShape:mps_input_shape
+                                                                   forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                                           name:nil];
+                
+            } else {
+                if (isDepthwiseConv) {
+                    MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                            dimension:-3
+                                                                        withDimension:-4
+                                                                                 name:nil];
+                    gradInputTensor =
+                    [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                             weightsTensor:weightTransposeTensor
+                                                                               outputShape:mps_input_shape
+                                                                                descriptor:depthWiseConv3dDescriptor_
+                                                                                      name:nil];
+                } else {
+                    
+                    gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                                      weightsTensor:weightTensor
+                                                                                        outputShape:mps_input_shape
+                                                                       forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                               name:nil];
+                }
+            }
 
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->weightTensor_ = weightTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
+          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+          newCachedGraph->weightTensor_ = weightTensor;
+          newCachedGraph->gradInputTensor_ = gradInputTensor;
+        }
+        return newCachedGraph;
+      });
+      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
+    }
 
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t, gradOutputShape);
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
@@ -391,8 +537,10 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                         IntArrayRef dilation,
                                         int64_t groups,
                                         bool bias_defined) {
-  using namespace at::native::mps;
+  namespace native_mps = at::native::mps;
   using namespace mps;
+  bool is3DConv = input_t.dim() == 5;
+
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
   auto memory_format = grad_output_t.suggest_memory_format();
@@ -415,12 +563,14 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   convolution_shape_check(c, input, grad_weight, grad_output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public MPSCachedGraph {
+  struct CachedGraph : public native_mps::MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* gradWeightTensor_ = nil;
   };
+
+  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   @autoreleasepool {
     MPSStream* stream = getCurrentMPSStream();
@@ -438,72 +588,117 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
     }
     MPSShape* mps_weight_shape = getMPSShape(weight_size);
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
-    string key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+    string key;
+    if (is3DConv) {
+        key = "mps_3d_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" +
+        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
+        to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
+        getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+    } else {
+        key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
         getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+    }
+    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
 
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-      MPSShape* inputShape = mps::getMPSShape(input_t);
-      bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
-                              mps_weight_shape.count >= 4 && !is_channels_last);
+    if (!cachedGraph) {
+      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
+        CachedGraph* newCachedGraph = nil;
 
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 at::MemoryFormat::Contiguous,
+        @autoreleasepool {
+          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
+
+          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+          MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+          MPSShape* inputShape = mps::getMPSShape(input_t);
+          bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
+                                  mps_weight_shape.count >= 4 && !is_channels_last);
+
+            if (is3DConv) {
+                fill_conv3d_desc(conv3dDescriptor_,
+                                 stride[2],stride[1],stride[0],
+                                 dilation[2],dilation[1],dilation[0],
+                                 padding[2],padding[1],padding[0],
                                  groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       at::MemoryFormat::Contiguous,
-                       groups);
-      }
+            } else {
+                if (isDepthwiseConv) {
+                    fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                             stride[1],
+                                             stride[0],
+                                             dilation[1],
+                                             dilation[0],
+                                             padding[1],
+                                             padding[0],
+                                             at::MemoryFormat::Contiguous,
+                                             groups);
+                } else {
+                    
+                    fill_conv_desc(conv2dDescriptor_,
+                                   stride[1],
+                                   stride[0],
+                                   dilation[1],
+                                   dilation[0],
+                                   padding[1],
+                                   padding[0],
+                                   at::MemoryFormat::Contiguous,
+                                   groups);
+                }
+            }
 
-      MPSGraphTensor* gradOutputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(
+              mpsGraph, native_mps::getMPSScalarType(grad_output_t.scalar_type()), gradOutputShape);
+          MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
-      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-      if (is_channels_last) {
-        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-      }
+          MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
+          if (is_channels_last) {
+            gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
+          }
 
-      MPSGraphTensor* gradWeightTensor;
-      if (isDepthwiseConv) {
-        NSNumber* outputFeatChannelDim = mps_weight_shape[0];
-        MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
-        MPSGraphTensor* gradWeightTensorTranspose =
-            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                         sourceTensor:inputTensor
-                                                                          outputShape:weightShapeTranspose
-                                                                           descriptor:depthWiseConv3dDescriptor_
-                                                                                 name:nil];
-        gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
-      } else {
-        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                               sourceTensor:inputTensor
-                                                                                outputShape:mps_weight_shape
-                                                               forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                       name:nil];
-      }
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradWeightTensor_ = gradWeightTensor;
-    });
+          MPSGraphTensor* gradWeightTensor;
+            
+            if (is3DConv) {
+                gradWeightTensor =
+                [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                    sourceTensor:inputTensor
+                                                                     outputShape:mps_weight_shape
+                                                    forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                            name:nil];
+            } else {
+                if (isDepthwiseConv) {
+                    NSNumber* outputFeatChannelDim = mps_weight_shape[0];
+                    MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
+                    MPSGraphTensor* gradWeightTensorTranspose =
+                    [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                                 sourceTensor:inputTensor
+                                                                                  outputShape:weightShapeTranspose
+                                                                                   descriptor:depthWiseConv3dDescriptor_
+                                                                                         name:nil];
+                    gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose
+                                                       dimension:-3
+                                                   withDimension:-4
+                                                            name:nil];
+                } else {
+                    
+                    gradWeightTensor =
+                    [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                        sourceTensor:inputTensor
+                                                                         outputShape:mps_weight_shape
+                                                        forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                name:nil];
+                }
+            }
+          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->gradWeightTensor_ = gradWeightTensor;
+        }
+        return newCachedGraph;
+      });
+      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
+    }
 
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t, gradOutputShape);
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);


### PR DESCRIPTION
Fixes #77818
- this pull request enables 3D convolutions (forward/backward) for MPS (Apple Silicon) within the same Convolution.mm file as conv2d.
- does not support channel_last (since pytorch doesn't implement channel_last for 3D tensors)
- does not support conv3d_transpose and treats depth-separable convolutions not as normal case (there are no MPS kernels available for either of those so far)  
- requires MacOS >=13.2 (Ventura), I'm not sure how to add this specific case to MPSGraphVenturaOps.h 
@kulinseth @albanD could you please check whether this is implemented as intended by you and whether we would require additional tests in test_mps.py?