### PR TITLE
Revert D44897935: Multisect successfully blamed D44897935 for test or build failures

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -1103,33 +1103,6 @@ class TestFSDPStateDict(FSDPTest):
                 else:
                     self.assertEqual(v, state_dict[k])
 
-    @skip_if_lt_x_gpu(2)
-    def test_shared_module_and_shared_parameter(self):
-        class TestDummyModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                torch.manual_seed(0)
-                self.net1 = nn.Sequential(nn.Linear(8, 16), nn.ReLU())
-                self.net2 = nn.Sequential(nn.Linear(16, 16), nn.ReLU())
-                self.net3 = self.net2
-                self.random_parameter = nn.Parameter(torch.Tensor(10))
-                self.shared_parameter = self.random_parameter
-
-            def forward(self, x):
-                return self.net3(self.net2(self.net1(x)))
-
-            def get_input(self):
-                return torch.rand(8, 8, device="cuda")
-
-        model = FSDP(TestDummyModel().cuda())
-        with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
-            state_dict = model.state_dict()
-            self.assertEqual(
-                state_dict["random_parameter"], state_dict["shared_parameter"]
-            )
-            self.assertEqual(state_dict["net2.0.bias"], state_dict["net3.0.bias"])
-            self.assertEqual(state_dict["net2.0.weight"], state_dict["net3.0.weight"])
-
 
 instantiate_parametrized_tests(TestFSDPStateDict)
 

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -205,9 +205,7 @@ def _get_param_to_fqns(
     """
 
     def module_fn(module, prefix, param_to_fqns):
-        for param_name, param in module.named_parameters(
-            recurse=False, remove_duplicate=False
-        ):
+        for param_name, param in module.named_parameters(recurse=False):
             local_fqns = (
                 param._fqns
                 if type(param) is flat_param_file.FlatParameter
@@ -249,7 +247,7 @@ def _get_param_to_fqns(
         model,
         module_fn,
         return_fn,
-        [key for key, _ in model.named_parameters(remove_duplicate=False)],
+        [key for key, _ in model.named_parameters()],
         param_to_unflat_param_names,
     )
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -571,8 +571,7 @@ def _get_state_names_for_states(
     param_names: List[str] = []
     buffer_names: List[str] = []
     param_to_param_name = {
-        param: param_name
-        for param_name, param in module.named_parameters(remove_duplicate=False)
+        param: param_name for param_name, param in module.named_parameters()
     }
     buffer_to_buffer_name = {
         buffer: buffer_name for buffer_name, buffer in module.named_buffers()
@@ -993,7 +992,7 @@ def _check_orig_params_flattened(
     ``fsdp_module``. This should be called as a sanity check after flattening
     the wrapped module's parameters.
     """
-    for param_name, param in fsdp_module.named_parameters(remove_duplicate=False):
+    for param_name, param in fsdp_module.named_parameters():
         if param not in ignored_params and not _is_fsdp_flattened(param):
             raise RuntimeError(
                 f"Found an unflattened parameter: {param_name}; "

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1097,9 +1097,7 @@ def _get_param_id_to_param_from_optim_input(
 
 def _get_flat_param_to_fqn(model: torch.nn.Module) -> Dict[nn.Parameter, str]:
     def module_fn(module, prefix, flat_param_to_fqn):
-        for param_name, param in module.named_parameters(
-            recurse=False, remove_duplicate=False
-        ):
+        for param_name, param in module.named_parameters(recurse=False):
             if type(param) is not FlatParameter:
                 continue
             fqn = clean_tensor_name(prefix + param_name)
@@ -1113,7 +1111,7 @@ def _get_flat_param_to_fqn(model: torch.nn.Module) -> Dict[nn.Parameter, str]:
         model,
         module_fn,
         return_fn,
-        [fqn for fqn, _ in model.named_parameters(remove_duplicate=False)],
+        [fqn for fqn, _ in model.named_parameters()],
         flat_param_to_fqn_ret,
     )
 
@@ -1137,7 +1135,7 @@ def _get_param_key_to_param(
             param_to_fqns is not None and flat_param_to_fqn is not None
         ), "The optimizer is a NamedOptimizer, `param_to_fqns` must not be None."
         assert model is not None
-        for key, _ in model.named_parameters(remove_duplicate=False):
+        for key, _ in model.named_parameters():
             clean_fqn_to_curr_fqn[clean_tensor_name(key)] = key
 
     param_key_to_param: Dict[Union[str, int], nn.Parameter] = {}
@@ -1565,7 +1563,7 @@ def _get_fqn_to_fsdp_param_info(model: nn.Module) -> Dict[str, FSDPParamInfo]:
         model,
         module_fn,
         return_fn,
-        [fqn for fqn, _ in model.named_parameters(remove_duplicate=False)],
+        [fqn for fqn, _ in model.named_parameters()],
         fqn_to_param_info,
     )
 

--- a/torch/distributed/fsdp/_trace_utils.py
+++ b/torch/distributed/fsdp/_trace_utils.py
@@ -98,7 +98,7 @@ class _ExecOrderTracer:
         tracer.call_module = functools.partial(
             self._patched_call_module, orig_call_module, self.exec_info
         )
-        fqn_to_param = dict(root_module.named_parameters(remove_duplicate=False))
+        fqn_to_param = dict(root_module.named_parameters())
         tracer.create_proxy = functools.partial(
             self._patched_create_proxy,
             orig_create_proxy,
@@ -139,7 +139,7 @@ class _ExecOrderTracer:
             Same return value as ``call_module``.
         """
         exec_info.module_forward_order.append(module)
-        named_params = list(module.named_parameters(remove_duplicate=False))
+        named_params = list(module.named_parameters())
         curr_module = exec_info.curr_module
         if named_params:
             assert (
@@ -225,7 +225,7 @@ class _ExecOrderTracer:
                         _ParamUsageInfo(curr_module, named_params)
                     )
         elif kind == "call_module":
-            named_params = list(curr_module.named_parameters(remove_duplicate=False))
+            named_params = list(curr_module.named_parameters())
             if named_params:
                 exec_info.module_to_param_usage_infos[curr_module].append(
                     _ParamUsageInfo(curr_module, named_params)

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -523,10 +523,8 @@ class FlatParamHandle:
         param_extensions: List[Any] = []
         is_padding_mask: List[bool] = []
         total_numel = total_numel_without_padding = 0
-        for submodule_name, submodule in module.named_modules(remove_duplicate=False):
-            for param_name, param in submodule.named_parameters(
-                recurse=False, remove_duplicate=False
-            ):
+        for submodule_name, submodule in module.named_modules():
+            for param_name, param in submodule.named_parameters(recurse=False):
                 if param not in params_set:
                     continue
                 if param in shared_param_memo:  # shared reference


### PR DESCRIPTION
Summary:
This diff is reverting D44897935
D44897935: [FSDP] Include duplicate parameters and modules when calling named_parameters and named_modules (#98912) by fegin has been identified to be causing the following test or build failures:

Tests affected:
- [caffe2/torch/fb/module_factory/sync_sgd/tests:test_pyper_data_parallel_wrapper - caffe2.torch.fb.module_factory.sync_sgd.tests.test_pyper_data_parallel_wrapper.PyPerDataParallelWrapperTest: test_fsdp_submodules_pyper](https://www.internalfb.com/intern/test/562950025957458/)

Here's the Multisect link:
https://www.internalfb.com/multisect/1893714
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: fegin

Differential Revision: D45027286

