### PR TITLE
Make testing._internal.common_utils safe to import

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -15,6 +15,7 @@ import gc
 import inspect
 import io
 import json
+import logging
 import math
 import operator
 import os
@@ -91,6 +92,7 @@ import torch.utils._pytree as pytree
 
 from .composite_compliance import no_dispatch
 
+log = logging.getLogger(__name__)
 torch.backends.disable_global_flags()
 
 FILE_SCHEMA = "file://"
@@ -113,11 +115,10 @@ disabled_tests_dict = {}
 slow_tests_dict = {}
 
 def maybe_load_json(filename):
-    if os.path.exists(filename):
+    if os.path.isfile(filename):
         with open(filename, 'r') as fp:
-            data = json.load(fp)
-            return data
-    print(f"Attempted to load {filename} but it does not exist.")
+            return json.load(fp)
+    log.warning("Attempted to load json file '%s' but it does not exist.", filename)
     return {}
 
 # set them here in case the tests are running in a subprocess that doesn't call run_tests

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -112,13 +112,19 @@ DEFAULT_SLOW_TESTS_FILE = '.pytorch-slow-tests.json'
 disabled_tests_dict = {}
 slow_tests_dict = {}
 
+def maybe_load_json(filename):
+    if os.path.exists(filename):
+        with open(filename, 'r') as fp:
+            data = json.load(fp)
+            return data
+    print(f"Attempted to load {filename} but it does not exist.")
+    return {}
+
 # set them here in case the tests are running in a subprocess that doesn't call run_tests
 if os.getenv("SLOW_TESTS_FILE", ""):
-    with open(os.getenv("SLOW_TESTS_FILE"), 'r') as fp:
-        slow_tests_dict = json.load(fp)
+    slow_tests_dict = maybe_load_json(os.getenv("SLOW_TESTS_FILE", ""))
 if os.getenv("DISABLED_TESTS_FILE", ""):
-    with open(os.getenv("DISABLED_TESTS_FILE"), 'r') as fp:
-        disabled_tests_dict = json.load(fp)
+    disabled_tests_dict = maybe_load_json(os.getenv("DISABLED_TESTS_FILE", ""))
 
 NATIVE_DEVICES = ('cpu', 'cuda', 'meta')
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99473
* __->__ #99659

In edge cases in CI, SLOW_TESTS_FILE is defined but does not point to an existing file.

Guessing this is due to a test case that opens a subprocses and cwd's but doesn't clean its env.

We shouldn't make importing common_utils fail, so issue a warning and proceed.