### PR TITLE
fix test failure in: pytorch/benchmark/fb/test_gpu:run_test_gpu

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -12,6 +12,7 @@ from torch._decomp.decompositions import pw_cast_for_opmath
 from torch.utils._mode_utils import no_dispatch
 
 from . import config, utils
+from torch._inductor.utils import do_bench
 
 log = logging.getLogger(__name__)
 aten = torch.ops.aten
@@ -155,7 +156,6 @@ def pad_addmm(input, mat1, mat2, m_padded_length, k_padded_length, n_padded_leng
 
 def should_pad_bench(mat1, mat2, op, input=None):
     assert utils.has_triton()
-    from triton.testing import do_bench
 
     with no_dispatch():
         if op is torch.ops.aten.mm or op is torch.ops.aten.addmm:


### PR DESCRIPTION
Summary: The same call to triton.testing.do_bench may return a tuple of item depending on triton version. Use the wrapper in inductor so the user always see an item.

Test Plan:
time buck2 test @//mode/opt //pytorch/benchmark/fb/test_gpu:run_test_gpu -- --exact 'pytorch/benchmark/fb/test_gpu:run_test_gpu - test_eval_gpu_dynamo_inductor_cudagraph_pad_permute_6_blue_reels_vdd_v2 (pytorch.benchmark.fb.test_gpu.test_gpu.TestBenchmarkFbGpu)'

time buck2 test @//mode/opt //pytorch/benchmark/fb/test_gpu:run_test_gpu

Differential Revision: D45200596



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @soumith @anijain2305 @desertfire