### PR TITLE
[ONNX] Cover 'undiscoverable' ops 'torch.ops.aten'

### DIFF
--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -68,6 +68,15 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             func, torch.randn(1, 1, 2), export_options=self.export_options
         )
 
+    def test_empty(self):
+        # Since `torch.empty` returns tensor with unintialized data, we cannot
+        # test this under `test_fx_to_onnx_with_onnxruntime.py` with result comparison.
+        def func(x):
+            return torch.empty(x.size(), dtype=torch.int64)
+
+        tensor_x = torch.randn(1, 1, 2)
+        _ = dynamo_export(func, tensor_x, export_options=self.export_options)
+
     @unittest.skip(
         "max_pool2d is not supported in ATen Lib: https://github.com/microsoft/onnx-script/issues/585"
     )

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -468,6 +468,25 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         _run_test_with_fx_to_onnx_exporter_and_onnx_runtime(self, SigmoidModel(), (x,))
 
+    @pytorch_test_common.skip_min_ort_version(
+        reason="ORT doesn't support dynamic fx exporter yet making SegFault flaky test",
+        version="1.15",
+        dynamic_only=True,
+    )
+    def test_log_sigmoid(self):
+        # This produces op as `torch.ops.aten.log_sigmoid_forward`, instead of the more
+        # conventional `torch.ops.aten.log_sigmoid`.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.m = torch.nn.LogSigmoid()
+
+            def forward(self, x):
+                return self.m(x)
+
+        input = torch.randn(2)
+        _run_test_with_fx_to_onnx_exporter_and_onnx_runtime(self, Model(), (input,))
+
     @pytorch_test_common.xfail(
         "RuntimeError: false INTERNAL ASSERT FAILED at "
         "'/home/titaiwang/pytorch/build/aten/src/ATen/RegisterFunctionalization_0.cpp':3725,"

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -468,6 +468,15 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         _run_test_with_fx_to_onnx_exporter_and_onnx_runtime(self, SigmoidModel(), (x,))
 
+    @pytorch_test_common.xfail(
+        "assert len(flattened_torch_outputs) == len(flattened_function_outputs)"
+    )
+    @pytorch_test_common.xfail(
+        "onnxruntime.capi.onnxruntime_pybind11_state.InvalidGraph: [ONNXRuntimeError] : "
+        "10 : INVALID_GRAPH : This is an invalid model. Type Error: Type 'tensor(float)' "
+        "of input parameter (1) of operator (aten_getitem) in node (aten_getitem_4) is "
+        "invalid."
+    )
     @pytorch_test_common.skip_min_ort_version(
         reason="ORT doesn't support dynamic fx exporter yet making SegFault flaky test",
         version="1.15",

--- a/torch/onnx/_internal/fx/function_dispatcher.py
+++ b/torch/onnx/_internal/fx/function_dispatcher.py
@@ -193,8 +193,6 @@ def _create_op_overload_to_exporter_key_table() -> (
                 # different exporter keys.
 
                 table[op_overload] = op_overload_packet._qualified_op_name
-    # NOTE: Below are not in torch.ops.aten/torch.ops.prim
-    table[torch.ops.aten.sym_size.int] = "aten::sym_size"
     return table
 
 

--- a/torch/onnx/_internal/fx/function_dispatcher.py
+++ b/torch/onnx/_internal/fx/function_dispatcher.py
@@ -86,6 +86,8 @@ _ATENLIB_FUNCTIONS = {
     "aten::le": ops.core.aten_le,
     "aten::leaky_relu": ops.nn.aten_leaky_relu,
     "aten::linear": ops.nn.aten_linear,
+    "aten::log_sigmoid": ops.nn.aten_log_sigmoid,
+    "aten::log_sigmoid_forward": ops.nn.aten_log_sigmoid,
     "aten::log_softmax": ops.special.aten_special_log_softmax,
     "aten::log": ops.core.aten_log,
     "aten::log10": ops.core.aten_log10,
@@ -95,7 +97,6 @@ _ATENLIB_FUNCTIONS = {
     "aten::logaddexp2": ops.core.aten_logaddexp2,
     "aten::logcumsumexp": ops.core.aten_logcumsumexp,
     "aten::logdet": ops.core.aten_logdet,
-    "aten::logsigmoid": ops.nn.aten_log_sigmoid,
     "aten::logsumexp": ops.core.aten_logsumexp,
     "aten::lt": ops.core.aten_lt,
     "aten::masked_fill": ops.core.aten_masked_fill,
@@ -159,8 +160,19 @@ def _create_op_overload_to_exporter_key_table() -> (
     # TODO(justinchuby): Improve how the table is constructed.
     table: Dict[Union[torch._ops.OpOverload, Callable], str] = {}
 
+    # Some ops in `torch.ops.aten` are not discoverable through `dir(torch.ops.aten)`,
+    # but retrievable via explicit lookup.
+    # https://github.com/pytorch/pytorch/issues/99681
+    # This is a workaround to make sure we register ONNX symbolic functions for these.
+    onnx_supported_aten_lookup_table = [
+        k.split("::")[1] for k in _ATENLIB_FUNCTIONS.keys() if k.startswith("aten::")
+    ]
+
     for op_namespace in (torch.ops.aten, torch.ops.prims):
-        for attr_name in dir(op_namespace):
+        attr_names = dir(op_namespace)
+        if op_namespace is torch.ops.aten:
+            attr_names += onnx_supported_aten_lookup_table
+        for attr_name in attr_names:
             op_overload_packet = getattr(op_namespace, attr_name)
             if not isinstance(op_overload_packet, torch._ops.OpOverloadPacket):
                 continue
@@ -203,8 +215,10 @@ def _create_onnx_friendly_decomposition_table() -> (
 ):
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = {}
     for op_overload, decomp_fn in torch._decomp.decomposition_table.items():
-        # Skip decomposition into "prim::*" ops, because they are not generally supported by ONNX.
-        # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX exporter.
+        # Skip decomposition into "prim::*" ops (defined in 'torch._refs'), because they
+        # are not generally supported by ONNX.
+        # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX
+        # symbolic function.
         if (
             "torch._refs" in decomp_fn.__module__
             or op_overload in _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99667
* __->__ #99682

Due to https://github.com/pytorch/pytorch/issues/99681, ops supported by torchlib in `function_dispatcher` may not get
registered. This PR works around it by doing reverse look up.
Also fixes aten signature for `log_sigmoid`, which appears to be an outlier with unique naming style.