### PR TITLE
[Release only change] mitigate issue caused by deprecated pip option

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -175,7 +175,7 @@ function checkout_install_torchdeploy() {
   pushd multipy
   git checkout "${commit}"
   python multipy/runtime/example/generate_examples.py
-  pip install -e . --install-option="--cudatests"
+  pip install -e .
   popd
   popd
 }
@@ -184,7 +184,6 @@ function test_torch_deploy(){
  pushd ..
  pushd multipy
  ./multipy/runtime/build/test_deploy
- ./multipy/runtime/build/test_deploy_gpu
  popd
  popd
 }


### PR DESCRIPTION
This PR should turn off the test that is failing due to pip update.

The failure is this one:
https://github.com/pytorch/pytorch/actions/runs/4722961778/jobs/8380243092

This fix was deployed in trunk some time ago as this PR:
https://github.com/pytorch/pytorch/pull/96593

However we can't pick this change above since it fails in docker builds.  Here are the failures:
https://github.com/pytorch/pytorch/actions/runs/4738469499/jobs/8422436411
