### PR TITLE
S390x tests

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -436,6 +436,7 @@ TEST(BoundShapeInference, ConcatMissingInput) {
       {spec.max_batch_size, 2, 60});
 }
 
+#ifdef USE_PYTORCH_QNNPACK
 // See https://github.com/pytorch/pytorch/issues/35544
 TEST(
     BoundShapeInference,
@@ -495,6 +496,7 @@ TEST(
       TensorProto_DataType_UINT8,
       true);
 }
+#endif /* USE_PYTORCH_QNNPACK */
 
 TEST(BoundShapeInference, ConcatInferInputBackwards) {
   NetDef net;
@@ -765,6 +767,7 @@ TEST(BoundShapeInference, Split) {
       {spec.max_batch_size, 48});
 }
 
+#ifdef USE_PYTORCH_QNNPACK
 // https://github.com/pytorch/pytorch/issues/41471
 TEST(BoundShapeInference, DISABLED_ON_WINDOWS(FC)) {
   NetDef net;
@@ -842,6 +845,7 @@ TEST(BoundShapeInference, DISABLED_ON_WINDOWS(FC)) {
       TensorProto_DataType_UINT8,
       true);
 }
+#endif /* USE_PYTORCH_QNNPACK */
 
 TEST(BoundShapeInference, FC3D) {
   NetDef net;

--- a/caffe2/utils/CMakeLists.txt
+++ b/caffe2/utils/CMakeLists.txt
@@ -70,10 +70,15 @@ set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS}
         utils/fatal_signal_asan_no_sig_test.cc
         utils/simple_queue_test.cc
         utils/proto_utils_test.cc
-        utils/cpuid_test.cc
         utils/smart_tensor_printer_test.cc
         utils/cast_test.cc
         )
+
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x")
+  set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS}
+          utils/cpuid_test.cc
+          )
+endif()
 
 set(Caffe2_GPU_TEST_SRCS ${Caffe2_GPU_TEST_SRCS}
         utils/math_gpu_test.cc


### PR DESCRIPTION
Disable tests using quantized operators if QNNPACK is not available

Two disabled tests use Int8FC operators
which are not available if QNNPACK is not available,
and fail only due to that.

Disable cpuid_test on s390x