### PR TITLE
[Profiler][Easy] Fix typo in Profiler report input shapes

### DIFF
--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -123,7 +123,7 @@ void initPythonBindings(PyObject* module) {
   py::class_<ProfilerConfig>(m, "ProfilerConfig")
       .def(py::init<
            ProfilerState,
-           bool, /* record_input_shapes */
+           bool, /* report_input_shapes */
            bool, /* profile_memory */
            bool, /* with_stack */
            bool, /* with_flops */


### PR DESCRIPTION
Summary:
There are two variables for profiler input shapes:
- In C++ interface: report_input_shapes
- In Python interface: record_shapes

Therefore record_input_shapes is a typo. We should also look to reducing redundant naming between the two.

Test Plan: CI

Pulled By: aaronenyeshi

