### PR TITLE
[BE] `stdint.h`->`cstdint`

### DIFF
--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <stdint.h>
 #include <mutex>
 #include <deque>
 #include <atomic>
 #include <typeinfo>
 #include <utility>
 #include <cstddef>
+#include <cstdint>
 
 #include <c10/util/Exception.h>
 #include <c10/util/C++17.h>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf8834b</samp>

Updated `Generator.h` to use C++ fixed-width integers from `std` instead of C ones. This avoids potential conflicts with other libraries or platforms.
