### PR TITLE
Update MacOS deployment target to 11.0

### DIFF
--- a/.ci/pytorch/macos-build.sh
+++ b/.ci/pytorch/macos-build.sh
@@ -47,11 +47,7 @@ compile_arm64() {
 }
 
 compile_x86_64() {
-  USE_DISTRIBUTED=0 WERROR=1 python setup.py bdist_wheel
-}
-
-compile_x86_64() {
-  USE_DISTRIBUTED=0 WERROR=1 python setup.py bdist_wheel
+  USE_DISTRIBUTED=0 WERROR=1 python setup.py bdist_wheel --plat-name=macosx_10_9_x86_64
 }
 
 build_lite_interpreter() {

--- a/.ci/pytorch/macos-common.sh
+++ b/.ci/pytorch/macos-common.sh
@@ -9,7 +9,7 @@ sysctl -a | grep machdep.cpu
 
 # These are required for both the build job and the test job.
 # In the latter to test cpp extensions.
-export MACOSX_DEPLOYMENT_TARGET=10.9
+export MACOSX_DEPLOYMENT_TARGET=11.0
 export CXX=clang++
 export CC=clang
 


### PR DESCRIPTION
MacOS-10.9 (Mavericks) was released a decade ago, update it to Big Sur, that was released in 2020. But keep platform name to 10_9, as `pip` treats platform as one CPython was built on, not the one it runs on. Delete duplicate `compile_x86_64` function from `macos_build.sh` and specify platform name there. 

Should fix MacOS x86 periodic build failures.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee4d5a8</samp>

> _`macosx_10_9` wheel_
> _Aligns with PyTorch support_
> _Winter of updates_
