### PR TITLE
[quant][pt2e] add dropout to executorch backend config

### DIFF
--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -356,6 +356,25 @@ def _get_embedding_op_configs() -> List[BackendPatternConfig]:
                 ._set_input_type_to_index({"weight": 1}))
     return embedding_op_configs
 
+def _get_default_op_configs() -> List[BackendPatternConfig]:
+    default_op_configs: List[BackendPatternConfig] = []
+    dtype_configs =[
+        qnnpack_default_op_qint8_symmetric_dtype_config,
+        executorch_default_op_quint8_dtype_config
+    ]
+    observation_type = ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
+
+    default_ops = [
+        torch.nn.Dropout,
+        F.dropout,
+    ]
+    for op in default_ops:
+        default_op_configs.append(
+            BackendPatternConfig(op)
+               .set_observation_type(observation_type)
+               .set_dtype_configs(dtype_configs))
+
+    return default_op_configs
 # =====================
 # |  BACKEND CONFIGS  |
 # =====================
@@ -371,4 +390,5 @@ def get_executorch_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_share_qparams_ops_configs()) \
         .set_backend_pattern_configs(_get_bn_configs()) \
         .set_backend_pattern_configs(_get_cat_configs()) \
-        .set_backend_pattern_configs(_get_embedding_op_configs())
+        .set_backend_pattern_configs(_get_embedding_op_configs()) \
+        .set_backend_pattern_configs(_get_default_op_configs())


### PR DESCRIPTION
Summary:
OD Model has a dropout layer in training, In order to match eager mode qat, we also fake quantize the drop out layer in prepare_qat_fx.

To do this we add the dropout layer to the default_op_configs in which the observation type uses a different observer from its input

Test Plan: buck test //executorch/exir/tests:quant_lowering_custom_backend_pass -- test_executorch_dropout

Differential Revision: D45095936

