### PR TITLE
Remove little endian asserts

### DIFF
--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
@@ -32,8 +32,6 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
   USE_SIMPLE_CTOR_DTOR(FloatToFused8BitRowwiseQuantizedOp)
 
   bool RunOnDevice() override {
-    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
-
     const auto& input = Input(DATA_FLOAT);
 
     CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");
@@ -119,8 +117,6 @@ class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
   USE_SIMPLE_CTOR_DTOR(Fused8BitRowwiseQuantizedToFloatOp)
 
   bool RunOnDevice() override {
-    CAFFE_ENFORCE(IS_LITTLE_ENDIAN, "Unsupported endianness");
-
     const auto& input = Input(DATA_FUSED_SCALE_BIAS_INT8);
 
     CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");

--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
@@ -28,8 +28,6 @@ class FloatToFusedNBitRowwiseQuantizedOp final : public Operator<CPUContext> {
   ~FloatToFusedNBitRowwiseQuantizedOp() override {}
 
   bool RunOnDevice() override {
-    CAFFE_ENFORCE(internal::is_little_endian(), "Unsupported endianness");
-
     const auto& input = Input(DATA_FLOAT);
 
     CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");
@@ -167,8 +165,6 @@ class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
   ~FusedNBitRowwiseQuantizedToFloatOp() override {}
 
   bool RunOnDevice() override {
-    CAFFE_ENFORCE(internal::is_little_endian(), "Unsupported endianness");
-
     const auto& input = Input(DATA_FUSED_SCALE_BIAS);
 
     CAFFE_ENFORCE_GT(input.dim(), 0, "Input's dimension must be at least 1");


### PR DESCRIPTION
They block tests test_embedding_bag_2bit_unpack,
test_embedding_bag_4bit_unpack and test_embedding_bag_byte_unpack in test/quantization/core/test_quantized_op.py.

Without these asserts tests start passing on big endian systems.

Fixes #97803
