### PR TITLE
[SPMD] Allow users to dynamically pass the last_iter to IterGraphModule

### DIFF
--- a/torch/distributed/_spmd/api.py
+++ b/torch/distributed/_spmd/api.py
@@ -574,6 +574,7 @@ def compile(
     def inner(func: Callable):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            last_train_step = kwargs.pop("last_train_step", False) if kwargs else False
             first_iter = False
             # Put the COMPILED_OBJECT_KEY in ``wrapper`` instead of ``func`` as
             # ``wrapper`` is the one that users will get.
@@ -592,7 +593,21 @@ def compile(
                     # TODO: SPMD should provid a default and configurable
                     # transformation.
                     compiled_obj.gm = gm_transformation(compiled_obj.gm)
-                output = compiled_obj.gm(*flat_inps)[0]
+                if not last_train_step:
+                    output = compiled_obj.gm(*flat_inps)[0]
+                else:
+                    # This is the last train step. Call IterGraphModule.forward()
+                    # with the `last_iter` argument and catch the exception in
+                    # case the compiled_obj is not wrapped with IterGraphModule.
+                    try:
+                        output = compiled_obj.gm(*flat_inps, last_iter=last_train_step)[
+                            0
+                        ]
+                    except TypeError as e:
+                        if "last_iter" not in str(e):
+                            raise e
+                        output = compiled_obj.gm(*flat_inps)[0]
+
                 return output
 
         return wrapper

--- a/torch/distributed/_spmd/gm_transformation.py
+++ b/torch/distributed/_spmd/gm_transformation.py
@@ -14,13 +14,11 @@ from torch.distributed._spmd.iter_graph_module import IterGraphModule
 class GraphModuleTransformation:
     def __init__(
         self,
-        num_iters: int,
         *,
         enable_graph_optimization: bool = False,
         enable_inductor: bool = False,
         dump_graphs: bool = False,
     ) -> None:
-        self.num_iters = num_iters
         self.enable_graph_optimization = enable_graph_optimization
         self.enable_inductor = enable_inductor
         self.dump_graphs = dump_graphs
@@ -38,7 +36,7 @@ class GraphModuleTransformation:
             schedule_comm_wait(iter_gm)
             remove_copy_from_optimizer(iter_gm)
         # Must be called after we are not going to move the graphs
-        iter_gm.setup(self.num_iters)
+        iter_gm.finalize_setup()
 
         if self.dump_graphs:
             dump_graphs_to_files(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99575

The current design of IterGraphModule requires users to specify the concrete iteration count which is not always possible and not very precise. This PR introduce `last_iter` to IterGraphModule.forward() which allows users to dynamically specify the last iteration.

Differential Revision: [D45129585](https://our.internmc.facebook.com/intern/diff/D45129585/)