### PR TITLE
Fix wrong path when reinstalling MacOS pip requirements

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -145,9 +145,10 @@ jobs:
           # Install pip dependencies if they are not found. This is to mitigate a peculiar
           # flaky missing dependencies on MacOS
           ${CONDA_RUN} python3 -c "import torch"
+          RC=$?
           popd
 
-          if [ $? -ne 0 ]; then
+          if [ "${RC}" -ne 0 ]; then
             ${CONDA_RUN} python3 -mpip install --ignore-installed -r "${PIP_REQUIREMENTS_FILE}"
           fi
           set -e

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -145,10 +145,11 @@ jobs:
           # Install pip dependencies if they are not found. This is to mitigate a peculiar
           # flaky missing dependencies on MacOS
           ${CONDA_RUN} python3 -c "import torch"
+          popd
+
           if [ $? -ne 0 ]; then
             ${CONDA_RUN} python3 -mpip install --ignore-installed -r "${PIP_REQUIREMENTS_FILE}"
           fi
-          popd
           set -e
 
           ${CONDA_RUN} python3 test/run_test.py --mps --verbose

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -190,10 +190,11 @@ jobs:
           # Install pip dependencies if they are not found. This is to mitigate a peculiar
           # flaky missing dependencies on MacOS
           ${CONDA_RUN} python3 -c "import torch"
+          popd
+
           if [ $? -ne 0 ]; then
             ${CONDA_RUN} python3 -mpip install --ignore-installed -r "${PIP_REQUIREMENTS_FILE}"
           fi
-          popd
           set -e
 
           ${CONDA_RUN} .ci/pytorch/macos-test.sh

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -190,9 +190,10 @@ jobs:
           # Install pip dependencies if they are not found. This is to mitigate a peculiar
           # flaky missing dependencies on MacOS
           ${CONDA_RUN} python3 -c "import torch"
+          RC=$?
           popd
 
-          if [ $? -ne 0 ]; then
+          if [ "${RC}" -ne 0 ]; then
             ${CONDA_RUN} python3 -mpip install --ignore-installed -r "${PIP_REQUIREMENTS_FILE}"
           fi
           set -e


### PR DESCRIPTION
I force merged this https://github.com/pytorch/pytorch/pull/99506 too soon to fix MacOS flaky in trunk and forgot to set the path to the pip requirements file correctly.  `popd` needs to be run before the reinstallation, so that the working directory is back to pytorch.