### PR TITLE
Check if input tensor is empty in torch.nn.Linear

### DIFF
--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -111,6 +111,8 @@ class Linear(Module):
             init.uniform_(self.bias, -bound, bound)
 
     def forward(self, input: Tensor) -> Tensor:
+        if input.numel() == 0:
+            raise ValueError("input tensor cannot be empty.")
         return F.linear(input, self.weight, self.bias)
 
     def extra_repr(self) -> str:


### PR DESCRIPTION
Fixes #99226 , raising a more meaningful error message if the input tensor is empty. 

Please note that I'm unsure if this is the best place to do error checking, any input on a better place to do it would be greatly appreciated.

If this change is satisfactory I'd be happy to write a test for it as well.

cc @jbschlosser @albanD 
