### PR TITLE
Init comm_nonblocking_ when creating AutoNcclGroup

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -415,6 +415,7 @@ AutoNcclGroup::AutoNcclGroup() {
   // nccl < 2.0 cannot be called concurrently with cudaFree
   (c10::cuda::getFreeMutex())->lock();
 #endif
+  comm_nonblocking_ = false;
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
   detail::NCCL_CHECK(ncclGroupStart());
 #endif


### PR DESCRIPTION
A quick, trial fix for #99677.

My guess is that when the code instantiates an `AutoNcclGroup` object, it comes with an uninitialized random value for member `comm_nonblocking_`. Then `if (comm_nonblocking_)` evaluates to true, and `NCCL_CHECK_TIMEOUT` triggered.

This change is safe (and needed) anyway whether it indeed fixes #99677.

Cc @eqy 