### PR TITLE
vmap support for special bessel functions

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,8 +429,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
-
-
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -384,6 +384,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE2(clamp_max, Tensor);
   UNARY_POINTWISE(clamp_max);
   POINTWISE_BOXED(clamp_max_);
+  BINARY_POINTWISE(complex);
 
   VARIADIC_BDIMS_BOXED(_euclidean_dist);
   // Implementation note: _binary_pointwise_helper performs a dtype promotion if args are scalars,
@@ -391,8 +392,9 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(_cdist_forward);
   VMAP_SUPPORT(_cdist_backward, cdist_backward_batch_rule);
 
-  // Commented out so we have a test op
-  // BINARY_SCALAR_2(copysign, Tensor, Scalar);
+  BINARY_SCALAR_2(copysign, Tensor, Scalar);
+  POINTWISE_BOXED(copysign_.Tensor);
+  POINTWISE_BOXED(copysign_.Scalar);
   BINARY_SCALAR_2(div, Tensor, Scalar);
   BINARY_SCALAR_2(div, Tensor_mode, Scalar_mode);
 
@@ -426,6 +428,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_SCALAR_3(remainder, Tensor, Scalar, Scalar_Tensor);
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
+
   POINTWISE_BOXED(special_bessel_j0);
   POINTWISE_BOXED(special_spherical_bessel_j0);
   POINTWISE_BOXED(special_bessel_j1);
@@ -437,12 +440,12 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   POINTWISE_BOXED(special_modified_bessel_k1);
   POINTWISE_BOXED(special_bessel_y0);
   POINTWISE_BOXED(special_bessel_y1);
-  
-  
+
 
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);
+
   VMAP_SUPPORT2(where, self, where_self_batch_rule);
 
   BINARY_SCALAR_3(xlogy, Tensor, Scalar_Other, Scalar_Self);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,17 +429,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
-  POINTWISE_BOXED(special_bessel_j0);
-  POINTWISE_BOXED(special_spherical_bessel_j0);
-  POINTWISE_BOXED(special_bessel_j1);
-  POINTWISE_BOXED(special_modified_bessel_i0);
-  POINTWISE_BOXED(special_modified_bessel_i1);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
-  POINTWISE_BOXED(special_modified_bessel_k0);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
-  POINTWISE_BOXED(special_modified_bessel_k1);
-  POINTWISE_BOXED(special_bessel_y0);
-  POINTWISE_BOXED(special_bessel_y1);
 
 
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -384,7 +384,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE2(clamp_max, Tensor);
   UNARY_POINTWISE(clamp_max);
   POINTWISE_BOXED(clamp_max_);
-  BINARY_POINTWISE(complex);
 
   VARIADIC_BDIMS_BOXED(_euclidean_dist);
   // Implementation note: _binary_pointwise_helper performs a dtype promotion if args are scalars,
@@ -392,9 +391,8 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(_cdist_forward);
   VMAP_SUPPORT(_cdist_backward, cdist_backward_batch_rule);
 
-  BINARY_SCALAR_2(copysign, Tensor, Scalar);
-  POINTWISE_BOXED(copysign_.Tensor);
-  POINTWISE_BOXED(copysign_.Scalar);
+  // Commented out so we have a test op
+  // BINARY_SCALAR_2(copysign, Tensor, Scalar);
   BINARY_SCALAR_2(div, Tensor, Scalar);
   BINARY_SCALAR_2(div, Tensor_mode, Scalar_mode);
 
@@ -428,11 +426,23 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_SCALAR_3(remainder, Tensor, Scalar, Scalar_Tensor);
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
+  
+  
 
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);
-
   VMAP_SUPPORT2(where, self, where_self_batch_rule);
 
   BINARY_SCALAR_3(xlogy, Tensor, Scalar_Other, Scalar_Self);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,19 +429,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
-  POINTWISE_BOXED(special_bessel_j0);
-  POINTWISE_BOXED(special_spherical_bessel_j0);
-  POINTWISE_BOXED(special_bessel_j1);
-  POINTWISE_BOXED(special_modified_bessel_i0);
-  POINTWISE_BOXED(special_modified_bessel_i1);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
-  POINTWISE_BOXED(special_modified_bessel_k0);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
-  POINTWISE_BOXED(special_modified_bessel_k1);
-  POINTWISE_BOXED(special_bessel_y0);
-  POINTWISE_BOXED(special_bessel_y1);
-
-
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,6 +429,17 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
 
 
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,6 +429,19 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
+
+
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesBinaryOps.cpp
@@ -429,6 +429,8 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   BINARY_POINTWISE(rrelu_with_noise);
   BINARY_SCALAR_2(rsub, Tensor, Scalar);
 
+
+
   BINARY_SCALAR_3_Tensor(special_xlog1py, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_xlogy, other_scalar, self_scalar);
   BINARY_SCALAR_3_Tensor(special_zeta, other_scalar, self_scalar);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -168,6 +168,19 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
 
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
+
+
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);
   UNARY_POINTWISE(hardshrink);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -167,6 +167,18 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1);
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
+
 
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -167,18 +167,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1);
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
-  POINTWISE_BOXED(special_bessel_j0);
-  POINTWISE_BOXED(special_spherical_bessel_j0);
-  POINTWISE_BOXED(special_bessel_j1);
-  POINTWISE_BOXED(special_modified_bessel_i0);
-  POINTWISE_BOXED(special_modified_bessel_i1);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
-  POINTWISE_BOXED(special_modified_bessel_k0);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
-  POINTWISE_BOXED(special_modified_bessel_k1);
-  POINTWISE_BOXED(special_bessel_y0);
-  POINTWISE_BOXED(special_bessel_y1);
-
 
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -167,6 +167,17 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1);
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
+  POINTWISE_BOXED(special_bessel_j0);
+  POINTWISE_BOXED(special_spherical_bessel_j0);
+  POINTWISE_BOXED(special_bessel_j1);
+  POINTWISE_BOXED(special_modified_bessel_i0);
+  POINTWISE_BOXED(special_modified_bessel_i1);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
+  POINTWISE_BOXED(special_modified_bessel_k0);
+  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
+  POINTWISE_BOXED(special_modified_bessel_k1);
+  POINTWISE_BOXED(special_bessel_y0);
+  POINTWISE_BOXED(special_bessel_y1);
 
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -167,17 +167,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1);
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
-  POINTWISE_BOXED(special_bessel_j0);
-  POINTWISE_BOXED(special_spherical_bessel_j0);
-  POINTWISE_BOXED(special_bessel_j1);
-  POINTWISE_BOXED(special_modified_bessel_i0);
-  POINTWISE_BOXED(special_modified_bessel_i1);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
-  POINTWISE_BOXED(special_modified_bessel_k0);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
-  POINTWISE_BOXED(special_modified_bessel_k1);
-  POINTWISE_BOXED(special_bessel_y0);
-  POINTWISE_BOXED(special_bessel_y1);
 
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);

--- a/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesUnaryOps.cpp
@@ -168,19 +168,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE(special_i1e);
   UNARY_POINTWISE(special_ndtri);
 
-  POINTWISE_BOXED(special_bessel_j0);
-  POINTWISE_BOXED(special_spherical_bessel_j0);
-  POINTWISE_BOXED(special_bessel_j1);
-  POINTWISE_BOXED(special_modified_bessel_i0);
-  POINTWISE_BOXED(special_modified_bessel_i1);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k0);
-  POINTWISE_BOXED(special_modified_bessel_k0);
-  POINTWISE_BOXED(special_scaled_modified_bessel_k1);
-  POINTWISE_BOXED(special_modified_bessel_k1);
-  POINTWISE_BOXED(special_bessel_y0);
-  POINTWISE_BOXED(special_bessel_y1);
-
-
   // Activation functions (from https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
   UNARY_POINTWISE_ALL(elu);
   UNARY_POINTWISE(hardshrink);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -27,8 +27,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     subtest,
     TEST_WITH_UBSAN,
-    IS_MACOS,
-    IS_X86
+    skipIfRocm,
 )
 from torch.testing._internal.common_device_type import \
     toleranceOverride, tol
@@ -46,7 +45,7 @@ from common_utils import (
     compute_quantities_for_vmap_test,
     is_valid_inplace_sample_input,
     decorate,
-    expectedFailureIf
+    DisableVmapFallback,
 )
 import types
 from collections import namedtuple
@@ -652,10 +651,7 @@ class TestVmapAPI(TestCase):
         vmap(foo, in_dims=(1,))(torch.randn(2, 3))
 
     def test_fallback_does_not_warn_by_default(self):
-        # NB: One day we will implement a batching rule for torch.atan2.
-        # If/when we do, this test should be replaced to test the fallback
-        # path on another operator to avoid bitrot.
-        op = torch.copysign
+        op = torch._test_functorch_fallback
         x = torch.randn(11)
         y = torch.randn(11)
         with warnings.catch_warnings(record=True) as wa:
@@ -669,7 +665,7 @@ class TestVmapAPI(TestCase):
         # NB: One day we will implement a batching rule for torch.atan2.
         # If/when we do, this test should be replaced to test the fallback
         # path on another operator to avoid bitrot.
-        op = torch.copysign
+        op = torch._test_functorch_fallback
         x = torch.randn(11)
         y = torch.randn(11)
         with warnings.catch_warnings(record=True) as wa:
@@ -687,10 +683,7 @@ class TestVmapAPI(TestCase):
         #     self.assertRegex(str(wa[-1].message), FALLBACK_REGEX)
 
     def test_fallback_zero_dim(self):
-        # NB: One day we will implement a batching rule for torch.atan2.
-        # If/when we do, this test should be replaced to test the fallback
-        # path on another operator to avoid bitrot.
-        op = torch.copysign
+        op = torch._test_functorch_fallback
         x = torch.randn(11)
         y = torch.randn(11)
         self._assert_uses_vmap_fallback((op,), (x, y))
@@ -717,24 +710,22 @@ class TestVmapAPI(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             vmap(op)(x, x)
 
-    def test_fallback_atan2(self):
-        # NB: One day we will implement a batching rule for torch.atan2.
-        # If/when we do, this test should be replaced to test the fallback
-        # path on another operator to avoid bitrot.
-        op = torch.copysign
+    def test_fallback_warning(self):
+        # We use a dummy function _test_functorch_fallback
+        # defined in prim_native_functions.cpp for this
+        op = torch._test_functorch_fallback
 
         x = torch.randn(5, 7, 11)
         y = torch.randn(5, 7, 11)
 
         self._assert_uses_vmap_fallback((op,), (x, y))
 
-        # fallback on torch.atan2
         x = torch.randn(7, 11, 5)
         y = torch.randn(5, 7, 11)
         result = vmap(op, (2, 0))(x, y)
         self.assertEqual(result, op(x.permute(2, 0, 1), y))
 
-        # fallback on torch.atan2, nested vmap
+        # nested vmap
         x = torch.randn(7, 11, 5)
         y = torch.randn(5, 7, 11)
         result = vmap(vmap(op), (2, 0))(x, y)
@@ -1051,6 +1042,11 @@ class TestVmapAPI(TestCase):
         y = reshape_dim_outof(-1, 6, x)
         self.assertEqual(y, x.reshape(12, 12, 6, 2))
 
+        # Case: `0` sized dim.
+        x = torch.randn(12, 12, 0)
+        y = reshape_dim_outof(-1, 6, x)
+        self.assertEqual(y.shape, torch.Size((12, 12, 6, 0)))
+
     def test_batch_rule_does_not_need_to_handle_no_batched_input(self):
         def f(x, y):
             res = torch.dot(y, torch.ones(2))
@@ -1061,6 +1057,16 @@ class TestVmapAPI(TestCase):
         out = vmap(vmap(f, in_dims=(0, None)), in_dims=(None, 0))(x, y)
         expected = torch.mv(y, torch.ones(2)).view(3, 1, 1) + x
         self.assertEqual(out, expected)
+
+    def test_decomposition_under_python_dispatcher(self):
+        # This test will raise an error if the vmap fallback gets invoked.
+        # Here we test that decomps registered to FuncTorchBatchedDecomposition
+        # are respected by the Python Dispatcher.
+        t = torch.ones(3, 3) * 5
+        with DisableVmapFallback():
+            with torch._dispatch.python.enable_python_dispatcher():
+                o = torch.vmap(torch.square)(t)
+        self.assertEqual(o, torch.square(t))
 
     def _test_vmap_autocast(self, device):
 
@@ -1162,6 +1168,21 @@ class TestVmapAPI(TestCase):
         out, out_dims = restore_vmap(f, (0, None), B, 'error')(x, y)
         self.assertEqual(out, f(None, y))
         self.assertEqual(out_dims, (None, None, None))
+
+    def test_data_attribute(self):
+        def foo(x):
+            y = x.data
+            return x
+
+        with self.assertRaisesRegex(RuntimeError, "accessing `data` under vmap transform"):
+            torch.func.vmap(foo)(torch.randn(3, 3))
+
+        def foo(x):
+            x.data = torch.ones(3, 3)
+            return x
+
+        with self.assertRaisesRegex(RuntimeError, "mutating directly with `.data` under vmap"):
+            torch.func.vmap(foo)(torch.randn(3, 3))
 
 
 def slice_inputs(inputs, bdims, i):
@@ -3417,7 +3438,7 @@ class TestVmapOperatorsOpInfo(TestCase):
             check_shape_only = op.name in ('empty_like', 'new_empty')
             for sample_input in sample_inputs_itr:
                 args = (sample_input.input,) + sample_input.args
-                if not any(map(lambda arg: isinstance(arg, torch.Tensor), args)):
+                if not any((isinstance(arg, torch.Tensor) for arg in args)):
                     # Atleast one tensor required for vmap.
                     continue
                 kwargs = sample_input.kwargs
@@ -3563,14 +3584,15 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('triu'),  # Exception not raised on error input
         xfail('as_strided', 'partial_views'),
 
+        # https://github.com/pytorch/pytorch/issues/96560
+        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
+        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
+        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
+
         # RuntimeError: output with shape [4, 4] doesn't match the broadcast shape [1, 4, 4]
         xfail('addcdiv'),
         xfail('addcmul'),
         xfail('clamp'),
-        # AssertionError: Tensor-likes are not equal!
-        xfail('bitwise_left_shift', device_type='cpu'),
-        decorate('bitwise_right_shift', device_type='cpu',
-                 decorator=expectedFailureIf(not (IS_MACOS and IS_X86))),
 
         # UBSAN: runtime error: shift exponent -1 is negative
         decorate('bitwise_left_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
@@ -3596,8 +3618,6 @@ class TestVmapOperatorsOpInfo(TestCase):
     @skipOps('TestVmapOperatorsOpInfo', 'test_op_has_batch_rule', vmap_fail.union({
         xfail('as_strided', 'partial_views'),
         skip('to'),  # RuntimeError: required rank 4 tensor to use channels_last format
-        xfail('complex'),
-        xfail('copysign'),
         xfail('fill'),
         # Batch norm got a batched tensor as input while the running_mean or running_var,
         # which will be updated in place, were not batched.
@@ -3643,7 +3663,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('unique'),
         xfail('nn.functional.ctc_loss'),
         xfail('nn.functional.gaussian_nll_loss'),
-        xfail('nn.functional.huber_loss'),
         # We can get this to work on CUDA through decomposition,
         # but fails on CPU due to max_pool1d_cpu not having a derivative
         xfail('nn.functional.max_pool1d'),
@@ -3660,7 +3679,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.embedding_bag'),
         xfail('linalg.tensorsolve'),
         xfail('bernoulli', ''),
-        xfail('linalg.lu_factor', ''),
         xfail('nn.functional.feature_alpha_dropout', 'with_train'),
         xfail('native_dropout_backward'),
         xfail('nn.functional.kl_div', ''),
@@ -3676,7 +3694,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.triplet_margin_loss', ''),
         xfail('nn.functional.pdist', ''),
         xfail('scatter_reduce', 'sum'),
-        xfail('nn.functional.smooth_l1_loss', ''),
         xfail('scatter_reduce', 'amax'),
         xfail('nn.functional.max_unpool1d', 'grad'),
         xfail('nn.functional.multi_margin_loss', ''),
@@ -3712,34 +3729,28 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('lu_solve', ''),
         xfail('special.hermite_polynomial_he'),
         xfail('nn.functional.dropout3d', ''),
-        xfail('linalg.ldl_factor', ''),
         xfail('special.chebyshev_polynomial_t'),
         xfail('as_strided_scatter', ''),
         xfail('equal', ''),
         xfail('linalg.lu', ''),
         skip('linalg.ldl_solve', ''),
         skip('_softmax_backward_data'),
-        # AssertionError: Tensor-likes are not equal!
-        # Issue: https://github.com/pytorch/pytorch/issues/70904
-        xfail('bitwise_left_shift', device_type='cpu'),
-        decorate('bitwise_right_shift', device_type='cpu',
-                 decorator=expectedFailureIf(not (IS_MACOS and IS_X86))),
         # UBSAN: runtime error: shift exponent -1 is negative
         decorate('bitwise_left_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         decorate('bitwise_right_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
+        # https://github.com/pytorch/pytorch/issues/96560
+        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
+        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
+        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
+
         # One or more of the overload doesn't have a Batch rule.
-        xfail('where'),
         xfail('bincount'),
-        xfail('float_power'),
-        xfail('gt'),
-        xfail('le'),
-        xfail('lt'),
-        xfail('ne'),
         # UBSAN: runtime error: 1.27043e+262 is outside the range of representable values of type 'float'
         decorate('special.zeta', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         # RuntimeError: Expected all tensors to be on the same device,
         # but found at least two devices, cuda:0 and cpu!
         xfail('ge', device_type='cuda'),
+        xfail('_upsample_bilinear2d_aa'),
     }))
     def test_op_has_batch_rule(self, device, dtype, op):
         # needs to be fixed
@@ -3786,8 +3797,6 @@ class TestVmapOperatorsOpInfo(TestCase):
             'scatter',
             'square',
             'sub',
-            'tril',
-            'triu',
             'trunc',
             'xlogy',
         )
@@ -4247,6 +4256,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         # IndexError: Dimension out of range (expected to be in range of [-1, 0], but got -2)
         # https://github.com/pytorch/pytorch/runs/8110653462?check_suite_focus=true
         # but it passes locally
+        xfail('linalg.diagonal'),
         skip('linalg.matrix_norm', ''),
         skip('linalg.ldl_solve', ''),
     })

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -27,7 +27,8 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     subtest,
     TEST_WITH_UBSAN,
-    skipIfRocm,
+    IS_MACOS,
+    IS_X86
 )
 from torch.testing._internal.common_device_type import \
     toleranceOverride, tol
@@ -45,7 +46,7 @@ from common_utils import (
     compute_quantities_for_vmap_test,
     is_valid_inplace_sample_input,
     decorate,
-    DisableVmapFallback,
+    expectedFailureIf
 )
 import types
 from collections import namedtuple
@@ -651,7 +652,10 @@ class TestVmapAPI(TestCase):
         vmap(foo, in_dims=(1,))(torch.randn(2, 3))
 
     def test_fallback_does_not_warn_by_default(self):
-        op = torch._test_functorch_fallback
+        # NB: One day we will implement a batching rule for torch.atan2.
+        # If/when we do, this test should be replaced to test the fallback
+        # path on another operator to avoid bitrot.
+        op = torch.copysign
         x = torch.randn(11)
         y = torch.randn(11)
         with warnings.catch_warnings(record=True) as wa:
@@ -665,7 +669,7 @@ class TestVmapAPI(TestCase):
         # NB: One day we will implement a batching rule for torch.atan2.
         # If/when we do, this test should be replaced to test the fallback
         # path on another operator to avoid bitrot.
-        op = torch._test_functorch_fallback
+        op = torch.copysign
         x = torch.randn(11)
         y = torch.randn(11)
         with warnings.catch_warnings(record=True) as wa:
@@ -683,7 +687,10 @@ class TestVmapAPI(TestCase):
         #     self.assertRegex(str(wa[-1].message), FALLBACK_REGEX)
 
     def test_fallback_zero_dim(self):
-        op = torch._test_functorch_fallback
+        # NB: One day we will implement a batching rule for torch.atan2.
+        # If/when we do, this test should be replaced to test the fallback
+        # path on another operator to avoid bitrot.
+        op = torch.copysign
         x = torch.randn(11)
         y = torch.randn(11)
         self._assert_uses_vmap_fallback((op,), (x, y))
@@ -710,22 +717,24 @@ class TestVmapAPI(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             vmap(op)(x, x)
 
-    def test_fallback_warning(self):
-        # We use a dummy function _test_functorch_fallback
-        # defined in prim_native_functions.cpp for this
-        op = torch._test_functorch_fallback
+    def test_fallback_atan2(self):
+        # NB: One day we will implement a batching rule for torch.atan2.
+        # If/when we do, this test should be replaced to test the fallback
+        # path on another operator to avoid bitrot.
+        op = torch.copysign
 
         x = torch.randn(5, 7, 11)
         y = torch.randn(5, 7, 11)
 
         self._assert_uses_vmap_fallback((op,), (x, y))
 
+        # fallback on torch.atan2
         x = torch.randn(7, 11, 5)
         y = torch.randn(5, 7, 11)
         result = vmap(op, (2, 0))(x, y)
         self.assertEqual(result, op(x.permute(2, 0, 1), y))
 
-        # nested vmap
+        # fallback on torch.atan2, nested vmap
         x = torch.randn(7, 11, 5)
         y = torch.randn(5, 7, 11)
         result = vmap(vmap(op), (2, 0))(x, y)
@@ -1042,11 +1051,6 @@ class TestVmapAPI(TestCase):
         y = reshape_dim_outof(-1, 6, x)
         self.assertEqual(y, x.reshape(12, 12, 6, 2))
 
-        # Case: `0` sized dim.
-        x = torch.randn(12, 12, 0)
-        y = reshape_dim_outof(-1, 6, x)
-        self.assertEqual(y.shape, torch.Size((12, 12, 6, 0)))
-
     def test_batch_rule_does_not_need_to_handle_no_batched_input(self):
         def f(x, y):
             res = torch.dot(y, torch.ones(2))
@@ -1057,16 +1061,6 @@ class TestVmapAPI(TestCase):
         out = vmap(vmap(f, in_dims=(0, None)), in_dims=(None, 0))(x, y)
         expected = torch.mv(y, torch.ones(2)).view(3, 1, 1) + x
         self.assertEqual(out, expected)
-
-    def test_decomposition_under_python_dispatcher(self):
-        # This test will raise an error if the vmap fallback gets invoked.
-        # Here we test that decomps registered to FuncTorchBatchedDecomposition
-        # are respected by the Python Dispatcher.
-        t = torch.ones(3, 3) * 5
-        with DisableVmapFallback():
-            with torch._dispatch.python.enable_python_dispatcher():
-                o = torch.vmap(torch.square)(t)
-        self.assertEqual(o, torch.square(t))
 
     def _test_vmap_autocast(self, device):
 
@@ -1168,21 +1162,6 @@ class TestVmapAPI(TestCase):
         out, out_dims = restore_vmap(f, (0, None), B, 'error')(x, y)
         self.assertEqual(out, f(None, y))
         self.assertEqual(out_dims, (None, None, None))
-
-    def test_data_attribute(self):
-        def foo(x):
-            y = x.data
-            return x
-
-        with self.assertRaisesRegex(RuntimeError, "accessing `data` under vmap transform"):
-            torch.func.vmap(foo)(torch.randn(3, 3))
-
-        def foo(x):
-            x.data = torch.ones(3, 3)
-            return x
-
-        with self.assertRaisesRegex(RuntimeError, "mutating directly with `.data` under vmap"):
-            torch.func.vmap(foo)(torch.randn(3, 3))
 
 
 def slice_inputs(inputs, bdims, i):
@@ -3438,7 +3417,7 @@ class TestVmapOperatorsOpInfo(TestCase):
             check_shape_only = op.name in ('empty_like', 'new_empty')
             for sample_input in sample_inputs_itr:
                 args = (sample_input.input,) + sample_input.args
-                if not any((isinstance(arg, torch.Tensor) for arg in args)):
+                if not any(map(lambda arg: isinstance(arg, torch.Tensor), args)):
                     # Atleast one tensor required for vmap.
                     continue
                 kwargs = sample_input.kwargs
@@ -3584,15 +3563,14 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('triu'),  # Exception not raised on error input
         xfail('as_strided', 'partial_views'),
 
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
-
         # RuntimeError: output with shape [4, 4] doesn't match the broadcast shape [1, 4, 4]
         xfail('addcdiv'),
         xfail('addcmul'),
         xfail('clamp'),
+        # AssertionError: Tensor-likes are not equal!
+        xfail('bitwise_left_shift', device_type='cpu'),
+        decorate('bitwise_right_shift', device_type='cpu',
+                 decorator=expectedFailureIf(not (IS_MACOS and IS_X86))),
 
         # UBSAN: runtime error: shift exponent -1 is negative
         decorate('bitwise_left_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
@@ -3618,6 +3596,8 @@ class TestVmapOperatorsOpInfo(TestCase):
     @skipOps('TestVmapOperatorsOpInfo', 'test_op_has_batch_rule', vmap_fail.union({
         xfail('as_strided', 'partial_views'),
         skip('to'),  # RuntimeError: required rank 4 tensor to use channels_last format
+        xfail('complex'),
+        xfail('copysign'),
         xfail('fill'),
         # Batch norm got a batched tensor as input while the running_mean or running_var,
         # which will be updated in place, were not batched.
@@ -3663,6 +3643,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('unique'),
         xfail('nn.functional.ctc_loss'),
         xfail('nn.functional.gaussian_nll_loss'),
+        xfail('nn.functional.huber_loss'),
         # We can get this to work on CUDA through decomposition,
         # but fails on CPU due to max_pool1d_cpu not having a derivative
         xfail('nn.functional.max_pool1d'),
@@ -3679,6 +3660,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.embedding_bag'),
         xfail('linalg.tensorsolve'),
         xfail('bernoulli', ''),
+        xfail('linalg.lu_factor', ''),
         xfail('nn.functional.feature_alpha_dropout', 'with_train'),
         xfail('native_dropout_backward'),
         xfail('nn.functional.kl_div', ''),
@@ -3694,6 +3676,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.triplet_margin_loss', ''),
         xfail('nn.functional.pdist', ''),
         xfail('scatter_reduce', 'sum'),
+        xfail('nn.functional.smooth_l1_loss', ''),
         xfail('scatter_reduce', 'amax'),
         xfail('nn.functional.max_unpool1d', 'grad'),
         xfail('nn.functional.multi_margin_loss', ''),
@@ -3712,56 +3695,51 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('chalf', ''),
         xfail('clamp_max', ''),
         xfail('jiterator_binary_return_by_ref', device_type='cuda'),
-        xfail('special.spherical_bessel_j0'),
         xfail('jiterator_unary', device_type='cuda'),
         xfail('jiterator_2inputs_2outputs', device_type='cuda'),
         xfail('special.airy_ai'),
         xfail('clamp_min', ''),
-        xfail('special.bessel_j0'),
         xfail('sparse.sampled_addmm'),
         xfail('sparse.mm', 'reduce'),
-        xfail('special.bessel_y0'),
         xfail('special.chebyshev_polynomial_u'),
-        xfail('special.modified_bessel_k1'),
         xfail('_segment_reduce', 'offsets'),
-        xfail('special.bessel_j1'),
         xfail('index_reduce', ''),
         xfail('special.laguerre_polynomial_l'),
         xfail('special.hermite_polynomial_h'),
         xfail('jiterator_binary', device_type='cuda'),
-        xfail('special.modified_bessel_i0'),
         xfail('jiterator_4inputs_with_extra_args', device_type='cuda'),
         xfail('_segment_reduce', 'lengths'),
         xfail('lu_solve', ''),
-        xfail('special.bessel_y1'),
         xfail('special.hermite_polynomial_he'),
-        xfail('special.scaled_modified_bessel_k0'),
         xfail('nn.functional.dropout3d', ''),
-        xfail('special.scaled_modified_bessel_k1'),
-        xfail('special.modified_bessel_k0'),
-        xfail('special.modified_bessel_i1'),
+        xfail('linalg.ldl_factor', ''),
         xfail('special.chebyshev_polynomial_t'),
         xfail('as_strided_scatter', ''),
         xfail('equal', ''),
         xfail('linalg.lu', ''),
         skip('linalg.ldl_solve', ''),
         skip('_softmax_backward_data'),
+        # AssertionError: Tensor-likes are not equal!
+        # Issue: https://github.com/pytorch/pytorch/issues/70904
+        xfail('bitwise_left_shift', device_type='cpu'),
+        decorate('bitwise_right_shift', device_type='cpu',
+                 decorator=expectedFailureIf(not (IS_MACOS and IS_X86))),
         # UBSAN: runtime error: shift exponent -1 is negative
         decorate('bitwise_left_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         decorate('bitwise_right_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
-
         # One or more of the overload doesn't have a Batch rule.
+        xfail('where'),
         xfail('bincount'),
+        xfail('float_power'),
+        xfail('gt'),
+        xfail('le'),
+        xfail('lt'),
+        xfail('ne'),
         # UBSAN: runtime error: 1.27043e+262 is outside the range of representable values of type 'float'
         decorate('special.zeta', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         # RuntimeError: Expected all tensors to be on the same device,
         # but found at least two devices, cuda:0 and cpu!
         xfail('ge', device_type='cuda'),
-        xfail('_upsample_bilinear2d_aa'),
     }))
     def test_op_has_batch_rule(self, device, dtype, op):
         # needs to be fixed
@@ -3808,6 +3786,8 @@ class TestVmapOperatorsOpInfo(TestCase):
             'scatter',
             'square',
             'sub',
+            'tril',
+            'triu',
             'trunc',
             'xlogy',
         )
@@ -4267,7 +4247,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         # IndexError: Dimension out of range (expected to be in range of [-1, 0], but got -2)
         # https://github.com/pytorch/pytorch/runs/8110653462?check_suite_focus=true
         # but it passes locally
-        xfail('linalg.diagonal'),
         skip('linalg.matrix_norm', ''),
         skip('linalg.ldl_solve', ''),
     })


### PR DESCRIPTION
Fixes #91402
## Description
This PR adds vmap support for the following bessel functions under torch.special. 
*  special.bessel_j0 
*  special.bessel_y0
*  special.bessel_j1
*  special.modified_bessel_i0
*  special.bessel_y1
*   special.scaled_modified_bessel_k0
*   special.scaled_modified_bessel_k1
*   special.modified_bessel_i1

## Files changed:
1. [aten/src/ATen/functorch/BatchRulesBinaryOps.cpp](https://github.com/pytorch/pytorch/compare/main...SiddharthIVEX:pytorch:sid/vmap_special_bessel?expand=1#diff-2e13c1e206ea201666a4b7db505ba3bf74f2f57288c394fa81337627d6194822)
2. [test/functorch/test_vmap.py](https://github.com/pytorch/pytorch/compare/main...SiddharthIVEX:pytorch:sid/vmap_special_bessel?expand=1#diff-17b0cd027c7b1ca042fcfe21cc86284d6e58fa46039f7e4297b22b8e02b68fea)

## How was the PR tested?
1. The unit tests under `test_vmap.py` were run and all of them passed. The output is shown below.
```
configfile: pytest.ini
plugins: hypothesis-6.71.0, anyio-2.2.0
collected 2003 items / 1981 deselected / 22 selected                                                                                                                 

test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_bessel_j0_cpu_float32 PASSED                                           [  4%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_bessel_j1_cpu_float32 PASSED                                           [  9%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_bessel_y0_cpu_float32 PASSED                                           [ 13%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_bessel_y1_cpu_float32 PASSED                                           [ 18%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_modified_bessel_i0_cpu_float32 PASSED                                  [ 22%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_modified_bessel_i1_cpu_float32 PASSED                                  [ 27%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_modified_bessel_k0_cpu_float32 PASSED                                  [ 31%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_modified_bessel_k1_cpu_float32 PASSED                                  [ 36%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_scaled_modified_bessel_k0_cpu_float32 PASSED                           [ 40%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_scaled_modified_bessel_k1_cpu_float32 PASSED                           [ 45%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_op_has_batch_rule_special_spherical_bessel_j0_cpu_float32 PASSED                                 [ 50%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_bessel_j0_cpu_float32 PASSED                                             [ 54%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_bessel_j1_cpu_float32 PASSED                                             [ 59%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_bessel_y0_cpu_float32 PASSED                                             [ 63%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_bessel_y1_cpu_float32 PASSED                                             [ 68%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_modified_bessel_i0_cpu_float32 PASSED                                    [ 72%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_modified_bessel_i1_cpu_float32 PASSED                                    [ 77%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_modified_bessel_k0_cpu_float32 PASSED                                    [ 81%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_modified_bessel_k1_cpu_float32 PASSED                                    [ 86%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_scaled_modified_bessel_k0_cpu_float32 PASSED                             [ 90%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_scaled_modified_bessel_k1_cpu_float32 PASSED                             [ 95%]
test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCPU::test_vmap_exhaustive_special_spherical_bessel_j0_cpu_float32 PASSED                                   [100%]

================================================================ 22 passed, 1981 deselected in 18.42s ================================================================

```

