### PR TITLE
Making fsdp device-agnostic for device implement cuda-semantics

### DIFF
--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -2,7 +2,6 @@ from .flat_param import FlatParameter
 from .fully_sharded_data_parallel import (
     BackwardPrefetch,
     CPUOffload,
-    FSDPDeviceHandler,
     FullStateDictConfig,
     FullyShardedDataParallel,
     LocalStateDictConfig,

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -2,6 +2,7 @@ from .flat_param import FlatParameter
 from .fully_sharded_data_parallel import (
     BackwardPrefetch,
     CPUOffload,
+    FSDPDeviceHandler,
     FullStateDictConfig,
     FullyShardedDataParallel,
     LocalStateDictConfig,

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -26,7 +26,6 @@ import torch.nn as nn
 from torch.distributed.algorithms._comm_hooks import default_hooks
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp._common_utils import (
-    _CUDADeviceHandler,
     _FSDPState,
     _get_module_fsdp_state,
     _is_fsdp_flattened,

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -210,7 +210,7 @@ def _communicate_optim_state(
             dist.all_gather_into_tensor(
                 tensor_buffer, value, group=fsdp_state.process_group
             )
-            torch.cuda.synchronize()
+            fsdp_state.device_handler.synchronize()
             unpadded_numel = cast(
                 nn.Parameter, flat_param._unpadded_unsharded_size
             ).numel()
@@ -276,7 +276,7 @@ def _unflatten_communicated_optim_state(
                     optim_state,
                     fsdp_state.rank,
                     fsdp_state.world_size,
-                    torch.cuda.device_count(),
+                    fsdp_state.device_handler.device_count(),
                     fsdp_state.process_group,
                 )
             unflat_state_param[state_name] = optim_state
@@ -1718,7 +1718,7 @@ def _gather_orig_param_state(
                 value,
                 fsdp_state.rank,
                 fsdp_state.world_size,
-                torch.cuda.device_count(),
+                fsdp_state.device_handler.device_count(),
                 fsdp_state.process_group,
             )
         value = value.cpu()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -161,7 +161,7 @@ def _lazy_init(
     """
     if state._is_root is not None:
         return  # no-op: already lazily initialized
-    if not torch.cuda.is_available():
+    if not state.device_handler.is_available():
         # Allow the FSDP constructor to run even without CUDA but check this
         # once we start real execution
         raise RuntimeError("FSDP does not support CPU only execution")
@@ -277,20 +277,20 @@ def _init_streams(
     data transfers. The streams should be shared across FSDP instances.
     """
     assert state._is_root
-    assert torch.cuda.is_available()
+    assert state.device_handler.is_available()
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._streams["unshard"] = torch.cuda.Stream()
+    state._streams["unshard"] = state.device_handler.Stream()
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
-    state._streams["post_backward"] = torch.cuda.Stream()
+    state._streams["post_backward"] = state.device_handler.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._streams["pre_unshard"] = torch.cuda.Stream()
+    state._streams["pre_unshard"] = state.device_handler.Stream()
     # Default stream for computation
-    state._streams["default"] = torch.cuda.current_stream()
+    state._streams["default"] = state.device_handler.current_stream()
     state._stream_to_name = {
-        torch.cuda.current_stream(): "default",
+        state.device_handler.current_stream(): "default",
         state._streams["unshard"]: "unshard",
         state._streams["pre_unshard"]: "pre_unshard",
         state._streams["post_backward"]: "post_backward",
@@ -315,7 +315,7 @@ def _unshard(
     if not handles:
         return
     any_ran_pre_unshard = False
-    with torch.cuda.stream(pre_unshard_stream):
+    with state.device_handler.stream(pre_unshard_stream):
         for handle in handles:
             ran_pre_unshard = handle.pre_unshard()
             any_ran_pre_unshard = any_ran_pre_unshard or ran_pre_unshard
@@ -325,7 +325,7 @@ def _unshard(
         event = state._free_event_queue.dequeue_if_needed()
         if event:
             event.synchronize()
-    with torch.cuda.stream(unshard_stream):
+    with state.device_handler.stream(unshard_stream):
         for handle in handles:
             handle.unshard()
             handle.post_unshard()
@@ -355,7 +355,7 @@ def _reshard(
     ):
         handle.reshard(free_unsharded_flat_param)
         if state.limit_all_gathers and free_unsharded_flat_param:
-            free_event = torch.cuda.Event()
+            free_event = state.device_handler.Event()
             free_event.record()
             state._free_event_queue.enqueue(free_event)
         handle.post_reshard()
@@ -440,7 +440,7 @@ def _pre_forward_unshard(
             state, handles, state._streams["unshard"], state._streams["pre_unshard"]
         )
     state._needs_pre_forward_unshard[handles_key] = False
-    torch.cuda.current_stream().wait_stream(state._streams["unshard"])
+    state.device_handler.current_stream().wait_stream(state._streams["unshard"])
     _prefetch_handles(state, handles_key, _PrefetchMode.FORWARD)
 
 
@@ -538,7 +538,7 @@ def _root_pre_forward(
             for handles_key in handles_keys:
                 state._needs_pre_forward_unshard[handles_key] = True
         _wait_for_computation_stream(
-            torch.cuda.current_stream(),
+            state.device_handler.current_stream(),
             state._streams["unshard"],
             state._streams["pre_unshard"],
         )
@@ -644,7 +644,7 @@ def _pre_backward_hook(
                     state._streams["unshard"],
                     state._streams["pre_unshard"],
                 )
-            torch.cuda.current_stream().wait_stream(state._streams["unshard"])
+            state.device_handler.current_stream().wait_stream(state._streams["unshard"])
 
         # Set this to `False` to ensure that a mistargeted prefetch does not
         # actually unshard these handles
@@ -712,9 +712,11 @@ def _post_backward_hook(
 
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
-        state._streams["post_backward"].wait_stream(torch.cuda.current_stream())
+        state._streams["post_backward"].wait_stream(
+            state.device_handler.current_stream()
+        )
 
-        with torch.cuda.stream(state._streams["post_backward"]):
+        with state.device_handler.stream(state._streams["post_backward"]):
             autograd_computed_grad = flat_param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
@@ -858,7 +860,9 @@ def _cast_grad_to_param_dtype(
         # caching allocator; for the sharded strategies, the gradient is
         # produced in the post-backward stream, so this `record_stream()`
         # should be a no-op
-        _no_dispatch_record_stream(low_prec_grad_data, torch.cuda.current_stream())
+        _no_dispatch_record_stream(
+            low_prec_grad_data, state.device_handler.current_stream()
+        )
 
 
 def _check_comm_hook(
@@ -912,12 +916,14 @@ def _post_backward_final_callback(
     root_state = state
 
     if root_state._sync_gradients:
-        torch.cuda.current_stream().wait_stream(root_state._streams["post_backward"])
+        state.device_handler.current_stream().wait_stream(
+            root_state._streams["post_backward"]
+        )
         if root_state.cpu_offload.offload_params:
             # Wait for non-blocking GPU -> CPU sharded gradient copies from the
             # post-backward hooks to finish explicitly since CPU gradients do
             # not automatically synchronize with the GPU
-            torch.cuda.current_stream().synchronize()
+            state.device_handler.current_stream().synchronize()
     root_state._exec_order_data.next_iter()
 
     for fsdp_state in state._all_fsdp_states:

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -171,7 +171,7 @@ def _unshard_fsdp_state_params(
     _validate_unshard_params_args(
         state, writeback, rank0_only, offload_to_cpu, with_grads
     )
-    torch.cuda.synchronize()
+    state.device_handler.synchronize()
     # If handles are shared by other module(s), the handle may be already unsharded.
     handles = [
         handle
@@ -194,7 +194,7 @@ def _unshard_fsdp_state_params(
     free_unsharded_flat_params = [handle.needs_unshard() for handle in handles]
     # No need to call `wait_stream()` since we unshard in the computation
     # stream directly
-    computation_stream = torch.cuda.current_stream()
+    computation_stream = state.device_handler.current_stream()
     _unshard(state, handles, computation_stream, computation_stream)
     if with_grads:
         _unshard_grads(handles)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -33,6 +33,7 @@ from torch.distributed.fsdp._common_utils import (
     _get_param_to_fqns,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
+    FSDPDeviceHandler,
     TrainingState,
 )
 from torch.distributed.fsdp._dynamo_utils import _annotate_modules_for_dynamo
@@ -382,7 +383,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         mixed_precision: Optional[MixedPrecision] = None,
         ignored_modules: Optional[Iterable[torch.nn.Module]] = None,
         param_init_fn: Optional[Callable[[nn.Module], None]] = None,
-        device_id: Optional[Union[int, torch.device]] = None,
+        device_id: Optional[Union[int, torch.device, FSDPDeviceHandler]] = None,
         sync_module_states: bool = False,
         forward_prefetch: bool = False,
         limit_all_gathers: bool = False,


### PR DESCRIPTION
Custom backend implementation based on privateuse1 with semantics identical to CUDA (CUDA is so popular), named for example 'my_device', and registered as the same module name torch.my_device.

This PR aims to satisfy the constraints of such a backend, which can be directly integrated into the current FSDP implementation.

The main issues addressed are:

#### 1. Device decision for FSDP wrapping of Modules without Parameters

Users typically organize FSDP code as follows:
```python
m = Module().to('my_device:0')
fsdp_m = FSDP(m)
```
or like this:
```python
m = Module()
fsdp_m = FSDP(m, device_id=torch.device('my_device', 0))
```
If the model has Parameters, everything works fine because FSDP will prioritize the device where the Parameters are located. However, for Modules without Parameters, the to() call has no side effects, and FSDP will assume the current CUDA device, which prevents the use of devices other than the current CUDA device for Modules without Parameters. Therefore, when FSDP is called with a device_id argument, this configuration takes top priority.

#### 2. Abstraction of a cuda-like device

Now, in addition to compute_device, _FSDPState includes a device_handler member. In fact, this device_handler is now just a reference to either torch.cuda or torch.my_device. From now on, code that works based on _FSDPState should use state.device_handler to operate streams create, wait or sync, just like using torch.cuda previously.