### PR TITLE
Use config-settings in place of install-options

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -170,7 +170,7 @@ function checkout_install_torchdeploy() {
   pushd multipy
   git checkout "${commit}"
   python multipy/runtime/example/generate_examples.py
-  pip install -e . --install-option="--cudatests"
+  pip install -e . --config-settings="--build-option=--cudatests"
   popd
   popd
 }

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -170,7 +170,7 @@ function checkout_install_torchdeploy() {
   pushd multipy
   git checkout "${commit}"
   python multipy/runtime/example/generate_examples.py
-  pip install -e . --config-settings="--build-option=--cudatests"
+  pip install -e . --config-settings="--user-options=--cudatests"
   popd
   popd
 }


### PR DESCRIPTION
Use config-setting in place of install-options
As of pip==23.1 https://github.com/pypa/pip/issues/11358 of --insatall-options is deprecated.

According to https://github.com/pypa/pip/issues/11358 flag can be passed using --config-settings.