### PR TITLE
Revert "Build Windows binaries with Visual Studio 2022 Build Tools (#90855)

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,7 +8,7 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache
 export SCCACHE_IGNORE_SERVER_IO_ERROR=1
-export VC_YEAR=2022
+export VC_YEAR=2019
 
 if [[ "${DESIRED_CUDA}" =~ cu1[1-2][0-9] ]]; then
     export BUILD_SPLIT_CUDA=ON

--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 source "${BINARY_ENV_FILE:-/c/w/env}"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
-export VC_YEAR=2022
+export VC_YEAR=2019
 
 pushd "$BUILDER_ROOT"
 


### PR DESCRIPTION
This reverts commit a88c15a849152291b1ebdab13860726dd8be1d81.  Once we have the AMI ready, we can revert this and use VS2022 again.  This is to mitigate flaky Windows build in trunk https://github.com/pytorch/builder/issues/1387.  

Note that as VS2019 is already available in the current AMI, it won't be installed again per logic in https://github.com/pytorch/builder/blob/main/windows/internal/vs2019_install.ps1#L25-L29. Thus, this helps avoid the flaky installation issue.