### PR TITLE
Improve OOM error message

### DIFF
--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(c10_cuda PUBLIC c10 torch::cudart)
 
 if(NOT WIN32)
 target_link_libraries(c10_cuda PRIVATE dl)
-target_compile_options(c10_cuda PRIVATE "-DPYTORCH_EXPANDABLE_SEGMENTS_SUPPORTED")
+target_compile_options(c10_cuda PRIVATE "-DPYTORCH_C10_DRIVER_API_SUPPORTED")
 endif()
 
 target_include_directories(

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1158,8 +1158,10 @@ static std::string reportProcessMemoryInfo(int device) {
       uuid[14],
       uuid[15]);
   nvmlDevice_t nvml_device;
-  auto x = DriverAPI::get()->nvmlDeviceGetHandleByUUID_(uuid_str, &nvml_device);
-  TORCH_INTERNAL_ASSERT(NVML_SUCCESS == x);
+  TORCH_INTERNAL_ASSERT(
+      NVML_SUCCESS ==
+      DriverAPI::get()->nvmlDeviceGetHandleByUUID_(uuid_str, &nvml_device));
+
   std::vector<nvmlProcessInfo_v1_t> procs(8);
   unsigned int size = procs.size();
   nvmlReturn_t r;

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -22,17 +22,17 @@
   _("libcuda.so", 0)                   \
   _("libnvidia-ml.so.1", 1)
 
-#define C10_FORALL_DRIVER_API(_)  \
-  _(cuMemAddressReserve, 0)       \
-  _(cuMemRelease, 0)              \
-  _(cuMemMap, 0)                  \
-  _(cuMemAddressFree, 0)          \
-  _(cuMemSetAccess, 0)            \
-  _(cuMemUnmap, 0)                \
-  _(cuMemCreate, 0)               \
-  _(cuGetErrorString, 0)          \
-  _(nvmlInit_v2, 1)               \
-  _(nvmlDeviceGetHandleByUUID, 1) \
+#define C10_FORALL_DRIVER_API(_)         \
+  _(cuMemAddressReserve, 0)              \
+  _(cuMemRelease, 0)                     \
+  _(cuMemMap, 0)                         \
+  _(cuMemAddressFree, 0)                 \
+  _(cuMemSetAccess, 0)                   \
+  _(cuMemUnmap, 0)                       \
+  _(cuMemCreate, 0)                      \
+  _(cuGetErrorString, 0)                 \
+  _(nvmlInit_v2, 1)                      \
+  _(nvmlDeviceGetHandleByPciBusId_v2, 1) \
   _(nvmlDeviceGetComputeRunningProcesses, 1)
 
 namespace c10 {

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -22,17 +22,17 @@
   _("libcuda.so", 0)                   \
   _("libnvidia-ml.so.1", 1)
 
-#define C10_FORALL_DRIVER_API(_)      \
-  _(cuMemAddressReserve, 0)           \
-  _(cuMemRelease, 0)                  \
-  _(cuMemMap, 0)                      \
-  _(cuMemAddressFree, 0)              \
-  _(cuMemSetAccess, 0)                \
-  _(cuMemUnmap, 0)                    \
-  _(cuMemCreate, 0)                   \
-  _(cuGetErrorString, 0)              \
-  _(nvmlInit_v2, 1)                   \
-  _(nvmlDeviceGetHandleByIndex_v2, 1) \
+#define C10_FORALL_DRIVER_API(_)  \
+  _(cuMemAddressReserve, 0)       \
+  _(cuMemRelease, 0)              \
+  _(cuMemMap, 0)                  \
+  _(cuMemAddressFree, 0)          \
+  _(cuMemSetAccess, 0)            \
+  _(cuMemUnmap, 0)                \
+  _(cuMemCreate, 0)               \
+  _(cuGetErrorString, 0)          \
+  _(nvmlInit_v2, 1)               \
+  _(nvmlDeviceGetHandleByUUID, 1) \
   _(nvmlDeviceGetComputeRunningProcesses, 1)
 
 namespace c10 {

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <cuda.h>
+#define NVML_NO_UNVERSIONED_FUNC_DEFS
+#include <nvml.h>
 
 #define C10_CUDA_DRIVER_CHECK(EXPR)                                        \
   do {                                                                     \
@@ -16,21 +18,28 @@
     }                                                                      \
   } while (0)
 
-#define C10_FORALL_DRIVER_API(_) \
-  _(cuMemAddressReserve)         \
-  _(cuMemRelease)                \
-  _(cuMemMap)                    \
-  _(cuMemAddressFree)            \
-  _(cuMemSetAccess)              \
-  _(cuMemUnmap)                  \
-  _(cuMemCreate)                 \
-  _(cuGetErrorString)
+#define C10_FORALL_DRIVER_LIBRARIES(_) \
+  _("libcuda.so", 0)                   \
+  _("libnvidia-ml.so.1", 1)
+
+#define C10_FORALL_DRIVER_API(_)      \
+  _(cuMemAddressReserve, 0)           \
+  _(cuMemRelease, 0)                  \
+  _(cuMemMap, 0)                      \
+  _(cuMemAddressFree, 0)              \
+  _(cuMemSetAccess, 0)                \
+  _(cuMemUnmap, 0)                    \
+  _(cuMemCreate, 0)                   \
+  _(cuGetErrorString, 0)              \
+  _(nvmlInit_v2, 1)                   \
+  _(nvmlDeviceGetHandleByIndex_v2, 1) \
+  _(nvmlDeviceGetComputeRunningProcesses, 1)
 
 namespace c10 {
 namespace cuda {
 
 struct DriverAPI {
-#define CREATE_MEMBER(name) decltype(&name) name##_;
+#define CREATE_MEMBER(name, n) decltype(&name) name##_;
   C10_FORALL_DRIVER_API(CREATE_MEMBER)
 #undef CREATE_MEMBER
   static DriverAPI* get();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99699
* #99670
* #99553
* #99275

This PR adds calls to nvml during an OOM to find out the total memory
in use by the process and any other CUDA processes on the device.

This makes it easier to identify cases where non-PyTorch libraries have
allocated memory or another process (such as a data loader) has also
allocated memory on the device.

This also rewords the other parts of the error message to make the meaning
of the memory statistics more clear with this new information:

"""
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 138.00 MiB.
GPU 0 has a total capacty of 15.90 GiB of which 8.44 MiB is free.
Process 1246069 has 577.00 MiB memory in use. Including non-PyTorch memory,
this process has 15.32 GiB memory in use. Of the allocated memory
14.12 GiB is allocated by PyTorch, and 410.41 MiB is reserved
by PyTorch but unallocated. If reserved but unallocated memory is large
try setting max_split_size_mb to avoid fragmentation.  See documentation
 for Memory Management and PYTORCH_CUDA_ALLOC_CONF
"""