### PR TITLE
[cond] error on closed over variables

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1703,14 +1703,25 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
                 return cond(pred, true_fn, false_fn, [x, y])
 
-        for Module in [ModuleAccidentallyPassingError, ModuleNoAccidentError, ModuleClosureReproError]:
+        for Module in [
+            ModuleAccidentallyPassingError,
+            ModuleNoAccidentError,
+            ModuleClosureReproError,
+        ]:
             mod = Module()
             x = torch.randn([3, 3])
             pred = torch.tensor(x[0][0].item() < 0)
-            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "Cannot inline.*closes over"):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.UserError,
+                "Cannot inline nested function.*because it closes over variables"
+            ):
                 torch._dynamo.export(mod.forward, pred, x)
 
-        for Module in [ModuleAccidentallyPassingFixed, ModuleNoAccidentFixed, ModuleClosureReproFixed]:
+        for Module in [
+            ModuleAccidentallyPassingFixed,
+            ModuleNoAccidentFixed,
+            ModuleClosureReproFixed,
+        ]:
             mod = Module()
             x = torch.randn([3, 3])
             pred = torch.tensor(x[0][0].item() < 0)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1713,7 +1713,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             pred = torch.tensor(x[0][0].item() < 0)
             with self.assertRaisesRegex(
                 torch._dynamo.exc.UserError,
-                "Cannot inline nested function.*because it closes over variables",
+                "Cannot create subgraph for nested function.*because it closes over variables",
             ):
                 torch._dynamo.export(mod.forward, pred, x)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1713,7 +1713,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             pred = torch.tensor(x[0][0].item() < 0)
             with self.assertRaisesRegex(
                 torch._dynamo.exc.UserError,
-                "Cannot inline nested function.*because it closes over variables"
+                "Cannot inline nested function.*because it closes over variables",
             ):
                 torch._dynamo.export(mod.forward, pred, x)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1573,43 +1573,6 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
     @config.patch(capture_scalar_outputs=True, dynamic_shapes=True)
-    def test_export_with_cond_nested_calls(self):
-        from functorch.experimental.control_flow import cond
-
-        class Module(torch.nn.Module):
-            # ok
-            def forward(self, pred, x):
-                return self.indirection(pred, x)
-
-            def indirection(self, pred, x):
-                def true_fn(y):
-                    return y + 2
-
-                def false_fn(y):
-                    return y - 2
-
-                def shallow(x):
-                    return x * 2
-
-                def deep(x):
-                    return cond(
-                        x[0][0] > 0,
-                        true_fn,
-                        false_fn,
-                        [x],
-                    )
-
-                return cond(pred, shallow, deep, [x])
-
-        mod = Module()
-        x = torch.randn([3, 3])
-        pred = torch.tensor(x[0][0].item() < 0)
-        real_result = mod.forward(pred, x)
-        out_graph, _ = torch._dynamo.export(mod.forward, pred, x)
-        dynamo_result = out_graph(pred, x)
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
-
-    @config.patch(capture_scalar_outputs=True, dynamic_shapes=True)
     def test_export_with_cond_closure(self):
         from functorch.experimental.control_flow import cond
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1539,6 +1539,186 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         dynamo_result_2 = out_graph(pred, x)
         self.assertTrue(torch._dynamo.utils.same(real_result_2, dynamo_result_2))
 
+    @config.patch(capture_scalar_outputs=True, dynamic_shapes=True)
+    def test_export_with_cond_branches_calling_methods(self):
+        from functorch.experimental.control_flow import cond
+
+        class Module(torch.nn.Module):
+            # ok
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def t(self, val):
+                return val + 1
+
+            def f(self, val):
+                return val - 1
+
+            def true_fn(self, val):
+                return self.linear(val) + self.t(val)
+
+            def false_fn(self, val):
+                return self.linear(val) - self.f(val)
+
+            def forward(self, pred, x):
+                return cond(pred, self.true_fn, self.false_fn, [x])
+
+        mod = Module()
+        x = torch.randn([3, 3])
+        pred = torch.tensor(x[0][0].item() < 0)
+        real_result = mod.forward(pred, x)
+        out_graph, _ = torch._dynamo.export(mod.forward, pred, x)
+        dynamo_result = out_graph(pred, x)
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+
+    @config.patch(capture_scalar_outputs=True, dynamic_shapes=True)
+    def test_export_with_cond_nested_calls(self):
+        from functorch.experimental.control_flow import cond
+
+        class Module(torch.nn.Module):
+            # ok
+            def forward(self, pred, x):
+                return self.indirection(pred, x)
+
+            def indirection(self, pred, x):
+                def true_fn(y):
+                    return y + 2
+
+                def false_fn(y):
+                    return y - 2
+
+                def shallow(x):
+                    return x * 2
+
+                def deep(x):
+                    return cond(
+                        x[0][0] > 0,
+                        true_fn,
+                        false_fn,
+                        [x],
+                    )
+
+                return cond(pred, shallow, deep, [x])
+
+        mod = Module()
+        x = torch.randn([3, 3])
+        pred = torch.tensor(x[0][0].item() < 0)
+        real_result = mod.forward(pred, x)
+        out_graph, _ = torch._dynamo.export(mod.forward, pred, x)
+        dynamo_result = out_graph(pred, x)
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+
+    @config.patch(capture_scalar_outputs=True, dynamic_shapes=True)
+    def test_export_with_cond_closure(self):
+        from functorch.experimental.control_flow import cond
+
+        class ModuleAccidentallyPassingError(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x):
+                def true_fn(val):
+                    return x * 2
+
+                def false_fn(val):
+                    return x - 2
+
+                return cond(pred, true_fn, false_fn, [x])
+
+        class ModuleAccidentallyPassingFixed(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x):
+                def true_fn(x):
+                    return x * 2
+
+                def false_fn(x):
+                    return x - 2
+
+                return cond(pred, true_fn, false_fn, [x])
+
+        class ModuleNoAccidentError(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x):
+                def true_fn(val):
+                    return x * 2
+
+                def false_fn(val):
+                    return x - 2
+
+                return cond(pred, true_fn, false_fn, [x + 1])
+
+        class ModuleNoAccidentFixed(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x):
+                def true_fn(x):
+                    return x * 2
+
+                def false_fn(x):
+                    return x - 2
+
+                return cond(pred, true_fn, false_fn, [x + 1])
+
+        class ModuleClosureReproError(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, pred, x):
+                y = x + x
+
+                def true_fn(val):
+                    return self.linear(val) * (x + y)
+
+                def false_fn(val):
+                    return val * (y - x)
+
+                return cond(pred, true_fn, false_fn, [x])
+
+        class ModuleClosureReproFixed(torch.nn.Module):
+            # error
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, pred, x):
+                y = x + x
+
+                def true_fn(x, y):
+                    return self.linear(x) * (x + y)
+
+                def false_fn(x, y):
+                    return x * (y - x)
+
+                return cond(pred, true_fn, false_fn, [x, y])
+
+        for Module in [ModuleAccidentallyPassingError, ModuleNoAccidentError, ModuleClosureReproError]:
+            mod = Module()
+            x = torch.randn([3, 3])
+            pred = torch.tensor(x[0][0].item() < 0)
+            with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "Cannot inline.*closes over"):
+                torch._dynamo.export(mod.forward, pred, x)
+
+        for Module in [ModuleAccidentallyPassingFixed, ModuleNoAccidentFixed, ModuleClosureReproFixed]:
+            mod = Module()
+            x = torch.randn([3, 3])
+            pred = torch.tensor(x[0][0].item() < 0)
+            real_result = mod.forward(pred, x)
+            out_graph, _ = torch._dynamo.export(mod.forward, pred, x)
+            dynamo_result = out_graph(pred, x)
+            self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+
     @config.patch(dynamic_shapes=True)
     def test_export_with_cond_dynamic_shape_pred(self):
         from functorch.experimental.control_flow import cond

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -42,13 +42,7 @@ from .bytecode_transformation import (
     unique_id,
 )
 from .codegen import PyCodegen
-from .exc import (
-    BackendCompilerFailed,
-    unimplemented,
-    Unsupported,
-    UserError,
-    UserErrorType,
-)
+from .exc import BackendCompilerFailed, unimplemented, Unsupported
 from .guards import GuardBuilder
 from .output_graph import GraphCompileReason, OutputGraph, OutputGraphState
 from .replay_record import DummyModule, ExecutionRecorder
@@ -2035,24 +2029,6 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             unimplemented(
                 f"call torch._dynamo.disable() wrapped function {func.get_function()}"
             )
-
-        if isinstance(func, NestedUserFunctionVariable) and func.closure is not None:
-            # closure vars other than 'self' are not in scope of generated code, so error early
-            # TODO(avik): we should eventually support this.
-            # (Feature request tracked here: https://github.com/pytorch/pytorch/issues/99401)
-            closure_vars = [
-                var.name
-                for var in func.closure.items
-                if isinstance(var, ClosureVariable) and var.name != "self"
-            ]
-            if closure_vars:
-                code = func.get_code()
-                raise UserError(
-                    UserErrorType.ANTI_PATTERN,
-                    f"Cannot inline nested function '{code.co_name}' at {code.co_filename}:{code.co_firstlineno} "
-                    f"because it closes over variables {closure_vars}. "
-                    f"Please rewrite '{code.co_name}' to take {closure_vars} as additional arguments.",
-                )
 
     @staticmethod
     def inline_call_(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2030,6 +2030,17 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 f"call torch._dynamo.disable() wrapped function {func.get_function()}"
             )
 
+        if isinstance(func, NestedUserFunctionVariable) and func.closure is not None:
+            cvs = [cv.name for cv in func.closure.items if isinstance(cv, ClosureVariable) and cv.name != "self"]
+            if cvs:
+                code = func.get_code()
+                unimplemented(
+                    f"Cannot inline nested function '{code.co_name}' at {code.co_filename}:{code.co_firstlineno} "
+                    f"because it closes over variables {cvs}. "
+                    f"Please rewrite '{code.co_name}' to take {cvs} as additional arguments."
+                )
+
+
     @staticmethod
     def inline_call_(
         parent, func: VariableTracker, args: List[VariableTracker], kwargs

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -782,6 +782,7 @@ class TorchHigherOrderOperator(VariableTracker):
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
         from . import (
+            ClosureVariable,
             ConstantVariable,
             ListVariable,
             NestedUserFunctionVariable,
@@ -832,6 +833,25 @@ class TorchHigherOrderOperator(VariableTracker):
             )
 
         def speculate_subgraph(f, sub_args, graph_checkpoint, checkpoint):
+            if isinstance(f, NestedUserFunctionVariable) and f.closure is not None:
+                # closure vars other than 'self' are not in scope of generated code, so error early
+                # TODO(avik): we should eventually support this.
+                # (Feature request tracked here: https://github.com/pytorch/pytorch/issues/99401)
+                closure_vars = [
+                    var.name
+                    for var in f.closure.items
+                    if isinstance(var, ClosureVariable) and var.name != "self"
+                ]
+                if closure_vars:
+                    code = f.get_code()
+                    raise torch._dynamo.exc.UserError(
+                        torch._dynamo.exc.UserErrorType.ANTI_PATTERN,
+                        f"Cannot create subgraph for nested function '{code.co_name}' "
+                        f"at {code.co_filename}:{code.co_firstlineno} because "
+                        f"it closes over variables {closure_vars}. Please rewrite "
+                        f"'{code.co_name}' to take {closure_vars} as additional args.",
+                    )
+
             # Setup the subgraph we're going to capture into
             tx.output.graph = torch.fx.Graph()
             tx.output.input_name_to_proxy.clear()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99367

As reported in https://github.com/pytorch/pytorch/issues/90469, the implementation of inlining nested function branches for `cond` doesn't properly handle variables captured from outer scopes. This leads to some examples accidentally working, some others generating incorrect code that don't crash but do the wrong thing, and still others that outright crash because of references to non-existent variables.

Properly supporting closed variables is tricky (see https://github.com/pytorch/pytorch/pull/91981 for an abandoned attempt). While this is definitely something we should be able to support longer term, for now it is better to explicitly error and suggest the fix to the user (amounting to rewriting branches to take closed variables explicitly).

Differential Revision: [D45058621](https://our.internmc.facebook.com/intern/diff/D45058621/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire