### PR TITLE
Fix fake tracing of cross entropy with label smoothing and weight

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <ATen/native/Resize.h>
 #include <c10/util/SmallBuffer.h>
+#include <ATen/TensorSubclassLikeUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -579,9 +580,22 @@ Tensor cross_entropy_loss_label_smoothing(
     switch (reduction) {
       case Reduction::Mean:
         if (weight.defined()) {
-          // TODO: This code can path can be removed if #61309 is resolved
-          // loss is normalized by the weights to be consistent with nll_loss_nd
-          ret = smooth_loss.sum() / weight.gather(0, target.masked_select(~ignore_mask).flatten()).sum();
+          if (isTensorSubclassLike(weight)){
+            // we will collect weights from 0 index which is always valid
+            // and mask them out if they are ignored
+            auto filtered_target = target.masked_fill(ignore_mask, 0);
+            auto tgt_weights = weight.gather(0, filtered_target.flatten());
+            auto weight_sum =
+                tgt_weights.masked_fill_(ignore_mask.flatten(), 0).sum();
+            ret = smooth_loss.sum() / weight_sum;
+          } else {
+            // TODO: This code can path can be removed if #61309 is resolved
+            // loss is normalized by the weights to be consistent with
+            // nll_loss_nd
+            ret = smooth_loss.sum() /
+                weight.gather(0, target.masked_select(~ignore_mask).flatten())
+                    .sum();
+          }
         } else {
           auto true_mask = ~ignore_mask;
           ret = smooth_loss.sum()/ true_mask.sum();

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -558,7 +558,7 @@ Tensor cross_entropy_loss_label_smoothing(
     auto input = at::log_softmax(self, class_dim, self.scalar_type());
     auto nllloss = at::nll_loss_nd_symint(input, target, weight, reduction, ignore_index);
 
-    auto n_classes = input.sym_size(class_dim);
+    auto n_classes = input.size(class_dim);
 
     Tensor smooth_loss;
     if (weight.defined()) {

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -558,7 +558,7 @@ Tensor cross_entropy_loss_label_smoothing(
     auto input = at::log_softmax(self, class_dim, self.scalar_type());
     auto nllloss = at::nll_loss_nd_symint(input, target, weight, reduction, ignore_index);
 
-    auto n_classes = input.size(class_dim);
+    auto n_classes = input.sym_size(class_dim);
 
     Tensor smooth_loss;
     if (weight.defined()) {

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2757,10 +2757,6 @@ aot_autograd_module_failures = set({
                                # of a tracing tensor with aten._local_scalar_dense.default -
                                # erroring out! It's likely that this is caused by data-dependent
                                # control flow or similar.
-    torch.nn.CrossEntropyLoss,  # RuntimeError: It appears that you're trying to get value out
-                                # of a tracing tensor with aten._local_scalar_dense.default -
-                                # erroring out! It's likely that this is caused by data-dependent
-                                # control flow or similar.
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input
                                   # to a causal mask tensor, to see if Boolean is_causal should be set
                                   # for TrnasformerEncoder layers, MHA and sdp custom kernels
@@ -2774,7 +2770,6 @@ symbolic_aot_autograd_module_failures = {
     torch.nn.Transformer,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
-    torch.nn.CrossEntropyLoss,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad1d,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad2d,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2770,7 +2770,7 @@ symbolic_aot_autograd_module_failures = {
     torch.nn.Transformer,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
-    torch.nn.CrossEntropyLoss, # Cannot call sizes() on tensor with symbolic sizes/strides
+    torch.nn.CrossEntropyLoss,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad1d,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad2d,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2770,6 +2770,7 @@ symbolic_aot_autograd_module_failures = {
     torch.nn.Transformer,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
+    torch.nn.CrossEntropyLoss, # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad1d,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.ReplicationPad2d,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -836,14 +836,16 @@ class FakeTensorOperatorInvariants(TestCase):
     def test_cross_entropy_loss(self):
         inp = torch.randn(3, 5)
         target = torch.randint(5, (3,), dtype=torch.long)
+        weight = torch.rand(5)
         fn = torch.nn.functional.cross_entropy
-        ref = fn(inp, target)
-        with FakeTensorMode() as m:
-            meta_args = [m.from_tensor(a) if isinstance(a, torch.Tensor) else a for a in (inp, target)]
+        for w in (weight, None):
+            args = (inp, target, w)
+            ref = fn(*args)
+            with FakeTensorMode() as m:
+                meta_args = [m.from_tensor(a) if isinstance(a, torch.Tensor) else a for a in args]
+                meta_out = torch.nn.functional.cross_entropy(*meta_args, label_smoothing=0.5)
 
-            meta_out = torch.nn.functional.cross_entropy(*meta_args, label_smoothing=0.5)
-
-        self.assertEqual(ref.size(), meta_out.size())
+            self.assertEqual(ref.size(), meta_out.size())
 
 
     @skipIfRocm


### PR DESCRIPTION
Fixes #99726
Adds a special path in cross entropy implementation for tensor subclasses, we don't always use it as it requires slightly more memory and is a bit slower. 
