### PR TITLE
Turn off Windows Defender in temp folder on binary build workflow

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -49,7 +49,7 @@ concurrency:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -46,10 +46,13 @@ concurrency:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
 {%- endmacro -%}
 
 {%- macro checkout(submodules="recursive", deep_clone=True, directory="", repository="pytorch/pytorch", branch="", checkout_pr_head=True) -%}

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -183,7 +183,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -309,7 +309,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -419,7 +419,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -546,7 +546,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -656,7 +656,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -782,7 +782,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -891,7 +891,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1017,7 +1017,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1127,7 +1127,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1254,7 +1254,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1364,7 +1364,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1490,7 +1490,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1599,7 +1599,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1725,7 +1725,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1835,7 +1835,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1962,7 +1962,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2072,7 +2072,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2198,7 +2198,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2307,7 +2307,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2433,7 +2433,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2543,7 +2543,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2670,7 +2670,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2780,7 +2780,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -71,10 +71,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -177,10 +180,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -300,10 +306,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,10 +416,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -531,10 +543,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -638,10 +653,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -761,10 +779,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -867,10 +888,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -990,10 +1014,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1097,10 +1124,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1221,10 +1251,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1328,10 +1361,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1451,10 +1487,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1557,10 +1596,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1680,10 +1722,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1787,10 +1832,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1911,10 +1959,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2018,10 +2069,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2141,10 +2195,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2247,10 +2304,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2370,10 +2430,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2477,10 +2540,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2601,10 +2667,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2708,10 +2777,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -186,7 +186,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -70,10 +70,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -180,10 +183,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -75,10 +75,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -185,10 +188,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -315,10 +321,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -425,10 +434,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -555,10 +567,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -665,10 +680,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -795,10 +813,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -905,10 +926,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1036,10 +1060,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1147,10 +1174,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1279,10 +1309,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1390,10 +1423,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1522,10 +1558,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1633,10 +1672,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1765,10 +1807,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1876,10 +1921,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2008,10 +2056,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2119,10 +2170,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2251,10 +2305,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2362,10 +2419,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2494,10 +2554,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2605,10 +2668,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2737,10 +2803,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2848,10 +2917,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -191,7 +191,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -324,7 +324,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -437,7 +437,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -570,7 +570,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -683,7 +683,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -816,7 +816,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -929,7 +929,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1063,7 +1063,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1177,7 +1177,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1312,7 +1312,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1426,7 +1426,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1561,7 +1561,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1675,7 +1675,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1810,7 +1810,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1924,7 +1924,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2059,7 +2059,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2173,7 +2173,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2308,7 +2308,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2422,7 +2422,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2557,7 +2557,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2671,7 +2671,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2806,7 +2806,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2920,7 +2920,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -186,7 +186,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -70,10 +70,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -180,10 +183,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -75,10 +75,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -185,10 +188,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -315,10 +321,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -425,10 +434,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -555,10 +567,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -665,10 +680,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -795,10 +813,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -905,10 +926,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1036,10 +1060,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1147,10 +1174,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1279,10 +1309,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1390,10 +1423,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1522,10 +1558,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1633,10 +1672,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1765,10 +1807,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1876,10 +1921,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2008,10 +2056,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2119,10 +2170,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2251,10 +2305,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2362,10 +2419,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2494,10 +2554,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2605,10 +2668,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2737,10 +2803,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2848,10 +2917,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -191,7 +191,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -324,7 +324,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -437,7 +437,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -570,7 +570,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -683,7 +683,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -816,7 +816,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -929,7 +929,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1063,7 +1063,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1177,7 +1177,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1312,7 +1312,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1426,7 +1426,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1561,7 +1561,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1675,7 +1675,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1810,7 +1810,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1924,7 +1924,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2059,7 +2059,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2173,7 +2173,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2308,7 +2308,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2422,7 +2422,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2557,7 +2557,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2671,7 +2671,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2806,7 +2806,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2920,7 +2920,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -183,7 +183,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -309,7 +309,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -419,7 +419,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -546,7 +546,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -656,7 +656,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -782,7 +782,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -891,7 +891,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1017,7 +1017,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1127,7 +1127,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1254,7 +1254,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1364,7 +1364,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1490,7 +1490,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1599,7 +1599,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1725,7 +1725,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1835,7 +1835,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -1962,7 +1962,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2072,7 +2072,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2198,7 +2198,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2307,7 +2307,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2433,7 +2433,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2543,7 +2543,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2670,7 +2670,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True
@@ -2780,7 +2780,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TEMP -ErrorAction Ignore
           # Let's both exclude the path and disable Windows Defender completely just to be sure
           # that it doesn't interfere
           Set-MpPreference -DisableRealtimeMonitoring $True

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -71,10 +71,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -177,10 +180,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -300,10 +306,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,10 +416,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -531,10 +543,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -638,10 +653,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -761,10 +779,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -867,10 +888,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -990,10 +1014,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1097,10 +1124,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1221,10 +1251,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1328,10 +1361,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1451,10 +1487,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1557,10 +1596,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1680,10 +1722,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1787,10 +1832,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1911,10 +1959,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2018,10 +2069,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2141,10 +2195,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2247,10 +2304,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2370,10 +2430,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2477,10 +2540,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2601,10 +2667,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2708,10 +2777,13 @@ jobs:
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
       # Since it's just a defensive command, the workflow should continue even the command fails
-      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      - name: Disables Windows Defender scheduled and real-time scanning for files in directories used by PyTorch
         shell: powershell
         run: |
-          Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+          Add-MpPreference -ExclusionPath $(Get-Location).tostring(),$Env:TMPDIR -ErrorAction Ignore
+          # Let's both exclude the path and disable Windows Defender completely just to be sure
+          # that it doesn't interfere
+          Set-MpPreference -DisableRealtimeMonitoring $True
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.


### PR DESCRIPTION
This issue starts to show up recently https://github.com/pytorch/pytorch/actions/runs/4724983231/jobs/8385139626 and I'm pretty sure that the root cause is Windows Defender as I did a similar fix on Windows CI a while ago https://github.com/pytorch/pytorch/pull/96931.  Without this, Windows binary build could fail flakily when Windows Defender chooses to delete/quarantine a file in the temp folder.