### PR TITLE
Fix test/test_proxy_tensor

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -698,12 +698,14 @@ def make_fx(f, decomposition_table=None, tracing_mode="real", _allow_non_fake_in
         if tracing_mode == "real":
             fake_tensor_mode = nullcontext()
         elif tracing_mode == "fake":
+            import torch._dynamo
             fake_tensor_mode = torch._dynamo.utils.detect_fake_mode(args)
             if fake_tensor_mode is None:
                 fake_tensor_mode = FakeTensorMode(
                     allow_fallback_kernels=True,
                     allow_non_fake_inputs=_allow_non_fake_inputs)
         elif tracing_mode == "symbolic":
+            import torch._dynamo
             fake_tensor_mode = torch._dynamo.utils.detect_fake_mode(args)
             if fake_tensor_mode is None:
                 shape_env = ShapeEnv()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #99439
* #99416
* __->__ #99415

test_proxy_tensor fails when run by itself (python test/test_proxy_tensor.py -v),
but not when all of the tests are run together.

The cause is that torch._dynamo isn't imported in
torch/fx/experimenta/proxy_tensor.py but it is using functions from the
torch._dynamo package.

The fix in this PR is to add the import statements. In the future we can
consider always importing torch._dynamo on `import torch` or moving the
import to the top of the file, but there are some serious circular
dependencies to be worked out.

NB: an import in the middle of the file makes the function a bit slow
the first time the import happens but all subsequent calls are fast.

Test Plan:
- python test/test_proxy_tensor.py