### PR TITLE
Fix byteswapping

### DIFF
--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -323,8 +323,7 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
   if (torch::utils::THP_nativeByteOrder() ==
       torch::utils::THPByteOrder::THP_BIG_ENDIAN) {
     int64_t tsize = size; // convert little endian storage to big endian cpu
-    torch::utils::THP_decodeInt64Buffer(
-        &size, (const uint8_t*)&tsize, torch::utils::THP_nativeByteOrder(), 1);
+    torch::utils::THP_decodeInt64Buffer(&size, (const uint8_t*)&tsize, true, 1);
   }
   int64_t nbytes = element_size * size;
   if (!storage.defined()) {
@@ -370,22 +369,13 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
       // NOLINTNEXTLINE(bugprone-branch-clone)
       if (element_size == 2) {
         torch::utils::THP_decodeInt16Buffer(
-            (int16_t*)data + i,
-            le_buffer.get(),
-            torch::utils::THP_nativeByteOrder(),
-            to_convert);
+            (int16_t*)data + i, le_buffer.get(), true, to_convert);
       } else if (element_size == 4) {
         torch::utils::THP_decodeInt32Buffer(
-            (int32_t*)data + i,
-            le_buffer.get(),
-            torch::utils::THP_nativeByteOrder(),
-            to_convert);
+            (int32_t*)data + i, le_buffer.get(), true, to_convert);
       } else if (element_size == 8) {
         torch::utils::THP_decodeInt64Buffer(
-            (int64_t*)data + i,
-            le_buffer.get(),
-            torch::utils::THP_nativeByteOrder(),
-            to_convert);
+            (int64_t*)data + i, le_buffer.get(), true, to_convert);
       }
     }
   }

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -69,41 +69,41 @@ static inline void swapBytes64(void* ptr) {
   memcpy(ptr, &output, sizeof(uint64_t));
 }
 
-static inline uint16_t decodeUInt16LE(const uint8_t* data) {
+static inline uint16_t decodeUInt16(const uint8_t* data) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint16_t output;
   memcpy(&output, data, sizeof(uint16_t));
   return output;
 }
 
-static inline uint16_t decodeUInt16BE(const uint8_t* data) {
-  uint16_t output = decodeUInt16LE(data);
+static inline uint16_t decodeUInt16ByteSwapped(const uint8_t* data) {
+  uint16_t output = decodeUInt16(data);
   swapBytes16(&output);
   return output;
 }
 
-static inline uint32_t decodeUInt32LE(const uint8_t* data) {
+static inline uint32_t decodeUInt32(const uint8_t* data) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint32_t output;
   memcpy(&output, data, sizeof(uint32_t));
   return output;
 }
 
-static inline uint32_t decodeUInt32BE(const uint8_t* data) {
-  uint32_t output = decodeUInt32LE(data);
+static inline uint32_t decodeUInt32ByteSwapped(const uint8_t* data) {
+  uint32_t output = decodeUInt32(data);
   swapBytes32(&output);
   return output;
 }
 
-static inline uint64_t decodeUInt64LE(const uint8_t* data) {
+static inline uint64_t decodeUInt64(const uint8_t* data) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint64_t output;
   memcpy(&output, data, sizeof(uint64_t));
   return output;
 }
 
-static inline uint64_t decodeUInt64BE(const uint8_t* data) {
-  uint64_t output = decodeUInt64LE(data);
+static inline uint64_t decodeUInt64ByteSwapped(const uint8_t* data) {
+  uint64_t output = decodeUInt64(data);
   swapBytes64(&output);
   return output;
 }
@@ -125,7 +125,7 @@ void THP_decodeInt16Buffer(
     size_t len) {
   for (const auto i : c10::irange(len)) {
     dst[i] =
-        (int16_t)(do_byte_swap ? decodeUInt16BE(src) : decodeUInt16LE(src));
+        (int16_t)(do_byte_swap ? decodeUInt16ByteSwapped(src) : decodeUInt16(src));
     src += sizeof(int16_t);
   }
 }
@@ -137,7 +137,7 @@ void THP_decodeInt32Buffer(
     size_t len) {
   for (const auto i : c10::irange(len)) {
     dst[i] =
-        (int32_t)(do_byte_swap ? decodeUInt32BE(src) : decodeUInt32LE(src));
+        (int32_t)(do_byte_swap ? decodeUInt32ByteSwapped(src) : decodeUInt32(src));
     src += sizeof(int32_t);
   }
 }
@@ -149,7 +149,7 @@ void THP_decodeInt64Buffer(
     size_t len) {
   for (const auto i : c10::irange(len)) {
     dst[i] =
-        (int64_t)(do_byte_swap ? decodeUInt64BE(src) : decodeUInt64LE(src));
+        (int64_t)(do_byte_swap ? decodeUInt64ByteSwapped(src) : decodeUInt64(src));
     src += sizeof(int64_t);
   }
 }
@@ -165,7 +165,7 @@ void THP_decodeHalfBuffer(
       uint16_t x;
       c10::Half f;
     };
-    x = (do_byte_swap ? decodeUInt16BE(src) : decodeUInt16LE(src));
+    x = (do_byte_swap ? decodeUInt16ByteSwapped(src) : decodeUInt16(src));
     dst[i] = f;
     src += sizeof(uint16_t);
   }
@@ -177,7 +177,8 @@ void THP_decodeBFloat16Buffer(
     bool do_byte_swap,
     size_t len) {
   for (const auto i : c10::irange(len)) {
-    uint16_t x = (do_byte_swap ? decodeUInt16BE(src) : decodeUInt16LE(src));
+    uint16_t x =
+        (do_byte_swap ? decodeUInt16ByteSwapped(src) : decodeUInt16(src));
     std::memcpy(&dst[i], &x, sizeof(dst[i]));
     src += sizeof(uint16_t);
   }
@@ -204,7 +205,7 @@ void THP_decodeFloatBuffer(
       uint32_t x;
       float f;
     };
-    x = (do_byte_swap ? decodeUInt32BE(src) : decodeUInt32LE(src));
+    x = (do_byte_swap ? decodeUInt32ByteSwapped(src) : decodeUInt32(src));
     dst[i] = f;
     src += sizeof(float);
   }
@@ -221,7 +222,7 @@ void THP_decodeDoubleBuffer(
       uint64_t x;
       double d;
     };
-    x = (do_byte_swap ? decodeUInt64BE(src) : decodeUInt64LE(src));
+    x = (do_byte_swap ? decodeUInt64ByteSwapped(src) : decodeUInt64(src));
     dst[i] = d;
     src += sizeof(double);
   }
@@ -244,9 +245,9 @@ void THP_decodeComplexFloatBuffer(
       float im;
     };
 
-    x = (do_byte_swap ? decodeUInt32BE(src) : decodeUInt32LE(src));
+    x = (do_byte_swap ? decodeUInt32ByteSwapped(src) : decodeUInt32(src));
     src += sizeof(float);
-    y = (do_byte_swap ? decodeUInt32BE(src) : decodeUInt32LE(src));
+    y = (do_byte_swap ? decodeUInt32ByteSwapped(src) : decodeUInt32(src));
     src += sizeof(float);
 
     dst[i] = c10::complex<float>(re, im);
@@ -270,9 +271,9 @@ void THP_decodeComplexDoubleBuffer(
       double im;
     };
 
-    x = (do_byte_swap ? decodeUInt64BE(src) : decodeUInt64LE(src));
+    x = (do_byte_swap ? decodeUInt64ByteSwapped(src) : decodeUInt64(src));
     src += sizeof(double);
-    y = (do_byte_swap ? decodeUInt64BE(src) : decodeUInt64LE(src));
+    y = (do_byte_swap ? decodeUInt64ByteSwapped(src) : decodeUInt64(src));
     src += sizeof(double);
 
     dst[i] = c10::complex<double>(re, im);
@@ -284,7 +285,7 @@ void THP_decodeInt16Buffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeInt16Buffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeInt16Buffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeInt32Buffer(
@@ -292,7 +293,7 @@ void THP_decodeInt32Buffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeInt32Buffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeInt32Buffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeInt64Buffer(
@@ -300,7 +301,7 @@ void THP_decodeInt64Buffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeInt64Buffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeInt64Buffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeHalfBuffer(
@@ -308,7 +309,7 @@ void THP_decodeHalfBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeHalfBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeHalfBuffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeBFloat16Buffer(
@@ -316,7 +317,7 @@ void THP_decodeBFloat16Buffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeBFloat16Buffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeBFloat16Buffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeBoolBuffer(
@@ -324,7 +325,7 @@ void THP_decodeBoolBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeBoolBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeBoolBuffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeFloatBuffer(
@@ -332,7 +333,7 @@ void THP_decodeFloatBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeFloatBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeFloatBuffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeDoubleBuffer(
@@ -340,7 +341,7 @@ void THP_decodeDoubleBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeDoubleBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeDoubleBuffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeComplexFloatBuffer(
@@ -348,7 +349,7 @@ void THP_decodeComplexFloatBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeComplexFloatBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeComplexFloatBuffer(dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_decodeComplexDoubleBuffer(
@@ -356,7 +357,8 @@ void THP_decodeComplexDoubleBuffer(
     const uint8_t* src,
     THPByteOrder order,
     size_t len) {
-  THP_decodeComplexDoubleBuffer(dst, src, (order == THP_BIG_ENDIAN), len);
+  THP_decodeComplexDoubleBuffer(
+      dst, src, (order != THP_nativeByteOrder()), len);
 }
 
 void THP_encodeInt16Buffer(

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -262,12 +262,12 @@ void THP_decodeComplexDoubleBuffer(
   for (const auto i : c10::irange(len)) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     union {
-      uint32_t x;
+      uint64_t x;
       double re;
     };
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     union {
-      uint32_t y;
+      uint64_t y;
       double im;
     };
 


### PR DESCRIPTION
On big endian systems byteswapping should be done other way around.

This change fixes TestE2ETensorPipe.TestTrainingLoop test from
test_cpp_rpc testsuite on big endian systems.

Use uint64_t when decoding double values.