### PR TITLE
[quant][pt2] Fix QNNPACK quantizer activation qscheme

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
@@ -81,17 +81,17 @@ def get_symmetric_quantization_config(
         dtype=torch.int8,
         quant_min=-128,
         quant_max=127,
-        qscheme=torch.per_tensor_symmetric,
+        qscheme=torch.per_tensor_affine,
         is_dynamic=False,
     )
-    qscheme = (
+    weight_qscheme = (
         torch.per_channel_symmetric if is_per_channel else torch.per_tensor_symmetric
     )
     weight_quantization_spec = QuantizationSpec(
         dtype=torch.int8,
         quant_min=-127,
         quant_max=127,
-        qscheme=qscheme,
+        qscheme=weight_qscheme,
         ch_axis=1,
         is_dynamic=False,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99845

Summary: https://github.com/pytorch/pytorch/pull/99066 refactored
some duplicate code in the QNNPACK quantizer but inadvertently
changed the activation qscheme: it was `per_tensor_affine` before
the PR, but became `per_tensor_symmetric` after. This no longer
matches the definitions in the corresponding qconfigs, e.g.:

https://github.com/pytorch/pytorch/blob/6d5040a1ace7583862992bd1a1b606e873557fe1/torch/ao/quantization/qconfig.py#L288

Reviewers: kimishpatel, jerryzh168