### PR TITLE
[BE] Refactoring test execution and improving comments

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -825,6 +825,7 @@ def get_pytest_args(options):
     pytest_args.extend(rerun_options)
     return pytest_args
 
+
 CUSTOM_HANDLERS = {
     "test_cuda_primary_ctx": run_test_with_subprocess,
     "test_cuda_nvml_based_avail": run_test_with_subprocess,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -237,6 +237,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
 ]
 
+# The tests inside these files should never be run in parallel with each other
 RUN_PARALLEL_BLOCKLIST = [
     "test_cpp_extensions_jit",
     "test_cpp_extensions_open_device_registration",
@@ -253,6 +254,8 @@ RUN_PARALLEL_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
 ] + FSDP_TEST
 
+# Test files that should always be run serially with other test files, 
+# but it's okay if the tests inside them are run in parallel with each other.
 CI_SERIAL_LIST = [
     "test_nn",
     "test_fake_tensor",
@@ -822,7 +825,7 @@ def get_pytest_args(options):
     pytest_args.extend(rerun_options)
     return pytest_args
 
-
+# What are these for? We need to run them serially for some reason
 CUSTOM_HANDLERS = {
     "test_cuda_primary_ctx": run_test_with_subprocess,
     "test_cuda_nvml_based_avail": run_test_with_subprocess,

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -127,7 +127,10 @@ def _query_changed_test_files() -> List[str]:
 
 
 def get_reordered_tests(tests: List[str]) -> List[str]:
-    """Prioritize running test files that were edited in the git history."""
+    """
+    Get the reordered test filename list based on github PR history or git changed file.
+    We prioritize running test files that were changed.
+    """
     prioritized_tests: List[str] = []
     if len(prioritized_tests) == 0:
         try:

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -127,7 +127,7 @@ def _query_changed_test_files() -> List[str]:
 
 
 def get_reordered_tests(tests: List[str]) -> List[str]:
-    """Get the reordered test filename list based on github PR history or git changed file."""
+    """Prioritize running test files that were edited in the git history."""
     prioritized_tests: List[str] = []
     if len(prioritized_tests) == 0:
         try:


### PR DESCRIPTION
Sharing code between the code that handles test results in parallel vs serial mode.

Note that the original version of this code had an inconsistency between the two versions where it would execute `print_to_stderr(err_message)` on every test that ran in parallel, but for serial tests it would only invoke `print_to_stderr(err_message)` if `continue_on_error` was also specified.  By sharing code, this PR changes that behavior to be consistent between the two modes.

Also adding some comments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 029342c</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The PyTorch testing script, `run_test.py`, and shined_
> _A light on its obscure logic, with docstrings and comments_
> _And made it run more smoothly, with better error contents_