### PR TITLE
Remove unnecessary check when logging artifacts

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -234,10 +234,7 @@ def configure_artifact_log(log):
     # set propagate to False so that this artifact is not propagated
     # to its ancestor logger
     # this artifact is only logged when explicitly enabled (occurs below)
-    if (
-        log_registry.is_off_by_default(log.artifact_name)
-        and log.getEffectiveLevel() == logging.DEBUG
-    ):
+    if log_registry.is_off_by_default(log.artifact_name):
         log.propagate = False
 
     # enable artifact logging when explicitly enabled

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -230,10 +230,9 @@ VERBOSITY_REGEX = (
 
 
 def configure_artifact_log(log):
-    # if parent log is set to debug, but this artifact is off by default
-    # set propagate to False so that this artifact is not propagated
+    # If the artifact is off by default, then it should only be logged when explicitly
+    # enabled; set propagate to False so that this artifact is not propagated
     # to its ancestor logger
-    # this artifact is only logged when explicitly enabled (occurs below)
     if log_registry.is_off_by_default(log.artifact_name):
         log.propagate = False
 


### PR DESCRIPTION
Removes a check which would sometimes allow `off_by_default` artifacts to be logged if logged at a higher level. 

This change will only allow artifact messages to be displayed if the artifact is enabled, regardless of level. 

closes #99144