### PR TITLE
[WIP] Dynamo capture for HigherOrderOperator

### DIFF
--- a/aaa.py
+++ b/aaa.py
@@ -1,0 +1,60 @@
+import torch
+from torch._ops import HigherOrderOperator
+
+class Wrap(HigherOrderOperator):
+    def __init__(self):
+        super().__init__('wrap')
+
+    def __call__(self, func, *args):
+        return func(*args)
+
+wrap = Wrap()
+
+# Case 1: no free variables
+@torch.compile(backend='aot_eager')
+def f(x):
+    return wrap(lambda x: torch.sin(x), x)
+
+x = torch.randn(3, 3)
+f(x)
+
+# Case 2: free variables not being tracked.
+y = torch.randn(3, 3)
+
+@torch.compile(backend='aot_eager')
+def f(x):
+    return wrap(lambda x: x + y, x)
+
+x = torch.randn(3, 3)
+f(x)
+
+# Case 3: free variables are tracked.
+x = torch.randn(3, 3)
+y = torch.randn(3, 3)
+@torch.compile(backend='aot_eager')
+def f(x, y):
+    return wrap(lambda x: x + y, x)
+
+f(x, y)
+
+# Case 4: free variables not being tracked. nested case.
+# Doesn't work.
+# y = torch.randn(3, 3)
+# 
+# @torch.compile(backend='aot_eager')
+# def f(x):
+#     return wrap(lambda x: wrap(lambda x: x + y, x), x)
+# 
+# x = torch.randn(3, 3)
+# f(x)
+
+# Case 5: free variables are being tracked. nested case.
+# Doesn't work.
+# y = torch.randn(3, 3)
+# 
+# @torch.compile(backend='aot_eager')
+# def f(x, y):
+#     return wrap(lambda x: wrap(lambda x: x + y, x), x)
+# 
+# x = torch.randn(3, 3)
+# f(x, y)

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 def aot_autograd(**kwargs):
     def compiler_fn(gm: torch.fx.GraphModule, example_inputs):
+        print(gm.code)
         # Hack to get around circular import problems with aot_eager_decomp_partition
         if callable(kwargs.get("decompositions")):
             kwargs["decompositions"] = kwargs["decompositions"]()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -199,6 +199,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         frame_state,
     ):
         super().__init__()
+        self.freevars = set({})
         self.graph = torch.fx.Graph()
         # Map from graph input's `Source` to its `VariableTracker` to
         # de-duplicate graph inputs by source and reuse the tracker

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -790,3 +790,4 @@ class _Ops(types.ModuleType):
 
 # The ops "namespace"
 ops = _Ops()
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #99718

- This PR introduces a wrap(fn, *args) higher order operator.
- The semantics of `wrap(fn, *args)` is to just run `fn(*args)`

Underneath dynamo, this PR makes it so that we rewrite calls to
wrap(fn, *args) with wrap(new_fn, *new_args) where new_fn has
no free variables.

The approach taken in this PR is:
- we improve the notion of using Dynamo to trace out a "subgraph"
- when we are tracing out the "subgraph", we temporarily stash the
current tx.output and use a new tx.output to record the subgraph
- when this is going on, we still need to modify the original tx.output.
If we encounter new globals in the subgraph that are untracked, then we
need to make sure the original tx.output tracks them
- any tracked variables that are not directly inputs to the subgraph get
lifted to being inputs of the subgraph.

If we like this approach, then we are going to need to:
- generalize to tracing nested HigherOrderOperator. We'll probably need a stack
of OutputGraph, one for each level of nesting. Any tracked variables
that are lifted to be an input of an inner OutputGraph need to be lifted
to be inputs of the outer ones.
- generalize this approach to nested tx. Nested tx can happen when we
have a function call another function. They're all inlined (as far as I
can understand), but we still have nested tx.
- I'm not sure I got all the cases, so we need to add this handling to
more instructions in symbolic_convert.

Test Plan:
- see aaa.py. I've modified aot_eager to actually print out the graphs
that go to the backend, and they look like we'd expect.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire