### PR TITLE
Make lintrunner work with new main branch

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,4 +1,4 @@
-merge_base_with = "origin/master"
+merge_base_with = "origin/main"
 
 [[linter]]
 code = 'FLAKE8'


### PR DESCRIPTION
We've renamed the `master` branch to `main`. Lintrunner should check for a merge base from this new branch now

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9743d70</samp>

Updated the linter configuration to reflect the new default branch name. Changed `merge_base_with` from `origin/master` to `origin/main` in `.lintrunner.toml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9743d70</samp>

> _`merge_base_with` changed_
> _`origin/main` is the new_
> _branch name for pytorch_

