### PR TITLE
Support record_stream in dispatch mode

### DIFF
--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -43,6 +43,22 @@ static PyObject* THPStream_pynew(
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPStream_Wrap(const c10::Stream& stream) {
+  HANDLE_TH_ERRORS
+  auto type = (PyTypeObject*)THPStreamClass;
+  THPObjectPtr ptr(type->tp_alloc(type, 0));
+  if (!ptr) {
+    throw python_error();
+  }
+
+  THPStream* self = (THPStream*)ptr.get();
+  self->stream_id = stream.id();
+  self->device_index = stream.device_index();
+  self->device_type = static_cast<int64_t>(stream.device_type());
+  return ptr.release();
+  END_HANDLE_TH_ERRORS
+}
+
 static void THPStream_dealloc(THPStream* self) {
   Py_TYPE(self)->tp_free((PyObject*)self);
 }

--- a/torch/csrc/Stream.h
+++ b/torch/csrc/Stream.h
@@ -1,6 +1,7 @@
 #ifndef THP_STREAM_INC
 #define THP_STREAM_INC
 
+#include <c10/core/Stream.h>
 #include <c10/macros/Export.h>
 #include <torch/csrc/python_headers.h>
 
@@ -16,5 +17,7 @@ void THPStream_init(PyObject* module);
 inline bool THPStream_Check(PyObject* obj) {
   return THPStreamClass && PyObject_IsInstance(obj, (PyObject*)THPStreamClass);
 }
+
+PyObject* THPStream_Wrap(const c10::Stream& stream);
 
 #endif // THP_STREAM_INC

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -100,6 +100,10 @@ inline PyObject* wrap(at::IntArrayRef list) {
   return r.release();
 }
 
+inline PyObject* wrap(at::Stream stream) {
+  return THPStream_Wrap(stream);
+}
+
 namespace detail {
 template <typename F, typename Tuple, size_t... Is>
 void apply_with_idx_impl(

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -634,6 +634,8 @@ py::object toPyObject(IValue ivalue) {
     }
   } else if (ivalue.isDevice()) {
     return py::cast<py::object>(THPDevice_New(std::move(ivalue).toDevice()));
+  } else if (ivalue.isStream()) {
+    return py::cast(std::move(ivalue).toStream());
   } else if (ivalue.isGenericDict()) {
     auto dict = std::move(ivalue).toGenericDict();
     py::dict py_dict;

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -13,6 +13,7 @@
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Generator.h>
 #include <torch/csrc/MemoryFormat.h>
+#include <torch/csrc/Stream.h>
 #include <torch/csrc/utils/tensor_memoryformats.h>
 
 #include <stdexcept>
@@ -189,6 +190,32 @@ struct type_caster<at::Device> {
       return_value_policy /* policy */,
       handle /* parent */) {
     return handle(THPDevice_New(src));
+  }
+};
+
+template <>
+struct type_caster<c10::Stream> {
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  PYBIND11_TYPE_CASTER(c10::Stream, _("torch.Stream"));
+
+  bool load(handle src, bool) {
+    PyObject* obj = src.ptr();
+    if (THPStream_Check(obj)) {
+      value = c10::Stream::unpack3(
+          ((THPStream*)obj)->stream_id,
+          ((THPStream*)obj)->device_index,
+          static_cast<c10::DeviceType>(((THPStream*)obj)->device_type));
+      return true;
+    }
+    return false;
+  }
+
+  static handle cast(
+      const c10::Stream& src,
+      return_value_policy /* policy */,
+      handle /* parent */) {
+    return handle(THPStream_Wrap(src));
   }
 };
 

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -1133,6 +1133,7 @@ SUPPORTED_RETURN_TYPES = {
     "double",
     "at::IntArrayRef",
     "at::ScalarType",
+    "at::Stream",
 }
 
 


### PR DESCRIPTION
Summary:
Issuing a `t.record_stream(s)` call while a `TorchDispatchMode` is active was throwing because PyTorch was unable to convert a c10::Stream back to a Python object. It's now fixed.

Fixes https://github.com/pytorch/pytorch/issues/94403

Test Plan: Added a unit test

Differential Revision: D45117566

