### PR TITLE
Fix torch.nn.FractionalMaxPool2d output_size error

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7191,16 +7191,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
         net = torch.nn.ConvTranspose2d(8, 16, kernel_size=3, padding=(3, 3))
         y = net(x)
-    
+
     def test_fractional_max_pool2d_invalid_output_ratio(self):
-        arg_1 = [2,1]
-        arg_2 = [0.5,0.5,0.6]
-        arg_class = torch.nn.FractionalMaxPool2d(kernel_size=arg_1,output_ratio=arg_2,)
+        arg_1 = [2, 1]
+        arg_2 = [0.5, 0.5, 0.6]
+        arg_class = torch.nn.FractionalMaxPool2d(kernel_size=arg_1, output_ratio=arg_2,)
         arg_3_0_tensor = torch.rand([20, 16, 50, 32], dtype=torch.float32)
         arg_3_0 = arg_3_0_tensor.clone()
         arg_3 = [arg_3_0,]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError,
+                                    "fractional_max_pool2d requires output_ratio to either be a single Int or tuple of Ints."):
             res = arg_class(*arg_3)
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7191,6 +7191,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
         net = torch.nn.ConvTranspose2d(8, 16, kernel_size=3, padding=(3, 3))
         y = net(x)
+    
+    def test_fractional_max_pool2d_invalid_output_ratio(self):
+        arg_1 = [2,1]
+        arg_2 = [0.5,0.5,0.6]
+        arg_class = torch.nn.FractionalMaxPool2d(kernel_size=arg_1,output_ratio=arg_2,)
+        arg_3_0_tensor = torch.rand([20, 16, 50, 32], dtype=torch.float32)
+        arg_3_0 = arg_3_0_tensor.clone()
+        arg_3 = [arg_3_0,]
+
+        with self.assertRaises(ValueError):
+            res = arg_class(*arg_3)
 
 
 class TestFusionEval(TestCase):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -476,6 +476,8 @@ def fractional_max_pool2d_with_indices(
         raise ValueError("fractional_max_pool2d requires specifying either " "an output_size or an output_ratio")
     if output_size is None:
         assert output_ratio is not None
+        if len(output_ratio) > 2:
+            raise ValueError("fractional_max_pool2d requires output_ratio must either be a single Int or tuple of Ints.")
         _output_ratio = _pair(output_ratio)
         output_size = [int(input.size(-2) * _output_ratio[0]), int(input.size(-1) * _output_ratio[1])]
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -477,7 +477,7 @@ def fractional_max_pool2d_with_indices(
     if output_size is None:
         assert output_ratio is not None
         if len(output_ratio) > 2:
-            raise ValueError("fractional_max_pool2d requires output_ratio must either be a single Int or tuple of Ints.")
+            raise ValueError("fractional_max_pool2d requires output_ratio to either be a single Int or tuple of Ints.")
         _output_ratio = _pair(output_ratio)
         output_size = [int(input.size(-2) * _output_ratio[0]), int(input.size(-1) * _output_ratio[1])]
 


### PR DESCRIPTION
Fixes #99148 , raising an error if output_ratio's size > 2.

Justification for changes:

If an output size is not specified but an output ratio is, we call fractional_max_pool2d_with_indices. We then generate the value of output_size based on the first two integers of the output_ratio (line ~480 of torch.nn.functional.py). 

Thus, we should raise a value error in the case that the user passes an output_ratio (instead of an output_size) and the number of elements in output_ratio exceeds two. We must raise an error before calling torch._C._nn.franctional_max_pool2d as the value of output_size passed into torch._C._nn.fractional_max_pool2d is guaranteed to be of size 2 (as the existing code generates it from the first two indices of the passed in ratio). 

I would be happy to iterate on this if there are any issues.

cc @albanD 
