### PR TITLE
[FSDP][optim_state_dict][Easy] Temporarily disable rank0_only=True for use_orig_paramscaseEas

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -936,6 +936,8 @@ class TestFSDPOptimState(FSDPTest):
             fsdp_kwargs={"use_orig_params": True},
         )
 
+        # Enable this once use_orig_params supports rank0_only=Treu
+        """
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,
             state_dict_settings=StateDictSettings(
@@ -950,6 +952,7 @@ class TestFSDPOptimState(FSDPTest):
             num_iters=3,
             fsdp_kwargs={"use_orig_params": True},
         )
+        """
 
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,


### PR DESCRIPTION
Summary: We have not made use_orig_params=True support rank0_only optimizer_state_dict.

Test Plan: CI

Reviewed By: wz337

Differential Revision: D45054041

