### PR TITLE
improve mkldnn matmul performance when one input is contiguous tensor but the strides is not default contiguous strides

### DIFF
--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -179,6 +179,17 @@ void mkldnn_matmul(
   // Will remove this "contiguous" after mkldnn have fully supported
   Tensor mat1_ = is_mkldnn_optimized_format(mat1_unsqueezed) ? mat1_unsqueezed : mat1_unsqueezed.contiguous();
   Tensor mat2_ = is_mkldnn_optimized_format(mat2_unsqueezed) ? mat2_unsqueezed : mat2_unsqueezed.contiguous();
+  // Make sure mat1 and mat2 have default contiguous strides if they are contiguous tensors for better performance.
+  auto mat1_sizes = mat1_.sizes();
+  IntArrayRef mat1_default_contiguous_strides = c10::contiguous_strides(mat1_sizes);
+  if (mat1_.is_contiguous() && mat1_.strides() != mat1_default_contiguous_strides) {
+     mat1_ = mat1_.as_strided(mat1_sizes, mat1_default_contiguous_strides);
+  }
+  auto mat2_sizes = mat2_.sizes();
+  IntArrayRef mat2_default_contiguous_strides = c10::contiguous_strides(mat2_sizes);
+  if (mat2_.is_contiguous() && mat2_.strides() != mat2_default_contiguous_strides) {
+    mat2_ = mat2_.as_strided(mat2_sizes, mat2_default_contiguous_strides);
+  }
 
   // mkldnn_matmul only proceed CPU tensor
   const ideep::tensor x = itensor_view_from_dense(mat1_);

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1439,7 +1439,7 @@ class TestMkldnn(TestCase):
             # a2 is contiguous tensor but it's strides is not default contiguous strides.
             a2 = torch.as_strided(a1.clone(), [64, 1, 33], [33, 3, 1])
             self.assertTrue(a2.is_contiguous())
-            b = torch.randn(64, 33, 256).to(dtype = torch.bfloat16)
+            b = torch.randn(64, 33, 256).to(dtype=torch.bfloat16)
             y1 = torch.ops.aten.bmm(a1, b)
             y2 = torch.bmm(a2, b)
             self.assertEqual(y1, y2)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99539
* __->__ #99511


giving the following case:
```
import torch

a= torch.empty_strided([64, 1, 33], [33, 3, 1], dtype=torch.bfloat16).fill_(1)
b = torch.randn(64, 33, 256).to(dtype = torch.bfloat16)
y = torch.ops.aten.bmm(a, b)
```
```a``` is a contiguous tensor, but the strides are not defaulted contiguous strides ([33, 33, 1]), onednn matmul always running a non-optimized path:
```
onednn_verbose,exec,cpu,matmul,gemm:jit,undef,src_bf16::blocked:abc:f0 wei_bf16::blocked:abc:f0 dst_bf16::blocked:abc:f0,attr-scratchpad:user ,,64x1x33:64x33x256:64x1x256,7.28711
```
This PR will convert the inputs' stride to deafult contiguous stride before calling onednn to running an optimization path:
```
onednn_verbose,exec,cpu,matmul,brg:avx512_core_amx_bf16,undef,src_bf16::blocked:abc:f0 wei_bf16::blocked:abc:f0 dst_bf16::blocked:abc:f0,attr-scratchpad:user ,,64x1x33:64x33x256:64x1x256,3.06396
```


cc @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10