### PR TITLE
[Feature] storage pin memory support custom device.

### DIFF
--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -100,6 +100,34 @@ at::Tensor& custom_set_source_Storage(at::Tensor& result, c10::Storage src) {
   return result;
 }
 
+// basic dummy functions related to pin_memory.
+std::vector<void*> custom_pinned_data_ptr;
+
+at::Tensor custom__pin_memory(const Tensor& self, c10::optional<at::Device> device) {
+  TORCH_CHECK(self.device().is_cpu(), "cannot pin '", self.toString(), "' only dense CPU tensors can be pinned");
+
+  // record pinned data ptr
+  at::Tensor dump_pinned_tensor = self * 1.0;
+  custom_pinned_data_ptr.push_back(dump_pinned_tensor.storage().data_ptr().get());
+
+  return dump_pinned_tensor;
+}
+
+bool custom_is_pinned(const Tensor& self, c10::optional<at::Device> device) {
+  // Only CPU tensors can be pinned
+  if (!self.is_cpu()) {
+    return false;
+  }
+
+  void* query_pinned_ptr = self.storage().data_ptr().get();
+  for (const auto& iter_ptr : custom_pinned_data_ptr) {
+    if (iter_ptr == query_pinned_ptr) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // This macro does the heavy lifting.
 // With TORCH_LIBRARY_IMPL, you can register custom kernels for your backend.
 // For open registration, we're registering all of our kernels to the PrivateUse1 dispatch key.
@@ -116,6 +144,8 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("_copy_from", &custom__copy_from);
   m.impl("empty_strided", &custom_empty_strided);
   m.impl("set_.source_Storage", &custom_set_source_Storage);
+  m.impl("_pin_memory", &custom__pin_memory);
+  m.impl("is_pinned", &custom_is_pinned);
 }
 
 // This basic implementation doesn't bother dealing with different device indices

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -207,6 +207,39 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         with torch.random.fork_rng(device_type="foo"):
             pass
 
+    def test_open_device_storage_pin_memory(self):
+        torch.utils.rename_privateuse1_backend('foo')
+        with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
+            torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)
+
+        # Check if the pin_memory is functioning properly on custom device
+        cpu_tensor = torch.empty(3)
+        self.assertFalse(cpu_tensor.is_foo)
+        self.assertFalse(cpu_tensor.is_pinned("foo"))
+        cpu_tensor_pin = cpu_tensor.pin_memory("foo")
+        self.assertTrue(cpu_tensor_pin.is_pinned("foo"))
+
+
+        # Test storage pin_memory on custom device
+        cpu_storage = cpu_tensor.storage()
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+
+        cpu_storage_pin = cpu_storage.pin_memory("foo")
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
+
+        cpu_storage_pin_already = cpu_storage_pin.pin_memory("foo")
+        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
+        self.assertTrue(cpu_storage_pin_already.is_pinned("foo"))
+
+
+        # Test storage pin_memory on error device
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+        with self.assertRaisesRegex(TypeError, "cannot pin CPU memory to hpu device, please check the target device."):
+            cpu_storage_pin = cpu_storage.pin_memory("hpu")
+        self.assertFalse(cpu_storage.is_pinned("hpu"))
+        self.assertFalse(cpu_storage.is_pinned())
+
 
 if __name__ == "__main__":
     common.run_tests()


### PR DESCRIPTION
Fixes #99326 

Support storage pin_memory and is_pinned for custom device, by calling dispatched tensor operations.

@ezyang  this pr is what we have discussed in issue #99326, would you please take a moment to review it, thanks.



