### PR TITLE
Modify repeat_interleave docs to highlight potential overloading

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13225,7 +13225,7 @@ If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 .. function:: repeat_interleave(repeats, *) -> Tensor
    :noindex:
 
-Repeats 0 t[0] times, 1 t[1] times, 2 t[2] times, etc.
+Repeats 0 repeats[0] times, 1 repeats[1] times, 2 repeats[2] times, etc.
 
 Args:
     repeats (Tensor): The number of repetitions for each element.
@@ -13236,7 +13236,7 @@ Returns:
 Example::
 
     >>> torch.repeat_interleave(torch.tensor([1, 2, 3]))
-    tensor([1, 2, 2, 3, 3, 3])
+    tensor([0, 1, 1, 2, 2, 2])
 
 """.format(
         **common_args

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13222,18 +13222,13 @@ If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 `tensor([0, 0, ..., 1, 1, ..., 2, 2, ..., ...])` where `0` appears `n1` times,
 `1` appears `n2` times, `2` appears `n3` times, etc.
 
-.. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
+.. function:: repeat_interleave(repeats, *) -> Tensor
    :noindex:
 
 Repeats 0 t[0] times, 1 t[1] times, 2 t[2] times, etc.
 
 Args:
     repeats (Tensor): The number of repetitions for each element.
-
-Keyword args:
-    output_size (int, optional): Total output size for the given axis
-        ( e.g. sum of repeats). If given, it will avoid stream synchronization
-        needed to calculate output shape of the tensor.
 
 Returns:
     Tensor: Repeated tensor of size `sum(repeats)`.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13178,12 +13178,15 @@ repeat_interleave(input, repeats, dim=None, *, output_size=None) -> Tensor
 
 Repeat elements of a tensor.
 
+.. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
+   :noindex:
+
 .. warning::
 
     This is different from :meth:`torch.Tensor.repeat` but similar to ``numpy.repeat``.
 
 Args:
-    {input}
+    input (Tensor, optional): the input tensor.
     repeats (Tensor or int): The number of repetitions for each element.
         repeats is broadcasted to fit the shape of the given axis.
     dim (int, optional): The dimension along which to repeat values.
@@ -13217,9 +13220,6 @@ Example::
     tensor([[1, 2],
             [3, 4],
             [3, 4]])
-
-.. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
-   :noindex:
 
 If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 `tensor([0, 0, ..., 1, 1, ..., 2, 2, ..., ...])` where `0` appears `n1` times,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13178,15 +13178,12 @@ repeat_interleave(input, repeats, dim=None, *, output_size=None) -> Tensor
 
 Repeat elements of a tensor.
 
-.. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
-   :noindex:
-
 .. warning::
 
     This is different from :meth:`torch.Tensor.repeat` but similar to ``numpy.repeat``.
 
 Args:
-    input (Tensor, optional): the input tensor.
+    {input}
     repeats (Tensor or int): The number of repetitions for each element.
         repeats is broadcasted to fit the shape of the given axis.
     dim (int, optional): The dimension along which to repeat values.
@@ -13224,6 +13221,16 @@ Example::
 If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 `tensor([0, 0, ..., 1, 1, ..., 2, 2, ..., ...])` where `0` appears `n1` times,
 `1` appears `n2` times, `2` appears `n3` times, etc.
+
+.. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
+   :noindex:
+
+Args:
+    input (Tensor, optional): the input tensor.
+    repeats (Tensor or int): The number of repetitions for each element.
+        repeats is broadcasted to fit the shape of the given axis.
+    dim (int, optional): The dimension along which to repeat values.
+
 """.format(
         **common_args
     ),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13225,11 +13225,23 @@ If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 .. function:: repeat_interleave(repeats, *, output_size=None) -> Tensor
    :noindex:
 
+Repeats 0 t[0] times, 1 t[1] times, 2 t[2] times, etc.
+
 Args:
-    input (Tensor, optional): the input tensor.
-    repeats (Tensor or int): The number of repetitions for each element.
-        repeats is broadcasted to fit the shape of the given axis.
-    dim (int, optional): The dimension along which to repeat values.
+    repeats (Tensor): The number of repetitions for each element.
+
+Keyword args:
+    output_size (int, optional): Total output size for the given axis
+        ( e.g. sum of repeats). If given, it will avoid stream synchronization
+        needed to calculate output shape of the tensor.
+
+Returns:
+    Tensor: Repeated tensor of size `sum(repeats)`.
+
+Example::
+
+    >>> torch.repeat_interleave(torch.tensor([1, 2, 3]))
+    tensor([1, 2, 2, 3, 3, 3])
 
 """.format(
         **common_args


### PR DESCRIPTION
Fixes #99259 , drawing to attention that input is optional by putting a variation of the method signature at the top of the file and by modifying the input arguments.

Note that I'm not certain how to get the additional signature at the same level of indentation as the first one, but I think this change does a good job of highlighting the change is optional.

Would be happy to iterate on this if there are any issues.

cc @jbschlosser 