### PR TITLE
Separate is_cuda() and is_sparse() in TORCH_CHECK

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1206,12 +1206,9 @@ namespace {
 
 // Check validity of tensor
 void check_gpu_single_tensor(const at::Tensor& tensor) {
-  if (!tensor.is_cuda() || tensor.is_sparse()) {
-    TORCH_CHECK(false, "Tensors must be CUDA and dense");
-  }
-  if (!tensor.is_contiguous(tensor.suggest_memory_format())) {
-    TORCH_CHECK(false, "Tensors must be contiguous");
-  }
+  TORCH_CHECK(tensor.is_cuda(), "Tensors must be CUDA");
+  TORCH_CHECK(!tensor.is_sparse(), "Tensors must be dense");
+  TORCH_CHECK(tensor.is_contiguous(tensor.suggest_memory_format()), "Tensors must be contiguous");
 }
 
 // Checks that all `tensors' have the same type and shape and reside on distinct


### PR DESCRIPTION
Summary:
Switch checks in `check_gpu_single_tensor(...)`
From:
   if(!stmt) -> TORCH_CHECK(false, mst)
 to
   TORCH_CHECK(stmt, msg)

Also separated out the `is_cuda()` check from the `is_sparse()` check so that the message is more clear.

Test Plan: ci

Differential Revision: D45103310

