### PR TITLE
Automatic pulling ExtraFileMaps without explicit mapping.

### DIFF
--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -232,6 +232,22 @@ TEST(FlatbufferTest, ExtraFiles) {
 
   ASSERT_EQ(loaded_extra_files["metadata.json"], "abc");
   ASSERT_EQ(loaded_extra_files["mobile_info.json"], "{\"key\": 23}");
+
+  // Test if flatbuffer does not require any explicit key entries mapping in the
+  // extra file map.
+  std::unordered_map<std::string, std::string>
+      loaded_extra_files_without_explicit_entries;
+  auto mobile_module3 = _load_for_mobile(
+      ss,
+      c10::nullopt,
+      loaded_extra_files_without_explicit_entries,
+      MobileModuleLoadOptions::PARSE_ALL_EXTRA_FILE_MAPS);
+
+  ASSERT_EQ(
+      loaded_extra_files_without_explicit_entries["metadata.json"], "abc");
+  ASSERT_EQ(
+      loaded_extra_files_without_explicit_entries["mobile_info.json"],
+      "{\"key\": 23}");
 }
 
 TEST(FlatbufferTest, Conv) {

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -1,8 +1,7 @@
 #include <test/cpp/jit/test_utils.h>
 
-#include <gtest/gtest.h>
-
 #include <c10/core/TensorOptions.h>
+#include <gtest/gtest.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/frontend/resolver.h>
@@ -1015,6 +1014,20 @@ TEST(LiteInterpreterTest, ExtraFiles) {
   torch::jit::_load_for_mobile(iss, torch::kCPU, loaded_extra_files);
   ASSERT_EQ(loaded_extra_files["metadata.json"], "abc");
   ASSERT_EQ(loaded_extra_files["mobile_info.json"], "{\"key\": 23}");
+
+  std::unordered_map<std::string, std::string>
+      loaded_extra_files_without_explicit_mapping;
+  iss.seekg(0, iss.beg);
+  torch::jit::_load_for_mobile(
+      iss,
+      torch::kCPU,
+      loaded_extra_files_without_explicit_mapping,
+      MobileModuleLoadOptions::PARSE_ALL_EXTRA_FILE_MAPS);
+  ASSERT_EQ(
+      loaded_extra_files_without_explicit_mapping["metadata.json"], "abc");
+  ASSERT_EQ(
+      loaded_extra_files_without_explicit_mapping["mobile_info.json"],
+      "{\"key\": 23}");
 }
 
 TEST(LiteInterpreterTest, OpNameExportFetchRootOperators) {

--- a/torch/csrc/jit/mobile/import.h
+++ b/torch/csrc/jit/mobile/import.h
@@ -23,7 +23,8 @@ constexpr const char* kArchiveNameVersion = "version";
 TORCH_API mobile::Module _load_for_mobile(
     std::istream& in,
     c10::optional<at::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_file,
+    uint64_t module_load_options = kDefaultMobileLoadOptions);
 
 TORCH_API mobile::Module _load_for_mobile(
     const std::string& filename,

--- a/torch/csrc/jit/mobile/parse_operators.h
+++ b/torch/csrc/jit/mobile/parse_operators.h
@@ -7,6 +7,10 @@ using c10::IValue;
 
 enum MobileModuleLoadOptions {
   OPERATOR_CHECK = 1,
+  // PARSE_ALL_EXTRA_FILE_MAPS is used to gate for ExtraFileMaps to pull all
+  // files automatically without explicit entries mapping. Refer to PR for a
+  // detail: https://github.com/pytorch/pytorch/pull/99747
+  PARSE_ALL_EXTRA_FILE_MAPS = 2,
 };
 
 const uint64_t kDefaultMobileLoadOptions =


### PR DESCRIPTION
Summary:
It comes handy when we are trying to load a module with ExtraFileMaps after JITing since [*BytecodeDeserializer*](https://www.internalfb.com/code/aros/[144773a900f80d6bdb2cbc35f817532200b545be]/xros/third-party/caffe2/caffe2/torch/csrc/jit/mobile/import.cpp?lines=196%2C389%2C408%2C569%2C611) loops over extra maps entries that is given from end-user APIs.

We can simply uses [getAllRecord](https://www.internalfb.com/code/fbsource/[c8b0b670f4782345c954a292dc20f562dd95e263]/xplat/caffe2/caffe2/serialize/inline_container.cc?lines=31%2C67%2C72%2C79%2C86%2C92%2C174%2C178%2C222%2C243%2C275%2C283%2C304%2C322) so that we can easily pull all extra files embedded without explicitly mapping with high level [API ](https://www.internalfb.com/code/fbsource/fbcode/caffe2/torch/csrc/jit/mobile/import.cpp?lines=548-563)

Note :
- Flatbuffer by nature already extracts all embedded files without explicit mapping. I'm simply adding extra unit test for future refence if someone also interested in knowing later on

- only lite interpreter needs a change as diff does

Test Plan:
buck2 run //caffe2/test/cpp/jit:jit -- --gtest_filter=LiteInterpreterTest.ExtraFiles

buck2 run //caffe2/test/cpp/jit:jit -- --gtest_filter=FlatbufferTest.ExtraFiles

Differential Revision: D45170126

