### PR TITLE
De-select odd numbered heads from nn.MHA fastpath

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -593,8 +593,8 @@ class TestMultiheadAttentionNNDeviceType(NNTestCase):
         if device not in ['cpu', 'cuda']:
             self.skipTest("Fastpath only runs on CPU and CUDA.")
         with torch.autocast(device_type=device, enabled=False):
-            embed_dim = 14
-            num_heads = 7
+            embed_dim = 16
+            num_heads = 8
             batch_size = 8
             src_len = 5
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1140,6 +1140,8 @@ class MultiheadAttention(Module):
             why_not_fast_path = f"dtypes of query ({query.dtype}) and self.in_proj_weight ({self.in_proj_weight.dtype}) don't match"
         elif self.training:
             why_not_fast_path = "training is enabled"
+        elif (self.num_heads % 2) != 0:
+            why_not_fast_path = "self.num_heads is not even"
         elif not self.batch_first:
             why_not_fast_path = "batch_first was not True"
         elif self.bias_k is not None:


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/issues/97128

* Add test for mha num_heads %2 != 0
* Fix test
* Add test for bias false
* show test passes

Test Plan: sandcastle

Differential Revision: D45161767



cc @jbschlosser @bhosmer @cpuhrsch @erichan1