### PR TITLE
Fix tensor registration to work with coalescing collectives.

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4231,7 +4231,7 @@ class AllReduceCoalesced(ExternKernel):
             f"group={output_name}_pg, "
             "async_op=True)"
         )
-        wrapper.writeline(f"_register_tensor_work({inputs[0]}, {output_name}_work)")
+        wrapper.writeline(f"_register_tensor_work({output_name}, {output_name}_work)")
 
 
 class AllReduce(CollectiveKernel):

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -2,7 +2,6 @@ import warnings
 
 import weakref
 from typing import cast, List, Tuple, Union
-
 import sys
 import torch
 import torch.distributed as dist
@@ -79,55 +78,71 @@ As a wise man said once: Don't cross the streams (https://www.youtube.com/watch?
 data_ptr_to_work = dict()
 work_version = 0
 
-def _register_tensor_work(tensor, work):
-    # Note: called directly by inductor codegen currently
-    global data_ptr_to_work
-    global work_version
-    data_ptr_to_work[tensor.data_ptr()] = (work_version, work)
-    work_version += 1
+class _WaitRegistration:
+    def __init__(self, work):
+        global work_version
+        self.work = work
+        self.version = work_version
+        self.ptrs = []
+        self.cleanup_count = 0
+        work_version += 1
 
-def _wait_and_clear_tensor(data_ptr, version):
-    global data_ptr_to_work
-    version_and_work = data_ptr_to_work.get(data_ptr)
+    def _register(self, tensor):
+        global data_ptr_to_work
+        ptr = tensor.data_ptr()
+        data_ptr_to_work[ptr] = self
+        self.ptrs.append(ptr)
+        self.cleanup_count += 1
 
-    if version_and_work is not None and version_and_work[0] == version:
-        version_and_work[1].wait()
-        del data_ptr_to_work[data_ptr]
+    def wait(self):
+        if self.work is not None:
+            self.work.wait()
+            self.work = None
+        self.cleanup()
+
+    def decrement_live_tensor(self, ptr):
+        self.cleanup_count -= 1
+        if self.cleanup_count == 0:
+            self.cleanup()
+        else:
+            if data_ptr_to_work.get(ptr, None) == self:
+                del data_ptr_to_work[ptr]
+
+    def cleanup(self):
+        for ptr in self.ptrs:
+            if data_ptr_to_work.get(ptr, None) == self:
+                del data_ptr_to_work[ptr]
+
+
+def _register_tensor_work(tensor_or_list, work):
+    reg = _WaitRegistration(work)
+    if not isinstance(tensor_or_list, list):
+        tensor_or_list = [tensor_or_list]
+    for tensor in tensor_or_list:
+        reg._register(tensor)
+
+
+def _wait_reg_dec(ptr, wait_reg):
+    wait_reg.decrement_live_tensor(ptr)
 
 def _register_wrapper_tensor(tensor_wrapper, tensor):
     global data_ptr_to_work
-    version, _ = data_ptr_to_work.get(tensor.data_ptr(), (None, None))
-    if version is None:
+    wait_reg = data_ptr_to_work.get(tensor.data_ptr(), None)
+    if wait_reg is None:
         warnings.warn(
             "Trying to register finalizers to AsyncCollectiveTensor but the inner tensor is already gone"
         )
     else:
         # We force the collective to be waited in the case this tensor goes away to reduce the change of deadlocks.
-        weakref.finalize(tensor_wrapper, _wait_and_clear_tensor, tensor.data_ptr(), version)
+        weakref.finalize(tensor_wrapper, _wait_reg_dec, tensor.data_ptr(), wait_reg)
 
 def _wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
     global data_ptr_to_work
     data_ptr = tensor.data_ptr()
-    version_and_work = data_ptr_to_work.get(data_ptr)
-    if version_and_work is not None:
-        _wait_and_clear_tensor(data_ptr, version_and_work[0])
+    wait_reg = data_ptr_to_work.get(data_ptr)
+    if wait_reg is not None:
+        wait_reg.wait()
     return tensor
-
-class WaitHolder:
-    """
-    WaitHolder is an indirection to the tensor that needs to be waited on.
-
-    It decomples the tensor an AsyncCollectiveTensor wraps from
-    the tensor it needs to use with wait_tensor.
-    """
-
-    def __init__(self, lookup_tensor):
-        self.lookup_tensor = lookup_tensor
-
-    def wait_tensor(self):
-        if self.lookup_tensor is not None:
-            wait_tensor(self.lookup_tensor)
-            self.lookup_tensor = None
 
 class AsyncCollectiveTensor(torch.Tensor):
     r"""
@@ -137,19 +152,16 @@ class AsyncCollectiveTensor(torch.Tensor):
     def functional_collective(self, group, tag):
         tag, rankset, group_size = _expand_group(group, tag)
         tensor = torch.ops.c10d_functional.{collective}(self, tag, rankset, group_size)
-        res = AsyncCollectiveTensor(tensor)
-        _register_wrapper_tensor(res, tensor)
-        return res
+        return _maybe_wrap_tensor(tensor)
     """
     elem: torch.Tensor
-    _holder: WaitHolder
 
-    __slots__ = ['elem', '_holder']
+    __slots__ = ['elem']
 
     __torch_function__ = torch._C._disabled_torch_function_impl
 
     @staticmethod
-    def __new__(cls, elem: torch.Tensor, holder: WaitHolder):
+    def __new__(cls, elem: torch.Tensor):
 
         r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
             cls, elem.size(),
@@ -158,22 +170,20 @@ class AsyncCollectiveTensor(torch.Tensor):
             device=elem.device, requires_grad=False
         )
         r.elem = elem
-        r._holder = holder
         return r
 
     def __repr__(self):
         return f"AsyncCollectiveTensor({self.elem})"
 
     def trigger_wait(self):
-        self._holder.wait_tensor()
+        wait_tensor(self.elem)
         return self
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
         def unwrap(e: AsyncCollectiveTensor):
-            # TODO do we need to insert a wait_tensor op for all tensors or just the first one?
-            # Given only first usage of any of the output tensors needs to wait, for now we emit only one wait
-            e._holder.wait_tensor()
+            # wait_tensor is idepotent and will do stream sync only once
+            wait_tensor(e.elem)
             return e.elem
 
         unwrapped_args = tree_map_only(AsyncCollectiveTensor, unwrap, args)
@@ -210,7 +220,7 @@ def _all_reduce_coalesced(self, reduceOp, tag, ranks, group_size):
 
     inplace_tensor_list = [t.clone(memory_format=torch.contiguous_format) for t in self]
     work = dist.all_reduce_coalesced(inplace_tensor_list, op=op, group=group, async_op=True)
-    _register_tensor_work(inplace_tensor_list[0], work)
+    _register_tensor_work(inplace_tensor_list, work)
 
     return inplace_tensor_list
 
@@ -307,12 +317,12 @@ def _are_we_tracing() -> bool:
         return False
     return mode.tracer is not None
 
-def _maybe_wrap_tensor(self):
+def _maybe_wrap_tensor(self) -> torch.Tensor:
     if _are_we_tracing():
         return wait_tensor(self)
-    res = AsyncCollectiveTensor(self, WaitHolder(self))
+    res = AsyncCollectiveTensor(self)
     _register_wrapper_tensor(res, self)
-    return res
+    return cast(torch.Tensor, res)
 
 def wait_tensor(tensor):
     """
@@ -343,7 +353,6 @@ def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = 
     tag, rankset, group_size = _expand_group(group, tag)
     tensor = torch.ops.c10d_functional.all_reduce(self, reduceOp, tag, rankset, group_size)  # type: ignore[attr-defined]
     return _maybe_wrap_tensor(tensor)
-
 
 
 def all_gather_tensor(
@@ -431,20 +440,8 @@ def all_reduce_coalesced(self: List[torch.Tensor], reduceOp: str, group: RANK_TY
     """
     tag, rankset, group_size = _expand_group(group, tag)
     tensor_list = torch.ops.c10d_functional.all_reduce_coalesced(self, reduceOp, tag, rankset, group_size)  # type: ignore[attr-defined]
+    return list(map(_maybe_wrap_tensor, tensor_list))
 
-    if _are_we_tracing():
-        return list(map(wait_tensor, tensor_list))
-
-    res = []
-    lookup_tensor = tensor_list[0]
-    wh = WaitHolder(lookup_tensor)
-    for tensor in tensor_list:
-        act = AsyncCollectiveTensor(tensor, wh)
-        res.append(cast(torch.Tensor, act))
-
-    # FIXME we should register all tensors and ref count when to emit the wait
-    _register_wrapper_tensor(res[0], lookup_tensor)
-    return res
 
 # We now register meta kernels to deal with tracing
 def _all_reduce_meta(self, *args):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

We do it by making it possible to register multiple tensors for the same
worker and coordinate waiting/cleanup among them.

This ensures waiting on any number the output tensors will result in a
single stream sync. This simplifies codegen by inductor.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire