### PR TITLE
[MPS] Allow `float16` input to float32 `LayerNorm` (#96430)

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1300,6 +1300,9 @@ class TestMPS(TestCaseMPS):
             helper((2, 3, 4, 5), (4, 5), elementwise_affine=elementwise_affine)
             helper((2, 3, 4, 5, 6), (4, 5, 6), elementwise_affine=elementwise_affine)
 
+        # Regression test for https://github.com/pytorch/pytorch/issues/96113
+        torch.nn.LayerNorm((16,), elementwise_affine=True).to("mps")(torch.randn(1, 2, 16).to("mps", dtype=torch.float16))
+
     def test_instance_norm(self):
         def helper(shape, eps=1, momentum=0.1, wts=False, channels_last=False, track_running_stats=True, test_module=False):
 


### PR DESCRIPTION
Only for forward pass. This also fixes a regular float16 normalization path, i.e. something like:
```
torch.nn.LayerNorm((16,), elementwise_affine=True).to("mps", dtype=torch.float16)(torch.randn(1, 2, 16).to("mps", dtype=torch.float16))
```

Subset of https://github.com/pytorch/pytorch/pull/96208

Create constant with scalar using `input_mps_dtype` and use
`reciprocalWithTensor` instead of `divisionWithPrimaryTensor:1.0
secondaryTensor:`

Fixes https://github.com/pytorch/pytorch/issues/96113

Pull Request resolved: https://github.com/pytorch/pytorch/pull/96430
Approved by: https://github.com/kulinseth

(cherry picked from commit 075a49442dc813537075063fd2efb779a50ebe30)

