### PR TITLE
Fix flake8 lint errors - part 2 - manual fixes

### DIFF
--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -52,6 +52,6 @@ def get_step_logger(logger):
     step = next(_step_counter)
 
     def log(level, msg):
-        logger.log(level, f"Step {step}: {msg}")
+        logger.log(level, "Step %s: %s", step, msg)
 
     return log

--- a/torch/_functorch/compilers.py
+++ b/torch/_functorch/compilers.py
@@ -367,7 +367,10 @@ def _save_fx_default(current_name, folder_name, dump_example_input, gm, example_
         if len(gm_to_save.graph.nodes) == 0:
             log.log(
                 logging.WARNING,
-                f"No nodes in graph {current_name}_{type_name}_{graph_index}.",
+                "No nodes in graph {%s}_{%s}_{%s}.",
+                current_name,
+                type_name,
+                graph_index,
             )
             return
 

--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -69,7 +69,7 @@ def log_hook(fn: Callable, level=logging.INFO) -> Callable:
     @wraps(fn)
     def wrapped_fn(gm):
         val = fn(gm)
-        logger.log(level, f"Ran pass {fn}\t Return value: {val}",)
+        logger.log(level, "Ran pass %s\t Return value: %s", fn, val)
         return val
 
     return wrapped_fn

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -20,7 +20,7 @@ please report the benchmarks in ``benchmarks/overrides_benchmark``. See the
 instructions in the ``README.md`` in that directory.
 """
 
-import __future__
+import __future__  # noqa: F404
 
 import collections
 import functools


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99785
* __->__ #99799
* #99798



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire @kit1980 @malfet @Skylion007 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8aef78f</samp>

### Summary
📝🚀🛠️

<!--
1.  📝 for modifying the logging format and style
2.  🚀 for improving performance and avoiding unnecessary string creation
3.  🛠️ for fixing flake8 issues
-->
This pull request updates some logging calls to use old-style string formatting with `%s` placeholders instead of f-strings in `torch/_dynamo/logging.py`, `torch/_functorch/compilers.py`, and `torch/fx/passes/pass_manager.py` as part of a logging standardization effort. It also adds a `# noqa: F404` comment to the `import __future__` statement in `torch/overrides.py` to fix a flake8 warning.

> _`log` uses old style_
> _formatting strings with `%s`_
> _logging is faster_

### Walkthrough
*  Standardize logging format and style to use old-style string formatting with `%s` placeholders instead of f-string syntax for performance and consistency ([link](https://github.com/pytorch/pytorch/pull/99799/files?diff=unified&w=0#diff-18807f7fd187b8bc8e69e93722566195b36d5bf269099b415a6f90b552228d6bL55-R55), [link](https://github.com/pytorch/pytorch/pull/99799/files?diff=unified&w=0#diff-fae8a66564055743ec031edb87eb22edeebf7fdebef9d21660d5e6a6252e5222L370-R373), [link](https://github.com/pytorch/pytorch/pull/99799/files?diff=unified&w=0#diff-5f3e37ded032f24e247dcf4a3be4b73ea0cf21382e342631742e5a04550202e1L72-R72))
*  Suppress flake8 warning for `import __future__` statement in `torch/overrides.py` with `# noqa: F404` comment ([link](https://github.com/pytorch/pytorch/pull/99799/files?diff=unified&w=0#diff-4f601fe7f31e875ee4354882c0bb490bc35e51d3d413d058cc5fda3be8ca9f15L23-R23))

