### PR TITLE
torch._int_mm: fix triton kernel caching

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -739,7 +739,7 @@ class AlgorithmSelectorCache(PersistentCache):
         autotune_start_ts = time.time()
         timings = self.lookup(
             choices,
-            choices[0].name,
+            name,
             repr([self.key_of(x) for x in input_nodes]),
             autotune,
         )


### PR DESCRIPTION
Summary:

A fix to ensure that kernels generated for `torch._int_mm` can be cached. We can remove this hack one eager mode `torch._int_mm` is better supported.

Let me know if something more proper is needed instead of the hack.

Test plan:

```
// running the script below led to two compilations of triton
// int8,int8->int32 kernel before this PR, and only has
// one compilation which is reused after this PR

import torch
import torch.nn as nn

x = torch.randint(-128, 127, (32, 32), device='cuda', dtype=torch.int8)
y = torch.randint(-128, 127, (32, 32), device='cuda', dtype=torch.int8)

class M(nn.Module):
    def forward(self, x):
        x = torch._int_mm(x, y)
        x = x.to(torch.int8)
        x = torch._int_mm(x, y)
        return x

m = M().cuda().half()
m = torch.compile(m, options={"max-autotune": True})

z = m(x)
z = m(x)
```

Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire