### PR TITLE
Use pytest-resume to resume from the last run test when retry

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -268,3 +268,8 @@ pytest-cpp==2.3.0
 #Description: This is used by pytest to invoke C++ tests
 #Pinned versions: 2.3.0
 #test that import:
+
+pytest-resume==0.0.1
+#Description: This is used by pytest to resume from the last test run
+#Pinned versions: 0.0.1
+#test that import:

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -34,8 +34,8 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
 fi
 
-# TODO: Move both of them to Windows AMI
-python -m pip install pytest-rerunfailures==10.3 pytest-cpp==2.3.0
+# TODO: Move all of these to Windows AMI
+python -m pip install pytest-rerunfailures==10.3 pytest-cpp==2.3.0 pytest-resume==0.0.1
 
 run_tests() {
     # Run nvidia-smi if available

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -23,3 +23,4 @@ xdoctest==1.1.0
 filelock==3.6.0
 sympy==1.11.1
 pytest-cpp==2.3.0
+pytest-resume==0.0.1

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -904,7 +904,13 @@ def get_pytest_args(options, is_cpp_test=False):
     else:
         # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
         # failure
-        rerun_options = ["-x", "--reruns=2", "--sw"]
+        rerun_options = ["-x", "--reruns=2"]
+
+        if IS_CI:
+            # Only use this option in the CI when resuming from the last run test behavior is needed
+            rerun_options.append("--resume")
+        else:
+            rerun_options.append("--sw")
 
     pytest_args = [
         "-vv",


### PR DESCRIPTION
`pytest-stepwise` only resumes from the last failed test.  This makes sense when developing locally.  On the other hand, when retrying on the CI, it makes sense to retry / resume from the last executed test instead regardless of its status.  This is an experiment to use a new `pytest-resume` plugin https://pypi.org/project/pytest-resume/0.0.1 to achieve: 

1. If the last test fails, retry will resume from the last failed test similar to stepwise
1. if the test crashes (SIGXYZ) or times out, retry will resume from the last executed test as recorded in the case

Note that this plugin is like `stepwise` that it doesn't persist across jobs.  It only works in test file retry context.