### PR TITLE
[ONNX] Fix missing import numpy for docs example

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -96,6 +96,7 @@ For example after installing `ONNX Runtime <https://www.onnxruntime.ai>`_, you c
 load and run the model::
 
     import onnxruntime as ort
+    import numpy as np
 
     ort_session = ort.InferenceSession("alexnet.onnx")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99663

Fixes https://github.com/pytorch/pytorch/issues/99408