### PR TITLE
[buckbuild.bzl] Fix dep handling in cross-builds

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -566,13 +566,21 @@ def pt_operator_query_codegen(
         apple_sdks = None):
     oplist_dir_name = name + "_pt_oplist"
 
+    # Use a helper rule to properly resolves any `select()`s in deps.
+    fb_native.cxx_library(
+        name = oplist_dir_name + "-deps",
+        compatible_with = compatible_with,
+        deps = deps,
+        visibility = ["PUBLIC"],
+    )
+
     # @lint-ignore BUCKLINT
     fb_native.genrule(
         name = oplist_dir_name,
         cmd = ("$(exe {}tools:gen_oplist) ".format(ROOT_PATH) +
-               "--model_file_list_path $(@query_outputs 'attrfilter(labels, pt_operator_library, deps(set({deps})))') " +
+               "--model_file_list_path $(@query_outputs 'attrfilter(labels, pt_operator_library, deps(\":{name}-deps\"))') " +
                ("" if enforce_traced_op_list else "--allow_include_all_overloads ") +
-               "--output_dir $OUT ").format(deps = " ".join(["\"{}\"".format(d) for d in deps])),
+               "--output_dir $OUT ").format(name = oplist_dir_name),
         outs = get_gen_oplist_outs(),
         default_outs = ["."],
         compatible_with = compatible_with,

--- a/tools/build_defs/fb_native_wrapper.bzl
+++ b/tools/build_defs/fb_native_wrapper.bzl
@@ -15,7 +15,11 @@ def _read_config(**kwargs):
 def _filegroup(**kwargs):
     filegroup(**kwargs)
 
+def _cxx_library(**kwargs):
+    cxx_library(**kwargs)
+
 fb_native = struct(
+    cxx_library = _cxx_library,
     genrule = _genrule,
     read_config = _read_config,
     filegroup = _filegroup,


### PR DESCRIPTION
Summary:
Use a helper rule to handle `select()`s in `deps`.

Reviewed By: r1mikey

Differential Revision: D44960349

