### PR TITLE
make ATen/native/cuda/TensorModeKernel.cu data_ptr-correct

### DIFF
--- a/aten/src/ATen/native/cuda/TensorModeKernel.cpp
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cpp
@@ -80,6 +80,8 @@ void mode_kernel_impl(
     launch_fused_mode_kernel(
         values_transposed, indices_transposed, contiguous, slice_size, slices);
   } else {
+    // [Note: CUDA torch.mode clones self]
+    //
     // If transposed is already contiguous, it will return a tensor with the
     // same storage. So, since we do not want to modify self, we clone it.
     if (transposed.is_same(contiguous)) {

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cuh
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cuh
@@ -198,7 +198,7 @@ template <typename T, unsigned int Power2Size>
 __launch_bounds__(1024, 1)
 #endif
 __global__ void compute_mode(
-    T* input,
+    const T* input,
     at::cuda::detail::TensorInfo<T, unsigned int> values,
     at::cuda::detail::TensorInfo<int64_t, unsigned int> indices,
     int64_t sliceSize,


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/99525).
* __->__ #99525

make ATen/native/cuda/TensorModeKernel.cu data_ptr-correct

Test Plan: Rely on CI.

