### PR TITLE
Properly propagates checkpoint wrapper args and kwargs

### DIFF
--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -125,6 +125,8 @@ class CheckpointWrapper(ActivationWrapper):
                 use_reentrant=(
                     self.checkpoint_impl == CheckpointImpl.REENTRANT
                 ),
+                *checkpoint_fn_args,
+                **checkpoint_fn_kwargs,
             )
         else:
             # Construct user-specified checkpoint function.
@@ -229,7 +231,7 @@ def checkpoint_wrapper(
     """
 
     return CheckpointWrapper(
-        module, checkpoint_impl, checkpoint_fn, checkpoint_fn_args, checkpoint_fn_kwargs
+        module, checkpoint_impl, checkpoint_fn, *checkpoint_fn_args, **checkpoint_fn_kwargs
     )
 
 


### PR DESCRIPTION
It looks like passing `*args` and `**kwargs` to `checkpoint_wrapper()` does not work because someone forgot some `*`s. This adds them back in.