### PR TITLE
[MPS] Add encoder coalescing support for native kernels

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -17,6 +17,7 @@
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 typedef id<MTLCommandQueue> MTLCommandQueue_t;
 typedef id<MTLCommandBuffer> MTLCommandBuffer_t;
+typedef id<MTLComputeCommandEncoder> MTLComputeCommandEncoder_t;
 typedef id<MTLSharedEvent> MTLSharedEvent_t;
 typedef id<MTLDevice> MTLDevice_t;
 #else
@@ -24,6 +25,7 @@ typedef void* MTLCommandQueue_t;
 typedef void* MTLCommandQueue;
 typedef void* MTLCommandBuffer_t;
 typedef void* MTLCommandBuffer;
+typedef void* MTLComputeCommandEncoder_t;
 typedef void* MTLSharedEvent_t;
 typedef void* dispatch_queue_t;
 typedef void* MTLDevice_t;
@@ -60,7 +62,9 @@ public:
   dispatch_queue_t queue() const { return _serialQueue; }
 
   MPSCommandBuffer* commandBuffer();
+  MTLComputeCommandEncoder_t commandEncoder();
   void commit(bool flush);
+  void endKernelCoalescing();
   void commitAndWait();
   void commitAndContinue();
   void synchronize(SyncType syncType);
@@ -87,6 +91,8 @@ private:
   Stream _stream;
   MTLCommandQueue_t   _commandQueue = nil;
   MPSCommandBuffer*  _commandBuffer = nil;
+  MTLComputeCommandEncoder_t _commandEncoder = nil;
+
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
   void _flush(bool commitAndWait) const;
 

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -182,7 +182,7 @@ void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer,
 
 void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
-  endKernelCoalescing();
+    endKernelCoalescing();
 #if USE_COMMIT_AND_CONTINUE
     [mpsGraph encodeToCommandBuffer:commandBuffer()
                               feeds:feeds

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -180,8 +180,7 @@ void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name) {
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       NSError* error = nil;
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
       const IntArrayRef& iterShape = iter.shape();
       std::vector<uint32_t> iterShapeData(iterShape.size());
@@ -235,9 +234,6 @@ void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name) {
 
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
-
-      [computeEncoder endEncoding];
-      mpsStream->commit(true);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -210,7 +210,7 @@ void handle_tensor_scalar_binary_op(const Tensor& self,
     return;
   }
   dispatch_sync(stream->queue(), ^() {
-    id<MTLComputeCommandEncoder> commandEncoder  = stream->commandEncoder();
+    id<MTLComputeCommandEncoder> commandEncoder = stream->commandEncoder();
 
     id<MTLBuffer> outBuf = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
     id<MTLBuffer> selfBuf = __builtin_bit_cast(id<MTLBuffer>, self.storage().data());

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -180,8 +180,7 @@ void handle_tensor_tensor_binary_op(const Tensor& self,
     return;
   }
   dispatch_sync(stream->queue(), ^() {
-    id<MTLCommandBuffer> buffer = stream->commandBuffer();
-    id<MTLComputeCommandEncoder> commandEncoder = [buffer computeCommandEncoder];
+    id<MTLComputeCommandEncoder> commandEncoder = stream->commandEncoder();
 
     id<MTLBuffer> outBuf = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
     id<MTLBuffer> selfBuf = __builtin_bit_cast(id<MTLBuffer>, self.storage().data());
@@ -194,8 +193,6 @@ void handle_tensor_tensor_binary_op(const Tensor& self,
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset() * self.itemsize() atIndex:2];
     [commandEncoder setBuffer:otherBuf offset:other.storage_offset() * other.itemsize() atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-    [commandEncoder endEncoding];
-    stream->commit(true);
   });
 }
 
@@ -213,8 +210,7 @@ void handle_tensor_scalar_binary_op(const Tensor& self,
     return;
   }
   dispatch_sync(stream->queue(), ^() {
-    id<MTLCommandBuffer> buffer = stream->commandBuffer();
-    id<MTLComputeCommandEncoder> commandEncoder = [buffer computeCommandEncoder];
+    id<MTLComputeCommandEncoder> commandEncoder  = stream->commandEncoder();
 
     id<MTLBuffer> outBuf = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
     id<MTLBuffer> selfBuf = __builtin_bit_cast(id<MTLBuffer>, self.storage().data());
@@ -226,8 +222,6 @@ void handle_tensor_scalar_binary_op(const Tensor& self,
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset() * self.itemsize() atIndex:2];
     [commandEncoder setBytes:&sval length:sizeof(sval) atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-    [commandEncoder endEncoding];
-    stream->commit(true);
   });
 }
 
@@ -304,8 +298,7 @@ void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
   id<MTLComputePipelineState> cplState = getCPLState(
       MPSDevice::getInstance()->device(), getMetalType(output), getMetalType(self), getMetalType(self), "bitwise_not");
   dispatch_sync(stream->queue(), ^() {
-    id<MTLCommandBuffer> buffer = stream->commandBuffer();
-    id<MTLComputeCommandEncoder> commandEncoder = [buffer computeCommandEncoder];
+    id<MTLComputeCommandEncoder> commandEncoder = stream->commandEncoder();
 
     id<MTLBuffer> outBuf = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
     id<MTLBuffer> selfBuf = __builtin_bit_cast(id<MTLBuffer>, self.storage().data());
@@ -316,8 +309,6 @@ void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
     [commandEncoder setBuffer:outBuf offset:output.storage_offset() * output.itemsize() atIndex:1];
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset() * self.itemsize() atIndex:2];
     dispatch1DJob(commandEncoder, cplState, length);
-    [commandEncoder endEncoding];
-    stream->commit(true);
   });
   if (needs_output_copy) {
     output_.copy_(output);

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -138,8 +138,7 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       NSError* error = nil;
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
       const IntArrayRef& iterShape = iter.shape();
       std::vector<uint32_t> iterShapeData(iterShape.size());
@@ -195,9 +194,6 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
 
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
-
-      [computeEncoder endEncoding];
-      mpsStream->commit(true);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -76,8 +76,7 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
       }
 
       MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       id<MTLFunction> kernelDataOffsetsFunction =
           MPSDevice::getInstance()->metalIndexingFunction("kernel_index_offsets", nil);
       id<MTLComputePipelineState> kernelDataOffsetsPSO =
@@ -146,9 +145,6 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
 
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
-
-      [computeEncoder endEncoding];
-      mpsStream->synchronize(SyncType::COMMIT_AND_CONTINUE);
     }
   });
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -571,6 +571,7 @@ Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
 
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
+      mpsStream->endKernelCoalescing();
       id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
       uint64_t batchSize = A_.sizes().size() > 2 ? A_.size(0) : 1;
       uint64_t aRows = A_.size(-2);

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -187,8 +187,7 @@ void computeRepeatIndices(index_t* repeat_ptr,
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       id<MTLComputePipelineState> pipelineState = getPipelineState(MPSDevice::getInstance()->device(), scalar_type);
 
       [computeEncoder setComputePipelineState:pipelineState];
@@ -204,8 +203,6 @@ void computeRepeatIndices(index_t* repeat_ptr,
       MTLSize threadsPerThreadgroup = MTLSizeMake(threadsPerThreadgroup_, 1, 1);
 
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadsPerThreadgroup];
-      [computeEncoder endEncoding];
-      mpsStream->synchronize(SyncType::COMMIT_AND_CONTINUE);
     }
   });
 }


### PR DESCRIPTION
Add support for kernel coalescing to native kernels. 
This change reuses the same compute command encoder across successive metal kernel dispatches. The coalescing will stop when a graph op is encountered.      