### PR TITLE
Feature/fsdp use orig param rank0 only load osd

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -936,8 +936,7 @@ class TestFSDPOptimState(FSDPTest):
             fsdp_kwargs={"use_orig_params": True},
         )
 
-        # Enable this once use_orig_params supports rank0_only=Treu
-        """
+        # Passed
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,
             state_dict_settings=StateDictSettings(
@@ -952,7 +951,6 @@ class TestFSDPOptimState(FSDPTest):
             num_iters=3,
             fsdp_kwargs={"use_orig_params": True},
         )
-        """
 
         self._test_load_optim_state_with_optim_state_dict(
             _ModelClass.NESTED,

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1768,3 +1768,87 @@ def _shard_orig_param_state(
             value = value.flatten()[intra_param_start_idx : intra_param_end_idx + 1]
         new_optim_state[state_name] = value
     return new_optim_state
+
+
+def _scatter_orig_param_optim_state_dict(
+    optim_state_dict: Dict[str, Any],
+    model: nn.Module,
+    optim: Optional[torch.optim.Optimizer] = None,
+    group: Optional[dist.ProcessGroup] = None,
+) -> Dict[str, Any]:
+    """
+    TODO
+    This function derived from ``_flatten_optim_state_dict``.
+
+
+    Returns:
+        Dict[str, Any]: The sharded optimizer state dict.
+    """
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+    unflat_osd = optim_state_dict
+    if rank == 0 and ("state" not in unflat_osd or "param_groups" not in unflat_osd):
+        raise ValueError(
+            '`optim_state_dict` must have the keys "state" and '
+            '"param_groups" to be a valid optimizer state dict'
+        )
+
+    # Broadcast emtpy osd that the state keys and param groups reserved.
+    # TODO
+
+    param_to_fqns = _get_param_to_fqns(model)
+    fqn_to_fsdp_param_info = _get_fqn_to_fsdp_param_info(model)
+
+    # Construct the "state" part
+    flat_osd_state: Dict[Union[_OptimStateKey, str], Any] = {}
+    unflat_osd_state = unflat_osd["state"]
+    all_state_keys = set(unflat_osd_state.keys())
+
+    # local_state_dict is used to construct states of empty parameters.
+    # This should only be used if is_named_optimizer=True.
+    local_state_dict: Dict[str, Any] = {}
+    local_state_clean_fqns: Dict[str, str] = {}
+    if optim is not None:
+        local_state_dict = optim.state_dict()["state"]
+        for fqn in local_state_dict.keys():
+            clean_fqn = clean_tensor_name(fqn)
+            local_state_clean_fqns[clean_fqn] = fqn
+
+    for fqns in param_to_fqns.values():
+        fqn = fqns[0]
+        if fqn not in unflat_osd_state:
+            continue
+        all_state_keys.difference_update(fqns)
+        if fqn in fqn_to_fsdp_param_info:
+            fsdp_param_info = fqn_to_fsdp_param_info[fqn]
+            flat_state = _shard_orig_param_state(  # TODO
+                fsdp_param_info,
+                fqn,
+                unflat_osd_state[fqn],
+            )
+            key = _OptimStateKey(tuple(fqns), True)
+            # Only include non-empty states since as expected by
+            # `torch.optim.Optimizer` s unless the optimizer is KeyedOptimizer
+            # or NamedOptimizer.
+            if flat_state:
+                flat_osd_state[key] = flat_state
+            elif optim is not None:  # NamedOptimizer or KeyedOptimizer case.
+                assert len(fqns) == 1
+                local_wrapped_fqn = local_state_clean_fqns.get(fqn, "")
+                if local_wrapped_fqn:
+                    flat_osd_state[key] = copy.deepcopy(
+                        local_state_dict[local_wrapped_fqn]
+                    )
+        else:  # do not flatten non-FSDP parameters' states
+            assert len(fqns) == 1
+            key = _OptimStateKey(tuple(fqns), False)
+            flat_osd_state[key] = copy.copy(unflat_osd_state[fqn])
+
+    # Handle user-defined state, states that are not associated with parameters.
+    for key in all_state_keys:
+        flat_osd_state[key] = copy.copy(unflat_osd_state[key])
+
+    # Construct the "param_groups" part -- copy as is since it will be
+    # rekeyed later according to the target rank's optimizer
+    flat_osd_param_groups = copy.deepcopy(unflat_osd["param_groups"])
+    return {"state": flat_osd_state, "param_groups": flat_osd_param_groups}

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1810,7 +1810,7 @@ def _scatter_orig_param_optim_state_dict(
                 info = _PosDimTensorInfo(value.shape, value.dtype)
                 no_tensor_osd["state"][key][state_name] = info
         no_tensor_osd["param_groups"] = unflat_osd["param_groups"]
-    obj_list = [no_tensor_osd] if rank == 0 else [None]
+    obj_list = [no_tensor_osd] if rank == 0 else [None]  # type: ignore[list-item]
     dist.broadcast_object_list(obj_list, src=0, group=group)
     no_tensor_osd = obj_list[0]  # type: ignore[assignment]
     assert no_tensor_osd is not None

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1889,6 +1889,9 @@ def _scatter_orig_param_optim_state_dict(
                         )
                     dist.broadcast(broadcast_tensor, src=0, group=group)
                     non_FSDP_optim_state[state_name] = broadcast_tensor
+                else:
+                    # Save value if not a positive-dimension tensor
+                    non_FSDP_optim_state[state_name] = value
             flat_osd_state[key] = non_FSDP_optim_state
 
     # Handle user-defined state, states that are not associated with parameters.
@@ -1960,6 +1963,10 @@ def _scatter_orig_param_state(
                     non_zero_rank_optim_state[state_name] = sharded_tensor
                 else:
                     del sharded_tensor
+            else:
+                # Save value on target rank if not a positive-dimension tensor
+                if rank == target_rank:
+                    non_zero_rank_optim_state[state_name] = value
 
     # Lastly, shard on rank 0
     if rank != 0:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -90,6 +90,7 @@ from ._optim_utils import (
     _optim_state_dict,
     _process_pos_dim_tensor_state,
     _rekey_sharded_optim_state_dict,
+    _scatter_orig_param_optim_state_dict,
 )
 from ._state_dict_utils import _register_all_state_dict_hooks
 from ._unshard_param_utils import (
@@ -1293,7 +1294,20 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                     is_named_optimizer=is_named_optimizer,
                 )
             else:
-                raise NotImplementedError("TODO")
+                sharded_osd = _scatter_orig_param_optim_state_dict(
+                    optim_state_dict,
+                    model=model,
+                    optim=(optim if is_named_optimizer else None),
+                    group=group,
+                )
+                ret_state_dict = _rekey_sharded_optim_state_dict(
+                    sharded_osd,
+                    model=model,
+                    optim=optim,
+                    optim_input=optim_input,
+                    using_optim_input=using_optim_input,
+                    is_named_optimizer=is_named_optimizer,
+                )
         else:
             sharded_osd = _flatten_optim_state_dict(
                 optim_state_dict,


### PR DESCRIPTION
Support fsdp load optimizer state dict in rank0_only style (deprecated scatter_full_optim_state_dict) when use_orig_param is True.
Related discuss with @fegin in this PR #99136 
This implementation broadcasts no_tenosr_osd with _PosDimTensorInfo, and call ``_scatter_orig_param_state`` to shard and scatter FSDP parameters' states. ``_scatter_orig_param_state``broadcasts the _shard_param_infos to shard positive-dimension tensor and broadcast back.
The UT related exposed again and passed.