### PR TITLE
Creating a fast path for compare the tensors sharing the same storage

### DIFF
--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -29,7 +29,17 @@ bool tensorEqual(const at::Tensor& lhs, const at::Tensor& rhs) {
   if (lhs.device() != rhs.device()) {
     return false;
   }
-  return lhs.options().type_equal(rhs.options()) && lhs.equal(rhs);
+  auto type_equal = lhs.options().type_equal(rhs.options());
+  if (!type_equal) {
+    return false;
+  }
+  if (lhs.sizes().equals(rhs.sizes())
+      && lhs.strides().equals(rhs.strides())
+      && lhs.storage().is_alias_of(rhs.storage())
+      && lhs.storage_offset() == rhs.storage_offset()) {
+    return true;
+  }
+  return lhs.equal(rhs);
 }
 
 bool typeListEqual(


### PR DESCRIPTION
Summary:
For 423557497_225, most of the time is spent on matching whether some large tensors are equal. Actually, they are indeed equal, and these tensors share the same storage. So we create a fast path for such cases.

With the optimization, we reduced the model loading time from 9m11s to 2m37s.

Test Plan:
buck run mode/opt-split-dwarf scripts/lufang:load_pt_model -- --model_file_path=/data/local/models/423557497/225/423557497_225.predictor

TODO: add more unittest.

Differential Revision: D45174912

