### PR TITLE
Workaround issue with cross_entropy+label_smoothing

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2551,7 +2551,8 @@ def fn():
         self.assertEqual(y, 11)
         self.assertEqual(z, 61)
 
-    @unittest.skip("broken due to issue with Module.__constants__")
+    # requires_static_shapes due to: https://github.com/pytorch/pytorch/issues/99250
+    @requires_static_shapes
     def test_cross_entropy_loss_fancy_ctor(self):
         rand_5 = torch.randn(5)
         rand_3_5 = torch.randn(3, 5)
@@ -2573,7 +2574,6 @@ def fn():
         self.assertTrue(torch.allclose(dynamo_output, output))
 
     def test_cross_entropy_loss_simple_ctor(self):
-        output = None
         rand_3_5 = torch.randn(3, 5)
         target = torch.empty(3, dtype=torch.long).random_(5)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1197,6 +1197,10 @@ def get_fake_value(node, tx):
         # If the first argument is nn.Module, should copy to fake mode.
         args = (deepcopy_to_fake_tensor(args[0], tx.fake_mode),) + tuple(args[1:])
 
+        if isinstance(args[0], torch.nn.CrossEntropyLoss) and args[0].label_smoothing:
+            # Workaround https://github.com/pytorch/pytorch/issues/99250
+            tx.fake_mode.allow_non_fake_inputs = True
+
     if op == "call_module":
         nnmodule = tx.output.nn_modules[node.target]
 
@@ -1243,7 +1247,7 @@ def get_fake_value(node, tx):
             unimplemented("guard on data-dependent symbolic int/float")
         elif isinstance(cause, torch.utils._sympy.value_ranges.ValueRangeError):
             raise UserError(UserErrorType.CONSTRAIN_VIOLATION, e.args[0]) from e
-        raise TorchRuntimeError() from e
+        raise TorchRuntimeError(str(e)).with_traceback(e.__traceback__) from None
 
 
 def run_node(output_graph, node, args, kwargs, nnmodule):
@@ -1278,7 +1282,7 @@ def run_node(output_graph, node, args, kwargs, nnmodule):
     except Exception as e:
         raise RuntimeError(
             f"Failed running {op} {node.target}(*{args}, **{kwargs}):\n{e}\n(scroll up for backtrace)"
-        ) from e
+        ).with_traceback(e.__traceback__) from None
     raise AssertionError(op)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99251
* #98894


see https://github.com/pytorch/pytorch/issues/99250

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire