### PR TITLE
Fix test_multiple_devices_randint_cuda

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1407,6 +1407,11 @@ def sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
     if torch.cuda.is_available():
         inputs.append(((S,), {'device': 'cuda'}))
 
+    # Set supplied device if it was not defined
+    for i in inputs:
+        assert(isinstance(i[1], dict))
+        i[1].setdefault('device', device)
+
     for shape, kwargs in inputs:
         t = make_tensor(shape, dtype=dtype, device=device,
                         low=None, high=None,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1407,11 +1407,6 @@ def sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
     if torch.cuda.is_available():
         inputs.append(((S,), {'device': 'cuda'}))
 
-    # Set supplied device if it was not defined
-    for i in inputs:
-        assert(isinstance(i[1], dict))
-        i[1].setdefault('device', device)
-
     for shape, kwargs in inputs:
         t = make_tensor(shape, dtype=dtype, device=device,
                         low=None, high=None,
@@ -1455,6 +1450,7 @@ def sample_inputs_randint(self, device, dtype, requires_grad, **kwargs):
     high = 10
 
     for sample in sample_inputs_like_fns(self, device, dtype, requires_grad, **kwargs):
+        sample.kwargs.setdefault('device', device)
         # With high
         yield SampleInput(high, sample.input.shape, *sample.args, **sample.kwargs)
         # With low and high


### PR DESCRIPTION
The test fails with device mismatch error:
```
Traceback (most recent call last):
  File "/pytorch/torch/testing/_internal/common_utils.py", line 2137, in wrapper
    method(*args, **kwargs)
  File "/pytorch/torch/testing/_internal/common_device_type.py", line 401, in instantiated_test
    result = test(self, **param_kwargs)
  File "/pytorch/torch/testing/_internal/common_device_type.py", line 846, in test_wrapper
    return test(*args, **kwargs)
  File "/pytorch/torch/testing/_internal/common_device_type.py", line 1005, in only_fn
    return fn(slf, *args, **kwargs)
  File "/pytorch/torch/testing/_internal/common_device_type.py", line 1029, in multi_fn
    return fn(slf, devices, *args, **kwargs)
  File "/pytorch/test/test_ops.py", line 148, in test_multiple_devices
    self.assertTrue(result.device == cuda_device)
AssertionError: False is not true
```