### PR TITLE
[fx] Variatic arg matching

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -111,14 +111,14 @@ class TestMatcher(JitTestCase):
         match_s_result = maxpool_matcher.match(maxpool_s_graph)
         self.assertEqual(len(match_s_result), 1)
 
+        # Graph only contains "padding" argument
+        maxpool_p = torch.nn.MaxPool2d(kernel_size=2, padding=1)
+        maxpool_p_graph = make_fx(maxpool_p)(*inputs).graph
+        match_p_result = maxpool_matcher.match(maxpool_p_graph)
+        self.assertEqual(len(match_p_result), 1)
+
         # Graph only contains "stride, padding" argument
         maxpool_sp = torch.nn.MaxPool2d(kernel_size=2, stride=1, padding=1)
         maxpool_sp_graph = make_fx(maxpool_sp)(*inputs).graph
         match_sp_result = maxpool_matcher.match(maxpool_sp_graph)
         self.assertEqual(len(match_sp_result), 1)
-
-        # Graph only contains "stride, padding, dilation" argument
-        maxpool_spd = torch.nn.MaxPool2d(kernel_size=2, stride=1, padding=1, dilation=2)
-        maxpool_spd_graph = make_fx(maxpool_spd)(*inputs).graph
-        match_spd_result = maxpool_matcher.match(maxpool_spd_graph)
-        self.assertEqual(len(match_spd_result), 1)

--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -93,3 +93,32 @@ class TestMatcher(JitTestCase):
         subgraph_matcher = SubgraphMatcher(pattern_graph, ignore_literals=True)
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 1)
+
+    def test_variatic_arg_matching(self):
+        inputs = (torch.randn(20, 16, 50, 32),)
+
+        def maxpool(x, kernel_size, stride, padding, dilation):
+            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, padding, dilation)
+        maxpool_graph = torch.fx.symbolic_trace(maxpool).graph
+
+        maxpool_matcher = SubgraphMatcher(maxpool_graph)
+        match_result = maxpool_matcher.match(maxpool_graph)
+        self.assertEqual(len(match_result), 1)
+
+        # Graph only contains "stride" argument
+        maxpool_s = torch.nn.MaxPool2d(kernel_size=2, stride=1).eval()
+        maxpool_s_graph = make_fx(maxpool_s)(*inputs).graph
+        match_s_result = maxpool_matcher.match(maxpool_s_graph)
+        self.assertEqual(len(match_s_result), 1)
+
+        # Graph only contains "stride, padding" argument
+        maxpool_sp = torch.nn.MaxPool2d(kernel_size=2, stride=1, padding=1)
+        maxpool_sp_graph = make_fx(maxpool_sp)(*inputs).graph
+        match_sp_result = maxpool_matcher.match(maxpool_sp_graph)
+        self.assertEqual(len(match_sp_result), 1)
+
+        # Graph only contains "stride, padding, dilation" argument
+        maxpool_spd = torch.nn.MaxPool2d(kernel_size=2, stride=1, padding=1, dilation=2)
+        maxpool_spd_graph = make_fx(maxpool_spd)(*inputs).graph
+        match_spd_result = maxpool_matcher.match(maxpool_spd_graph)
+        self.assertEqual(len(match_spd_result), 1)

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -924,3 +924,16 @@ def forward(self, x):
         traced = symbolic_trace(M())
         matches = subgraph_rewriter.replace_pattern(traced, Pattern(), Replacement())
         self.assertEqual(len(matches), 1)
+
+    def test_matching_variable_arguments(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.max_pool2d_with_indices.default(x, 2)
+
+        def pattern(x, kernel_size, stride, padding, dilation):
+            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, padding, dilation)
+
+        traced = symbolic_trace(M())
+        matches = subgraph_rewriter.replace_pattern(traced, pattern, pattern)
+
+        self.assertEqual(len(matches), 1)

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -932,7 +932,7 @@ def forward(self, x):
 
         def pattern(x, kernel_size, stride):
             # default padding is [0, 0]
-            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, [0, 0])
+            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, padding=[0, 0])
 
         traced = symbolic_trace(M())
         matches = subgraph_rewriter.replace_pattern(traced, pattern, pattern)

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -928,10 +928,11 @@ def forward(self, x):
     def test_matching_variable_arguments(self):
         class M(torch.nn.Module):
             def forward(self, x):
-                return torch.ops.aten.max_pool2d_with_indices.default(x, 2)
+                return torch.ops.aten.max_pool2d_with_indices.default(x, [2, 2], stride=[2, 2])
 
-        def pattern(x, kernel_size, stride, padding, dilation):
-            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, padding, dilation)
+        def pattern(x, kernel_size, stride):
+            # default padding is [0, 0]
+            return torch.ops.aten.max_pool2d_with_indices.default(x, kernel_size, stride, [0, 0])
 
         traced = symbolic_trace(M())
         matches = subgraph_rewriter.replace_pattern(traced, pattern, pattern)

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -231,7 +231,7 @@ class SubgraphMatcher:
         # Flatten all args/kwargs into 1 list of args
         pn_args, gn_args = None, None
         if (
-            (len(pn.args) != len(gn.args) or len(pn.kwargs) != len(gn.kwargs)) and
+            (len(pn.args) != len(gn.args) or list(pn.kwargs.keys()) != list(gn.kwargs.keys())) and
             pn.op == "call_function" and
             isinstance(pn.target, torch._ops.OpOverload)
         ):
@@ -251,7 +251,7 @@ class SubgraphMatcher:
             pn_args = get_all_arguments(pn.args, pn.kwargs)
             gn_args = get_all_arguments(gn.args, gn.kwargs)
 
-        elif len(pn.args) == len(gn.args) and len(pn.kwargs) == len(gn.kwargs):
+        elif len(pn.args) == len(gn.args) and list(pn.kwargs.keys()) == list(gn.kwargs.keys()):
             pn_args = list(pn.args)
             gn_args = list(gn.args)
             pn_args.extend(list(pn.kwargs.values()))

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -236,7 +236,6 @@ def _replace_pattern(
         pattern_graph = pattern.graph
     else:
         pattern_graph = symbolic_trace(pattern).graph
-    print(pattern_graph)
 
     if isinstance(replacement, GraphModule):
         replacement_graph = replacement.graph

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -236,6 +236,7 @@ def _replace_pattern(
         pattern_graph = pattern.graph
     else:
         pattern_graph = symbolic_trace(pattern).graph
+    print(pattern_graph)
 
     if isinstance(replacement, GraphModule):
         replacement_graph = replacement.graph


### PR DESCRIPTION
For cases where the pattern graph matches on x number of arguments, but the matching graph omits some of these arguments (by using the default values instead), right now SubgraphMatcher fails because these graphs have a different number of arguments. So instead in the case where we see the pattern/replacement nodes have different number of arguments, we will add the default values onto whichever argument set is lacking arguments.

Note this support is only for when we are matching targets that are instances of OpOverload, which have a schema and default values tied to them.