### PR TITLE
[combined tracebacks] missing gil acquire

### DIFF
--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -52,6 +52,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
   void appendSymbolized(
       const std::vector<CapturedTraceback::PyFrame>& to_symbolize,
       SymbolizedTracebacks& result) override {
+    py::gil_scoped_acquire acquire;
     py::str line_s = "line";
     py::str name_s = "name";
     py::str filename_s = "filename";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99685
* #99553
* #99275

When this code was refactored, the GIL for appendSymbolized
was dropped accidentally.