### PR TITLE
refactor macro with AMP

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -1,11 +1,4 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
-#include <ATen/NativeFunctions.h>
 #include <ATen/autocast_mode.h>
-#include <ATen/Operators.h>
-
-#include <c10/util/intrusive_ptr.h>
-#include <c10/core/impl/LocalDispatchKeySet.h>
 
 #include <iostream>
 #include <exception>
@@ -194,114 +187,6 @@ Tensor cached_cast(at::ScalarType to_type, const Tensor& arg, DeviceType device_
   }
 }
 
-// Policies correspond to op categories that need code-divergent handling.
-// Wrapper templates below are specialized based on a policy template parameter.
-enum class CastPolicy : uint8_t {
-  lower_precision_fp = 0, // Cast all inputs to lower_precision_fp before running the op.
-                          // Currently, lower_precision_fp is fp16 for AutocastCUDA, and is defined by user(default bf16) for AutocastCPU.
-  fp32, // Cast all inputs to at::kFloat before running the op.
-  fp32_set_opt_dtype, // Treats functions (like softmax) that
-                      //   1. we'd like to run in fp32 and
-                      //   2. have a c10::optional<ScalarType> arg that controls the output type.
-                      // fp32_set_opt_dtype wrappers' policy is:  if the output type is already set,
-                      // don't touch it, otherwise, set it to at::kFloat.
-  fp32_append_dtype, // Treats functions (like norm) that
-                     //   1. we'd like to run in fp32 and
-                     //   2. have some overloads that accept an output type and other overloads that don't.
-                     // fp32_append_dtype wrappers wrap the overloads that don't have an output dtype.
-                     // The wrapper policy is:  append at::kFloat to the args, and redispatch to the
-                     // type-aware overload.
-  promote, // Run in the widest dtype among several args.
-};
-
-/********************************************************************************************************
-Templates to provide wrapper functions
-
-I'm copying the pattern used in core/boxing/impl/WrapFunctionIntoFunctor.h to extract args and return type.
-(see also https://stackoverflow.com/questions/46533698/how-to-deduce-argument-list-from-function-pointer)
-
-This strategy uses an exterior "WrapFunction" that extracts arguments on behalf of
-(in my case several specializations of) an interior "WrapFunction_".
-Interior WrapFunction_ specializations are defined for each CastPolicy.
-********************************************************************************************************/
-
-// Base template for WrapFunction_, which is specialized to contain a "call" method each CastPolicy
-template<CastPolicy policy, DeviceType device_type, class Redispatch, Redispatch* F, class Ret, class ArgList> struct WrapFunction_ {};
-
-// CastPolicy::lower_precision_fp General_DeviceType
-template<DeviceType device_type, class Redispatch, Redispatch* F, class Ret, class... Args>
-struct WrapFunction_<CastPolicy::lower_precision_fp, device_type, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
-  static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(get_autocast_dispatch_key_from_device_type(device_type));
-    return (*F)(cached_cast(get_lower_precision_fp_from_device_type(device_type), args, device_type)...);
-  }
-};
-
-// CastPolicy::fp32 General_DeviceType
-template<DeviceType device_type, class Redispatch, Redispatch* F, class Ret, class... Args>
-struct WrapFunction_<CastPolicy::fp32, device_type, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
-  static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(get_autocast_dispatch_key_from_device_type(device_type));
-    return (*F)(cached_cast(at::kFloat, args, device_type)...);
-  }
-};
-
-// CastPolicy::fp32_set_opt_dtype DeviceType::CUDA
-template<class Redispatch, Redispatch* F, class Ret, class... Args>
-struct WrapFunction_<CastPolicy::fp32_set_opt_dtype, DeviceType::CUDA, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
-  static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
-    if (firstarg_is_eligible(args...)) {
-      return (*F)(set_opt_dtype(at::kFloat, args)...);
-    } else {
-      // If ineligible, calls F with unaltered args.  Does not set opt dtype, because setting
-      // opt dtype explicitly may interfere with internal implicit promotion decisions.
-      return (*F)(args...);
-    }
-  }
-};
-
-// CastPolicy::fp32_append_dtype DeviceType::CUDA
-template<class Redispatch, Redispatch* F, class Ret, class... Args>
-struct WrapFunction_<CastPolicy::fp32_append_dtype, DeviceType::CUDA, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
-  static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
-    at::ScalarType out_type = type_from_firstarg(at::kFloat, args...);
-    return (*F)(args..., out_type);
-  }
-};
-
-// CastPolicy::promote General_DeviceType
-template<DeviceType device_type, class Redispatch, Redispatch* F, class Ret, class... Args>
-struct WrapFunction_<CastPolicy::promote, device_type, Redispatch, F, Ret, guts::typelist::typelist<Args...>> {
-  static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(get_autocast_dispatch_key_from_device_type(device_type));
-    auto to_type = promote_type(get_lower_precision_fp_from_device_type(device_type), device_type, args...);
-    return (*F)(cached_cast(to_type, args, device_type)...);
-  }
-};
-
-// Wrapper to infer return_type and parameter_types for WrapFunction_ (imitating core/boxing/impl/WrapFunctionIntoFunctor.h)
-template<CastPolicy policy,
-         DeviceType device_type,
-         class Registered, // The signature for which we're registering.  The dispatcher's calling code invokes our
-                           // registered functions with arguments matching Registered, so we register
-                           // WrapFunction_::call methods with a matching signature to properly field those arguments.
-                           // guts::function_traits below extracts return_type and parameter_types from Registered,
-                           // which WrapFunction_ templates above use to declare their call methods.
-         class Redispatch, // The signature for the function we're redispatching to.  In most cases this is the same
-                           // as Registered, but for some ops (for example, ops where we append a dtype) it's useful
-                           // to redispatch to a function with a different signature.
-         Redispatch* F>    // The actual function we're redispatching to.
-struct WrapFunction final {
-  using type = WrapFunction_<policy,
-                             device_type,
-                             Redispatch,
-                             F,
-                             typename guts::function_traits<Registered>::return_type,
-                             typename guts::function_traits<Registered>::parameter_types>;
-};
-
 /*******************************
 Banned functions
 *******************************/
@@ -315,57 +200,6 @@ Tensor binary_cross_entropy_banned(const Tensor &, const Tensor &, const c10::op
 }
 
 namespace {
-/*****************************************************************************************************************
-This section performs load-time registration for autocast wrappers.
-
-It's debatable at what level operations should be patched.  We'd like casts to be autograd-exposed
-and precede autograd history recording, so that for lower_precision_fp ops, input tensors are saved for backward
-in lower_precision_fp rather than fp32.  Saving inputs in lower_precision_fp can significantly reduce
-a model's memory footprint.
-
-Option 1 (strawman):  Patch only at the level of explicit calls into cudnn/cublas (cudnn_convolution, etc),
-because those are the code paths that are guaranteed to use Tensor Cores, therefore they're the ones that
-will benefit most from lower_precision_fp.   Potential pitfall:  convolutions (and other ops) are wrapped in several
-layers of at::* calls.  If one of those happens to record autograd history, then we've lost the
-opportunity to save inputs in lower_precision_fp.
-
-Option 2:  Patch the Python-exposed surface of calls, to make 100% sure autograd history
-recording can't sneak in ahead of autocast.  This mirrors Apex most closely.
-
-I think Option 2 is the right answer for all ops, not just convolutions.  Option 2 is what I implement here.
-*****************************************************************************************************************/
-
-/********************************************************************************************************************
-Explicit registration for out-of-place ops
-
-The stuff below could be codegenned.  Ed said
-> you are going to have to write the function definition at some point, I wouldn't try to get clever about it
-Therefore, for the moment, this is all copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
-********************************************************************************************************************/
-
-#define ADD_NS(RAW_OP) at::RAW_OP
-
-// Common cases where registration signature matches redispatch signature
-// (that's why SIGNATURE is repeated in the WrapFunction instantiation)
-#define KERNEL(OP, POLICY) \
-  m.impl(TORCH_SELECTIVE_NAME("aten::" #OP), \
-    &WrapFunction<CastPolicy::POLICY, DeviceType::CUDA, decltype(ATEN_FN(OP)), decltype(ATEN_FN(OP)), &ATEN_FN(OP)>::type::call);
-#define KERNEL2(OP, OVERLOAD, POLICY) \
-  m.impl(TORCH_SELECTIVE_NAME("aten::" #OP "." #OVERLOAD), \
-    &WrapFunction<CastPolicy::POLICY, DeviceType::CUDA, decltype(ATEN_FN2(OP, OVERLOAD)), decltype(ATEN_FN2(OP, OVERLOAD)), &ATEN_FN2(OP, OVERLOAD)>::type::call);
-
-// Less-common but still useful case: redispatching to a function with a new signature (e.g. appending a dtype)
-#define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(REDISPATCH_FUNC, REGISTER_NAME, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, POLICY) \
-  m.impl(TORCH_SELECTIVE_NAME("aten::" REGISTER_NAME), \
-    &WrapFunction<CastPolicy::POLICY, DeviceType::CUDA, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, &REDISPATCH_FUNC>::type::call);
-
-// KERNEL_CPU registration for AutocastCPU
-#define KERNEL_CPU(OP, POLICY) \
-  m.impl(TORCH_SELECTIVE_NAME("aten::" #OP), \
-    &WrapFunction<CastPolicy::POLICY, DeviceType::CPU, decltype(ATEN_FN(OP)), decltype(ATEN_FN(OP)), &ATEN_FN(OP)>::type::call);
-#define KERNEL_CPU2(OP, OVERLOAD, POLICY) \
-  m.impl(TORCH_SELECTIVE_NAME("aten::" #OP "." #OVERLOAD), \
-    &WrapFunction<CastPolicy::POLICY, DeviceType::CPU, decltype(ATEN_FN2(OP, OVERLOAD)), decltype(ATEN_FN2(OP, OVERLOAD)), &ATEN_FN2(OP, OVERLOAD)>::type::call);
 
 /*****************************************
 Explicit registration for out-of-place ops
@@ -376,128 +210,128 @@ TORCH_LIBRARY_IMPL(_, Autocast, m) {
 
 TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   // lower_precision_fp
-  KERNEL2(_convolution, deprecated, lower_precision_fp)
-  KERNEL(_convolution, lower_precision_fp)
-  KERNEL(conv1d, lower_precision_fp)
-  KERNEL(conv2d, lower_precision_fp)
-  KERNEL(conv3d, lower_precision_fp)
-  KERNEL(conv_tbc, lower_precision_fp)
-  KERNEL(conv_transpose1d, lower_precision_fp)
-  KERNEL2(conv_transpose2d, input, lower_precision_fp)
-  KERNEL2(conv_transpose3d, input, lower_precision_fp)
-  KERNEL(convolution, lower_precision_fp)
-  KERNEL(cudnn_convolution, lower_precision_fp)
-  KERNEL(cudnn_convolution_transpose, lower_precision_fp)
-  KERNEL(prelu, lower_precision_fp)
-  KERNEL(addmm, lower_precision_fp)
-  KERNEL(addmv, lower_precision_fp)
-  KERNEL(addr, lower_precision_fp)
-  KERNEL(matmul, lower_precision_fp)
-  KERNEL(einsum, lower_precision_fp)
-  KERNEL(mm, lower_precision_fp)
-  KERNEL(mv, lower_precision_fp)
-  KERNEL(linear, lower_precision_fp)
-  KERNEL(addbmm, lower_precision_fp)
-  KERNEL(baddbmm, lower_precision_fp)
-  KERNEL(bmm, lower_precision_fp)
-  KERNEL(chain_matmul, lower_precision_fp)
-  KERNEL(linalg_multi_dot, lower_precision_fp)
-  KERNEL(_thnn_fused_lstm_cell, lower_precision_fp)
-  KERNEL(_thnn_fused_gru_cell, lower_precision_fp)
-  KERNEL(lstm_cell, lower_precision_fp)
-  KERNEL(gru_cell, lower_precision_fp)
-  KERNEL(rnn_tanh_cell, lower_precision_fp)
-  KERNEL(rnn_relu_cell, lower_precision_fp)
-  KERNEL(_scaled_dot_product_flash_attention, lower_precision_fp)
-  KERNEL(scaled_dot_product_attention, lower_precision_fp)
+  KERNEL_CUDA2(_convolution, deprecated, lower_precision_fp)
+  KERNEL_CUDA(_convolution, lower_precision_fp)
+  KERNEL_CUDA(conv1d, lower_precision_fp)
+  KERNEL_CUDA(conv2d, lower_precision_fp)
+  KERNEL_CUDA(conv3d, lower_precision_fp)
+  KERNEL_CUDA(conv_tbc, lower_precision_fp)
+  KERNEL_CUDA(conv_transpose1d, lower_precision_fp)
+  KERNEL_CUDA2(conv_transpose2d, input, lower_precision_fp)
+  KERNEL_CUDA2(conv_transpose3d, input, lower_precision_fp)
+  KERNEL_CUDA(convolution, lower_precision_fp)
+  KERNEL_CUDA(cudnn_convolution, lower_precision_fp)
+  KERNEL_CUDA(cudnn_convolution_transpose, lower_precision_fp)
+  KERNEL_CUDA(prelu, lower_precision_fp)
+  KERNEL_CUDA(addmm, lower_precision_fp)
+  KERNEL_CUDA(addmv, lower_precision_fp)
+  KERNEL_CUDA(addr, lower_precision_fp)
+  KERNEL_CUDA(matmul, lower_precision_fp)
+  KERNEL_CUDA(einsum, lower_precision_fp)
+  KERNEL_CUDA(mm, lower_precision_fp)
+  KERNEL_CUDA(mv, lower_precision_fp)
+  KERNEL_CUDA(linear, lower_precision_fp)
+  KERNEL_CUDA(addbmm, lower_precision_fp)
+  KERNEL_CUDA(baddbmm, lower_precision_fp)
+  KERNEL_CUDA(bmm, lower_precision_fp)
+  KERNEL_CUDA(chain_matmul, lower_precision_fp)
+  KERNEL_CUDA(linalg_multi_dot, lower_precision_fp)
+  KERNEL_CUDA(_thnn_fused_lstm_cell, lower_precision_fp)
+  KERNEL_CUDA(_thnn_fused_gru_cell, lower_precision_fp)
+  KERNEL_CUDA(lstm_cell, lower_precision_fp)
+  KERNEL_CUDA(gru_cell, lower_precision_fp)
+  KERNEL_CUDA(rnn_tanh_cell, lower_precision_fp)
+  KERNEL_CUDA(rnn_relu_cell, lower_precision_fp)
+  KERNEL_CUDA(_scaled_dot_product_flash_attention, lower_precision_fp)
+  KERNEL_CUDA(scaled_dot_product_attention, lower_precision_fp)
 
   // fp32
-  KERNEL(acos, fp32)
-  KERNEL(asin, fp32)
-  KERNEL(cosh, fp32)
-  KERNEL(erfinv, fp32)
-  KERNEL(exp, fp32)
-  KERNEL(expm1, fp32)
-  KERNEL(log, fp32)
-  KERNEL(log10, fp32)
-  KERNEL(log2, fp32)
-  KERNEL(log1p, fp32)
-  KERNEL(reciprocal, fp32)
-  KERNEL(rsqrt, fp32)
-  KERNEL(sinh, fp32)
-  KERNEL(tan, fp32)
-  KERNEL2(pow, Tensor_Scalar, fp32)
-  KERNEL2(pow, Tensor_Tensor, fp32)
-  KERNEL2(pow, Scalar, fp32)
-  KERNEL(softplus, fp32)
-  KERNEL(layer_norm, fp32)
-  KERNEL(native_layer_norm, fp32)
-  KERNEL(group_norm, fp32)
-  KERNEL2(frobenius_norm, dim, fp32)
-  KERNEL(nuclear_norm, fp32)
-  KERNEL2(nuclear_norm, dim, fp32)
-  KERNEL(cosine_similarity, fp32)
-  KERNEL(poisson_nll_loss, fp32)
-  KERNEL(cosine_embedding_loss, fp32)
-  KERNEL(nll_loss, fp32)
-  KERNEL(nll_loss2d, fp32)
-  KERNEL(hinge_embedding_loss, fp32)
-  KERNEL(kl_div, fp32)
-  KERNEL(l1_loss, fp32)
-  KERNEL(smooth_l1_loss, fp32)
-  KERNEL(huber_loss, fp32)
-  KERNEL(mse_loss, fp32)
-  KERNEL(margin_ranking_loss, fp32)
-  KERNEL(multilabel_margin_loss, fp32)
-  KERNEL(soft_margin_loss, fp32)
-  KERNEL(triplet_margin_loss, fp32)
-  KERNEL(multi_margin_loss, fp32)
-  KERNEL(binary_cross_entropy_with_logits, fp32)
-  KERNEL(dist, fp32)
-  KERNEL(pdist, fp32)
-  KERNEL(cdist, fp32)
-  KERNEL(renorm, fp32)
-  KERNEL(logsumexp, fp32)
+  KERNEL_CUDA(acos, fp32)
+  KERNEL_CUDA(asin, fp32)
+  KERNEL_CUDA(cosh, fp32)
+  KERNEL_CUDA(erfinv, fp32)
+  KERNEL_CUDA(exp, fp32)
+  KERNEL_CUDA(expm1, fp32)
+  KERNEL_CUDA(log, fp32)
+  KERNEL_CUDA(log10, fp32)
+  KERNEL_CUDA(log2, fp32)
+  KERNEL_CUDA(log1p, fp32)
+  KERNEL_CUDA(reciprocal, fp32)
+  KERNEL_CUDA(rsqrt, fp32)
+  KERNEL_CUDA(sinh, fp32)
+  KERNEL_CUDA(tan, fp32)
+  KERNEL_CUDA2(pow, Tensor_Scalar, fp32)
+  KERNEL_CUDA2(pow, Tensor_Tensor, fp32)
+  KERNEL_CUDA2(pow, Scalar, fp32)
+  KERNEL_CUDA(softplus, fp32)
+  KERNEL_CUDA(layer_norm, fp32)
+  KERNEL_CUDA(native_layer_norm, fp32)
+  KERNEL_CUDA(group_norm, fp32)
+  KERNEL_CUDA2(frobenius_norm, dim, fp32)
+  KERNEL_CUDA(nuclear_norm, fp32)
+  KERNEL_CUDA2(nuclear_norm, dim, fp32)
+  KERNEL_CUDA(cosine_similarity, fp32)
+  KERNEL_CUDA(poisson_nll_loss, fp32)
+  KERNEL_CUDA(cosine_embedding_loss, fp32)
+  KERNEL_CUDA(nll_loss, fp32)
+  KERNEL_CUDA(nll_loss2d, fp32)
+  KERNEL_CUDA(hinge_embedding_loss, fp32)
+  KERNEL_CUDA(kl_div, fp32)
+  KERNEL_CUDA(l1_loss, fp32)
+  KERNEL_CUDA(smooth_l1_loss, fp32)
+  KERNEL_CUDA(huber_loss, fp32)
+  KERNEL_CUDA(mse_loss, fp32)
+  KERNEL_CUDA(margin_ranking_loss, fp32)
+  KERNEL_CUDA(multilabel_margin_loss, fp32)
+  KERNEL_CUDA(soft_margin_loss, fp32)
+  KERNEL_CUDA(triplet_margin_loss, fp32)
+  KERNEL_CUDA(multi_margin_loss, fp32)
+  KERNEL_CUDA(binary_cross_entropy_with_logits, fp32)
+  KERNEL_CUDA(dist, fp32)
+  KERNEL_CUDA(pdist, fp32)
+  KERNEL_CUDA(cdist, fp32)
+  KERNEL_CUDA(renorm, fp32)
+  KERNEL_CUDA(logsumexp, fp32)
   // fp32_set_opt_dtype
-  KERNEL(prod, fp32_set_opt_dtype)
-  KERNEL2(prod, dim_int, fp32_set_opt_dtype)
-  KERNEL2(prod, dim_Dimname, fp32_set_opt_dtype)
-  KERNEL2(softmax, int, fp32_set_opt_dtype)
-  KERNEL2(softmax, Dimname, fp32_set_opt_dtype)
-  KERNEL2(log_softmax, int, fp32_set_opt_dtype)
-  KERNEL2(log_softmax, Dimname, fp32_set_opt_dtype)
-  KERNEL(cumprod, fp32_set_opt_dtype)
-  KERNEL2(cumprod, dimname, fp32_set_opt_dtype)
-  KERNEL(cumsum, fp32_set_opt_dtype)
-  KERNEL2(cumsum, dimname, fp32_set_opt_dtype)
-  KERNEL(linalg_vector_norm, fp32_set_opt_dtype)
-  KERNEL(linalg_matrix_norm, fp32_set_opt_dtype)
-  KERNEL2(linalg_matrix_norm, str_ord, fp32_set_opt_dtype)
+  KERNEL_CUDA(prod, fp32_set_opt_dtype)
+  KERNEL_CUDA2(prod, dim_int, fp32_set_opt_dtype)
+  KERNEL_CUDA2(prod, dim_Dimname, fp32_set_opt_dtype)
+  KERNEL_CUDA2(softmax, int, fp32_set_opt_dtype)
+  KERNEL_CUDA2(softmax, Dimname, fp32_set_opt_dtype)
+  KERNEL_CUDA2(log_softmax, int, fp32_set_opt_dtype)
+  KERNEL_CUDA2(log_softmax, Dimname, fp32_set_opt_dtype)
+  KERNEL_CUDA(cumprod, fp32_set_opt_dtype)
+  KERNEL_CUDA2(cumprod, dimname, fp32_set_opt_dtype)
+  KERNEL_CUDA(cumsum, fp32_set_opt_dtype)
+  KERNEL_CUDA2(cumsum, dimname, fp32_set_opt_dtype)
+  KERNEL_CUDA(linalg_vector_norm, fp32_set_opt_dtype)
+  KERNEL_CUDA(linalg_matrix_norm, fp32_set_opt_dtype)
+  KERNEL_CUDA2(linalg_matrix_norm, str_ord, fp32_set_opt_dtype)
   // commenting these out because they accept an explicit (not-optional) dtype, and we shouldn't try to flip that even
   // when autocasting.
-  // KERNEL2(norm, ScalarOpt_dtype, fp32_set_opt_dtype)
-  // KERNEL2(norm, ScalarOpt_dim_dtype, fp32_set_opt_dtype)
-  // KERNEL2(norm, names_ScalarOpt_dim_dtype, fp32_set_opt_dtype)
-  KERNEL(sum, fp32_set_opt_dtype)
-  KERNEL2(sum, dim_IntList, fp32_set_opt_dtype)
-  KERNEL2(sum, dim_DimnameList, fp32_set_opt_dtype)
+  // KERNEL_CUDA2(norm, ScalarOpt_dtype, fp32_set_opt_dtype)
+  // KERNEL_CUDA2(norm, ScalarOpt_dim_dtype, fp32_set_opt_dtype)
+  // KERNEL_CUDA2(norm, names_ScalarOpt_dim_dtype, fp32_set_opt_dtype)
+  KERNEL_CUDA(sum, fp32_set_opt_dtype)
+  KERNEL_CUDA2(sum, dim_IntList, fp32_set_opt_dtype)
+  KERNEL_CUDA2(sum, dim_DimnameList, fp32_set_opt_dtype)
   // fp32_append_dtype
   // The fp32_append_dtype wrapper overrides implicit promotion behavior.
   // norm does not implicitly promote, but be aware when adding new ops to this policy.
-  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "norm.Scalar", Tensor (const Tensor &, const Scalar&), Tensor (const Tensor &, const c10::optional<Scalar>&, ScalarType), fp32_append_dtype)
-  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "norm.ScalarOpt_dim", Tensor (const Tensor &, const c10::optional<Scalar>&, IntArrayRef, bool), Tensor (const Tensor &, const c10::optional<Scalar>&, IntArrayRef, bool, ScalarType), fp32_append_dtype)
-  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(ADD_NS(norm), "norm.names_ScalarOpt_dim", Tensor (const Tensor &, const c10::optional<Scalar>&, DimnameList, bool), Tensor (const Tensor &, const c10::optional<Scalar>&, DimnameList, bool, ScalarType), fp32_append_dtype)
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CUDA(ADD_NS(norm), "norm.Scalar", Tensor (const Tensor &, const Scalar&), Tensor (const Tensor &, const c10::optional<Scalar>&, ScalarType), fp32_append_dtype)
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CUDA(ADD_NS(norm), "norm.ScalarOpt_dim", Tensor (const Tensor &, const c10::optional<Scalar>&, IntArrayRef, bool), Tensor (const Tensor &, const c10::optional<Scalar>&, IntArrayRef, bool, ScalarType), fp32_append_dtype)
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CUDA(ADD_NS(norm), "norm.names_ScalarOpt_dim", Tensor (const Tensor &, const c10::optional<Scalar>&, DimnameList, bool), Tensor (const Tensor &, const c10::optional<Scalar>&, DimnameList, bool, ScalarType), fp32_append_dtype)
   // promote
-  KERNEL(addcdiv, promote)
-  KERNEL(addcmul, promote)
-  KERNEL(atan2, promote)
-  KERNEL(bilinear, promote)
-  KERNEL(cross, promote)
-  KERNEL(dot, promote)
-  KERNEL(grid_sampler, promote)
-  KERNEL(index_put, promote)
-  KERNEL(tensordot, promote)
-  KERNEL(scatter_add, promote)
+  KERNEL_CUDA(addcdiv, promote)
+  KERNEL_CUDA(addcmul, promote)
+  KERNEL_CUDA(atan2, promote)
+  KERNEL_CUDA(bilinear, promote)
+  KERNEL_CUDA(cross, promote)
+  KERNEL_CUDA(dot, promote)
+  KERNEL_CUDA(grid_sampler, promote)
+  KERNEL_CUDA(index_put, promote)
+  KERNEL_CUDA(tensordot, promote)
+  KERNEL_CUDA(scatter_add, promote)
 
   m.impl(TORCH_SELECTIVE_NAME("aten::binary_cross_entropy"),
          TORCH_FN((&at::autocast::binary_cross_entropy_banned)));
@@ -641,6 +475,7 @@ TORCH_LIBRARY_IMPL(aten, AutocastCPU, m) {
   KERNEL_CPU2(index_copy, dimname, promote)
 
 }
+
 } // namespace
 } // namespace autocast
 } // namespace at

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/Operators.h>
+#include <torch/library.h>
+
+#include <c10/core/impl/LocalDispatchKeySet.h>
+#include <c10/util/intrusive_ptr.h>
 
 namespace at {
 namespace autocast {
@@ -273,6 +279,333 @@ inline at::ScalarType type_from_firstarg(
     Args... args) {
   return (is_eligible(arg) ? to_type : arg.scalar_type());
 }
+
+// Policies correspond to op categories that need code-divergent handling.
+// Wrapper templates below are specialized based on a policy template parameter.
+enum class CastPolicy : uint8_t {
+  lower_precision_fp = 0, // Cast all inputs to lower_precision_fp before
+                          // running the op. Currently, lower_precision_fp is
+                          // fp16 for AutocastCUDA, and is defined by user
+                          // (default bf16) for AutocastCPU or other device.
+  fp32, // Cast all inputs to at::kFloat before running the op.
+  fp32_set_opt_dtype, // Treats functions (like softmax) that
+                      //  1. we'd like to run in fp32 and
+                      //  2. have a c10::optional<ScalarType> arg that controls
+                      //  the output type.
+                      // fp32_set_opt_dtype wrappers' policy is: if the output
+                      // type is already set, don't touch it, otherwise, set
+                      // it to at::kFloat.
+  fp32_append_dtype, // Treats functions (like norm) that
+                     //  1. we'd like to run in fp32 and
+                     //  2. have some overloads that accept an output type and
+                     //  other overloads that don't.
+                     // fp32_append_dtype wrappers wrap the overloads that don't
+                     // have an output dtype.
+                     // The wrapper policy is:  append at::kFloat to the args,
+                     // and redispatch to the type-aware overload.
+  promote, // Run in the widest dtype among several args.
+};
+
+/********************************************************************************************************
+Templates to provide wrapper functions
+
+I'm copying the pattern used in core/boxing/impl/WrapFunctionIntoFunctor.h to
+extract args and return type. (see also
+https://stackoverflow.com/questions/46533698/how-to-deduce-argument-list-from-function-pointer)
+
+This strategy uses an exterior "WrapFunction" that extracts arguments on behalf
+of (in my case several specializations of) an interior "WrapFunction_".
+Interior WrapFunction_ specializations are defined for each CastPolicy.
+********************************************************************************************************/
+
+// Base template for WrapFunction_, which is specialized to contain a "call"
+// method each CastPolicy
+template <
+    CastPolicy policy,
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class ArgList>
+struct WrapFunction_ {};
+
+// CastPolicy::lower_precision_fp General_DeviceType
+template <
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class... Args>
+struct WrapFunction_<
+    CastPolicy::lower_precision_fp,
+    device_type,
+    Redispatch,
+    F,
+    Ret,
+    guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(
+        get_autocast_dispatch_key_from_device_type(device_type));
+    return (*F)(cached_cast(
+        get_lower_precision_fp_from_device_type(device_type),
+        args,
+        device_type)...);
+  }
+};
+
+// CastPolicy::fp32 General_DeviceType
+template <
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class... Args>
+struct WrapFunction_<
+    CastPolicy::fp32,
+    device_type,
+    Redispatch,
+    F,
+    Ret,
+    guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(
+        get_autocast_dispatch_key_from_device_type(device_type));
+    return (*F)(cached_cast(at::kFloat, args, device_type)...);
+  }
+};
+
+// CastPolicy::fp32_set_opt_dtype DeviceType::CUDA
+template <class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<
+    CastPolicy::fp32_set_opt_dtype,
+    DeviceType::CUDA,
+    Redispatch,
+    F,
+    Ret,
+    guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
+    if (firstarg_is_eligible(args...)) {
+      return (*F)(set_opt_dtype(at::kFloat, args)...);
+    } else {
+      // If ineligible, calls F with unaltered args.  Does not set opt dtype,
+      // because setting opt dtype explicitly may interfere with internal
+      // implicit promotion decisions.
+      return (*F)(args...);
+    }
+  }
+};
+
+// CastPolicy::fp32_append_dtype DeviceType::CUDA
+template <class Redispatch, Redispatch* F, class Ret, class... Args>
+struct WrapFunction_<
+    CastPolicy::fp32_append_dtype,
+    DeviceType::CUDA,
+    Redispatch,
+    F,
+    Ret,
+    guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
+    at::ScalarType out_type = type_from_firstarg(at::kFloat, args...);
+    return (*F)(args..., out_type);
+  }
+};
+
+// CastPolicy::promote General_DeviceType
+template <
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class... Args>
+struct WrapFunction_<
+    CastPolicy::promote,
+    device_type,
+    Redispatch,
+    F,
+    Ret,
+    guts::typelist::typelist<Args...>> {
+  static Ret call(Args... args) {
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(
+        get_autocast_dispatch_key_from_device_type(device_type));
+    auto to_type = promote_type(
+        get_lower_precision_fp_from_device_type(device_type),
+        device_type,
+        args...);
+    return (*F)(cached_cast(to_type, args, device_type)...);
+  }
+};
+
+// Wrapper to infer return_type and parameter_types for WrapFunction_ (imitating
+// core/boxing/impl/WrapFunctionIntoFunctor.h)
+template <
+    CastPolicy policy,
+    DeviceType device_type,
+    class Registered, // The signature for which we're registering.  The
+                      // dispatcher's calling code invokes our registered
+                      // functions with arguments matching Registered, so we
+                      // register WrapFunction_::call methods with a matching
+                      // signature to properly field those arguments.
+    // guts::function_traits below extracts return_type and
+    // parameter_types from Registered, which WrapFunction_
+    // templates above use to declare their call methods.
+    class Redispatch, // The signature for the function we're redispatching to.
+                      // In most cases this is the same as Registered, but for
+                      // some ops (for example, ops where we append a dtype)
+                      // it's useful to redispatch to a function with a
+                      // different signature.
+    Redispatch* F> // The actual function we're redispatching to.
+struct WrapFunction final {
+  using type = WrapFunction_<
+      policy,
+      device_type,
+      Redispatch,
+      F,
+      typename guts::function_traits<Registered>::return_type,
+      typename guts::function_traits<Registered>::parameter_types>;
+};
+
+/*****************************************************************************************************************
+This section performs load-time registration for autocast wrappers.
+
+It's debatable at what level operations should be patched.  We'd like casts to
+be autograd-exposed and precede autograd history recording, so that for
+lower_precision_fp ops, input tensors are saved for backward in
+lower_precision_fp rather than fp32.  Saving inputs in lower_precision_fp
+can significantly reduce a model's memory footprint.
+
+Option 1 (strawman):  Patch only at the level of explicit calls into
+cudnn/cublas (cudnn_convolution, etc), because those are the code paths that are
+guaranteed to use Tensor Cores, therefore they're the ones that will benefit
+most from lower_precision_fp.   Potential pitfall:  convolutions (and other ops)
+are wrapped in several layers of at::* calls.  If one of those happens to record
+autograd history, then we've lost the opportunity to save inputs in
+lower_precision_fp.
+
+Option 2:  Patch the Python-exposed surface of calls, to make 100% sure autograd
+history recording can't sneak in ahead of autocast.  This mirrors Apex most
+closely.
+
+I think Option 2 is the right answer for all ops, not just convolutions. Option
+2 is what I implement here.
+*****************************************************************************************************************/
+
+/********************************************************************************************************************
+Explicit registration for out-of-place ops
+
+The stuff below could be codegenned.  Ed said
+> you are going to have to write the function definition at some point, I
+wouldn't try to get clever about it Therefore, for the moment, this is all
+copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
+********************************************************************************************************************/
+
+#define ADD_NS(RAW_OP) at::RAW_OP
+
+// Common cases where registration signature matches redispatch signature
+// (that's why SIGNATURE is repeated in the WrapFunction instantiation)
+#define KERNEL(DISPATCHKEY, OP, POLICY)   \
+  m.impl(                                 \
+      TORCH_SELECTIVE_NAME("aten::" #OP), \
+      &WrapFunction<                      \
+          CastPolicy::POLICY,             \
+          DISPATCHKEY,                    \
+          decltype(ATEN_FN(OP)),          \
+          decltype(ATEN_FN(OP)),          \
+          &ATEN_FN(OP)>::type::call);
+
+#define KERNEL2(DISPATCHKEY, OP, OVERLOAD, POLICY)      \
+  m.impl(                                               \
+      TORCH_SELECTIVE_NAME("aten::" #OP "." #OVERLOAD), \
+      &WrapFunction<                                    \
+          CastPolicy::POLICY,                           \
+          DISPATCHKEY,                                  \
+          decltype(ATEN_FN2(OP, OVERLOAD)),             \
+          decltype(ATEN_FN2(OP, OVERLOAD)),             \
+          &ATEN_FN2(OP, OVERLOAD)>::type::call);
+
+// Less-common but still useful case: redispatching to a function
+// with a new signature (e.g. appending a dtype)
+#define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(      \
+    DISPATCHKEY,                                    \
+    REDISPATCH_FUNC,                                \
+    REGISTER_NAME,                                  \
+    REGISTER_SIGNATURE,                             \
+    REDISPATCH_SIGNATURE,                           \
+    POLICY)                                         \
+  m.impl(                                           \
+      TORCH_SELECTIVE_NAME("aten::" REGISTER_NAME), \
+      &WrapFunction<                                \
+          CastPolicy::POLICY,                       \
+          DISPATCHKEY,                              \
+          REGISTER_SIGNATURE,                       \
+          REDISPATCH_SIGNATURE,                     \
+          &REDISPATCH_FUNC>::type::call);
+
+// KERNEL_CPU/KERNEL_CPU2/KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CPU
+// registration for AutocastCPU
+#define KERNEL_CPU(OP, POLICY) KERNEL(c10::DeviceType::CPU, OP, POLICY)
+
+#define KERNEL_CPU2(OP, OVERLOAD, POLICY) \
+  KERNEL2(c10::DeviceType::CPU, OP, OVERLOAD, POLICY)
+
+#define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CPU( \
+    REDISPATCH_FUNC,                               \
+    REGISTER_NAME,                                 \
+    REGISTER_SIGNATURE,                            \
+    REDISPATCH_SIGNATURE,                          \
+    POLICY)                                        \
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(           \
+      c10::DeviceType::CPU,                        \
+      REDISPATCH_FUNC,                             \
+      REGISTER_NAME,                               \
+      REGISTER_SIGNATURE,                          \
+      REDISPATCH_SIGNATURE,                        \
+      POLICY)
+
+// KERNEL_CUDA/KERNEL_CUDA2/KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CUDA
+// registration for AutocastCUDA
+#define KERNEL_CUDA(OP, POLICY) KERNEL(c10::DeviceType::CUDA, OP, POLICY)
+
+#define KERNEL_CUDA2(OP, OVERLOAD, POLICY) \
+  KERNEL2(c10::DeviceType::CUDA, OP, OVERLOAD, POLICY)
+
+#define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_CUDA( \
+    REDISPATCH_FUNC,                                \
+    REGISTER_NAME,                                  \
+    REGISTER_SIGNATURE,                             \
+    REDISPATCH_SIGNATURE,                           \
+    POLICY)                                         \
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(            \
+      c10::DeviceType::CUDA,                        \
+      REDISPATCH_FUNC,                              \
+      REGISTER_NAME,                                \
+      REGISTER_SIGNATURE,                           \
+      REDISPATCH_SIGNATURE,                         \
+      POLICY)
+
+// KERNEL_PRIVATEUSEONE/KERNEL_PRIVATEUSEONE2/
+// KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_PRIVATEUSEONE
+// registration for AutocastPrivateUse1
+#define KERNEL_PRIVATEUSEONE(OP, POLICY) \
+  KERNEL(c10::DeviceType::PrivateUse1, OP, POLICY)
+
+#define KERNEL_PRIVATEUSEONE2(OP, OVERLOAD, POLICY) \
+  KERNEL2(c10::DeviceType::PrivateUse1, OP, OVERLOAD, POLICY)
+
+#define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_PRIVATEUSEONE( \
+    REDISPATCH_FUNC,                                         \
+    REGISTER_NAME,                                           \
+    REGISTER_SIGNATURE,                                      \
+    REDISPATCH_SIGNATURE,                                    \
+    POLICY)                                                  \
+  KERNEL_DIFFERENT_REDISPATCH_SIGNATURE(                     \
+      c10::DeviceType::PrivateUse1,                          \
+      REDISPATCH_FUNC,                                       \
+      REGISTER_NAME,                                         \
+      REGISTER_SIGNATURE,                                    \
+      REDISPATCH_SIGNATURE,                                  \
+      POLICY)
 
 } // namespace autocast
 } // namespace at

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -374,17 +374,23 @@ struct WrapFunction_<
   }
 };
 
-// CastPolicy::fp32_set_opt_dtype DeviceType::CUDA
-template <class Redispatch, Redispatch* F, class Ret, class... Args>
+// CastPolicy::fp32_set_opt_dtype General_DeviceType
+template <
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class... Args>
 struct WrapFunction_<
     CastPolicy::fp32_set_opt_dtype,
-    DeviceType::CUDA,
+    device_type,
     Redispatch,
     F,
     Ret,
     guts::typelist::typelist<Args...>> {
   static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(
+        get_autocast_dispatch_key_from_device_type(device_type));
     if (firstarg_is_eligible(args...)) {
       return (*F)(set_opt_dtype(at::kFloat, args)...);
     } else {
@@ -396,17 +402,23 @@ struct WrapFunction_<
   }
 };
 
-// CastPolicy::fp32_append_dtype DeviceType::CUDA
-template <class Redispatch, Redispatch* F, class Ret, class... Args>
+// CastPolicy::fp32_append_dtype General_DeviceType
+template <
+    DeviceType device_type,
+    class Redispatch,
+    Redispatch* F,
+    class Ret,
+    class... Args>
 struct WrapFunction_<
     CastPolicy::fp32_append_dtype,
-    DeviceType::CUDA,
+    device_type,
     Redispatch,
     F,
     Ret,
     guts::typelist::typelist<Args...>> {
   static Ret call(Args... args) {
-    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(
+        get_autocast_dispatch_key_from_device_type(device_type));
     at::ScalarType out_type = type_from_firstarg(at::kFloat, args...);
     return (*F)(args..., out_type);
   }

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -320,8 +320,8 @@ class autocast:
         elif self.device == self.custom_backend_name:
             if torch.autocast_decrement_nesting() == 0:
                 torch.clear_autocast_cache()
-            self.custom_device_mod.set_autocast_enabled(self._enabled)
-            self.custom_device_mod.set_autocast_dtype(self.fast_dtype)
+            self.custom_device_mod.set_autocast_enabled(self.prev)
+            self.custom_device_mod.set_autocast_dtype(self.prev_fastdtype)
         else:
             if torch.autocast_decrement_nesting() == 0:
                 torch.clear_autocast_cache()


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
as the tiltle, optimize the macro with AMP and put the macro in `.hpp` file, so that we can use it for custom device.  @bdhirsh  @albanD  
as we talked at this discuss, optimize the macros so that we can add a new macro for other devide, and move these macros to `.hpp` so that we can include these macros with custom device to configure the ops. 
https://dev-discuss.pytorch.org/t/improve-the-extension-with-privateuse1-for-custom-device/1196/7 
cc @mcarilli @ptrblck @leslie-fang-intel @jgong5