### PR TITLE
Add Batch Rule for aten::narrow.Tensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4010,7 +4010,14 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CompositeImplicitAutograd: narrow_tensor_symint
+    CompositeExplicitAutograd: narrow_tensor_symint
+
+- func: narrow_backward(Tensor grad_output, SymInt[] input_sizes, int dim, Tensor start, SymInt length) -> Tensor
+  variants: function
+  device_check: NoCheck
+  device_guard: False
+  dispatch:
+    CompositeExplicitAutograd: narrow_backward_symint
 
 - func: native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)
   dispatch:

--- a/aten/src/ATen/native/ts_native_functions.yaml
+++ b/aten/src/ATen/native/ts_native_functions.yaml
@@ -195,6 +195,8 @@ supported:
   - slice_backward
   - new_empty_strided
   - narrow_copy
+  - narrow.Tensor
+  - narrow_backward
   - pixel_shuffle
   - pixel_unshuffle
   - select_backward
@@ -205,6 +207,8 @@ symint:
   - empty.memory_format
   - expand_copy
   - narrow_copy
+  - narrow.Tensor
+  - narrow_backward
   - view_copy
   - as_strided_copy
   - as_strided_scatter

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3515,7 +3515,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.gaussian_nll_loss'),  # data-dependent control flow error
         xfail('nn.functional.embedding_bag'),  # embedding renorm vmap inplace incompatible
         xfail('__rpow__'),  # https://github.com/pytorch/functorch/issues/617
-        xfail('narrow'),  # Batching rule not implemented for aten::narrow.Tensor
 
         # required rank 4 tensor to use channels_last format
         xfail('bfloat16'),
@@ -3686,7 +3685,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('svd_lowrank', ''),
         xfail('diagflat', ''),
         xfail('special.log_ndtr'),
-        xfail('narrow'),  # Batching rule not implemented for aten::narrow.Tensor
         xfail('nn.functional.triplet_margin_loss', ''),
         xfail('nn.functional.pdist', ''),
         xfail('scatter_reduce', 'sum'),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3011,3 +3011,9 @@
 
 - name: _foreach_maximum.ScalarList(Tensor[] self, Scalar[] scalars) -> Tensor[]
   self: at::where(self[i] == scalars[i], grads[i] / 2, grads[i]).masked_fill_(self[i] < scalars[i], 0)
+
+- name: narrow.Tensor(Tensor(a) self, int dim, Tensor start, SymInt length) -> Tensor(a)
+  self: narrow_tensor_symint(grad, self.sym_sizes(), dim, start, length)
+
+- name: narrow_backward(Tensor grad_output, SymInt[] input_sizes, int dim, Tensor start, SymInt length) -> Tensor
+  self: narrow_backward_symint(grad, self.sym_sizes(), dim, start, length)


### PR DESCRIPTION
Summary:
Add batch support for `aten::narrow.Tensor`.

Similar logic to `narrow_copy`

Fix: #99558 

Test Plan: Please SEE contbuild & OSS CI.

Differential Revision: D45197155

