### PR TITLE
Test and document dynamo backward hooks support

### DIFF
--- a/docs/source/compile/nn-module.rst
+++ b/docs/source/compile/nn-module.rst
@@ -28,6 +28,13 @@ By default, `torch.compile` will trace the contents of `nn.Module.__call__` whic
 and run forward/pre-forward hooks.  If you install hooks before calling `torch.compile` and then do not remove
 or alter the hooks later, your use case should be supported by default.
 
+Backward/Pre-backward hooks are generally also supported, with similar caveats: currently graph-breaks in dynamo
+occur when accessing backward_hooks dicts, which is probably avoiable with some work.  Graph-breaks also impact the
+timing of firing backward hooks, since graph-segments are run as autograd-functions which produce all their grads at
+the same time.  Assuming it were possible for dynamo to not graph-break on the presence of backward-hooks, we would
+still expect the backward hooks for a series of modules to all fire together after the whole compiled graph's backward
+ran.
+
 **hooks on 'allowed modules'**
 `torch.compile` treats common modules such as torch.conv, as well as modules that are difficult to trace, specially
 by allowing them to be called opaquely in the dynamo graph instead of traced into by dynamo.  For such modules, hooks

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1622,6 +1622,71 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         print(f"Expected Layers: {forward_handles.keys()}")
         self.assertTrue(activations.keys() == forward_handles.keys())
 
+    def test_backward_hooks(self):
+        # this test shouldn't care whether hook guards are enabled or not
+
+        class CustomLinear(torch.nn.Module):
+            # not an 'allowed module', so should not graph-break
+            def __init__(self, a, b):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(a, b))
+
+            def forward(self, x):
+                return torch.mm(x, self.weight)
+
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net = torch.nn.Sequential(
+                    *[CustomLinear(10, 10)]
+                    + [CustomLinear(10, 10000)]
+                    + [CustomLinear(10000, 5)]
+                )
+
+            def forward(self, x):
+                return self.net(x)
+
+        model = ToyModel()
+        backward_hook_handles = {}
+        pre_backward_hook_handles = {}
+
+        grad_sizes = {}
+
+        def backward_hook(name, mod, grad_inp, grad_out):
+            grad_sizes[name] = (
+                (gi.shape for gi in grad_inp),
+                (go.shape for go in grad_out),
+            )
+            return None
+
+        pre_grad_sizes = {}
+
+        def backward_pre_hook(name, mod, grad_out):
+            pre_grad_sizes[name] = (go.shape for go in grad_out)
+            return None
+
+        for name, module in model.named_modules():
+            backward_hook_handles[name] = module.register_full_backward_hook(
+                partial(backward_hook, name)
+            )
+
+            pre_backward_hook_handles[name] = module.register_full_backward_pre_hook(
+                partial(backward_pre_hook, name)
+            )
+
+        model = torch.compile(model, backend="aot_eager")
+
+        for i in range(2):
+            # second iteration is key, hooks would have fired during aot trace
+            # on first iter
+            x = torch.randn((20, 10))
+            pred = model(x)
+            loss = pred.sum()
+            loss.backward()
+
+        self.assertTrue(grad_sizes.keys() == backward_hook_handles.keys())
+        self.assertTrue(pre_grad_sizes.keys() == pre_backward_hook_handles.keys())
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99382

No new support added, but backward hooks are working and now there is a test and some documentation about the limitations (hooks firing after whole graph).

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire