### PR TITLE
Temporarily move trunk MacOS jobs to unstable

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -87,53 +87,6 @@ jobs:
           { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
-  macos-12-py3-arm64-build:
-    name: macos-12-py3-arm64
-    uses: ./.github/workflows/_mac-build.yml
-    with:
-      sync-tag: macos-12-py3-arm64-build
-      build-environment: macos-12-py3-arm64
-      runner-type: macos-m1-12
-      build-generates-artifacts: true
-      # To match the one pre-installed in the m1 runners
-      python-version: 3.9.12
-      # We need to set the environment file here instead of trying to detect it automatically because
-      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
-      # is needed when building PyTorch MacOS arm64 from x86-64
-      environment-file: .github/requirements/conda-env-macOS-ARM64
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-12" },
-          { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-12" },
-          { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-12" },
-        ]}
-
-  macos-12-py3-arm64-mps-test:
-    name: macos-12-py3-arm64-mps
-    uses: ./.github/workflows/_mac-test-mps.yml
-    needs: macos-12-py3-arm64-build
-    if: needs.macos-12-py3-arm64-build.outputs.build-outcome == 'success'
-    with:
-      sync-tag: macos-12-py3-arm64-mps-test
-      build-environment: macos-12-py3-arm64
-      # Same as the build job
-      python-version: 3.9.12
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1 },
-        ]}
-
-  macos-12-py3-arm64-test:
-    name: macos-12-py3-arm64
-    uses: ./.github/workflows/_mac-test.yml
-    needs: macos-12-py3-arm64-build
-    with:
-      build-environment: macos-12-py3-arm64
-      # Same as the build job
-      python-version: 3.9.12
-      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
-      arch: arm64
-
   win-vs2019-cuda11_7-py3-build:
     name: win-vs2019-cuda11.7-py3
     uses: ./.github/workflows/_win-build.yml

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -76,3 +76,50 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+      
+  macos-12-py3-arm64-build:
+    name: macos-12-py3-arm64
+    uses: ./.github/workflows/_mac-build.yml
+    with:
+      sync-tag: macos-12-py3-arm64-build
+      build-environment: macos-12-py3-arm64
+      runner-type: macos-m1-12
+      build-generates-artifacts: true
+      # To match the one pre-installed in the m1 runners
+      python-version: 3.9.12
+      # We need to set the environment file here instead of trying to detect it automatically because
+      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
+      # is needed when building PyTorch MacOS arm64 from x86-64
+      environment-file: .github/requirements/conda-env-macOS-ARM64
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-12" },
+          { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-12" },
+          { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-12" },
+        ]}
+
+  macos-12-py3-arm64-mps-test:
+    name: macos-12-py3-arm64-mps
+    uses: ./.github/workflows/_mac-test-mps.yml
+    needs: macos-12-py3-arm64-build
+    if: needs.macos-12-py3-arm64-build.outputs.build-outcome == 'success'
+    with:
+      sync-tag: macos-12-py3-arm64-mps-test
+      build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1 },
+        ]}
+
+  macos-12-py3-arm64-test:
+    name: macos-12-py3-arm64
+    uses: ./.github/workflows/_mac-test.yml
+    needs: macos-12-py3-arm64-build
+    with:
+      build-environment: macos-12-py3-arm64
+      # Same as the build job
+      python-version: 3.9.12
+      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
+      arch: arm64

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -76,7 +76,7 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-      
+
   macos-12-py3-arm64-build:
     name: macos-12-py3-arm64
     uses: ./.github/workflows/_mac-build.yml


### PR DESCRIPTION
The jobs are failing currently with ModuleNotFoundError: No module named 'sympy'
https://github.com/pytorch/pytorch/actions/runs/4768448427/jobs/8477908005

Probably because of revert of https://github.com/pytorch/pytorch/pull/99506 ?
