### PR TITLE
Allow torch.fx to take Modules that return dataclass

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -7,6 +7,9 @@ import operator
 import traceback
 import collections
 
+from dataclasses import is_dataclass, fields
+
+
 from .graph import magic_methods, reflectable_magic_methods, Graph
 from typing import Tuple, Dict, OrderedDict, Optional, Iterable, Any, Iterator, Callable
 from .node import Target, Node, Argument, base_types, map_aggregate
@@ -258,6 +261,11 @@ class TracerBase:
         if isinstance(a, Proxy):
             # base case: we unwrap the Proxy object
             return a.node
+
+        if is_dataclass(a):
+            kwargs = {field.name: self.create_arg(getattr(a, field.name)) for field in fields(a)}
+            return self.create_node("call_function", a.__class__, (), kwargs)
+
         elif isinstance(a, base_types) or a is None or a is ...:
             return a
         raise NotImplementedError(f"argument of type: {type(a)}")


### PR DESCRIPTION
Summary:
Currently torch.fx support Modules with input of namedtuple/dataclass, return as namedtuple, but does not allow Module.forward to return a dataclass, running `test_trace_return_dataclass` without this change will have following error:

  NotImplementedError: argument of type: <class 'test_fx.TestFX.test_trace_return_dataclass.<locals>.MyOutput'>
  File "test_trace_return_dataclass
    traced_graph = symbolic_trace(module).graph
  File "test/__fx__/fx#link-tree/torch/fx/_symbolic_trace.py", line 1114, in symbolic_trace
    graph = tracer.trace(root, concrete_args)
  File "test/__fx__/fx#link-tree/torch/fx/_symbolic_trace.py", line 783, in trace
    (self.create_arg(fn(*args)),),
  File "test/__fx__/fx#link-tree/torch/fx/_symbolic_trace.py", line 378, in create_arg
    return super().create_arg(a)
  File "test/__fx__/fx#link-tree/torch/fx/proxy.py", line 269, in create_arg
    raise NotImplementedError(f"argument of type: {type(a)}")

this diff handle dataclass type.

Test Plan:
buck test @//mode/opt @//mode/inplace //caffe2/test:fx -- test_trace_

  graph():
    %d : torch.Tensor [#users=1] = placeholder[target=d]
    %my_output : [#users=1] = call_function[target=test_fx.MyOutput](args = (), kwargs = {foo: %d, bar: %d})
    return my_output

Differential Revision: D44916519

