### PR TITLE
Skip some detectron2_maskrcnn models with KeyError _ignore_torch_cuda_oom

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -84,6 +84,11 @@ CI_SKIP[CI("eager", training=False)] = [
     "torchrec_dlrm",
     # Huggingface
     "DebertaV2ForQuestionAnswering",  # OOM
+    # KeyError: '_ignore_torch_cuda_oom'
+    "detectron2_maskrcnn_r_101_c4",
+    "detectron2_maskrcnn_r_101_fpn",
+    "detectron2_maskrcnn_r_50_c4",
+    "detectron2_maskrcnn_r_50_fpn",
 ]
 
 CI_SKIP[CI("eager", training=True)] = [


### PR DESCRIPTION
These tests are failing in trunk https://hud.pytorch.org/pytorch/pytorch/commit/233cc34d3b8a1b92eeeea78661463f8ec660fbcd with `KeyError: '_ignore_torch_cuda_oom'`

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire