### PR TITLE
Decompose arange.default to arange.start_step

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -184,6 +184,8 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.addcmul_,
             aten.addr,
             aten.aminmax,
+            aten.arange.default,
+            aten.arange.start,
             aten.avg_pool2d_backward,
             aten.binary_cross_entropy,
             aten.binary_cross_entropy_backward,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3356,8 +3356,7 @@ def nansum(self, dim=None, keepdim=False, *, dtype=None):
     return aten.sum(torch.where(torch.isnan(self), 0, self), dim, keepdim, dtype=dtype)
 
 
-@register_decomposition(aten.arange.default)
-@out_wrapper()
+@register_decomposition([aten.arange.default, aten.arange.out])
 def arange_default(
     end: NumberType,
     *,
@@ -3371,8 +3370,7 @@ def arange_default(
     )
 
 
-@register_decomposition(aten.arange.start)
-@out_wrapper()
+@register_decomposition([aten.arange.start, aten.arange.start_out])
 def arange_start(
     start: NumberType,
     end: NumberType,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3357,6 +3357,7 @@ def nansum(self, dim=None, keepdim=False, *, dtype=None):
 
 
 @register_decomposition([aten.arange.default, aten.arange.out])
+@out_wrapper()
 def arange_default(
     end: NumberType,
     *,
@@ -3370,7 +3371,7 @@ def arange_default(
     )
 
 
-@register_decomposition([aten.arange.start, aten.arange.start_out])
+@register_decomposition([aten.arange.start])
 def arange_start(
     start: NumberType,
     end: NumberType,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3356,6 +3356,37 @@ def nansum(self, dim=None, keepdim=False, *, dtype=None):
     return aten.sum(torch.where(torch.isnan(self), 0, self), dim, keepdim, dtype=dtype)
 
 
+@register_decomposition(aten.arange.default)
+@out_wrapper()
+def arange_default(
+    end: NumberType,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: torch.layout = torch.strided,
+    device: Optional[torch.device] = None,
+    pin_memory: bool = False,
+):
+    return aten.arange.start_step(
+        0, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+
+
+@register_decomposition(aten.arange.start)
+@out_wrapper()
+def arange_start(
+    start: NumberType,
+    end: NumberType,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: torch.layout = torch.strided,
+    device: Optional[torch.device] = None,
+    pin_memory: bool = False,
+):
+    return aten.arange.start_step(
+        start, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -277,8 +277,6 @@ def out_wrapper(*out_names: str, exact_dtype: bool = False):
         _fn.__annotations__ = fn.__annotations__
         _fn.__annotations__["out"] = out_type
         _fn.__annotations__["return"] = return_type
-        if "arange" in str(_fn):
-            breakpoint()
         return _fn
 
     return _out_wrapper

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -277,6 +277,8 @@ def out_wrapper(*out_names: str, exact_dtype: bool = False):
         _fn.__annotations__ = fn.__annotations__
         _fn.__annotations__["out"] = out_type
         _fn.__annotations__["return"] = return_type
+        if "arange" in str(_fn):
+            breakpoint()
         return _fn
 
     return _out_wrapper

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4432,7 +4432,6 @@ def arange_start_step(
 @register_decomposition(aten.arange.default)
 @out_wrapper()
 def arange_default(
-    start: NumberType,
     end: NumberType,
     *,
     dtype: Optional[torch.dtype] = None,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4340,7 +4340,7 @@ def empty_like(
 
 @register_decomposition([aten.arange.start_step])
 @out_wrapper()
-def arange_start_step(
+def arange(
     start: NumberType = 0,
     end: Optional[NumberType] = None,
     step: NumberType = 1,
@@ -4427,37 +4427,6 @@ def arange_start_step(
     if requires_grad:
         result.requires_grad_(True)
     return result
-
-
-@register_decomposition(aten.arange.default)
-@out_wrapper()
-def arange_default(
-    end: NumberType,
-    *,
-    dtype: Optional[torch.dtype] = None,
-    layout: torch.layout = torch.strided,
-    device: Optional[torch.device] = None,
-    pin_memory: bool = False,
-) -> TensorLikeType:
-    return aten.arange.start_step(
-        0, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
-    )
-
-
-@register_decomposition(aten.arange.start)
-@out_wrapper()
-def arange_start(
-    start: NumberType,
-    end: NumberType,
-    *,
-    dtype: Optional[torch.dtype] = None,
-    layout: torch.layout = torch.strided,
-    device: Optional[torch.device] = None,
-    pin_memory: bool = False,
-) -> TensorLikeType:
-    return aten.arange.start_step(
-        start, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
-    )
 
 
 @register_decomposition(aten.lerp)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4338,7 +4338,7 @@ def empty_like(
     )
 
 
-@register_decomposition(aten.arange.start_step)
+@register_decomposition([aten.arange.start_step])
 @out_wrapper()
 def arange_start_step(
     start: NumberType = 0,
@@ -4431,16 +4431,34 @@ def arange_start_step(
 
 @register_decomposition(aten.arange.default)
 @out_wrapper()
-def arange(
-    end: Optional[NumberType] = None,
+def arange_default(
+    start: NumberType,
+    end: NumberType,
     *,
     dtype: Optional[torch.dtype] = None,
     layout: torch.layout = torch.strided,
     device: Optional[torch.device] = None,
     pin_memory: bool = False,
-    requires_grad: bool = False,
 ) -> TensorLikeType:
-    return aten.arange.start_step(0, end, 1, dtype, layout, device, pin_memory, requires_grad)
+    return aten.arange.start_step(
+        0, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+
+
+@register_decomposition(aten.arange.start)
+@out_wrapper()
+def arange_start(
+    start: NumberType,
+    end: NumberType,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: torch.layout = torch.strided,
+    device: Optional[torch.device] = None,
+    pin_memory: bool = False,
+) -> TensorLikeType:
+    return aten.arange.start_step(
+        start, end, 1, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
 
 
 @register_decomposition(aten.lerp)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4338,9 +4338,9 @@ def empty_like(
     )
 
 
-@register_decomposition(aten.arange)
+@register_decomposition(aten.arange.start_step)
 @out_wrapper()
-def arange(
+def arange_start_step(
     start: NumberType = 0,
     end: Optional[NumberType] = None,
     step: NumberType = 1,
@@ -4427,6 +4427,20 @@ def arange(
     if requires_grad:
         result.requires_grad_(True)
     return result
+
+
+@register_decomposition(aten.arange.default)
+@out_wrapper()
+def arange(
+    end: Optional[NumberType] = None,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: torch.layout = torch.strided,
+    device: Optional[torch.device] = None,
+    pin_memory: bool = False,
+    requires_grad: bool = False,
+) -> TensorLikeType:
+    return aten.arange.start_step(0, end, 1, dtype, layout, device, pin_memory, requires_grad)
 
 
 @register_decomposition(aten.lerp)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4338,7 +4338,7 @@ def empty_like(
     )
 
 
-@register_decomposition([aten.arange.start_step])
+@register_decomposition([aten.arange.start_step, aten.arange.start_out])
 @out_wrapper()
 def arange(
     start: NumberType = 0,


### PR DESCRIPTION
The aten op arange.default is not in the core aten IR, and should decompose into the arange.start_step op.