### PR TITLE
Implement the get_device method in the storage base class.

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -39,7 +39,10 @@ class _StorageBase:
     def type(self, dtype: str = None, non_blocking: bool = False) -> T: ...  # noqa: E704
     def cuda(self, device=None, non_blocking=False, **kwargs) -> T: ...  # noqa: E704
     def element_size(self) -> int: ...  # noqa: E704
-    def get_device(self) -> int: ...  # noqa: E704
+
+    def get_device(self) -> int:
+        return self.device.index
+
     def data_ptr(self) -> int: ...  # noqa: E704
 
     # Defined in torch/csrc/generic/StorageSharing.cpp


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
like #99817, I find a method is missing, 
I'm not sure if it was intentionally removed. But I found that the function is still called on the python side, and the function seems to be very simple to implement.
So I made a change in python side.
cc @ezyang @albanD Could you take a look.