### PR TITLE
Add support for call_method patterns

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -36,6 +36,21 @@ class TestSplitCatFxPasses(TestCase):
         def unequal_split(x):
             return [torch.relu(s) for s in torch.split(x, 3, 1)]
 
+        def arg_only_cm(x):
+            return [torch.relu(s) for s in x.split(2, 1)]
+
+        def kwarg1_cm(x):
+            return [torch.relu(s) for s in x.split(2, dim=1)]
+
+        def kwarg2_cm(x):
+            return [torch.relu(s) for s in x.split(split_size=2, dim=1)]
+
+        def multi_split_cm(x):
+            return [s.split(2, 1) for s in x.split(2, 1)]
+
+        def unequal_split_cm(x):
+            return [torch.relu(s) for s in x.split(3, 1)]
+
         args = [
             torch.randn(2, 32),
         ]
@@ -47,6 +62,11 @@ class TestSplitCatFxPasses(TestCase):
             (no_replace, 0),
             (multi_split, 17),
             (unequal_split, 1),
+            (arg_only_cm, 1),
+            (kwarg1_cm, 1),
+            (kwarg2_cm, 1),
+            (multi_split_cm, 17),
+            (unequal_split_cm, 1),
         ]:
             expected = fn(*args)
             actual = torch.compile(fn, dynamic=True)(*args)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -3,7 +3,14 @@ import logging
 
 import torch
 from torch._dynamo.utils import counters
-from ..pattern_matcher import Arg, CallFunction, get_arg_value, MULTIPLE, PatternEntry
+from ..pattern_matcher import (
+    Arg,
+    CallFunction,
+    CallMethod,
+    get_arg_value,
+    MULTIPLE,
+    PatternEntry,
+)
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +61,9 @@ def _split_cat_init():
             dim=Arg(),
             _users=MULTIPLE,
         ),
+        CallMethod("split", Arg(), Arg(), Arg(), _users=MULTIPLE),
+        CallMethod("split", Arg(), Arg(), dim=Arg(), _users=MULTIPLE),
+        CallMethod("split", Arg(), split_size=Arg(), dim=Arg(), _users=MULTIPLE),
     ]:
         pattern = NormalizeSplit(pattern=pattern, extra_check=lambda arg: True)
         pattern.register(patterns)


### PR DESCRIPTION
Summary: This add support for CallMethod patterns in pattern_matcher. Also extends split_cat transforms to normalize tensor.split() type nodes

Test Plan: Unit tests (fb + OSS)

Differential Revision: D45195548



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire