### PR TITLE
[ROCM] Do not send "debug"=True down to triton.compile

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1121,7 +1121,11 @@ class TritonKernel(Kernel):
             load_buffer = self.loads
 
         # Assert that the loaded indices will not read garbage
-        if indirect_indexing and config.triton.assert_indirect_indexing and torch.version.hip is None:
+        if (
+            indirect_indexing
+            and config.triton.assert_indirect_indexing
+            and torch.version.hip is None
+        ):
             self.gen_assert_indirect_indexing(load_buffer, original_index, mask)
 
         result_var = self.cse.generate(load_buffer, line)
@@ -1142,8 +1146,11 @@ class TritonKernel(Kernel):
         original_index = index
         index, mask_vars, mask, expand_str = self.indexing(index, dense_indexing=True)
 
-        if indirect_indexing and config.triton.assert_indirect_indexing and torch.version.hip is None:
-            self.gen_assert_indirect_indexing(self.stores, original_index, mask)
+        if (
+            indirect_indexing
+            and config.triton.assert_indirect_indexing
+            and torch.version.hip is None
+        ):            self.gen_assert_indirect_indexing(self.stores, original_index, mask)
 
         if mode is None:
             line = f"tl.store({var} + ({index}), {value}, {mask})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1121,7 +1121,7 @@ class TritonKernel(Kernel):
             load_buffer = self.loads
 
         # Assert that the loaded indices will not read garbage
-        if indirect_indexing and config.triton.assert_indirect_indexing:
+        if indirect_indexing and config.triton.assert_indirect_indexing and torch.version.hip is None:
             self.gen_assert_indirect_indexing(load_buffer, original_index, mask)
 
         result_var = self.cse.generate(load_buffer, line)
@@ -1142,7 +1142,7 @@ class TritonKernel(Kernel):
         original_index = index
         index, mask_vars, mask, expand_str = self.indexing(index, dense_indexing=True)
 
-        if indirect_indexing and config.triton.assert_indirect_indexing:
+        if indirect_indexing and config.triton.assert_indirect_indexing and torch.version.hip is None:
             self.gen_assert_indirect_indexing(self.stores, original_index, mask)
 
         if mode is None:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1150,7 +1150,8 @@ class TritonKernel(Kernel):
             indirect_indexing
             and config.triton.assert_indirect_indexing
             and torch.version.hip is None
-        ):            self.gen_assert_indirect_indexing(self.stores, original_index, mask)
+        ):
+            self.gen_assert_indirect_indexing(self.stores, original_index, mask)
 
         if mode is None:
             line = f"tl.store({var} + ({index}), {value}, {mask})"

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -105,7 +105,12 @@ class CachingAutotuner(KernelInterface):
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
-        compile_meta["debug"] = config.triton.assert_indirect_indexing
+
+        if torch.version.hip is None:
+            compile_meta["debug"] = config.triton.assert_indirect_indexing
+        else:
+            compile_meta["debug"] = False
+
         if warm_cache_only_with_cc:
             triton.compile(
                 self.fn,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -105,7 +105,10 @@ class CachingAutotuner(KernelInterface):
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
-        compile_meta["debug"] = config.triton.assert_indirect_indexing and torch.version.hip is None
+        compile_meta["debug"] = compile_meta["debug"] = (
+config.triton.assert_indirect_indexing and torch.version.hip is None
+        )
+        
 
         if warm_cache_only_with_cc:
             triton.compile(

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -106,9 +106,8 @@ class CachingAutotuner(KernelInterface):
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
         compile_meta["debug"] = compile_meta["debug"] = (
-config.triton.assert_indirect_indexing and torch.version.hip is None
+            config.triton.assert_indirect_indexing and torch.version.hip is None
         )
-        
 
         if warm_cache_only_with_cc:
             triton.compile(

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -105,11 +105,7 @@ class CachingAutotuner(KernelInterface):
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
-
-        if torch.version.hip is None:
-            compile_meta["debug"] = config.triton.assert_indirect_indexing
-        else:
-            compile_meta["debug"] = False
+        compile_meta["debug"] = config.triton.assert_indirect_indexing and torch.version.hip is None
 
         if warm_cache_only_with_cc:
             triton.compile(


### PR DESCRIPTION
ROCm's version of triton does not currently support tl.device_assert.

This operator among others is effectively a no-op unless "debug" = True is passed in the triton.compile function.

Until we have full suport for tl.device_assert, avoid enabling the debug flag in triton.compile, so we do not have to find every possible location tl.device_assert may be used.

Fixes #99725


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire