### PR TITLE
Fix a minor bug about method generation.

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -231,7 +231,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             self.assertFalse(self.module.custom_add_called())
             self.assertTrue(z2.is_foo)
 
-        def test_open_device_storage_pin_memory(self):
+        def test_open_device_storage_pin_memory():
             torch.utils.rename_privateuse1_backend('foo')
             with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
                 torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -89,157 +89,164 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         remove_build_path()
 
     def test_open_device_registration(self):
-        self.assertFalse(self.module.custom_add_called())
+        def test_base_device_registration():
+            torch.utils.rename_privateuse1_backend('foo')
+            self.assertFalse(self.module.custom_add_called())
+            # create a tensor using our custom device object
+            device = self.module.custom_device()
+            x = torch.empty(4, 4, device=device)
+            y = torch.empty(4, 4, device=device)
+            # Check that our device is correct.
+            self.assertTrue(x.device == device)
+            self.assertFalse(x.is_cpu)
+            self.assertFalse(self.module.custom_add_called())
+            # calls out custom add kernel, registered to the dispatcher
+            z = x + y
+            # check that it was called
+            self.assertTrue(self.module.custom_add_called())
+            z_cpu = z.to(device='cpu')
+            # Check that our cross-device copy correctly copied the data to cpu
+            self.assertTrue(z_cpu.is_cpu)
+            self.assertFalse(z.is_cpu)
+            self.assertTrue(z.device == device)
+            self.assertEqual(z, z_cpu)
+            z2 = z_cpu + z_cpu
 
-        # create a tensor using our custom device object.
-        device = self.module.custom_device()
+        # check whether the error can be reported correctly
+        def test_before_common_registration():
+            # check that register module name should be the same as custom backend
+            with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
+                torch._register_device_module('xxx', DummyModule)
+            # check generator registered before using
+            with self.assertRaisesRegex(RuntimeError, "torch has no module of"):
+                with torch.random.fork_rng(device_type="foo"):
+                    pass
+            # check attributes before registered
+            self.assertFalse(hasattr(torch.Tensor, 'is_foo'))
+            self.assertFalse(hasattr(torch.Tensor, 'foo'))
+            self.assertFalse(hasattr(torch.TypedStorage, 'is_foo'))
+            self.assertFalse(hasattr(torch.TypedStorage, 'foo'))
+            self.assertFalse(hasattr(torch.UntypedStorage, 'is_foo'))
+            self.assertFalse(hasattr(torch.UntypedStorage, 'foo'))
+            self.assertFalse(hasattr(torch.nn.Module, 'foo'))
 
-        x = torch.empty(4, 4, device=device)
-        y = torch.empty(4, 4, device=device)
+        def test_after_common_registration():
+            # check attributes after registered
+            self.assertTrue(hasattr(torch.Tensor, 'is_foo'))
+            self.assertTrue(hasattr(torch.Tensor, 'foo'))
+            self.assertTrue(hasattr(torch.TypedStorage, 'is_foo'))
+            self.assertTrue(hasattr(torch.TypedStorage, 'foo'))
+            self.assertTrue(hasattr(torch.UntypedStorage, 'is_foo'))
+            self.assertTrue(hasattr(torch.UntypedStorage, 'foo'))
+            self.assertTrue(hasattr(torch.nn.Module, 'foo'))
 
-        # Check that our device is correct.
-        self.assertTrue(x.device == device)
-        self.assertFalse(x.is_cpu)
+        def test_common_registration():
+            # first rename custom backend
+            torch.utils.rename_privateuse1_backend('foo')
+            # backend name can only rename once
+            with self.assertRaisesRegex(RuntimeError, "torch.register_privateuse1_backend()"):
+                torch.utils.rename_privateuse1_backend('xxx')
+            # register foo module, torch.foo
+            torch._register_device_module('foo', DummyModule)
+            # default set for_tensor and for_module are True, so only set for_storage is True
+            torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
+            # generator tensor and module can be registered only once
+            with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
+                torch.utils.generate_methods_for_privateuse1_backend()
 
-        self.assertFalse(self.module.custom_add_called())
-
-        # calls out custom add kernel, registered to the dispatcher
-        z = x + y
-
-        # check that it was called
-        self.assertTrue(self.module.custom_add_called())
-
-        z_cpu = z.to(device='cpu')
-
-        # Check that our cross-device copy correctly copied the data to cpu
-        self.assertTrue(z_cpu.is_cpu)
-        self.assertFalse(z.is_cpu)
-        self.assertTrue(z.device == device)
-        self.assertEqual(z, z_cpu)
-
-        z2 = z_cpu + z_cpu
-
-        # None of our CPU operations should call the custom add function.
-        self.assertFalse(self.module.custom_add_called())
-
-        # check generator registered befor use
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Please register a generator to the PrivateUse1 dispatch key"):
-            gen_ = torch.Generator(device=device)
-
-        self.module.register_generator()
-
-        gen = torch.Generator(device=device)
-        self.assertTrue(gen.device == device)
-
-        # generator can be registered only once
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Only can register a generator to the PrivateUse1 dispatch key once"):
+        def test_generator_registration():
+            device = self.module.custom_device()
+            # None of our CPU operations should call the custom add function.
+            self.assertFalse(self.module.custom_add_called())
+            # check generator registered before using
+            with self.assertRaisesRegex(RuntimeError,
+                                        "Please register a generator to the PrivateUse1 dispatch key"):
+                gen_ = torch.Generator(device=device)
             self.module.register_generator()
+            gen = torch.Generator(device=device)
+            self.assertTrue(gen.device == device)
+            # generator can be registered only once
+            with self.assertRaisesRegex(RuntimeError,
+                                        "Only can register a generator to the PrivateUse1 dispatch key once"):
+                self.module.register_generator()
 
-        # check whether print tensor.type() meets the expectation
-        torch.utils.rename_privateuse1_backend('foo')
-        dtypes = {
-            torch.bool: 'torch.foo.BoolTensor',
-            torch.double: 'torch.foo.DoubleTensor',
-            torch.float32: 'torch.foo.FloatTensor',
-            torch.half: 'torch.foo.HalfTensor',
-            torch.int32: 'torch.foo.IntTensor',
-            torch.int64: 'torch.foo.LongTensor',
-            torch.int8: 'torch.foo.CharTensor',
-            torch.short: 'torch.foo.ShortTensor',
-            torch.uint8: 'torch.foo.ByteTensor',
-        }
-        for tt, dt in dtypes.items():
-            test_tensor = torch.empty(4, 4, dtype=tt, device=device)
-            self.assertTrue(test_tensor.type() == dt)
-
-        # check whether the attributes and methods of the corresponding custom backend are generated correctly
-        torch.utils.rename_privateuse1_backend('foo')
-        torch.utils.generate_methods_for_privateuse1_backend()
-        with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
-            torch.utils.generate_methods_for_privateuse1_backend()
-
-        x = torch.empty(4, 4)
-        self.assertFalse(x.is_foo)
-        x = x.foo()
-        self.assertTrue(x.is_foo)
-        self.assertTrue(hasattr(torch.nn.Module, 'foo'))
-
-        # check whether the attributes and methods for storage of the corresponding custom backend are generated correctly
-        torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)
-
-        x = torch.empty(4, 4)
-        # check TypedStorage
-        z1 = x.storage()
-        self.assertFalse(z1.is_foo)
-        z1 = z1.foo()
-        self.assertFalse(self.module.custom_add_called())
-        self.assertTrue(z1.is_foo)
-        with self.assertRaisesRegex(RuntimeError, "Invalid device"):
-            z1.foo(torch.device("cpu"))
-        z1 = z1.cpu()
-
-        y = torch.empty(4, 4)
-        # check UntypedStorage
-        z2 = y.untyped_storage()
-        self.assertFalse(z2.is_foo)
-        z2 = z2.foo()
-        self.assertFalse(self.module.custom_add_called())
-        self.assertTrue(z2.is_foo)
-
-        storage = torch.UntypedStorage(4, device=torch.device('foo'))
-        self.assertEqual(torch.serialization.location_tag(storage), 'foo')
-        cpu_storage = torch.empty(4, 4).storage()
-        foo_storage = torch.serialization.default_restore_location(cpu_storage, 'foo:0')
-        self.assertTrue(foo_storage.is_foo)
-
-    def test_open_device_random(self):
-        torch.utils.rename_privateuse1_backend('foo')
-        with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
-            torch._register_device_module('xxx', DummyModule)
-
-        with self.assertRaisesRegex(RuntimeError, "torch has no module of"):
+        def test_open_device_random():
             with torch.random.fork_rng(device_type="foo"):
                 pass
-        torch._register_device_module('foo', DummyModule)
 
-        with torch.random.fork_rng(device_type="foo"):
-            pass
+        def test_open_device_tensor():
+            device = self.module.custom_device()
+            # check whether print tensor.type() meets the expectation
+            dtypes = {
+                torch.bool: 'torch.foo.BoolTensor',
+                torch.double: 'torch.foo.DoubleTensor',
+                torch.float32: 'torch.foo.FloatTensor',
+                torch.half: 'torch.foo.HalfTensor',
+                torch.int32: 'torch.foo.IntTensor',
+                torch.int64: 'torch.foo.LongTensor',
+                torch.int8: 'torch.foo.CharTensor',
+                torch.short: 'torch.foo.ShortTensor',
+                torch.uint8: 'torch.foo.ByteTensor',
+            }
+            for tt, dt in dtypes.items():
+                test_tensor = torch.empty(4, 4, dtype=tt, device=device)
+                self.assertTrue(test_tensor.type() == dt)
+            # check whether the attributes and methods of the corresponding custom backend are generated correctly
+            x = torch.empty(4, 4)
+            self.assertFalse(x.is_foo)
+            x = x.foo(torch.device("foo"))
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(x.is_foo)
+            # test different device type input
+            y = torch.empty(4, 4)
+            self.assertFalse(y.is_foo)
+            y = y.foo(torch.device("foo:0"))
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(y.is_foo)
+            # test different device type input
+            z = torch.empty(4, 4)
+            self.assertFalse(z.is_foo)
+            z = z.foo(0)
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(z.is_foo)
 
-    def test_open_device_storage_pin_memory(self):
-        torch.utils.rename_privateuse1_backend('foo')
-        with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
-            torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)
+        def test_open_device_storage():
+            # check whether the attributes and methods for storage of the corresponding custom backend are generated correctly
+            x = torch.empty(4, 4)
+            z1 = x.storage()
+            self.assertFalse(z1.is_foo)
+            z1 = z1.foo()
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(z1.is_foo)
+            with self.assertRaisesRegex(RuntimeError, "Invalid device"):
+                z1.foo(torch.device("cpu"))
+            z1 = z1.cpu()
+            self.assertFalse(self.module.custom_add_called())
+            self.assertFalse(z1.is_foo)
+            # check UntypedStorage
+            y = torch.empty(4, 4)
+            z2 = y.untyped_storage()
+            self.assertFalse(z2.is_foo)
+            z2 = z2.foo()
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(z2.is_foo)
 
-        # Check if the pin_memory is functioning properly on custom device
-        cpu_tensor = torch.empty(3)
-        self.assertFalse(cpu_tensor.is_foo)
-        self.assertFalse(cpu_tensor.is_pinned("foo"))
-        cpu_tensor_pin = cpu_tensor.pin_memory("foo")
-        self.assertTrue(cpu_tensor_pin.is_pinned("foo"))
+        def test_open_device_serialization():
+            storage = torch.UntypedStorage(4, device=torch.device('foo'))
+            self.assertEqual(torch.serialization.location_tag(storage), 'foo')
+            cpu_storage = torch.empty(4, 4).storage()
+            foo_storage = torch.serialization.default_restore_location(cpu_storage, 'foo:0')
+            self.assertTrue(foo_storage.is_foo)
 
-
-        # Test storage pin_memory on custom device
-        cpu_storage = cpu_tensor.storage()
-        self.assertFalse(cpu_storage.is_pinned("foo"))
-
-        cpu_storage_pin = cpu_storage.pin_memory("foo")
-        self.assertFalse(cpu_storage.is_pinned("foo"))
-        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
-
-        cpu_storage_pin_already = cpu_storage_pin.pin_memory("foo")
-        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
-        self.assertTrue(cpu_storage_pin_already.is_pinned("foo"))
-
-
-        # Test storage pin_memory on error device
-        self.assertFalse(cpu_storage.is_pinned("foo"))
-        with self.assertRaisesRegex(TypeError, "cannot pin CPU memory to hpu device, please check the target device."):
-            cpu_storage_pin = cpu_storage.pin_memory("hpu")
-        self.assertFalse(cpu_storage.is_pinned("hpu"))
-        self.assertFalse(cpu_storage.is_pinned())
-
+        test_base_device_registration()
+        test_before_common_registration()
+        test_common_registration()
+        test_after_common_registration()
+        test_generator_registration()
+        test_open_device_random()
+        test_open_device_tensor()
+        test_open_device_storage()
+        test_open_device_serialization()
 
 if __name__ == "__main__":
     common.run_tests()

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -230,7 +230,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             z2 = z2.foo()
             self.assertFalse(self.module.custom_add_called())
             self.assertTrue(z2.is_foo)
-        
+
         def test_open_device_storage_pin_memory(self):
             torch.utils.rename_privateuse1_backend('foo')
             with self.assertRaisesRegex(RuntimeError, "The custom device module of"):


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

when create a torch.device obj, like `x=torch.device("foo")`, the device index is None.

So in this scenario, we need to get the current device index again.

cc @albanD Could you take a look about my changes.