### PR TITLE
enable dispatch stub for backend PrivateUse1

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -131,8 +131,8 @@ void* DispatchStubImpl::get_call_ptr(
 #endif
 
     case DeviceType::PrivateUse1:
-      TORCH_INTERNAL_ASSERT(private_use1_dispatch_ptr, "DispatchStub: missing PrivateUse1 kernel");
-      return private_use1_dispatch_ptr;
+      TORCH_INTERNAL_ASSERT(privateuse1_dispatch_ptr, "DispatchStub: missing PrivateUse1 kernel");
+      return privateuse1_dispatch_ptr;
 
     default:
       AT_ERROR("DispatchStub: unsupported device type", device_type);

--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -130,6 +130,10 @@ void* DispatchStubImpl::get_call_ptr(
       return mps_dispatch_ptr;
 #endif
 
+    case DeviceType::PrivateUse1:
+      TORCH_INTERNAL_ASSERT(private_use1_dispatch_ptr, "DispatchStub: missing PrivateUse1 kernel");
+      return private_use1_dispatch_ptr;
+
     default:
       AT_ERROR("DispatchStub: unsupported device type", device_type);
   }

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -114,13 +114,13 @@ struct TORCH_API DispatchStubImpl {
     void* cuda_dispatch_ptr;
     void* hip_dispatch_ptr;
     void* mps_dispatch_ptr;
-    void* private_use1_dispatch_ptr;
+    void* privateuse1_dispatch_ptr;
   #else
     std::atomic<void*> cpu_dispatch_ptr{nullptr};
     void* cuda_dispatch_ptr = nullptr;
     void* hip_dispatch_ptr = nullptr;
     void* mps_dispatch_ptr = nullptr;
-    void* private_use1_dispatch_ptr = nullptr;
+    void* privateuse1_dispatch_ptr = nullptr;
   #endif
 };
 
@@ -172,8 +172,8 @@ public:
     impl.mps_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
   }
 
-  void set_private_use1_dispatch_ptr(FnPtr fn_ptr) {
-    impl.private_use1_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
+  void set_privateuse1_dispatch_ptr(FnPtr fn_ptr) {
+    impl.privateuse1_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
   }
 
   static TORCH_API FnPtr DEFAULT;
@@ -213,6 +213,13 @@ struct RegisterHIPDispatch {
   RegisterHIPDispatch(DispatchStub &stub, typename DispatchStub::FnPtr value) {
     // TODO: make this point at hip_dispatch_ptr
     stub.set_cuda_dispatch_ptr(value);
+  }
+};
+
+template <typename DispatchStub>
+struct RegisterPRIVATEUSE1Dispatch {
+  RegisterPRIVATEUSE1Dispatch(DispatchStub &stub, typename DispatchStub::FnPtr value) {
+    stub.set_privateuse1_dispatch_ptr(value);
   }
 };
 
@@ -279,6 +286,9 @@ struct RegisterHIPDispatch {
 
 #define REGISTER_MPS_DISPATCH(name, fn) \
   static RegisterMPSDispatch<struct name> name ## __register(name, fn);
+
+#define REGISTER_PRIVATEUSE1_DISPATCH(name, fn) \
+  static RegisterPRIVATEUSE1Dispatch<struct name> name ## __register(name, fn);
 
 // NB: This macro must be used in an actual 'cu' file; if you try using
 // it from a 'cpp' file it will not work!

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -114,11 +114,13 @@ struct TORCH_API DispatchStubImpl {
     void* cuda_dispatch_ptr;
     void* hip_dispatch_ptr;
     void* mps_dispatch_ptr;
+    void* private_use1_dispatch_ptr;
   #else
     std::atomic<void*> cpu_dispatch_ptr{nullptr};
     void* cuda_dispatch_ptr = nullptr;
     void* hip_dispatch_ptr = nullptr;
     void* mps_dispatch_ptr = nullptr;
+    void* private_use1_dispatch_ptr = nullptr;
   #endif
 };
 
@@ -168,6 +170,10 @@ public:
 
   void set_mps_dispatch_ptr(FnPtr fn_ptr) {
     impl.mps_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
+  }
+
+  void set_private_use1_dispatch_ptr(FnPtr fn_ptr) {
+    impl.private_use1_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
   }
 
   static TORCH_API FnPtr DEFAULT;

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -1,5 +1,7 @@
 #include <c10/core/impl/alloc_cpu.h>
 #include <c10/core/Allocator.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/ArrayRef.h>
 
 #include <torch/csrc/Device.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
@@ -10,7 +12,6 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/UnaryOps.h>
-#include <ATen/native/cpu/Loops.h>
 #include <ATen/ops/abs_native.h>
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
@@ -19,6 +20,8 @@ static uint64_t add_counter = 0;
 static uint64_t last_saved_value = 0;
 static c10::DeviceIndex custom_device_index = 0;
 
+static uint64_t abs_counter = 0;
+static uint64_t last_abs_saved_value = 0;
 // register guard
 namespace at {
 namespace detail {
@@ -27,100 +30,20 @@ C10_REGISTER_GUARD_IMPL(PrivateUse1, c10::impl::NoOpDeviceGuardImpl<DeviceType::
 
 }} // namespace at::detail
 
-struct CustomBackendMetadata : public c10::BackendMeta {
-  // for testing this field will mutate when clone() is called by shallow_copy_from.
-  int backend_version_format_{-1};
-  int format_number_{-1};
-  mutable bool cloned_{false};
-  // define the constructor
-  CustomBackendMetadata(int backend_version_format, int format_number): backend_version_format_(backend_version_format), format_number_(format_number) {}
-  c10::intrusive_ptr<c10::BackendMeta> clone(const c10::intrusive_ptr<c10::BackendMeta>& ptr) const override {
-    cloned_ = true;
-    return c10::BackendMeta::clone(ptr);
-  }
-};
-
-// we need to register two functions for serialization
-void for_serialization(const at::Tensor& t, std::unordered_map<std::string, bool>& m) {
-  if (t.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr() == nullptr) {
-    return;
-  }
-  CustomBackendMetadata* tmeta = dynamic_cast<CustomBackendMetadata*>(t.unsafeGetTensorImpl()->get_backend_meta());
-  if (tmeta->backend_version_format_ == 1) {
-    m["backend_version_format"] = true;
-  }
-  if (tmeta->format_number_ == 29) {
-    m["format_number"] = true;
-  }
-}
-
-void for_deserialization(const at::Tensor& t, std::unordered_map<std::string, bool>& m) {
-  int backend_version_format{-1};
-  int format_number{-1};
-  if (m.find("backend_version_format") != m.end()) {
-    backend_version_format = 1;
-  }
-  if (m.find("format_number") != m.end()) {
-    format_number = 29;
-  }
-  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(new CustomBackendMetadata(backend_version_format, format_number))};
-  t.unsafeGetTensorImpl()->set_backend_meta(new_tmeta);
-}
-
-void custom_serialization_registry(){
-torch::jit::TensorBackendMetaRegistry(c10::DeviceType::PrivateUse1, &for_serialization, &for_deserialization);
-}
-
-//check if BackendMeta serialization correctly
-bool check_backend_meta(const at::Tensor& t) {
-  if (t.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr()) {
-    CustomBackendMetadata* tmeta = dynamic_cast<CustomBackendMetadata*>(t.unsafeGetTensorImpl()->get_backend_meta());
-    if (tmeta->backend_version_format_==1 && tmeta->format_number_==29) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// a fake set function is exposed to the Python side
-void custom_set_backend_meta(const at::Tensor& t) {
-  int backend_version_format{1};
-  int format_number{29};
-  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(new CustomBackendMetadata(backend_version_format, format_number))};
-  t.unsafeGetTensorImpl()->set_backend_meta(new_tmeta);
-}
-
 namespace {
 
-template <typename T>
-static T abs_impl(T v) {
-  return std::abs(v);
+void abs_kernel(::at::TensorIteratorBase& iter) {
+  // Since this custom device is just for testing, not bothering to implement kernels.
+  abs_counter += 1;
 }
 
-template <>
-C10_UNUSED uint8_t abs_impl(uint8_t v) {
-  return v;
-}
+} // namespace
 
-void abs_kernel(TensorIteratorBase& iter) {
-  auto dtype = iter.dtype();
-  if (dtype == kComplexHalf) {
-    using scalar_t = c10::complex<Half>;
-    using opmath_t = at::opmath_type<scalar_t>;
-    cpu_kernel(iter, [=](scalar_t a) -> scalar_t { return abs_impl(opmath_t{a}); });
-  } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "abs_cpu", [&]() {
-      cpu_kernel_vec(
-          iter,
-          [=](scalar_t a) -> scalar_t { return abs_impl(a); },
-          [=](Vectorized<scalar_t> a) { return a.abs(); });
-    });
-  }
-}
+namespace at::native {
 
 REGISTER_PRIVATEUSE1_DISPATCH(abs_stub, &abs_kernel);
 
-} // namespace
+} // namespace at::native
 
 // basic dummy add function
 at::Tensor custom_add_Tensor(const at::Tensor & self, const at::Tensor & other, const at::Scalar & alpha) {
@@ -130,7 +53,7 @@ at::Tensor custom_add_Tensor(const at::Tensor & self, const at::Tensor & other, 
 }
 
 // basic abs function
-at::Tensor & abs_out(at::Tensor & out, const at::Tensor & self) {
+at::Tensor& custom_abs_out(const at::Tensor& self, at::Tensor& out) {
   return at::native::abs_out(self, out);
 }
 
@@ -256,7 +179,7 @@ const at::Tensor& custom_resize_(const at::Tensor& self, at::IntArrayRef size,
 // This macro registers your kernels to the PyTorch Dispatcher.
 // More details on the dispatcher can be found at http://blog.ezyang.com/2020/09/lets-talk-about-the-pytorch-dispatcher/.
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
-  m.impl("abs.out", &abs_out);
+  m.impl("abs.out", &custom_abs_out);
   m.impl("add.Tensor", &custom_add_Tensor);
   m.impl("empty.memory_format", &custom_empty_symint);
   m.impl("fill_.Scalar", &custom_fill__scalar);
@@ -282,6 +205,15 @@ bool custom_add_called() {
   if (add_counter > last_saved_value) {
     called = true;
     last_saved_value = add_counter;
+  }
+  return called;
+}
+
+bool custom_abs_called() {
+  bool called = false;
+  if (abs_counter > last_abs_saved_value) {
+    called = true;
+    last_abs_saved_value = abs_counter;
   }
   return called;
 }
@@ -316,6 +248,7 @@ void set_custom_device_index(c10::DeviceIndex device_index) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("custom_device", &get_custom_device, "get custom device object");
     m.def("custom_add_called", &custom_add_called, "check if our custom add function was called");
+    m.def("custom_abs_called", &custom_abs_called, "check if our custom abs function was called");
     m.def("register_generator", &register_generator, "register generator for custom device");
     m.def("set_custom_device_index", &set_custom_device_index, "set custom device index");
 }

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -173,9 +173,11 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         def test_open_device_dispatchstub():
             # test kernels could be reused by privateuse1 backend through dispatchstub
             torch.utils.rename_privateuse1_backend('foo')
-            input_data = torch.randn(3, 4, 5, dtype=torch.float32, device='cpu')
-            foo_input_data = input_data.to('foo')
-            self.assertTrue(torch.abs(input_data) == torch.abs(foo_input_data).to('cpu'))
+            input_data = torch.randn(3, 4, 5, dtype=torch.float32, device="cpu")
+            foo_input_data = input_data.to("foo")
+            self.assertFalse(self.module.custom_abs_called())
+            torch.abs(foo_input_data)
+            self.assertTrue(self.module.custom_abs_called())
 
         def test_open_device_random():
             with torch.random.fork_rng(device_type="foo"):

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -170,6 +170,13 @@ class TestCppExtensionOpenRgistration(common.TestCase):
                                         "Only can register a generator to the PrivateUse1 dispatch key once"):
                 self.module.register_generator()
 
+        def test_open_device_dispatchstub():
+            # test kernels could be reused by privateuse1 backend through dispatchstub
+            torch.utils.rename_privateuse1_backend('foo')
+            input_data = torch.randn(3, 4, 5, dtype=torch.float32, device='cpu')
+            foo_input_data = input_data.to('foo')
+            self.assertTrue(torch.abs(input_data) == torch.abs(foo_input_data).to('cpu'))
+
         def test_open_device_random():
             with torch.random.fork_rng(device_type="foo"):
                 pass
@@ -286,6 +293,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_common_registration()
         test_after_common_registration()
         test_generator_registration()
+        test_open_device_dispatchstub()
         test_open_device_random()
         test_open_device_tensor()
         test_open_device_storage()


### PR DESCRIPTION
When expanding the new backend of pytorch in the form of out ot tree, Privateuse1 will be reused. So we also need to support PrivateUse1 in the dispatch stub module

cc @bdhirsh