### PR TITLE
Improve the precision of abs() and sign() for large values

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -120,13 +120,8 @@ public:
     auto val_2 = _mm256_mul_pd(values, values);     // a*a     b*b
     return _mm256_hadd_pd(val_2, val_2);            // a*a+b*b a*a+b*b
   }
-  __m256d abs_() const {
-    return _mm256_sqrt_pd(abs_2_());                // abs     abs
-  }
   Vectorized<c10::complex<double>> abs() const {
-    const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,
-                                                                     0xFFFFFFFFFFFFFFFF, 0x0000000000000000));
-    return _mm256_and_pd(abs_(), real_mask);        // abs     0
+    return Sleef_hypotd4_u05(real_(), imag().values);
   }
   __m256d angle_() const {
     //angle = atan2(b/a)
@@ -140,14 +135,15 @@ public:
     return _mm256_and_pd(angle, real_mask);         // angle    0
   }
   Vectorized<c10::complex<double>> sgn() const {
-    auto abs = abs_();
+    auto abs_zero = abs().values;             // abs 0
+    auto abs = _mm256_movedup_pd(abs_zero);  // abs abs
+
     auto zero = _mm256_setzero_pd();
     auto mask = _mm256_cmp_pd(abs, zero, _CMP_EQ_OQ);
-    auto abs_val = Vectorized(abs);
 
-    auto div = values / abs_val.values;       // x / abs(x)
+    auto div = values / abs;
 
-    return blendv(div, zero, mask);
+    return _mm256_blendv_pd(div, zero, mask);
   }
   __m256d real_() const {
     const __m256d real_mask = _mm256_castsi256_pd(_mm256_setr_epi64x(0xFFFFFFFFFFFFFFFF, 0x0000000000000000,

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -156,13 +156,8 @@ public:
     auto ret = _mm256_hadd_ps(val_2, val_2);        // a*a+b*b a*a+b*b
     return _mm256_permute_ps(ret, 0xD8);
   }
-  __m256 abs_() const {
-    return _mm256_sqrt_ps(abs_2_());                // abs     abs
-  }
   Vectorized<c10::complex<float>> abs() const {
-    const __m256 real_mask = _mm256_castsi256_ps(_mm256_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
-                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));
-    return _mm256_and_ps(abs_(), real_mask);        // abs     0
+    return Sleef_hypotf8_u05(real_(), imag().values);
   }
   __m256 angle_() const {
     //angle = atan2(b/a)
@@ -176,12 +171,13 @@ public:
     return _mm256_and_ps(angle, real_mask);         // angle    0
   }
   Vectorized<c10::complex<float>> sgn() const {
-    auto abs = abs_();
+    auto abs_zero = abs().values;            // abs 0
+    auto abs = _mm256_moveldup_ps(abs_zero);  // abs abs
+
     auto zero = _mm256_setzero_ps();
     auto mask = _mm256_cmp_ps(abs, zero, _CMP_EQ_OQ);
-    auto abs_val = Vectorized(abs);
 
-    auto div = values / abs_val.values;       // x / abs(x)
+    auto div = values / abs;
 
     return _mm256_blendv_ps(div, zero, mask);
   }

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -174,9 +174,9 @@ public:
     return hadd_pd(val_2, val_2);            // a*a+b*b a*a+b*b
   }
   __m512d abs_() const {
-    auto real = _mm256_movedup_pd(values);        // real real
+    auto real = _mm512_movedup_pd(values);        // real real
     // movehdup_pd does not exist...
-    auto imag = _mm256_permute_pd(values, 0xff);  // imag imag
+    auto imag = _mm512_permute_pd(values, 0xff);  // imag imag
     return Sleef_hypotd8_u05(real, imag);         // abs  abs
   }
   Vectorized<c10::complex<double>> abs() const {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -679,8 +679,17 @@ public:
     auto ret = hadd_ps(val_2, val_2);               // a*a+b*b a*a+b*b
     return ret;
   }
+  __m512 abs_() const {
+    auto real = _mm512_moveldup_ps(values);    // real real
+    auto imag = _mm512_movehdup_ps(values);    // imag imag
+    return Sleef_hypotf16_u05(real, imag);     // abs  abs
+  }
   Vectorized<c10::complex<float>> abs() const {
-    return Sleef_hypotf16_u05(real_(), imag().values);
+    const __m512 real_mask = _mm512_castsi512_ps(_mm512_setr_epi32(0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
+                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
+                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000,
+                                                                   0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000));
+    return _mm512_and_ps(abs_(), real_mask);        // abs     0
   }
   __m512 angle_() const {
     //angle = atan2(b/a)
@@ -696,14 +705,10 @@ public:
     return _mm512_and_ps(angle, real_mask);         // angle    0
   }
   Vectorized<c10::complex<float>> sgn() const {
-    auto abs_zero = abs().values;             // abs 0
-    auto abs = _mm512_moveldup_ps(abs_zero);  // abs abs
-
+    auto abs = abs_();
     auto zero = _mm512_setzero_ps();
     auto mask = _mm512_cmp_ps_mask(abs, zero, _CMP_EQ_OQ);
-
     auto div = values / abs;
-
     return _mm512_mask_blend_ps(mask, div, zero);
   }
   __m512 real_() const {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13181,11 +13181,7 @@ op_db: List[OpInfo] = [
                 toleranceOverride({torch.float16: tol(atol=1e-03, rtol=1.3e-04)}), 'TestUnaryUfuncs',), ],
         skips=(
             DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_small',
-                         dtypes=(torch.int, torch.int8)),
-            # pytorch computes (0+nanj), numpy computes (-5e-18-1j) for input (-501.-1.0000e+20j)
-            DecorateInfo(unittest.expectedFailure, 'TestUnaryUfuncs',
-                         "test_reference_numerics_large", dtypes=(torch.complex64,), device_type='cpu',
-                         active_if=not IS_MACOS and not IS_WINDOWS),),
+                         dtypes=(torch.int, torch.int8)),),
     ),
     UnaryUfuncInfo(
         'nn.functional.tanhshrink',
@@ -14074,14 +14070,6 @@ op_db: List[OpInfo] = [
                        # Reference: https://github.com/pytorch/pytorch/issues/41245
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     dtypes=[torch.bfloat16, torch.float16, torch.float32, torch.float64]),
-                       # Reference: https://github.com/pytorch/pytorch/issues/53958
-                       # Test fails in comparison on Nan as the `equal_nan` is True for
-                       # comparing the CPU tensors.
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                    device_type='cpu', dtypes=[torch.complex64, torch.complex128]),
-                       # Reference: https://github.com/pytorch/pytorch/issues/48486
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
-                                    device_type='cpu', dtypes=[torch.complex64]),
                        DecorateInfo(unittest.skip("Skipped! sparse backward not supported"),
                                     'TestSparseUnaryUfuncs', 'test_sparse_fn_grad'),
                    )),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8884,10 +8884,6 @@ op_db: List[OpInfo] = [
                                     'test_inplace_gradgrad', dtypes=(torch.cdouble,)),
                        DecorateInfo(unittest.skip("In-place abs not supported for complex tensors"), 'TestFwdGradients',
                                     'test_inplace_forward_mode_AD', dtypes=(torch.cdouble,)),
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                    device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
-                       DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_large',
-                                    device_type='cpu', dtypes=[torch.cfloat]),
                        DecorateInfo(unittest.skip("In-place abs not supported for complex tensors"), "TestSparseUnaryUfuncs",
                                     "test_inplace", dtypes=(torch.cdouble, torch.cfloat, torch.chalf)),
                        # Reference: https://github.com/pytorch/pytorch/issues/49224
@@ -18077,18 +18073,7 @@ python_ref_db = [
     #
     ElementwiseUnaryPythonRefInfo(
         "_refs.abs",
-        torch_opinfo_name="abs",
-        skips=(
-            # Reference result was farther (0.0) from the precise computation
-            # than the torch result was (nan)!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref',
-                         dtypes=(torch.chalf,), device_type='cpu', active_if=not (IS_MACOS or IS_WINDOWS)),
-            # Reference result was farther (0.0) from the precise computation
-            # than the torch result was (nan)!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                         dtypes=(torch.chalf,), device_type='cpu', active_if=not (IS_MACOS or IS_WINDOWS)),
-        )
-    ),
+        torch_opinfo_name="abs"),
     ElementwiseUnaryPythonRefInfo(
         "_refs.acos",
         torch_opinfo_name="acos",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99550

@ev-br found in
https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/117#issuecomment-1514959633
that the precision of `abs()` for large values in the vectorised case is less-than-good.
This PR fixes this issue. While doing that, we are able to comment out a
few tests on extremal values.

Fixes https://github.com/pytorch/pytorch/issues/53958 https://github.com/pytorch/pytorch/issues/48486

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10