### PR TITLE
[MPS][BE] Introduce `LookUpOrCreateCachedGraph`

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -281,6 +281,25 @@ struct MPSGraphCache
 
 };
 
+// Common template for creating graph with a specified cache if missing
+template<typename T>
+inline T* LookUpOrCreateCachedGraph(const std::string& key, std::function<void(MPSGraph*, T*)> instantiate) {
+  auto cache_ = MPSGraphCache::getInstance();
+  if (auto rc  = cache_->LookUpAs<T>(key)) {
+    return rc;
+  }
+  return cache_->CreateCachedGraphAs<T>(key, ^mps::MPSCachedGraph*() {
+    T* newCachedGraph = nil;
+    @autoreleasepool {
+      // Initialize graph
+      auto mpsGraph = mps::make_mps_graph();
+      newCachedGraph = new T(mpsGraph);
+      instantiate(mpsGraph, newCachedGraph);
+    }
+    return newCachedGraph;
+  });
+}
+
 // Common math operations
 MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
 

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -39,7 +39,6 @@ namespace at::native {
 Tensor relu_mps(const Tensor& self) {
   using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   MPSStream* stream = getCurrentMPSStream();
 
@@ -50,26 +49,14 @@ Tensor relu_mps(const Tensor& self) {
 
   @autoreleasepool {
     string key = "relu" + getTensorsStringKey({self});
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      // passing selector of reLUWithTensor on the mpsGraph object
+      MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          // passing selector of reLUWithTensor on the mpsGraph object
-          MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, nil, false);
@@ -100,32 +87,18 @@ Tensor& relu_mps_(Tensor& self) {
     out = at::empty_like(self, MemoryFormat::Contiguous);
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "relu_" + getTensorsStringKey({self});
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      // passing selector of reLUWithTensor on the mpsGraph object
+      MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          // passing selector of reLUWithTensor on the mpsGraph object
-          MPSGraphTensor* outputTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, executeGatherOp ? out : output, nil, false);
@@ -151,41 +124,26 @@ TORCH_IMPL_FUNC(leaky_relu_out_mps)(const Tensor& self, const Scalar& negative_s
   using CachedGraph = MPSUnaryCachedGraph;
   TORCH_CHECK(output.is_mps());
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "leaky_relu" + getTensorsStringKey({self}) + ":" + to_string(negative_slope.to<double>());
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
+                                                              shape:@[ @1 ]
+                                                           dataType:getMPSDataType(self)];
+      MPSGraphTensor* negSlopeMulXTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                     secondaryTensor:negSlopeTensor
+                                                                                name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph maximumWithPrimaryTensor:negSlopeMulXTensor
+                                                        secondaryTensor:inputTensor
+                                                                   name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-          MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
-                                                                  shape:@[ @1 ]
-                                                               dataType:getMPSDataType(self)];
-          MPSGraphTensor* negSlopeMulXTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                         secondaryTensor:negSlopeTensor
-                                                                                    name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph maximumWithPrimaryTensor:negSlopeMulXTensor
-                                                            secondaryTensor:inputTensor
-                                                                       name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = tmpCachedGraph->as<CachedGraph>();
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -211,49 +169,34 @@ TORCH_IMPL_FUNC(leaky_relu_backward_out_mps)
   using CachedGraph = MPSUnaryGradCachedGraph;
   TORCH_CHECK(output.is_mps());
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key =
         "leaky_relu_backward" + getTensorsStringKey({self, grad_output}) + ":" + to_string(negative_slope.to<double>());
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
+                                                              shape:@[ @1 ]
+                                                           dataType:getMPSScalarType(self)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSScalarType(self)];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                               secondaryTensor:zeroTensor
+                                                                          name:nil];
+      MPSGraphTensor* gradientsMulNegSlopeTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
+                                                                             secondaryTensor:negSlopeTensor
+                                                                                        name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                        truePredicateTensor:gradOutputTensor
+                                                       falsePredicateTensor:gradientsMulNegSlopeTensor
+                                                                       name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-          MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
-                                                                  shape:@[ @1 ]
-                                                               dataType:getMPSScalarType(self)];
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSScalarType(self)];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                   secondaryTensor:zeroTensor
-                                                                              name:nil];
-          MPSGraphTensor* gradientsMulNegSlopeTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                                 secondaryTensor:negSlopeTensor
-                                                                                            name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                            truePredicateTensor:gradOutputTensor
-                                                           falsePredicateTensor:gradientsMulNegSlopeTensor
-                                                                           name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
@@ -281,45 +224,30 @@ TORCH_IMPL_FUNC(log_softmax_mps_out)
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "log_softmax_mps_out" + getTensorsStringKey({self}) + ":" + to_string(dim);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* maximumsTensor = [mpsGraph reductionMaximumWithTensor:inputTensor axis:dim name:nil];
+      MPSGraphTensor* inputTensorSubMax = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                                 secondaryTensor:maximumsTensor
+                                                                            name:nil];
+      MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:inputTensorSubMax name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* exponentTensorReduced = [mpsGraph reductionSumWithTensor:exponentTensor axis:dim name:nil];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced name:nil];
 
-          MPSGraphTensor* maximumsTensor = [mpsGraph reductionMaximumWithTensor:inputTensor axis:dim name:nil];
-          MPSGraphTensor* inputTensorSubMax = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                     secondaryTensor:maximumsTensor
-                                                                                name:nil];
-          MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:inputTensorSubMax name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
+                                                            secondaryTensor:logSumExpTensor
+                                                                       name:nil];
 
-          MPSGraphTensor* exponentTensorReduced = [mpsGraph reductionSumWithTensor:exponentTensor axis:dim name:nil];
-
-          MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
-                                                                secondaryTensor:logSumExpTensor
-                                                                           name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
@@ -344,42 +272,27 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "log_softmax_backward_mps_out:" + getMPSTypeString(grad_output) + ":" + to_string(dim);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:outputTensor name:nil];
+      MPSGraphTensor* sumTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axis:dim name:nil];
+      MPSGraphTensor* multiplicationTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
+                                                                       secondaryTensor:sumTensor
+                                                                                  name:nil];
+      MPSGraphTensor* resultTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
+                                                            secondaryTensor:multiplicationTensor
+                                                                       name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-          MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:outputTensor name:nil];
-          MPSGraphTensor* sumTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axis:dim name:nil];
-          MPSGraphTensor* multiplicationTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
-                                                                           secondaryTensor:sumTensor
-                                                                                      name:nil];
-          MPSGraphTensor* resultTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
-                                                                secondaryTensor:multiplicationTensor
-                                                                           name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->gradInputTensor_ = resultTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->gradInputTensor_ = resultTensor;
+    });
 
     Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -409,8 +322,6 @@ std::tuple<Tensor&, Tensor&> log_sigmoid_forward_out_mps(const Tensor& self, Ten
 
   output.resize_as_(self);
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   bool executeGatherOp =
@@ -420,34 +331,19 @@ std::tuple<Tensor&, Tensor&> log_sigmoid_forward_out_mps(const Tensor& self, Ten
 
   @autoreleasepool {
     string key = "log_sigmoid_forward_out:" + getTensorsStringKey({self});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* minTensor = [mpsGraph minimumWithPrimaryTensor:inputTensor secondaryTensor:zeroTensor name:nil];
+      MPSGraphTensor* absInputTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+      MPSGraphTensor* negAbsInputTensor = [mpsGraph negativeWithTensor:absInputTensor name:nil];
+      MPSGraphTensor* expNegAbsInputTensor = [mpsGraph exponentWithTensor:negAbsInputTensor name:nil];
+      MPSGraphTensor* outputTensor = at::native::mps::log1p(mpsGraph, expNegAbsInputTensor);
+      outputTensor = [mpsGraph subtractionWithPrimaryTensor:minTensor secondaryTensor:outputTensor name:nil];
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* minTensor = [mpsGraph minimumWithPrimaryTensor:inputTensor
-                                                         secondaryTensor:zeroTensor
-                                                                    name:nil];
-          MPSGraphTensor* absInputTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
-          MPSGraphTensor* negAbsInputTensor = [mpsGraph negativeWithTensor:absInputTensor name:nil];
-          MPSGraphTensor* expNegAbsInputTensor = [mpsGraph exponentWithTensor:negAbsInputTensor name:nil];
-          MPSGraphTensor* outputTensor = at::native::mps::log1p(mpsGraph, expNegAbsInputTensor);
-          outputTensor = [mpsGraph subtractionWithPrimaryTensor:minTensor secondaryTensor:outputTensor name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder outputPlaceholder =
@@ -490,8 +386,6 @@ Tensor& log_sigmoid_backward_mps_out(const Tensor& grad_output,
 
   grad_input.resize_as_(self);
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   bool executeGatherOp =
@@ -501,57 +395,38 @@ Tensor& log_sigmoid_backward_mps_out(const Tensor& grad_output,
 
   @autoreleasepool {
     string key = "log_sigmoid_backward_out:" + getTensorsStringKey({self, grad_output});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* negOneTensor = [mpsGraph constantWithScalar:-1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* inputNegPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                        secondaryTensor:zeroTensor
-                                                                                   name:nil];
-          MPSGraphTensor* maxDerivativeTensor = [mpsGraph selectWithPredicateTensor:inputNegPredicateTensor
-                                                                truePredicateTensor:oneTensor
-                                                               falsePredicateTensor:zeroTensor
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* negOneTensor = [mpsGraph constantWithScalar:-1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* inputNegPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                    secondaryTensor:zeroTensor
                                                                                name:nil];
-          MPSGraphTensor* signTensor = [mpsGraph selectWithPredicateTensor:inputNegPredicateTensor
-                                                       truePredicateTensor:oneTensor
-                                                      falsePredicateTensor:negOneTensor
-                                                                      name:nil];
-          MPSGraphTensor* absInputTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
-          MPSGraphTensor* negAbsInputTensor = [mpsGraph negativeWithTensor:absInputTensor name:nil];
-          MPSGraphTensor* expNegAbsInputTensor = [mpsGraph exponentWithTensor:negAbsInputTensor name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:expNegAbsInputTensor
-                                                             secondaryTensor:oneTensor
-                                                                        name:nil];
-          outputTensor = [mpsGraph divisionWithPrimaryTensor:expNegAbsInputTensor
-                                             secondaryTensor:outputTensor
-                                                        name:nil];
-          outputTensor = [mpsGraph multiplicationWithPrimaryTensor:signTensor secondaryTensor:outputTensor name:nil];
-          outputTensor = [mpsGraph subtractionWithPrimaryTensor:maxDerivativeTensor
-                                                secondaryTensor:outputTensor
-                                                           name:nil];
-          outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                   secondaryTensor:outputTensor
-                                                              name:nil];
+      MPSGraphTensor* maxDerivativeTensor = [mpsGraph selectWithPredicateTensor:inputNegPredicateTensor
+                                                            truePredicateTensor:oneTensor
+                                                           falsePredicateTensor:zeroTensor
+                                                                           name:nil];
+      MPSGraphTensor* signTensor = [mpsGraph selectWithPredicateTensor:inputNegPredicateTensor
+                                                   truePredicateTensor:oneTensor
+                                                  falsePredicateTensor:negOneTensor
+                                                                  name:nil];
+      MPSGraphTensor* absInputTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+      MPSGraphTensor* negAbsInputTensor = [mpsGraph negativeWithTensor:absInputTensor name:nil];
+      MPSGraphTensor* expNegAbsInputTensor = [mpsGraph exponentWithTensor:negAbsInputTensor name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:expNegAbsInputTensor
+                                                         secondaryTensor:oneTensor
+                                                                    name:nil];
+      outputTensor = [mpsGraph divisionWithPrimaryTensor:expNegAbsInputTensor secondaryTensor:outputTensor name:nil];
+      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:signTensor secondaryTensor:outputTensor name:nil];
+      outputTensor = [mpsGraph subtractionWithPrimaryTensor:maxDerivativeTensor secondaryTensor:outputTensor name:nil];
+      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor secondaryTensor:outputTensor name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->gradInputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->gradInputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
@@ -591,45 +466,29 @@ TORCH_IMPL_FUNC(sigmoid_backward_out_mps)(const Tensor& grad_output, const Tenso
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "sigmoid_backward_out_mps:" + getMPSTypeString(grad_output);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* oneMinusSigmoidTensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                         secondaryTensor:outputTensor
-                                                                                    name:nil];
-          MPSGraphTensor* timesTensor = [mpsGraph multiplicationWithPrimaryTensor:oneMinusSigmoidTensor
-                                                                  secondaryTensor:outputTensor
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* oneMinusSigmoidTensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
+                                                                     secondaryTensor:outputTensor
+                                                                                name:nil];
+      MPSGraphTensor* timesTensor = [mpsGraph multiplicationWithPrimaryTensor:oneMinusSigmoidTensor
+                                                              secondaryTensor:outputTensor
+                                                                         name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
+                                                                  secondaryTensor:timesTensor
                                                                              name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                      secondaryTensor:timesTensor
-                                                                                 name:nil];
 
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -657,43 +516,27 @@ TORCH_IMPL_FUNC(tanh_backward_out_mps)(const Tensor& grad_output, const Tensor& 
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "tanh_backward_out_mps:" + getMPSTypeString(grad_output);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* tanh2Tensor = [mpsGraph squareWithTensor:outputTensor name:nil];
+      MPSGraphTensor* oneMinusTanh2Tensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
+                                                                   secondaryTensor:tanh2Tensor
+                                                                              name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
+                                                                  secondaryTensor:oneMinusTanh2Tensor
+                                                                             name:nil];
 
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* tanh2Tensor = [mpsGraph squareWithTensor:outputTensor name:nil];
-          MPSGraphTensor* oneMinusTanh2Tensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                       secondaryTensor:tanh2Tensor
-                                                                                  name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                      secondaryTensor:oneMinusTanh2Tensor
-                                                                                 name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -718,51 +561,37 @@ TORCH_IMPL_FUNC(threshold_out_mps)
   using CachedGraph = MPSUnaryCachedGraph;
   TORCH_CHECK(self.is_mps());
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "threshold_out_mps" + getTensorsStringKey({self}) + ":" + to_string(threshold.to<double>()) + ":" +
         to_string(value.to<double>());
 
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-          MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                                   shape:@[ @1 ]
-                                                                dataType:getMPSDataType(self)];
-
-          MPSGraphTensor* valueTensor = [mpsGraph constantWithScalar:value.to<double>()
+      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
                                                                shape:@[ @1 ]
                                                             dataType:getMPSDataType(self)];
 
-          // x > threshold
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                   secondaryTensor:thresholdTensor
-                                                                              name:nil];
+      MPSGraphTensor* valueTensor = [mpsGraph constantWithScalar:value.to<double>()
+                                                           shape:@[ @1 ]
+                                                        dataType:getMPSDataType(self)];
 
-          // result = (self > threshold) ? self : value
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                         truePredicateTensor:inputTensor
-                                                        falsePredicateTensor:valueTensor
-                                                                        name:nil];
+      // x > threshold
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                               secondaryTensor:thresholdTensor
+                                                                          name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      // result = (self > threshold) ? self : value
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                     truePredicateTensor:inputTensor
+                                                    falsePredicateTensor:valueTensor
+                                                                    name:nil];
+
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -785,51 +614,37 @@ TORCH_IMPL_FUNC(threshold_backward_out_mps)
   TORCH_CHECK(self.is_mps());
   TORCH_CHECK(grad.is_mps());
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key =
         "threshold_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + to_string(threshold.to<double>());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
+                                                               shape:@[ @1 ]
+                                                            dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
 
-          MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                                   shape:@[ @1 ]
-                                                                dataType:getMPSDataType(self)];
+      // x > threshold
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                               secondaryTensor:thresholdTensor
+                                                                          name:nil];
 
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
+      // result = (self > threshold) ? grad : zeroTensor
+      MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                        truePredicateTensor:gradTensor
+                                                       falsePredicateTensor:zeroTensor
+                                                                       name:nil];
 
-          // x > threshold
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                   secondaryTensor:thresholdTensor
-                                                                              name:nil];
-
-          // result = (self > threshold) ? grad : zeroTensor
-          MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                            truePredicateTensor:gradTensor
-                                                           falsePredicateTensor:zeroTensor
-                                                                           name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
@@ -897,37 +712,23 @@ TORCH_IMPL_FUNC(gelu_out_mps)(const Tensor& self, c10::string_view approximate, 
   if (output.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "gelu_out_mps" + getTensorsStringKey({self}) + ":" + c10::str(approximate);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
-
-          MPSGraphTensor* outputTensor = nil;
-          if (approximate == "tanh") {
-            outputTensor = tanh(mpsGraph, inputTensor);
-          } else {
-            outputTensor = normcdf(mpsGraph, inputTensor);
-          }
-          outputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor secondaryTensor:inputTensor name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* outputTensor = nil;
+      if (approximate == "tanh") {
+        outputTensor = tanh(mpsGraph, inputTensor);
+      } else {
+        outputTensor = normcdf(mpsGraph, inputTensor);
+      }
+      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor secondaryTensor:inputTensor name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -951,96 +752,73 @@ TORCH_IMPL_FUNC(gelu_backward_out_mps)
   if (grad_input.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + c10::str(approximate);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      auto dataType = getMPSDataType(self);
 
-        @autoreleasepool {
-          auto dataType = getMPSDataType(self);
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), getMPSShape(grad));
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(self));
+      MPSGraphTensor* outputTensor = nil;
+      if (approximate == "tanh") {
+        constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * (0.5f);
+        constexpr float kKappa = 0.044715f;
+        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* kappaf = [mpsGraph constantWithScalar:kKappa shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* threef = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* x_sq = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                         secondaryTensor:inputTensor
+                                                                    name:nil];
+        MPSGraphTensor* x_cube = [mpsGraph multiplicationWithPrimaryTensor:x_sq secondaryTensor:inputTensor name:nil];
+        MPSGraphTensor* inner = [mpsGraph multiplicationWithPrimaryTensor:kappaf secondaryTensor:x_cube name:nil];
+        inner = [mpsGraph additionWithPrimaryTensor:inner secondaryTensor:inputTensor name:nil];
+        inner = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner name:nil];
+        MPSGraphTensor* tanhInner = [mpsGraph tanhWithTensor:inner name:nil];
+        MPSGraphTensor* left = [mpsGraph multiplicationWithPrimaryTensor:halff secondaryTensor:inputTensor name:nil];
+        MPSGraphTensor* right = [mpsGraph additionWithPrimaryTensor:onef secondaryTensor:tanhInner name:nil];
+        MPSGraphTensor* left_derivative = [mpsGraph multiplicationWithPrimaryTensor:halff
+                                                                    secondaryTensor:right
+                                                                               name:nil];
+        MPSGraphTensor* tanh_derivative = [mpsGraph multiplicationWithPrimaryTensor:tanhInner
+                                                                    secondaryTensor:tanhInner
+                                                                               name:nil];
+        tanh_derivative = [mpsGraph subtractionWithPrimaryTensor:onef secondaryTensor:tanh_derivative name:nil];
+        MPSGraphTensor* inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:threef
+                                                                     secondaryTensor:kappaf
+                                                                                name:nil];
+        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:inner_derivative secondaryTensor:x_sq name:nil];
+        inner_derivative = [mpsGraph additionWithPrimaryTensor:inner_derivative secondaryTensor:onef name:nil];
+        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner_derivative name:nil];
+        MPSGraphTensor* right_derivative = [mpsGraph multiplicationWithPrimaryTensor:left
+                                                                     secondaryTensor:tanh_derivative
+                                                                                name:nil];
+        right_derivative = [mpsGraph multiplicationWithPrimaryTensor:right_derivative
+                                                     secondaryTensor:inner_derivative
+                                                                name:nil];
+        outputTensor = [mpsGraph additionWithPrimaryTensor:left_derivative secondaryTensor:right_derivative name:nil];
+        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:outputTensor name:nil];
+      } else {
+        constexpr float kBeta = M_2_SQRTPI * M_SQRT1_2 * (0.5);
+        MPSGraphTensor* halff = [mpsGraph constantWithScalar:-0.5f shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
+        MPSGraphTensor* cdf = normcdf(mpsGraph, inputTensor);
+        MPSGraphTensor* pdfMul = [mpsGraph squareWithTensor:inputTensor name:nil];
+        pdfMul = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:halff name:nil];
+        pdfMul = [mpsGraph exponentWithTensor:pdfMul name:nil];
+        MPSGraphTensor* pdf = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:betaf name:nil];
+        pdf = [mpsGraph multiplicationWithPrimaryTensor:inputTensor secondaryTensor:pdf name:nil];
+        pdf = [mpsGraph additionWithPrimaryTensor:pdf secondaryTensor:cdf name:nil];
+        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:pdf name:nil];
+      }
 
-          MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), getMPSShape(grad));
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(self));
-          MPSGraphTensor* outputTensor = nil;
-          if (approximate == "tanh") {
-            constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * (0.5f);
-            constexpr float kKappa = 0.044715f;
-            MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* kappaf = [mpsGraph constantWithScalar:kKappa shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* threef = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* x_sq = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                             secondaryTensor:inputTensor
-                                                                        name:nil];
-            MPSGraphTensor* x_cube = [mpsGraph multiplicationWithPrimaryTensor:x_sq
-                                                               secondaryTensor:inputTensor
-                                                                          name:nil];
-            MPSGraphTensor* inner = [mpsGraph multiplicationWithPrimaryTensor:kappaf secondaryTensor:x_cube name:nil];
-            inner = [mpsGraph additionWithPrimaryTensor:inner secondaryTensor:inputTensor name:nil];
-            inner = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner name:nil];
-            MPSGraphTensor* tanhInner = [mpsGraph tanhWithTensor:inner name:nil];
-            MPSGraphTensor* left = [mpsGraph multiplicationWithPrimaryTensor:halff
-                                                             secondaryTensor:inputTensor
-                                                                        name:nil];
-            MPSGraphTensor* right = [mpsGraph additionWithPrimaryTensor:onef secondaryTensor:tanhInner name:nil];
-            MPSGraphTensor* left_derivative = [mpsGraph multiplicationWithPrimaryTensor:halff
-                                                                        secondaryTensor:right
-                                                                                   name:nil];
-            MPSGraphTensor* tanh_derivative = [mpsGraph multiplicationWithPrimaryTensor:tanhInner
-                                                                        secondaryTensor:tanhInner
-                                                                                   name:nil];
-            tanh_derivative = [mpsGraph subtractionWithPrimaryTensor:onef secondaryTensor:tanh_derivative name:nil];
-            MPSGraphTensor* inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:threef
-                                                                         secondaryTensor:kappaf
-                                                                                    name:nil];
-            inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:inner_derivative
-                                                         secondaryTensor:x_sq
-                                                                    name:nil];
-            inner_derivative = [mpsGraph additionWithPrimaryTensor:inner_derivative secondaryTensor:onef name:nil];
-            inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:betaf
-                                                         secondaryTensor:inner_derivative
-                                                                    name:nil];
-            MPSGraphTensor* right_derivative = [mpsGraph multiplicationWithPrimaryTensor:left
-                                                                         secondaryTensor:tanh_derivative
-                                                                                    name:nil];
-            right_derivative = [mpsGraph multiplicationWithPrimaryTensor:right_derivative
-                                                         secondaryTensor:inner_derivative
-                                                                    name:nil];
-            outputTensor = [mpsGraph additionWithPrimaryTensor:left_derivative
-                                               secondaryTensor:right_derivative
-                                                          name:nil];
-            outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:outputTensor name:nil];
-          } else {
-            constexpr float kBeta = M_2_SQRTPI * M_SQRT1_2 * (0.5);
-            MPSGraphTensor* halff = [mpsGraph constantWithScalar:-0.5f shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-            MPSGraphTensor* cdf = normcdf(mpsGraph, inputTensor);
-            MPSGraphTensor* pdfMul = [mpsGraph squareWithTensor:inputTensor name:nil];
-            pdfMul = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:halff name:nil];
-            pdfMul = [mpsGraph exponentWithTensor:pdfMul name:nil];
-            MPSGraphTensor* pdf = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:betaf name:nil];
-            pdf = [mpsGraph multiplicationWithPrimaryTensor:inputTensor secondaryTensor:pdf name:nil];
-            pdf = [mpsGraph additionWithPrimaryTensor:pdf secondaryTensor:cdf name:nil];
-            outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:pdf name:nil];
-          }
-
-          newCachedGraph->gradOutputTensor_ = gradTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = outputTensor;
+    });
 
     Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
@@ -1079,69 +857,55 @@ void elu_variants_out_mps(const Tensor& self,
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = func_name + ":" + getTensorsStringKey({self}) + ":" + to_string(alpha.to<double>()) + ":" +
         to_string(scale.to<double>()) + ":" + to_string(input_scale.to<double>());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // scale * (max(0, x) + min(0, alpha * (exp(input_scale * x) - 1) ))
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
+                                                           shape:@[ @1 ]
+                                                        dataType:getMPSDataType(self)];
 
-          // scale * (max(0, x) + min(0, alpha * (exp(input_scale * x) - 1) ))
+      MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
+                                                                shape:@[ @1 ]
+                                                             dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
+      MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
+                                                           shape:@[ @1 ]
+                                                        dataType:getMPSDataType(self)];
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
-                                                                    shape:@[ @1 ]
-                                                                 dataType:getMPSDataType(self)];
-
-          MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
-
-          MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                        secondaryTensor:inputScaleTensor
-                                                                                   name:nil];
-          MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:scaledInputTensor name:nil];
-          MPSGraphTensor* exponentMinusOneTensor = [mpsGraph subtractionWithPrimaryTensor:exponentTensor
-                                                                          secondaryTensor:unitTensor
-                                                                                     name:nil];
-          MPSGraphTensor* alphaTimesTensor = [mpsGraph multiplicationWithPrimaryTensor:exponentMinusOneTensor
-                                                                       secondaryTensor:alphaTensor
-                                                                                  name:nil];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                   secondaryTensor:zeroTensor
+      MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                    secondaryTensor:inputScaleTensor
+                                                                               name:nil];
+      MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:scaledInputTensor name:nil];
+      MPSGraphTensor* exponentMinusOneTensor = [mpsGraph subtractionWithPrimaryTensor:exponentTensor
+                                                                      secondaryTensor:unitTensor
+                                                                                 name:nil];
+      MPSGraphTensor* alphaTimesTensor = [mpsGraph multiplicationWithPrimaryTensor:exponentMinusOneTensor
+                                                                   secondaryTensor:alphaTensor
                                                                               name:nil];
-          MPSGraphTensor* fusedOutput = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                        truePredicateTensor:inputTensor
-                                                       falsePredicateTensor:alphaTimesTensor
-                                                                       name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:fusedOutput
-                                                                   secondaryTensor:scaleTensor
-                                                                              name:nil];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                               secondaryTensor:zeroTensor
+                                                                          name:nil];
+      MPSGraphTensor* fusedOutput = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                    truePredicateTensor:inputTensor
+                                                   falsePredicateTensor:alphaTimesTensor
+                                                                   name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:fusedOutput
+                                                               secondaryTensor:scaleTensor
+                                                                          name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder outputPlaceholder =
@@ -1190,8 +954,6 @@ TORCH_IMPL_FUNC(elu_backward_out_mps)
     return;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -1199,75 +961,63 @@ TORCH_IMPL_FUNC(elu_backward_out_mps)
         to_string(alpha.to<double>()) + ":" + to_string(scale.to<double>()) + ":" +
         to_string(input_scale.to<double>()) + ":" + to_string(is_result);
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* selfOrResultTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_or_result);
+      MPSGraphTensor* lessThanZeroGradTensor = nil;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* selfOrResultTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_or_result);
-          MPSGraphTensor* lessThanZeroGradTensor = nil;
-
-          if (is_result) {
-            MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
-                                                                 shape:@[ @1 ]
-                                                              dataType:getMPSDataType(grad_output)];
-            MPSGraphTensor* resultPlusAlphaTensor = [mpsGraph additionWithPrimaryTensor:selfOrResultTensor
-                                                                        secondaryTensor:alphaTensor
-                                                                                   name:nil];
-            auto constMul = scale.to<double>() * input_scale.to<double>();
-            MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
-                                                                    shape:@[ @1 ]
-                                                                 dataType:getMPSDataType(grad_output)];
-            lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:resultPlusAlphaTensor
-                                                               secondaryTensor:constMulTensor
-                                                                          name:nil];
-          } else {
-            MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
-                                                                      shape:@[ @1 ]
-                                                                   dataType:getMPSDataType(grad_output)];
-            MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:selfOrResultTensor
-                                                                          secondaryTensor:inputScaleTensor
-                                                                                     name:nil];
-            MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:scaledInputTensor name:nil];
-            auto constMul = scale.to<double>() * input_scale.to<double>() * alpha.to<double>();
-            MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
-                                                                    shape:@[ @1 ]
-                                                                 dataType:getMPSDataType(grad_output)];
-            lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
-                                                               secondaryTensor:constMulTensor
-                                                                          name:nil];
-          }
-
-          MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:selfOrResultTensor
-                                                                   secondaryTensor:zeroTensor
-                                                                              name:nil];
-          MPSGraphTensor* gradTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                       truePredicateTensor:scaleTensor
-                                                      falsePredicateTensor:lessThanZeroGradTensor
+      if (is_result) {
+        MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
+                                                             shape:@[ @1 ]
+                                                          dataType:getMPSDataType(grad_output)];
+        MPSGraphTensor* resultPlusAlphaTensor = [mpsGraph additionWithPrimaryTensor:selfOrResultTensor
+                                                                    secondaryTensor:alphaTensor
+                                                                               name:nil];
+        auto constMul = scale.to<double>() * input_scale.to<double>();
+        MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
+                                                                shape:@[ @1 ]
+                                                             dataType:getMPSDataType(grad_output)];
+        lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:resultPlusAlphaTensor
+                                                           secondaryTensor:constMulTensor
                                                                       name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
-                                                                      secondaryTensor:gradOutputTensor
+      } else {
+        MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
+                                                                  shape:@[ @1 ]
+                                                               dataType:getMPSDataType(grad_output)];
+        MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:selfOrResultTensor
+                                                                      secondaryTensor:inputScaleTensor
                                                                                  name:nil];
+        MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:scaledInputTensor name:nil];
+        auto constMul = scale.to<double>() * input_scale.to<double>() * alpha.to<double>();
+        MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
+                                                                shape:@[ @1 ]
+                                                             dataType:getMPSDataType(grad_output)];
+        lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
+                                                           secondaryTensor:constMulTensor
+                                                                      name:nil];
+      }
 
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = selfOrResultTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
+                                                           shape:@[ @1 ]
+                                                        dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:selfOrResultTensor
+                                                               secondaryTensor:zeroTensor
+                                                                          name:nil];
+      MPSGraphTensor* gradTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                   truePredicateTensor:scaleTensor
+                                                  falsePredicateTensor:lessThanZeroGradTensor
+                                                                  name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
+
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = selfOrResultTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output, nil, executeGatherOp);
     Placeholder selfOrResultPlaceholder = Placeholder(cachedGraph->inputTensor_, self_or_result, nil, executeGatherOp);
@@ -1306,40 +1056,25 @@ TORCH_IMPL_FUNC(glu_out_mps)(const Tensor& self, const int64_t dim, const Tensor
   const int64_t nIn = self.size(wrap_dim);
   TORCH_CHECK(nIn % 2 == 0, "Halving dimension must be even, but dimension ", wrap_dim, " is size ", nIn);
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "glu_out_mps" + getTensorsStringKey({self}) + ":" + to_string(dim);
-    ;
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
+      NSArray<MPSGraphTensor*>* outputTensorsArray = [mpsGraph splitTensor:inputTensor
+                                                                 numSplits:2
+                                                                      axis:wrap_dim
+                                                                      name:nil];
+      MPSGraphTensor* firstHalf = outputTensorsArray[0];
+      MPSGraphTensor* secondHalf = [mpsGraph sigmoidWithTensor:outputTensorsArray[1] name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
-          NSArray<MPSGraphTensor*>* outputTensorsArray = [mpsGraph splitTensor:inputTensor
-                                                                     numSplits:2
-                                                                          axis:wrap_dim
+      MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:firstHalf
+                                                               secondaryTensor:secondHalf
                                                                           name:nil];
-          MPSGraphTensor* firstHalf = outputTensorsArray[0];
-          MPSGraphTensor* secondHalf = [mpsGraph sigmoidWithTensor:outputTensorsArray[1] name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:firstHalf
-                                                                   secondaryTensor:secondHalf
-                                                                              name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -1368,63 +1103,49 @@ Tensor& glu_backward_mps_out(const Tensor& grad_output, const Tensor& self, cons
   const int64_t nIn = self.size(wrap_dim);
   TORCH_CHECK(nIn % 2 == 0, "Halving dimension must be even, but dimension ", wrap_dim, " is size ", nIn);
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "glu_backward_mps_out" + getTensorsStringKey({grad_output, self}) + ":" + to_string(dim);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_output), getMPSShape(grad_output));
+      NSArray<MPSGraphTensor*>* inputTensorsArray = [mpsGraph splitTensor:inputTensor
+                                                                numSplits:2
+                                                                     axis:wrap_dim
+                                                                     name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // first half
+      MPSGraphTensor* sigmoidOutputTensor = [mpsGraph sigmoidWithTensor:inputTensorsArray[1] name:nil];
+      MPSGraphTensor* firstHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:sigmoidOutputTensor
+                                                                        secondaryTensor:gradOutputTensor
+                                                                                   name:nil];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
-          MPSGraphTensor* gradOutputTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_output), getMPSShape(grad_output));
-          NSArray<MPSGraphTensor*>* inputTensorsArray = [mpsGraph splitTensor:inputTensor
-                                                                    numSplits:2
-                                                                         axis:wrap_dim
-                                                                         name:nil];
+      // second half
+      MPSGraphTensor* one_val = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
 
-          // first half
-          MPSGraphTensor* sigmoidOutputTensor = [mpsGraph sigmoidWithTensor:inputTensorsArray[1] name:nil];
-          MPSGraphTensor* firstHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:sigmoidOutputTensor
-                                                                            secondaryTensor:gradOutputTensor
-                                                                                       name:nil];
+      MPSGraphTensor* secondHalfOutputTensor = [mpsGraph subtractionWithPrimaryTensor:one_val
+                                                                      secondaryTensor:sigmoidOutputTensor
+                                                                                 name:nil];
+      secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
+                                                         secondaryTensor:sigmoidOutputTensor
+                                                                    name:nil];
+      secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
+                                                         secondaryTensor:inputTensorsArray[0]
+                                                                    name:nil];
+      secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
+                                                         secondaryTensor:gradOutputTensor
+                                                                    name:nil];
 
-          // second half
-          MPSGraphTensor* one_val = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-
-          MPSGraphTensor* secondHalfOutputTensor = [mpsGraph subtractionWithPrimaryTensor:one_val
-                                                                          secondaryTensor:sigmoidOutputTensor
-                                                                                     name:nil];
-          secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
-                                                             secondaryTensor:sigmoidOutputTensor
-                                                                        name:nil];
-          secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
-                                                             secondaryTensor:inputTensorsArray[0]
-                                                                        name:nil];
-          secondHalfOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:secondHalfOutputTensor
-                                                             secondaryTensor:gradOutputTensor
-                                                                        name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph concatTensor:firstHalfOutputTensor
-                                                     withTensor:secondHalfOutputTensor
-                                                      dimension:wrap_dim
-                                                           name:nil];
-          newCachedGraph->gradInputTensor_ = outputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* outputTensor = [mpsGraph concatTensor:firstHalfOutputTensor
+                                                 withTensor:secondHalfOutputTensor
+                                                  dimension:wrap_dim
+                                                       name:nil];
+      newCachedGraph->gradInputTensor_ = outputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+    });
 
     Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
@@ -1471,8 +1192,6 @@ TORCH_IMPL_FUNC(softplus_out_mps)
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
   MPSScalar beta_scalar = getMPSScalar(beta, ScalarType::Float);
   MPSScalar threshold_scalar = getMPSScalar(threshold, ScalarType::Float);
@@ -1481,48 +1200,37 @@ TORCH_IMPL_FUNC(softplus_out_mps)
     string key = "softplus_out_mps:" + getTensorsStringKey({self}) + ":" + std::to_string(beta.to<double>()) + ":" +
         std::to_string(threshold.to<double>());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* betaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSDataType(ScalarType::Float));
 
-          MPSGraphTensor* betaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSDataType(ScalarType::Float));
+      MPSGraphTensor* thresholdTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSDataType(ScalarType::Float));
 
-          MPSGraphTensor* thresholdTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSDataType(ScalarType::Float));
+      MPSGraphTensor* reluTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
 
-          MPSGraphTensor* reluTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-
-          MPSGraphTensor* reciprocalBetaTensor = [mpsGraph reciprocalWithTensor:betaTensor name:nil];
-          MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:betaTensor
+      MPSGraphTensor* reciprocalBetaTensor = [mpsGraph reciprocalWithTensor:betaTensor name:nil];
+      MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                           secondaryTensor:betaTensor
+                                                                      name:nil];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
+                                                               secondaryTensor:thresholdTensor
                                                                           name:nil];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
-                                                                   secondaryTensor:thresholdTensor
-                                                                              name:nil];
-          MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
-          MPSGraphTensor* log1pTensor = at::native::mps::log1p(mpsGraph, expTensor);
-          MPSGraphTensor* softplusTensor = [mpsGraph multiplicationWithPrimaryTensor:log1pTensor
-                                                                     secondaryTensor:reciprocalBetaTensor
-                                                                                name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                         truePredicateTensor:reluTensor
-                                                        falsePredicateTensor:softplusTensor
-                                                                        name:nil];
+      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
+      MPSGraphTensor* log1pTensor = at::native::mps::log1p(mpsGraph, expTensor);
+      MPSGraphTensor* softplusTensor = [mpsGraph multiplicationWithPrimaryTensor:log1pTensor
+                                                                 secondaryTensor:reciprocalBetaTensor
+                                                                            name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                     truePredicateTensor:reluTensor
+                                                    falsePredicateTensor:softplusTensor
+                                                                    name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->betaTensor_ = betaTensor;
-          newCachedGraph->thresholdTensor_ = thresholdTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->betaTensor_ = betaTensor;
+      newCachedGraph->thresholdTensor_ = thresholdTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
 
@@ -1559,60 +1267,47 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "softplus_backward_out_mps:" + getTensorsStringKey({grad_output, self}) + ":" +
         std::to_string(beta.to<double>()) + ":" + std::to_string(threshold.to<double>());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* betaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(ScalarType::Float));
 
-          MPSGraphTensor* betaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(ScalarType::Float));
+      MPSGraphTensor* thresholdTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(ScalarType::Float));
 
-          MPSGraphTensor* thresholdTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(ScalarType::Float));
-
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:betaTensor
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                           secondaryTensor:betaTensor
+                                                                      name:nil];
+      MPSGraphTensor* expBxTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
+      MPSGraphTensor* unitExpBxTensor = [mpsGraph additionWithPrimaryTensor:expBxTensor
+                                                            secondaryTensor:unitTensor
+                                                                       name:nil];
+      MPSGraphTensor* rTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
+                                                          secondaryTensor:expBxTensor
+                                                                     name:nil];
+      rTensor = [mpsGraph divisionWithPrimaryTensor:rTensor secondaryTensor:unitExpBxTensor name:nil];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
+                                                               secondaryTensor:thresholdTensor
                                                                           name:nil];
-          MPSGraphTensor* expBxTensor = [mpsGraph exponentWithTensor:bxTensor name:nil];
-          MPSGraphTensor* unitExpBxTensor = [mpsGraph additionWithPrimaryTensor:expBxTensor
-                                                                secondaryTensor:unitTensor
-                                                                           name:nil];
-          MPSGraphTensor* rTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                              secondaryTensor:expBxTensor
-                                                                         name:nil];
-          rTensor = [mpsGraph divisionWithPrimaryTensor:rTensor secondaryTensor:unitExpBxTensor name:nil];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:bxTensor
-                                                                   secondaryTensor:thresholdTensor
-                                                                              name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                         truePredicateTensor:gradOutputTensor
-                                                        falsePredicateTensor:rTensor
-                                                                        name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                     truePredicateTensor:gradOutputTensor
+                                                    falsePredicateTensor:rTensor
+                                                                    name:nil];
 
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->betaTensor_ = betaTensor;
-          newCachedGraph->thresholdTensor_ = thresholdTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->betaTensor_ = betaTensor;
+      newCachedGraph->thresholdTensor_ = thresholdTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder gradInputPlaceholder = Placeholder(cachedGraph->outputTensor_, grad_input);
@@ -1647,49 +1342,34 @@ Tensor prelu_mps(const Tensor& self, const Tensor& weight_) {
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "prelu_mps:" + getTensorsStringKey({self, weight_});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_);
 
-          MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* reluTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
+      MPSGraphTensor* predicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                            secondaryTensor:zeroTensor
+                                                                       name:nil];
+      MPSGraphTensor* weightedTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                       truePredicateTensor:inputTensor
+                                                      falsePredicateTensor:zeroTensor
+                                                                      name:nil];
+      weightedTensor = [mpsGraph multiplicationWithPrimaryTensor:weightedTensor secondaryTensor:weightTensor name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:reluTensor
+                                                         secondaryTensor:weightedTensor
+                                                                    name:nil];
 
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* reluTensor = [mpsGraph reLUWithTensor:inputTensor name:nil];
-          MPSGraphTensor* predicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                secondaryTensor:zeroTensor
-                                                                           name:nil];
-          MPSGraphTensor* weightedTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                           truePredicateTensor:inputTensor
-                                                          falsePredicateTensor:zeroTensor
-                                                                          name:nil];
-          weightedTensor = [mpsGraph multiplicationWithPrimaryTensor:weightedTensor
-                                                     secondaryTensor:weightTensor
-                                                                name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:reluTensor
-                                                             secondaryTensor:weightedTensor
-                                                                        name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -1724,56 +1404,42 @@ std::tuple<Tensor, Tensor> prelu_backward_mps(const Tensor& grad_output, const T
     MPSGraphTensor* weightedGradTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "prelu_backward_mps:" + getTensorsStringKey({grad_output, self, weight_});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-          MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_);
-
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* weightedGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:weightTensor
-                                                                               secondaryTensor:gradOutputTensor
-                                                                                          name:nil];
-          MPSGraphTensor* inputGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                            secondaryTensor:gradOutputTensor
-                                                                                       name:nil];
-          MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                   secondaryTensor:zeroTensor
-                                                                              name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                         truePredicateTensor:gradOutputTensor
-                                                        falsePredicateTensor:weightedGradOutputTensor
-                                                                        name:nil];
-          MPSGraphTensor* weightedGradTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                               truePredicateTensor:zeroTensor
-                                                              falsePredicateTensor:inputGradOutputTensor
-                                                                              name:nil];
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->weightedGradTensor_ = weightedGradTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* weightedGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:weightTensor
+                                                                           secondaryTensor:gradOutputTensor
+                                                                                      name:nil];
+      MPSGraphTensor* inputGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                        secondaryTensor:gradOutputTensor
+                                                                                   name:nil];
+      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                               secondaryTensor:zeroTensor
+                                                                          name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                     truePredicateTensor:gradOutputTensor
+                                                    falsePredicateTensor:weightedGradOutputTensor
+                                                                    name:nil];
+      MPSGraphTensor* weightedGradTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
+                                                           truePredicateTensor:zeroTensor
+                                                          falsePredicateTensor:inputGradOutputTensor
+                                                                          name:nil];
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->weightedGradTensor_ = weightedGradTensor;
+    });
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_);
@@ -1805,41 +1471,27 @@ TORCH_IMPL_FUNC(silu_out_mps)(const Tensor& self, const Tensor& result) {
   if (result.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "silu_out_mps:" + getTensorsStringKey({self});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor name:nil];
-          MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput name:nil];
-          MPSGraphTensor* expPlusOneTensor = [mpsGraph additionWithPrimaryTensor:expNegativeTensor
-                                                                 secondaryTensor:unitTensor
-                                                                            name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph divisionWithPrimaryTensor:inputTensor
-                                                             secondaryTensor:expPlusOneTensor
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor name:nil];
+      MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput name:nil];
+      MPSGraphTensor* expPlusOneTensor = [mpsGraph additionWithPrimaryTensor:expNegativeTensor
+                                                             secondaryTensor:unitTensor
                                                                         name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph divisionWithPrimaryTensor:inputTensor
+                                                         secondaryTensor:expPlusOneTensor
+                                                                    name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -1865,58 +1517,42 @@ TORCH_IMPL_FUNC(silu_backward_out_mps)
   if (grad_input.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "silu_out_backward_mps:" + getTensorsStringKey({grad_output});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor name:nil];
-          MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput name:nil];
-          MPSGraphTensor* expPlusOneTensor = [mpsGraph additionWithPrimaryTensor:expNegativeTensor
-                                                                 secondaryTensor:unitTensor
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor name:nil];
+      MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput name:nil];
+      MPSGraphTensor* expPlusOneTensor = [mpsGraph additionWithPrimaryTensor:expNegativeTensor
+                                                             secondaryTensor:unitTensor
+                                                                        name:nil];
+      MPSGraphTensor* sigmoidTensor = [mpsGraph reciprocalWithTensor:expPlusOneTensor name:nil];
+      MPSGraphTensor* oneMinusSigmoid = [mpsGraph subtractionWithPrimaryTensor:unitTensor
+                                                               secondaryTensor:sigmoidTensor
+                                                                          name:nil];
+      MPSGraphTensor* inputTimesDiff = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                 secondaryTensor:oneMinusSigmoid
                                                                             name:nil];
-          MPSGraphTensor* sigmoidTensor = [mpsGraph reciprocalWithTensor:expPlusOneTensor name:nil];
-          MPSGraphTensor* oneMinusSigmoid = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                   secondaryTensor:sigmoidTensor
-                                                                              name:nil];
-          MPSGraphTensor* inputTimesDiff = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                     secondaryTensor:oneMinusSigmoid
-                                                                                name:nil];
-          MPSGraphTensor* onePlusTensor = [mpsGraph additionWithPrimaryTensor:unitTensor
-                                                              secondaryTensor:inputTimesDiff
-                                                                         name:nil];
-          MPSGraphTensor* gradTensor = [mpsGraph multiplicationWithPrimaryTensor:sigmoidTensor
-                                                                 secondaryTensor:onePlusTensor
-                                                                            name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
-                                                                      secondaryTensor:gradOutputTensor
-                                                                                 name:nil];
+      MPSGraphTensor* onePlusTensor = [mpsGraph additionWithPrimaryTensor:unitTensor
+                                                          secondaryTensor:inputTimesDiff
+                                                                     name:nil];
+      MPSGraphTensor* gradTensor = [mpsGraph multiplicationWithPrimaryTensor:sigmoidTensor
+                                                             secondaryTensor:onePlusTensor
+                                                                        name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
 
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
@@ -1945,42 +1581,28 @@ TORCH_IMPL_FUNC(hardsigmoid_out_mps)(const Tensor& self, const Tensor& result) {
   if (result.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "hardsigmoid_out_mps:" + getTensorsStringKey({self});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* sixTensor = [mpsGraph constantWithScalar:6.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* inputPlusThreeTensor = [mpsGraph additionWithPrimaryTensor:inputTensor
+                                                                 secondaryTensor:threeTensor
+                                                                            name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* sixTensor = [mpsGraph constantWithScalar:6.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* inputPlusThreeTensor = [mpsGraph additionWithPrimaryTensor:inputTensor
-                                                                     secondaryTensor:threeTensor
-                                                                                name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph clampWithTensor:inputPlusThreeTensor
-                                                    minValueTensor:zeroTensor
-                                                    maxValueTensor:sixTensor
-                                                              name:nil];
-          outputTensor = [mpsGraph divisionWithPrimaryTensor:outputTensor secondaryTensor:sixTensor name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* outputTensor = [mpsGraph clampWithTensor:inputPlusThreeTensor
+                                                minValueTensor:zeroTensor
+                                                maxValueTensor:sixTensor
+                                                          name:nil];
+      outputTensor = [mpsGraph divisionWithPrimaryTensor:outputTensor secondaryTensor:sixTensor name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -2006,55 +1628,41 @@ TORCH_IMPL_FUNC(hardsigmoid_backward_out_mps)
   if (grad_input.numel() == 0)
     return;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "hardsigmoid_backward_out_mps:" + getTensorsStringKey({self});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* highTensor = [mpsGraph constantWithScalar:3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:-3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* oneSixTensor = [mpsGraph constantWithScalar:1.0 / 6.0
+                                                            shape:@[ @1 ]
+                                                         dataType:getMPSDataType(self)];
+      MPSGraphTensor* inputLessThanHighPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                             secondaryTensor:highTensor
+                                                                                        name:nil];
+      MPSGraphTensor* inputGreaterThanLowPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                                                  secondaryTensor:lowTensor
+                                                                                             name:nil];
+      MPSGraphTensor* inIntervalTensor = [mpsGraph logicalANDWithPrimaryTensor:inputLessThanHighPredicateTensor
+                                                               secondaryTensor:inputGreaterThanLowPredicateTensor
+                                                                          name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
+                                                               secondaryTensor:oneSixTensor
+                                                                          name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* highTensor = [mpsGraph constantWithScalar:3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:-3.0 shape:@[ @1 ] dataType:getMPSDataType(self)];
-          MPSGraphTensor* oneSixTensor = [mpsGraph constantWithScalar:1.0 / 6.0
-                                                                shape:@[ @1 ]
-                                                             dataType:getMPSDataType(self)];
-          MPSGraphTensor* inputLessThanHighPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                                 secondaryTensor:highTensor
-                                                                                            name:nil];
-          MPSGraphTensor* inputGreaterThanLowPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                                      secondaryTensor:lowTensor
-                                                                                                 name:nil];
-          MPSGraphTensor* inIntervalTensor = [mpsGraph logicalANDWithPrimaryTensor:inputLessThanHighPredicateTensor
-                                                                   secondaryTensor:inputGreaterThanLowPredicateTensor
-                                                                              name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                   secondaryTensor:oneSixTensor
-                                                                              name:nil];
-
-          outputTensor = [mpsGraph selectWithPredicateTensor:inIntervalTensor
-                                         truePredicateTensor:outputTensor
-                                        falsePredicateTensor:zeroTensor
-                                                        name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->gradInputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      outputTensor = [mpsGraph selectWithPredicateTensor:inIntervalTensor
+                                     truePredicateTensor:outputTensor
+                                    falsePredicateTensor:zeroTensor
+                                                    name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->gradInputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
@@ -2097,68 +1705,54 @@ Tensor& hardtanh_backward_out_mps(const Tensor& grad_output,
   if (grad_input.numel() == 0)
     return grad_input;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "hardtanh_backward_out_mps:" + getTensorsStringKey({grad_output}) + ":" + to_string(min.to<double>()) +
         ":" + to_string(max.to<double>());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-          // TODO: Compute gradient
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min.to<double>()
-                                                             shape:@[ @1 ]
-                                                          dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
-                                                             shape:@[ @1 ]
-                                                          dataType:getMPSDataType(grad_output)];
-          MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                                 secondaryTensor:maxTensor
-                                                                                            name:nil];
-          MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                             secondaryTensor:minTensor
+      // TODO: Compute gradient
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min.to<double>()
+                                                         shape:@[ @1 ]
+                                                      dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
+                                                         shape:@[ @1 ]
+                                                      dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                                             secondaryTensor:maxTensor
                                                                                         name:nil];
-          MPSGraphTensor* greaterThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
-                                                                     truePredicateTensor:zeroTensor
-                                                                    falsePredicateTensor:unitTensor
+      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                         secondaryTensor:minTensor
                                                                                     name:nil];
-          MPSGraphTensor* lesserThanMinGradTensor = [mpsGraph selectWithPredicateTensor:lesserThanMinPredicateTensor
-                                                                    truePredicateTensor:zeroTensor
-                                                                   falsePredicateTensor:unitTensor
-                                                                                   name:nil];
-          MPSGraphTensor* gradTensor = [mpsGraph multiplicationWithPrimaryTensor:greaterThanMaxGradTensor
-                                                                 secondaryTensor:lesserThanMinGradTensor
-                                                                            name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
-                                                                      secondaryTensor:gradOutputTensor
-                                                                                 name:nil];
+      MPSGraphTensor* greaterThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
+                                                                 truePredicateTensor:zeroTensor
+                                                                falsePredicateTensor:unitTensor
+                                                                                name:nil];
+      MPSGraphTensor* lesserThanMinGradTensor = [mpsGraph selectWithPredicateTensor:lesserThanMinPredicateTensor
+                                                                truePredicateTensor:zeroTensor
+                                                               falsePredicateTensor:unitTensor
+                                                                               name:nil];
+      MPSGraphTensor* gradTensor = [mpsGraph multiplicationWithPrimaryTensor:greaterThanMaxGradTensor
+                                                             secondaryTensor:lesserThanMinGradTensor
+                                                                        name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
 
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
@@ -2194,67 +1788,55 @@ Tensor& hardswish_out_mps(const Tensor& self, Tensor& output) {
     out = at::empty_like(output, MemoryFormat::Contiguous);
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "hardswish_out_mps" + getTensorsStringKey({self});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* negativeThreeTensor = [mpsGraph constantWithScalar:-3.0f
-                                                                       shape:@[ @1 ]
-                                                                    dataType:getMPSDataType(self)];
+      MPSGraphTensor* negativeThreeTensor = [mpsGraph constantWithScalar:-3.0f
+                                                                   shape:@[ @1 ]
+                                                                dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* sixTensor = [mpsGraph constantWithScalar:6.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
+      MPSGraphTensor* sixTensor = [mpsGraph constantWithScalar:6.0f shape:@[ @1 ] dataType:getMPSDataType(self)];
 
-          MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
-                                                                                    secondaryTensor:negativeThreeTensor
-                                                                                               name:nil];
+      MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                secondaryTensor:negativeThreeTensor
+                                                                                           name:nil];
 
-          MPSGraphTensor* lessThanMaxPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                           secondaryTensor:threeTensor
-                                                                                      name:nil];
+      MPSGraphTensor* lessThanMaxPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                       secondaryTensor:threeTensor
+                                                                                  name:nil];
 
-          MPSGraphTensor* inputPlusThreeTensor = [mpsGraph additionWithPrimaryTensor:inputTensor
-                                                                     secondaryTensor:threeTensor
-                                                                                name:nil];
+      MPSGraphTensor* inputPlusThreeTensor = [mpsGraph additionWithPrimaryTensor:inputTensor
+                                                                 secondaryTensor:threeTensor
+                                                                            name:nil];
 
-          MPSGraphTensor* inputDivSixTensor = [mpsGraph divisionWithPrimaryTensor:inputPlusThreeTensor
-                                                                  secondaryTensor:sixTensor
-                                                                             name:nil];
+      MPSGraphTensor* inputDivSixTensor = [mpsGraph divisionWithPrimaryTensor:inputPlusThreeTensor
+                                                              secondaryTensor:sixTensor
+                                                                         name:nil];
 
-          MPSGraphTensor* weightedTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                     secondaryTensor:inputDivSixTensor
-                                                                                name:nil];
+      MPSGraphTensor* weightedTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                 secondaryTensor:inputDivSixTensor
+                                                                            name:nil];
 
-          MPSGraphTensor* tempTensor = [mpsGraph selectWithPredicateTensor:lessThanMaxPredicateTensor
-                                                       truePredicateTensor:weightedTensor
-                                                      falsePredicateTensor:inputTensor
-                                                                      name:nil];
+      MPSGraphTensor* tempTensor = [mpsGraph selectWithPredicateTensor:lessThanMaxPredicateTensor
+                                                   truePredicateTensor:weightedTensor
+                                                  falsePredicateTensor:inputTensor
+                                                                  name:nil];
 
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:lessThanMinPredicateTensor
-                                                         truePredicateTensor:zeroTensor
-                                                        falsePredicateTensor:tempTensor
-                                                                        name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:lessThanMinPredicateTensor
+                                                     truePredicateTensor:zeroTensor
+                                                    falsePredicateTensor:tempTensor
+                                                                    name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
     Placeholder outputPlaceholder =
         Placeholder(cachedGraph->outputTensor_, out.has_storage() ? out : output, nil, false);
@@ -2297,76 +1879,65 @@ Tensor hardswish_backward_mps(const Tensor& grad_output, const Tensor& self) {
     return grad_input;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "hardswish_backward_mps" + getTensorsStringKey({self});
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
 
-          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
 
-          MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0f
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0f
+                                                           shape:@[ @1 ]
+                                                        dataType:getMPSDataType(grad_output)];
 
-          MPSGraphTensor* negativeThreeTensor = [mpsGraph constantWithScalar:-3.0f
-                                                                       shape:@[ @1 ]
-                                                                    dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* negativeThreeTensor = [mpsGraph constantWithScalar:-3.0f
+                                                                   shape:@[ @1 ]
+                                                                dataType:getMPSDataType(grad_output)];
 
-          MPSGraphTensor* halfTensor = [mpsGraph constantWithScalar:0.5f
-                                                              shape:@[ @1 ]
-                                                           dataType:getMPSDataType(grad_output)];
+      MPSGraphTensor* halfTensor = [mpsGraph constantWithScalar:0.5f
+                                                          shape:@[ @1 ]
+                                                       dataType:getMPSDataType(grad_output)];
 
-          MPSGraphTensor* tempTensor = [mpsGraph divisionWithPrimaryTensor:inputTensor
-                                                           secondaryTensor:threeTensor
+      MPSGraphTensor* tempTensor = [mpsGraph divisionWithPrimaryTensor:inputTensor
+                                                       secondaryTensor:threeTensor
+                                                                  name:nil];
+
+      MPSGraphTensor* weightedTensor = [mpsGraph additionWithPrimaryTensor:tempTensor
+                                                           secondaryTensor:halfTensor
                                                                       name:nil];
 
-          MPSGraphTensor* weightedTensor = [mpsGraph additionWithPrimaryTensor:tempTensor
-                                                               secondaryTensor:halfTensor
-                                                                          name:nil];
+      MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                secondaryTensor:negativeThreeTensor
+                                                                                           name:nil];
 
-          MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
-                                                                                    secondaryTensor:negativeThreeTensor
-                                                                                               name:nil];
+      MPSGraphTensor* lessThanMaxPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                       secondaryTensor:threeTensor
+                                                                                  name:nil];
 
-          MPSGraphTensor* lessThanMaxPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                           secondaryTensor:threeTensor
-                                                                                      name:nil];
+      MPSGraphTensor* lessThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:lessThanMaxPredicateTensor
+                                                              truePredicateTensor:weightedTensor
+                                                             falsePredicateTensor:unitTensor
+                                                                             name:nil];
 
-          MPSGraphTensor* lessThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:lessThanMaxPredicateTensor
-                                                                  truePredicateTensor:weightedTensor
-                                                                 falsePredicateTensor:unitTensor
-                                                                                 name:nil];
+      MPSGraphTensor* gradTensor = [mpsGraph selectWithPredicateTensor:lessThanMinPredicateTensor
+                                                   truePredicateTensor:zeroTensor
+                                                  falsePredicateTensor:lessThanMaxGradTensor
+                                                                  name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
 
-          MPSGraphTensor* gradTensor = [mpsGraph selectWithPredicateTensor:lessThanMinPredicateTensor
-                                                       truePredicateTensor:zeroTensor
-                                                      falsePredicateTensor:lessThanMaxGradTensor
-                                                                      name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
-                                                                      secondaryTensor:gradOutputTensor
-                                                                                 name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -106,55 +106,42 @@ void binaryOpTensor(const Tensor& self,
     }
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, other, output_});
-    BinaryOpCachedGraph* cachedGraph = static_cast<BinaryOpCachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<BinaryOpCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->primaryTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType), getMPSShape(self));
+      newCachedGraph->secondaryTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType), getMPSShape(other));
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        BinaryOpCachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new BinaryOpCachedGraph(mpsGraph);
-          newCachedGraph->primaryTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType), getMPSShape(self));
-          newCachedGraph->secondaryTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType), getMPSShape(other));
+      MPSGraphTensor* primaryCastTensor = newCachedGraph->primaryTensor;
+      MPSGraphTensor* secondaryCastTensor = newCachedGraph->secondaryTensor;
 
-          MPSGraphTensor* primaryCastTensor = newCachedGraph->primaryTensor;
-          MPSGraphTensor* secondaryCastTensor = newCachedGraph->secondaryTensor;
-
-          // this type inference is only required at the time of graph creation
-          ScalarType common_dtype = c10::promoteTypes(inputDataType, otherDataType);
-          if (isIntegralType(common_dtype, true)) {
-            // integer inputs must be cast to float, if output is float
-            if (isFloatingType(outputDataType)) {
-              common_dtype = outputDataType;
-              // in boolean comparison ops with signed vs. unsigned integers, we always cast to the unsigned type
-            } else if (outputDataType == ScalarType::Bool &&
-                       (inputDataType == ScalarType::Byte || otherDataType == ScalarType::Byte)) {
-              common_dtype = ScalarType::Byte;
-            }
-          }
-          if (inputDataType != common_dtype) {
-            primaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->primaryTensor, common_dtype);
-          }
-          if (otherDataType != common_dtype) {
-            secondaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->secondaryTensor, common_dtype);
-          }
-          newCachedGraph->outputTensor = binaryBlock(newCachedGraph, primaryCastTensor, secondaryCastTensor);
-          // Cast output tensor to an expected type if needed, which addresses discrepancy when int64 scalar is added to
-          // int32 tensor Output tensor should have been promoted but it remains an int32 tensor
-          if (outputDataType != common_dtype ||
-              [newCachedGraph->outputTensor dataType] != getMPSDataType(outputDataType)) {
-            newCachedGraph->outputTensor = castMPSTensor(mpsGraph, newCachedGraph->outputTensor, outputDataType);
-          }
+      // this type inference is only required at the time of graph creation
+      ScalarType common_dtype = c10::promoteTypes(inputDataType, otherDataType);
+      if (isIntegralType(common_dtype, true)) {
+        // integer inputs must be cast to float, if output is float
+        if (isFloatingType(outputDataType)) {
+          common_dtype = outputDataType;
+          // in boolean comparison ops with signed vs. unsigned integers, we always cast to the unsigned type
+        } else if (outputDataType == ScalarType::Bool &&
+                   (inputDataType == ScalarType::Byte || otherDataType == ScalarType::Byte)) {
+          common_dtype = ScalarType::Byte;
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<BinaryOpCachedGraph*>(tmpCachedGraph);
-    }
+      }
+      if (inputDataType != common_dtype) {
+        primaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->primaryTensor, common_dtype);
+      }
+      if (otherDataType != common_dtype) {
+        secondaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->secondaryTensor, common_dtype);
+      }
+      newCachedGraph->outputTensor = binaryBlock(newCachedGraph, primaryCastTensor, secondaryCastTensor);
+      // Cast output tensor to an expected type if needed, which addresses discrepancy when int64 scalar is added to
+      // int32 tensor Output tensor should have been promoted but it remains an int32 tensor
+      if (outputDataType != common_dtype || [newCachedGraph->outputTensor dataType] != getMPSDataType(outputDataType)) {
+        newCachedGraph->outputTensor = castMPSTensor(mpsGraph, newCachedGraph->outputTensor, outputDataType);
+      }
+    });
 
     NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
     Placeholder selfPlaceholder;

--- a/aten/src/ATen/native/mps/operations/Blas.mm
+++ b/aten/src/ATen/native/mps/operations/Blas.mm
@@ -24,57 +24,43 @@ Tensor dot_mps(const Tensor& self, const Tensor& other) {
   using CachedGraph = MPSBinaryCachedGraph;
   auto output = at::empty({}, self.scalar_type(), c10::nullopt, kMPS, c10::nullopt, c10::nullopt);
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     string key = "dot_mps" + getTensorsStringKey({self, other});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* otherTensor = mpsGraphRankedPlaceHolder(mpsGraph, other);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* castSelf = nil;
+      MPSGraphTensor* castOther = nil;
 
-          MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
+      if (self.scalar_type() == ScalarType::Short || self.scalar_type() == ScalarType::Byte ||
+          self.scalar_type() == ScalarType::Char) {
+        castSelf = [mpsGraph castTensor:selfTensor toType:MPSDataTypeInt32 name:@"castSelfTensor"];
+        castOther = [mpsGraph castTensor:otherTensor toType:MPSDataTypeInt32 name:@"castOtherTensor"];
+      } else {
+        castSelf = selfTensor;
+        castOther = otherTensor;
+      }
 
-          MPSGraphTensor* castSelf = nil;
-          MPSGraphTensor* castOther = nil;
+      MPSGraphTensor* dot = [mpsGraph multiplicationWithPrimaryTensor:castSelf
+                                                      secondaryTensor:castOther
+                                                                 name:@"multiplication"];
 
-          if (self.scalar_type() == ScalarType::Short || self.scalar_type() == ScalarType::Byte ||
-              self.scalar_type() == ScalarType::Char) {
-            castSelf = [mpsGraph castTensor:selfTensor toType:MPSDataTypeInt32 name:@"castSelfTensor"];
-            castOther = [mpsGraph castTensor:otherTensor toType:MPSDataTypeInt32 name:@"castOtherTensor"];
-          } else {
-            castSelf = selfTensor;
-            castOther = otherTensor;
-          }
+      MPSGraphTensor* dotProductTensor = [mpsGraph reductionSumWithTensor:dot axes:nil name:@"dotProduct"];
 
-          MPSGraphTensor* dot = [mpsGraph multiplicationWithPrimaryTensor:castSelf
-                                                          secondaryTensor:castOther
-                                                                     name:@"multiplication"];
+      if (self.scalar_type() == ScalarType::Short || self.scalar_type() == ScalarType::Byte ||
+          self.scalar_type() == ScalarType::Char)
+        dotProductTensor = [mpsGraph castTensor:dotProductTensor
+                                         toType:getMPSDataType(self)
+                                           name:@"castDotProductTensor"];
 
-          MPSGraphTensor* dotProductTensor = [mpsGraph reductionSumWithTensor:dot axes:nil name:@"dotProduct"];
-
-          if (self.scalar_type() == ScalarType::Short || self.scalar_type() == ScalarType::Byte ||
-              self.scalar_type() == ScalarType::Char)
-            dotProductTensor = [mpsGraph castTensor:dotProductTensor
-                                             toType:getMPSDataType(self)
-                                               name:@"castDotProductTensor"];
-
-          newCachedGraph->inputTensor_ = selfTensor;
-          newCachedGraph->otherTensor_ = otherTensor;
-          newCachedGraph->outputTensor_ = dotProductTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = selfTensor;
+      newCachedGraph->otherTensor_ = otherTensor;
+      newCachedGraph->outputTensor_ = dotProductTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder otherPlaceholder = Placeholder(cachedGraph->otherTensor_, other);
@@ -110,13 +96,12 @@ Tensor& addmv_out_mps_impl(const Tensor& self,
   c10::MaybeOwned<Tensor> self_ = expand_size(self, {mat.size(0)});
   auto betaval = beta_.toComplexDouble();
 
-  struct CachedGraph : public mps::MPSCachedGraph {
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* selfTensor_ = nil;
     MPSGraphTensor* matMulVecTensor_ = nil;
     MPSGraphTensor* outputTensor_ = nil;
   };
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
 
   MPSStream* stream = at::mps::getCurrentMPSStream();
   Tensor matMulVec = at::mm(mat, vec.unsqueeze(1)).squeeze(1);
@@ -124,50 +109,38 @@ Tensor& addmv_out_mps_impl(const Tensor& self,
   @autoreleasepool {
     string key = "addmv_out_mps_impl" + getTensorsStringKey({self, matMulVec}) + ":" + to_string(beta_.toDouble()) +
         ":" + to_string(alpha_.toDouble());
-    CachedGraph* cachedGraph = nil;
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* matMulVecTensor = mpsGraphRankedPlaceHolder(mpsGraph, matMulVec);
+      MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Intermediates for beta and alpha
+      MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha_.toDouble()
+                                                        dataType:getMPSScalarType(mat.scalar_type())];
 
-          MPSGraphTensor* matMulVecTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, matMulVec);
-          MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
+      // Intermediates for multiplying by beta and alpha
+      MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:matMulVecTensor
+                                                                          secondaryTensor:alphaTensor
+                                                                                     name:@"MM/alpha*(mat@vec)"];
+      newCachedGraph->outputTensor_ = productTimesAlphaTensor;
 
-          // Intermediates for beta and alpha
-          MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha_.toDouble()
-                                                            dataType:getMPSScalarType(mat.scalar_type())];
+      if (betaval != 0.0) {
+        MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta_.toDouble()
+                                                         dataType:getMPSScalarType(self.scalar_type())];
 
-          // Intermediates for multiplying by beta and alpha
-          MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:matMulVecTensor
-                                                                              secondaryTensor:alphaTensor
-                                                                                         name:@"MM/alpha*(mat@vec)"];
-          newCachedGraph->outputTensor_ = productTimesAlphaTensor;
+        MPSGraphTensor* selfTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:selfTensor
+                                                                        secondaryTensor:betaTensor
+                                                                                   name:@"MM/beta*input"];
 
-          if (betaval != 0.0) {
-            MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta_.toDouble()
-                                                             dataType:getMPSScalarType(self.scalar_type())];
+        MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
+                                                           secondaryTensor:selfTimesBetaTensor
+                                                                      name:@"MM/beta*input + alpha*(mat@vec)"];
 
-            MPSGraphTensor* selfTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:selfTensor
-                                                                            secondaryTensor:betaTensor
-                                                                                       name:@"MM/beta*input"];
+        newCachedGraph->outputTensor_ = outputTensor;
+      }
 
-            MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
-                                                               secondaryTensor:selfTimesBetaTensor
-                                                                          name:@"MM/beta*input + alpha*(mat@vec)"];
-
-            newCachedGraph->outputTensor_ = outputTensor;
-          }
-
-          newCachedGraph->selfTensor_ = selfTensor;
-          newCachedGraph->matMulVecTensor_ = matMulVecTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->selfTensor_ = selfTensor;
+      newCachedGraph->matMulVecTensor_ = matMulVecTensor;
+    });
 
     Placeholder matMulVecPlaceholder = Placeholder(cachedGraph->matMulVecTensor_, matMulVec);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -182,7 +155,7 @@ Tensor& addmv_out_mps_impl(const Tensor& self,
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return result;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -73,7 +73,7 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
   TORCH_CHECK(input_t.dim() < 5, "Conv3D is not supported on MPS");
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");
 
-  namespace native_mps = at::native::mps;
+  using namespace at::native::mps;
   CheckedFrom c = "mps_convolution";
   TensorArg input{input_t, "input", 1}, weight{weight_t, "weight", 2};
   checkAllSameType(c, {input, weight});
@@ -105,15 +105,13 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* biasTensor_ = nil;
     MPSGraphTensor* weightTensor_ = nil;
     MPSGraphTensor* outputTensor_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   auto stream = at::mps::getCurrentMPSStream();
 
@@ -145,96 +143,81 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
         ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
         to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
         to_string(bias_defined) + ":" + bias_shape_key;
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
     MPSShape* inputShape = mps::getMPSShape(input_t, memory_format);
-    if (!cachedGraph) {
-      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+      MPSShape* weightShape = mps::getMPSShape(weight_t);
+      bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
+                              weightShape.count >= 4 && !is_channels_last);
+      if (isDepthwiseConv) {
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 memory_format,
+                                 groups);
+      } else {
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       memory_format,
+                       groups);
+      }
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input_t), inputShape);
+      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
-          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-          MPSShape* weightShape = mps::getMPSShape(weight_t);
-          bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
-                                  weightShape.count >= 4 && !is_channels_last);
-          if (isDepthwiseConv) {
-            fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                     stride[1],
-                                     stride[0],
-                                     dilation[1],
-                                     dilation[0],
-                                     padding[1],
-                                     padding[0],
-                                     memory_format,
-                                     groups);
-          } else {
-            fill_conv_desc(conv2dDescriptor_,
-                           stride[1],
-                           stride[0],
-                           dilation[1],
-                           dilation[0],
-                           padding[1],
-                           padding[0],
-                           memory_format,
-                           groups);
-          }
+      MPSGraphTensor* biasTensor = nil;
+      if (bias_defined) {
+        biasTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(bias_opt.value()));
+      }
 
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(
-              mpsGraph, native_mps::getMPSScalarType(input_t.scalar_type()), inputShape);
-          MPSGraphTensor* weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
+      MPSGraphTensor* outputTensor;
+      if (isDepthwiseConv) {
+        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                dimension:-3
+                                                            withDimension:-4
+                                                                     name:nil];
+        outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
+                                                          weightsTensor:weightTransposeTensor
+                                                             descriptor:depthWiseConv3dDescriptor_
+                                                                   name:nil];
+      } else {
+        outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
+                                                 weightsTensor:weightTensor
+                                                    descriptor:conv2dDescriptor_
+                                                          name:nil];
+      }
 
-          MPSGraphTensor* biasTensor = nil;
-          if (bias_defined) {
-            biasTensor =
-                native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(bias_opt.value()));
-          }
+      if (is_channels_last) {
+        outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
+      }
 
-          MPSGraphTensor* outputTensor;
-          if (isDepthwiseConv) {
-            MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                    dimension:-3
-                                                                withDimension:-4
-                                                                         name:nil];
-            outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
-                                                              weightsTensor:weightTransposeTensor
-                                                                 descriptor:depthWiseConv3dDescriptor_
-                                                                       name:nil];
-          } else {
-            outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
-                                                     weightsTensor:weightTensor
-                                                        descriptor:conv2dDescriptor_
-                                                              name:nil];
-          }
+      if (bias_defined) {
+        outputTensor = [mpsGraph additionWithPrimaryTensor:outputTensor secondaryTensor:biasTensor name:nil];
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->biasTensor_ = biasTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
-          if (is_channels_last) {
-            outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
-          }
-
-          if (bias_defined) {
-            outputTensor = [mpsGraph additionWithPrimaryTensor:outputTensor secondaryTensor:biasTensor name:nil];
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->biasTensor_ = biasTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
-
-    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, inputShape);
-    auto weightsPlaceholder = native_mps::Placeholder(cachedGraph->weightTensor_, weight_t);
-    auto biasPlaceholder = native_mps::Placeholder();
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, inputShape);
+    auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
+    auto biasPlaceholder = Placeholder();
     // Reshape the bias to be broadcastable with output of conv2d
     if (bias_defined)
-      biasPlaceholder =
-          native_mps::Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, *output);
+      biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, *output);
 
     NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =
         [[[NSMutableDictionary alloc] initWithCapacity:3] autorelease];
@@ -247,7 +230,7 @@ Tensor _mps_convolution_impl(const Tensor& input_t,
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return *output;
@@ -271,7 +254,7 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                       IntArrayRef dilation,
                                       int64_t groups,
                                       bool bias_defined) {
-  namespace native_mps = at::native::mps;
+  using namespace at::native::mps;
   using namespace mps;
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_input";
@@ -287,14 +270,12 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
   convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
     MPSGraphTensor* weightTensor_ = nil;
     MPSGraphTensor* gradInputTensor_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   // Add backward with input
   @autoreleasepool {
@@ -319,83 +300,71 @@ Tensor mps_convolution_backward_input(IntArrayRef input_size,
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
         getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
 
-    if (!cachedGraph) {
-      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
+      // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
+      bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
+                              weightOutputShape.count >= 4 && !is_channels_last);
 
-          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+      if (isDepthwiseConv) {
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 at::MemoryFormat::Contiguous,
+                                 groups);
+      } else {
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       at::MemoryFormat::Contiguous,
+                       groups);
+      }
 
-          MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
-          // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
-          bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
-                                  weightOutputShape.count >= 4 && !is_channels_last);
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
+      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
-          if (isDepthwiseConv) {
-            fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                     stride[1],
-                                     stride[0],
-                                     dilation[1],
-                                     dilation[0],
-                                     padding[1],
-                                     padding[0],
-                                     at::MemoryFormat::Contiguous,
-                                     groups);
-          } else {
-            fill_conv_desc(conv2dDescriptor_,
-                           stride[1],
-                           stride[0],
-                           dilation[1],
-                           dilation[0],
-                           padding[1],
-                           padding[0],
-                           at::MemoryFormat::Contiguous,
-                           groups);
-          }
+      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
+      if (is_channels_last) {
+        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
+      }
+      MPSGraphTensor* gradInputTensor;
+      if (isDepthwiseConv) {
+        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                dimension:-3
+                                                            withDimension:-4
+                                                                     name:nil];
+        gradInputTensor =
+            [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                     weightsTensor:weightTransposeTensor
+                                                                       outputShape:mps_input_shape
+                                                                        descriptor:depthWiseConv3dDescriptor_
+                                                                              name:nil];
+      } else {
+        gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                          weightsTensor:weightTensor
+                                                                            outputShape:mps_input_shape
+                                                           forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                   name:nil];
+      }
 
-          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(
-              mpsGraph, native_mps::getMPSScalarType(grad_output_t.scalar_type()), gradOutputShape);
-          MPSGraphTensor* weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
-
-          MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-          if (is_channels_last) {
-            gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-          }
-          MPSGraphTensor* gradInputTensor;
-          if (isDepthwiseConv) {
-            MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                    dimension:-3
-                                                                withDimension:-4
-                                                                         name:nil];
-            gradInputTensor =
-                [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                         weightsTensor:weightTransposeTensor
-                                                                           outputShape:mps_input_shape
-                                                                            descriptor:depthWiseConv3dDescriptor_
-                                                                                  name:nil];
-          } else {
-            gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                              weightsTensor:weightTensor
-                                                                                outputShape:mps_input_shape
-                                                               forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                       name:nil];
-          }
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t, gradOutputShape);
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
@@ -422,7 +391,7 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                         IntArrayRef dilation,
                                         int64_t groups,
                                         bool bias_defined) {
-  namespace native_mps = at::native::mps;
+  using namespace at::native::mps;
   using namespace mps;
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
@@ -446,14 +415,12 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   convolution_shape_check(c, input, grad_weight, grad_output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* gradWeightTensor_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   @autoreleasepool {
     MPSStream* stream = getCurrentMPSStream();
@@ -475,84 +442,68 @@ Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
         getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
 
-    if (!cachedGraph) {
-      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+      MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+          [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+      MPSShape* inputShape = mps::getMPSShape(input_t);
+      bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
+                              mps_weight_shape.count >= 4 && !is_channels_last);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      if (isDepthwiseConv) {
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 at::MemoryFormat::Contiguous,
+                                 groups);
+      } else {
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       at::MemoryFormat::Contiguous,
+                       groups);
+      }
 
-          MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-          MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-              [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-          MPSShape* inputShape = mps::getMPSShape(input_t);
-          bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
-                                  mps_weight_shape.count >= 4 && !is_channels_last);
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
-          if (isDepthwiseConv) {
-            fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                     stride[1],
-                                     stride[0],
-                                     dilation[1],
-                                     dilation[0],
-                                     padding[1],
-                                     padding[0],
-                                     at::MemoryFormat::Contiguous,
-                                     groups);
-          } else {
-            fill_conv_desc(conv2dDescriptor_,
-                           stride[1],
-                           stride[0],
-                           dilation[1],
-                           dilation[0],
-                           padding[1],
-                           padding[0],
-                           at::MemoryFormat::Contiguous,
-                           groups);
-          }
+      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
+      if (is_channels_last) {
+        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
+      }
 
-          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(
-              mpsGraph, native_mps::getMPSScalarType(grad_output_t.scalar_type()), gradOutputShape);
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-
-          MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-          if (is_channels_last) {
-            gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-          }
-
-          MPSGraphTensor* gradWeightTensor;
-          if (isDepthwiseConv) {
-            NSNumber* outputFeatChannelDim = mps_weight_shape[0];
-            MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
-            MPSGraphTensor* gradWeightTensorTranspose =
-                [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                             sourceTensor:inputTensor
-                                                                              outputShape:weightShapeTranspose
-                                                                               descriptor:depthWiseConv3dDescriptor_
-                                                                                     name:nil];
-            gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose
-                                               dimension:-3
-                                           withDimension:-4
-                                                    name:nil];
-          } else {
-            gradWeightTensor =
-                [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                    sourceTensor:inputTensor
-                                                                     outputShape:mps_weight_shape
-                                                    forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                            name:nil];
-          }
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradWeightTensor_ = gradWeightTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      MPSGraphTensor* gradWeightTensor;
+      if (isDepthwiseConv) {
+        NSNumber* outputFeatChannelDim = mps_weight_shape[0];
+        MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
+        MPSGraphTensor* gradWeightTensorTranspose =
+            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                         sourceTensor:inputTensor
+                                                                          outputShape:weightShapeTranspose
+                                                                           descriptor:depthWiseConv3dDescriptor_
+                                                                                 name:nil];
+        gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
+      } else {
+        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                               sourceTensor:inputTensor
+                                                                                outputShape:mps_weight_shape
+                                                               forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                       name:nil];
+      }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradWeightTensor_ = gradWeightTensor;
+    });
 
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_t, gradOutputShape);
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -51,62 +51,50 @@ Tensor& random_mps_impl(Tensor& self,
     return self;
   }
   auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self}) + ":" + to_string(val1) + ":" + to_string(val2);
-    auto cachedGraph = cache_->LookUpAs<RandomCachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<RandomCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->stateTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @(at::mps::detail::PHILOX_STATE_N) ]);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<RandomCachedGraph>(key, ^MPSCachedGraph*() {
-        RandomCachedGraph* newCachedGraph = nil;
+      // FP16, FP32 and Int32 are the only data types supported for distributions on MPS backend.
+      const MPSDataType inputDataType = [&] {
+        // only for random_mps, we pass interval range of type int64_t
+        if (std::is_same<scalar_t, int64_t>::value)
+          return MPSDataTypeInt32;
+        else
+          return (self.scalar_type() == ScalarType::Half) ? MPSDataTypeFloat16 : MPSDataTypeFloat32;
+      }();
+      const MPSDataType outputDataType = (std::is_same<scalar_t, bool>::value) ? MPSDataTypeBool : inputDataType;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new RandomCachedGraph(mpsGraph);
-          newCachedGraph->stateTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @(at::mps::detail::PHILOX_STATE_N) ]);
-
-          // FP16, FP32 and Int32 are the only data types supported for distributions on MPS backend.
-          const MPSDataType inputDataType = [&] {
-            // only for random_mps, we pass interval range of type int64_t
-            if (std::is_same<scalar_t, int64_t>::value)
-              return MPSDataTypeInt32;
-            else
-              return (self.scalar_type() == ScalarType::Half) ? MPSDataTypeFloat16 : MPSDataTypeFloat32;
-          }();
-          const MPSDataType outputDataType = (std::is_same<scalar_t, bool>::value) ? MPSDataTypeBool : inputDataType;
-
-          MPSGraphRandomOpDescriptor* desc = [MPSGraphRandomOpDescriptor descriptorWithDistribution:distribution
-                                                                                           dataType:inputDataType];
-          if (distribution == MPSGraphRandomDistributionUniform) {
-            if (inputDataType == MPSDataTypeInt32) {
-              desc.minInteger = static_cast<NSInteger>(val1);
-              desc.maxInteger = static_cast<NSInteger>(val2);
-            } else {
-              desc.min = static_cast<float>(val1);
-              desc.max = static_cast<float>(val2);
-            }
-          } else if (distribution == MPSGraphRandomDistributionNormal) {
-            desc.mean = static_cast<float>(val1);
-            desc.standardDeviation = static_cast<float>(val2);
-          }
-          // we don't use the output state tensor from the MPSGraph API as it requires reading back from GPU to CPU.
-          // Instead, we keep the Philox state in the MPSGenerator and use the PyTorch's philox_engine to maintain
-          // the counters, and feed them to the graph manually
-          NSArray<MPSGraphTensor*>* resultTensors = [mpsGraph randomTensorWithShape:getMPSShape(self)
-                                                                         descriptor:desc
-                                                                        stateTensor:newCachedGraph->stateTensor
-                                                                               name:nil];
-          newCachedGraph->resultTensor = randomBlock ? randomBlock(newCachedGraph, resultTensors[0]) : resultTensors[0];
-          // results will be cast if self's scalar type isn't directly supported by MPS backend.
-          if (getMPSDataType(self) != outputDataType)
-            newCachedGraph->resultTensor = castMPSTensor(mpsGraph, newCachedGraph->resultTensor, self.scalar_type());
+      MPSGraphRandomOpDescriptor* desc = [MPSGraphRandomOpDescriptor descriptorWithDistribution:distribution
+                                                                                       dataType:inputDataType];
+      if (distribution == MPSGraphRandomDistributionUniform) {
+        if (inputDataType == MPSDataTypeInt32) {
+          desc.minInteger = static_cast<NSInteger>(val1);
+          desc.maxInteger = static_cast<NSInteger>(val2);
+        } else {
+          desc.min = static_cast<float>(val1);
+          desc.max = static_cast<float>(val2);
         }
-        return newCachedGraph;
-      });
-    }
+      } else if (distribution == MPSGraphRandomDistributionNormal) {
+        desc.mean = static_cast<float>(val1);
+        desc.standardDeviation = static_cast<float>(val2);
+      }
+      // we don't use the output state tensor from the MPSGraph API as it requires reading back from GPU to CPU.
+      // Instead, we keep the Philox state in the MPSGenerator and use the PyTorch's philox_engine to maintain
+      // the counters, and feed them to the graph manually
+      NSArray<MPSGraphTensor*>* resultTensors = [mpsGraph randomTensorWithShape:getMPSShape(self)
+                                                                     descriptor:desc
+                                                                    stateTensor:newCachedGraph->stateTensor
+                                                                           name:nil];
+      newCachedGraph->resultTensor = randomBlock ? randomBlock(newCachedGraph, resultTensors[0]) : resultTensors[0];
+      // results will be cast if self's scalar type isn't directly supported by MPS backend.
+      if (getMPSDataType(self) != outputDataType)
+        newCachedGraph->resultTensor = castMPSTensor(mpsGraph, newCachedGraph->resultTensor, self.scalar_type());
+    });
     // feed the updated state values to the graph
     MPSNDArrayDescriptor* stateDesc =
         [MPSNDArrayDescriptor descriptorWithDataType:MPSDataTypeInt32 shape:@[ @(at::mps::detail::PHILOX_STATE_N) ]];
@@ -445,104 +433,89 @@ Tensor& multinomial_with_replacement_mps_kernel(const Tensor& self,
   auto result_v = inputSize == 1 ? result.view({numDist, n_sample}) : result;
 
   MPSStream* stream = getCurrentMPSStream();
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = "multinomial_with_replacement:" + getTensorsStringKey({self}) + ":" + to_string(n_sample);
-    auto cachedGraph = cache_->LookUpAs<RandomCachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<RandomCachedGraph>(key, ^MPSCachedGraph*() {
-        RandomCachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSShape* prob_shape = getMPSShape(self_v);
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new RandomCachedGraph(mpsGraph);
-          newCachedGraph->stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @7 ]);
+    auto cachedGraph = LookUpOrCreateCachedGraph<RandomCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSShape* prob_shape = getMPSShape(self_v);
+      newCachedGraph->stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @7 ]);
 
-          auto prob_dtype = getMPSDataType(self_v);
+      auto prob_dtype = getMPSDataType(self_v);
 
-          // This is probability weights
-          newCachedGraph->probTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self_v), prob_shape);
+      // This is probability weights
+      newCachedGraph->probTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self_v), prob_shape);
 
-          MPSGraphTensor* sumProbs = [mpsGraph reductionSumWithTensor:newCachedGraph->probTensor axis:-1 name:nil];
+      MPSGraphTensor* sumProbs = [mpsGraph reductionSumWithTensor:newCachedGraph->probTensor axis:-1 name:nil];
 
-          MPSGraphTensor* normalizedProbs = [mpsGraph divisionWithPrimaryTensor:newCachedGraph->probTensor
-                                                                secondaryTensor:sumProbs
-                                                                           name:nil];
-
-          auto ns_numCategories = [NSNumber numberWithInt:numCategories];
-          auto ns_numDist = [NSNumber numberWithInt:numDist];
-          auto ns_n_sample = [NSNumber numberWithInt:n_sample];
-
-          MPSGraphTensor* ones = [mpsGraph constantWithScalar:1.0f
-                                                        shape:@[ ns_numCategories, ns_numCategories ]
-                                                     dataType:prob_dtype];
-          auto zeroTensor = [mpsGraph constantWithScalar:0.0f dataType:MPSDataTypeInt32];
-          auto minusOneTensor = [mpsGraph constantWithScalar:-1.0f dataType:MPSDataTypeInt32];
-
-          MPSGraphTensor* upperTriangle = [mpsGraph bandPartWithTensor:ones
-                                                        numLowerTensor:zeroTensor
-                                                        numUpperTensor:minusOneTensor
-                                                                  name:nil];
-          MPSGraphTensor* upperProbRange = [mpsGraph matrixMultiplicationWithPrimaryTensor:normalizedProbs
-                                                                           secondaryTensor:upperTriangle
-                                                                                      name:nil];
-
-          MPSGraphTensor* lowerProbRange = [mpsGraph subtractionWithPrimaryTensor:upperProbRange
-                                                                  secondaryTensor:normalizedProbs
-                                                                             name:nil];
-
-          upperProbRange = [mpsGraph reshapeTensor:upperProbRange
-                                         withShape:@[ ns_numDist, @1, ns_numCategories ]
-                                              name:nil];
-          lowerProbRange = [mpsGraph reshapeTensor:lowerProbRange
-                                         withShape:@[ ns_numDist, @1, ns_numCategories ]
-                                              name:nil];
-
-          MPSGraphRandomOpDescriptor* descriptor =
-              [MPSGraphRandomOpDescriptor descriptorWithDistribution:MPSGraphRandomDistributionUniform
-                                                            dataType:prob_dtype];
-          NSArray<MPSGraphTensor*>* generatorTensors = [mpsGraph randomTensorWithShape:@[ ns_numDist, ns_n_sample, @1 ]
-                                                                            descriptor:descriptor
-                                                                           stateTensor:newCachedGraph->stateTensor
-                                                                                  name:nil];
-          MPSGraphTensor* randomTensor = generatorTensors[0];
-
-          auto broadcastShape = @[ ns_numDist, ns_n_sample, ns_numCategories ];
-          int broadcastShapeVals[3] = {numDist, static_cast<int>(n_sample), numCategories};
-          MPSGraphTensor* broadcastShapeTensor = [mpsGraph
-              constantWithData:[NSData dataWithBytes:broadcastShapeVals length:sizeof(int) * broadcastShape.count]
-                         shape:@[ [NSNumber numberWithUnsignedInteger:broadcastShape.count] ]
-                      dataType:MPSDataTypeUInt32];
-
-          MPSGraphTensor* samplesTensor = [mpsGraph broadcastTensor:randomTensor toShape:broadcastShape name:nil];
-          MPSGraphTensor* sampleAbove = [mpsGraph greaterThanWithPrimaryTensor:samplesTensor
-                                                               secondaryTensor:lowerProbRange
-                                                                          name:nil];
-          MPSGraphTensor* sampleBelow = [mpsGraph lessThanWithPrimaryTensor:samplesTensor
-                                                            secondaryTensor:upperProbRange
+      MPSGraphTensor* normalizedProbs = [mpsGraph divisionWithPrimaryTensor:newCachedGraph->probTensor
+                                                            secondaryTensor:sumProbs
                                                                        name:nil];
-          MPSGraphTensor* sampleWithin = [mpsGraph logicalANDWithPrimaryTensor:sampleAbove
-                                                               secondaryTensor:sampleBelow
-                                                                          name:nil];
-          MPSGraphTensor* sampleMask = [mpsGraph castTensor:sampleWithin toType:MPSDataTypeInt32 name:@"sampleMask"];
-          MPSGraphTensor* categoriesTensor = [mpsGraph coordinateAlongAxis:-1
-                                                           withShapeTensor:broadcastShapeTensor
+
+      auto ns_numCategories = [NSNumber numberWithInt:numCategories];
+      auto ns_numDist = [NSNumber numberWithInt:numDist];
+      auto ns_n_sample = [NSNumber numberWithInt:n_sample];
+
+      MPSGraphTensor* ones = [mpsGraph constantWithScalar:1.0f
+                                                    shape:@[ ns_numCategories, ns_numCategories ]
+                                                 dataType:prob_dtype];
+      auto zeroTensor = [mpsGraph constantWithScalar:0.0f dataType:MPSDataTypeInt32];
+      auto minusOneTensor = [mpsGraph constantWithScalar:-1.0f dataType:MPSDataTypeInt32];
+
+      MPSGraphTensor* upperTriangle = [mpsGraph bandPartWithTensor:ones
+                                                    numLowerTensor:zeroTensor
+                                                    numUpperTensor:minusOneTensor
+                                                              name:nil];
+      MPSGraphTensor* upperProbRange = [mpsGraph matrixMultiplicationWithPrimaryTensor:normalizedProbs
+                                                                       secondaryTensor:upperTriangle
+                                                                                  name:nil];
+
+      MPSGraphTensor* lowerProbRange = [mpsGraph subtractionWithPrimaryTensor:upperProbRange
+                                                              secondaryTensor:normalizedProbs
+                                                                         name:nil];
+
+      upperProbRange = [mpsGraph reshapeTensor:upperProbRange withShape:@[ ns_numDist, @1, ns_numCategories ] name:nil];
+      lowerProbRange = [mpsGraph reshapeTensor:lowerProbRange withShape:@[ ns_numDist, @1, ns_numCategories ] name:nil];
+
+      MPSGraphRandomOpDescriptor* descriptor =
+          [MPSGraphRandomOpDescriptor descriptorWithDistribution:MPSGraphRandomDistributionUniform dataType:prob_dtype];
+      NSArray<MPSGraphTensor*>* generatorTensors = [mpsGraph randomTensorWithShape:@[ ns_numDist, ns_n_sample, @1 ]
+                                                                        descriptor:descriptor
+                                                                       stateTensor:newCachedGraph->stateTensor
+                                                                              name:nil];
+      MPSGraphTensor* randomTensor = generatorTensors[0];
+
+      auto broadcastShape = @[ ns_numDist, ns_n_sample, ns_numCategories ];
+      int broadcastShapeVals[3] = {numDist, static_cast<int>(n_sample), numCategories};
+      MPSGraphTensor* broadcastShapeTensor =
+          [mpsGraph constantWithData:[NSData dataWithBytes:broadcastShapeVals length:sizeof(int) * broadcastShape.count]
+                               shape:@[ [NSNumber numberWithUnsignedInteger:broadcastShape.count] ]
+                            dataType:MPSDataTypeUInt32];
+
+      MPSGraphTensor* samplesTensor = [mpsGraph broadcastTensor:randomTensor toShape:broadcastShape name:nil];
+      MPSGraphTensor* sampleAbove = [mpsGraph greaterThanWithPrimaryTensor:samplesTensor
+                                                           secondaryTensor:lowerProbRange
                                                                       name:nil];
-          MPSGraphTensor* binnedSamplesTensor = [mpsGraph multiplicationWithPrimaryTensor:categoriesTensor
-                                                                          secondaryTensor:sampleMask
-                                                                                     name:nil];
-          MPSGraphTensor* reducedTensor = [mpsGraph reductionSumWithTensor:binnedSamplesTensor axis:-1 name:nil];
-          MPSGraphTensor* reshapeTensor = [mpsGraph reshapeTensor:reducedTensor
-                                                        withShape:@[ ns_numDist, ns_n_sample ]
-                                                             name:nil];
-          newCachedGraph->resultTensor = [mpsGraph castTensor:reshapeTensor
-                                                       toType:getMPSDataType(result)
-                                                         name:@"resultTensor"];
-        }
-        return newCachedGraph;
-      });
-    }
+      MPSGraphTensor* sampleBelow = [mpsGraph lessThanWithPrimaryTensor:samplesTensor
+                                                        secondaryTensor:upperProbRange
+                                                                   name:nil];
+      MPSGraphTensor* sampleWithin = [mpsGraph logicalANDWithPrimaryTensor:sampleAbove
+                                                           secondaryTensor:sampleBelow
+                                                                      name:nil];
+      MPSGraphTensor* sampleMask = [mpsGraph castTensor:sampleWithin toType:MPSDataTypeInt32 name:@"sampleMask"];
+      MPSGraphTensor* categoriesTensor = [mpsGraph coordinateAlongAxis:-1
+                                                       withShapeTensor:broadcastShapeTensor
+                                                                  name:nil];
+      MPSGraphTensor* binnedSamplesTensor = [mpsGraph multiplicationWithPrimaryTensor:categoriesTensor
+                                                                      secondaryTensor:sampleMask
+                                                                                 name:nil];
+      MPSGraphTensor* reducedTensor = [mpsGraph reductionSumWithTensor:binnedSamplesTensor axis:-1 name:nil];
+      MPSGraphTensor* reshapeTensor = [mpsGraph reshapeTensor:reducedTensor
+                                                    withShape:@[ ns_numDist, ns_n_sample ]
+                                                         name:nil];
+      newCachedGraph->resultTensor = [mpsGraph castTensor:reshapeTensor
+                                                   toType:getMPSDataType(result)
+                                                     name:@"resultTensor"];
+    });
     // update the Philox state values on each run of the same graph
     MPSNDArrayDescriptor* stateDesc =
         [MPSNDArrayDescriptor descriptorWithDataType:MPSDataTypeInt32 shape:@[ @(at::mps::detail::PHILOX_STATE_N) ]];

--- a/aten/src/ATen/native/mps/operations/Eye.mm
+++ b/aten/src/ATen/native/mps/operations/Eye.mm
@@ -6,6 +6,7 @@
 #else
 #include <ATen/ops/eye_native.h>
 #endif
+
 // Steps to add op for MPS backend:
 // 1. Register the op in aten/src/ATen/native/native_functions.yaml with the "MPS" dispatch key
 // 2. Define the function interface for the MPS backend similar to other
@@ -35,6 +36,8 @@ Tensor& eye_out_mps(int64_t n, Tensor& result) {
   return eye_out_mps(n, n, result);
 }
 
+using namespace mps;
+
 Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
   // This is one example of boiler-plate error checking, taking after CPU/CUDA counterparts
   TORCH_CHECK(n >= 0, "n must be greater or equal to 0, got ", n);
@@ -48,7 +51,6 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
     return result;
 
   // Get MPS stream
-  using namespace mps;
   MPSStream* stream = getCurrentMPSStream();
 
   auto outputDataType = result.scalar_type();
@@ -70,38 +72,25 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     // A key is used to identify the MPSGraph which was created once, and can be reused if the parameters, data types
     // etc match the earlier created MPSGraph
     string key = "eye_out_mps:" + getTensorsStringKey({result});
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
+      MPSGraphTensor* onesTensor = [mpsGraph constantWithScalar:1.0f
+                                                          shape:getMPSShape(result)
+                                                       dataType:getMPSDataType(inputDataType)];
 
-        @autoreleasepool {
-          // Initialize graph
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* onesTensor = [mpsGraph constantWithScalar:1.0f
-                                                              shape:getMPSShape(result)
-                                                           dataType:getMPSDataType(inputDataType)];
+      // Here we can call the MPSGraph API needed to execute the operation.
+      // The API details can be found here:
+      // https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph
+      MPSGraphTensor* outputTensor = [mpsGraph bandPartWithTensor:onesTensor numLower:0 numUpper:0 name:nil];
 
-          // Here we can call the MPSGraph API needed to execute the operation.
-          // The API details can be found here:
-          // https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph
-          MPSGraphTensor* outputTensor = [mpsGraph bandPartWithTensor:onesTensor numLower:0 numUpper:0 name:nil];
-
-          if ([outputTensor dataType] != getMPSDataType(outputDataType)) {
-            outputTensor = castMPSTensor(mpsGraph, outputTensor, outputDataType);
-          }
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      if ([outputTensor dataType] != getMPSDataType(outputDataType)) {
+        outputTensor = castMPSTensor(mpsGraph, outputTensor, outputDataType);
+      }
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     // Create placeholders which use the keys of the CachedGraph to create inputs and outputs of the operation
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -285,86 +285,73 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   // coordinates     = [0,  1,  2,  3]
   // scatterResult   = [0,  3]
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = "nonzero_out_mps" + getTensorsStringKey(self);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSDataType inputDataType = getMPSDataType(self);
+      MPSShape* inputShape = getMPSShape(self);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSDataType inputDataType = getMPSDataType(self);
-          MPSShape* inputShape = getMPSShape(self);
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
-          MPSGraphTensor* scatterDataTensor =
-              mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
-          MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];
-          MPSGraphTensor* minusMaxDimTensor = [mpsGraph constantWithScalar:-maxDimensions dataType:MPSDataTypeInt32];
-          MPSGraphTensor* inputNotEqualToZeroTensor = [mpsGraph notEqualWithPrimaryTensor:inputTensor
-                                                                          secondaryTensor:zeroTensor
-                                                                                     name:nil];
-          MPSGraphTensor* countNonzero = [mpsGraph reductionSumWithTensor:inputNotEqualToZeroTensor axis:0 name:nil];
-          MPSGraphTensor* maskTensor = [mpsGraph castTensor:inputNotEqualToZeroTensor
-                                                     toType:MPSDataTypeInt32
-                                                       name:@"castToInt32"];
-          MPSGraphTensor* indicesTensor = [mpsGraph cumulativeSumWithTensor:maskTensor axis:0 name:nil];
-          MPSGraphTensor* indicesMinusOneTensor = [mpsGraph subtractionWithPrimaryTensor:indicesTensor
-                                                                         secondaryTensor:oneTensor
-                                                                                    name:nil];
-          MPSGraphTensor* maskedIndicesTensor = [mpsGraph selectWithPredicateTensor:inputNotEqualToZeroTensor
-                                                                truePredicateTensor:indicesMinusOneTensor
-                                                               falsePredicateTensor:minusMaxDimTensor
-                                                                               name:nil];
-          MPSGraphTensor* coordinatesTensor = [mpsGraph reshapeTensor:[mpsGraph coordinateAlongAxis:0
-                                                                                          withShape:inputShape
-                                                                                               name:nil]
-                                                            withShape:@[ @-1 ]
-                                                                 name:nil];
-          if (nDim > 1) {
-            NSMutableArray<MPSGraphTensor*>* maskedIndicesTensorArray = [NSMutableArray arrayWithCapacity:nDim];
-            NSMutableArray<MPSGraphTensor*>* coordinatesTensorArray = [NSMutableArray arrayWithCapacity:nDim];
-
-            MPSGraphTensor* constantRankTensor = [mpsGraph constantWithScalar:nDim dataType:MPSDataTypeInt32];
-            maskedIndicesTensorArray[0] = [mpsGraph multiplicationWithPrimaryTensor:maskedIndicesTensor
-                                                                    secondaryTensor:constantRankTensor
-                                                                               name:nil];
-            coordinatesTensorArray[0] = coordinatesTensor;
-            for (int i = 1; i < nDim; i++) {
-              maskedIndicesTensorArray[i] = [mpsGraph additionWithPrimaryTensor:maskedIndicesTensorArray[i - 1]
-                                                                secondaryTensor:oneTensor
+      MPSGraphTensor* inputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
+      MPSGraphTensor* scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
+      MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];
+      MPSGraphTensor* minusMaxDimTensor = [mpsGraph constantWithScalar:-maxDimensions dataType:MPSDataTypeInt32];
+      MPSGraphTensor* inputNotEqualToZeroTensor = [mpsGraph notEqualWithPrimaryTensor:inputTensor
+                                                                      secondaryTensor:zeroTensor
+                                                                                 name:nil];
+      MPSGraphTensor* countNonzero = [mpsGraph reductionSumWithTensor:inputNotEqualToZeroTensor axis:0 name:nil];
+      MPSGraphTensor* maskTensor = [mpsGraph castTensor:inputNotEqualToZeroTensor
+                                                 toType:MPSDataTypeInt32
+                                                   name:@"castToInt32"];
+      MPSGraphTensor* indicesTensor = [mpsGraph cumulativeSumWithTensor:maskTensor axis:0 name:nil];
+      MPSGraphTensor* indicesMinusOneTensor = [mpsGraph subtractionWithPrimaryTensor:indicesTensor
+                                                                     secondaryTensor:oneTensor
+                                                                                name:nil];
+      MPSGraphTensor* maskedIndicesTensor = [mpsGraph selectWithPredicateTensor:inputNotEqualToZeroTensor
+                                                            truePredicateTensor:indicesMinusOneTensor
+                                                           falsePredicateTensor:minusMaxDimTensor
                                                                            name:nil];
-              coordinatesTensorArray[i] = [mpsGraph reshapeTensor:[mpsGraph coordinateAlongAxis:i
+      MPSGraphTensor* coordinatesTensor = [mpsGraph reshapeTensor:[mpsGraph coordinateAlongAxis:0
                                                                                       withShape:inputShape
                                                                                            name:nil]
                                                         withShape:@[ @-1 ]
                                                              name:nil];
-            }
-            maskedIndicesTensor = [mpsGraph concatTensors:maskedIndicesTensorArray dimension:0 interleave:YES name:nil];
-            coordinatesTensor = [mpsGraph concatTensors:coordinatesTensorArray dimension:0 interleave:YES name:nil];
-          }
+      if (nDim > 1) {
+        NSMutableArray<MPSGraphTensor*>* maskedIndicesTensorArray = [NSMutableArray arrayWithCapacity:nDim];
+        NSMutableArray<MPSGraphTensor*>* coordinatesTensorArray = [NSMutableArray arrayWithCapacity:nDim];
 
-          MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:scatterDataTensor
-                                                           updatesTensor:coordinatesTensor
-                                                           indicesTensor:maskedIndicesTensor
-                                                                    axis:0
-                                                                    mode:MPSGraphScatterModeSet
-                                                                    name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->scatterDataTensor_ = scatterDataTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->countNonzeroTensor_ = countNonzero;
+        MPSGraphTensor* constantRankTensor = [mpsGraph constantWithScalar:nDim dataType:MPSDataTypeInt32];
+        maskedIndicesTensorArray[0] = [mpsGraph multiplicationWithPrimaryTensor:maskedIndicesTensor
+                                                                secondaryTensor:constantRankTensor
+                                                                           name:nil];
+        coordinatesTensorArray[0] = coordinatesTensor;
+        for (int i = 1; i < nDim; i++) {
+          maskedIndicesTensorArray[i] = [mpsGraph additionWithPrimaryTensor:maskedIndicesTensorArray[i - 1]
+                                                            secondaryTensor:oneTensor
+                                                                       name:nil];
+          coordinatesTensorArray[i] = [mpsGraph reshapeTensor:[mpsGraph coordinateAlongAxis:i
+                                                                                  withShape:inputShape
+                                                                                       name:nil]
+                                                    withShape:@[ @-1 ]
+                                                         name:nil];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+        maskedIndicesTensor = [mpsGraph concatTensors:maskedIndicesTensorArray dimension:0 interleave:YES name:nil];
+        coordinatesTensor = [mpsGraph concatTensors:coordinatesTensorArray dimension:0 interleave:YES name:nil];
+      }
+
+      MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:scatterDataTensor
+                                                       updatesTensor:coordinatesTensor
+                                                       indicesTensor:maskedIndicesTensor
+                                                                axis:0
+                                                                mode:MPSGraphScatterModeSet
+                                                                name:nil];
+
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->scatterDataTensor_ = scatterDataTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->countNonzeroTensor_ = countNonzero;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, apparentInputShape);
     Placeholder countNonzeroPlaceholder = Placeholder(cachedGraph->countNonzeroTensor_, count_nonzero);
@@ -437,7 +424,6 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
 
   using CachedGraph = mps::MPSUnaryCachedGraph;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   MPSDataType inputDataType = getMPSScalarType(self.scalar_type());
   MPSDataType outputDataType = getMPSScalarType(self.scalar_type());
   if (!is_macos_13_or_newer()) {
@@ -453,23 +439,12 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
     // A key is used to identify the MPSGraph which was created once, and can be reused if the parameters, data types
     // etc match the earlier created MPSGraph
     string key = "flip_mps:" + getTensorsStringKey({self}) + ":" + string([ns_dims_key UTF8String]);
-    auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
-          MPSGraphTensor* outputTensor = [mpsGraph reverseTensor:inputTensor axes:ns_dims name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
+      MPSGraphTensor* outputTensor = [mpsGraph reverseTensor:inputTensor axes:ns_dims name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     // Create placeholders which use the keys of the CachedGraph to create inputs and outputs of the operation
     Placeholder inputPlaceholder =
@@ -516,52 +491,38 @@ TORCH_IMPL_FUNC(index_add_mps_out)
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "index_add_mps_out" + getTensorsStringKey({self, index, source}) + ":" + std::to_string(dim);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
+      MPSGraphTensor* sourceTensor = mpsGraphRankedPlaceHolder(mpsGraph, source);
+      MPSGraphTensor* alphaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(casted_type));
+      MPSGraphTensor* castedInputTensor = inputTensor;
+      MPSGraphTensor* castedSourceTensor = sourceTensor;
+      if (source.scalar_type() != casted_type) {
+        castedInputTensor = castMPSTensor(mpsGraph, castedInputTensor, casted_type);
+        castedSourceTensor = castMPSTensor(mpsGraph, castedSourceTensor, casted_type);
+      }
+      MPSGraphTensor* alphaSourceSlice = [mpsGraph multiplicationWithPrimaryTensor:castedSourceTensor
+                                                                   secondaryTensor:alphaTensor
+                                                                              name:nil];
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-          MPSGraphTensor* sourceTensor = mpsGraphRankedPlaceHolder(mpsGraph, source);
-          MPSGraphTensor* alphaTensor = mpsGraphScalarPlaceHolder(mpsGraph, getMPSScalarType(casted_type));
-          MPSGraphTensor* castedInputTensor = inputTensor;
-          MPSGraphTensor* castedSourceTensor = sourceTensor;
-          if (source.scalar_type() != casted_type) {
-            castedInputTensor = castMPSTensor(mpsGraph, castedInputTensor, casted_type);
-            castedSourceTensor = castMPSTensor(mpsGraph, castedSourceTensor, casted_type);
-          }
-          MPSGraphTensor* alphaSourceSlice = [mpsGraph multiplicationWithPrimaryTensor:castedSourceTensor
-                                                                       secondaryTensor:alphaTensor
-                                                                                  name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:castedInputTensor
-                                                           updatesTensor:alphaSourceSlice
-                                                           indicesTensor:indexTensor
-                                                                    axis:dim
-                                                                    mode:MPSGraphScatterModeAdd
-                                                                    name:nil];
-          if (source.scalar_type() != casted_type) {
-            outputTensor = castMPSTensor(mpsGraph, outputTensor, source.scalar_type());
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->indexTensor_ = indexTensor;
-          newCachedGraph->sourceTensor_ = sourceTensor;
-          newCachedGraph->alphaTensor_ = alphaTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:castedInputTensor
+                                                       updatesTensor:alphaSourceSlice
+                                                       indicesTensor:indexTensor
+                                                                axis:dim
+                                                                mode:MPSGraphScatterModeAdd
+                                                                name:nil];
+      if (source.scalar_type() != casted_type) {
+        outputTensor = castMPSTensor(mpsGraph, outputTensor, source.scalar_type());
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->indexTensor_ = indexTensor;
+      newCachedGraph->sourceTensor_ = sourceTensor;
+      newCachedGraph->alphaTensor_ = alphaTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index);
@@ -665,7 +626,6 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   auto inputType = getMPSDataType(self);
   auto outputType = getMPSDataType(output);
   if (inputType == MPSDataTypeUInt8 || (!is_macos_13_or_newer() && inputType == MPSDataTypeBool)) {
@@ -677,32 +637,20 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
 
   @autoreleasepool {
     string key = "index_select_out_mps" + getTensorsStringKey({self, index}) + ":" + std::to_string(dim);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self));
+      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* outputTensor = [mpsGraph gatherWithUpdatesTensor:inputTensor
+                                                         indicesTensor:indexTensor
+                                                                  axis:dim
+                                                       batchDimensions:0
+                                                                  name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self));
-          MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-
-          MPSGraphTensor* outputTensor = [mpsGraph gatherWithUpdatesTensor:inputTensor
-                                                             indicesTensor:indexTensor
-                                                                      axis:dim
-                                                           batchDimensions:0
-                                                                      name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->indexTensor_ = indexTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->indexTensor_ = indexTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_,
                                               self,
@@ -753,8 +701,6 @@ Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Scalar& value) 
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSDataType inputDataType = getMPSScalarType(self.scalar_type());
   MPSDataType maskDataType = getMPSScalarType(b_mask->scalar_type());
   // Workaround for `selectWithPredicateTensor` on macOS Monterey where bool data type may cause a hang
@@ -770,38 +716,27 @@ Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Scalar& value) 
   MPSScalar valueScalar = getMPSScalar(value, value.type());
   @autoreleasepool {
     string key = "masked_fill" + getTensorsStringKey({self, *b_mask}) + ":" + getMPSTypeString(value.type());
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
+      MPSGraphTensor* maskTensor = mpsGraphRankedPlaceHolder(mpsGraph, maskDataType, getMPSShape(*b_mask));
+      MPSGraphTensor* valueTensor = mpsGraphScalarPlaceHolder(mpsGraph, value);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSDataType valueType = getMPSScalarType(value.type());
+      MPSGraphTensor* castValueTensor = valueTensor;
+      if (valueType != inputDataType) {
+        castValueTensor = [mpsGraph castTensor:valueTensor toType:inputDataType name:@"castValueTensor"];
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
-          MPSGraphTensor* maskTensor = mpsGraphRankedPlaceHolder(mpsGraph, maskDataType, getMPSShape(*b_mask));
-          MPSGraphTensor* valueTensor = mpsGraphScalarPlaceHolder(mpsGraph, value);
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:maskTensor
+                                                     truePredicateTensor:castValueTensor
+                                                    falsePredicateTensor:inputTensor
+                                                                    name:nil];
 
-          MPSDataType valueType = getMPSScalarType(value.type());
-          MPSGraphTensor* castValueTensor = valueTensor;
-          if (valueType != inputDataType) {
-            castValueTensor = [mpsGraph castTensor:valueTensor toType:inputDataType name:@"castValueTensor"];
-          }
-
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:maskTensor
-                                                         truePredicateTensor:castValueTensor
-                                                        falsePredicateTensor:inputTensor
-                                                                        name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->maskTensor_ = maskTensor;
-          newCachedGraph->valueTensor_ = valueTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->maskTensor_ = maskTensor;
+      newCachedGraph->valueTensor_ = valueTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder =
         Placeholder(cachedGraph->inputTensor_, self, /*mpsShape*/ nil, /*gatherTensorData=*/true, inputDataType);
@@ -832,15 +767,13 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
                                     int64_t padding_idx,
                                     bool scale_grad_by_freq) {
   // TODO: implement padding_idx & scale_grad_by_freq.
-  namespace native_mps = at::native::mps;
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  using namespace at::native::mps;
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* incomingGradTensor_ = nil;
     MPSGraphTensor* indicesTensor_ = nil;
     MPSGraphTensor* outgoingGradTensor_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   IntArrayRef incoming_gradient_shape = grad_.sizes();
   int64_t num_incoming_gradient_dims = incoming_gradient_shape.size();
@@ -860,59 +793,42 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
   auto stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "edb_mps:" + native_mps::getMPSTypeString(grad_) + ":indices" + std::to_string(num_indices_dims) +
-        ":num_weights" + std::to_string(num_weights) + ":padding_idx" + std::to_string(padding_idx) + ":scaled" +
+    string key = "edb_mps:" + getMPSTypeString(grad_) + ":indices" + std::to_string(num_indices_dims) + ":num_weights" +
+        std::to_string(num_weights) + ":padding_idx" + std::to_string(padding_idx) + ":scaled" +
         std::to_string(scale_grad_by_freq);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    // Initialize once if configuration not found in cache
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* incomingGradTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_));
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* indicesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(indices));
 
-          MPSGraphTensor* incomingGradTensor =
-              native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(grad_));
+      MPSGraphTensor* reshapedIndicesTensor = indicesTensor;
 
-          MPSGraphTensor* indicesTensor =
-              native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(indices));
+      MPSGraphTensor* castGradTensor = incomingGradTensor;
+      MPSDataType dataType = mps::getMPSDataType(grad_);
+      // issue 105486100, scatterNDWithUpdatesTensor produces wrong result for float16
+      if (dataType == MPSDataTypeFloat16) {
+        castGradTensor = [mpsGraph castTensor:incomingGradTensor toType:MPSDataTypeFloat32 name:@"castGradTensor"];
+      }
+      if (num_indices_dims != 0) {
+        reshapedIndicesTensor = [mpsGraph expandDimsOfTensor:indicesTensor axes:@[ @-1 ] name:nil];
+      }
 
-          MPSGraphTensor* reshapedIndicesTensor = indicesTensor;
-
-          MPSGraphTensor* castGradTensor = incomingGradTensor;
-          MPSDataType dataType = mps::getMPSDataType(grad_);
-          // issue 105486100, scatterNDWithUpdatesTensor produces wrong result for float16
-          if (dataType == MPSDataTypeFloat16) {
-            castGradTensor = [mpsGraph castTensor:incomingGradTensor toType:MPSDataTypeFloat32 name:@"castGradTensor"];
-          }
-          if (num_indices_dims != 0) {
-            reshapedIndicesTensor = [mpsGraph expandDimsOfTensor:indicesTensor axes:@[ @-1 ] name:nil];
-          }
-
-          auto outgoingGradTensor =
-              [mpsGraph scatterNDWithUpdatesTensor:castGradTensor
-                                     indicesTensor:reshapedIndicesTensor
-                                             shape:native_mps::getMPSShape(IntArrayRef(outgoing_gradient_shape))
-                                   batchDimensions:0
-                                              mode:MPSGraphScatterModeAdd
-                                              name:@"edb"];
-          if (dataType == MPSDataTypeFloat16) {
-            outgoingGradTensor = [mpsGraph castTensor:outgoingGradTensor
-                                               toType:MPSDataTypeFloat16
-                                                 name:@"castGradTensor"];
-          }
-          newCachedGraph->incomingGradTensor_ = incomingGradTensor;
-          newCachedGraph->indicesTensor_ = indicesTensor;
-          newCachedGraph->outgoingGradTensor_ = outgoingGradTensor;
-        }
-        return newCachedGraph;
-      });
-    }
-    auto incomingGradPlaceholder = native_mps::Placeholder(cachedGraph->incomingGradTensor_, grad_);
-    auto indicesPlaceholder = native_mps::Placeholder(cachedGraph->indicesTensor_, indices);
-    auto outgoingGradPlaceholder = native_mps::Placeholder(cachedGraph->outgoingGradTensor_, outgoing_gradient);
+      auto outgoingGradTensor = [mpsGraph scatterNDWithUpdatesTensor:castGradTensor
+                                                       indicesTensor:reshapedIndicesTensor
+                                                               shape:getMPSShape(IntArrayRef(outgoing_gradient_shape))
+                                                     batchDimensions:0
+                                                                mode:MPSGraphScatterModeAdd
+                                                                name:@"edb"];
+      if (dataType == MPSDataTypeFloat16) {
+        outgoingGradTensor = [mpsGraph castTensor:outgoingGradTensor toType:MPSDataTypeFloat16 name:@"castGradTensor"];
+      }
+      newCachedGraph->incomingGradTensor_ = incomingGradTensor;
+      newCachedGraph->indicesTensor_ = indicesTensor;
+      newCachedGraph->outgoingGradTensor_ = outgoingGradTensor;
+    });
+    auto incomingGradPlaceholder = Placeholder(cachedGraph->incomingGradTensor_, grad_);
+    auto indicesPlaceholder = Placeholder(cachedGraph->indicesTensor_, indices);
+    auto outgoingGradPlaceholder = Placeholder(cachedGraph->outgoingGradTensor_, outgoing_gradient);
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
       incomingGradPlaceholder.getMPSGraphTensor() : incomingGradPlaceholder.getMPSGraphTensorData(),
@@ -921,7 +837,7 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outgoingGradPlaceholder.getMPSGraphTensor() : outgoingGradPlaceholder.getMPSGraphTensorData()};
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
   return outgoing_gradient;
 }
@@ -1013,7 +929,6 @@ Tensor& index_fill_mps_(Tensor& self, int64_t dim, const Tensor& index, const Te
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   auto inputType = getMPSDataType(self);
   auto sourceType = getMPSDataType(source);
   if (inputType == MPSDataTypeUInt8 || (!is_macos_13_or_newer() && inputType == MPSDataTypeBool)) {
@@ -1026,37 +941,25 @@ Tensor& index_fill_mps_(Tensor& self, int64_t dim, const Tensor& index, const Te
 
   @autoreleasepool {
     string key = "index_fill_mps_" + getTensorsStringKey({self, index, expanded_source}) + ":" + std::to_string(dim);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self));
-          MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-          MPSGraphTensor* updateTensor = mpsGraphRankedPlaceHolder(mpsGraph, expanded_source);
-          MPSGraphTensor* castedUpdateTensor = updateTensor;
-          if (inputType != sourceType) {
-            castedUpdateTensor = castMPSTensor(mpsGraph, updateTensor, inputType);
-          }
-          MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:inputTensor
-                                                           updatesTensor:castedUpdateTensor
-                                                           indicesTensor:indexTensor
-                                                                    axis:(NSInteger)dim
-                                                                    mode:MPSGraphScatterModeSet
-                                                                    name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->indexTensor_ = indexTensor;
-          newCachedGraph->updateTensor_ = updateTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self));
+      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
+      MPSGraphTensor* updateTensor = mpsGraphRankedPlaceHolder(mpsGraph, expanded_source);
+      MPSGraphTensor* castedUpdateTensor = updateTensor;
+      if (inputType != sourceType) {
+        castedUpdateTensor = castMPSTensor(mpsGraph, updateTensor, inputType);
+      }
+      MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:inputTensor
+                                                       updatesTensor:castedUpdateTensor
+                                                       indicesTensor:indexTensor
+                                                                axis:(NSInteger)dim
+                                                                mode:MPSGraphScatterModeSet
+                                                                name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->indexTensor_ = indexTensor;
+      newCachedGraph->updateTensor_ = updateTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_,
                                               self,

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -112,45 +112,27 @@ Tensor& mm_out_mps_impl(const Tensor& self, const Tensor& other, Tensor& output)
 
   MPSStream* stream = getCurrentMPSStream();
 
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "mm_out_mps_impl" + getTensorsStringKey({self, other});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* selfTensor = nil;
+      MPSGraphTensor* otherTensor = nil;
+      MPSGraphTensor* outputTensor = nil;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      if (self.numel() == 0 || other.numel() == 0) {
+        outputTensor = [mpsGraph constantWithScalar:0. shape:getMPSShape(output_sizes) dataType:getMPSDataType(output)];
 
-          MPSGraphTensor* selfTensor = nil;
-          MPSGraphTensor* otherTensor = nil;
-          MPSGraphTensor* outputTensor = nil;
+      } else {
+        selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
+        otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
+        outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:selfTensor secondaryTensor:otherTensor name:nil];
+      }
 
-          if (self.numel() == 0 || other.numel() == 0) {
-            outputTensor = [mpsGraph constantWithScalar:0.
-                                                  shape:getMPSShape(output_sizes)
-                                               dataType:getMPSDataType(output)];
-
-          } else {
-            selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
-            otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
-            outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:selfTensor
-                                                           secondaryTensor:otherTensor
-                                                                      name:nil];
-          }
-
-          newCachedGraph->inputTensor_ = selfTensor;
-          newCachedGraph->otherTensor_ = otherTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = selfTensor;
+      newCachedGraph->otherTensor_ = otherTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder selfPlaceholder = Placeholder();
     Placeholder otherPlaceholder = Placeholder();
 
@@ -234,65 +216,49 @@ Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = (opType == ADDBMM_OP_TYPE) ? ("addbmm_out_mps_impl") : ("baddbmm_out_mps_impl");
     key += getTensorsStringKey({batch1, batch2, input}) + ":" + to_string(beta.toDouble()) + ":" +
         to_string(alpha.toDouble());
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, input);
+      MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
+      MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Intermediates for beta and alpha
+      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
+                                                       dataType:getMPSScalarType(input.scalar_type())];
+      MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
+                                                        dataType:getMPSScalarType(batch1.scalar_type())];
 
-          MPSGraphTensor* inputTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, input);
-          MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
-          MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
+                                                                      secondaryTensor:batch2Tensor
+                                                                                 name:@"(batch1@batch2)"];
 
-          // Intermediates for beta and alpha
-          MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
-                                                           dataType:getMPSScalarType(input.scalar_type())];
-          MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
-                                                            dataType:getMPSScalarType(batch1.scalar_type())];
+      MPSGraphTensor* reductionSumTensor = productTensor;
+      if (opType == ADDBMM_OP_TYPE) {
+        reductionSumTensor = [mpsGraph reductionSumWithTensor:productTensor axis:0 name:@"reductionSum(batch1@batch2)"];
+      }
 
-          MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
-                                                                          secondaryTensor:batch2Tensor
-                                                                                     name:@"(batch1@batch2)"];
+      // Intermediates for multiplying by beta and alpha
+      MPSGraphTensor* reductionSumTimesAlphaTensor =
+          [mpsGraph multiplicationWithPrimaryTensor:reductionSumTensor
+                                    secondaryTensor:alphaTensor
+                                               name:@"alpha*(batch1@batch2)"];
+      MPSGraphTensor* biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                                      secondaryTensor:betaTensor
+                                                                                 name:@"beta*input"];
 
-          MPSGraphTensor* reductionSumTensor = productTensor;
-          if (opType == ADDBMM_OP_TYPE) {
-            reductionSumTensor = [mpsGraph reductionSumWithTensor:productTensor
-                                                             axis:0
-                                                             name:@"reductionSum(batch1@batch2)"];
-          }
+      MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:reductionSumTimesAlphaTensor
+                                                         secondaryTensor:biasTimesBetaTensor
+                                                                    name:@"beta*input + alpha*(batch1@batch2)"];
 
-          // Intermediates for multiplying by beta and alpha
-          MPSGraphTensor* reductionSumTimesAlphaTensor =
-              [mpsGraph multiplicationWithPrimaryTensor:reductionSumTensor
-                                        secondaryTensor:alphaTensor
-                                                   name:@"alpha*(batch1@batch2)"];
-          MPSGraphTensor* biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                                          secondaryTensor:betaTensor
-                                                                                     name:@"beta*input"];
-
-          MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:reductionSumTimesAlphaTensor
-                                                             secondaryTensor:biasTimesBetaTensor
-                                                                        name:@"beta*input + alpha*(batch1@batch2)"];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->batch1Tensor_ = batch1Tensor;
-          newCachedGraph->batch2Tensor_ = batch2Tensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->batch1Tensor_ = batch1Tensor;
+      newCachedGraph->batch2Tensor_ = batch2Tensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder batch1Placeholder = Placeholder(cachedGraph->batch1Tensor_, batch1);
     Placeholder batch2Placeholder = Placeholder(cachedGraph->batch2Tensor_, batch2);
@@ -374,79 +340,65 @@ Tensor& addmm_out_mps_impl(const Tensor& bias,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "addmm_out_mps_impl" + getTensorsStringKey({self, other, *bias_}) + ":" + to_string(transpose_mat1) +
         ":" + to_string(transpose_mat2) + ":" + to_string(beta.toDouble()) + ":" + to_string(alpha.toDouble());
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
+      MPSGraphTensor* biasTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, *bias_);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* t1 = nil;
+      MPSGraphTensor* t2 = nil;
 
-          MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
-          MPSGraphTensor* biasTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, *bias_);
+      if (transpose_mat1)
+        t1 = [mpsGraph transposeTensor:selfTensor dimension:-1 withDimension:-2 name:nil];
+      else
+        t1 = selfTensor;
 
-          MPSGraphTensor* t1 = nil;
-          MPSGraphTensor* t2 = nil;
+      if (transpose_mat2)
+        t2 = [mpsGraph transposeTensor:otherTensor dimension:-1 withDimension:-2 name:nil];
+      else
+        t2 = otherTensor;
 
-          if (transpose_mat1)
-            t1 = [mpsGraph transposeTensor:selfTensor dimension:-1 withDimension:-2 name:nil];
-          else
-            t1 = selfTensor;
+      // TODO: Use alpha and beta here with fill_.Scalar and mul
+      // Intermediate as placeholder
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:t1
+                                                                      secondaryTensor:t2
+                                                                                 name:@"MM/(mat1@mat2)"];
 
-          if (transpose_mat2)
-            t2 = [mpsGraph transposeTensor:otherTensor dimension:-1 withDimension:-2 name:nil];
-          else
-            t2 = otherTensor;
+      // Intermediates for beta and alpha
+      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
+                                                       dataType:getMPSScalarType((*bias_).scalar_type())];
+      MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
+                                                        dataType:getMPSScalarType(self.scalar_type())];
 
-          // TODO: Use alpha and beta here with fill_.Scalar and mul
-          // Intermediate as placeholder
-          MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:t1
-                                                                          secondaryTensor:t2
-                                                                                     name:@"MM/(mat1@mat2)"];
+      // Intermediates for multiplying by beta and alpha
+      MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:productTensor
+                                                                          secondaryTensor:alphaTensor
+                                                                                     name:@"MM/alpha*(mat1@mat2)"];
+      MPSGraphTensor* biasTimesBetaTensor = biasTensor;
+      if (is_beta_non_zero) {
+        biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:biasTensor
+                                                        secondaryTensor:betaTensor
+                                                                   name:@"MM/beta*input"];
+      }
 
-          // Intermediates for beta and alpha
-          MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
-                                                           dataType:getMPSScalarType((*bias_).scalar_type())];
-          MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
-                                                            dataType:getMPSScalarType(self.scalar_type())];
+      if (transpose_mat1_times_mat2)
+        biasTimesBetaTensor = [mpsGraph transposeTensor:biasTimesBetaTensor dimension:-1 withDimension:-2 name:nil];
 
-          // Intermediates for multiplying by beta and alpha
-          MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:productTensor
-                                                                              secondaryTensor:alphaTensor
-                                                                                         name:@"MM/alpha*(mat1@mat2)"];
-          MPSGraphTensor* biasTimesBetaTensor = biasTensor;
-          if (is_beta_non_zero) {
-            biasTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:biasTensor
-                                                            secondaryTensor:betaTensor
-                                                                       name:@"MM/beta*input"];
-          }
+      MPSGraphTensor* outputTensor = productTimesAlphaTensor;
+      if (is_beta_non_zero) {
+        outputTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
+                                           secondaryTensor:biasTimesBetaTensor
+                                                      name:@"MM/beta*input + alpha*(mat1@mat2)"];
+      }
 
-          if (transpose_mat1_times_mat2)
-            biasTimesBetaTensor = [mpsGraph transposeTensor:biasTimesBetaTensor dimension:-1 withDimension:-2 name:nil];
-
-          MPSGraphTensor* outputTensor = productTimesAlphaTensor;
-          if (is_beta_non_zero) {
-            outputTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
-                                               secondaryTensor:biasTimesBetaTensor
-                                                          name:@"MM/beta*input + alpha*(mat1@mat2)"];
-          }
-
-          newCachedGraph->selfTensor_ = selfTensor;
-          newCachedGraph->otherTensor_ = otherTensor;
-          newCachedGraph->biasTensor_ = biasTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->selfTensor_ = selfTensor;
+      newCachedGraph->otherTensor_ = otherTensor;
+      newCachedGraph->biasTensor_ = biasTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->selfTensor_, self);
     Placeholder otherPlaceholder = Placeholder(cachedGraph->otherTensor_, other);
@@ -462,7 +414,7 @@ Tensor& addmm_out_mps_impl(const Tensor& bias,
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return output;
@@ -489,35 +441,21 @@ Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& res
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "bmm_out_mps_impl" + getTensorsStringKey({batch1, batch2});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
+      MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
+                                                                      secondaryTensor:batch2Tensor
+                                                                                 name:@"MM/(batch1@batch2)"];
 
-          MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
-          MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
-
-          MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
-                                                                          secondaryTensor:batch2Tensor
-                                                                                     name:@"MM/(batch1@batch2)"];
-
-          newCachedGraph->batch1Tensor_ = batch1Tensor;
-          newCachedGraph->batch2Tensor_ = batch2Tensor;
-          newCachedGraph->outputTensor_ = productTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->batch1Tensor_ = batch1Tensor;
+      newCachedGraph->batch2Tensor_ = batch2Tensor;
+      newCachedGraph->outputTensor_ = productTensor;
+    });
     Placeholder batch1Placeholder = Placeholder(cachedGraph->batch1Tensor_, batch1);
     Placeholder batch2Placeholder = Placeholder(cachedGraph->batch2Tensor_, batch2);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
@@ -693,62 +631,48 @@ Tensor& addr_out_mps(const Tensor& self,
     MPSGraphTensor* resultTensor_ = nil;
   };
 
-  mps::MPSGraphCache* cache_ = mps::MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "addr_out_mps_impl" + getTensorsStringKey({vec1, vec2, *self_}) + ":" + to_string(beta.toDouble()) +
         ":" + to_string(alpha.toDouble());
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* t1 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec1), inputShape);
+      MPSGraphTensor* t2 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec2), otherShape);
+      MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, *self_);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Intermediate as placeholder
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:t1
+                                                                      secondaryTensor:t2
+                                                                                 name:@"MM/(vec1Xvec2)"];
 
-          MPSGraphTensor* t1 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec1), inputShape);
-          MPSGraphTensor* t2 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec2), otherShape);
-          MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, *self_);
+      // Intermediates for beta and alpha
+      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
+                                                       dataType:getMPSScalarType((*self_).scalar_type())];
+      MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
+                                                        dataType:getMPSScalarType(vec1.scalar_type())];
 
-          // Intermediate as placeholder
-          MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:t1
-                                                                          secondaryTensor:t2
-                                                                                     name:@"MM/(vec1Xvec2)"];
+      // Intermediates for multiplying by beta and alpha
+      MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:productTensor
+                                                                          secondaryTensor:alphaTensor
+                                                                                     name:@"MM/alpha*(vec1Xvec2)"];
+      MPSGraphTensor* selfTimesBetaTensor = selfTensor;
+      if (is_beta_non_zero) {
+        selfTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:selfTensor
+                                                        secondaryTensor:betaTensor
+                                                                   name:@"MM/beta*input"];
+      }
 
-          // Intermediates for beta and alpha
-          MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta.toDouble()
-                                                           dataType:getMPSScalarType((*self_).scalar_type())];
-          MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.toDouble()
-                                                            dataType:getMPSScalarType(vec1.scalar_type())];
+      MPSGraphTensor* resultTensor = productTimesAlphaTensor;
+      if (is_beta_non_zero) {
+        resultTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
+                                           secondaryTensor:selfTimesBetaTensor
+                                                      name:@"MM/beta*input+alpha*(vec1@vec2)"];
+      }
 
-          // Intermediates for multiplying by beta and alpha
-          MPSGraphTensor* productTimesAlphaTensor = [mpsGraph multiplicationWithPrimaryTensor:productTensor
-                                                                              secondaryTensor:alphaTensor
-                                                                                         name:@"MM/alpha*(vec1Xvec2)"];
-          MPSGraphTensor* selfTimesBetaTensor = selfTensor;
-          if (is_beta_non_zero) {
-            selfTimesBetaTensor = [mpsGraph multiplicationWithPrimaryTensor:selfTensor
-                                                            secondaryTensor:betaTensor
-                                                                       name:@"MM/beta*input"];
-          }
-
-          MPSGraphTensor* resultTensor = productTimesAlphaTensor;
-          if (is_beta_non_zero) {
-            resultTensor = [mpsGraph additionWithPrimaryTensor:productTimesAlphaTensor
-                                               secondaryTensor:selfTimesBetaTensor
-                                                          name:@"MM/beta*input+alpha*(vec1@vec2)"];
-          }
-
-          newCachedGraph->vec1Tensor_ = t1;
-          newCachedGraph->vec2Tensor_ = t2;
-          newCachedGraph->selfTensor_ = selfTensor;
-          newCachedGraph->resultTensor_ = resultTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->vec1Tensor_ = t1;
+      newCachedGraph->vec2Tensor_ = t2;
+      newCachedGraph->selfTensor_ = selfTensor;
+      newCachedGraph->resultTensor_ = resultTensor;
+    });
 
     Placeholder vec1Placeholder = Placeholder(cachedGraph->vec1Tensor_, vec1, inputShape);
     Placeholder vec2Placeholder = Placeholder(cachedGraph->vec2Tensor_, vec2, otherShape);

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -56,40 +56,26 @@ Tensor& mse_loss_backward_out_impl(const Tensor& grad_output,
     MPSGraphTensor *inputTensor = nil, *targetTensor = nil;
     MPSGraphTensor *gradInputTensor = nil, *gradOutputTensor = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = op_name + reductionToString(reduction) + ":" + to_string(grad_input.sizes()[1]) +
         getTensorsStringKey({input, target, grad_output});
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
+      newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      cachedGraph = static_cast<CachedGraph*>(cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-          newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-          MPSGraphTensor* normTensor = [mpsGraph constantWithScalar:norm dataType:MPSDataTypeFloat32];
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                              secondaryTensor:newCachedGraph->targetTensor
-                                                                         name:nil];
-          MPSGraphTensor* diffGradientTensor =
-              [mpsGraph multiplicationWithPrimaryTensor:diffTensor
-                                        secondaryTensor:newCachedGraph->gradOutputTensor
-                                                   name:nil];
-          newCachedGraph->gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:diffGradientTensor
-                                                                      secondaryTensor:normTensor
-                                                                                 name:nil];
-        }
-        return newCachedGraph;
-      }));
-    }
+      MPSGraphTensor* normTensor = [mpsGraph constantWithScalar:norm dataType:MPSDataTypeFloat32];
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
+                                                          secondaryTensor:newCachedGraph->targetTensor
+                                                                     name:nil];
+      MPSGraphTensor* diffGradientTensor = [mpsGraph multiplicationWithPrimaryTensor:diffTensor
+                                                                     secondaryTensor:newCachedGraph->gradOutputTensor
+                                                                                name:nil];
+      newCachedGraph->gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:diffGradientTensor
+                                                                  secondaryTensor:normTensor
+                                                                             name:nil];
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
     Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor, grad_input);
@@ -220,58 +206,45 @@ Tensor& bce_loss_out_impl(const Tensor& input,
   Tensor input_squeezed = input.squeeze();
   Tensor target_squeezed = target.squeeze();
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key =
         op_name + reductionToString(reduction) + getTensorsStringKey({input_squeezed, target_squeezed, weight});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      cachedGraph = static_cast<CachedGraph*>(cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_squeezed);
+      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target_squeezed);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* bceLossUnweighted = nil;
+      // if grad_output is defined, then it's a backward pass
+      if (grad_output.defined()) {
+        newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+        bceLossUnweighted = bce_backward_mps(newCachedGraph);
+      } else {
+        bceLossUnweighted = bce_forward_mps(newCachedGraph);
+      }
 
-          newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_squeezed);
-          newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target_squeezed);
+      MPSGraphTensor* bceLoss = bceLossUnweighted;
+      if (weight.defined()) {
+        newCachedGraph->weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
+        bceLoss = [mpsGraph multiplicationWithPrimaryTensor:bceLossUnweighted
+                                            secondaryTensor:newCachedGraph->weightTensor
+                                                       name:nil];
+      }
 
-          MPSGraphTensor* bceLossUnweighted = nil;
-          // if grad_output is defined, then it's a backward pass
-          if (grad_output.defined()) {
-            newCachedGraph->gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-            bceLossUnweighted = bce_backward_mps(newCachedGraph);
-          } else {
-            bceLossUnweighted = bce_forward_mps(newCachedGraph);
-          }
-
-          MPSGraphTensor* bceLoss = bceLossUnweighted;
-          if (weight.defined()) {
-            newCachedGraph->weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
-            bceLoss = [mpsGraph multiplicationWithPrimaryTensor:bceLossUnweighted
-                                                secondaryTensor:newCachedGraph->weightTensor
-                                                           name:nil];
-          }
-
-          if (grad_output.defined()) {
-            if (reduction == at::Reduction::Mean) {
-              MPSGraphTensor* inputNumel = [mpsGraph constantWithScalar:static_cast<double>(input.numel())
-                                                               dataType:MPSDataTypeFloat32];
-              newCachedGraph->gradInputTensor = [mpsGraph divisionWithPrimaryTensor:bceLoss
-                                                                    secondaryTensor:inputNumel
-                                                                               name:nil];
-            } else {
-              newCachedGraph->gradInputTensor = bceLoss;
-            }
-          } else {
-            newCachedGraph->lossTensor = reduceTensor(bceLoss, reduction, mpsGraph, input_squeezed.sizes().size());
-          }
+      if (grad_output.defined()) {
+        if (reduction == at::Reduction::Mean) {
+          MPSGraphTensor* inputNumel = [mpsGraph constantWithScalar:static_cast<double>(input.numel())
+                                                           dataType:MPSDataTypeFloat32];
+          newCachedGraph->gradInputTensor = [mpsGraph divisionWithPrimaryTensor:bceLoss
+                                                                secondaryTensor:inputNumel
+                                                                           name:nil];
+        } else {
+          newCachedGraph->gradInputTensor = bceLoss;
         }
-        return newCachedGraph;
-      }));
-    }
+      } else {
+        newCachedGraph->lossTensor = reduceTensor(bceLoss, reduction, mpsGraph, input_squeezed.sizes().size());
+      }
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_squeezed);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target_squeezed);
     Placeholder lossPlaceholder = Placeholder(cachedGraph->lossTensor, loss_squeezed);
@@ -344,68 +317,57 @@ void nllnd_loss_backward_impl(Tensor& grad_input_arg,
         to_string(numClasses) + ":" + to_string(ignore_index) + ":" + to_string(isWeightsArrayValid) + ":" +
         reductionToString(reduction);
 
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
+      MPSGraphTensor* weightTensor = nil;
+      if (isWeightsArrayValid) {
+        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
+      }
+      MPSGraphTensor* totalWeightTensor = mpsGraphRankedPlaceHolder(mpsGraph, total_weight);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-          MPSGraphTensor* weightTensor = nil;
-          if (isWeightsArrayValid) {
-            weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
-          }
-          MPSGraphTensor* totalWeightTensor = mpsGraphRankedPlaceHolder(mpsGraph, total_weight);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* udpatedTargetTensor = targetTensor;
 
-          MPSGraphTensor* udpatedTargetTensor = targetTensor;
-
-          // Replace ignored_index with length depth + 1 so that oneHotAPI ignores it
-          if (ignore_index != -100) {
-            MPSGraphTensor* ignoreIndexTensor = [mpsGraph constantWithScalar:ignore_index dataType:MPSDataTypeInt64];
-            MPSGraphTensor* numClassesTensor = [mpsGraph constantWithScalar:(numClasses + 1) dataType:MPSDataTypeInt64];
-            MPSGraphTensor* isEqualTensor = [mpsGraph equalWithPrimaryTensor:targetTensor
-                                                             secondaryTensor:ignoreIndexTensor
-                                                                        name:@"isEqualTensor"];
-            udpatedTargetTensor = [mpsGraph selectWithPredicateTensor:isEqualTensor
-                                                  truePredicateTensor:numClassesTensor
-                                                 falsePredicateTensor:targetTensor
-                                                                 name:@"predicateTensor"];
-          }
-          MPSGraphTensor* oneHotTensor = [mpsGraph oneHotWithIndicesTensor:udpatedTargetTensor
-                                                                     depth:numClasses
-                                                                      axis:1
-                                                                  dataType:inputTensor.dataType
-                                                                   onValue:-1.0f
-                                                                  offValue:0.0f
-                                                                      name:nil];
-          if (isWeightsArrayValid) {
-            oneHotTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
-                                                     secondaryTensor:weightTensor
-                                                                name:@"scaleByWeightTensor"];
-          }
-          if (reduction == Reduction::Mean) {
-            oneHotTensor = [mpsGraph divisionNoNaNWithPrimaryTensor:oneHotTensor
-                                                    secondaryTensor:totalWeightTensor
-                                                               name:@"divisionTensor"];
-          }
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
-                                                                      secondaryTensor:gradOutputTensor
-                                                                                 name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->totalWeightTensor_ = totalWeightTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      // Replace ignored_index with length depth + 1 so that oneHotAPI ignores it
+      if (ignore_index != -100) {
+        MPSGraphTensor* ignoreIndexTensor = [mpsGraph constantWithScalar:ignore_index dataType:MPSDataTypeInt64];
+        MPSGraphTensor* numClassesTensor = [mpsGraph constantWithScalar:(numClasses + 1) dataType:MPSDataTypeInt64];
+        MPSGraphTensor* isEqualTensor = [mpsGraph equalWithPrimaryTensor:targetTensor
+                                                         secondaryTensor:ignoreIndexTensor
+                                                                    name:@"isEqualTensor"];
+        udpatedTargetTensor = [mpsGraph selectWithPredicateTensor:isEqualTensor
+                                              truePredicateTensor:numClassesTensor
+                                             falsePredicateTensor:targetTensor
+                                                             name:@"predicateTensor"];
+      }
+      MPSGraphTensor* oneHotTensor = [mpsGraph oneHotWithIndicesTensor:udpatedTargetTensor
+                                                                 depth:numClasses
+                                                                  axis:1
+                                                              dataType:inputTensor.dataType
+                                                               onValue:-1.0f
+                                                              offValue:0.0f
+                                                                  name:nil];
+      if (isWeightsArrayValid) {
+        oneHotTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
+                                                 secondaryTensor:weightTensor
+                                                            name:@"scaleByWeightTensor"];
+      }
+      if (reduction == Reduction::Mean) {
+        oneHotTensor = [mpsGraph divisionNoNaNWithPrimaryTensor:oneHotTensor
+                                                secondaryTensor:totalWeightTensor
+                                                           name:@"divisionTensor"];
+      }
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->totalWeightTensor_ = totalWeightTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
@@ -473,8 +435,6 @@ void nllnd_loss_forward_impl(Tensor& output,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   auto input = input_arg.dim() == 1 ? input_arg.view({1, input_arg.size(0)}) : input_arg;
@@ -493,133 +453,116 @@ void nllnd_loss_forward_impl(Tensor& output,
     string key = "nllnd_loss_forward_impl:" + to_string(ignore_index) + ":" + to_string(isWeightsArrayValid) + ":" +
         reductionToString(reduction) + ":" + [ns_shape_key UTF8String] + ":" + getMPSTypeString(input) + ":" +
         getMPSTypeString(target) + ":" + getMPSTypeString(weight);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
+      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(target), target_shape);
+      MPSGraphTensor* weightTensor = nil;
+      if (isWeightsArrayValid)
+        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(weight), weight_shape);
+      MPSGraphTensor* mps_batchSizeTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batchSizeTensor));
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* mpsGraphBatchSizeTensor = mps_batchSizeTensor;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // The transposes are needed to get the class dimension (dim 1) to the inner most dim for gather op.
+      // The transpose become nop in the 2D case.
+      MPSGraphTensor* mpsTransposeTensor = inputTensor;
+      int classDim = 1;
+      int lastDim = input.sizes().size() - 1;
+      mpsTransposeTensor = [mpsGraph transposeTensor:inputTensor dimension:classDim withDimension:lastDim name:nil];
+      for (int i = 0; i < lastDim - 2; ++i) {
+        mpsTransposeTensor = [mpsGraph transposeTensor:mpsTransposeTensor
+                                             dimension:classDim + i
+                                         withDimension:classDim + i + 1
+                                                  name:nil];
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
-          MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(target), target_shape);
-          MPSGraphTensor* weightTensor = nil;
-          if (isWeightsArrayValid)
-            weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(weight), weight_shape);
-          MPSGraphTensor* mps_batchSizeTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batchSizeTensor));
+      MPSGraphTensor* mpsGatherTensor = [mpsGraph gatherWithUpdatesTensor:mpsTransposeTensor
+                                                            indicesTensor:targetTensor
+                                                                     axis:lastDim
+                                                          batchDimensions:lastDim
+                                                                     name:@"gatherTensor"];
 
-          MPSGraphTensor* mpsGraphBatchSizeTensor = mps_batchSizeTensor;
+      bool isIgnoreIndexValid = (ignore_index != -100);
+      MPSGraphTensor* weightGatherTensor;
 
-          // The transposes are needed to get the class dimension (dim 1) to the inner most dim for gather op.
-          // The transpose become nop in the 2D case.
-          MPSGraphTensor* mpsTransposeTensor = inputTensor;
-          int classDim = 1;
-          int lastDim = input.sizes().size() - 1;
-          mpsTransposeTensor = [mpsGraph transposeTensor:inputTensor dimension:classDim withDimension:lastDim name:nil];
-          for (int i = 0; i < lastDim - 2; ++i) {
-            mpsTransposeTensor = [mpsGraph transposeTensor:mpsTransposeTensor
-                                                 dimension:classDim + i
-                                             withDimension:classDim + i + 1
-                                                      name:nil];
-          }
+      if (isWeightsArrayValid) {
+        weightGatherTensor = [mpsGraph gatherWithUpdatesTensor:weightTensor
+                                                 indicesTensor:targetTensor
+                                                          axis:0
+                                               batchDimensions:0
+                                                          name:@"weightGatherTensor"];
+        MPSGraphTensor* mpsGatherCopyTensor = [mpsGraph identityWithTensor:mpsGatherTensor name:@"identityTensor"];
+        mpsGatherTensor = [mpsGraph multiplicationWithPrimaryTensor:weightGatherTensor
+                                                    secondaryTensor:mpsGatherCopyTensor
+                                                               name:@"scaledLossTensor"];
+      }
 
-          MPSGraphTensor* mpsGatherTensor = [mpsGraph gatherWithUpdatesTensor:mpsTransposeTensor
-                                                                indicesTensor:targetTensor
-                                                                         axis:lastDim
-                                                              batchDimensions:lastDim
-                                                                         name:@"gatherTensor"];
+      // Both these cases need recomputation of denominator when reductionMode == mean
+      if (isIgnoreIndexValid || isWeightsArrayValid) {
+        // Setup tensors
+        MPSGraphTensor* mpsGraphZeroTensor = [mpsGraph constantWithScalar:0.0 dataType:mpsGatherTensor.dataType];
+        MPSGraphTensor* mpsGraphOneTensor = [mpsGraph constantWithScalar:1.0 dataType:mpsGatherTensor.dataType];
+        // @TODO: Remove this identity call with ToT StarSky MPSGraph
+        MPSGraphTensor* mpsGraphOneTensorCopy = [mpsGraph identityWithTensor:mpsGraphOneTensor
+                                                                        name:@"IdentityHackTensor"];
 
-          bool isIgnoreIndexValid = (ignore_index != -100);
-          MPSGraphTensor* weightGatherTensor;
+        MPSGraphTensor* mpsGraphIsEqualTensor;
 
-          if (isWeightsArrayValid) {
-            weightGatherTensor = [mpsGraph gatherWithUpdatesTensor:weightTensor
-                                                     indicesTensor:targetTensor
-                                                              axis:0
-                                                   batchDimensions:0
-                                                              name:@"weightGatherTensor"];
-            MPSGraphTensor* mpsGatherCopyTensor = [mpsGraph identityWithTensor:mpsGatherTensor name:@"identityTensor"];
-            mpsGatherTensor = [mpsGraph multiplicationWithPrimaryTensor:weightGatherTensor
-                                                        secondaryTensor:mpsGatherCopyTensor
-                                                                   name:@"scaledLossTensor"];
-          }
-
-          // Both these cases need recomputation of denominator when reductionMode == mean
-          if (isIgnoreIndexValid || isWeightsArrayValid) {
-            // Setup tensors
-            MPSGraphTensor* mpsGraphZeroTensor = [mpsGraph constantWithScalar:0.0 dataType:mpsGatherTensor.dataType];
-            MPSGraphTensor* mpsGraphOneTensor = [mpsGraph constantWithScalar:1.0 dataType:mpsGatherTensor.dataType];
-            // @TODO: Remove this identity call with ToT StarSky MPSGraph
-            MPSGraphTensor* mpsGraphOneTensorCopy = [mpsGraph identityWithTensor:mpsGraphOneTensor
-                                                                            name:@"IdentityHackTensor"];
-
-            MPSGraphTensor* mpsGraphIsEqualTensor;
-
-            if (isIgnoreIndexValid) {
-              MPSGraphTensor* mpsGraphIndexTensor = [mpsGraph constantWithScalar:ignore_index
-                                                                        dataType:MPSDataTypeInt64];
-              // Equal tensor
-              mpsGraphIsEqualTensor = [mpsGraph equalWithPrimaryTensor:targetTensor
-                                                       secondaryTensor:mpsGraphIndexTensor
-                                                                  name:@"isEqualTensor"];
-              // Zero out loss
-              MPSGraphTensor* mpsGatherCopyTensor = [mpsGraph identityWithTensor:mpsGatherTensor
-                                                                            name:@"identityTensor"];
-              mpsGatherTensor = [mpsGraph selectWithPredicateTensor:mpsGraphIsEqualTensor
-                                                truePredicateTensor:mpsGraphZeroTensor
-                                               falsePredicateTensor:mpsGatherCopyTensor
-                                                               name:@"predicateTensor"];
-            }
-
-            if (isWeightsArrayValid) {
-              mpsGraphOneTensorCopy = weightGatherTensor;
-              if (!isIgnoreIndexValid) {
-                mpsGraphIsEqualTensor = [mpsGraph constantWithScalar:0.0
-                                                               shape:targetTensor.shape
-                                                            dataType:targetTensor.dataType];
-              }
-            }
-
-            // Compute new batch size
-            MPSGraphTensor* mpsSelectOneTensor = [mpsGraph selectWithPredicateTensor:mpsGraphIsEqualTensor
-                                                                 truePredicateTensor:mpsGraphZeroTensor
-                                                                falsePredicateTensor:mpsGraphOneTensorCopy
-                                                                                name:@"predicateOneTensor"];
-            mpsGraphBatchSizeTensor = [mpsGraph reductionSumWithTensor:mpsSelectOneTensor
-                                                                  axes:nil
-                                                                  name:@"batchSizeReductionTensor"];
-          }
-
-          MPSGraphTensor* mpsGraphNegTensor = [mpsGraph negativeWithTensor:mpsGatherTensor name:@"negativeTensor"];
-
-          MPSGraphTensor* mpsGraphReducedTensor = mpsGraphNegTensor;
-
-          if (!(reduction == Reduction::None)) {
-            mpsGraphReducedTensor = [mpsGraph reductionSumWithTensor:mpsGraphNegTensor
-                                                                axes:nil
-                                                                name:@"reductionSumTensor"];
-            if (reduction == Reduction::Mean) {
-              mpsGraphReducedTensor = [mpsGraph divisionNoNaNWithPrimaryTensor:mpsGraphReducedTensor
-                                                               secondaryTensor:mpsGraphBatchSizeTensor
-                                                                          name:@"divisionTensor"];
-            }
-          }
-
-          mpsGraphReducedTensor = [mpsGraph reshapeTensor:mpsGraphReducedTensor withShape:getMPSShape(output) name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->batchSizeTensor_ = mps_batchSizeTensor;
-          newCachedGraph->totalWeightTensor_ = mpsGraphBatchSizeTensor;
-          newCachedGraph->outputTensor_ = mpsGraphReducedTensor;
+        if (isIgnoreIndexValid) {
+          MPSGraphTensor* mpsGraphIndexTensor = [mpsGraph constantWithScalar:ignore_index dataType:MPSDataTypeInt64];
+          // Equal tensor
+          mpsGraphIsEqualTensor = [mpsGraph equalWithPrimaryTensor:targetTensor
+                                                   secondaryTensor:mpsGraphIndexTensor
+                                                              name:@"isEqualTensor"];
+          // Zero out loss
+          MPSGraphTensor* mpsGatherCopyTensor = [mpsGraph identityWithTensor:mpsGatherTensor name:@"identityTensor"];
+          mpsGatherTensor = [mpsGraph selectWithPredicateTensor:mpsGraphIsEqualTensor
+                                            truePredicateTensor:mpsGraphZeroTensor
+                                           falsePredicateTensor:mpsGatherCopyTensor
+                                                           name:@"predicateTensor"];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+
+        if (isWeightsArrayValid) {
+          mpsGraphOneTensorCopy = weightGatherTensor;
+          if (!isIgnoreIndexValid) {
+            mpsGraphIsEqualTensor = [mpsGraph constantWithScalar:0.0
+                                                           shape:targetTensor.shape
+                                                        dataType:targetTensor.dataType];
+          }
+        }
+
+        // Compute new batch size
+        MPSGraphTensor* mpsSelectOneTensor = [mpsGraph selectWithPredicateTensor:mpsGraphIsEqualTensor
+                                                             truePredicateTensor:mpsGraphZeroTensor
+                                                            falsePredicateTensor:mpsGraphOneTensorCopy
+                                                                            name:@"predicateOneTensor"];
+        mpsGraphBatchSizeTensor = [mpsGraph reductionSumWithTensor:mpsSelectOneTensor
+                                                              axes:nil
+                                                              name:@"batchSizeReductionTensor"];
+      }
+
+      MPSGraphTensor* mpsGraphNegTensor = [mpsGraph negativeWithTensor:mpsGatherTensor name:@"negativeTensor"];
+
+      MPSGraphTensor* mpsGraphReducedTensor = mpsGraphNegTensor;
+
+      if (!(reduction == Reduction::None)) {
+        mpsGraphReducedTensor = [mpsGraph reductionSumWithTensor:mpsGraphNegTensor axes:nil name:@"reductionSumTensor"];
+        if (reduction == Reduction::Mean) {
+          mpsGraphReducedTensor = [mpsGraph divisionNoNaNWithPrimaryTensor:mpsGraphReducedTensor
+                                                           secondaryTensor:mpsGraphBatchSizeTensor
+                                                                      name:@"divisionTensor"];
+        }
+      }
+
+      mpsGraphReducedTensor = [mpsGraph reshapeTensor:mpsGraphReducedTensor withShape:getMPSShape(output) name:nil];
+
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->batchSizeTensor_ = mps_batchSizeTensor;
+      newCachedGraph->totalWeightTensor_ = mpsGraphBatchSizeTensor;
+      newCachedGraph->outputTensor_ = mpsGraphReducedTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target);
@@ -665,8 +608,6 @@ void smooth_l1_loss_impl(const Tensor& input,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -675,81 +616,67 @@ void smooth_l1_loss_impl(const Tensor& input,
 
     string key = "smooth_l1_loss_impl:" + reductionToString(reduction) + ":" + [ns_shape_key UTF8String] + ":" +
         to_string(beta) + ":" + getMPSTypeString(input) + ":" + getMPSTypeString(target);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      // smooth_l1_loss_mps:
+      // ln = 0.5 * ( xn - yn ) ^ 2 / beta,       if |xn - yn| < beta
+      //    = | xn - yn | - 0.5 * beta,           otherwise
 
-        // smooth_l1_loss_mps:
-        // ln = 0.5 * ( xn - yn ) ^ 2 / beta,       if |xn - yn| < beta
-        //    = | xn - yn | - 0.5 * beta,           otherwise
+      MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input));
+      MPSGraphTensor* targetTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(target));
 
-        @autoreleasepool {
-          // Initialize graph
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Setup tensors
+      MPSGraphTensor* mpsGraphHalfTensor = [mpsGraph constantWithScalar:0.5 dataType:inputTensor.dataType];
+      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta dataType:inputTensor.dataType];
+      // 0.5 * beta
+      MPSGraphTensor* halfTensorMulBetaTensor = [mpsGraph constantWithScalar:beta * 0.5 dataType:inputTensor.dataType];
+      // Calculating first part of the equation:
+      // ln = 0.5(xn - yn)^2/beta, if |xn - yn| < beta
 
-          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input));
-          MPSGraphTensor* targetTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(target));
-
-          // Setup tensors
-          MPSGraphTensor* mpsGraphHalfTensor = [mpsGraph constantWithScalar:0.5 dataType:inputTensor.dataType];
-          MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta dataType:inputTensor.dataType];
-          // 0.5 * beta
-          MPSGraphTensor* halfTensorMulBetaTensor = [mpsGraph constantWithScalar:beta * 0.5
-                                                                        dataType:inputTensor.dataType];
-          // Calculating first part of the equation:
-          // ln = 0.5(xn - yn)^2/beta, if |xn - yn| < beta
-
-          // xn - yn
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                              secondaryTensor:targetTensor
-                                                                         name:nil];
-
-          // | xn - yn |
-          MPSGraphTensor* diffAbsTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
-
-          // | xn - yn | < beta
-          MPSGraphTensor* diffAbsLessThanBetaTensor = [mpsGraph lessThanWithPrimaryTensor:diffAbsTensor
-                                                                          secondaryTensor:betaTensor
-                                                                                     name:nil];
-
-          // ( xn - yn ) ^ 2
-          MPSGraphTensor* diffSquare = [mpsGraph squareWithTensor:diffTensor name:nil];
-
-          // 0.5 * ( xn - yn ) ^ 2
-          MPSGraphTensor* diffSquareMulHalfTensor = [mpsGraph multiplicationWithPrimaryTensor:diffSquare
-                                                                              secondaryTensor:mpsGraphHalfTensor
-                                                                                         name:nil];
-
-          // 0.5 * ( xn - yn ) ^ 2 / beta
-          MPSGraphTensor* loss1Temp = [mpsGraph divisionWithPrimaryTensor:diffSquareMulHalfTensor
-                                                          secondaryTensor:betaTensor
+      // xn - yn
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                          secondaryTensor:targetTensor
                                                                      name:nil];
 
-          // Calculating second part of the equation:
-          // | xn - yn | - 0.5 * beta, if | xn - yn | >= beta
+      // | xn - yn |
+      MPSGraphTensor* diffAbsTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
 
-          // | xn - yn | - 0.5 * beta
-          MPSGraphTensor* loss2Temp = [mpsGraph subtractionWithPrimaryTensor:diffAbsTensor
-                                                             secondaryTensor:halfTensorMulBetaTensor
-                                                                        name:nil];
+      // | xn - yn | < beta
+      MPSGraphTensor* diffAbsLessThanBetaTensor = [mpsGraph lessThanWithPrimaryTensor:diffAbsTensor
+                                                                      secondaryTensor:betaTensor
+                                                                                 name:nil];
 
-          MPSGraphTensor* lossTensor = [mpsGraph selectWithPredicateTensor:diffAbsLessThanBetaTensor
-                                                       truePredicateTensor:loss1Temp
-                                                      falsePredicateTensor:loss2Temp
-                                                                      name:@"lossTensor"];
+      // ( xn - yn ) ^ 2
+      MPSGraphTensor* diffSquare = [mpsGraph squareWithTensor:diffTensor name:nil];
 
-          MPSGraphTensor* outputTensor = reduceTensor(lossTensor, reduction, mpsGraph, 1);
+      // 0.5 * ( xn - yn ) ^ 2
+      MPSGraphTensor* diffSquareMulHalfTensor = [mpsGraph multiplicationWithPrimaryTensor:diffSquare
+                                                                          secondaryTensor:mpsGraphHalfTensor
+                                                                                     name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      // 0.5 * ( xn - yn ) ^ 2 / beta
+      MPSGraphTensor* loss1Temp = [mpsGraph divisionWithPrimaryTensor:diffSquareMulHalfTensor
+                                                      secondaryTensor:betaTensor
+                                                                 name:nil];
+
+      // Calculating second part of the equation:
+      // | xn - yn | - 0.5 * beta, if | xn - yn | >= beta
+
+      // | xn - yn | - 0.5 * beta
+      MPSGraphTensor* loss2Temp = [mpsGraph subtractionWithPrimaryTensor:diffAbsTensor
+                                                         secondaryTensor:halfTensorMulBetaTensor
+                                                                    name:nil];
+
+      MPSGraphTensor* lossTensor = [mpsGraph selectWithPredicateTensor:diffAbsLessThanBetaTensor
+                                                   truePredicateTensor:loss1Temp
+                                                  falsePredicateTensor:loss2Temp
+                                                                  name:@"lossTensor"];
+
+      MPSGraphTensor* outputTensor = reduceTensor(lossTensor, reduction, mpsGraph, 1);
+
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, mpsInputShape);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target, mpsInputShape);
@@ -832,61 +759,48 @@ void smooth_l1_loss_backward_impl(const Tensor& grad_output,
     string key = "smooth_l1_loss_backward" + getTensorsStringKey({input, grad_output, grad_input, target}) + ":" +
         reductionToString(reduction) + ":" + to_string(beta);
 
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-          MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta dataType:MPSDataTypeFloat32];
-          // xn - yn
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                              secondaryTensor:targetTensor
-                                                                         name:nil];
-          // | xn - yn |
-          MPSGraphTensor* diffAbsTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
-          // | xn - yn | < beta
-          MPSGraphTensor* diffAbsLessThanBetaTensor = [mpsGraph lessThanWithPrimaryTensor:diffAbsTensor
-                                                                          secondaryTensor:betaTensor
-                                                                                     name:nil];
-          // ( xn - yn ) / beta
-          MPSGraphTensor* truePredicateTensor = [mpsGraph divisionWithPrimaryTensor:diffTensor
-                                                                    secondaryTensor:betaTensor
-                                                                               name:nil];
-          // ( x - y ) / | x - y |
-          MPSGraphTensor* falsePredicateTensor = [mpsGraph divisionWithPrimaryTensor:diffTensor
-                                                                     secondaryTensor:diffAbsTensor
-                                                                                name:nil];
-
-          MPSGraphTensor* lossTensor = [mpsGraph selectWithPredicateTensor:diffAbsLessThanBetaTensor
-                                                       truePredicateTensor:truePredicateTensor
-                                                      falsePredicateTensor:falsePredicateTensor
-                                                                      name:@"lossTensor"];
-          MPSGraphTensor* outputTensor = lossTensor;
-          if (reduction == Reduction::Mean) {
-            MPSGraphTensor* numelTensor = [mpsGraph constantWithScalar:(double)input.numel()
-                                                              dataType:MPSDataTypeFloat32];
-            outputTensor = [mpsGraph divisionWithPrimaryTensor:lossTensor secondaryTensor:numelTensor name:nil];
-          }
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor
-                                                                      secondaryTensor:gradOutputTensor
+      MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta dataType:MPSDataTypeFloat32];
+      // xn - yn
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                          secondaryTensor:targetTensor
+                                                                     name:nil];
+      // | xn - yn |
+      MPSGraphTensor* diffAbsTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
+      // | xn - yn | < beta
+      MPSGraphTensor* diffAbsLessThanBetaTensor = [mpsGraph lessThanWithPrimaryTensor:diffAbsTensor
+                                                                      secondaryTensor:betaTensor
                                                                                  name:nil];
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      // ( xn - yn ) / beta
+      MPSGraphTensor* truePredicateTensor = [mpsGraph divisionWithPrimaryTensor:diffTensor
+                                                                secondaryTensor:betaTensor
+                                                                           name:nil];
+      // ( x - y ) / | x - y |
+      MPSGraphTensor* falsePredicateTensor = [mpsGraph divisionWithPrimaryTensor:diffTensor
+                                                                 secondaryTensor:diffAbsTensor
+                                                                            name:nil];
+
+      MPSGraphTensor* lossTensor = [mpsGraph selectWithPredicateTensor:diffAbsLessThanBetaTensor
+                                                   truePredicateTensor:truePredicateTensor
+                                                  falsePredicateTensor:falsePredicateTensor
+                                                                  name:@"lossTensor"];
+      MPSGraphTensor* outputTensor = lossTensor;
+      if (reduction == Reduction::Mean) {
+        MPSGraphTensor* numelTensor = [mpsGraph constantWithScalar:(double)input.numel() dataType:MPSDataTypeFloat32];
+        outputTensor = [mpsGraph divisionWithPrimaryTensor:lossTensor secondaryTensor:numelTensor name:nil];
+      }
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor
+                                                                  secondaryTensor:gradOutputTensor
+                                                                             name:nil];
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target);
     Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
@@ -930,62 +844,47 @@ Tensor& huber_loss_out_mps(const Tensor& input, const Tensor& target, int64_t re
     MPSGraphTensor* targetTensor_ = nil;
     MPSGraphTensor* outputTensor_ = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = op_name + ":" + reductionToString(reduction) + ":" + std::to_string(delta) + ":" +
         getTensorsStringKey({input, target});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSDataType input_type = getMPSScalarType(input.scalar_type());
+      MPSGraphTensor* deltaTensor = [mpsGraph constantWithScalar:delta shape:@[ @1 ] dataType:input_type];
+      MPSGraphTensor* halfTensor = [mpsGraph constantWithScalar:.5f shape:@[ @1 ] dataType:input_type];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                          secondaryTensor:targetTensor
+                                                                     name:nil];
+      MPSGraphTensor* absDiffTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
+      MPSGraphTensor* firstCondTensor = [mpsGraph multiplicationWithPrimaryTensor:absDiffTensor
+                                                                  secondaryTensor:absDiffTensor
+                                                                             name:nil];
+      firstCondTensor = [mpsGraph multiplicationWithPrimaryTensor:firstCondTensor secondaryTensor:halfTensor name:nil];
+      MPSGraphTensor* secondCondTensor = [mpsGraph multiplicationWithPrimaryTensor:deltaTensor
+                                                                   secondaryTensor:halfTensor
+                                                                              name:nil];
+      secondCondTensor = [mpsGraph subtractionWithPrimaryTensor:absDiffTensor
+                                                secondaryTensor:secondCondTensor
+                                                           name:nil];
+      secondCondTensor = [mpsGraph multiplicationWithPrimaryTensor:deltaTensor
+                                                   secondaryTensor:secondCondTensor
+                                                              name:nil];
+      MPSGraphTensor* outputTensor =
+          [mpsGraph selectWithPredicateTensor:[mpsGraph lessThanOrEqualToWithPrimaryTensor:absDiffTensor
+                                                                           secondaryTensor:deltaTensor
+                                                                                      name:nil]
+                          truePredicateTensor:firstCondTensor
+                         falsePredicateTensor:secondCondTensor
+                                         name:nil];
 
-          MPSDataType input_type = getMPSScalarType(input.scalar_type());
-          MPSGraphTensor* deltaTensor = [mpsGraph constantWithScalar:delta shape:@[ @1 ] dataType:input_type];
-          MPSGraphTensor* halfTensor = [mpsGraph constantWithScalar:.5f shape:@[ @1 ] dataType:input_type];
-
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                              secondaryTensor:targetTensor
-                                                                         name:nil];
-          MPSGraphTensor* absDiffTensor = [mpsGraph absoluteWithTensor:diffTensor name:nil];
-          MPSGraphTensor* firstCondTensor = [mpsGraph multiplicationWithPrimaryTensor:absDiffTensor
-                                                                      secondaryTensor:absDiffTensor
-                                                                                 name:nil];
-          firstCondTensor = [mpsGraph multiplicationWithPrimaryTensor:firstCondTensor
-                                                      secondaryTensor:halfTensor
-                                                                 name:nil];
-          MPSGraphTensor* secondCondTensor = [mpsGraph multiplicationWithPrimaryTensor:deltaTensor
-                                                                       secondaryTensor:halfTensor
-                                                                                  name:nil];
-          secondCondTensor = [mpsGraph subtractionWithPrimaryTensor:absDiffTensor
-                                                    secondaryTensor:secondCondTensor
-                                                               name:nil];
-          secondCondTensor = [mpsGraph multiplicationWithPrimaryTensor:deltaTensor
-                                                       secondaryTensor:secondCondTensor
-                                                                  name:nil];
-          MPSGraphTensor* outputTensor =
-              [mpsGraph selectWithPredicateTensor:[mpsGraph lessThanOrEqualToWithPrimaryTensor:absDiffTensor
-                                                                               secondaryTensor:deltaTensor
-                                                                                          name:nil]
-                              truePredicateTensor:firstCondTensor
-                             falsePredicateTensor:secondCondTensor
-                                             name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->outputTensor_ = reduceTensor(outputTensor, reduction, mpsGraph, input.sizes().size());
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->outputTensor_ = reduceTensor(outputTensor, reduction, mpsGraph, input.sizes().size());
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -1029,8 +928,6 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -1039,80 +936,68 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
 
     string key = "huber_loss_backward_out_mps:" + reductionToString(reduction) + ":" + std::to_string(delta) + ":" +
         [ns_shape_key UTF8String] + ":" + getMPSTypeString(input) + ":" + getMPSTypeString(target);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      cachedGraph = static_cast<CachedGraph*>(cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(new_grad_output), getMPSShape(new_grad_output));
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
+      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(target), getMPSShape(target));
+      MPSGraphTensor* isMeanReductionTensor =
+          [mpsGraph constantWithScalar:is_mean_reduction
+                              dataType:MPSDataTypeInt64]; // constant does not support MPSDataTypeBool
+      MPSGraphTensor* inputNumelTensor = [mpsGraph constantWithScalar:input_numel
+                                                             dataType:getMPSDataType(new_grad_output)];
 
-        @autoreleasepool {
-          // Initialize graph
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* gradOutputTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(new_grad_output), getMPSShape(new_grad_output));
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
-          MPSGraphTensor* targetTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(target), getMPSShape(target));
-          MPSGraphTensor* isMeanReductionTensor =
-              [mpsGraph constantWithScalar:is_mean_reduction
-                                  dataType:MPSDataTypeInt64]; // constant does not support MPSDataTypeBool
-          MPSGraphTensor* inputNumelTensor = [mpsGraph constantWithScalar:input_numel
-                                                                 dataType:getMPSDataType(new_grad_output)];
+      MPSGraphTensor* normGradOutputTensor =
+          [mpsGraph selectWithPredicateTensor:isMeanReductionTensor
+                          truePredicateTensor:[mpsGraph divisionWithPrimaryTensor:gradOutputTensor
+                                                                  secondaryTensor:inputNumelTensor
+                                                                             name:nil]
+                         falsePredicateTensor:gradOutputTensor
+                                         name:nil];
+      MPSGraphTensor* deltaTensor = [mpsGraph constantWithScalar:delta
+                                                           shape:getMPSShape(target)
+                                                        dataType:getMPSDataType(target)];
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                          secondaryTensor:targetTensor
+                                                                     name:nil];
+      MPSGraphTensor* normGradOutputDeltaTensor = [mpsGraph multiplicationWithPrimaryTensor:normGradOutputTensor
+                                                                            secondaryTensor:deltaTensor
+                                                                                       name:nil];
+      // first condition: (input - target) <= -delta
+      // formula: -norm * grad_output * delta
+      MPSGraphTensor* firstCondTensor = [mpsGraph negativeWithTensor:normGradOutputDeltaTensor name:nil];
+      // second condition: (input - target) >= delta
+      // formula: norm * grad_output * delta
+      MPSGraphTensor* secondCondTensor = normGradOutputDeltaTensor;
 
-          MPSGraphTensor* normGradOutputTensor =
-              [mpsGraph selectWithPredicateTensor:isMeanReductionTensor
-                              truePredicateTensor:[mpsGraph divisionWithPrimaryTensor:gradOutputTensor
-                                                                      secondaryTensor:inputNumelTensor
-                                                                                 name:nil]
-                             falsePredicateTensor:gradOutputTensor
-                                             name:nil];
-          MPSGraphTensor* deltaTensor = [mpsGraph constantWithScalar:delta
-                                                               shape:getMPSShape(target)
-                                                            dataType:getMPSDataType(target)];
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                              secondaryTensor:targetTensor
-                                                                         name:nil];
-          MPSGraphTensor* normGradOutputDeltaTensor = [mpsGraph multiplicationWithPrimaryTensor:normGradOutputTensor
-                                                                                secondaryTensor:deltaTensor
-                                                                                           name:nil];
-          // first condition: (input - target) <= -delta
-          // formula: -norm * grad_output * delta
-          MPSGraphTensor* firstCondTensor = [mpsGraph negativeWithTensor:normGradOutputDeltaTensor name:nil];
-          // second condition: (input - target) >= delta
-          // formula: norm * grad_output * delta
-          MPSGraphTensor* secondCondTensor = normGradOutputDeltaTensor;
+      // third condition: (input - target) within -delta to delta
+      // formula: norm * (input - target) * grad_output
+      MPSGraphTensor* thirdCondTensor = [mpsGraph multiplicationWithPrimaryTensor:normGradOutputTensor
+                                                                  secondaryTensor:diffTensor
+                                                                             name:nil];
 
-          // third condition: (input - target) within -delta to delta
-          // formula: norm * (input - target) * grad_output
-          MPSGraphTensor* thirdCondTensor = [mpsGraph multiplicationWithPrimaryTensor:normGradOutputTensor
-                                                                      secondaryTensor:diffTensor
-                                                                                 name:nil];
+      MPSGraphTensor* secondThirdTensor =
+          [mpsGraph selectWithPredicateTensor:[mpsGraph greaterThanOrEqualToWithPrimaryTensor:diffTensor
+                                                                              secondaryTensor:deltaTensor
+                                                                                         name:nil]
+                          truePredicateTensor:secondCondTensor
+                         falsePredicateTensor:thirdCondTensor
+                                         name:nil];
+      MPSGraphTensor* outputTensor = [mpsGraph
+          selectWithPredicateTensor:[mpsGraph
+                                        lessThanOrEqualToWithPrimaryTensor:diffTensor
+                                                           secondaryTensor:[mpsGraph negativeWithTensor:deltaTensor
+                                                                                                   name:nil]
+                                                                      name:nil]
+                truePredicateTensor:firstCondTensor
+               falsePredicateTensor:secondThirdTensor
+                               name:nil];
 
-          MPSGraphTensor* secondThirdTensor =
-              [mpsGraph selectWithPredicateTensor:[mpsGraph greaterThanOrEqualToWithPrimaryTensor:diffTensor
-                                                                                  secondaryTensor:deltaTensor
-                                                                                             name:nil]
-                              truePredicateTensor:secondCondTensor
-                             falsePredicateTensor:thirdCondTensor
-                                             name:nil];
-          MPSGraphTensor* outputTensor = [mpsGraph
-              selectWithPredicateTensor:[mpsGraph
-                                            lessThanOrEqualToWithPrimaryTensor:diffTensor
-                                                               secondaryTensor:[mpsGraph negativeWithTensor:deltaTensor
-                                                                                                       name:nil]
-                                                                          name:nil]
-                    truePredicateTensor:firstCondTensor
-                   falsePredicateTensor:secondThirdTensor
-                                   name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->targetTensor_ = targetTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      }));
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->targetTensor_ = targetTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, new_grad_output);
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
@@ -1145,31 +1030,19 @@ TORCH_IMPL_FUNC(mse_loss_out_mps)(const Tensor& input, const Tensor& target, int
     MPSGraphTensor* targetTensor = nil;
     MPSGraphTensor* outputTensor = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = op_name + reductionToString(reduction) + getTensorsStringKey({input, target});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      cachedGraph = static_cast<CachedGraph*>(cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          newCachedGraph->targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-
-          MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                              secondaryTensor:newCachedGraph->targetTensor
-                                                                         name:nil];
-          MPSGraphTensor* diffSquareTensor = [mpsGraph squareWithTensor:diffTensor name:nil];
-          newCachedGraph->outputTensor = reduceTensor(diffSquareTensor, reduction, mpsGraph, input.sizes().size());
-        }
-        return newCachedGraph;
-      }));
-    }
+      MPSGraphTensor* diffTensor = [mpsGraph subtractionWithPrimaryTensor:newCachedGraph->inputTensor
+                                                          secondaryTensor:newCachedGraph->targetTensor
+                                                                     name:nil];
+      MPSGraphTensor* diffSquareTensor = [mpsGraph squareWithTensor:diffTensor name:nil];
+      newCachedGraph->outputTensor = reduceTensor(diffSquareTensor, reduction, mpsGraph, input.sizes().size());
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor, target);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, output);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -70,8 +70,8 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
                                                          Tensor& output,
                                                          Tensor& save_mean,
                                                          Tensor& save_var) {
-  namespace native_mps = at::native::mps;
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  using namespace at::native::mps;
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* weightTensor_ = nil;
@@ -84,8 +84,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
     MPSGraphTensor* runningMeanInplaceUpdate_ = nil;
     MPSGraphTensor* runningVarInplaceUpdate_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   auto stream = at::mps::getCurrentMPSStream();
 
@@ -127,21 +125,19 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
     // Reduction axes
     NSMutableArray<NSNumber*>* axes = [NSMutableArray<NSNumber*> arrayWithCapacity:(num_input_dims - 1)];
 
-    native_mps::get_shapes(
-        input_shape_readonly, input_shape, new_mean_shape, axes, num_input_dims, memory_format, false);
+    get_shapes(input_shape_readonly, input_shape, new_mean_shape, axes, num_input_dims, memory_format, false);
 
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
     string key = "batch_norm_mps_out:" + mem_format_key + ":" + std::to_string(epsilon) + ":" +
         std::to_string(momentum) + ":" + std::to_string(train) + ":" + std::to_string(has_running_mean) + ":" +
         std::to_string(has_weight) + ":" + std::to_string(has_bias) + ":" + [ns_shape_key UTF8String] + ":" +
-        native_mps::getTensorsStringKey({self,
-                                         weight_opt.value_or(Tensor()),
-                                         bias_opt.value_or(Tensor()),
-                                         running_mean_opt.value_or(Tensor()),
-                                         running_var_opt.value_or(Tensor())});
-    auto input_mps_dtype = native_mps::getMPSDataType(self);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+        getTensorsStringKey({self,
+                             weight_opt.value_or(Tensor()),
+                             bias_opt.value_or(Tensor()),
+                             running_mean_opt.value_or(Tensor()),
+                             running_var_opt.value_or(Tensor())});
+    auto input_mps_dtype = getMPSDataType(self);
 
     // Dim where channels are located
     int channelsDim;
@@ -156,192 +152,175 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
       executeGatherOp = false;
     }
 
-    if (!cachedGraph) {
-      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
+      MPSGraphTensor* weightTensor = nil;
+      // Should have shape of mean
+      if (has_weight)
+        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(weight_opt.value()), new_mean_shape);
+      MPSGraphTensor* biasTensor = nil;
+      if (has_bias)
+        biasTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(bias_opt.value()), new_mean_shape);
+      MPSGraphTensor* runningMeanTensor = nil;
+      MPSGraphTensor* runningVarTensor = nil;
+      if (has_running_mean) {
+        runningMeanTensor =
+            mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(running_mean_opt.value()), new_mean_shape);
+        runningVarTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(running_var_opt.value()), new_mean_shape);
+      }
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Mean and inv std tensors to be saved and returned
+      MPSGraphTensor* saveMeanTensor = nil;
+      MPSGraphTensor* saveVarTensor = nil;
 
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
-          MPSGraphTensor* weightTensor = nil;
-          // Should have shape of mean
-          if (has_weight)
-            weightTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(weight_opt.value()), new_mean_shape);
-          MPSGraphTensor* biasTensor = nil;
-          if (has_bias)
-            biasTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(bias_opt.value()), new_mean_shape);
-          MPSGraphTensor* runningMeanTensor = nil;
-          MPSGraphTensor* runningVarTensor = nil;
-          if (has_running_mean) {
-            runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(running_mean_opt.value()), new_mean_shape);
-            runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(running_var_opt.value()), new_mean_shape);
-          }
+      // Running stats inplace update
+      MPSGraphTensor* runningMeanInplaceUpdate = nil;
+      MPSGraphTensor* runningVarInplaceUpdate = nil;
 
-          // Mean and inv std tensors to be saved and returned
-          MPSGraphTensor* saveMeanTensor = nil;
-          MPSGraphTensor* saveVarTensor = nil;
+      MPSGraphTensor* updatedRunningMeanTensor = nil;
+      MPSGraphTensor* updatedRunningVarTensor = nil;
+      MPSGraphTensor* scaledInverseSqrtVariance = nil;
 
-          // Running stats inplace update
-          MPSGraphTensor* runningMeanInplaceUpdate = nil;
-          MPSGraphTensor* runningVarInplaceUpdate = nil;
+      /*
+      If train:
+        If has_running_mean:
+          Update the running stats to be stored into save_mean and save_var,
+          AND to be used in current batchnorm computation
+        Else:
+          Just calculate the var using batch variance
+      If not train:
+        Check if running mean exists (maybe do this check before making graph)
+        Copy the running mean into the mean to be saved
+        Calculate the save_var directly from the running variance
 
-          MPSGraphTensor* updatedRunningMeanTensor = nil;
-          MPSGraphTensor* updatedRunningVarTensor = nil;
-          MPSGraphTensor* scaledInverseSqrtVariance = nil;
+      Compute the batch norm output and stats to be saved
+      */
+      MPSGraphTensor* varTensor = nil;
 
-          /*
-          If train:
-            If has_running_mean:
-              Update the running stats to be stored into save_mean and save_var,
-              AND to be used in current batchnorm computation
-            Else:
-              Just calculate the var using batch variance
-          If not train:
-            Check if running mean exists (maybe do this check before making graph)
-            Copy the running mean into the mean to be saved
-            Calculate the save_var directly from the running variance
-
-          Compute the batch norm output and stats to be saved
-          */
-          MPSGraphTensor* varTensor = nil;
-
-          if (train) {
-            // Compute mean and variance of the current batch
-            MPSGraphTensor* batchMeanTensor = [mpsGraph meanOfTensor:inputTensor axes:axes name:nil];
-            MPSGraphTensor* batchVarianceTensor = [mpsGraph varianceOfTensor:inputTensor axes:axes name:nil];
-            varTensor = batchVarianceTensor;
-            if (has_running_mean) {
-              // TODO: This is not the formula used in PyTorch, is this OK? Seems more robust
-              // float besselCorrectionTerm = float(N) / std::max(N - 1.0f, 1.0f);
-              float besselCorrectionTerm = float(N) / float(N - 1.0f);
-              MPSGraphTensor* besselConstantTensor = [mpsGraph constantWithScalar:(double)besselCorrectionTerm
-                                                                            shape:@[ @1 ]
-                                                                         dataType:input_mps_dtype];
-              MPSGraphTensor* unbiasedVarianceTensor = [mpsGraph multiplicationWithPrimaryTensor:batchVarianceTensor
-                                                                                 secondaryTensor:besselConstantTensor
-                                                                                            name:nil];
-              MPSGraphTensor* momentumTensor = [mpsGraph constantWithScalar:(double)momentum
-                                                                      shape:@[ @1 ]
-                                                                   dataType:input_mps_dtype];
-              MPSGraphTensor* oneMinusMomentum = [mpsGraph constantWithScalar:(double)(1.0 - momentum)
+      if (train) {
+        // Compute mean and variance of the current batch
+        MPSGraphTensor* batchMeanTensor = [mpsGraph meanOfTensor:inputTensor axes:axes name:nil];
+        MPSGraphTensor* batchVarianceTensor = [mpsGraph varianceOfTensor:inputTensor axes:axes name:nil];
+        varTensor = batchVarianceTensor;
+        if (has_running_mean) {
+          // TODO: This is not the formula used in PyTorch, is this OK? Seems more robust
+          // float besselCorrectionTerm = float(N) / std::max(N - 1.0f, 1.0f);
+          float besselCorrectionTerm = float(N) / float(N - 1.0f);
+          MPSGraphTensor* besselConstantTensor = [mpsGraph constantWithScalar:(double)besselCorrectionTerm
                                                                         shape:@[ @1 ]
                                                                      dataType:input_mps_dtype];
-              // Compute updated running mean
-              MPSGraphTensor* scaledBatchMean = [mpsGraph multiplicationWithPrimaryTensor:batchMeanTensor
-                                                                          secondaryTensor:momentumTensor
-                                                                                     name:nil];
-              MPSGraphTensor* scaledRunningMean = [mpsGraph multiplicationWithPrimaryTensor:runningMeanTensor
-                                                                            secondaryTensor:oneMinusMomentum
-                                                                                       name:nil];
-              updatedRunningMeanTensor = [mpsGraph additionWithPrimaryTensor:scaledBatchMean
-                                                             secondaryTensor:scaledRunningMean
-                                                                        name:nil];
-              // Compute updated running var
-              MPSGraphTensor* scaledCorrectedBatchVar = [mpsGraph multiplicationWithPrimaryTensor:unbiasedVarianceTensor
-                                                                                  secondaryTensor:momentumTensor
-                                                                                             name:nil];
-              MPSGraphTensor* scaledRunningVar = [mpsGraph multiplicationWithPrimaryTensor:runningVarTensor
-                                                                           secondaryTensor:oneMinusMomentum
-                                                                                      name:nil];
-              updatedRunningVarTensor = [mpsGraph additionWithPrimaryTensor:scaledCorrectedBatchVar
-                                                            secondaryTensor:scaledRunningVar
-                                                                       name:nil];
-            }
-            // Update saved mean and inverse std tensor
-            MPSGraphTensor* epsilonTensor = [mpsGraph constantWithScalar:(double)epsilon
-                                                                   shape:@[ @1 ]
-                                                                dataType:input_mps_dtype];
-
-            MPSGraphTensor* varianceEps = [mpsGraph additionWithPrimaryTensor:batchVarianceTensor
-                                                              secondaryTensor:epsilonTensor
-                                                                         name:@"varianceEps"];
-
-            MPSGraphTensor* sqrtVariance = [mpsGraph squareRootWithTensor:varianceEps name:@"sqrtVariance"];
-            scaledInverseSqrtVariance = [mpsGraph reciprocalWithTensor:sqrtVariance name:nil];
-            // Update saved mean and inverse std tensor
-            saveMeanTensor = batchMeanTensor;
-            saveVarTensor = scaledInverseSqrtVariance;
-          } else { // Test
-            TORCH_CHECK(has_running_mean);
-            saveMeanTensor = [mpsGraph identityWithTensor:runningMeanTensor name:nil];
-            saveVarTensor = [mpsGraph identityWithTensor:runningVarTensor name:nil];
-            varTensor = saveVarTensor;
-          }
-
-          // Compute output of batch norm
-          MPSGraphTensor* outputTensor = [mpsGraph normalizationWithTensor:inputTensor
-                                                                meanTensor:saveMeanTensor
-                                                            varianceTensor:varTensor
-                                                               gammaTensor:weightTensor
-                                                                betaTensor:biasTensor
-                                                                   epsilon:(float)epsilon
-                                                                      name:nil];
-
-          // Reshape saved mean and var to fit output
-          saveMeanTensor = [mpsGraph reshapeTensor:saveMeanTensor withShape:@[ new_mean_shape[channelsDim] ] name:nil];
-          saveVarTensor = [mpsGraph reshapeTensor:saveVarTensor withShape:@[ new_mean_shape[channelsDim] ] name:nil];
-
-          if (train && has_running_mean) {
-            // Running stats inplace update
-            runningMeanInplaceUpdate = [mpsGraph reshapeTensor:updatedRunningMeanTensor
-                                                     withShape:@[ input_shape[channelsDim] ]
-                                                          name:nil];
-            runningVarInplaceUpdate = [mpsGraph reshapeTensor:updatedRunningVarTensor
-                                                    withShape:@[ input_shape[channelsDim] ]
-                                                         name:nil];
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->biasTensor_ = biasTensor;
-          newCachedGraph->runningMeanTensor_ = runningMeanTensor;
-          newCachedGraph->runningVarTensor_ = runningVarTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->saveMeanTensor_ = saveMeanTensor;
-          newCachedGraph->saveVarTensor_ = saveVarTensor;
-          newCachedGraph->runningMeanInplaceUpdate_ = runningMeanInplaceUpdate;
-          newCachedGraph->runningVarInplaceUpdate_ = runningVarInplaceUpdate;
+          MPSGraphTensor* unbiasedVarianceTensor = [mpsGraph multiplicationWithPrimaryTensor:batchVarianceTensor
+                                                                             secondaryTensor:besselConstantTensor
+                                                                                        name:nil];
+          MPSGraphTensor* momentumTensor = [mpsGraph constantWithScalar:(double)momentum
+                                                                  shape:@[ @1 ]
+                                                               dataType:input_mps_dtype];
+          MPSGraphTensor* oneMinusMomentum = [mpsGraph constantWithScalar:(double)(1.0 - momentum)
+                                                                    shape:@[ @1 ]
+                                                                 dataType:input_mps_dtype];
+          // Compute updated running mean
+          MPSGraphTensor* scaledBatchMean = [mpsGraph multiplicationWithPrimaryTensor:batchMeanTensor
+                                                                      secondaryTensor:momentumTensor
+                                                                                 name:nil];
+          MPSGraphTensor* scaledRunningMean = [mpsGraph multiplicationWithPrimaryTensor:runningMeanTensor
+                                                                        secondaryTensor:oneMinusMomentum
+                                                                                   name:nil];
+          updatedRunningMeanTensor = [mpsGraph additionWithPrimaryTensor:scaledBatchMean
+                                                         secondaryTensor:scaledRunningMean
+                                                                    name:nil];
+          // Compute updated running var
+          MPSGraphTensor* scaledCorrectedBatchVar = [mpsGraph multiplicationWithPrimaryTensor:unbiasedVarianceTensor
+                                                                              secondaryTensor:momentumTensor
+                                                                                         name:nil];
+          MPSGraphTensor* scaledRunningVar = [mpsGraph multiplicationWithPrimaryTensor:runningVarTensor
+                                                                       secondaryTensor:oneMinusMomentum
+                                                                                  name:nil];
+          updatedRunningVarTensor = [mpsGraph additionWithPrimaryTensor:scaledCorrectedBatchVar
+                                                        secondaryTensor:scaledRunningVar
+                                                                   name:nil];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+        // Update saved mean and inverse std tensor
+        MPSGraphTensor* epsilonTensor = [mpsGraph constantWithScalar:(double)epsilon
+                                                               shape:@[ @1 ]
+                                                            dataType:input_mps_dtype];
 
-    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, self, input_shape, executeGatherOp);
-    auto weightPlaceholder = native_mps::Placeholder();
+        MPSGraphTensor* varianceEps = [mpsGraph additionWithPrimaryTensor:batchVarianceTensor
+                                                          secondaryTensor:epsilonTensor
+                                                                     name:@"varianceEps"];
+
+        MPSGraphTensor* sqrtVariance = [mpsGraph squareRootWithTensor:varianceEps name:@"sqrtVariance"];
+        scaledInverseSqrtVariance = [mpsGraph reciprocalWithTensor:sqrtVariance name:nil];
+        // Update saved mean and inverse std tensor
+        saveMeanTensor = batchMeanTensor;
+        saveVarTensor = scaledInverseSqrtVariance;
+      } else { // Test
+        TORCH_CHECK(has_running_mean);
+        saveMeanTensor = [mpsGraph identityWithTensor:runningMeanTensor name:nil];
+        saveVarTensor = [mpsGraph identityWithTensor:runningVarTensor name:nil];
+        varTensor = saveVarTensor;
+      }
+
+      // Compute output of batch norm
+      MPSGraphTensor* outputTensor = [mpsGraph normalizationWithTensor:inputTensor
+                                                            meanTensor:saveMeanTensor
+                                                        varianceTensor:varTensor
+                                                           gammaTensor:weightTensor
+                                                            betaTensor:biasTensor
+                                                               epsilon:(float)epsilon
+                                                                  name:nil];
+
+      // Reshape saved mean and var to fit output
+      saveMeanTensor = [mpsGraph reshapeTensor:saveMeanTensor withShape:@[ new_mean_shape[channelsDim] ] name:nil];
+      saveVarTensor = [mpsGraph reshapeTensor:saveVarTensor withShape:@[ new_mean_shape[channelsDim] ] name:nil];
+
+      if (train && has_running_mean) {
+        // Running stats inplace update
+        runningMeanInplaceUpdate = [mpsGraph reshapeTensor:updatedRunningMeanTensor
+                                                 withShape:@[ input_shape[channelsDim] ]
+                                                      name:nil];
+        runningVarInplaceUpdate = [mpsGraph reshapeTensor:updatedRunningVarTensor
+                                                withShape:@[ input_shape[channelsDim] ]
+                                                     name:nil];
+      }
+
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->biasTensor_ = biasTensor;
+      newCachedGraph->runningMeanTensor_ = runningMeanTensor;
+      newCachedGraph->runningVarTensor_ = runningVarTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->saveMeanTensor_ = saveMeanTensor;
+      newCachedGraph->saveVarTensor_ = saveVarTensor;
+      newCachedGraph->runningMeanInplaceUpdate_ = runningMeanInplaceUpdate;
+      newCachedGraph->runningVarInplaceUpdate_ = runningVarInplaceUpdate;
+    });
+
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape, executeGatherOp);
+    auto weightPlaceholder = Placeholder();
     if (has_weight)
-      weightPlaceholder = native_mps::Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
-    auto biasPlaceholder = native_mps::Placeholder();
+      weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
+    auto biasPlaceholder = Placeholder();
     if (has_bias)
-      biasPlaceholder = native_mps::Placeholder(cachedGraph->biasTensor_, bias_opt.value(), new_mean_shape);
-    auto runningMeanPlaceholder = native_mps::Placeholder();
-    auto runningVarPlaceholder = native_mps::Placeholder();
+      biasPlaceholder = Placeholder(cachedGraph->biasTensor_, bias_opt.value(), new_mean_shape);
+    auto runningMeanPlaceholder = Placeholder();
+    auto runningVarPlaceholder = Placeholder();
     if (has_running_mean) {
-      runningMeanPlaceholder =
-          native_mps::Placeholder(cachedGraph->runningMeanTensor_, running_mean_opt.value(), new_mean_shape);
-      runningVarPlaceholder =
-          native_mps::Placeholder(cachedGraph->runningVarTensor_, running_var_opt.value(), new_mean_shape);
+      runningMeanPlaceholder = Placeholder(cachedGraph->runningMeanTensor_, running_mean_opt.value(), new_mean_shape);
+      runningVarPlaceholder = Placeholder(cachedGraph->runningVarTensor_, running_var_opt.value(), new_mean_shape);
     }
 
-    auto runningMeanInplaceUpdatePlaceholder = native_mps::Placeholder();
-    auto runningVarInplaceUpdatePlaceholder = native_mps::Placeholder();
+    auto runningMeanInplaceUpdatePlaceholder = Placeholder();
+    auto runningVarInplaceUpdatePlaceholder = Placeholder();
 
     if (train && has_running_mean) {
       runningMeanInplaceUpdatePlaceholder =
-          native_mps::Placeholder(cachedGraph->runningMeanInplaceUpdate_, running_mean_opt.value());
-      runningVarInplaceUpdatePlaceholder =
-          native_mps::Placeholder(cachedGraph->runningVarInplaceUpdate_, running_var_opt.value());
+          Placeholder(cachedGraph->runningMeanInplaceUpdate_, running_mean_opt.value());
+      runningVarInplaceUpdatePlaceholder = Placeholder(cachedGraph->runningVarInplaceUpdate_, running_var_opt.value());
     }
 
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output, input_shape, false);
-    auto saveMeanPlaceholder = native_mps::Placeholder(cachedGraph->saveMeanTensor_, save_mean);
-    auto saveVarPlaceholder = native_mps::Placeholder(cachedGraph->saveVarTensor_, save_var);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, input_shape, false);
+    auto saveMeanPlaceholder = Placeholder(cachedGraph->saveMeanTensor_, save_mean);
+    auto saveVarPlaceholder = Placeholder(cachedGraph->saveVarTensor_, save_var);
 
     NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
     feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
@@ -367,7 +346,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
           runningVarInplaceUpdatePlaceholder.getMPSGraphTensorData();
     }
 
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   if (!train) {
@@ -524,10 +503,10 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                           at::MemoryFormat::Contiguous);
   }
 
-  namespace native_mps = at::native::mps;
+  using namespace at::native::mps;
 
   // Derive from MPSCachedGraph
-  struct CachedGraph : public native_mps::MPSCachedGraph {
+  struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
     MPSGraphTensor* inputTensor_ = nil;
@@ -540,8 +519,6 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
     MPSGraphTensor* gradWeightTensor_ = nil;
     MPSGraphTensor* gradBiasTensor_ = nil;
   };
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
   auto stream = at::mps::getCurrentMPSStream();
 
@@ -579,246 +556,219 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
     // Reduction axes
     NSMutableArray<NSNumber*>* axes = [NSMutableArray<NSNumber*> arrayWithCapacity:(num_input_dims - 1)];
 
-    native_mps::get_shapes(
-        input_shape_readonly, input_shape, new_mean_shape, axes, num_input_dims, memory_format, true);
+    get_shapes(input_shape_readonly, input_shape, new_mean_shape, axes, num_input_dims, memory_format, true);
 
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
     string key = "batch_norm_backward_mps:" + mem_format_key + ":" + std::to_string(epsilon) + ":" +
         std::to_string(train) + ":" + std::to_string(has_running_mean) + ":" + std::to_string(has_weight) + ":" +
-        [ns_shape_key UTF8String] + ":" + c10::Join(",", grad_input_mask) + ":" + native_mps::getMPSTypeString(input);
-    auto input_mps_dtype = native_mps::getMPSDataType(input);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+        [ns_shape_key UTF8String] + ":" + c10::Join(",", grad_input_mask) + ":" + getMPSTypeString(input);
+    auto input_mps_dtype = getMPSDataType(input);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      // NCHW - Channels dim is 1
+      int channelsDim = 1;
 
-    if (!cachedGraph) {
-      native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      auto inputTensorOriginal = mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
+      // Shape is the ORIGINAL NCHW shape
+      auto gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_out), input_shape_readonly);
+      MPSGraphTensor* weightTensor = nil;
+      if (has_weight)
+        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(weight_opt.value()), new_mean_shape);
+      MPSGraphTensor* runningMeanTensor = nil;
+      MPSGraphTensor* runningVarTensor = nil;
+      if (has_running_mean) {
+        runningMeanTensor =
+            mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(running_mean_opt.value()), new_mean_shape);
+        runningVarTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(running_var_opt.value()), new_mean_shape);
+      }
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Mean and inv std tensors to be saved and returned
+      MPSGraphTensor* saveMeanTensor = nil;
+      MPSGraphTensor* saveVarTensor = nil;
+      if (has_save_mean) {
+        saveMeanTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(save_mean_opt.value()), new_mean_shape);
+        saveVarTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(save_var_opt.value()), new_mean_shape);
+      }
 
-          // NCHW - Channels dim is 1
-          int channelsDim = 1;
+      MPSGraphTensor* gradInputTensor = nil;
+      MPSGraphTensor* gradWeightTensor = nil;
+      MPSGraphTensor* gradBiasTensor = nil;
+      MPSGraphTensor* inputTensor = nil;
 
-          MPSGraphTensor* inputTensorOriginal =
-              native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
-          // Shape is the ORIGINAL NCHW shape
-          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(
-              mpsGraph, native_mps::getMPSDataType(grad_out), input_shape_readonly);
-          MPSGraphTensor* weightTensor = nil;
-          if (has_weight)
-            weightTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(weight_opt.value()), new_mean_shape);
-          MPSGraphTensor* runningMeanTensor = nil;
-          MPSGraphTensor* runningVarTensor = nil;
-          if (has_running_mean) {
-            runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(running_mean_opt.value()), new_mean_shape);
-            runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(running_var_opt.value()), new_mean_shape);
-          }
+      if (memory_format == at::MemoryFormat::Contiguous)
+        inputTensor = inputTensorOriginal;
+      else {
+        // Reshape/transpose the input as needed
+        auto N = input_shape[0];
+        auto H = input_shape[1];
+        auto W = input_shape[2];
+        auto C = input_shape[3];
 
-          // Mean and inv std tensors to be saved and returned
-          MPSGraphTensor* saveMeanTensor = nil;
-          MPSGraphTensor* saveVarTensor = nil;
-          if (has_save_mean) {
-            saveMeanTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(save_mean_opt.value()), new_mean_shape);
-            saveVarTensor = native_mps::mpsGraphRankedPlaceHolder(
-                mpsGraph, native_mps::getMPSDataType(save_var_opt.value()), new_mean_shape);
-          }
+        inputTensor = [mpsGraph reshapeTensor:inputTensorOriginal
+                                    withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
+                                         name:nil];
+        inputTensor = [mpsGraph transposeTensor:inputTensor dimension:1 withDimension:2 name:nil];
+        inputTensor = [mpsGraph reshapeTensor:inputTensor withShape:@[ N, C, H, W ] name:nil];
+      }
 
-          MPSGraphTensor* gradInputTensor = nil;
-          MPSGraphTensor* gradWeightTensor = nil;
-          MPSGraphTensor* gradBiasTensor = nil;
-          MPSGraphTensor* inputTensor = nil;
-
-          if (memory_format == at::MemoryFormat::Contiguous)
-            inputTensor = inputTensorOriginal;
-          else {
-            // Reshape/transpose the input as needed
-            auto N = input_shape[0];
-            auto H = input_shape[1];
-            auto W = input_shape[2];
-            auto C = input_shape[3];
-
-            inputTensor = [mpsGraph reshapeTensor:inputTensorOriginal
-                                        withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
-                                             name:nil];
-            inputTensor = [mpsGraph transposeTensor:inputTensor dimension:1 withDimension:2 name:nil];
-            inputTensor = [mpsGraph reshapeTensor:inputTensor withShape:@[ N, C, H, W ] name:nil];
-          }
-
-          if (train) {
-            // Use save_mean and save_var
-            MPSGraphTensor* epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon dataType:input_mps_dtype];
-            MPSGraphTensor* revertSaveVarTensor = saveVarTensor;
-            revertSaveVarTensor = [mpsGraph reciprocalWithTensor:revertSaveVarTensor name:nil];
-            revertSaveVarTensor = [mpsGraph multiplicationWithPrimaryTensor:revertSaveVarTensor
-                                                            secondaryTensor:revertSaveVarTensor
-                                                                       name:nil];
-            revertSaveVarTensor = [mpsGraph subtractionWithPrimaryTensor:revertSaveVarTensor
-                                                         secondaryTensor:epsilonTensor
-                                                                    name:nil];
-            if (grad_input_mask[1]) {
-              gradWeightTensor = [mpsGraph normalizationGammaGradientWithIncomingGradientTensor:gradOutputTensor
-                                                                                   sourceTensor:inputTensor
-                                                                                     meanTensor:saveMeanTensor
-                                                                                 varianceTensor:revertSaveVarTensor
-                                                                                  reductionAxes:axes
-                                                                                        epsilon:(float)epsilon
-                                                                                           name:nil];
-            }
-            if (grad_input_mask[2]) {
-              gradBiasTensor = [mpsGraph normalizationBetaGradientWithIncomingGradientTensor:gradOutputTensor
-                                                                                sourceTensor:inputTensor
-                                                                               reductionAxes:axes
-                                                                                        name:nil];
-            }
-            if (grad_input_mask[0]) {
-              gradInputTensor = [mpsGraph normalizationGradientWithIncomingGradientTensor:gradOutputTensor
-                                                                             sourceTensor:inputTensor
-                                                                               meanTensor:saveMeanTensor
-                                                                           varianceTensor:revertSaveVarTensor
-                                                                              gammaTensor:weightTensor
-                                                                      gammaGradientTensor:gradWeightTensor
-                                                                       betaGradientTensor:gradBiasTensor
-                                                                            reductionAxes:axes
-                                                                                  epsilon:(float)epsilon
-                                                                                     name:nil];
-            }
-          } else {
-            // Use running mean and running var
-            MPSGraphTensor* rsqrtTensor = nil;
-            MPSGraphTensor* epsilonTensor = nil;
-            if (grad_input_mask[1]) {
-              epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon shape:@[ @1 ] dataType:input_mps_dtype];
-              MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                  secondaryTensor:runningMeanTensor
-                                                                             name:nil];
-              MPSGraphTensor* varianceEpsTensor = [mpsGraph additionWithPrimaryTensor:runningVarTensor
-                                                                      secondaryTensor:epsilonTensor
-                                                                                 name:nil];
-              rsqrtTensor = [mpsGraph reverseSquareRootWithTensor:varianceEpsTensor name:nil];
-              MPSGraphTensor* bnForwardTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
-                                                                          secondaryTensor:rsqrtTensor
-                                                                                     name:nil];
-              MPSGraphTensor* gradBnMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnForwardTensor
-                                                                          secondaryTensor:gradOutputTensor
-                                                                                     name:nil];
-              gradWeightTensor = [mpsGraph reductionSumWithTensor:gradBnMulTensor axes:axes name:nil];
-            }
-            if (grad_input_mask[2]) {
-              gradBiasTensor = [mpsGraph normalizationBetaGradientWithIncomingGradientTensor:gradOutputTensor
-                                                                                sourceTensor:inputTensor
-                                                                               reductionAxes:axes
-                                                                                        name:nil];
-            }
-            if (grad_input_mask[0]) {
-              MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
-                                                                  shape:input_shape_readonly
-                                                               dataType:input_mps_dtype];
-              if (!epsilonTensor)
-                epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon shape:@[ @1 ] dataType:input_mps_dtype];
-              if (!rsqrtTensor) {
-                MPSGraphTensor* varianceEpsTensor = [mpsGraph additionWithPrimaryTensor:runningVarTensor
-                                                                        secondaryTensor:epsilonTensor
-                                                                                   name:nil];
-                rsqrtTensor = [mpsGraph reverseSquareRootWithTensor:varianceEpsTensor name:nil];
-              }
-
-              gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:unitTensor
-                                                          secondaryTensor:rsqrtTensor
-                                                                     name:nil];
-              if (has_weight)
-                gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
-                                                            secondaryTensor:weightTensor
-                                                                       name:nil];
-              gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
-                                                          secondaryTensor:gradOutputTensor
-                                                                     name:nil];
-            }
-          }
-
-          if (grad_input_mask[1]) {
-            gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor
-                                             withShape:@[ input_shape_readonly[channelsDim] ]
-                                                  name:nil];
-          }
-          if (grad_input_mask[2]) {
-            gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor
-                                           withShape:@[ input_shape_readonly[channelsDim] ]
-                                                name:nil];
-          }
-
-          MPSGraphTensor* gradInputTensorFinal = nil;
-
-          if (memory_format == at::MemoryFormat::Contiguous)
-            gradInputTensorFinal = gradInputTensor;
-          else {
-            // Reshape/transpose the input as needed
-            auto N = input_shape[0];
-            auto H = input_shape[1];
-            auto W = input_shape[2];
-            auto C = input_shape[3];
-
-            gradInputTensorFinal =
-                [mpsGraph reshapeTensor:gradInputTensor
-                              withShape:@[ N, C, ([NSNumber numberWithInt:[H intValue] * [W intValue]]) ]
-                                   name:nil];
-            gradInputTensorFinal = [mpsGraph transposeTensor:gradInputTensorFinal dimension:1 withDimension:2 name:nil];
-            gradInputTensorFinal = [mpsGraph reshapeTensor:gradInputTensorFinal withShape:@[ N, H, W, C ] name:nil];
-          }
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensorOriginal;
-          newCachedGraph->weightTensor_ = weightTensor;
-          newCachedGraph->runningMeanTensor_ = runningMeanTensor;
-          newCachedGraph->runningVarTensor_ = runningVarTensor;
-          newCachedGraph->saveMeanTensor_ = saveMeanTensor;
-          newCachedGraph->saveVarTensor_ = saveVarTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensorFinal;
-          newCachedGraph->gradWeightTensor_ = gradWeightTensor;
-          newCachedGraph->gradBiasTensor_ = gradBiasTensor;
+      if (train) {
+        // Use save_mean and save_var
+        MPSGraphTensor* epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon dataType:input_mps_dtype];
+        MPSGraphTensor* revertSaveVarTensor = saveVarTensor;
+        revertSaveVarTensor = [mpsGraph reciprocalWithTensor:revertSaveVarTensor name:nil];
+        revertSaveVarTensor = [mpsGraph multiplicationWithPrimaryTensor:revertSaveVarTensor
+                                                        secondaryTensor:revertSaveVarTensor
+                                                                   name:nil];
+        revertSaveVarTensor = [mpsGraph subtractionWithPrimaryTensor:revertSaveVarTensor
+                                                     secondaryTensor:epsilonTensor
+                                                                name:nil];
+        if (grad_input_mask[1]) {
+          gradWeightTensor = [mpsGraph normalizationGammaGradientWithIncomingGradientTensor:gradOutputTensor
+                                                                               sourceTensor:inputTensor
+                                                                                 meanTensor:saveMeanTensor
+                                                                             varianceTensor:revertSaveVarTensor
+                                                                              reductionAxes:axes
+                                                                                    epsilon:(float)epsilon
+                                                                                       name:nil];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+        if (grad_input_mask[2]) {
+          gradBiasTensor = [mpsGraph normalizationBetaGradientWithIncomingGradientTensor:gradOutputTensor
+                                                                            sourceTensor:inputTensor
+                                                                           reductionAxes:axes
+                                                                                    name:nil];
+        }
+        if (grad_input_mask[0]) {
+          gradInputTensor = [mpsGraph normalizationGradientWithIncomingGradientTensor:gradOutputTensor
+                                                                         sourceTensor:inputTensor
+                                                                           meanTensor:saveMeanTensor
+                                                                       varianceTensor:revertSaveVarTensor
+                                                                          gammaTensor:weightTensor
+                                                                  gammaGradientTensor:gradWeightTensor
+                                                                   betaGradientTensor:gradBiasTensor
+                                                                        reductionAxes:axes
+                                                                              epsilon:(float)epsilon
+                                                                                 name:nil];
+        }
+      } else {
+        // Use running mean and running var
+        MPSGraphTensor* rsqrtTensor = nil;
+        MPSGraphTensor* epsilonTensor = nil;
+        if (grad_input_mask[1]) {
+          epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon shape:@[ @1 ] dataType:input_mps_dtype];
+          MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                              secondaryTensor:runningMeanTensor
+                                                                         name:nil];
+          MPSGraphTensor* varianceEpsTensor = [mpsGraph additionWithPrimaryTensor:runningVarTensor
+                                                                  secondaryTensor:epsilonTensor
+                                                                             name:nil];
+          rsqrtTensor = [mpsGraph reverseSquareRootWithTensor:varianceEpsTensor name:nil];
+          MPSGraphTensor* bnForwardTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
+                                                                      secondaryTensor:rsqrtTensor
+                                                                                 name:nil];
+          MPSGraphTensor* gradBnMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnForwardTensor
+                                                                      secondaryTensor:gradOutputTensor
+                                                                                 name:nil];
+          gradWeightTensor = [mpsGraph reductionSumWithTensor:gradBnMulTensor axes:axes name:nil];
+        }
+        if (grad_input_mask[2]) {
+          gradBiasTensor = [mpsGraph normalizationBetaGradientWithIncomingGradientTensor:gradOutputTensor
+                                                                            sourceTensor:inputTensor
+                                                                           reductionAxes:axes
+                                                                                    name:nil];
+        }
+        if (grad_input_mask[0]) {
+          MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
+                                                              shape:input_shape_readonly
+                                                           dataType:input_mps_dtype];
+          if (!epsilonTensor)
+            epsilonTensor = [mpsGraph constantWithScalar:(float)epsilon shape:@[ @1 ] dataType:input_mps_dtype];
+          if (!rsqrtTensor) {
+            MPSGraphTensor* varianceEpsTensor = [mpsGraph additionWithPrimaryTensor:runningVarTensor
+                                                                    secondaryTensor:epsilonTensor
+                                                                               name:nil];
+            rsqrtTensor = [mpsGraph reverseSquareRootWithTensor:varianceEpsTensor name:nil];
+          }
 
-    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input, input_shape);
-    auto gradOutputPlaceholder =
-        native_mps::Placeholder(cachedGraph->gradOutputTensor_, grad_out, input_shape_readonly);
-    auto weightPlaceholder = native_mps::Placeholder();
+          gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:unitTensor secondaryTensor:rsqrtTensor name:nil];
+          if (has_weight)
+            gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
+                                                        secondaryTensor:weightTensor
+                                                                   name:nil];
+          gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradInputTensor
+                                                      secondaryTensor:gradOutputTensor
+                                                                 name:nil];
+        }
+      }
+
+      if (grad_input_mask[1]) {
+        gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor
+                                         withShape:@[ input_shape_readonly[channelsDim] ]
+                                              name:nil];
+      }
+      if (grad_input_mask[2]) {
+        gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor
+                                       withShape:@[ input_shape_readonly[channelsDim] ]
+                                            name:nil];
+      }
+
+      MPSGraphTensor* gradInputTensorFinal = nil;
+
+      if (memory_format == at::MemoryFormat::Contiguous)
+        gradInputTensorFinal = gradInputTensor;
+      else {
+        // Reshape/transpose the input as needed
+        auto N = input_shape[0];
+        auto H = input_shape[1];
+        auto W = input_shape[2];
+        auto C = input_shape[3];
+
+        gradInputTensorFinal = [mpsGraph reshapeTensor:gradInputTensor
+                                             withShape:@[ N, C, ([NSNumber numberWithInt:[H intValue] * [W intValue]]) ]
+                                                  name:nil];
+        gradInputTensorFinal = [mpsGraph transposeTensor:gradInputTensorFinal dimension:1 withDimension:2 name:nil];
+        gradInputTensorFinal = [mpsGraph reshapeTensor:gradInputTensorFinal withShape:@[ N, H, W, C ] name:nil];
+      }
+
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensorOriginal;
+      newCachedGraph->weightTensor_ = weightTensor;
+      newCachedGraph->runningMeanTensor_ = runningMeanTensor;
+      newCachedGraph->runningVarTensor_ = runningVarTensor;
+      newCachedGraph->saveMeanTensor_ = saveMeanTensor;
+      newCachedGraph->saveVarTensor_ = saveVarTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensorFinal;
+      newCachedGraph->gradWeightTensor_ = gradWeightTensor;
+      newCachedGraph->gradBiasTensor_ = gradBiasTensor;
+    });
+
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, input_shape);
+    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_out, input_shape_readonly);
+    auto weightPlaceholder = Placeholder();
     if (has_weight)
-      weightPlaceholder = native_mps::Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
-    auto runningMeanPlaceholder = native_mps::Placeholder();
-    auto runningVarPlaceholder = native_mps::Placeholder();
+      weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
+    auto runningMeanPlaceholder = Placeholder();
+    auto runningVarPlaceholder = Placeholder();
     if (has_running_mean) {
-      runningMeanPlaceholder =
-          native_mps::Placeholder(cachedGraph->runningMeanTensor_, running_mean_opt.value(), new_mean_shape);
-      runningVarPlaceholder =
-          native_mps::Placeholder(cachedGraph->runningVarTensor_, running_var_opt.value(), new_mean_shape);
+      runningMeanPlaceholder = Placeholder(cachedGraph->runningMeanTensor_, running_mean_opt.value(), new_mean_shape);
+      runningVarPlaceholder = Placeholder(cachedGraph->runningVarTensor_, running_var_opt.value(), new_mean_shape);
     }
-    auto saveMeanPlaceholder = native_mps::Placeholder();
-    auto saveVarPlaceholder = native_mps::Placeholder();
+    auto saveMeanPlaceholder = Placeholder();
+    auto saveVarPlaceholder = Placeholder();
     if (has_save_mean) {
-      saveMeanPlaceholder =
-          native_mps::Placeholder(cachedGraph->saveMeanTensor_, save_mean_opt.value(), new_mean_shape);
-      saveVarPlaceholder = native_mps::Placeholder(cachedGraph->saveVarTensor_, save_var_opt.value(), new_mean_shape);
+      saveMeanPlaceholder = Placeholder(cachedGraph->saveMeanTensor_, save_mean_opt.value(), new_mean_shape);
+      saveVarPlaceholder = Placeholder(cachedGraph->saveVarTensor_, save_var_opt.value(), new_mean_shape);
     }
 
-    auto gradInputPlaceholder = native_mps::Placeholder();
+    auto gradInputPlaceholder = Placeholder();
     if (grad_input_mask[0])
-      gradInputPlaceholder = native_mps::Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape);
-    auto gradWeightPlaceholder = native_mps::Placeholder();
+      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape);
+    auto gradWeightPlaceholder = Placeholder();
     if (grad_input_mask[1])
-      gradWeightPlaceholder = native_mps::Placeholder(cachedGraph->gradWeightTensor_, grad_weight);
-    auto gradBiasPlaceholder = native_mps::Placeholder();
+      gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);
+    auto gradBiasPlaceholder = Placeholder();
 
     if (grad_input_mask[2])
-      gradBiasPlaceholder = native_mps::Placeholder(cachedGraph->gradBiasTensor_, grad_bias);
+      gradBiasPlaceholder = Placeholder(cachedGraph->gradBiasTensor_, grad_bias);
 
     NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
     feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
@@ -842,7 +792,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
     if (grad_input_mask[2])
       results[gradBiasPlaceholder.getMPSGraphTensor()] = gradBiasPlaceholder.getMPSGraphTensorData();
 
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return std::make_tuple(grad_input, grad_weight, grad_bias);
@@ -968,10 +918,10 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
                                        at::MemoryFormat::Contiguous);
   }
   if (M > 0) {
-    namespace native_mps = at::native::mps;
+    using namespace at::native::mps;
 
     // Derive from MPSCachedGraph
-    struct CachedGraph : public native_mps::MPSCachedGraph {
+    struct CachedGraph : public MPSCachedGraph {
       CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
       MPSGraphTensor* gradOutputTensor_ = nil;
       MPSGraphTensor* inputTensor_ = nil;
@@ -982,8 +932,6 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
       MPSGraphTensor* gradWeightTensor_ = nil;
       MPSGraphTensor* gradBiasTensor_ = nil;
     };
-
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
 
     auto stream = at::mps::getCurrentMPSStream();
 
@@ -1039,171 +987,154 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
       for (const auto i : c10::irange(num_normalized_dims))
         bn_gamma_shape[i + 2] = input_shape[i + num_channel_dims];
 
-      string key = "layer_norm_backward_mps:" + std::to_string(has_weight) + ":" +
-          native_mps::getArrayRefString(normalized_shape) + ":" + native_mps::getArrayRefString((*X).sizes()) + ":" +
-          native_mps::getMPSTypeString(*X);
+      string key = "layer_norm_backward_mps:" + std::to_string(has_weight) + ":" + getArrayRefString(normalized_shape) +
+          ":" + getArrayRefString((*X).sizes()) + ":" + getMPSTypeString(*X);
+      auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+        MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *X);
+        MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *dOut);
+        MPSGraphTensor* weightTensor = nil;
+        if (has_weight)
+          weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, *gamma);
 
-      CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+        // Mean and inv std tensors to be saved and returned
+        MPSGraphTensor* meanTensor = mpsGraphRankedPlaceHolder(mpsGraph, mean);
+        MPSGraphTensor* rstdTensor = mpsGraphRankedPlaceHolder(mpsGraph, rstd);
 
-      if (!cachedGraph) {
-        native_mps::MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^native_mps::MPSCachedGraph*() {
-          CachedGraph* newCachedGraph = nil;
+        MPSGraphTensor* gradInputTensor = nil;
+        MPSGraphTensor* gradWeightTensor = nil;
+        MPSGraphTensor* gradBiasTensor = nil;
 
-          @autoreleasepool {
-            MPSGraph* mpsGraph = native_mps::make_mps_graph();
-            newCachedGraph = new CachedGraph(mpsGraph);
+        if (grad_input_mask[1]) {
+          MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:inputTensor
+                                                              secondaryTensor:meanTensor
+                                                                         name:nil];
+          MPSGraphTensor* bnForwardTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
+                                                                      secondaryTensor:rstdTensor
+                                                                                 name:nil];
+          MPSGraphTensor* gradBnMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnForwardTensor
+                                                                      secondaryTensor:gradOutputTensor
+                                                                                 name:nil];
+          gradWeightTensor = [mpsGraph reductionSumWithTensor:gradBnMulTensor axes:gamma_axes name:nil];
+        }
+        if (grad_input_mask[2]) {
+          gradBiasTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axes:gamma_axes name:nil];
+        }
+        if (grad_input_mask[0]) {
+          // Reshape input to [1, M, -1]
+          // Reshape mean and rstd to [1, M, -1]
+          // Reshape gamma to [1, 1, -1] (-1 has N dims)
 
-            MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, *X);
-            MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, *dOut);
-            MPSGraphTensor* weightTensor = nil;
-            if (has_weight)
-              weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, *gamma);
-
-            // Mean and inv std tensors to be saved and returned
-            MPSGraphTensor* meanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, mean);
-            MPSGraphTensor* rstdTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, rstd);
-
-            MPSGraphTensor* gradInputTensor = nil;
-            MPSGraphTensor* gradWeightTensor = nil;
-            MPSGraphTensor* gradBiasTensor = nil;
-
-            if (grad_input_mask[1]) {
-              MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                  secondaryTensor:meanTensor
-                                                                             name:nil];
-              MPSGraphTensor* bnForwardTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
-                                                                          secondaryTensor:rstdTensor
-                                                                                     name:nil];
-              MPSGraphTensor* gradBnMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnForwardTensor
-                                                                          secondaryTensor:gradOutputTensor
-                                                                                     name:nil];
-              gradWeightTensor = [mpsGraph reductionSumWithTensor:gradBnMulTensor axes:gamma_axes name:nil];
-            }
-            if (grad_input_mask[2]) {
-              gradBiasTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axes:gamma_axes name:nil];
-            }
-            if (grad_input_mask[0]) {
-              // Reshape input to [1, M, -1]
-              // Reshape mean and rstd to [1, M, -1]
-              // Reshape gamma to [1, 1, -1] (-1 has N dims)
-
-              MPSGraphTensor* bnInputTensor = [mpsGraph reshapeTensor:inputTensor withShape:bn_shape name:nil];
-              MPSGraphTensor* bnGradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensor
-                                                                 withShape:bn_shape
+          MPSGraphTensor* bnInputTensor = [mpsGraph reshapeTensor:inputTensor withShape:bn_shape name:nil];
+          MPSGraphTensor* bnGradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensor withShape:bn_shape name:nil];
+          // Do this at the end
+          if (has_weight) {
+            MPSGraphTensor* bnGammaTensor = [mpsGraph reshapeTensor:weightTensor withShape:bn_gamma_shape name:nil];
+            bnGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
+                                                           secondaryTensor:bnGammaTensor
                                                                       name:nil];
-              // Do this at the end
-              if (has_weight) {
-                MPSGraphTensor* bnGammaTensor = [mpsGraph reshapeTensor:weightTensor withShape:bn_gamma_shape name:nil];
-                bnGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                               secondaryTensor:bnGammaTensor
-                                                                          name:nil];
-              }
-              MPSGraphTensor* bnMeanTensor = [mpsGraph reshapeTensor:meanTensor withShape:bn_mean_shape name:nil];
-              MPSGraphTensor* bnRstdTensor = [mpsGraph reshapeTensor:rstdTensor withShape:bn_mean_shape name:nil];
+          }
+          MPSGraphTensor* bnMeanTensor = [mpsGraph reshapeTensor:meanTensor withShape:bn_mean_shape name:nil];
+          MPSGraphTensor* bnRstdTensor = [mpsGraph reshapeTensor:rstdTensor withShape:bn_mean_shape name:nil];
 
-              MPSGraphTensor* mulTensor = [mpsGraph constantWithScalar:N shape:@[ @1 ] dataType:MPSDataTypeInt32];
+          MPSGraphTensor* mulTensor = [mpsGraph constantWithScalar:N shape:@[ @1 ] dataType:MPSDataTypeInt32];
 
-              MPSGraphTensor* numberToReduceTensor = mulTensor;
+          MPSGraphTensor* numberToReduceTensor = mulTensor;
 
-              MPSGraphTensor* cast2Tensor = [mpsGraph castTensor:numberToReduceTensor
-                                                          toType:bnInputTensor.dataType
-                                                            name:@"cast2Tensor"];
+          MPSGraphTensor* cast2Tensor = [mpsGraph castTensor:numberToReduceTensor
+                                                      toType:bnInputTensor.dataType
+                                                        name:@"cast2Tensor"];
 
-              MPSGraphTensor* sizeReciprocalTensor = [mpsGraph reciprocalWithTensor:cast2Tensor name:nil];
+          MPSGraphTensor* sizeReciprocalTensor = [mpsGraph reciprocalWithTensor:cast2Tensor name:nil];
 
-              // TODO: Reduce redundant computation
-              MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:bnInputTensor
-                                                                  secondaryTensor:bnMeanTensor
-                                                                             name:nil];
+          // TODO: Reduce redundant computation
+          MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:bnInputTensor
+                                                              secondaryTensor:bnMeanTensor
+                                                                         name:nil];
 
-              MPSGraphTensor* normalizedTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
-                                                                           secondaryTensor:bnRstdTensor
-                                                                                      name:nil];
+          MPSGraphTensor* normalizedTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
+                                                                       secondaryTensor:bnRstdTensor
+                                                                                  name:nil];
 
-              MPSGraphTensor* bnGradMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                                          secondaryTensor:normalizedTensor
-                                                                                     name:nil];
-
-              MPSGraphTensor* gammaGradient = [mpsGraph reductionSumWithTensor:bnGradMulTensor axes:bn_axes name:nil];
-
-              MPSGraphTensor* betaGradient = [mpsGraph reductionSumWithTensor:bnGradOutputTensor axes:bn_axes name:nil];
-
-              MPSGraphTensor* gradient1 = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                                    secondaryTensor:bnRstdTensor
-                                                                               name:nil];
-
-              MPSGraphTensor* gradient2_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
-                                                                      secondaryTensor:xMinusMean
+          MPSGraphTensor* bnGradMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
+                                                                      secondaryTensor:normalizedTensor
                                                                                  name:nil];
 
-              // reverseVariance is square of rstd
-              MPSGraphTensor* reverseVariance = [mpsGraph squareWithTensor:bnRstdTensor name:nil];
-              MPSGraphTensor* gradient2_2 = [mpsGraph multiplicationWithPrimaryTensor:gammaGradient
-                                                                      secondaryTensor:reverseVariance
-                                                                                 name:nil];
+          MPSGraphTensor* gammaGradient = [mpsGraph reductionSumWithTensor:bnGradMulTensor axes:bn_axes name:nil];
 
-              MPSGraphTensor* gradient2 = [mpsGraph multiplicationWithPrimaryTensor:gradient2_1
-                                                                    secondaryTensor:gradient2_2
-                                                                               name:nil];
+          MPSGraphTensor* betaGradient = [mpsGraph reductionSumWithTensor:bnGradOutputTensor axes:bn_axes name:nil];
 
-              MPSGraphTensor* gradient3_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
-                                                                      secondaryTensor:betaGradient
-                                                                                 name:nil];
-
-              MPSGraphTensor* gradient3 = [mpsGraph multiplicationWithPrimaryTensor:gradient3_1
-                                                                    secondaryTensor:bnRstdTensor
-                                                                               name:nil];
-
-              MPSGraphTensor* gradient4 = [mpsGraph subtractionWithPrimaryTensor:gradient1
-                                                                 secondaryTensor:gradient2
-                                                                            name:nil];
-
-              MPSGraphTensor* gradient = [mpsGraph subtractionWithPrimaryTensor:gradient4
-                                                                secondaryTensor:gradient3
+          MPSGraphTensor* gradient1 = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
+                                                                secondaryTensor:bnRstdTensor
                                                                            name:nil];
 
-              gradInputTensor = [mpsGraph reshapeTensor:gradient withShape:input_shape name:nil];
-            }
+          MPSGraphTensor* gradient2_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
+                                                                  secondaryTensor:xMinusMean
+                                                                             name:nil];
 
-            if (grad_input_mask[1]) {
-              gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor withShape:gamma_shape name:nil];
-            }
-            if (grad_input_mask[2]) {
-              gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor withShape:gamma_shape name:nil];
-            }
+          // reverseVariance is square of rstd
+          MPSGraphTensor* reverseVariance = [mpsGraph squareWithTensor:bnRstdTensor name:nil];
+          MPSGraphTensor* gradient2_2 = [mpsGraph multiplicationWithPrimaryTensor:gammaGradient
+                                                                  secondaryTensor:reverseVariance
+                                                                             name:nil];
 
-            newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-            newCachedGraph->inputTensor_ = inputTensor;
-            newCachedGraph->weightTensor_ = weightTensor;
-            newCachedGraph->meanTensor_ = meanTensor;
-            newCachedGraph->rstdTensor_ = rstdTensor;
-            newCachedGraph->gradInputTensor_ = gradInputTensor;
-            newCachedGraph->gradWeightTensor_ = gradWeightTensor;
-            newCachedGraph->gradBiasTensor_ = gradBiasTensor;
-          }
-          return newCachedGraph;
-        });
-        cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-      }
+          MPSGraphTensor* gradient2 = [mpsGraph multiplicationWithPrimaryTensor:gradient2_1
+                                                                secondaryTensor:gradient2_2
+                                                                           name:nil];
 
-      auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, *X);
-      auto gradOutputPlaceholder = native_mps::Placeholder(cachedGraph->gradOutputTensor_, *dOut);
-      auto weightPlaceholder = native_mps::Placeholder();
+          MPSGraphTensor* gradient3_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
+                                                                  secondaryTensor:betaGradient
+                                                                             name:nil];
+
+          MPSGraphTensor* gradient3 = [mpsGraph multiplicationWithPrimaryTensor:gradient3_1
+                                                                secondaryTensor:bnRstdTensor
+                                                                           name:nil];
+
+          MPSGraphTensor* gradient4 = [mpsGraph subtractionWithPrimaryTensor:gradient1
+                                                             secondaryTensor:gradient2
+                                                                        name:nil];
+
+          MPSGraphTensor* gradient = [mpsGraph subtractionWithPrimaryTensor:gradient4
+                                                            secondaryTensor:gradient3
+                                                                       name:nil];
+
+          gradInputTensor = [mpsGraph reshapeTensor:gradient withShape:input_shape name:nil];
+        }
+
+        if (grad_input_mask[1]) {
+          gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor withShape:gamma_shape name:nil];
+        }
+        if (grad_input_mask[2]) {
+          gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor withShape:gamma_shape name:nil];
+        }
+
+        newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+        newCachedGraph->inputTensor_ = inputTensor;
+        newCachedGraph->weightTensor_ = weightTensor;
+        newCachedGraph->meanTensor_ = meanTensor;
+        newCachedGraph->rstdTensor_ = rstdTensor;
+        newCachedGraph->gradInputTensor_ = gradInputTensor;
+        newCachedGraph->gradWeightTensor_ = gradWeightTensor;
+        newCachedGraph->gradBiasTensor_ = gradBiasTensor;
+      });
+
+      auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, *X);
+      auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, *dOut);
+      auto weightPlaceholder = Placeholder();
       if (has_weight)
-        weightPlaceholder = native_mps::Placeholder(cachedGraph->weightTensor_, *gamma);
-      auto saveMeanPlaceholder = native_mps::Placeholder(cachedGraph->meanTensor_, mean);
-      auto saveVarPlaceholder = native_mps::Placeholder(cachedGraph->rstdTensor_, rstd);
+        weightPlaceholder = Placeholder(cachedGraph->weightTensor_, *gamma);
+      auto saveMeanPlaceholder = Placeholder(cachedGraph->meanTensor_, mean);
+      auto saveVarPlaceholder = Placeholder(cachedGraph->rstdTensor_, rstd);
 
-      auto gradInputPlaceholder = native_mps::Placeholder();
+      auto gradInputPlaceholder = Placeholder();
       if (grad_input_mask[0])
-        gradInputPlaceholder = native_mps::Placeholder(cachedGraph->gradInputTensor_, grad_input);
-      auto gradWeightPlaceholder = native_mps::Placeholder();
+        gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
+      auto gradWeightPlaceholder = Placeholder();
       if (grad_input_mask[1])
-        gradWeightPlaceholder = native_mps::Placeholder(cachedGraph->gradWeightTensor_, grad_weight);
-      auto gradBiasPlaceholder = native_mps::Placeholder();
+        gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);
+      auto gradBiasPlaceholder = Placeholder();
       ;
       if (grad_input_mask[2])
-        gradBiasPlaceholder = native_mps::Placeholder(cachedGraph->gradBiasTensor_, grad_bias);
+        gradBiasPlaceholder = Placeholder(cachedGraph->gradBiasTensor_, grad_bias);
 
       NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
       feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
@@ -1221,7 +1152,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
       if (grad_input_mask[2])
         results[gradBiasPlaceholder.getMPSGraphTensor()] = gradBiasPlaceholder.getMPSGraphTensorData();
 
-      native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+      runMPSGraph(stream, cachedGraph->graph(), feeds, results);
     }
   }
   return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -247,72 +247,61 @@ Tensor& pad_out_template(Tensor& output,
     dataType = MPSDataTypeInt8;
   }
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({input, grad_output, output}) + ":[" + getArrayRefString(padding) +
         "]:" + std::to_string(constantValue);
 
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(input));
-          const bool needsSlice = startMask != dims_mask || endMask != dims_mask;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(input));
+      const bool needsSlice = startMask != dims_mask || endMask != dims_mask;
 
-          if (!is_backward_pass) {
-            MPSGraphTensor* padTensor = [mpsGraph padTensor:newCachedGraph->inputTensor_
-                                            withPaddingMode:mode
+      if (!is_backward_pass) {
+        MPSGraphTensor* padTensor = [mpsGraph padTensor:newCachedGraph->inputTensor_
+                                        withPaddingMode:mode
+                                            leftPadding:leftPadding
+                                           rightPadding:rightPadding
+                                          constantValue:constantValue
+                                                   name:nil];
+        // workaround for the right padding bug in Monterey
+        if (needsSlice) {
+          newCachedGraph->gradInputTensor_ =
+              [mpsGraph sliceTensor:padTensor
+                             starts:[NSArray arrayWithObjects:startsVec.data() count:ndims]
+                               ends:[NSArray arrayWithObjects:endsVec.data() count:ndims]
+                            strides:[NSArray arrayWithObjects:stridesVec.data() count:ndims]
+                          startMask:startMask
+                            endMask:endMask
+                        squeezeMask:0
+                               name:nil];
+        } else {
+          newCachedGraph->gradInputTensor_ = padTensor;
+        }
+      } else {
+        newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(grad_output));
+        MPSGraphTensor* padGradTensor =
+            [mpsGraph padGradientWithIncomingGradientTensor:newCachedGraph->gradOutputTensor_
+                                               sourceTensor:newCachedGraph->inputTensor_
+                                                paddingMode:mode
                                                 leftPadding:leftPadding
                                                rightPadding:rightPadding
-                                              constantValue:constantValue
                                                        name:nil];
-            // workaround for the right padding bug in Monterey
-            if (needsSlice) {
-              newCachedGraph->gradInputTensor_ =
-                  [mpsGraph sliceTensor:padTensor
-                                 starts:[NSArray arrayWithObjects:startsVec.data() count:ndims]
-                                   ends:[NSArray arrayWithObjects:endsVec.data() count:ndims]
-                                strides:[NSArray arrayWithObjects:stridesVec.data() count:ndims]
-                              startMask:startMask
-                                endMask:endMask
-                            squeezeMask:0
-                                   name:nil];
-            } else {
-              newCachedGraph->gradInputTensor_ = padTensor;
-            }
-          } else {
-            newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(grad_output));
-            MPSGraphTensor* padGradTensor =
-                [mpsGraph padGradientWithIncomingGradientTensor:newCachedGraph->gradOutputTensor_
-                                                   sourceTensor:newCachedGraph->inputTensor_
-                                                    paddingMode:mode
-                                                    leftPadding:leftPadding
-                                                   rightPadding:rightPadding
-                                                           name:nil];
-            // workaround for negative padding issue with padGradientWithIncomingGradientTensor()
-            if (needsSlice) {
-              newCachedGraph->gradInputTensor_ =
-                  [mpsGraph sliceGradientTensor:padGradTensor
-                               fwdInShapeTensor:[mpsGraph shapeOfTensor:newCachedGraph->inputTensor_ name:nil]
-                                         starts:[NSArray arrayWithObjects:startsVec.data() count:ndims]
-                                           ends:[NSArray arrayWithObjects:endsVec.data() count:ndims]
-                                        strides:[NSArray arrayWithObjects:stridesVec.data() count:ndims]
-                                      startMask:startMask
-                                        endMask:endMask
-                                    squeezeMask:0
-                                           name:nil];
-            } else {
-              newCachedGraph->gradInputTensor_ = padGradTensor;
-            }
-          }
+        // workaround for negative padding issue with padGradientWithIncomingGradientTensor()
+        if (needsSlice) {
+          newCachedGraph->gradInputTensor_ =
+              [mpsGraph sliceGradientTensor:padGradTensor
+                           fwdInShapeTensor:[mpsGraph shapeOfTensor:newCachedGraph->inputTensor_ name:nil]
+                                     starts:[NSArray arrayWithObjects:startsVec.data() count:ndims]
+                                       ends:[NSArray arrayWithObjects:endsVec.data() count:ndims]
+                                    strides:[NSArray arrayWithObjects:stridesVec.data() count:ndims]
+                                  startMask:startMask
+                                    endMask:endMask
+                                squeezeMask:0
+                                       name:nil];
+        } else {
+          newCachedGraph->gradInputTensor_ = padGradTensor;
         }
-        return newCachedGraph;
-      });
-    }
+      }
+    });
 
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, nullptr, true, dataType);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, output, nullptr, true, dataType);

--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -36,53 +36,40 @@ void addc_mul_div_out_mps(const Tensor& self,
     MPSGraphTensor *inputTensor = nil, *outputTensor = nil;
     MPSGraphTensor *firstTensor = nil, *secondTensor = nil, *valueTensor = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, tensor1, tensor2});
 
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      ScalarType common_dtype =
+          c10::promoteTypes(self.scalar_type(), c10::promoteTypes(tensor1.scalar_type(), tensor2.scalar_type()));
+      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      newCachedGraph->firstTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor1);
+      newCachedGraph->secondTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor2);
+      newCachedGraph->valueTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), @[ @1 ]);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        ScalarType common_dtype =
-            c10::promoteTypes(self.scalar_type(), c10::promoteTypes(tensor1.scalar_type(), tensor2.scalar_type()));
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          newCachedGraph->firstTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor1);
-          newCachedGraph->secondTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor2);
-          newCachedGraph->valueTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), @[ @1 ]);
-
-          // the tensor to be optionally multiplied by value_scalar
-          MPSGraphTensor* multiplicandTensor = nil;
-          auto firstTensor = castMPSTensor(mpsGraph, newCachedGraph->firstTensor, common_dtype);
-          auto secondTensor = castMPSTensor(mpsGraph, newCachedGraph->secondTensor, common_dtype);
-          if (is_div) {
-            multiplicandTensor = [mpsGraph divisionWithPrimaryTensor:firstTensor secondaryTensor:secondTensor name:nil];
-          } else {
-            multiplicandTensor = [mpsGraph multiplicationWithPrimaryTensor:firstTensor
-                                                           secondaryTensor:secondTensor
-                                                                      name:nil];
-          }
-          // the tensor to be added to input_tensor
-          MPSGraphTensor* addendTensor = [mpsGraph
-              multiplicationWithPrimaryTensor:multiplicandTensor
-                              secondaryTensor:castMPSTensor(mpsGraph, newCachedGraph->valueTensor, common_dtype)
+      // the tensor to be optionally multiplied by value_scalar
+      MPSGraphTensor* multiplicandTensor = nil;
+      auto firstTensor = castMPSTensor(mpsGraph, newCachedGraph->firstTensor, common_dtype);
+      auto secondTensor = castMPSTensor(mpsGraph, newCachedGraph->secondTensor, common_dtype);
+      if (is_div) {
+        multiplicandTensor = [mpsGraph divisionWithPrimaryTensor:firstTensor secondaryTensor:secondTensor name:nil];
+      } else {
+        multiplicandTensor = [mpsGraph multiplicationWithPrimaryTensor:firstTensor
+                                                       secondaryTensor:secondTensor
+                                                                  name:nil];
+      }
+      // the tensor to be added to input_tensor
+      MPSGraphTensor* addendTensor =
+          [mpsGraph multiplicationWithPrimaryTensor:multiplicandTensor
+                                    secondaryTensor:castMPSTensor(mpsGraph, newCachedGraph->valueTensor, common_dtype)
+                                               name:nil];
+      auto outputTensor =
+          [mpsGraph additionWithPrimaryTensor:castMPSTensor(mpsGraph, newCachedGraph->inputTensor, common_dtype)
+                              secondaryTensor:addendTensor
                                          name:nil];
-          auto outputTensor =
-              [mpsGraph additionWithPrimaryTensor:castMPSTensor(mpsGraph, newCachedGraph->inputTensor, common_dtype)
-                                  secondaryTensor:addendTensor
-                                             name:nil];
-          newCachedGraph->outputTensor = castMPSTensor(mpsGraph, outputTensor, output.scalar_type());
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->outputTensor = castMPSTensor(mpsGraph, outputTensor, output.scalar_type());
+    });
 
     // Inputs as placeholders
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor, self);

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -104,13 +104,12 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
     auto mpsDataType = getMPSDataType(result);
     @autoreleasepool {
       string key = "arange_mps_out" + getTensorsStringKey({result}) + ":" + to_string(size);
-      auto cachedGraph = static_cast<RangeCachedGraph*>(cache_->LookUp(key));
+      auto cachedGraph = cache_->LookUpAs<RangeCachedGraph>(key);
       if (!cachedGraph) {
-        auto* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
+        cachedGraph = cache_->CreateCachedGraphAs<RangeCachedGraph>(key, ^MPSCachedGraph*() {
           auto mpsGraph = make_mps_graph();
           return new RangeCachedGraph(mpsGraph, mpsDataType, size);
         });
-        cachedGraph = static_cast<RangeCachedGraph*>(tmpCachedGraph);
       }
       Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, r);
       NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
@@ -174,13 +173,12 @@ Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step
     auto mpsDataType = getMPSDataType(result);
     @autoreleasepool {
       string key = "arange_mps_out" + getTensorsStringKey({result}) + ":" + to_string(size);
-      auto cachedGraph = static_cast<RangeCachedGraph*>(cache_->LookUp(key));
+      auto cachedGraph = cache_->LookUpAs<RangeCachedGraph>(key);
       if (!cachedGraph) {
-        auto* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
+        cachedGraph = cache_->CreateCachedGraphAs<RangeCachedGraph>(key, ^MPSCachedGraph*() {
           auto mpsGraph = make_mps_graph();
           return new RangeCachedGraph(mpsGraph, mpsDataType, size);
         });
-        cachedGraph = static_cast<RangeCachedGraph*>(tmpCachedGraph);
       }
       Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, r);
       NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -224,10 +224,10 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
     @autoreleasepool {
       string key =
           "linspace_out_mps:" + getTensorsStringKey({result}) + ":" + to_string(steps) + to_string(start_less_end);
-      RangeCachedGraph* cachedGraph = static_cast<RangeCachedGraph*>(cache_->LookUp(key));
+      auto cachedGraph = cache_->LookUpAs<RangeCachedGraph>(key);
 
       if (!cachedGraph) {
-        MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
+        cachedGraph = cache_->CreateCachedGraphAs<RangeCachedGraph>(key, ^MPSCachedGraph*() {
           RangeCachedGraph* newCachedGraph = nil;
 
           @autoreleasepool {
@@ -242,7 +242,6 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
           }
           return newCachedGraph;
         });
-        cachedGraph = static_cast<RangeCachedGraph*>(tmpCachedGraph);
       }
 
       NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -165,7 +165,6 @@ void reduction_out_mps(const Tensor& input_t,
 
   set_axes_and_shapes(input_t, opt_dim, axes, apparent_input_shape, apparent_output_shape, output_shape);
   NSArray<NSNumber*>* wrappedAxes = mps::getTensorAxes(input_t, opt_dim);
-  auto cache_ = MPSGraphCache::getInstance();
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     if (reduction_type == MPSReductionType::PROD) {
@@ -183,86 +182,73 @@ void reduction_out_mps(const Tensor& input_t,
         std::to_string(keepdim) + ":" + std::to_string(reduction_type) + ":" + getTensorsStringKey(output_t) + ":" +
         dtype_str;
     using CachedGraph = MPSUnaryCachedGraph;
-    auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      auto inputScalarType = input_t.scalar_type();
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* castInputTensor = inputTensor;
+      MPSDataType inputCastType = MPSDataTypeInvalid;
+      if (dtype.has_value() &&
+          (dtype.value() == kFloat || dtype.value() == kHalf || dtype.value() == kInt ||
+           (dtype.value() == kLong && macOS13_3_plus))) {
+        inputCastType = getMPSDataType(dtype.value());
+      } else if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
+                 (inputScalarType != kLong || !macOS13_3_plus)) {
+        inputCastType = getMPSDataType(kFloat);
+      } else if (!is_macos_13_or_newer() && inputScalarType == kHalf) {
+        inputCastType = getMPSDataType(kFloat);
+      }
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          auto inputScalarType = input_t.scalar_type();
+      if (inputCastType != MPSDataTypeInvalid) {
+        castInputTensor = castMPSTensor(mpsGraph, inputTensor, inputCastType);
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-          MPSGraphTensor* castInputTensor = inputTensor;
-          MPSDataType inputCastType = MPSDataTypeInvalid;
-          if (dtype.has_value() &&
-              (dtype.value() == kFloat || dtype.value() == kHalf || dtype.value() == kInt ||
-               (dtype.value() == kLong && macOS13_3_plus))) {
-            inputCastType = getMPSDataType(dtype.value());
-          } else if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
-                     (inputScalarType != kLong || !macOS13_3_plus)) {
-            inputCastType = getMPSDataType(kFloat);
-          } else if (!is_macos_13_or_newer() && inputScalarType == kHalf) {
-            inputCastType = getMPSDataType(kFloat);
-          }
+      MPSGraphTensor* castOutputTensor = nil;
 
-          if (inputCastType != MPSDataTypeInvalid) {
-            castInputTensor = castMPSTensor(mpsGraph, inputTensor, inputCastType);
-          }
+      if (reduction_type == MPSReductionType::SUM) {
+        castOutputTensor = [mpsGraph reductionSumWithTensor:castInputTensor axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::PROD) {
+        castOutputTensor = [mpsGraph reductionProductWithTensor:castInputTensor axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::MEAN) {
+        castOutputTensor = [mpsGraph meanOfTensor:castInputTensor axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::COUNT_NONZERO) {
+        MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0 dataType:castInputTensor.dataType];
 
-          MPSGraphTensor* castOutputTensor = nil;
+        MPSGraphTensor* nonZeros = [mpsGraph notEqualWithPrimaryTensor:castInputTensor secondaryTensor:zeros name:nil];
 
-          if (reduction_type == MPSReductionType::SUM) {
-            castOutputTensor = [mpsGraph reductionSumWithTensor:castInputTensor axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::PROD) {
-            castOutputTensor = [mpsGraph reductionProductWithTensor:castInputTensor axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::MEAN) {
-            castOutputTensor = [mpsGraph meanOfTensor:castInputTensor axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::COUNT_NONZERO) {
-            MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0 dataType:castInputTensor.dataType];
+        castOutputTensor = [mpsGraph reductionSumWithTensor:nonZeros axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::AMAX) {
+        castOutputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::AMIN) {
+        castOutputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axes:wrappedAxes name:nil];
+      } else if (reduction_type == MPSReductionType::TRACE) {
+        MPSGraphTensor* bandPartWithTensor = [mpsGraph bandPartWithTensor:castInputTensor
+                                                                 numLower:0
+                                                                 numUpper:0
+                                                                     name:nil];
+        castOutputTensor = [mpsGraph reductionSumWithTensor:bandPartWithTensor axes:@[ @0, @1 ] name:nil];
+      } else if (reduction_type == MPSReductionType::NANSUM) {
+        // Create a 0 tensor of the same shape as inputTensor
+        MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0.0 dataType:castInputTensor.dataType];
+        // Find NaNs
+        MPSGraphTensor* nanMask = [mpsGraph isNaNWithTensor:castInputTensor name:nil];
+        // Replace NaNs with 0
+        MPSGraphTensor* nanReplaced = [mpsGraph selectWithPredicateTensor:nanMask
+                                                      truePredicateTensor:zeros
+                                                     falsePredicateTensor:castInputTensor
+                                                                     name:nil];
+        // Sum
+        castOutputTensor = [mpsGraph reductionSumWithTensor:nanReplaced axes:wrappedAxes name:nil];
+      }
 
-            MPSGraphTensor* nonZeros = [mpsGraph notEqualWithPrimaryTensor:castInputTensor
-                                                           secondaryTensor:zeros
-                                                                      name:nil];
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
+      }
 
-            castOutputTensor = [mpsGraph reductionSumWithTensor:nonZeros axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::AMAX) {
-            castOutputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::AMIN) {
-            castOutputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axes:wrappedAxes name:nil];
-          } else if (reduction_type == MPSReductionType::TRACE) {
-            MPSGraphTensor* bandPartWithTensor = [mpsGraph bandPartWithTensor:castInputTensor
-                                                                     numLower:0
-                                                                     numUpper:0
-                                                                         name:nil];
-            castOutputTensor = [mpsGraph reductionSumWithTensor:bandPartWithTensor axes:@[ @0, @1 ] name:nil];
-          } else if (reduction_type == MPSReductionType::NANSUM) {
-            // Create a 0 tensor of the same shape as inputTensor
-            MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0.0 dataType:castInputTensor.dataType];
-            // Find NaNs
-            MPSGraphTensor* nanMask = [mpsGraph isNaNWithTensor:castInputTensor name:nil];
-            // Replace NaNs with 0
-            MPSGraphTensor* nanReplaced = [mpsGraph selectWithPredicateTensor:nanMask
-                                                          truePredicateTensor:zeros
-                                                         falsePredicateTensor:castInputTensor
-                                                                         name:nil];
-            // Sum
-            castOutputTensor = [mpsGraph reductionSumWithTensor:nanReplaced axes:wrappedAxes name:nil];
-          }
-
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
@@ -301,8 +287,6 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     TORCH_CHECK(wrap_dim < static_cast<decltype(wrap_dim)>(input_shape.size()),
                 "norm_out_mps: reduction dim must be in the range of input shape")
   }
-
-  auto cache_ = MPSGraphCache::getInstance();
 
   auto p = opt_p.has_value() ? opt_p.get().to<double>() : Scalar(2.0).to<double>();
   auto reciprocal_p = 1 / p;
@@ -343,73 +327,59 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     string key =
         string("norm_out_mps:") + [ns_key UTF8String] + ":" + tensor_key + ":p" + to_string(p) + ":" + keepdim_info;
 
-    auto cachedGraph = cache_->LookUpAs<MPSBinaryCachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<MPSBinaryCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<MPSBinaryCachedGraph>(key, ^MPSCachedGraph*() {
-        MPSBinaryCachedGraph* newCachedGraph = nil;
+      if (cdist) {
+        newCachedGraph->otherTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, other_tensor);
+      }
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new MPSBinaryCachedGraph(mpsGraph);
-          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
+      MPSGraphTensor* inputTensor = cdist
+          ? normOpBlock(newCachedGraph, newCachedGraph->inputTensor_, newCachedGraph->otherTensor_)
+          : newCachedGraph->inputTensor_;
+      if (opt_dtype.has_value()) {
+        inputTensor = [mpsGraph castTensor:inputTensor toType:mps_input_dtype name:@"castInputTensor"];
+      }
 
-          if (cdist) {
-            newCachedGraph->otherTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, other_tensor);
-          }
+      MPSGraphTensor* outputTensor;
 
-          MPSGraphTensor* inputTensor = cdist
-              ? normOpBlock(newCachedGraph, newCachedGraph->inputTensor_, newCachedGraph->otherTensor_)
-              : newCachedGraph->inputTensor_;
-          if (opt_dtype.has_value()) {
-            inputTensor = [mpsGraph castTensor:inputTensor toType:mps_input_dtype name:@"castInputTensor"];
-          }
+      if (pIsZero) {
+        MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+        MPSGraphTensor* powerValTensor = [mpsGraph constantWithScalar:p dataType:mps_input_dtype];
+        MPSGraphTensor* powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
+                                                       secondaryTensor:powerValTensor
+                                                                  name:nil];
+        outputTensor = [mpsGraph reductionSumWithTensor:powerTensor axes:wrappedAxes name:nil];
+      } else if (pIsPosInf) {
+        MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+        outputTensor = [mpsGraph reductionMaximumWithTensor:absoluteTensor axes:wrappedAxes name:nil];
+      } else if (pIsNegInf) {
+        MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+        outputTensor = [mpsGraph reductionMinimumWithTensor:absoluteTensor axes:wrappedAxes name:nil];
+      } else {
+        MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
 
-          MPSGraphTensor* outputTensor;
+        MPSGraphTensor* powerValTensor = [mpsGraph constantWithScalar:p dataType:mps_input_dtype];
 
-          if (pIsZero) {
-            MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
-            MPSGraphTensor* powerValTensor = [mpsGraph constantWithScalar:p dataType:mps_input_dtype];
-            MPSGraphTensor* powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
-                                                           secondaryTensor:powerValTensor
-                                                                      name:nil];
-            outputTensor = [mpsGraph reductionSumWithTensor:powerTensor axes:wrappedAxes name:nil];
-          } else if (pIsPosInf) {
-            MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
-            outputTensor = [mpsGraph reductionMaximumWithTensor:absoluteTensor axes:wrappedAxes name:nil];
-          } else if (pIsNegInf) {
-            MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
-            outputTensor = [mpsGraph reductionMinimumWithTensor:absoluteTensor axes:wrappedAxes name:nil];
-          } else {
-            MPSGraphTensor* absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor name:nil];
+        MPSGraphTensor* reciprocalPowerValTensor = [mpsGraph constantWithScalar:reciprocal_p dataType:mps_input_dtype];
 
-            MPSGraphTensor* powerValTensor = [mpsGraph constantWithScalar:p dataType:mps_input_dtype];
+        MPSGraphTensor* powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
+                                                       secondaryTensor:powerValTensor
+                                                                  name:nil];
 
-            MPSGraphTensor* reciprocalPowerValTensor = [mpsGraph constantWithScalar:reciprocal_p
-                                                                           dataType:mps_input_dtype];
+        MPSGraphTensor* reductionSumTensor = [mpsGraph reductionSumWithTensor:powerTensor axes:wrappedAxes name:nil];
 
-            MPSGraphTensor* powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
-                                                           secondaryTensor:powerValTensor
-                                                                      name:nil];
+        outputTensor = [mpsGraph powerWithPrimaryTensor:reductionSumTensor
+                                        secondaryTensor:reciprocalPowerValTensor
+                                                   name:nil];
+      }
 
-            MPSGraphTensor* reductionSumTensor = [mpsGraph reductionSumWithTensor:powerTensor
-                                                                             axes:wrappedAxes
-                                                                             name:nil];
+      if (cdist) {
+        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:mps::getMPSShape(output_t) name:nil];
+      }
 
-            outputTensor = [mpsGraph powerWithPrimaryTensor:reductionSumTensor
-                                            secondaryTensor:reciprocalPowerValTensor
-                                                       name:nil];
-          }
-
-          if (cdist) {
-            outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:mps::getMPSShape(output_t) name:nil];
-          }
-
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto otherPlaceholder = Placeholder();
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
@@ -456,7 +426,6 @@ Tensor std_var_common_impl_mps(const Tensor& input_t,
   const auto correction_value = correction.value_or(1.0).toDouble();
   int64_t correction_n = 1;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_t, dim);
 
   int64_t num_output_dims = 0;
@@ -573,38 +542,25 @@ Tensor std_var_common_impl_mps(const Tensor& input_t,
     string key = op_key + ":" + getTensorsStringKey(input_t) + ":" + use_dim_info + ":" + keepdim_info + ":" +
         string([ns_key UTF8String]) + ":" + bessel_corrected + ":" + std::to_string(correction_value);
 
-    auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    // Initialize once if configuration not found in cache
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
+      MPSGraphTensor* outputTensor = nil;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-          MPSGraphTensor* outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
-          MPSGraphTensor* outputTensor = nil;
-
-          if (use_correction && correction_value) {
-            MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction
-                                                               dataType:getMPSDataType(input_t)];
-            MPSGraphTensor* correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
-                                                                        secondaryTensor:besselTensor
-                                                                                   name:nil];
-            outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:correctedTensor name:nil]
-                                                              : correctedTensor;
-          } else {
-            outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:outputVarTensor name:nil]
-                                                              : outputVarTensor;
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      if (use_correction && correction_value) {
+        MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction dataType:getMPSDataType(input_t)];
+        MPSGraphTensor* correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
+                                                                    secondaryTensor:besselTensor
+                                                                               name:nil];
+        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:correctedTensor name:nil]
+                                                          : correctedTensor;
+      } else {
+        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:outputVarTensor name:nil]
+                                                          : outputVarTensor;
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
@@ -627,7 +583,6 @@ Tensor min_max_mps_impl(const Tensor& input_t, MPSReductionType reduction_type, 
 
   using CachedGraph = MPSUnaryCachedGraph;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   IntArrayRef input_shape = input_t.sizes();
   int64_t num_in_elements = c10::multiply_integers(input_shape);
 
@@ -639,39 +594,28 @@ Tensor min_max_mps_impl(const Tensor& input_t, MPSReductionType reduction_type, 
 
   @autoreleasepool {
     string key = func_name + mps::getTensorsStringKey(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    // Initialize once if configuration not found in cache
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+    CachedGraph* cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* castOutputTensor = nil;
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
 
-          MPSGraphTensor* castOutputTensor = nil;
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+      NSArray<NSNumber*>* axes = getTensorAxes(input_t);
+      if (reduction_type == MPSReductionType::MAX) {
+        castOutputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axes:axes name:nil];
+      } else if (reduction_type == MPSReductionType::MIN) {
+        castOutputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axes:axes name:nil];
+      }
 
-          NSArray<NSNumber*>* axes = getTensorAxes(input_t);
-          if (reduction_type == MPSReductionType::MAX) {
-            castOutputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axes:axes name:nil];
-          } else if (reduction_type == MPSReductionType::MIN) {
-            castOutputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axes:axes name:nil];
-          }
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
+      }
 
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, @[ @1 ]);
@@ -716,8 +660,6 @@ void min_max_out_mps(const Tensor& input_t,
     MPSGraphTensor* indicesTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
 
   // Calculate the output shape according to keepdim=True
@@ -735,52 +677,40 @@ void min_max_out_mps(const Tensor& input_t,
 
   @autoreleasepool {
     string key = func_name + getTensorsStringKey({input_t, indices_t}) + ":" + to_string(dim_);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* outputTensor = nil;
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      if (reduction_type == MPSReductionType::MAX) {
+        outputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
+      } else if (reduction_type == MPSReductionType::MIN) {
+        outputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-          MPSGraphTensor* outputTensor = nil;
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-          ;
+      MPSGraphTensor* argreduceOutTensor = nil;
+      if (reduction_type == MPSReductionType::MAX)
+        argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor
+                                                                axis:(NSInteger)dim_
+                                                                name:@"argmax_out"];
+      else if (reduction_type == MPSReductionType::MIN)
+        argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor
+                                                                axis:(NSInteger)dim_
+                                                                name:@"argmax_out"];
 
-          if (reduction_type == MPSReductionType::MAX) {
-            outputTensor = [mpsGraph reductionMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-          } else if (reduction_type == MPSReductionType::MIN) {
-            outputTensor = [mpsGraph reductionMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-          }
+      MPSGraphTensor* indicesTensor = nil;
+      if ([argreduceOutTensor dataType] != MPSDataTypeInt64) {
+        indicesTensor = [mpsGraph castTensor:argreduceOutTensor toType:MPSDataTypeInt64 name:@"cast_out"];
+      }
 
-          MPSGraphTensor* argreduceOutTensor = nil;
-          if (reduction_type == MPSReductionType::MAX)
-            argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor
-                                                                    axis:(NSInteger)dim_
-                                                                    name:@"argmax_out"];
-          else if (reduction_type == MPSReductionType::MIN)
-            argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor
-                                                                    axis:(NSInteger)dim_
-                                                                    name:@"argmax_out"];
-
-          MPSGraphTensor* indicesTensor = nil;
-          if ([argreduceOutTensor dataType] != MPSDataTypeInt64) {
-            indicesTensor = [mpsGraph castTensor:argreduceOutTensor toType:MPSDataTypeInt64 name:@"cast_out"];
-          }
-
-          if ([outputTensor dataType] != getMPSDataType(output_t)) {
-            outputTensor = castMPSTensor(mpsGraph, outputTensor, output_t.scalar_type());
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->indicesTensor_ = indicesTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      if ([outputTensor dataType] != getMPSDataType(output_t)) {
+        outputTensor = castMPSTensor(mpsGraph, outputTensor, output_t.scalar_type());
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->indicesTensor_ = indicesTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
@@ -863,7 +793,6 @@ void argmax_argmin_out_mps(const Tensor& input_t,
                            MPSReductionType reduction_type,
                            const std::string& func_name) {
   using CachedGraph = MPSUnaryCachedGraph;
-  auto cache_ = MPSGraphCache::getInstance();
 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "argmax_argmin_out");
@@ -915,48 +844,37 @@ void argmax_argmin_out_mps(const Tensor& input_t,
     NSString* ns_key = [[apparent_in_shape valueForKey:@"description"] componentsJoinedByString:@","];
     string key =
         func_name + ":" + to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" + string([ns_key UTF8String]);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      auto inputScalarType = input_t.scalar_type();
+      MPSGraphTensor* inputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(inputScalarType), apparent_in_shape);
+      MPSGraphTensor* argreduceOutTensor = nil;
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* castInputTensor = inputTensor;
+      if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
+          (inputScalarType != kLong || !macOS13_3_plus)) {
+        castInputTensor = castMPSTensor(mpsGraph, inputTensor, kFloat);
+      }
+      if (reduction_type == MPSReductionType::MAX) {
+        argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
+      } else {
+        argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
+      }
 
-          auto inputScalarType = input_t.scalar_type();
-          MPSGraphTensor* inputTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(inputScalarType), apparent_in_shape);
-          MPSGraphTensor* argreduceOutTensor = nil;
+      MPSGraphTensor* outputTensor = argreduceOutTensor;
+      if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());
+      }
 
-          MPSGraphTensor* castInputTensor = inputTensor;
-          if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
-              (inputScalarType != kLong || !macOS13_3_plus)) {
-            castInputTensor = castMPSTensor(mpsGraph, inputTensor, kFloat);
-          }
-          if (reduction_type == MPSReductionType::MAX) {
-            argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-          } else {
-            argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-          }
+      MPSGraphTensor* outputClampedTensor =
+          [mpsGraph clampWithTensor:outputTensor
+                     minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
+                     maxValueTensor:[mpsGraph constantWithScalar:LLONG_MAX dataType:MPSDataTypeInt64]
+                               name:nil];
 
-          MPSGraphTensor* outputTensor = argreduceOutTensor;
-          if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());
-          }
-
-          MPSGraphTensor* outputClampedTensor =
-              [mpsGraph clampWithTensor:outputTensor
-                         minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
-                         maxValueTensor:[mpsGraph constantWithScalar:LLONG_MAX dataType:MPSDataTypeInt64]
-                                   name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputClampedTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputClampedTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
@@ -1240,7 +1158,6 @@ TORCH_IMPL_FUNC(any_out_mps)
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "any_out");
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
   native::zero_numel_check_dims(input_t, dim_, "any()");
 
@@ -1260,31 +1177,20 @@ TORCH_IMPL_FUNC(any_out_mps)
     MPSShape* input_t_shape = getMPSShape(input_t);
     string key = string("any_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" +
         getMPSTypeString(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSDataType input_type = getMPSDataType(input_t);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSDataType input_type = getMPSDataType(input_t);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-          MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor axis:dim_ name:nil];
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (MPSDataTypeBool != [castOutputTensor dataType]) {
-            outputTensor = [mpsGraph castTensor:castOutputTensor toType:MPSDataTypeBool name:@"outputTensor"];
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+      MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor axis:dim_ name:nil];
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (MPSDataTypeBool != [castOutputTensor dataType]) {
+        outputTensor = [mpsGraph castTensor:castOutputTensor toType:MPSDataTypeBool name:@"outputTensor"];
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
@@ -1316,38 +1222,25 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "any_all_out");
 
-  auto cache_ = MPSGraphCache::getInstance();
   auto stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
     string key = string("any_all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + getMPSTypeString(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSDataType input_type = getMPSDataType(input_t);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+      MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor axes:nil name:nil];
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSDataType input_type = getMPSDataType(input_t);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-          MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor axes:nil name:nil];
-
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t);
@@ -1375,7 +1268,6 @@ TORCH_IMPL_FUNC(all_out_mps)
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "all_out");
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
   native::zero_numel_check_dims(input_t, dim_, "all()");
 
@@ -1395,30 +1287,19 @@ TORCH_IMPL_FUNC(all_out_mps)
     MPSShape* input_t_shape = getMPSShape(input_t);
     string key = string("all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" +
         getMPSTypeString(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSDataType input_type = getMPSDataType(input_t);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-          MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axis:dim_ name:nil];
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (MPSDataTypeBool != [castOutputTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, castOutputTensor, MPSDataTypeBool);
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSDataType input_type = getMPSDataType(input_t);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+      MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axis:dim_ name:nil];
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (MPSDataTypeBool != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, MPSDataTypeBool);
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
@@ -1444,38 +1325,25 @@ TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "all_all_out");
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   auto stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
     string key = string("all_all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + getMPSTypeString(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSDataType input_type = getMPSDataType(input_t);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+      MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axes:nil name:nil];
+      MPSGraphTensor* outputTensor = castOutputTensor;
+      if (MPSDataTypeBool != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, MPSDataTypeBool);
+      }
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSDataType input_type = getMPSDataType(input_t);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-          MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axes:nil name:nil];
-          MPSGraphTensor* outputTensor = castOutputTensor;
-          if (MPSDataTypeBool != [castOutputTensor dataType]) {
-            outputTensor = castMPSTensor(mpsGraph, castOutputTensor, MPSDataTypeBool);
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t);
@@ -1557,8 +1425,6 @@ Tensor median_mps(const Tensor& input_t) {
 
   using CachedGraph = MPSUnaryCachedGraph;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   IntArrayRef input_shape = input_t.sizes();
 
   // calculate total no. of elements in the input tensor to reduce it to one dimension
@@ -1575,32 +1441,22 @@ Tensor median_mps(const Tensor& input_t) {
 
   @autoreleasepool {
     string key = "median_mps:" + mps::getMPSTypeString(input_t) + mps::getTensorsStringKey(input_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    // Initialize once if configuration not found in cache
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
 
-          auto reshapedTensor = [mpsGraph reshapeTensor:castInputTensor withShape:@[ @-1 ] name:nil];
-          auto sortedTensor = [mpsGraph sortWithTensor:reshapedTensor axis:((NSUInteger)(int)0)name:nil];
-          auto outputTensor = [mpsGraph sliceTensor:sortedTensor
-                                          dimension:0
-                                              start:((NSUInteger)(int)((num_in_elements + 1) / 2) - 1)
-                                             length:1
-                                               name:nil];
+      auto reshapedTensor = [mpsGraph reshapeTensor:castInputTensor withShape:@[ @-1 ] name:nil];
+      auto sortedTensor = [mpsGraph sortWithTensor:reshapedTensor axis:((NSUInteger)(int)0)name:nil];
+      auto outputTensor = [mpsGraph sliceTensor:sortedTensor
+                                      dimension:0
+                                          start:((NSUInteger)(int)((num_in_elements + 1) / 2) - 1)
+                                         length:1
+                                           name:nil];
 
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, @[ @1 ]);
@@ -1644,7 +1500,6 @@ void median_out_mps(const Tensor& input_t,
     MPSGraphTensor* indicesTensor_ = nil;
   };
 
-  auto cache_ = MPSGraphCache::getInstance();
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "median_out");
 
@@ -1667,42 +1522,30 @@ void median_out_mps(const Tensor& input_t,
   @autoreleasepool {
     string key =
         func_name + ":" + to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" + getTensorsStringKey(indices_t);
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
 
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* sortedTensor = [mpsGraph sortWithTensor:castInputTensor axis:((NSUInteger)(int)dim_)name:nil];
 
-        @autoreleasepool {
-          auto mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* outputTensor = [mpsGraph sliceTensor:sortedTensor
+                                                 dimension:dim_
+                                                     start:((NSUInteger)(int)((dim_total_elements + 1) / 2) - 1)
+                                                    length:1
+                                                      name:nil];
+      MPSGraphTensor* argreduceOutTensor = nil;
+      argreduceOutTensor = [mpsGraph argSortWithTensor:castInputTensor axis:(NSInteger)dim_ name:@"argmax_out"];
+      MPSGraphTensor* argOutputTensor = [mpsGraph sliceTensor:argreduceOutTensor
+                                                    dimension:dim_
+                                                        start:((NSUInteger)(int)((dim_total_elements + 1) / 2) - 1)
+                                                       length:1
+                                                         name:nil];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
-
-          MPSGraphTensor* sortedTensor = [mpsGraph sortWithTensor:castInputTensor axis:((NSUInteger)(int)dim_)name:nil];
-
-          MPSGraphTensor* outputTensor = [mpsGraph sliceTensor:sortedTensor
-                                                     dimension:dim_
-                                                         start:((NSUInteger)(int)((dim_total_elements + 1) / 2) - 1)
-                                                        length:1
-                                                          name:nil];
-          MPSGraphTensor* argreduceOutTensor = nil;
-          argreduceOutTensor = [mpsGraph argSortWithTensor:castInputTensor axis:(NSInteger)dim_ name:@"argmax_out"];
-          MPSGraphTensor* argOutputTensor = [mpsGraph sliceTensor:argreduceOutTensor
-                                                        dimension:dim_
-                                                            start:((NSUInteger)(int)((dim_total_elements + 1) / 2) - 1)
-                                                           length:1
-                                                             name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->indicesTensor_ = argOutputTensor;
-        }
-        return newCachedGraph;
-      });
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->indicesTensor_ = argOutputTensor;
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -126,8 +126,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
     NSMutableArray<MPSGraphTensor*>* recurrentBiasList_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -135,176 +133,150 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
         std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) + "_has_biases_" +
         std::to_string(has_biases) + "_dropout_" + std::to_string(dropout_p) + "_batch_first_" +
         std::to_string(batch_first);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      NSMutableArray<MPSGraphTensor*>* kernelWeightsList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList =
+          [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* kernelBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* layersOutputsList = [[NSMutableArray alloc] initWithCapacity:num_layers];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          NSMutableArray<MPSGraphTensor*>* kernelWeightsList = [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList =
-              [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* kernelBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* layersOutputsList = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      for (const auto i : c10::irange(total_layers)) {
+        [kernelWeightsList
+            addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
+        [recurrentKernelWeightsList
+            addObject:mpsGraphRankedPlaceHolder(
+                          mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
+        if (has_biases) {
+          [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
+          [recurrentBiasList
+              addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
+        }
+      }
 
-          for (const auto i : c10::irange(total_layers)) {
-            [kernelWeightsList
-                addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
-            [recurrentKernelWeightsList
-                addObject:mpsGraphRankedPlaceHolder(
-                              mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
-            if (has_biases) {
-              [kernelBiasList
-                  addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
-              [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(
-                                               mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
-            }
-          }
+      MPSGraphLSTMDescriptor* opDesc = [MPSGraphLSTMDescriptor descriptor];
+      opDesc.training = true;
+      opDesc.bidirectional = bidirectional;
+      opDesc.produceCell = true;
 
-          MPSGraphLSTMDescriptor* opDesc = [MPSGraphLSTMDescriptor descriptor];
-          opDesc.training = true;
-          opDesc.bidirectional = bidirectional;
-          opDesc.produceCell = true;
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
+      MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
+      MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
+      std::vector<MPSGraphTensor*> inputTensors = {
+          inputTensor,
+          stateTensor,
+          cellStateTensor,
+      };
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
-          MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
-          MPSGraphTensor* cellStateTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
-          std::vector<MPSGraphTensor*> inputTensors = {
-              inputTensor,
-              stateTensor,
-              cellStateTensor,
-          };
+      if (batch_first) {
+        inputTensor = [mpsGraph transposeTensor:inputTensor dimension:0 withDimension:1 name:nil];
+      }
 
-          if (batch_first) {
-            inputTensor = [mpsGraph transposeTensor:inputTensor dimension:0 withDimension:1 name:nil];
-          }
+      MPSGraphTensor* inputTensor_ = inputTensor;
+      NSArray<MPSGraphTensor*>* outputs = nil;
+      NSMutableArray<MPSGraphTensor*>* outputStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* outputCellStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* outputZStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* outputCellStateFwdArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      for (int i = 0; i < num_layers; i++) {
+        auto tensorsData = getMPSTensorsFromPytorchTensors(mpsGraph,
+                                                           stateTensor,
+                                                           cellStateTensor,
+                                                           recurrentKernelWeightsList,
+                                                           kernelWeightsList,
+                                                           kernelBiasList,
+                                                           recurrentBiasList,
+                                                           has_biases,
+                                                           bidirectional,
+                                                           i);
+        MPSGraphTensor *stateTensor_ = std::get<0>(tensorsData), *cellStateTensor_ = std::get<1>(tensorsData);
+        MPSGraphTensor *recurrentWeight_ = std::get<2>(tensorsData), *inputWeight_ = std::get<3>(tensorsData);
+        MPSGraphTensor* biasTensor_ = std::get<4>(tensorsData);
 
-          MPSGraphTensor* inputTensor_ = inputTensor;
-          NSArray<MPSGraphTensor*>* outputs = nil;
-          NSMutableArray<MPSGraphTensor*>* outputStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* outputCellStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* outputZStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* outputCellStateFwdArray =
-              [[NSMutableArray alloc] initWithCapacity:num_layers];
-          for (int i = 0; i < num_layers; i++) {
-            auto tensorsData = getMPSTensorsFromPytorchTensors(mpsGraph,
-                                                               stateTensor,
-                                                               cellStateTensor,
-                                                               recurrentKernelWeightsList,
-                                                               kernelWeightsList,
-                                                               kernelBiasList,
-                                                               recurrentBiasList,
-                                                               has_biases,
-                                                               bidirectional,
-                                                               i);
-            MPSGraphTensor *stateTensor_ = std::get<0>(tensorsData), *cellStateTensor_ = std::get<1>(tensorsData);
-            MPSGraphTensor *recurrentWeight_ = std::get<2>(tensorsData), *inputWeight_ = std::get<3>(tensorsData);
-            MPSGraphTensor* biasTensor_ = std::get<4>(tensorsData);
+        outputs = [mpsGraph LSTMWithSourceTensor:inputTensor_
+                                 recurrentWeight:recurrentWeight_
+                                     inputWeight:inputWeight_
+                                            bias:biasTensor_
+                                       initState:stateTensor_
+                                        initCell:cellStateTensor_
+                                      descriptor:opDesc
+                                            name:nil];
 
-            outputs = [mpsGraph LSTMWithSourceTensor:inputTensor_
-                                     recurrentWeight:recurrentWeight_
-                                         inputWeight:inputWeight_
-                                                bias:biasTensor_
-                                           initState:stateTensor_
-                                            initCell:cellStateTensor_
-                                          descriptor:opDesc
-                                                name:nil];
+        inputTensor_ = [outputs objectAtIndex:0];
+        // no need to keep the final layer output copy as it is
+        // returned anyway and not used in backprop
+        if (i != num_layers - 1) {
+          [layersOutputsList addObject:[mpsGraph expandDimsOfTensor:inputTensor_ axis:0 name:nil]];
+        }
+        if (dropout_p > 0.0 && train && (i != num_layers - 1)) {
+          inputTensor_ = [mpsGraph dropoutTensor:inputTensor_ rate:dropout_p name:nil];
+        }
 
-            inputTensor_ = [outputs objectAtIndex:0];
-            // no need to keep the final layer output copy as it is
-            // returned anyway and not used in backprop
-            if (i != num_layers - 1) {
-              [layersOutputsList addObject:[mpsGraph expandDimsOfTensor:inputTensor_ axis:0 name:nil]];
-            }
-            if (dropout_p > 0.0 && train && (i != num_layers - 1)) {
-              inputTensor_ = [mpsGraph dropoutTensor:inputTensor_ rate:dropout_p name:nil];
-            }
+        if (bidirectional) {
+          // [1, N, 2 * H]
+          auto stateLastT = [mpsGraph sliceTensor:[outputs objectAtIndex:0] dimension:0 start:-1 length:1 name:nil];
+          auto stateFirstT = [mpsGraph sliceTensor:[outputs objectAtIndex:0] dimension:0 start:0 length:1 name:nil];
+          // [1, N, H] ([1, N, 0:H])
+          auto stateForward = [mpsGraph sliceTensor:stateLastT dimension:-1 start:0 length:hx[0].sizes()[2] name:nil];
+          // [1, N, H] ([1, N, H:2H])
+          auto stateBack = [mpsGraph sliceTensor:stateFirstT
+                                       dimension:-1
+                                           start:hx[0].sizes()[2]
+                                          length:hx[0].sizes()[2]
+                                            name:nil];
+          [outputStateArray addObject:stateForward];
+          [outputStateArray addObject:stateBack];
 
-            if (bidirectional) {
-              // [1, N, 2 * H]
-              auto stateLastT = [mpsGraph sliceTensor:[outputs objectAtIndex:0] dimension:0 start:-1 length:1 name:nil];
-              auto stateFirstT = [mpsGraph sliceTensor:[outputs objectAtIndex:0] dimension:0 start:0 length:1 name:nil];
-              // [1, N, H] ([1, N, 0:H])
-              auto stateForward = [mpsGraph sliceTensor:stateLastT
+          auto cellStateLastT = [mpsGraph sliceTensor:[outputs objectAtIndex:1] dimension:0 start:-1 length:1 name:nil];
+          auto cellStateFirstT = [mpsGraph sliceTensor:[outputs objectAtIndex:1] dimension:0 start:0 length:1 name:nil];
+          auto cellStateForward = [mpsGraph sliceTensor:cellStateLastT
                                               dimension:-1
                                                   start:0
-                                                 length:hx[0].sizes()[2]
+                                                 length:hx[1].sizes()[2]
                                                    name:nil];
-              // [1, N, H] ([1, N, H:2H])
-              auto stateBack = [mpsGraph sliceTensor:stateFirstT
+          auto cellStateBack = [mpsGraph sliceTensor:cellStateFirstT
                                            dimension:-1
-                                               start:hx[0].sizes()[2]
-                                              length:hx[0].sizes()[2]
+                                               start:hx[1].sizes()[2]
+                                              length:hx[1].sizes()[2]
                                                 name:nil];
-              [outputStateArray addObject:stateForward];
-              [outputStateArray addObject:stateBack];
-
-              auto cellStateLastT = [mpsGraph sliceTensor:[outputs objectAtIndex:1]
-                                                dimension:0
-                                                    start:-1
-                                                   length:1
-                                                     name:nil];
-              auto cellStateFirstT = [mpsGraph sliceTensor:[outputs objectAtIndex:1]
-                                                 dimension:0
-                                                     start:0
-                                                    length:1
-                                                      name:nil];
-              auto cellStateForward = [mpsGraph sliceTensor:cellStateLastT
-                                                  dimension:-1
-                                                      start:0
-                                                     length:hx[1].sizes()[2]
-                                                       name:nil];
-              auto cellStateBack = [mpsGraph sliceTensor:cellStateFirstT
-                                               dimension:-1
-                                                   start:hx[1].sizes()[2]
-                                                  length:hx[1].sizes()[2]
-                                                    name:nil];
-              [outputCellStateArray addObject:cellStateForward];
-              [outputCellStateArray addObject:cellStateBack];
-            } else {
-              [outputStateArray addObject:[mpsGraph sliceTensor:[outputs objectAtIndex:0]
+          [outputCellStateArray addObject:cellStateForward];
+          [outputCellStateArray addObject:cellStateBack];
+        } else {
+          [outputStateArray addObject:[mpsGraph sliceTensor:[outputs objectAtIndex:0]
+                                                  dimension:0
+                                                      start:-1
+                                                     length:1
+                                                       name:nil]];
+          [outputCellStateArray addObject:[mpsGraph sliceTensor:[outputs objectAtIndex:1]
                                                       dimension:0
                                                           start:-1
                                                          length:1
                                                            name:nil]];
-              [outputCellStateArray addObject:[mpsGraph sliceTensor:[outputs objectAtIndex:1]
-                                                          dimension:0
-                                                              start:-1
-                                                             length:1
-                                                               name:nil]];
-            }
-            [outputCellStateFwdArray addObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:1] axis:0 name:nil]];
-            [outputZStateArray addObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:2] axis:0 name:nil]];
-          }
-
-          MPSGraphTensor* outputTensor = inputTensor_;
-          if (batch_first) {
-            outputTensor = [mpsGraph transposeTensor:outputTensor dimension:0 withDimension:1 name:nil];
-          }
-          MPSGraphTensor* outputStates = [mpsGraph concatTensors:outputStateArray dimension:0 name:nil];
-          MPSGraphTensor* outputCellStates = [mpsGraph concatTensors:outputCellStateArray dimension:0 name:nil];
-          MPSGraphTensor* outputZStates = [mpsGraph concatTensors:outputZStateArray dimension:0 name:nil];
-          MPSGraphTensor* outputCellStatesFwd = [mpsGraph concatTensors:outputCellStateFwdArray dimension:0 name:nil];
-          MPSGraphTensor* layersOutputs =
-              (num_layers > 1) ? [mpsGraph concatTensors:layersOutputsList dimension:0 name:nil] : nil;
-
-          std::vector<MPSGraphTensor*> outputTensors = {
-              outputTensor, outputStates, outputCellStates, outputZStates, outputCellStatesFwd, layersOutputs};
-          newCachedGraph->inputTensors_ = inputTensors;
-          newCachedGraph->outputTensors_ = outputTensors;
-          newCachedGraph->kernelWeightsList_ = kernelWeightsList;
-          newCachedGraph->recurrentKernelWeightsList_ = recurrentKernelWeightsList;
-          newCachedGraph->biasList_ = kernelBiasList;
-          newCachedGraph->recurrentBiasList_ = recurrentBiasList;
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+        [outputCellStateFwdArray addObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:1] axis:0 name:nil]];
+        [outputZStateArray addObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:2] axis:0 name:nil]];
+      }
+
+      MPSGraphTensor* outputTensor = inputTensor_;
+      if (batch_first) {
+        outputTensor = [mpsGraph transposeTensor:outputTensor dimension:0 withDimension:1 name:nil];
+      }
+      MPSGraphTensor* outputStates = [mpsGraph concatTensors:outputStateArray dimension:0 name:nil];
+      MPSGraphTensor* outputCellStates = [mpsGraph concatTensors:outputCellStateArray dimension:0 name:nil];
+      MPSGraphTensor* outputZStates = [mpsGraph concatTensors:outputZStateArray dimension:0 name:nil];
+      MPSGraphTensor* outputCellStatesFwd = [mpsGraph concatTensors:outputCellStateFwdArray dimension:0 name:nil];
+      MPSGraphTensor* layersOutputs =
+          (num_layers > 1) ? [mpsGraph concatTensors:layersOutputsList dimension:0 name:nil] : nil;
+
+      std::vector<MPSGraphTensor*> outputTensors = {
+          outputTensor, outputStates, outputCellStates, outputZStates, outputCellStatesFwd, layersOutputs};
+      newCachedGraph->inputTensors_ = inputTensors;
+      newCachedGraph->outputTensors_ = outputTensors;
+      newCachedGraph->kernelWeightsList_ = kernelWeightsList;
+      newCachedGraph->recurrentKernelWeightsList_ = recurrentKernelWeightsList;
+      newCachedGraph->biasList_ = kernelBiasList;
+      newCachedGraph->recurrentBiasList_ = recurrentBiasList;
+    });
 
     NSMutableArray<MPSGraphTensor*>* kernelWeightsList = cachedGraph->kernelWeightsList_;
     NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList = cachedGraph->recurrentKernelWeightsList_;
@@ -429,8 +401,6 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
     MPSGraphTensor* gradCellState_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   // Get stream
   MPSStream* stream = getCurrentMPSStream();
   @autoreleasepool {
@@ -438,283 +408,262 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
         getMPSTypeString(input) + "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" +
         std::to_string(bidirectional) + "_has_biases_" + std::to_string(has_biases) + "_batch_first_" +
         std::to_string(batch_first);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      NSMutableArray<MPSGraphTensor*>* kernelWeightsList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList =
+          [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* kernelBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      NSMutableArray<MPSGraphTensor*>* recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
 
-          NSMutableArray<MPSGraphTensor*>* kernelWeightsList = [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList =
-              [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* kernelBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
-          NSMutableArray<MPSGraphTensor*>* recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
+      for (const auto i : c10::irange(total_layers)) {
+        [kernelWeightsList
+            addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
+        [recurrentKernelWeightsList
+            addObject:mpsGraphRankedPlaceHolder(
+                          mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
+        if (has_biases) {
+          [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
+          [recurrentBiasList
+              addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
+        }
+      }
 
-          for (const auto i : c10::irange(total_layers)) {
-            [kernelWeightsList
-                addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
-            [recurrentKernelWeightsList
-                addObject:mpsGraphRankedPlaceHolder(
-                              mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
-            if (has_biases) {
-              [kernelBiasList
-                  addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
-              [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(
-                                               mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
-            }
-          }
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
+      MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
+      MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
+      MPSGraphTensor* zStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(z_state));
+      MPSGraphTensor* gradientTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_y), getMPSShape(grad_y));
+      MPSGraphTensor* gradientCyTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_cy), getMPSShape(grad_cy));
+      MPSGraphTensor* gradientHyTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_hy), getMPSShape(grad_hy));
+      MPSGraphTensor* cellStateFwdTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(cell_state_fwd), getMPSShape(cell_state_fwd));
+      MPSGraphTensor* layersOutputsTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(layersOutputs), getMPSShape(layersOutputs));
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
-          MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
-          MPSGraphTensor* cellStateTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
-          MPSGraphTensor* zStateTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(z_state));
-          MPSGraphTensor* gradientTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_y), getMPSShape(grad_y));
-          MPSGraphTensor* gradientCyTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_cy), getMPSShape(grad_cy));
-          MPSGraphTensor* gradientHyTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_hy), getMPSShape(grad_hy));
-          MPSGraphTensor* cellStateFwdTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(cell_state_fwd), getMPSShape(cell_state_fwd));
-          MPSGraphTensor* layersOutputsTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(layersOutputs), getMPSShape(layersOutputs));
+      std::vector<MPSGraphTensor*> inputs = {inputTensor,
+                                             stateTensor,
+                                             cellStateTensor,
+                                             gradientTensor,
+                                             zStateTensor,
+                                             cellStateFwdTensor,
+                                             gradientHyTensor,
+                                             gradientCyTensor,
+                                             layersOutputsTensor};
 
-          std::vector<MPSGraphTensor*> inputs = {inputTensor,
-                                                 stateTensor,
-                                                 cellStateTensor,
-                                                 gradientTensor,
-                                                 zStateTensor,
-                                                 cellStateFwdTensor,
-                                                 gradientHyTensor,
-                                                 gradientCyTensor,
-                                                 layersOutputsTensor};
+      if (batch_first) {
+        inputTensor = [mpsGraph transposeTensor:inputTensor dimension:0 withDimension:1 name:nil];
 
-          if (batch_first) {
-            inputTensor = [mpsGraph transposeTensor:inputTensor dimension:0 withDimension:1 name:nil];
+        gradientTensor = [mpsGraph transposeTensor:gradientTensor dimension:0 withDimension:1 name:nil];
+      }
 
-            gradientTensor = [mpsGraph transposeTensor:gradientTensor dimension:0 withDimension:1 name:nil];
-          }
+      newCachedGraph->recurrentKernelWeightsList_ = recurrentKernelWeightsList;
+      newCachedGraph->kernelWeightsList_ = kernelWeightsList;
+      newCachedGraph->biasList_ = kernelBiasList;
+      newCachedGraph->recurrentBiasList_ = recurrentBiasList;
+      newCachedGraph->inputTensors_ = inputs;
 
-          newCachedGraph->recurrentKernelWeightsList_ = recurrentKernelWeightsList;
-          newCachedGraph->kernelWeightsList_ = kernelWeightsList;
-          newCachedGraph->biasList_ = kernelBiasList;
-          newCachedGraph->recurrentBiasList_ = recurrentBiasList;
-          newCachedGraph->inputTensors_ = inputs;
+      MPSGraphLSTMDescriptor* opDesc = [MPSGraphLSTMDescriptor descriptor];
+      opDesc.training = true; // train;
+      opDesc.bidirectional = bidirectional;
+      opDesc.produceCell = true;
 
-          MPSGraphLSTMDescriptor* opDesc = [MPSGraphLSTMDescriptor descriptor];
-          opDesc.training = true; // train;
-          opDesc.bidirectional = bidirectional;
-          opDesc.produceCell = true;
+      MPSGraphTensor* gradientTensor_ = gradientTensor;
 
-          MPSGraphTensor* gradientTensor_ = gradientTensor;
+      NSArray<MPSGraphTensor*>* outputs = nil;
 
-          NSArray<MPSGraphTensor*>* outputs = nil;
+      NSMutableArray<MPSGraphTensor*>* gradRecWeightsArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* gradWeightsArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* gradBiasArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* gradStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* gradCellStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
 
-          NSMutableArray<MPSGraphTensor*>* gradRecWeightsArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* gradWeightsArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* gradBiasArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* gradStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
-          NSMutableArray<MPSGraphTensor*>* gradCellStateArray = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      for (int i = num_layers - 1; i >= 0; i--) {
+        MPSGraphTensor* zState = [mpsGraph sliceTensor:zStateTensor dimension:0 start:i length:1 name:nil];
+        zState = [mpsGraph squeezeTensor:zState axis:0 name:nil];
+        MPSGraphTensor* cellStateFwd = [mpsGraph sliceTensor:cellStateFwdTensor dimension:0 start:i length:1 name:nil];
+        cellStateFwd = [mpsGraph squeezeTensor:cellStateFwd axis:0 name:nil];
+        auto tensorsData = getMPSTensorsFromPytorchTensors(mpsGraph,
+                                                           stateTensor,
+                                                           cellStateTensor,
+                                                           recurrentKernelWeightsList,
+                                                           kernelWeightsList,
+                                                           kernelBiasList,
+                                                           recurrentBiasList,
+                                                           has_biases,
+                                                           bidirectional,
+                                                           i);
+        MPSGraphTensor *stateTensor_ = std::get<0>(tensorsData), *cellStateTensor_ = std::get<1>(tensorsData);
+        MPSGraphTensor *recurrentWeight_ = std::get<2>(tensorsData), *inputWeight_ = std::get<3>(tensorsData);
+        MPSGraphTensor* biasTensor_ = std::get<4>(tensorsData);
 
-          for (int i = num_layers - 1; i >= 0; i--) {
-            MPSGraphTensor* zState = [mpsGraph sliceTensor:zStateTensor dimension:0 start:i length:1 name:nil];
-            zState = [mpsGraph squeezeTensor:zState axis:0 name:nil];
-            MPSGraphTensor* cellStateFwd = [mpsGraph sliceTensor:cellStateFwdTensor
-                                                       dimension:0
-                                                           start:i
-                                                          length:1
-                                                            name:nil];
-            cellStateFwd = [mpsGraph squeezeTensor:cellStateFwd axis:0 name:nil];
-            auto tensorsData = getMPSTensorsFromPytorchTensors(mpsGraph,
-                                                               stateTensor,
-                                                               cellStateTensor,
-                                                               recurrentKernelWeightsList,
-                                                               kernelWeightsList,
-                                                               kernelBiasList,
-                                                               recurrentBiasList,
-                                                               has_biases,
-                                                               bidirectional,
-                                                               i);
-            MPSGraphTensor *stateTensor_ = std::get<0>(tensorsData), *cellStateTensor_ = std::get<1>(tensorsData);
-            MPSGraphTensor *recurrentWeight_ = std::get<2>(tensorsData), *inputWeight_ = std::get<3>(tensorsData);
-            MPSGraphTensor* biasTensor_ = std::get<4>(tensorsData);
+        MPSGraphTensor *gradientHyTensor_ = nil, *gradientCyTensor_ = nil;
+        if (bidirectional) {
+          gradientHyTensor_ = [mpsGraph sliceTensor:gradientHyTensor dimension:0 start:i * 2 length:2 name:nil];
+          // [2, N, H] -> [N, 2, H]
+          gradientHyTensor_ = [mpsGraph transposeTensor:gradientHyTensor_ dimension:0 withDimension:1 name:nil];
+          // [N, 2, H] -> [N, 2 * H]
+          gradientHyTensor_ = [mpsGraph flatten2DTensor:gradientHyTensor_ axis:1 name:nil];
 
-            MPSGraphTensor *gradientHyTensor_ = nil, *gradientCyTensor_ = nil;
-            if (bidirectional) {
-              gradientHyTensor_ = [mpsGraph sliceTensor:gradientHyTensor dimension:0 start:i * 2 length:2 name:nil];
-              // [2, N, H] -> [N, 2, H]
-              gradientHyTensor_ = [mpsGraph transposeTensor:gradientHyTensor_ dimension:0 withDimension:1 name:nil];
-              // [N, 2, H] -> [N, 2 * H]
-              gradientHyTensor_ = [mpsGraph flatten2DTensor:gradientHyTensor_ axis:1 name:nil];
+          gradientCyTensor_ = [mpsGraph sliceTensor:gradientCyTensor dimension:0 start:i * 2 length:2 name:nil];
+          gradientCyTensor_ = [mpsGraph transposeTensor:gradientCyTensor_ dimension:0 withDimension:1 name:nil];
+          gradientCyTensor_ = [mpsGraph flatten2DTensor:gradientCyTensor_ axis:1 name:nil];
+        } else {
+          gradientHyTensor_ = [mpsGraph sliceTensor:gradientHyTensor dimension:0 start:i length:1 name:nil];
 
-              gradientCyTensor_ = [mpsGraph sliceTensor:gradientCyTensor dimension:0 start:i * 2 length:2 name:nil];
-              gradientCyTensor_ = [mpsGraph transposeTensor:gradientCyTensor_ dimension:0 withDimension:1 name:nil];
-              gradientCyTensor_ = [mpsGraph flatten2DTensor:gradientCyTensor_ axis:1 name:nil];
-            } else {
-              gradientHyTensor_ = [mpsGraph sliceTensor:gradientHyTensor dimension:0 start:i length:1 name:nil];
+          gradientCyTensor_ = [mpsGraph sliceTensor:gradientCyTensor dimension:0 start:i length:1 name:nil];
+        }
 
-              gradientCyTensor_ = [mpsGraph sliceTensor:gradientCyTensor dimension:0 start:i length:1 name:nil];
-            }
+        MPSGraphTensor* iterationInputTensor_ = nil;
+        if (i == 0) {
+          iterationInputTensor_ = inputTensor;
+        } else {
+          iterationInputTensor_ = [mpsGraph sliceTensor:layersOutputsTensor
+                                              dimension:0
+                                                  // the last element in layersOutputsTensor
+                                                  // contains **inputs** for the **last** layer
+                                                  // and so on
+                                                  start:i - num_layers
+                                                 length:1
+                                                   name:nil];
+          iterationInputTensor_ = [mpsGraph squeezeTensor:iterationInputTensor_ axis:0 name:nil];
+        }
 
-            MPSGraphTensor* iterationInputTensor_ = nil;
-            if (i == 0) {
-              iterationInputTensor_ = inputTensor;
-            } else {
-              iterationInputTensor_ = [mpsGraph sliceTensor:layersOutputsTensor
-                                                  dimension:0
-                                                      // the last element in layersOutputsTensor
-                                                      // contains **inputs** for the **last** layer
-                                                      // and so on
-                                                      start:i - num_layers
-                                                     length:1
-                                                       name:nil];
-              iterationInputTensor_ = [mpsGraph squeezeTensor:iterationInputTensor_ axis:0 name:nil];
-            }
-
-            outputs = [mpsGraph LSTMGradientsWithSourceTensor:iterationInputTensor_
-                                              recurrentWeight:recurrentWeight_
-                                               sourceGradient:gradientTensor_
-                                                       zState:zState
-                                                cellOutputFwd:cellStateFwd
-                                                stateGradient:gradientHyTensor_
-                                                 cellGradient:gradientCyTensor_
-                                                  inputWeight:inputWeight_
-                                                         bias:biasTensor_
-                                                    initState:stateTensor_
-                                                     initCell:cellStateTensor_
-                                                         mask:nil
-                                                     peephole:nil
-                                                   descriptor:opDesc
-                                                         name:nil];
-
-            gradientTensor_ = [outputs objectAtIndex:0];
-            if (bidirectional) {
-              int outputIter = 1;
-              auto gradRecWeightsBidirectional = [outputs objectAtIndex:outputIter++];
-              auto gradRecWeightFwd = [mpsGraph sliceTensor:gradRecWeightsBidirectional
-                                                  dimension:0
-                                                      start:0
-                                                     length:1
-                                                       name:nil];
-              gradRecWeightFwd = [mpsGraph squeezeTensor:gradRecWeightFwd axis:0 name:nil];
-              auto gradRecWeightBack = [mpsGraph sliceTensor:gradRecWeightsBidirectional
-                                                   dimension:0
-                                                       start:1
-                                                      length:1
-                                                        name:nil];
-              gradRecWeightBack = [mpsGraph squeezeTensor:gradRecWeightBack axis:0 name:nil];
-
-              // inverse order
-              [gradRecWeightsArray insertObject:gradRecWeightBack atIndex:0];
-              [gradRecWeightsArray insertObject:gradRecWeightFwd atIndex:0];
-
-              auto gradWeightsBidirectional = [outputs objectAtIndex:outputIter++];
-              auto gradWeightFwd = [mpsGraph sliceTensor:gradWeightsBidirectional
-                                               dimension:0
-                                                   start:0
-                                                  length:hidden_size * 4
-                                                    name:nil];
-              auto gradWeightBack = [mpsGraph sliceTensor:gradWeightsBidirectional
-                                                dimension:0
-                                                    start:hidden_size * 4
-                                                   length:hidden_size * 4
+        outputs = [mpsGraph LSTMGradientsWithSourceTensor:iterationInputTensor_
+                                          recurrentWeight:recurrentWeight_
+                                           sourceGradient:gradientTensor_
+                                                   zState:zState
+                                            cellOutputFwd:cellStateFwd
+                                            stateGradient:gradientHyTensor_
+                                             cellGradient:gradientCyTensor_
+                                              inputWeight:inputWeight_
+                                                     bias:biasTensor_
+                                                initState:stateTensor_
+                                                 initCell:cellStateTensor_
+                                                     mask:nil
+                                                 peephole:nil
+                                               descriptor:opDesc
                                                      name:nil];
 
-              [gradWeightsArray insertObject:gradWeightBack atIndex:0];
-              [gradWeightsArray insertObject:gradWeightFwd atIndex:0];
-
-              if (has_biases) {
-                // has shape [1, 1, 8H] vs [8H] as should be
-                // so, squeeze these two first dimensions
-                auto gradBiasBidirectional = [outputs objectAtIndex:outputIter++];
-                gradBiasBidirectional = [mpsGraph squeezeTensor:gradBiasBidirectional axes:@[ @0, @1 ] name:nil];
-                auto gradBiasFwd = [mpsGraph sliceTensor:gradBiasBidirectional
+        gradientTensor_ = [outputs objectAtIndex:0];
+        if (bidirectional) {
+          int outputIter = 1;
+          auto gradRecWeightsBidirectional = [outputs objectAtIndex:outputIter++];
+          auto gradRecWeightFwd = [mpsGraph sliceTensor:gradRecWeightsBidirectional
+                                              dimension:0
+                                                  start:0
+                                                 length:1
+                                                   name:nil];
+          gradRecWeightFwd = [mpsGraph squeezeTensor:gradRecWeightFwd axis:0 name:nil];
+          auto gradRecWeightBack = [mpsGraph sliceTensor:gradRecWeightsBidirectional
                                                dimension:0
-                                                   start:0
-                                                  length:hidden_size * 4
+                                                   start:1
+                                                  length:1
                                                     name:nil];
-                auto gradBiasBack = [mpsGraph sliceTensor:gradBiasBidirectional
-                                                dimension:0
-                                                    start:hidden_size * 4
-                                                   length:hidden_size * 4
-                                                     name:nil];
+          gradRecWeightBack = [mpsGraph squeezeTensor:gradRecWeightBack axis:0 name:nil];
 
-                [gradBiasArray insertObject:gradBiasBack atIndex:0];
-                [gradBiasArray insertObject:gradBiasFwd atIndex:0];
-              }
+          // inverse order
+          [gradRecWeightsArray insertObject:gradRecWeightBack atIndex:0];
+          [gradRecWeightsArray insertObject:gradRecWeightFwd atIndex:0];
 
-              auto gradStateBidirectional = [outputs objectAtIndex:outputIter++];
-              auto gradStateFwd = [mpsGraph sliceTensor:gradStateBidirectional
+          auto gradWeightsBidirectional = [outputs objectAtIndex:outputIter++];
+          auto gradWeightFwd = [mpsGraph sliceTensor:gradWeightsBidirectional
+                                           dimension:0
+                                               start:0
+                                              length:hidden_size * 4
+                                                name:nil];
+          auto gradWeightBack = [mpsGraph sliceTensor:gradWeightsBidirectional
+                                            dimension:0
+                                                start:hidden_size * 4
+                                               length:hidden_size * 4
+                                                 name:nil];
+
+          [gradWeightsArray insertObject:gradWeightBack atIndex:0];
+          [gradWeightsArray insertObject:gradWeightFwd atIndex:0];
+
+          if (has_biases) {
+            // has shape [1, 1, 8H] vs [8H] as should be
+            // so, squeeze these two first dimensions
+            auto gradBiasBidirectional = [outputs objectAtIndex:outputIter++];
+            gradBiasBidirectional = [mpsGraph squeezeTensor:gradBiasBidirectional axes:@[ @0, @1 ] name:nil];
+            auto gradBiasFwd = [mpsGraph sliceTensor:gradBiasBidirectional
+                                           dimension:0
+                                               start:0
+                                              length:hidden_size * 4
+                                                name:nil];
+            auto gradBiasBack = [mpsGraph sliceTensor:gradBiasBidirectional
+                                            dimension:0
+                                                start:hidden_size * 4
+                                               length:hidden_size * 4
+                                                 name:nil];
+
+            [gradBiasArray insertObject:gradBiasBack atIndex:0];
+            [gradBiasArray insertObject:gradBiasFwd atIndex:0];
+          }
+
+          auto gradStateBidirectional = [outputs objectAtIndex:outputIter++];
+          auto gradStateFwd = [mpsGraph sliceTensor:gradStateBidirectional
+                                          dimension:1
+                                              start:0
+                                             length:hidden_size
+                                               name:nil];
+          auto gradStateBack = [mpsGraph sliceTensor:gradStateBidirectional
+                                           dimension:1
+                                               start:hidden_size
+                                              length:hidden_size
+                                                name:nil];
+
+          [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:gradStateBack axis:0 name:nil] atIndex:0];
+          [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:gradStateFwd axis:0 name:nil] atIndex:0];
+
+          auto gradCellStateBidirectional = [outputs objectAtIndex:outputIter++];
+          auto gradCellStateFwd = [mpsGraph sliceTensor:gradCellStateBidirectional
                                               dimension:1
                                                   start:0
                                                  length:hidden_size
                                                    name:nil];
-              auto gradStateBack = [mpsGraph sliceTensor:gradStateBidirectional
+          auto gradCellStateBack = [mpsGraph sliceTensor:gradCellStateBidirectional
                                                dimension:1
                                                    start:hidden_size
                                                   length:hidden_size
                                                     name:nil];
 
-              [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:gradStateBack axis:0 name:nil] atIndex:0];
-              [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:gradStateFwd axis:0 name:nil] atIndex:0];
-
-              auto gradCellStateBidirectional = [outputs objectAtIndex:outputIter++];
-              auto gradCellStateFwd = [mpsGraph sliceTensor:gradCellStateBidirectional
-                                                  dimension:1
-                                                      start:0
-                                                     length:hidden_size
-                                                       name:nil];
-              auto gradCellStateBack = [mpsGraph sliceTensor:gradCellStateBidirectional
-                                                   dimension:1
-                                                       start:hidden_size
-                                                      length:hidden_size
-                                                        name:nil];
-
-              [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:gradCellStateBack axis:0 name:nil]
-                                       atIndex:0];
-              [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:gradCellStateFwd axis:0 name:nil]
-                                       atIndex:0];
-            } else {
-              int outputIter = 1;
-              [gradRecWeightsArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
-              [gradWeightsArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
-              if (has_biases) {
-                [gradBiasArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
-              }
-              [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:outputIter++]
+          [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:gradCellStateBack axis:0 name:nil] atIndex:0];
+          [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:gradCellStateFwd axis:0 name:nil] atIndex:0];
+        } else {
+          int outputIter = 1;
+          [gradRecWeightsArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
+          [gradWeightsArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
+          if (has_biases) {
+            [gradBiasArray insertObject:[outputs objectAtIndex:outputIter++] atIndex:0];
+          }
+          [gradStateArray insertObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:outputIter++]
+                                                               axis:0
+                                                               name:nil]
+                               atIndex:0];
+          [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:outputIter++]
                                                                    axis:0
                                                                    name:nil]
                                    atIndex:0];
-              [gradCellStateArray insertObject:[mpsGraph expandDimsOfTensor:[outputs objectAtIndex:outputIter++]
-                                                                       axis:0
-                                                                       name:nil]
-                                       atIndex:0];
-            }
-          }
-          if (batch_first) {
-            MPSGraphTensor* gradientTensorTransposed = [mpsGraph transposeTensor:gradientTensor_
-                                                                       dimension:0
-                                                                   withDimension:1
-                                                                            name:nil];
-            newCachedGraph->gradOutput_ = gradientTensorTransposed;
-          } else {
-            newCachedGraph->gradOutput_ = gradientTensor_;
-          }
-
-          newCachedGraph->gradRecWeights_ = gradRecWeightsArray;
-          newCachedGraph->gradWeights_ = gradWeightsArray;
-          newCachedGraph->gradBias_ = gradBiasArray;
-          newCachedGraph->gradState_ = [mpsGraph concatTensors:gradStateArray dimension:0 name:nil];
-          newCachedGraph->gradCellState_ = [mpsGraph concatTensors:gradCellStateArray dimension:0 name:nil];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      }
+      if (batch_first) {
+        MPSGraphTensor* gradientTensorTransposed = [mpsGraph transposeTensor:gradientTensor_
+                                                                   dimension:0
+                                                               withDimension:1
+                                                                        name:nil];
+        newCachedGraph->gradOutput_ = gradientTensorTransposed;
+      } else {
+        newCachedGraph->gradOutput_ = gradientTensor_;
+      }
+
+      newCachedGraph->gradRecWeights_ = gradRecWeightsArray;
+      newCachedGraph->gradWeights_ = gradWeightsArray;
+      newCachedGraph->gradBias_ = gradBiasArray;
+      newCachedGraph->gradState_ = [mpsGraph concatTensors:gradStateArray dimension:0 name:nil];
+      newCachedGraph->gradCellState_ = [mpsGraph concatTensors:gradCellStateArray dimension:0 name:nil];
+    });
 
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensors_[0], input);
     Placeholder statePlaceholder = Placeholder(cachedGraph->inputTensors_[1], hx[0]);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -34,8 +34,6 @@ TORCH_IMPL_FUNC(gather_out_mps)
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     MPSShape* input_shape = getMPSShape(self);
     MPSShape* index_shape = getMPSShape(index);
@@ -61,57 +59,43 @@ TORCH_IMPL_FUNC(gather_out_mps)
       output_type = MPSDataTypeInt8;
     }
     string key = "gather_out_mps" + getTensorsStringKey({self, index, output}) + ":" + std::to_string(dim);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, getMPSShape(self));
+      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* getInput = inputTensor;
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Slice into the input tensor IF NEEDED
+      if (needSlice) {
+        NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+        NSMutableArray<NSNumber*>* ends = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+        NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, getMPSShape(self));
-          MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-
-          MPSGraphTensor* getInput = inputTensor;
-
-          // Slice into the input tensor IF NEEDED
-          if (needSlice) {
-            NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-            NSMutableArray<NSNumber*>* ends = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-            NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-            for (const auto i : c10::irange(num_input_dims)) {
-              // All strides are 1
-              strides[i] = @1;
-              // All starts are 0
-              starts[i] = @0;
-              ends[i] = (i != dim) ? index_shape[i] : input_shape[i];
-            }
-
-            getInput = [mpsGraph sliceTensor:inputTensor starts:starts ends:ends strides:strides name:nil];
-          }
-
-          MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor
-                                                          toType:MPSDataTypeInt32
-                                                            name:(NSString* _Nonnull)nil];
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-method-access"
-          MPSGraphTensor* outputTensor = [mpsGraph gatherAlongAxis:(NSInteger)dim
-                                                 withUpdatesTensor:getInput
-                                                     indicesTensor:castIndexTensor
-                                                              name:nil];
-#pragma clang diagnostic pop
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->indexTensor_ = indexTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
+        for (const auto i : c10::irange(num_input_dims)) {
+          // All strides are 1
+          strides[i] = @1;
+          // All starts are 0
+          starts[i] = @0;
+          ends[i] = (i != dim) ? index_shape[i] : input_shape[i];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+
+        getInput = [mpsGraph sliceTensor:inputTensor starts:starts ends:ends strides:strides name:nil];
+      }
+
+      MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor
+                                                      toType:MPSDataTypeInt32
+                                                        name:(NSString* _Nonnull)nil];
+
+      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-method-access")
+      MPSGraphTensor* outputTensor = [mpsGraph gatherAlongAxis:(NSInteger)dim
+                                             withUpdatesTensor:getInput
+                                                 indicesTensor:castIndexTensor
+                                                          name:nil];
+      C10_DIAGNOSTIC_POP()
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->indexTensor_ = indexTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape, true, input_type);
     Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index, index_shape);
@@ -155,8 +139,6 @@ void scatter_mps_general(const Tensor& self_arg,
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     MPSShape* input_shape = getMPSShape(self);
     MPSShape* index_shape = getMPSShape(index);
@@ -193,135 +175,122 @@ void scatter_mps_general(const Tensor& self_arg,
 
     string key = func_name + getTensorsStringKey({self, index, src, output}) + ":" + std::to_string(dim) + ":" +
         std::string(reduce);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
+      MPSGraphTensor* srcTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      MPSGraphTensor* outputTensor = nil;
+      MPSGraphTensor* castSrcTensor = srcTensor;
+      MPSGraphTensor* castInputTensor = inputTensor;
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-          MPSGraphTensor* srcTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
+      if (needsCast) {
+        castSrcTensor = [mpsGraph castTensor:srcTensor toType:src_type name:@"cast"];
+        castInputTensor = [mpsGraph castTensor:inputTensor toType:src_type name:@"cast"];
+      }
+      MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor toType:MPSDataTypeInt32 name:@"cast"];
 
-          MPSGraphTensor* outputTensor = nil;
-          MPSGraphTensor* castSrcTensor = srcTensor;
-          MPSGraphTensor* castInputTensor = inputTensor;
+      MPSGraphTensor* slicedSrc = castSrcTensor;
+      MPSGraphTensor* slicedInput = castInputTensor;
 
-          if (needsCast) {
-            castSrcTensor = [mpsGraph castTensor:srcTensor toType:src_type name:@"cast"];
-            castInputTensor = [mpsGraph castTensor:inputTensor toType:src_type name:@"cast"];
-          }
-          MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor toType:MPSDataTypeInt32 name:@"cast"];
+      // Use in case input needs to be smaller to get scatter
+      NSMutableArray<NSNumber*>* scatterInputShape = [NSMutableArray arrayWithArray:input_shape];
 
-          MPSGraphTensor* slicedSrc = castSrcTensor;
-          MPSGraphTensor* slicedInput = castInputTensor;
+      // Slice into the src or input tensors IF NEEDED
+      if (needSlice || inputNeedSlice) {
+        NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+        NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+        NSMutableArray<NSNumber*>* ends_src = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
 
-          // Use in case input needs to be smaller to get scatter
-          NSMutableArray<NSNumber*>* scatterInputShape = [NSMutableArray arrayWithArray:input_shape];
-
-          // Slice into the src or input tensors IF NEEDED
-          if (needSlice || inputNeedSlice) {
-            NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-            NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-            NSMutableArray<NSNumber*>* ends_src = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-            for (const auto i : c10::irange(num_input_dims)) {
-              strides[i] = @1;
-              starts[i] = @0;
-              ends_src[i] = index_shape[i];
-              scatterInputShape[i] = (i != dim) ? index_shape[i] : input_shape[i];
-            }
-            if (needSlice) {
-              slicedSrc = [mpsGraph sliceTensor:castSrcTensor starts:starts ends:ends_src strides:strides name:nil];
-            }
-            if (inputNeedSlice) {
-              slicedInput = [mpsGraph sliceTensor:castInputTensor
-                                           starts:starts
-                                             ends:scatterInputShape
-                                          strides:strides
-                                             name:nil];
-            }
-          }
-          MPSGraphScatterMode scatter_mode = MPSGraphScatterModeSet;
-
-          if (reduce == "sum" || reduce == "add")
-            scatter_mode = MPSGraphScatterModeAdd;
-          else if (reduce == "prod" || reduce == "multiply")
-            scatter_mode = MPSGraphScatterModeMul;
-          else if (reduce == "amax")
-            scatter_mode = MPSGraphScatterModeMax;
-          else if (reduce == "amin")
-            scatter_mode = MPSGraphScatterModeMin;
-
-            // Scatter this into the input with set mode
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-method-access"
-          MPSGraphTensor* scatterTensor = [mpsGraph scatterAlongAxis:(NSInteger)dim
-                                                      withDataTensor:slicedInput
-                                                       updatesTensor:slicedSrc
-                                                       indicesTensor:castIndexTensor
-                                                                mode:scatter_mode
-                                                                name:nil];
-#pragma clang diagnostic pop
-          if (inputNeedSlice) {
-            // Make an array of scatter indices tensors
-            NSMutableArray<MPSGraphTensor*>* indicesTensors =
-                [NSMutableArray<MPSGraphTensor*> arrayWithCapacity:num_input_dims];
-
-            // 1. Concatenate the coord tensors
-            // 2. Flatten the values
-            // 3. Scatter into input with add mode
-
-            std::vector<int> shape_data(num_input_dims);
-
-            for (const auto i : c10::irange(num_input_dims)) {
-              shape_data[i] = {[scatterInputShape[i] intValue]};
-            }
-
-            MPSGraphTensor* scatterInputShapeTensor =
-                [mpsGraph constantWithData:[NSData dataWithBytes:shape_data.data() length:num_input_dims * sizeof(int)]
-                                     shape:@[ [NSNumber numberWithUnsignedInt:num_input_dims] ]
-                                  dataType:MPSDataTypeInt32];
-
-            for (const auto i : c10::irange(num_input_dims)) {
-              MPSGraphTensor* axisTensor = [mpsGraph constantWithScalar:i dataType:MPSDataTypeInt32];
-              MPSGraphTensor* scatter_currentIndexTensor = [mpsGraph coordinateAlongAxisTensor:axisTensor
-                                                                               withShapeTensor:scatterInputShapeTensor
-                                                                                          name:nil];
-              scatter_currentIndexTensor = [mpsGraph reshapeTensor:scatter_currentIndexTensor
-                                                         withShape:@[ @-1, @1 ]
-                                                              name:nil];
-              indicesTensors[i] = scatter_currentIndexTensor;
-            }
-
-            MPSGraphTensor* scatter_fullIndexTensor = [mpsGraph concatTensors:indicesTensors
-                                                                    dimension:(NSInteger)1
-                                                                         name:nil];
-
-            MPSGraphTensor* flatValuesTensor = [mpsGraph reshapeTensor:scatterTensor withShape:@[ @-1 ] name:nil];
-
-            outputTensor = [mpsGraph scatterNDWithDataTensor:castInputTensor
-                                               updatesTensor:flatValuesTensor
-                                               indicesTensor:scatter_fullIndexTensor
-                                             batchDimensions:0
-                                                        mode:MPSGraphScatterModeSet
-                                                        name:nil];
-          } else {
-            outputTensor = scatterTensor;
-          }
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->srcTensor_ = srcTensor;
-          newCachedGraph->indexTensor_ = indexTensor;
-          newCachedGraph->outputTensor_ =
-              needsCast ? castMPSTensor(mpsGraph, outputTensor, output.scalar_type()) : outputTensor;
+        for (const auto i : c10::irange(num_input_dims)) {
+          strides[i] = @1;
+          starts[i] = @0;
+          ends_src[i] = index_shape[i];
+          scatterInputShape[i] = (i != dim) ? index_shape[i] : input_shape[i];
         }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+        if (needSlice) {
+          slicedSrc = [mpsGraph sliceTensor:castSrcTensor starts:starts ends:ends_src strides:strides name:nil];
+        }
+        if (inputNeedSlice) {
+          slicedInput = [mpsGraph sliceTensor:castInputTensor
+                                       starts:starts
+                                         ends:scatterInputShape
+                                      strides:strides
+                                         name:nil];
+        }
+      }
+      MPSGraphScatterMode scatter_mode = MPSGraphScatterModeSet;
+
+      if (reduce == "sum" || reduce == "add")
+        scatter_mode = MPSGraphScatterModeAdd;
+      else if (reduce == "prod" || reduce == "multiply")
+        scatter_mode = MPSGraphScatterModeMul;
+      else if (reduce == "amax")
+        scatter_mode = MPSGraphScatterModeMax;
+      else if (reduce == "amin")
+        scatter_mode = MPSGraphScatterModeMin;
+
+      // Scatter this into the input with set mode
+      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-method-access")
+      MPSGraphTensor* scatterTensor = [mpsGraph scatterAlongAxis:(NSInteger)dim
+                                                  withDataTensor:slicedInput
+                                                   updatesTensor:slicedSrc
+                                                   indicesTensor:castIndexTensor
+                                                            mode:scatter_mode
+                                                            name:nil];
+      C10_DIAGNOSTIC_POP()
+      if (inputNeedSlice) {
+        // Make an array of scatter indices tensors
+        NSMutableArray<MPSGraphTensor*>* indicesTensors =
+            [NSMutableArray<MPSGraphTensor*> arrayWithCapacity:num_input_dims];
+
+        // 1. Concatenate the coord tensors
+        // 2. Flatten the values
+        // 3. Scatter into input with add mode
+
+        std::vector<int> shape_data(num_input_dims);
+
+        for (const auto i : c10::irange(num_input_dims)) {
+          shape_data[i] = {[scatterInputShape[i] intValue]};
+        }
+
+        MPSGraphTensor* scatterInputShapeTensor =
+            [mpsGraph constantWithData:[NSData dataWithBytes:shape_data.data() length:num_input_dims * sizeof(int)]
+                                 shape:@[ [NSNumber numberWithUnsignedInt:num_input_dims] ]
+                              dataType:MPSDataTypeInt32];
+
+        for (const auto i : c10::irange(num_input_dims)) {
+          MPSGraphTensor* axisTensor = [mpsGraph constantWithScalar:i dataType:MPSDataTypeInt32];
+          MPSGraphTensor* scatter_currentIndexTensor = [mpsGraph coordinateAlongAxisTensor:axisTensor
+                                                                           withShapeTensor:scatterInputShapeTensor
+                                                                                      name:nil];
+          scatter_currentIndexTensor = [mpsGraph reshapeTensor:scatter_currentIndexTensor
+                                                     withShape:@[ @-1, @1 ]
+                                                          name:nil];
+          indicesTensors[i] = scatter_currentIndexTensor;
+        }
+
+        MPSGraphTensor* scatter_fullIndexTensor = [mpsGraph concatTensors:indicesTensors
+                                                                dimension:(NSInteger)1
+                                                                     name:nil];
+
+        MPSGraphTensor* flatValuesTensor = [mpsGraph reshapeTensor:scatterTensor withShape:@[ @-1 ] name:nil];
+
+        outputTensor = [mpsGraph scatterNDWithDataTensor:castInputTensor
+                                           updatesTensor:flatValuesTensor
+                                           indicesTensor:scatter_fullIndexTensor
+                                         batchDimensions:0
+                                                    mode:MPSGraphScatterModeSet
+                                                    name:nil];
+      } else {
+        outputTensor = scatterTensor;
+      }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->srcTensor_ = srcTensor;
+      newCachedGraph->indexTensor_ = indexTensor;
+      newCachedGraph->outputTensor_ =
+          needsCast ? castMPSTensor(mpsGraph, outputTensor, output.scalar_type()) : outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape);
     Placeholder srcPlaceholder = Placeholder(cachedGraph->srcTensor_, src, src_shape);

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -61,8 +61,6 @@ TORCH_IMPL_FUNC(softmax_mps_out)
   using CachedGraph = MPSUnaryCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string mem_format_key = get_mem_format_string(memory_format);
     MPSShape* input_shape_readonly = mps::getMPSShape(input);
@@ -96,42 +94,29 @@ TORCH_IMPL_FUNC(softmax_mps_out)
 
     string key = "softmax_mps_out:" + mem_format_key + ":" + getMPSTypeString(input) + ":" + [ns_shape_key UTF8String] +
         ":" + std::to_string(dim_);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      // passing selector of softMaxWithTensor on the mpsGraph object
+      MPSGraphTensor* outputTensor = [mpsGraph softMaxWithTensor:inputTensor axis:(NSInteger)dim_ name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      // Output needs to be contiguous format
+      if (memory_format == at::MemoryFormat::ChannelsLast) {
+        auto N = input_shape[0];
+        auto H = input_shape[1];
+        auto W = input_shape[2];
+        auto C = input_shape[3];
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
+        outputTensor = [mpsGraph reshapeTensor:outputTensor
+                                     withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
+                                          name:nil];
+        outputTensor = [mpsGraph transposeTensor:outputTensor dimension:1 withDimension:2 name:nil];
+        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:@[ N, C, H, W ] name:nil];
+      }
 
-          // passing selector of softMaxWithTensor on the mpsGraph object
-          MPSGraphTensor* outputTensor = [mpsGraph softMaxWithTensor:inputTensor axis:(NSInteger)dim_ name:nil];
-
-          // Output needs to be contiguous format
-          if (memory_format == at::MemoryFormat::ChannelsLast) {
-            auto N = input_shape[0];
-            auto H = input_shape[1];
-            auto W = input_shape[2];
-            auto C = input_shape[3];
-
-            outputTensor = [mpsGraph reshapeTensor:outputTensor
-                                         withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
-                                              name:nil];
-            outputTensor = [mpsGraph transposeTensor:outputTensor dimension:1 withDimension:2 name:nil];
-            outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:@[ N, C, H, W ] name:nil];
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, input_shape);
     // This must be the Contiguous shape
@@ -171,46 +156,31 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
   using CachedGraph = MPSUnaryGradCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     MPSShape* grad_shape = mps::getMPSShape(grad);
     NSString* ns_shape_key = [[grad_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
     string key = "softmax_backward_mps_out:" + getMPSTypeString(output) + ":" + [ns_shape_key UTF8String] + ":" +
         std::to_string(dim_);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* softmaxTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(output), grad_shape);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), grad_shape);
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* mulTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
+                                                            secondaryTensor:gradOutputTensor
+                                                                       name:nil];
+      MPSGraphTensor* mulSumTensor = [mpsGraph reductionSumWithTensor:mulTensor axis:(NSInteger)dim_ name:nil];
+      MPSGraphTensor* gradSubTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
+                                                             secondaryTensor:mulSumTensor
+                                                                        name:nil];
+      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
+                                                                  secondaryTensor:gradSubTensor
+                                                                             name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* softmaxTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(output), grad_shape);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), grad_shape);
-
-          MPSGraphTensor* mulTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
-                                                                secondaryTensor:gradOutputTensor
-                                                                           name:nil];
-          MPSGraphTensor* mulSumTensor = [mpsGraph reductionSumWithTensor:mulTensor axis:(NSInteger)dim_ name:nil];
-          MPSGraphTensor* gradSubTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
-                                                                 secondaryTensor:mulSumTensor
-                                                                            name:nil];
-          MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
-                                                                      secondaryTensor:gradSubTensor
-                                                                                 name:nil];
-
-          newCachedGraph->outputTensor_ = softmaxTensor;
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->gradInputTensor_ = gradInputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->outputTensor_ = softmaxTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->gradInputTensor_ = gradInputTensor;
+    });
 
     Placeholder softmaxPlaceholder = Placeholder(cachedGraph->outputTensor_, output, grad_shape);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad, grad_shape);

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -52,44 +52,34 @@ TORCH_IMPL_FUNC(sort_stable_out_mps)
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor *selfTensor = nil, *valuesTensor = nil, *indicesTensor = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     // Input as placeholders
     MPSShape* input_shape = getMPSShape(self);
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
     string key = string("sort:") + [ns_shape_key UTF8String] + ":" + getMPSTypeString(self) + ":dim" + to_string(dim) +
         ":descending" + to_string(descending);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      cachedGraph = static_cast<CachedGraph*>(cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), input_shape);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), input_shape);
 
-          MPSGraphTensor* castInputTensor =
-              castToIHFTypes(mpsGraph, newCachedGraph->selfTensor, self, /*includesInt64=*/macOS13_3_plus);
-          MPSGraphTensor* sortedTensor = [mpsGraph sortWithTensor:castInputTensor
-                                                             axis:(NSInteger)dim
-                                                       descending:(BOOL)descending
-                                                             name:@"sort_out"];
-          if ([sortedTensor dataType] != getMPSDataType(values)) {
-            sortedTensor = castMPSTensor(mpsGraph, sortedTensor, values.scalar_type());
-          }
-          MPSGraphTensor* argSortedTensor = [mpsGraph argSortWithTensor:castInputTensor
-                                                                   axis:(NSInteger)dim
-                                                             descending:(BOOL)descending
-                                                                   name:@"argsort_out"];
-          if ([argSortedTensor dataType] != getMPSDataType(indices)) {
-            argSortedTensor = castMPSTensor(mpsGraph, argSortedTensor, indices.scalar_type());
-          }
-          newCachedGraph->valuesTensor = sortedTensor;
-          newCachedGraph->indicesTensor = argSortedTensor;
-        }
-        return newCachedGraph;
-      }));
-    }
+      MPSGraphTensor* castInputTensor =
+          castToIHFTypes(mpsGraph, newCachedGraph->selfTensor, self, /*includesInt64=*/macOS13_3_plus);
+      MPSGraphTensor* sortedTensor = [mpsGraph sortWithTensor:castInputTensor
+                                                         axis:(NSInteger)dim
+                                                   descending:(BOOL)descending
+                                                         name:@"sort_out"];
+      if ([sortedTensor dataType] != getMPSDataType(values)) {
+        sortedTensor = castMPSTensor(mpsGraph, sortedTensor, values.scalar_type());
+      }
+      MPSGraphTensor* argSortedTensor = [mpsGraph argSortWithTensor:castInputTensor
+                                                               axis:(NSInteger)dim
+                                                         descending:(BOOL)descending
+                                                               name:@"argsort_out"];
+      if ([argSortedTensor dataType] != getMPSDataType(indices)) {
+        argSortedTensor = castMPSTensor(mpsGraph, argSortedTensor, indices.scalar_type());
+      }
+      newCachedGraph->valuesTensor = sortedTensor;
+      newCachedGraph->indicesTensor = argSortedTensor;
+    });
     Placeholder inputPlaceholder = Placeholder(cachedGraph->selfTensor, self);
     // Outputs as placeholders
     Placeholder valuesPlaceholder = Placeholder(cachedGraph->valuesTensor, values);

--- a/aten/src/ATen/native/mps/operations/SummaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/SummaryOps.mm
@@ -15,54 +15,40 @@ Tensor& bincount_mps_impl(const Tensor& self, const Tensor& weights, Tensor& out
   };
 
   MPSStream* stream = getCurrentMPSStream();
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   bool has_weights = weights.defined();
 
   @autoreleasepool {
     string key = "bincount_mps_impl" + getTensorsStringKey({self, weights});
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(output.scalar_type()));
 
-        @autoreleasepool {
-          // Initialize graph
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* scatterDataTensor =
-              mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(output.scalar_type()));
+      MPSGraphTensor* updatesTensor = nil;
+      if (has_weights) {
+        updatesTensor = mpsGraphRankedPlaceHolder(mpsGraph, weights);
+      } else {
+        updatesTensor = [mpsGraph constantWithScalar:1.0f shape:getMPSShape(self) dataType:getMPSDataType(output)];
+      }
 
-          MPSGraphTensor* updatesTensor = nil;
-          if (has_weights) {
-            updatesTensor = mpsGraphRankedPlaceHolder(mpsGraph, weights);
-          } else {
-            updatesTensor = [mpsGraph constantWithScalar:1.0f shape:getMPSShape(self) dataType:getMPSDataType(output)];
-          }
+      MPSGraphTensor* castedInputTensor = inputTensor;
+      if (self.scalar_type() == kByte) {
+        castedInputTensor = [mpsGraph castTensor:inputTensor toType:MPSDataTypeInt32 name:@"castInputTensor"];
+      }
 
-          MPSGraphTensor* castedInputTensor = inputTensor;
-          if (self.scalar_type() == kByte) {
-            castedInputTensor = [mpsGraph castTensor:inputTensor toType:MPSDataTypeInt32 name:@"castInputTensor"];
-          }
+      MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:scatterDataTensor
+                                                       updatesTensor:updatesTensor
+                                                       indicesTensor:castedInputTensor
+                                                                axis:0
+                                                                mode:MPSGraphScatterModeAdd
+                                                                name:nil];
 
-          MPSGraphTensor* outputTensor = [mpsGraph scatterWithDataTensor:scatterDataTensor
-                                                           updatesTensor:updatesTensor
-                                                           indicesTensor:castedInputTensor
-                                                                    axis:0
-                                                                    mode:MPSGraphScatterModeAdd
-                                                                    name:nil];
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->scatterDataTensor_ = scatterDataTensor;
-          if (has_weights) {
-            newCachedGraph->weightsTensor_ = updatesTensor;
-          }
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+      newCachedGraph->scatterDataTensor_ = scatterDataTensor;
+      if (has_weights) {
+        newCachedGraph->weightsTensor_ = updatesTensor;
+      }
+    });
 
     // Create placeholders which use the keys of the CachedGraph to create inputs and outputs of the operation
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, self);

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -189,32 +189,18 @@ void clamp_scalar_out_mps(const Tensor& input_t,
     // the optional min/max refs could affect how we build the cached graph
     string key = op_name + (has_min ? ("_min:" + to_string(min_scalar)) : "") +
         (has_max ? ("_max:" + to_string(max_scalar)) : "") + "_scalar:" + getTensorsStringKey({input_t});
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      if (has_min)
+        newCachedGraph->minTensor = [mpsGraph
+            constantWithScalar:min_scalar
+                         shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
+      if (has_max)
+        newCachedGraph->maxTensor = [mpsGraph
+            constantWithScalar:max_scalar
+                         shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          if (has_min)
-            newCachedGraph->minTensor = [mpsGraph
-                constantWithScalar:min_scalar
-                             shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
-          if (has_max)
-            newCachedGraph->maxTensor = [mpsGraph
-                constantWithScalar:max_scalar
-                             shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
-
-          clamp_mps_graph(newCachedGraph, input_t);
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      clamp_mps_graph(newCachedGraph, input_t);
+    });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, output_t);
@@ -291,8 +277,6 @@ Tensor& where_self_out_mps(const Tensor& condition, const Tensor& self, const Te
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSDataType conditionDataType = getMPSScalarType(condition.scalar_type());
   MPSDataType selfDataType = getMPSScalarType(self.scalar_type());
   MPSDataType otherDataType = getMPSScalarType(other.scalar_type());
@@ -313,35 +297,21 @@ Tensor& where_self_out_mps(const Tensor& condition, const Tensor& self, const Te
   @autoreleasepool {
     string key = "where_self_out_mps:" + getTensorsStringKey({cond_bool, self, other});
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* conditionTensor = mpsGraphRankedPlaceHolder(mpsGraph, conditionDataType, getMPSShape(cond_bool));
+      MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, selfDataType, getMPSShape(self));
+      MPSGraphTensor* otherTensor = mpsGraphRankedPlaceHolder(mpsGraph, otherDataType, getMPSShape(other));
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:conditionTensor
+                                                     truePredicateTensor:selfTensor
+                                                    falsePredicateTensor:otherTensor
+                                                                    name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* conditionTensor =
-              mpsGraphRankedPlaceHolder(mpsGraph, conditionDataType, getMPSShape(cond_bool));
-          MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, selfDataType, getMPSShape(self));
-          MPSGraphTensor* otherTensor = mpsGraphRankedPlaceHolder(mpsGraph, otherDataType, getMPSShape(other));
-
-          MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:conditionTensor
-                                                         truePredicateTensor:selfTensor
-                                                        falsePredicateTensor:otherTensor
-                                                                        name:nil];
-
-          newCachedGraph->conditionTensor_ = conditionTensor;
-          newCachedGraph->selfTensor_ = selfTensor;
-          newCachedGraph->otherTensor_ = otherTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->conditionTensor_ = conditionTensor;
+      newCachedGraph->selfTensor_ = selfTensor;
+      newCachedGraph->otherTensor_ = otherTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder conditionPlaceholder = Placeholder(
         cachedGraph->conditionTensor_, cond_bool, /*mpsShape=*/nullptr, /*gatherTensorData=*/true, conditionDataType);
@@ -435,58 +405,47 @@ Tensor& nan_to_num_out_mps(const Tensor& self,
     MPSGraphTensor* posInfReplacementTensor = nil;
     MPSGraphTensor* negInfReplacementTensor = nil;
   };
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = "nan_to_num" + getTensorsStringKey({self});
     MPSDataType self_dtype = getMPSScalarType(self.scalar_type());
 
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      newCachedGraph->nanReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
+      newCachedGraph->posInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
+      newCachedGraph->negInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
 
-          newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          newCachedGraph->nanReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-          newCachedGraph->posInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-          newCachedGraph->negInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-
-          MPSGraphTensor* nanFreeTensor =
-              [mpsGraph selectWithPredicateTensor:[mpsGraph isNaNWithTensor:newCachedGraph->selfTensor name:nil]
-                              truePredicateTensor:newCachedGraph->nanReplacementTensor
-                             falsePredicateTensor:newCachedGraph->selfTensor
-                                             name:nil];
-          MPSGraphTensor* subZeroTensor = [mpsGraph lessThanWithPrimaryTensor:nanFreeTensor
-                                                              secondaryTensor:[mpsGraph constantWithScalar:0.0
-                                                                                                  dataType:self_dtype]
-                                                                         name:nil];
-          MPSGraphTensor* isInfTensor = [mpsGraph isInfiniteWithTensor:nanFreeTensor name:nil];
-          // workaround for Monterey; On Ventura the output of lessThan() is always Boolean
-          if (subZeroTensor.dataType != MPSDataTypeBool) {
-            subZeroTensor = castMPSTensor(mpsGraph, subZeroTensor, kBool);
-          }
-          if (isInfTensor.dataType != MPSDataTypeBool) {
-            isInfTensor = castMPSTensor(mpsGraph, isInfTensor, kBool);
-          }
-          MPSGraphTensor* isNegInfTensor = [mpsGraph logicalANDWithPrimaryTensor:subZeroTensor
-                                                                 secondaryTensor:isInfTensor
-                                                                            name:nil];
-          MPSGraphTensor* negInfFreeTensor = [mpsGraph selectWithPredicateTensor:isNegInfTensor
-                                                             truePredicateTensor:newCachedGraph->negInfReplacementTensor
-                                                            falsePredicateTensor:nanFreeTensor
-                                                                            name:nil];
-          newCachedGraph->outputTensor =
-              [mpsGraph selectWithPredicateTensor:[mpsGraph isInfiniteWithTensor:negInfFreeTensor name:nil]
-                              truePredicateTensor:newCachedGraph->posInfReplacementTensor
-                             falsePredicateTensor:negInfFreeTensor
-                                             name:nil];
-        }
-        return newCachedGraph;
-      });
-    }
+      MPSGraphTensor* nanFreeTensor =
+          [mpsGraph selectWithPredicateTensor:[mpsGraph isNaNWithTensor:newCachedGraph->selfTensor name:nil]
+                          truePredicateTensor:newCachedGraph->nanReplacementTensor
+                         falsePredicateTensor:newCachedGraph->selfTensor
+                                         name:nil];
+      MPSGraphTensor* subZeroTensor = [mpsGraph lessThanWithPrimaryTensor:nanFreeTensor
+                                                          secondaryTensor:[mpsGraph constantWithScalar:0.0
+                                                                                              dataType:self_dtype]
+                                                                     name:nil];
+      MPSGraphTensor* isInfTensor = [mpsGraph isInfiniteWithTensor:nanFreeTensor name:nil];
+      // workaround for Monterey; On Ventura the output of lessThan() is always Boolean
+      if (subZeroTensor.dataType != MPSDataTypeBool) {
+        subZeroTensor = castMPSTensor(mpsGraph, subZeroTensor, kBool);
+      }
+      if (isInfTensor.dataType != MPSDataTypeBool) {
+        isInfTensor = castMPSTensor(mpsGraph, isInfTensor, kBool);
+      }
+      MPSGraphTensor* isNegInfTensor = [mpsGraph logicalANDWithPrimaryTensor:subZeroTensor
+                                                             secondaryTensor:isInfTensor
+                                                                        name:nil];
+      MPSGraphTensor* negInfFreeTensor = [mpsGraph selectWithPredicateTensor:isNegInfTensor
+                                                         truePredicateTensor:newCachedGraph->negInfReplacementTensor
+                                                        falsePredicateTensor:nanFreeTensor
+                                                                        name:nil];
+      newCachedGraph->outputTensor = [mpsGraph selectWithPredicateTensor:[mpsGraph isInfiniteWithTensor:negInfFreeTensor
+                                                                                                   name:nil]
+                                                     truePredicateTensor:newCachedGraph->posInfReplacementTensor
+                                                    falsePredicateTensor:negInfFreeTensor
+                                                                    name:nil];
+    });
     MPSScalar nanReplacementScalar, posInfReplacementScalar, negInfReplacementScalar;
     AT_DISPATCH_FLOATING_TYPES_AND(kHalf, self.scalar_type(), "nan_to_num_mps", [&]() {
       scalar_t nan_replacement = static_cast<scalar_t>(nan.value_or(0.));

--- a/aten/src/ATen/native/mps/operations/TriangularOps.mm
+++ b/aten/src/ATen/native/mps/operations/TriangularOps.mm
@@ -25,49 +25,32 @@ TORCH_IMPL_FUNC(triu_mps_out)
   }
   MPSStream* stream = getCurrentMPSStream();
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = "triu_mps_out" + mps::getTensorsStringKey({self}) + ":" + std::to_string(k);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* outputTensor = nil;
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* minusOneTensor = [mpsGraph constantWithScalar:-1 dataType:MPSDataTypeInt32];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      if (k > 0) {
+        MPSGraphTensor* diagMinusOneTensor = [mpsGraph constantWithScalar:(k - 1) dataType:MPSDataTypeInt32];
+        MPSGraphTensor* complementTensor = [mpsGraph bandPartWithTensor:inputTensor
+                                                         numLowerTensor:minusOneTensor
+                                                         numUpperTensor:diagMinusOneTensor
+                                                                   name:nil];
+        outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor secondaryTensor:complementTensor name:nil];
+      } else {
+        MPSGraphTensor* minusDiagTensor = [mpsGraph constantWithScalar:(-k) dataType:MPSDataTypeInt32];
+        outputTensor = [mpsGraph bandPartWithTensor:inputTensor
+                                     numLowerTensor:minusDiagTensor
+                                     numUpperTensor:minusOneTensor
+                                               name:nil];
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* outputTensor = nil;
-
-          MPSGraphTensor* minusOneTensor = [mpsGraph constantWithScalar:-1 dataType:MPSDataTypeInt32];
-
-          if (k > 0) {
-            MPSGraphTensor* diagMinusOneTensor = [mpsGraph constantWithScalar:(k - 1) dataType:MPSDataTypeInt32];
-            MPSGraphTensor* complementTensor = [mpsGraph bandPartWithTensor:inputTensor
-                                                             numLowerTensor:minusOneTensor
-                                                             numUpperTensor:diagMinusOneTensor
-                                                                       name:nil];
-            outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                  secondaryTensor:complementTensor
-                                                             name:nil];
-          } else {
-            MPSGraphTensor* minusDiagTensor = [mpsGraph constantWithScalar:(-k) dataType:MPSDataTypeInt32];
-            outputTensor = [mpsGraph bandPartWithTensor:inputTensor
-                                         numLowerTensor:minusDiagTensor
-                                         numUpperTensor:minusOneTensor
-                                                   name:nil];
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
@@ -91,49 +74,33 @@ TORCH_IMPL_FUNC(tril_mps_out)
   }
 
   MPSStream* stream = getCurrentMPSStream();
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
     string key = "tril_mps_out" + mps::getTensorsStringKey({self}) + ":" + std::to_string(k);
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* outputTensor = nil;
 
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+      MPSGraphTensor* minusOneTensor = [mpsGraph constantWithScalar:-1 dataType:MPSDataTypeInt32];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+      if (k >= 0) {
+        MPSGraphTensor* diagTensor = [mpsGraph constantWithScalar:k dataType:MPSDataTypeInt32];
+        outputTensor = [mpsGraph bandPartWithTensor:inputTensor
+                                     numLowerTensor:minusOneTensor
+                                     numUpperTensor:diagTensor
+                                               name:nil];
+      } else {
+        MPSGraphTensor* negDiagMinusOneTensor = [mpsGraph constantWithScalar:(-k - 1) dataType:MPSDataTypeInt32];
+        MPSGraphTensor* complementTensor = [mpsGraph bandPartWithTensor:inputTensor
+                                                         numLowerTensor:negDiagMinusOneTensor
+                                                         numUpperTensor:minusOneTensor
+                                                                   name:nil];
+        outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor secondaryTensor:complementTensor name:nil];
+      }
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* outputTensor = nil;
-
-          MPSGraphTensor* minusOneTensor = [mpsGraph constantWithScalar:-1 dataType:MPSDataTypeInt32];
-
-          if (k >= 0) {
-            MPSGraphTensor* diagTensor = [mpsGraph constantWithScalar:k dataType:MPSDataTypeInt32];
-            outputTensor = [mpsGraph bandPartWithTensor:inputTensor
-                                         numLowerTensor:minusOneTensor
-                                         numUpperTensor:diagTensor
-                                                   name:nil];
-          } else {
-            MPSGraphTensor* negDiagMinusOneTensor = [mpsGraph constantWithScalar:(-k - 1) dataType:MPSDataTypeInt32];
-            MPSGraphTensor* complementTensor = [mpsGraph bandPartWithTensor:inputTensor
-                                                             numLowerTensor:negDiagMinusOneTensor
-                                                             numUpperTensor:minusOneTensor
-                                                                       name:nil];
-            outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                  secondaryTensor:complementTensor
-                                                             name:nil];
-          }
-
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->outputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->outputTensor_ = outputTensor;
+    });
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -68,28 +68,17 @@ void unary_op(const Tensor& self,
     output.copy_(self);
     return;
   }
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, output});
-    auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
-
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<MPSUnaryCachedGraph>(key, ^MPSCachedGraph*() {
-        MPSUnaryCachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
-          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          MPSGraphTensor* castTensor = newCachedGraph->inputTensor_;
-          // Integer input must be cast to float if output is float
-          if (isIntegralType(self.scalar_type(), true) && isFloatingType(output.scalar_type())) {
-            castTensor = castMPSTensor(mpsGraph, newCachedGraph->inputTensor_, output.scalar_type());
-          }
-          newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
-        }
-        return newCachedGraph;
-      });
-    }
+    auto cachedGraph = LookUpOrCreateCachedGraph<MPSUnaryCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      MPSGraphTensor* castTensor = newCachedGraph->inputTensor_;
+      // Integer input must be cast to float if output is float
+      if (isIntegralType(self.scalar_type(), true) && isFloatingType(output.scalar_type())) {
+        castTensor = castMPSTensor(mpsGraph, newCachedGraph->inputTensor_, output.scalar_type());
+      }
+      newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
+    });
 
     bool gatherTensorData = true;
     if (!output.is_contiguous() || output.is_view()) {
@@ -319,61 +308,45 @@ TORCH_IMPL_FUNC(logit_backward_out_mps)
 
   double eps_ = eps ? eps.value() : -1.0;
 
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
     std::string key = "logit_backward_out_mps:" + getTensorsStringKey({grad_output, input}) + ":" + "[" +
         (eps.has_value() ? std::to_string(eps.value()) : "-1") + "]";
 
-    CachedGraph* cachedGraph = static_cast<CachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      MPSGraphTensor* outputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_input);
+      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:eps_ shape:@[ @1 ] dataType:inputTensor.dataType];
+      MPSGraphTensor* inputLessThanLowPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                            secondaryTensor:lowTensor
+                                                                                       name:nil];
+      MPSGraphTensor* highTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor secondaryTensor:lowTensor name:nil];
+      MPSGraphTensor* inputGreaterThanHighPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                                                   secondaryTensor:highTensor
+                                                                                              name:nil];
+      MPSGraphTensor* outOfIntervalTensor = [mpsGraph logicalORWithPrimaryTensor:inputLessThanLowPredicateTensor
+                                                                 secondaryTensor:inputGreaterThanHighPredicateTensor
+                                                                            name:nil];
+      MPSGraphTensor* oneMinusInputTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor
+                                                                   secondaryTensor:inputTensor
+                                                                              name:nil];
+      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                               secondaryTensor:oneMinusInputTensor
+                                                          name:nil];
+      outputTensor = [mpsGraph divisionWithPrimaryTensor:gradOutputTensor secondaryTensor:outputTensor name:nil];
+      outputTensor = [mpsGraph selectWithPredicateTensor:outOfIntervalTensor
+                                     truePredicateTensor:zeroTensor
+                                    falsePredicateTensor:outputTensor
+                                                    name:nil];
 
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
-
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-          MPSGraphTensor* outputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_input);
-          MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:eps_ shape:@[ @1 ] dataType:inputTensor.dataType];
-          MPSGraphTensor* inputLessThanLowPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                                secondaryTensor:lowTensor
-                                                                                           name:nil];
-          MPSGraphTensor* highTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor
-                                                              secondaryTensor:lowTensor
-                                                                         name:nil];
-          MPSGraphTensor* inputGreaterThanHighPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                                       secondaryTensor:highTensor
-                                                                                                  name:nil];
-          MPSGraphTensor* outOfIntervalTensor = [mpsGraph logicalORWithPrimaryTensor:inputLessThanLowPredicateTensor
-                                                                     secondaryTensor:inputGreaterThanHighPredicateTensor
-                                                                                name:nil];
-          MPSGraphTensor* oneMinusInputTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor
-                                                                       secondaryTensor:inputTensor
-                                                                                  name:nil];
-          outputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                   secondaryTensor:oneMinusInputTensor
-                                                              name:nil];
-          outputTensor = [mpsGraph divisionWithPrimaryTensor:gradOutputTensor secondaryTensor:outputTensor name:nil];
-          outputTensor = [mpsGraph selectWithPredicateTensor:outOfIntervalTensor
-                                         truePredicateTensor:zeroTensor
-                                        falsePredicateTensor:outputTensor
-                                                        name:nil];
-
-          newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-          newCachedGraph->inputTensor_ = inputTensor;
-          newCachedGraph->gradInputTensor_ = outputTensor;
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<CachedGraph*>(tmpCachedGraph);
-    }
+      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->inputTensor_ = inputTensor;
+      newCachedGraph->gradInputTensor_ = outputTensor;
+    });
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -179,37 +179,21 @@ static UniqueCachedGraph* getUniqueGraph(const Tensor& self,
                                          const bool return_counts,
                                          const bool consecutive,
                                          c10::optional<int64_t> dim) {
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
   @autoreleasepool {
     string key = getUniqueKey(self.scalar_type(), self.sizes(), return_inverse, return_counts, consecutive, dim);
-    UniqueCachedGraph* cachedGraph = static_cast<UniqueCachedGraph*>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSCachedGraph* tmpCachedGraph = cache_->CreateCachedGraph(key, ^MPSCachedGraph*() {
-        UniqueCachedGraph* newCachedGraph = nil;
+    return LookUpOrCreateCachedGraph<UniqueCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      // Workaround for MPSShaderLibrary bug
+      // TODO: Remove once https://github.com/pytorch/pytorch/issues/82305 is resolved
+      auto inputType = getMPSScalarType(self.scalar_type());
+      newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self.sizes()));
 
-        @autoreleasepool {
-          // Initialize graph
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new UniqueCachedGraph(mpsGraph);
+      auto outputTensors = buildUniqueGraph(self, newCachedGraph, return_inverse, return_counts, consecutive, dim);
 
-          // Workaround for MPSShaderLibrary bug
-          // TODO: Remove once https://github.com/pytorch/pytorch/issues/82305 is resolved
-          auto inputType = getMPSScalarType(self.scalar_type());
-          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self.sizes()));
-
-          auto outputTensors = buildUniqueGraph(self, newCachedGraph, return_inverse, return_counts, consecutive, dim);
-
-          newCachedGraph->outputTensor_ = outputTensors[0];
-          newCachedGraph->inverseIndicesTensor_ = outputTensors[1];
-          newCachedGraph->countsTensor_ = outputTensors[2];
-          newCachedGraph->lengthTensor_ = outputTensors[3];
-        }
-        return newCachedGraph;
-      });
-      cachedGraph = static_cast<UniqueCachedGraph*>(tmpCachedGraph);
-    }
-    return cachedGraph;
+      newCachedGraph->outputTensor_ = outputTensors[0];
+      newCachedGraph->inverseIndicesTensor_ = outputTensors[1];
+      newCachedGraph->countsTensor_ = outputTensors[2];
+      newCachedGraph->lengthTensor_ = outputTensors[3];
+    });
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -98,131 +98,120 @@ void upsample_out_template(const Tensor& input,
         getTensorsStringKey({input}) + ":[" + to_string(scale_h) + "," + to_string(scale_w) + "]:[" +
         (is_backward_pass ? getArrayRefString(input_size) : "Undefined") + "]";
 
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-    if (!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
-        CachedGraph* newCachedGraph = nil;
-        @autoreleasepool {
-          MPSGraph* mpsGraph = make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
+      newCachedGraph->outputSizeTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @(2) ]);
 
-          newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-          newCachedGraph->outputSizeTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @(2) ]);
+      MPSGraphTensor* scaleOffsetTensor = nullptr;
+      MPSGraphTensor* inputSizeTensor = nullptr;
 
-          MPSGraphTensor* scaleOffsetTensor = nullptr;
-          MPSGraphTensor* inputSizeTensor = nullptr;
-
-          if (scale_w > 0.0) {
-            const float outScales[4] = {scale_h, scale_w, offset_y, offset_x};
-            scaleOffsetTensor = [mpsGraph constantWithData:[NSData dataWithBytes:outScales length:sizeof(outScales)]
-                                                     shape:@[ @4 ]
-                                                  dataType:MPSDataTypeFloat32];
-          }
-          if (is_backward_pass) {
-            std::vector<NSNumber*> inputSizeVec(4);
-            inputSizeVec[0] = @(input_size[0]);
-            inputSizeVec[1] = @(input_size[1]);
-            inputSizeVec[2] = @(input_size[2]);
-            inputSizeVec[3] = @(input_dim.size() > 3 ? input_size[3] : 1);
-            inputSizeTensor = [mpsGraph constantWithScalar:0
-                                                     shape:[NSArray arrayWithObjects:inputSizeVec.data()
-                                                                               count:input_dim.size()]
-                                                  dataType:getMPSDataType(input)];
-          }
-          if (is_macOS_13_0_or_newer) {
-            if (!is_backward_pass) {
-              if (scaleOffsetTensor && !align_corners) {
-                if (resizeMode == MPSGraphResizeNearest) {
-                  newCachedGraph->outputTensor = [mpsGraph resizeNearestWithTensor:newCachedGraph->inputTensor
-                                                                        sizeTensor:newCachedGraph->outputSizeTensor
-                                                                 scaleOffsetTensor:scaleOffsetTensor
-                                                               nearestRoundingMode:nearestRoundingMode
-                                                                            layout:dataLayout
-                                                                              name:nil];
-                } else { // bilinear forward
-                  newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithTensor:newCachedGraph->inputTensor
-                                                                         sizeTensor:newCachedGraph->outputSizeTensor
-                                                                  scaleOffsetTensor:scaleOffsetTensor
-                                                                             layout:dataLayout
-                                                                               name:nil];
-                }
-              } else { // scaleOffsetTensor == nil || align_corners
-                if (resizeMode == MPSGraphResizeNearest) {
-                  newCachedGraph->outputTensor = [mpsGraph resizeNearestWithTensor:newCachedGraph->inputTensor
-                                                                        sizeTensor:newCachedGraph->outputSizeTensor
-                                                               nearestRoundingMode:nearestRoundingMode
-                                                                      centerResult:centerResults
-                                                                      alignCorners:align_corners
-                                                                            layout:dataLayout
-                                                                              name:nil];
-                } else { // bilinear forward
-                  newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithTensor:newCachedGraph->inputTensor
-                                                                         sizeTensor:newCachedGraph->outputSizeTensor
-                                                                       centerResult:centerResults
-                                                                       alignCorners:align_corners
-                                                                             layout:dataLayout
-                                                                               name:nil];
-                }
-              }
-            } else { // is_backward_pass == true
-              if (scaleOffsetTensor && !align_corners) {
-                if (resizeMode == MPSGraphResizeNearest) {
-                  newCachedGraph->outputTensor = [mpsGraph resizeNearestWithGradientTensor:newCachedGraph->inputTensor
-                                                                                     input:inputSizeTensor
-                                                                         scaleOffsetTensor:scaleOffsetTensor
-                                                                       nearestRoundingMode:nearestRoundingMode
-                                                                                    layout:dataLayout
-                                                                                      name:nil];
-                } else { // bilinear backward
-                  newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithGradientTensor:newCachedGraph->inputTensor
-                                                                                      input:inputSizeTensor
-                                                                          scaleOffsetTensor:scaleOffsetTensor
-                                                                                     layout:dataLayout
-                                                                                       name:nil];
-                }
-              } else { // scaleOffsetTensor == nil || align_corners
-                if (resizeMode == MPSGraphResizeNearest) {
-                  newCachedGraph->outputTensor = [mpsGraph resizeNearestWithGradientTensor:newCachedGraph->inputTensor
-                                                                                     input:inputSizeTensor
-                                                                       nearestRoundingMode:nearestRoundingMode
-                                                                              centerResult:centerResults
-                                                                              alignCorners:align_corners
-                                                                                    layout:dataLayout
-                                                                                      name:nil];
-                } else { // bilinear backward
-                  newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithGradientTensor:newCachedGraph->inputTensor
-                                                                                      input:inputSizeTensor
-                                                                               centerResult:centerResults
-                                                                               alignCorners:align_corners
-                                                                                     layout:dataLayout
-                                                                                       name:nil];
-                }
-              }
+      if (scale_w > 0.0) {
+        const float outScales[4] = {scale_h, scale_w, offset_y, offset_x};
+        scaleOffsetTensor = [mpsGraph constantWithData:[NSData dataWithBytes:outScales length:sizeof(outScales)]
+                                                 shape:@[ @4 ]
+                                              dataType:MPSDataTypeFloat32];
+      }
+      if (is_backward_pass) {
+        std::vector<NSNumber*> inputSizeVec(4);
+        inputSizeVec[0] = @(input_size[0]);
+        inputSizeVec[1] = @(input_size[1]);
+        inputSizeVec[2] = @(input_size[2]);
+        inputSizeVec[3] = @(input_dim.size() > 3 ? input_size[3] : 1);
+        inputSizeTensor = [mpsGraph constantWithScalar:0
+                                                 shape:[NSArray arrayWithObjects:inputSizeVec.data()
+                                                                           count:input_dim.size()]
+                                              dataType:getMPSDataType(input)];
+      }
+      if (is_macOS_13_0_or_newer) {
+        if (!is_backward_pass) {
+          if (scaleOffsetTensor && !align_corners) {
+            if (resizeMode == MPSGraphResizeNearest) {
+              newCachedGraph->outputTensor = [mpsGraph resizeNearestWithTensor:newCachedGraph->inputTensor
+                                                                    sizeTensor:newCachedGraph->outputSizeTensor
+                                                             scaleOffsetTensor:scaleOffsetTensor
+                                                           nearestRoundingMode:nearestRoundingMode
+                                                                        layout:dataLayout
+                                                                          name:nil];
+            } else { // bilinear forward
+              newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithTensor:newCachedGraph->inputTensor
+                                                                     sizeTensor:newCachedGraph->outputSizeTensor
+                                                              scaleOffsetTensor:scaleOffsetTensor
+                                                                         layout:dataLayout
+                                                                           name:nil];
             }
-          } else { // if macOS version < 13.0 (for backwards compatibility)
-            if (!is_backward_pass) {
-              newCachedGraph->outputTensor = [mpsGraph resizeTensor:newCachedGraph->inputTensor
-                                                         sizeTensor:newCachedGraph->outputSizeTensor
-                                                               mode:resizeMode
-                                                       centerResult:centerResults
-                                                       alignCorners:align_corners
-                                                             layout:dataLayout
-                                                               name:nil];
-            } else {
-              newCachedGraph->outputTensor = [mpsGraph resizeWithGradientTensor:newCachedGraph->inputTensor
-                                                                          input:inputSizeTensor
-                                                                           mode:resizeMode
+          } else { // scaleOffsetTensor == nil || align_corners
+            if (resizeMode == MPSGraphResizeNearest) {
+              newCachedGraph->outputTensor = [mpsGraph resizeNearestWithTensor:newCachedGraph->inputTensor
+                                                                    sizeTensor:newCachedGraph->outputSizeTensor
+                                                           nearestRoundingMode:nearestRoundingMode
+                                                                  centerResult:centerResults
+                                                                  alignCorners:align_corners
+                                                                        layout:dataLayout
+                                                                          name:nil];
+            } else { // bilinear forward
+              newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithTensor:newCachedGraph->inputTensor
+                                                                     sizeTensor:newCachedGraph->outputSizeTensor
                                                                    centerResult:centerResults
                                                                    alignCorners:align_corners
                                                                          layout:dataLayout
                                                                            name:nil];
             }
           }
+        } else { // is_backward_pass == true
+          if (scaleOffsetTensor && !align_corners) {
+            if (resizeMode == MPSGraphResizeNearest) {
+              newCachedGraph->outputTensor = [mpsGraph resizeNearestWithGradientTensor:newCachedGraph->inputTensor
+                                                                                 input:inputSizeTensor
+                                                                     scaleOffsetTensor:scaleOffsetTensor
+                                                                   nearestRoundingMode:nearestRoundingMode
+                                                                                layout:dataLayout
+                                                                                  name:nil];
+            } else { // bilinear backward
+              newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithGradientTensor:newCachedGraph->inputTensor
+                                                                                  input:inputSizeTensor
+                                                                      scaleOffsetTensor:scaleOffsetTensor
+                                                                                 layout:dataLayout
+                                                                                   name:nil];
+            }
+          } else { // scaleOffsetTensor == nil || align_corners
+            if (resizeMode == MPSGraphResizeNearest) {
+              newCachedGraph->outputTensor = [mpsGraph resizeNearestWithGradientTensor:newCachedGraph->inputTensor
+                                                                                 input:inputSizeTensor
+                                                                   nearestRoundingMode:nearestRoundingMode
+                                                                          centerResult:centerResults
+                                                                          alignCorners:align_corners
+                                                                                layout:dataLayout
+                                                                                  name:nil];
+            } else { // bilinear backward
+              newCachedGraph->outputTensor = [mpsGraph resizeBilinearWithGradientTensor:newCachedGraph->inputTensor
+                                                                                  input:inputSizeTensor
+                                                                           centerResult:centerResults
+                                                                           alignCorners:align_corners
+                                                                                 layout:dataLayout
+                                                                                   name:nil];
+            }
+          }
         }
-        return newCachedGraph;
-      });
-    }
+      } else { // if macOS version < 13.0 (for backwards compatibility)
+        if (!is_backward_pass) {
+          newCachedGraph->outputTensor = [mpsGraph resizeTensor:newCachedGraph->inputTensor
+                                                     sizeTensor:newCachedGraph->outputSizeTensor
+                                                           mode:resizeMode
+                                                   centerResult:centerResults
+                                                   alignCorners:align_corners
+                                                         layout:dataLayout
+                                                           name:nil];
+        } else {
+          newCachedGraph->outputTensor = [mpsGraph resizeWithGradientTensor:newCachedGraph->inputTensor
+                                                                      input:inputSizeTensor
+                                                                       mode:resizeMode
+                                                               centerResult:centerResults
+                                                               alignCorners:align_corners
+                                                                     layout:dataLayout
+                                                                       name:nil];
+        }
+      }
+    });
     MPSNDArrayDescriptor* sizeDesc = [MPSNDArrayDescriptor descriptorWithDataType:MPSDataTypeInt32 shape:@[ @(2) ]];
     MPSNDArray* sizeNDArray = [[[MPSNDArray alloc] initWithDevice:stream->device() descriptor:sizeDesc] autorelease];
     [sizeNDArray writeBytes:(int32_t[]){(int32_t)output_height, (int32_t)output_width} strideBytes:nil];


### PR DESCRIPTION
A template that replaces following common pattern:
```cpp
  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
  CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);

  if (!cachedGraph) {
    cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^MPSCachedGraph*() {
      CachedGraph* newCachedGraph = nil;

      @autoreleasepool {
        MPSGraph* mpsGraph = make_mps_graph();
        newCachedGraph = new PoolingCachedGraph(mpsGraph);
        ...
      }
      return newCachedGraph:
   );
 }
```
with
```cpp
  auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
    ...
  });
```

Fixes memory leak in addmv_out_mps_impl, where new entires were added the cache without doing the lookup first.
