### PR TITLE
add checkpoint support for custom device

### DIFF
--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -18,13 +18,13 @@ torch.utils.checkpoint
     The stashing logic saves and restores the RNG state for CPU and another
     device type (infer the device type from Tensor arguments excluding CPU
     tensors by ``_infer_device_type``) to the ``run_fn``. If there are multiple
-    device, Device state will only be saved for devices of a single device type,
+    device, device state will only be saved for devices of a single device type,
     and the remaining devices will be ignored. Consequently, if any checkpointed
     functions involve randomness, this may result in incorrect gradients. (Note
     that if CUDA devices are among the devices detected, it will be prioritized;
     otherwise, the first device encountered will be selected.) If there are no
-    CPU-tensors, the default device type(default value is `cuda`, and it could be
-    set to other device by ``DefaultDevice``) will be saved and restored.
+    CPU-tensors, the default device type state (default value is `cuda`, and it
+    could be set to other device by ``DefaultDevice``) will be saved and restored.
     However, the logic has no way to anticipate if the user will move
     Tensors to a new device within the ``run_fn`` itself.  Therefore, if you move
     Tensors to a new device ("new" meaning not belonging to the set of

--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -24,7 +24,7 @@ torch.utils.checkpoint
     that if CUDA devices are among the devices detected, it will be prioritized;
     otherwise, the first device encountered will be selected.) If there are no
     CPU-tensors, the default device type state (default value is `cuda`, and it
-    could be set to other device by ``DefaultDevice``) will be saved and restored.
+    could be set to other device by ``DefaultDeviceType``) will be saved and restored.
     However, the logic has no way to anticipate if the user will move
     Tensors to a new device within the ``run_fn`` itself.  Therefore, if you move
     Tensors to a new device ("new" meaning not belonging to the set of

--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -15,12 +15,12 @@ torch.utils.checkpoint
     to ``checkpoint`` or ``checkpoint_sequential`` to omit stashing and
     restoring the RNG state during each checkpoint.
 
-    The stashing logic saves and restores the RNG state for CPU and another 
+    The stashing logic saves and restores the RNG state for CPU and another
     device type (infer the device type from Tensor arguments excluding CPU
     tensors by ``_infer_device_type``) to the ``run_fn``. If there are multiple
     device, Device state will only be saved for devices of a single device type,
-    and the remaining devices will be ignored. Consequently, if any checkpointed 
-    functions involve randomness, this may result in incorrect gradients. (Note 
+    and the remaining devices will be ignored. Consequently, if any checkpointed
+    functions involve randomness, this may result in incorrect gradients. (Note
     that if CUDA devices are among the devices detected, it will be prioritized;
     otherwise, the first device encountered will be selected.) If there are no
     CPU-tensors, the default device type(default value is `cuda`, and it could be

--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -15,8 +15,16 @@ torch.utils.checkpoint
     to ``checkpoint`` or ``checkpoint_sequential`` to omit stashing and
     restoring the RNG state during each checkpoint.
 
-    The stashing logic saves and restores the RNG state for the current device
-    and the device of all cuda Tensor arguments to the ``run_fn``.
+    The stashing logic saves and restores the RNG state for CPU and another 
+    device type (infer the device type from Tensor arguments excluding CPU
+    tensors by ``_infer_device_type``) to the ``run_fn``. If there are multiple
+    device, Device state will only be saved for devices of a single device type,
+    and the remaining devices will be ignored. Consequently, if any checkpointed 
+    functions involve randomness, this may result in incorrect gradients. (Note 
+    that if CUDA devices are among the devices detected, it will be prioritized;
+    otherwise, the first device encountered will be selected.) If there are no
+    CPU-tensors, the default device type(default value is `cuda`, and it could be
+    set to other device by ``DefaultDevice``) will be saved and restored.
     However, the logic has no way to anticipate if the user will move
     Tensors to a new device within the ``run_fn`` itself.  Therefore, if you move
     Tensors to a new device ("new" meaning not belonging to the set of

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -43,11 +43,11 @@ class _DefaultDevice(object):
     _default_device_type = "cuda"
 
     @staticmethod
-    def set_device_type(device: str = "cuda"):
+    def _set_device_type(device: str = "cuda"):
         _DefaultDevice._default_device_type = device
 
     @staticmethod
-    def get_device_type():
+    def _get_device_type():
         return _DefaultDevice._default_device_type
 
 def _infer_device_type(*args):
@@ -60,7 +60,7 @@ def _infer_device_type(*args):
                       "this may result in incorrect gradients. (Note that if CUDA devices are among the devices "
                       "detected, it will be prioritized; otherwise, the first device encountered will be selected.)")
     if len(device_types) == 0:
-        return _DefaultDevice.get_device_type()
+        return _DefaultDevice._get_device_type()
     elif "cuda" in device_types:
         return "cuda"
     else:
@@ -97,6 +97,7 @@ def set_device_states(devices, states) -> None:
 
 
 def _get_autocast_kwargs(device="cuda"):
+
     if device == "cuda":
         device_autocast_kwargs = {"enabled": torch.is_autocast_enabled(),
                                   "dtype": torch.get_autocast_gpu_dtype(),

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -51,7 +51,7 @@ def get_device_states(*args) -> Tuple[List[int], List[torch.Tensor]]:
     # This will not error out if "arg" is a CPU tensor or a non-tensor type because
     # the conditionals short-circuit.
     fwd_device_ids = list({arg.get_device() for arg in args
-                        if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu"})
+                          if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu"})
     device_types = list({arg.device.type for arg in args
                         if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu"})
     if len(device_types) > 1:

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -39,24 +39,26 @@ def _get_device_module(device='cuda'):
     device_module = getattr(torch, device)
     return device_module
 
-class _DefaultDevice(object):
+class DefaultDevice(object):
     _default_device_type = "cuda"
 
     @staticmethod
     def set_device_type(device: str = "cuda"):
-        _DefaultDevice._default_device_type = device
+        DefaultDevice._default_device_type = device
 
     @staticmethod
     def get_device_type():
-        return _DefaultDevice._default_device_type
+        return DefaultDevice._default_device_type
 
 def infer_device_type(*args):
     device_types = list({arg.device.type for arg in args
                         if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu"})
-    if len(device_types) > 1:
-        raise ValueError("Expected all tensor args except CPU tensor to be on the same device,"
-                         " but found at least two devices, ", device_types)
-    return _DefaultDevice.get_device_type() if len(device_types) == 0 else device_types[0]
+    if len(device_types) == 0:
+        return DefaultDevice.get_device_type()
+    elif "cuda" in device_types:
+        return "cuda"
+    else:
+        return device_types[0]
 
 # We can't know if the run_fn will internally move some args to different devices,
 # which would require logic to preserve rng states for those devices as well.

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -42,7 +42,7 @@ def _get_device_module(device='cuda'):
 
 class DefaultDevice(object):
     r"""Set/Get the default device type for checkpoint.
-        In func of `_infer_device_type`, if there are no no-CPU 
+        In func of `_infer_device_type`, if there are no no-CPU
         tensors, it will return the default device type, and the
         default vaule is `cuda`.
     """

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -41,19 +41,33 @@ def _get_device_module(device='cuda'):
     return device_module
 
 class DefaultDevice(object):
-    r"""Set/Get the default device type for checkpoint.
-        In func of `_infer_device_type`, if there are no no-CPU
-        tensors, it will return the default device type, and the
-        default vaule is `cuda`.
+    r"""
+    A class that manages the default device type for checkpointing. 
+    If no non-CPU tensors are present, the default device type will be used.
+    The default value is 'cuda'. The device type is used in the checkpointing 
+    process when determining which device states to save and restore
+    for recomputation.
     """
     _default_device_type = "cuda"
 
     @staticmethod
     def set_device_type(device: str = "cuda"):
+        """
+        Set the default device type for checkpointing.
+
+        Args:
+            device (str): The device type to be set as default. Default is 'cuda'.
+        """
         DefaultDevice._default_device_type = device
 
     @staticmethod
-    def get_device_type():
+    def get_device_type() -> str:
+        """
+        Get the current default device type for checkpointing.
+
+        Returns:
+            str: The current default device type.
+        """
         return DefaultDevice._default_device_type
 
 def _infer_device_type(*args):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -11,7 +11,7 @@ __all__ = [
     "checkpoint", "checkpoint_sequential", "CheckpointFunction",
     "check_backward_validity", "detach_variable", "get_device_states",
     "set_device_states", "noop_context_fn", "set_checkpoint_early_stop",
-    "DefaultDevice"
+    "DefaultDeviceType"
 ]
 
 def detach_variable(inputs: Tuple[Any, ...]) -> Tuple[torch.Tensor, ...]:
@@ -40,13 +40,13 @@ def _get_device_module(device='cuda'):
     device_module = getattr(torch, device)
     return device_module
 
-class DefaultDevice(object):
+class DefaultDeviceType(object):
     r"""
-    A class that manages the default device type for checkpointing. 
-    If no non-CPU tensors are present, the default device type will be used.
-    The default value is 'cuda'. The device type is used in the checkpointing 
-    process when determining which device states to save and restore
-    for recomputation.
+    A class that manages the default device type for checkpointing.
+    If no non-CPU tensors are present, the default device type will
+    be used. The default value is 'cuda'. The device type is used in
+    the checkpointing process when determining which device states
+    to save and restore for recomputation.
     """
     _default_device_type = "cuda"
 
@@ -58,7 +58,7 @@ class DefaultDevice(object):
         Args:
             device (str): The device type to be set as default. Default is 'cuda'.
         """
-        DefaultDevice._default_device_type = device
+        DefaultDeviceType._default_device_type = device
 
     @staticmethod
     def get_device_type() -> str:
@@ -68,7 +68,7 @@ class DefaultDevice(object):
         Returns:
             str: The current default device type.
         """
-        return DefaultDevice._default_device_type
+        return DefaultDeviceType._default_device_type
 
 def _infer_device_type(*args):
     device_types = list({arg.device.type for arg in args
@@ -80,7 +80,7 @@ def _infer_device_type(*args):
                       "this may result in incorrect gradients. (Note that if CUDA devices are among the devices "
                       "detected, it will be prioritized; otherwise, the first device encountered will be selected.)")
     if len(device_types) == 0:
-        return DefaultDevice.get_device_type()
+        return DefaultDeviceType.get_device_type()
     elif "cuda" in device_types:
         return "cuda"
     else:


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1、add checkpoint support for custom device
2、add a device argument, I want to add a device="cuda" parameter to the func `forward` of `CheckpointFunction`, and I can specify the device type when using it, but the func `apply` of `torch.autograd.Function` does not support `kwargs`, so I added a variable named `_device`.