### PR TITLE
[2.0.1] Remove redundant `found_inf` recompute

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2512,6 +2512,43 @@ torch.cuda.synchronize()
                         actual = actual.squeeze()
                     self.assertEqual(state_control[k], actual)
 
+    # Make sure that the parameters become nonsense when scaled gradients are finite
+    # but they get invalidated before `optimizer.step`, after `GradScaler.unscale_`
+    def test_params_invalidated_with_grads_invalidated_between_unscale_and_step(self):
+        for optimizer_ctor, optimizer_kwargs in product(
+            (torch.optim.Adam, torch.optim.AdamW),
+            (
+                {"foreach": False, "fused": False},
+                {"foreach": True, "fused": False},
+                {"foreach": False, "fused": True},
+            ),
+        ):
+            with self.subTest(optimizer=optimizer_ctor, optimizer_kwargs=optimizer_kwargs):
+                self._test_grads_invalidated_between_unscale_and_step(optimizer_ctor, optimizer_kwargs)
+
+    def _test_grads_invalidated_between_unscale_and_step(self, optimizer_ctor, optimizer_kwargs):
+        model, _, optimizer, _, data, loss_fn, _ = self._create_scaling_case(
+            optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs,
+        )
+        scaler = torch.cuda.amp.GradScaler(init_scale=128.0)
+
+        for input, target in data:
+            optimizer.zero_grad()
+            with torch.autocast('cuda', enabled=True):
+                output = model(input)
+                loss = loss_fn(output, target)
+            scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+
+            # deliberately break grads
+            for j, param in enumerate(model.parameters()):
+                param.grad.copy_(torch.inf if j % 2 else torch.nan)
+
+            scaler.step(optimizer)
+            scaler.update()
+
+        self.assertTrue(all((p.isnan().any() or p.isinf().any()) for p in model.parameters()))
+
     def test_grad_scaling_clipping(self):
         def run(data, model, optimizer, scaler, loss_fn, skip_iter, try_scaling_api):
             max_norm = 0.2  # A reasonable value that actually has an effect, based on printouts of grads

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -336,6 +336,8 @@ class GradScaler:
             # and `found_inf` to the passed optimizer so that the optimizer can utilize those
             # to skip the parameter updates or unscale gradients before updating parameters in
             # the fused kernel, e.g. `FusedAdamMathFunctor`.
+            # In this behavior, `GradScaler._check_inf_per_device` is called if `OptState.READY`,
+            # while the method is expected to be called by users side, i.e. their optimizers.
             kwargs_ = kwargs
             has_grad_scaler_kwarg = "grad_scaler" in inspect.signature(optimizer.step).parameters
             if has_grad_scaler_kwarg:
@@ -346,11 +348,13 @@ class GradScaler:
                     FutureWarning)
                 kwargs_.update({"grad_scaler": self})
             else:
+                if optimizer_state["stage"] is OptState.READY:
+                    self._check_inf_per_device(optimizer)
                 scaler = self._get_scale_async()
                 found_inf = cast(
                     torch.Tensor,
                     sum([
-                        t.to(scaler.device, non_blocking=True) for t in self._check_inf_per_device(optimizer).values()
+                        t.to(scaler.device, non_blocking=True) for t in optimizer_state["found_inf_per_device"].values()
                     ])
                 )
                 optimizer.grad_scale = None if optimizer_state["stage"] == OptState.UNSCALED else scaler


### PR DESCRIPTION
from `_step_supports_amp_unscaling` path (#98620)

Rel: https://github.com/pytorch/pytorch/pull/98613
