### PR TITLE
Add CUDA-12.1 manywheel build to trunk

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -189,6 +189,7 @@ def generate_wheels_matrix(
     os: str,
     arches: Optional[List[str]] = None,
     python_versions: Optional[List[str]] = None,
+    gen_special_an_non_special_wheel: bool = True,
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
     if os == "linux":
@@ -249,6 +250,8 @@ def generate_wheels_matrix(
                         ),
                     }
                 )
+                if not gen_special_an_non_special_wheel:
+                    continue
 
             ret.append(
                 {

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -146,15 +146,8 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         os=OperatingSystem.LINUX,
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(
-            OperatingSystem.LINUX, arches=["11.8"], python_versions=["3.8"]
-        ),
-        branches="main",
-    ),
-    BinaryBuildWorkflow(
-        os=OperatingSystem.LINUX,
-        package_type="manywheel",
-        build_configs=generate_binary_build_matrix.generate_wheels_matrix(
-            OperatingSystem.LINUX, arches=["11.7"], python_versions=["3.8"]
+            OperatingSystem.LINUX, arches=["11.7", "12.1"], python_versions=["3.8"],
+            gen_special_an_non_special_wheel = False,
         ),
         branches="main",
     ),

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -146,7 +146,9 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         os=OperatingSystem.LINUX,
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(
-            OperatingSystem.LINUX, arches=["11.7", "12.1"], python_versions=["3.8"],
+            OperatingSystem.LINUX,
+            arches=["11.7", "12.1"],
+            python_versions=["3.8"],
             gen_special_an_non_special_wheel=False,
         ),
         branches="main",

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -147,7 +147,7 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(
             OperatingSystem.LINUX, arches=["11.7", "12.1"], python_versions=["3.8"],
-            gen_special_an_non_special_wheel = False,
+            gen_special_an_non_special_wheel=False,
         ),
         branches="main",
     ),

--- a/.github/workflows/generated-linux-binary-manywheel-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-main.yml
@@ -71,7 +71,7 @@ jobs:
       runs_on: linux.4xlarge.nvidia.gpu
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  manywheel-py3_8-cuda11_7-build:
+  manywheel-py3_8-cuda12_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
     uses: ./.github/workflows/_binary-build-linux.yml
     with:
@@ -80,19 +80,19 @@ jobs:
       PACKAGE_TYPE: manywheel
       # TODO: This is a legacy variable that we eventually want to get rid of in
       #       favor of GPU_ARCH_VERSION
-      DESIRED_CUDA: cu117
-      GPU_ARCH_VERSION: 11.7
+      DESIRED_CUDA: cu121
+      GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.7
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
       DESIRED_PYTHON: "3.8"
-      build_name: manywheel-py3_8-cuda11_7
+      build_name: manywheel-py3_8-cuda12_1
       build_environment: linux-binary-manywheel
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  manywheel-py3_8-cuda11_7-test:  # Testing
+  manywheel-py3_8-cuda12_1-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: manywheel-py3_8-cuda11_7-build
+    needs: manywheel-py3_8-cuda12_1-build
     uses: ./.github/workflows/_binary-test-linux.yml
     with:
       PYTORCH_ROOT: /pytorch
@@ -100,12 +100,12 @@ jobs:
       PACKAGE_TYPE: manywheel
       # TODO: This is a legacy variable that we eventually want to get rid of in
       #       favor of GPU_ARCH_VERSION
-      DESIRED_CUDA: cu117
-      GPU_ARCH_VERSION: 11.7
+      DESIRED_CUDA: cu121
+      GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.7
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
       DESIRED_PYTHON: "3.8"
-      build_name: manywheel-py3_8-cuda11_7
+      build_name: manywheel-py3_8-cuda12_1
       build_environment: linux-binary-manywheel
       runs_on: linux.4xlarge.nvidia.gpu
     secrets:


### PR DESCRIPTION
As CUDA-11.7 is getting deprecated anyway.

Also, fix the problem when script actually generated the same workflow twice, overriding 11.8 ones with 11.7+11.7-with-pypi

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0c6c182</samp>

> _Oh we are the PyTorch crew and we have a job to do_
> _We build and test the manywheel package with CUDA 11.8_
> _So heave away, me hearties, heave away with all your might_
> _We'll smoke the Linux binary and make sure it runs all right_

