### PR TITLE
Rename sym_shapes logger to dynamic

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -3,7 +3,7 @@ from ._internal import register_artifact, register_log
 register_log("dynamo", "torch._dynamo")
 register_log("aot", "torch._functorch.aot_autograd")
 register_log("inductor", "torch._inductor")
-register_log("sym_shapes", "torch.fx.experimental.symbolic_shapes")
+register_log("dynamic", "torch.fx.experimental.symbolic_shapes")
 
 register_artifact("guards")
 register_artifact("bytecode")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99335

This matches the logging with the user facing UX dynamic=True,
rather than a new abbreviation that shows up no where else
in the codebase.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>