### PR TITLE
Allow current frame count to prefix torch logs

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -15,7 +15,7 @@ from .eval_frame import (
 )
 from .exc import IncorrectUsage
 from .external_utils import is_compiling
-from .utils import compilation_metrics, guard_failures, orig_code_map, reset_frame_count
+from .utils import compilation_metrics, guard_failures, orig_code_map
 
 __all__ = [
     "allow_in_graph",
@@ -53,7 +53,6 @@ def reset():
     resume_execution.ContinueExecutionCache.cache.clear()
     eval_frame.most_recent_backend = None
     compilation_metrics.clear()
-    reset_frame_count()
 
 
 def allow_in_graph(fn):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -205,10 +205,6 @@ def exception_handler(e, code, frame=None):
     if config.suppress_errors:
         log.error(format_error_msg(e, code, record_filename, frame))
 
-
-FRAME_COUNTER = 0
-
-
 def convert_frame_assert(
     compiler_fn: CompilerFn,
     one_graph: bool = True,
@@ -221,12 +217,7 @@ def convert_frame_assert(
     def _convert_frame_assert(
         frame: types.FrameType, cache_size: int, hooks: Hooks, frame_state
     ):
-        increment_frame()
-        global FRAME_COUNTER
-        if "_id" not in frame_state:
-            frame_state["_id"] = FRAME_COUNTER
-            FRAME_COUNTER += 1
-
+        increment_frame(frame_state)
         code = frame.f_code
 
         if code in input_codes and (

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -104,14 +104,6 @@ def increment_frame(frame_state):
         frame_state["_id"] = TOTAL_FRAME_COUNTER
         TOTAL_FRAME_COUNTER += 1
 
-
-# Note: Called for you by dynamo - you almost never ever want to invoke this yourself.
-def reset_frame_count():
-    global TOTAL_FRAME_COUNTER
-    frame_phase_timing.clear()
-    TOTAL_FRAME_COUNTER = 0
-
-
 op_count = 0
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -95,7 +95,7 @@ def dynamo_profiled(func):
 frame_phase_timing = collections.OrderedDict()
 
 TOTAL_FRAME_COUNTER = 0
-torch._logging._internal.register_formatter_prefix_fn(lambda: f"frame {TOTAL_FRAME_COUNTER}: ")
+torch._logging._internal.register_formatter_prefix_fn(lambda: f"{TOTAL_FRAME_COUNTER}: ")
 
 # Note: Called for you by dynamo - you almost never ever want to invoke this yourself.
 def increment_frame(frame_state):

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -15,7 +15,7 @@ LOG_ENV_VAR = "TORCH_LOGS"
 
 FORMATTER_PREFIXES : List[Callable[[], str]] = []
 
-class ExtenableLogFormatter(logging.Formatter):
+class ExtendableLogFormatter(logging.Formatter):
     def __init__(self, fmt=None, datefmt=None):
         super().__init__(fmt, datefmt)
 
@@ -29,7 +29,7 @@ class ExtenableLogFormatter(logging.Formatter):
         record.msg = prefix + record.msg
         return super().format(record)
 
-DEFAULT_FORMATTER = ExtenableLogFormatter(
+DEFAULT_FORMATTER = ExtendableLogFormatter(
     "[%(asctime)s] %(name)s: [%(levelname)s] %(message)s"
 )
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1419,7 +1419,7 @@ class LoggingShapeGuardPrinter(ShapeGuardPrinter):
 
 
 TLS = threading.local()
-ENV_COUNTER = collections.Counter()
+
 
 class ShapeEnvLoggerAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1419,7 +1419,7 @@ class LoggingShapeGuardPrinter(ShapeGuardPrinter):
 
 
 TLS = threading.local()
-
+ENV_COUNTER = collections.Counter()
 
 class ShapeEnvLoggerAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):


### PR DESCRIPTION
ex:
```
[2023-04-17 19:09:27,420] torch._dynamo.symbolic_convert: [INFO] frame 3: Step 1: torchdynamo start tracing forward
[2023-04-17 19:09:30,386] torch._dynamo.symbolic_convert: [INFO] frame 3: Step 1: torchdynamo done tracing forward (RETURN_VALUE)
[2023-04-17 19:09:30,443] torch._dynamo.output_graph: [INFO] frame 3: Step 2: calling compiler function inductor
[2023-04-17 19:09:36,757] torch._inductor.ir: [WARNING] frame 3: Could not do split reduction due to dynamic shapes; performance may be worse
[2023-04-17 19:09:38,860] torch._dynamo.output_graph: [INFO] frame 3: Step 2: done compiler function inductor
```

cc @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @soumith @desertfire