### PR TITLE
Fix inconsistent torch.nn.MaxPool1d output on cpu and gpu

### DIFF
--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -31,6 +31,7 @@ static void check_max_pool1d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
+
   TORCH_CHECK(
       self.dim() == 2 || self.dim() == 3,
       "max_pool1d() Expected 2D or 3D input tensor, but got ", self.sizes());

--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -31,7 +31,6 @@ static void check_max_pool1d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
-
   TORCH_CHECK(
       self.dim() == 2 || self.dim() == 3,
       "max_pool1d() Expected 2D or 3D input tensor, but got ", self.sizes());
@@ -75,7 +74,7 @@ static void check_max_pool1d(
       dilation[0] > 0, "max_pool1d() dilation must be greater than zero, but got ", dilation[0]);
 
   const int64_t OW = pooling_output_shape(self.size(-1), kernel_size[0], padding[0], stride[0], dilation[0], ceil_mode);
-  TORCH_CHECK(OW >= 0, "max_pool1d() Invalid computed output size: ", OW);
+  TORCH_CHECK(OW > 0, "max_pool1d() Invalid computed output size: ", OW);
 }
 
 } // namespace

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7235,7 +7235,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         arg_class = torch.nn.MaxPool1d(kernel_size=arg_1, stride=arg_2, return_indices=arg_3)
         arg_4_0 = torch.as_tensor([[0.3204]])
         arg_4 = [arg_4_0,]
-        with self.assertRaisesRegex(RuntimeError, "max_pool1d() Invalid computed output size: 0"):
+
+        with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
 class TestFusionEval(TestCase):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7227,7 +7227,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(ValueError,
                                     "fractional_max_pool2d requires output_ratio to either be a single Int or tuple of Ints."):
             res = arg_class(*arg_3)
-        
+
     def test_max_pool1d_invalid_output_size(self):
         arg_1 = 3
         arg_2 = 255

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7227,7 +7227,16 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(ValueError,
                                     "fractional_max_pool2d requires output_ratio to either be a single Int or tuple of Ints."):
             res = arg_class(*arg_3)
-
+        
+    def test_max_pool1d_invalid_output_size(self):
+        arg_1 = 3
+        arg_2 = 255
+        arg_3 = False
+        arg_class = torch.nn.MaxPool1d(kernel_size=arg_1, stride=arg_2, return_indices=arg_3)
+        arg_4_0 = torch.as_tensor([[0.3204]])
+        arg_4 = [arg_4_0,]
+        with self.assertRaisesRegex(RuntimeError, "max_pool1d() Invalid computed output size: 0"):
+            res = arg_class(*arg_4)
 
 class TestFusionEval(TestCase):
     @given(X=hu.tensor(shapes=((5, 3, 5, 5),)),


### PR DESCRIPTION
Fixes #99412 , correctly raising an error when an output of invalid size is calculated.

Would be happy to iterate on this if there are any issues.

cc @malfet @jbschlosser 