### PR TITLE
[memory allocator] fix ifdef typo

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -803,7 +803,7 @@ class CachingAllocatorConfig {
   }
 
   static bool expandable_segments() {
-#ifndef EXPANDABLE_SEGMENTS_SUPPORTED
+#ifndef PYTORCH_EXPANDABLE_SEGMENTS_SUPPORTED
     if (instance().m_expandable_segments) {
       TORCH_WARN_ONCE("expandable_segments not supported on this platform")
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99553
* #99275

First PR went in with the expandable allocator accidentally disabled
which happened trying to fix the build on weird architectures.