### PR TITLE
inductor: fix split+cat issue when cat order is not align the split output's order

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -300,6 +300,15 @@ def is_valid_splitwithsizes_cat(match):
     # All parts of split should be included in the cat
     if get_item_args != set(range(len(split_sizes))):
         return False
+    # The order of get_item_args should same with cat_node used.
+    # For example, if the split_node like split_with_sizes(input, [2, 2, 3], 1),
+    # the cat node should be like cat([get_item(0), get_item(1), get_item(2)], 1).
+    cat_items_args_order = [
+        get_arg_value(item_node, 1) for item_node in get_arg_value(cat_node, 0)
+    ]
+    if cat_items_args_order != list(get_item_args):
+        return False
+
     return True
 
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -306,7 +306,7 @@ def is_valid_splitwithsizes_cat(match):
     cat_items_args_order = [
         get_arg_value(item_node, 1) for item_node in get_arg_value(cat_node, 0)
     ]
-    if cat_items_args_order != list(get_item_args):
+    if cat_items_args_order != list(range(len(split_sizes))):
         return False
 
     return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99702
* __->__ #99700


we should make sure the cat order does align with the split output's order before removing the cat operation. Fix https://github.com/pytorch/pytorch/issues/99686.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire