### PR TITLE
[caffe2] Enable xplat compilation of ovrsource flavors

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -122,7 +122,7 @@ def get_glsl_paths():
 
     if len(paths) % 2 != 0:
         fail(
-            "gen_vulkan_spv.additional_glsl_paths must contain an even number of elements"
+            "gen_vulkan_spv.additional_glsl_paths must contain an even number of elements",
         )
 
     return " ".join(
@@ -136,7 +136,7 @@ def get_glsl_paths():
                 len(paths),
                 2,
             )
-        ]
+        ],
     )
 
 # @lint-ignore BUCKRESTRICTEDSYNTAX
@@ -175,8 +175,8 @@ THIRD_PARTY_LIBS = {
     "pyyaml": ["//third-party/pyyaml:pyyaml", "//third_party:pyyaml"],
     "rt": ["//xplat/third-party/linker_lib:rt", "//third_party:rt"],
     "ruy": ["//third-party/ruy:ruy_xplat_lib", "//third_party:ruy_lib"],
-    "typing-extensions": ["//third-party/typing-extensions:typing-extensions", "//third_party:typing-extensions"],
     "sleef_arm": ["//third-party/sleef:sleef_arm", "//third_party:sleef_arm"],
+    "typing-extensions": ["//third-party/typing-extensions:typing-extensions", "//third_party:typing-extensions"],
 }
 
 def third_party(name):
@@ -675,9 +675,7 @@ def gen_aten_libtorch_files(name, extra_params = [], compatible_with = [], apple
         default_outs = ["."],
         bash = "mkdir -p tools && " +
                "$(exe {}tools:generate_code_bin) ".format(ROOT_PATH) + " ".join(
-            # Mobile build only needs libtorch - skip python bindings for now, except
-            # for ovrsource, which needs Python bindings.
-            (["--subset libtorch"] if not is_arvr_mode() else []) + [
+            [
                 "--native-functions-path $(location {}:aten_src_path)/aten/src/ATen/native/native_functions.yaml".format(ROOT),
                 "--tags-path $(location {}:aten_src_path)/aten/src/ATen/native/tags.yaml".format(ROOT),
                 "--install_dir $OUT",
@@ -685,9 +683,7 @@ def gen_aten_libtorch_files(name, extra_params = [], compatible_with = [], apple
         ),
         cmd_exe = "@powershell -Command New-Item -Path tools -ItemType Directory -Force; " +
                   "$(exe {}tools:generate_code_bin) ".format(ROOT_PATH) + " ".join(
-            # Mobile build only needs libtorch - skip python bindings for now, except
-            # for ovrsource, which needs Python bindings.
-            (["--subset libtorch"] if not is_arvr_mode() else []) + [
+            [
                 "--native-functions-path $(location {}:aten_src_path)/aten/src/ATen/native/native_functions.yaml".format(ROOT),
                 "--tags-path $(location {}:aten_src_path)/aten/src/ATen/native/tags.yaml".format(ROOT),
                 "--install_dir $OUT",
@@ -1948,7 +1944,7 @@ def define_buck_targets(
             ] + select({
                 "DEFAULT": [],
                 "ovr_config//runtime:fbcode-arm64": [
-                  third_party("sleef_arm"),
+                    third_party("sleef_arm"),
                 ],
             }),
             compiler_flags = get_aten_compiler_flags(),

--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -35,6 +35,7 @@ def define_c10_ovrsource(name, is_mobile):
             "ovr_config//compiler:cl": [
                 "/w",
             ],
+            "ovr_config//compiler:clang": ["-fexceptions"],
             "ovr_config//toolchain/clang:win": [
                 "-Wno-error",
                 "-Wno-shadow",
@@ -159,7 +160,7 @@ def define_ovrsource_targets():
     oxx_static_library(
         name = "c10_ovrsource",
         compatible_with = cpu_supported_platforms,
-        exported_deps = select({
+        public_deps = select({
             "DEFAULT": [":c10_full_ovrsource"],
             "ovr_config//os:android": [":c10_mobile_ovrsource"],
             "ovr_config//os:iphoneos": [":c10_mobile_ovrsource"],

--- a/pt_template_srcs.bzl
+++ b/pt_template_srcs.bzl
@@ -3,7 +3,6 @@
 # being built
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load(":build_variables.bzl", "aten_native_source_list")
 load(
     ":ufunc_defs.bzl",
@@ -111,7 +110,7 @@ def get_gen_oplist_outs():
     }
 
 def get_generate_code_bin_outs():
-    outs = {
+    return {
         "autograd/generated/ADInplaceOrViewTypeEverything.cpp": ["autograd/generated/ADInplaceOrViewTypeEverything.cpp"],
         "autograd/generated/ADInplaceOrViewType_0.cpp": ["autograd/generated/ADInplaceOrViewType_0.cpp"],
         "autograd/generated/ADInplaceOrViewType_1.cpp": ["autograd/generated/ADInplaceOrViewType_1.cpp"],
@@ -130,31 +129,26 @@ def get_generate_code_bin_outs():
         "autograd/generated/VariableType_2.cpp": ["autograd/generated/VariableType_2.cpp"],
         "autograd/generated/VariableType_3.cpp": ["autograd/generated/VariableType_3.cpp"],
         "autograd/generated/VariableType_4.cpp": ["autograd/generated/VariableType_4.cpp"],
+        "autograd/generated/python_enum_tag.cpp": ["autograd/generated/python_enum_tag.cpp"],
+        "autograd/generated/python_fft_functions.cpp": ["autograd/generated/python_fft_functions.cpp"],
+        "autograd/generated/python_functions.h": ["autograd/generated/python_functions.h"],
+        "autograd/generated/python_functions_0.cpp": ["autograd/generated/python_functions_0.cpp"],
+        "autograd/generated/python_functions_1.cpp": ["autograd/generated/python_functions_1.cpp"],
+        "autograd/generated/python_functions_2.cpp": ["autograd/generated/python_functions_2.cpp"],
+        "autograd/generated/python_functions_3.cpp": ["autograd/generated/python_functions_3.cpp"],
+        "autograd/generated/python_functions_4.cpp": ["autograd/generated/python_functions_4.cpp"],
+        "autograd/generated/python_linalg_functions.cpp": ["autograd/generated/python_linalg_functions.cpp"],
+        "autograd/generated/python_nested_functions.cpp": ["autograd/generated/python_nested_functions.cpp"],
+        "autograd/generated/python_nn_functions.cpp": ["autograd/generated/python_nn_functions.cpp"],
+        "autograd/generated/python_return_types.cpp": ["autograd/generated/python_return_types.cpp"],
+        "autograd/generated/python_sparse_functions.cpp": ["autograd/generated/python_sparse_functions.cpp"],
+        "autograd/generated/python_special_functions.cpp": ["autograd/generated/python_special_functions.cpp"],
+        "autograd/generated/python_torch_functions_0.cpp": ["autograd/generated/python_torch_functions_0.cpp"],
+        "autograd/generated/python_torch_functions_1.cpp": ["autograd/generated/python_torch_functions_1.cpp"],
+        "autograd/generated/python_torch_functions_2.cpp": ["autograd/generated/python_torch_functions_2.cpp"],
+        "autograd/generated/python_variable_methods.cpp": ["autograd/generated/python_variable_methods.cpp"],
         "autograd/generated/variable_factories.h": ["autograd/generated/variable_factories.h"],
     }
-
-    if is_arvr_mode():
-        outs.update({
-            "autograd/generated/python_enum_tag.cpp": ["autograd/generated/python_enum_tag.cpp"],
-            "autograd/generated/python_fft_functions.cpp": ["autograd/generated/python_fft_functions.cpp"],
-            "autograd/generated/python_functions.h": ["autograd/generated/python_functions.h"],
-            "autograd/generated/python_functions_0.cpp": ["autograd/generated/python_functions_0.cpp"],
-            "autograd/generated/python_functions_1.cpp": ["autograd/generated/python_functions_1.cpp"],
-            "autograd/generated/python_functions_2.cpp": ["autograd/generated/python_functions_2.cpp"],
-            "autograd/generated/python_functions_3.cpp": ["autograd/generated/python_functions_3.cpp"],
-            "autograd/generated/python_functions_4.cpp": ["autograd/generated/python_functions_4.cpp"],
-            "autograd/generated/python_linalg_functions.cpp": ["autograd/generated/python_linalg_functions.cpp"],
-            "autograd/generated/python_nested_functions.cpp": ["autograd/generated/python_nested_functions.cpp"],
-            "autograd/generated/python_nn_functions.cpp": ["autograd/generated/python_nn_functions.cpp"],
-            "autograd/generated/python_return_types.cpp": ["autograd/generated/python_return_types.cpp"],
-            "autograd/generated/python_sparse_functions.cpp": ["autograd/generated/python_sparse_functions.cpp"],
-            "autograd/generated/python_special_functions.cpp": ["autograd/generated/python_special_functions.cpp"],
-            "autograd/generated/python_torch_functions_0.cpp": ["autograd/generated/python_torch_functions_0.cpp"],
-            "autograd/generated/python_torch_functions_1.cpp": ["autograd/generated/python_torch_functions_1.cpp"],
-            "autograd/generated/python_torch_functions_2.cpp": ["autograd/generated/python_torch_functions_2.cpp"],
-            "autograd/generated/python_variable_methods.cpp": ["autograd/generated/python_variable_methods.cpp"],
-        })
-    return outs
 
 def get_template_registration_files_outs(is_oss = False):
     outs = {}


### PR DESCRIPTION
Summary: Instead of redirecting to empty targets in xplat build modes, enable compilation of ovrsource flavors in xplat build modes.

Reviewed By: 0ctavius

Differential Revision: D44529823

