### PR TITLE
[Feature] storage pin memory support custom device.

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -207,6 +207,39 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         with torch.random.fork_rng(device_type="foo"):
             pass
 
+    def test_open_device_storage_pin_memory(self):
+        torch.utils.rename_privateuse1_backend('foo')
+        with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
+            torch.utils.generate_methods_for_privateuse1_backend(for_tensor=False, for_module=False, for_storage=True)
+
+        # Check if the pin_memory is functioning properly on custom device
+        cpu_tensor = torch.empty(3)
+        self.assertFalse(cpu_tensor.is_foo)
+        self.assertFalse(cpu_tensor.is_pinned("foo"))
+        cpu_tensor_pin = cpu_tensor.pin_memory("foo")
+        self.assertTrue(cpu_tensor_pin.is_pinned("foo"))
+
+
+        # Test storage pin_memory on custom device
+        cpu_storage = cpu_tensor.storage()
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+
+        cpu_storage_pin = cpu_storage.pin_memory("foo")
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
+
+        cpu_storage_pin_already = cpu_storage_pin.pin_memory("foo")
+        self.assertTrue(cpu_storage_pin.is_pinned("foo"))
+        self.assertTrue(cpu_storage_pin_already.is_pinned("foo"))
+
+
+        # Test storage pin_memory on error device
+        self.assertFalse(cpu_storage.is_pinned("foo"))
+        with self.assertRaisesRegex(TypeError, "cannot pin CPU memory to hpu device, please check the target device."):
+            cpu_storage_pin = cpu_storage.pin_memory("hpu")
+        self.assertFalse(cpu_storage.is_pinned("hpu"))
+        self.assertFalse(cpu_storage.is_pinned())
+
 
 if __name__ == "__main__":
     common.run_tests()

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -192,18 +192,23 @@ class _StorageBase:
         return self._to(torch.cfloat)
 
     def pin_memory(self, device="cuda"):
-        """Copies the storage to pinned memory, if it's not already pinned."""
-        if self.is_cuda:
+        """Copies the CPU storage to pinned memory, if it's not already pinned."""
+        if self.device.type != 'cpu':
             raise TypeError(f"cannot pin '{self.type()}' only CPU memory can be pinned")
-        """For other backends, device need to set.
-           If not set, the default behaviour is CUDA device. Currently, only CUDA is supported.
-        """
-        if device != "cuda":
-            raise TypeError(f"cannot pin memory to {device} device, only CUDA is supported.")
 
-        import torch.cuda
-        allocator = torch.cuda.memory._host_allocator()  # type: ignore[attr-defined]
-        return type(self)(self.size(), allocator=allocator).copy_(self)
+        """For other backends, device need to set. If not set, the default behaviour is CUDA device."""
+        if device == "cuda":
+            import torch.cuda
+            allocator = torch.cuda.memory._host_allocator()  # type: ignore[attr-defined]
+            return type(self)(self.size(), allocator=allocator).copy_(self)
+        else :
+            import torch
+            if torch._C._get_privateuse1_backend_name() == device:
+                pinned_tensor = torch.tensor([], dtype=torch.uint8, device=self.device).set_(
+                    cast(Storage, self)).pin_memory(device)
+                return pinned_tensor._typed_storage()._untyped_storage
+            else :
+                raise TypeError(f"cannot pin CPU memory to {device} device, please check the target device.")
 
     def share_memory_(self):
         """Moves the storage to shared memory.
@@ -989,9 +994,17 @@ class TypedStorage:
     def _expired(cls, *args, **kwargs):
         return UntypedStorage._expired(*args, **kwargs)
 
-    def is_pinned(self):
-        _warn_typed_storage_removal()
-        return self._untyped_storage.is_pinned()
+    def is_pinned(self, device="cuda"):
+        """For other backends, device need to set. If not set, the default behaviour is CUDA device."""
+        if device == "cuda":
+            _warn_typed_storage_removal()
+            return self._untyped_storage.is_pinned()
+        elif torch._C._get_privateuse1_backend_name() == device:
+            return torch.tensor([], dtype=torch.uint8, device=self.device).set_(
+                cast(Storage, self._untyped_storage)).is_pinned(device)
+        else:
+            # Currently, cannot pin CPU storage memory to other device, except for cuda and privateuse1.
+            return False
 
     def _write_file(self, *args, **kwargs):
         return self._untyped_storage._write_file(*args, **kwargs)


### PR DESCRIPTION
Fixes #99326 

Support storage pin_memory and is_pinned for custom device, by calling dispatched tensor operations.

@ezyang  this pr is what we have discussed in issue #99326, would you please take a moment to review it, thanks.



