### PR TITLE
Rename DispatchKey.PrivateUse1 to custom device in torchgen.

### DIFF
--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -13,8 +13,10 @@ from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.model import (
     Annotation,
     CustomClassType,
+    dispatch_keys,
     DispatchKey,
     NativeFunctionsGroup,
+    rename_dispatch_key_privateuse1,
     Type,
 )
 
@@ -157,6 +159,28 @@ cannot use CUDAFunctorOnSelf on non-binary function""",
         self.assertTrue(isinstance(custom_class_type, CustomClassType))
         self.assertEqual(custom_class_name, custom_class_type.class_name)
         self.assertEqual(custom_class_name_with_prefix, str(custom_class_type))
+
+    def test_rename_dispatch_key_privateuse1(self) -> None:
+        # save the original function ptr
+        dispatch_key_str_func = DispatchKey.__str__
+        dispatch_key_parse_func = DispatchKey.parse
+        custom_device_name = "FOO"
+        rename_dispatch_key_privateuse1(custom_device_name)
+        try:
+            self.assertEqual(str(DispatchKey.PrivateUse1), custom_device_name)
+            self.assertEqual(
+                DispatchKey.parse(custom_device_name), DispatchKey.PrivateUse1
+            )
+        finally:
+            # restores the original function ptr
+            DispatchKey.__str__ = dispatch_key_str_func  # type: ignore[assignment]
+            DispatchKey.parse = dispatch_key_parse_func  # type: ignore[assignment]
+            private_use_one_name = "PrivateUse1"
+            self.assertEqual(str(DispatchKey.PrivateUse1), private_use_one_name)
+            self.assertEqual(
+                DispatchKey.parse(private_use_one_name), DispatchKey.PrivateUse1
+            )
+            dispatch_keys.pop()
 
 
 class TestAnnotation(expecttest.TestCase):

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -249,6 +249,31 @@ dispatch_keys = [
 ]
 
 
+def rename_dispatch_key_privateuse1(custom_device: str) -> None:
+    """
+    User can rename DispatchKey.PrivateUse1 to custom device rather than 'PrivateUse1'.
+    For example:
+    >>>from torchgen.model import DispatchKey, rename_dispatch_key_privateuse1
+    >>>rename_dispatch_key_privateuse1("FOO")
+    >>>str(DispatchKey.PrivateUse1) # "FOO"
+    >>>DispatchKey.parse("FOO") # DispatchKey.PrivateUse1
+    """
+
+    def rename_privateuse1(self: DispatchKey) -> str:
+        return self.name.replace("PrivateUse1", custom_device)
+
+    @staticmethod  # type: ignore[misc]
+    def parse_custom_device(value: str) -> "DispatchKey":
+        for k, v in DispatchKey.__members__.items():
+            if k == value.replace(custom_device, "PrivateUse1"):
+                return v
+        raise AssertionError(f"unknown dispatch key {value}")
+
+    DispatchKey.__str__ = rename_privateuse1  # type: ignore[assignment]
+    DispatchKey.parse = parse_custom_device  # type: ignore[assignment]
+    dispatch_keys.append(DispatchKey.PrivateUse1)
+
+
 # Dispatch keys that "support all backends".  These codegen slightly differently
 # then backend specific keys.
 def is_generic_dispatch_key(dk: DispatchKey) -> bool:


### PR DESCRIPTION
I want to use torchgen to generate code, and my yaml file format is the same as `native_functions.yaml`. 
I will use the PrivateUse1, but in my yaml file, I don't want to show PrivateUse1 to the user.
So I want to  achieve the following result(e.g. my device is `YPU`):
```
>>>from torchgen.model import DispatchKey
>>>str(DispatchKey.PrivateUse1)
"YPU"
>>>DispatchKey.parse("YPU")
DispatchKey.PrivateUse1
```
I also thought that not everyone would need this feature, so I add a new func to handle this scenario.