### PR TITLE
Allow getting type of ScriptObject

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -740,7 +740,7 @@ void initJitScriptBindings(PyObject* module) {
 
   auto object_class =
       py::class_<Object>(m, "ScriptObject")
-          .def("_type", [](Module& m) { return m.type(); })
+          .def("_type", [](Object& o) { return o.type(); })
           .def(
               "_get_method",
               [](Object& self, const std::string& name) -> Method {


### PR DESCRIPTION
Summary:
A very old refactor (https://github.com/pytorch/pytorch/pull/29500) split ScriptModule into ScriptObject (base class) and ScriptModule (subclass). When moving methods around, the `_type` method was moved from ScriptModule to ScriptObject, but the type of its argument wasn't changed. Therefore, it is now impossible to invoke `_type` on a ScriptObject.

The reason I need this fix is that I am using PyTorch's dispatch mode to intercept some operators that accept/return custom classes, which end up being encoded as ScriptObject, and in order to properly handle them I need to be able to verify their type.

Test Plan: N/A

Differential Revision: D45118675

