### PR TITLE
Fixed compiling on macOS 12 with SDK from 13

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -4,8 +4,7 @@
 // TODO: Remove me when moved to MacOS 13
 @interface MPSGraph (VenturaOps)
 
-#if !defined(__MAC_13_0) && \
-    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED < 130000
 
 typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
 {


### PR DESCRIPTION
The current version of Xcode for macOS 12.6.3 is using SDK for macOS 13 that leads to an error like:
```
error: redefinition of 'MPSGraphResizeNearestRoundingMode'
```

To prevent that a condition here should use `MAC_OS_X_VERSION_MAX_ALLOWED` instead of `MAC_OS_X_VERSION_MIN_REQUIRED` that allows to track the used SDK, and not OS.

Value on macOS 13 with SDK 13:
```
MAC_OS_X_VERSION_MIN_REQUIRED: 130000
MAC_OS_X_VERSION_MAX_ALLOWED: 130100
```
and on macOS 12 with SDK 13:
```
MAC_OS_X_VERSION_MIN_REQUIRED: 120000
MAC_OS_X_VERSION_MAX_ALLOWED: 130100
```

I've also changed code to numeric version that fixed build on SDK which has no idea about macOS 13 :)

Fixes #ISSUE_NUMBER
