### PR TITLE
Fix buck  parsing in OSS build

### DIFF
--- a/pt_ops.bzl
+++ b/pt_ops.bzl
@@ -1,4 +1,4 @@
-load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
+load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 load("//tools/build_defs:expect.bzl", "expect")
 load("//tools/build_defs:fb_xplat_genrule.bzl", "fb_xplat_genrule")
 load("//tools/build_defs:type_defs.bzl", "is_list", "is_string")


### PR DESCRIPTION
By removing `@fbsource` cell prefix from `pt_ops.bzl`


Fixes https://github.com/pytorch/pytorch/issues/99642
