### PR TITLE
[quant][pt2e][improvement] pt2e quant flow preserve metadata and graph module type

### DIFF
--- a/torch/ao/quantization/_quantize_pt2e.py
+++ b/torch/ao/quantization/_quantize_pt2e.py
@@ -82,4 +82,10 @@ def prepare_pt2e_quantizer(
 def convert_pt2e(
     model: GraphModule
 ):
-    return _convert_to_reference_decomposed_fx(model)
+    quantized_model = _convert_to_reference_decomposed_fx(model)
+    # preserve the metadata and type of the original model
+    # TODO: this can be an assert if fx sybmolic tracing also has this by default
+    if hasattr(model, "meta"):
+        quantized_model.meta.update(model.meta)
+    quantized_model.__class__ = type(model)
+    return quantized_model

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -1054,17 +1054,22 @@ def convert(
 
     # remove deadcode after converting observers to quant/dequant ops
     model.graph.eliminate_dead_code()
-    model = GraphModule(model, model.graph)
+    quantized_model = GraphModule(model, model.graph)
+    # preserve the metadata and type of the original model
+    # TODO: this can be an assert if fx sybmolic tracing also has this by default
+    if hasattr(model, "meta"):
+        quantized_model.meta.update(model.meta)
+    quantized_model.__class__ = type(model)
 
     # TODO: maybe move this to quantize_fx.py
     if not is_reference:
-        model = lower_to_fbgemm(model, node_name_to_qconfig, node_name_to_scope)
+        quantized_model = lower_to_fbgemm(quantized_model, node_name_to_qconfig, node_name_to_scope)
 
     # TODO: this looks hacky, we want to check why we need this and see if we can
     # remove this
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:
-        _remove_qconfig(model)
-    model.delete_all_unused_submodules()
-    model.meta.pop("_observed_graph_module_attrs", None)
-    return model
+        _remove_qconfig(quantized_model)
+    quantized_model.delete_all_unused_submodules()
+    quantized_model.meta.pop("_observed_graph_module_attrs", None)
+    return quantized_model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99549

Summary:
att, this is to allow the quant flow to work with graph module produced by
exir capture (not yet oss'ed), it stores some type information for input and output
in model.meta, so we need to preserve these in the meta field

Test Plan:
will be tested internally to make sure users of pt2e quant flow don't need to
explicitly preserve metadata when they use this flow

Reviewers:

Subscribers:

Tasks:

Tags: