### PR TITLE
[fx] Remove replace_literals_with_placeholders

### DIFF
--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -221,7 +221,7 @@ class SubgraphMatcher:
                 elif isinstance(a1, (list, tuple)) and isinstance(a2, (list, tuple)):
                     matched = _match_args(a1, a2)
                 else:
-                    matched = self.ignore_literals or self._match_literals(a1, a2, match)
+                    matched = self._match_literals(a1, a2, match) or self.ignore_literals
 
                 if not matched:
                     return False


### PR DESCRIPTION
Summary:
SubraphMatcher contains an ignore_literals flag which we can turn on
instead.

Test Plan: CI

Differential Revision: D45168383

