### PR TITLE
Update docstring of torch.nn.functional.normalize()

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4673,7 +4673,7 @@ def normalize(input: Tensor, p: float = 2.0, dim: int = 1, eps: float = 1e-12, o
     Args:
         input: input tensor of any shape
         p (float): the exponent value in the norm formulation. Default: 2
-        dim (int): the dimension to reduce. Default: 1
+        dim (int or tuple of ints): the dimension to reduce. Default: 1
         eps (float): small value to avoid division by zero. Default: 1e-12
         out (Tensor, optional): the output tensor. If :attr:`out` is used, this
                                 operation won't be differentiable.


### PR DESCRIPTION
Fixes #99125

torch.nn.functional.normalize() already supports dim=tuple(int), but the docstring says int only.
