### PR TITLE
[inductor][non determinism] Disable autotuning when determinisitic mode is ON

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -824,9 +824,7 @@ def persistent_reduction(size_hints, reduction_hint=False, meta=None, filename=N
         c.kwargs.pop("RBLOCK")
 
     if not config.triton.autotune_pointwise:
-        configs = [
-            configs[0],
-        ]
+        configs = configs[:1]
 
     return cached_autotune(
         configs,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -168,14 +168,14 @@ class CachingAutotuner(KernelInterface):
 
         return launcher
 
-    def clip_benched_timing(self, x, threshold=0.01):
+    def round_benched_timing(self, x, decimal_places=2):
         """
-        Small kernels with different configs can have small but different
-        runtimes, changing the ranking of different autotuning configs and
-        making autotuning non deterministic. This function clips the benched
-        timing to a threshold, with a default value of 0.01 ms.
+        Sometimes different autotuning configs can have very small runtime
+        difference. This can affect the ranking of different configs, making
+        autotuning nondeterministic.  This function rounds the benched timing to
+        a default value of two decimal places.
         """
-        return builtins.max(x, threshold)
+        return builtins.round(x, decimal_places)
 
     def bench(self, launcher, *args, grid):
         """Measure the performance of a given launcher"""
@@ -200,7 +200,7 @@ class CachingAutotuner(KernelInterface):
                 stream=stream,
             )
 
-        return self.clip_benched_timing(do_bench(kernel_call, rep=40, fast_flush=True))
+        return self.round_benched_timing(do_bench(kernel_call, rep=40, fast_flush=True))
 
     def clone_args(self, *args):
         from .compile_fx import clone_preserve_strides

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -168,12 +168,12 @@ class CachingAutotuner(KernelInterface):
 
         return launcher
 
-    def round_benched_timing(self, x, decimal_places=2):
+    def round_benched_timing(self, x, decimal_places=1):
         """
         Sometimes different autotuning configs can have very small runtime
         difference. This can affect the ranking of different configs, making
         autotuning nondeterministic.  This function rounds the benched timing to
-        a default value of two decimal places.
+        a default value of one decimal place, i.e., precision of 0.1 ms.
         """
         return builtins.round(x, decimal_places)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99851
* #99793


This removes a source of non-determinism seen in `sebotnet33ts_256`. However, we should see if we can reduce non-determinism in autotuning in general.


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire