### PR TITLE
fix _privateuse1_tag bug and modify wrap_storage_to implement

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -259,7 +259,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         def test_open_device_serialization():
             storage = torch.UntypedStorage(4, device=torch.device('foo'))
-            self.assertEqual(torch.serialization.location_tag(storage), 'foo')
+            self.assertEqual(torch.serialization.location_tag(storage), 'foo:0')
             cpu_storage = torch.empty(4, 4).storage()
             foo_storage = torch.serialization.default_restore_location(cpu_storage, 'foo:0')
             self.assertTrue(foo_storage.is_foo)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -159,7 +159,10 @@ def _meta_tag(obj):
 def _privateuse1_tag(obj):
     backend_name = torch._C._get_privateuse1_backend_name()
     if obj.device.type == backend_name:
-        return backend_name
+        if obj.device.index is None:
+            return backend_name
+        else:
+            return backend_name + ':' + str(obj.device.index)
 
 
 def _cpu_deserialize(obj, location):


### PR DESCRIPTION
**1. Fix _privateuse1_tag bug in `torch/serialization.py`**
Add device_index after device_type.

**2. Modify wrap_storage_to implement in `torch/utils/backend_registration.py`**
Use tensor to build storage rather than UntypedStorage.

Reason:
In `UntypedStorage` `THPStorage_pynew()` method, `c10::GetAllocator` do not has PrivateUse1 specific implementation

See StorageImpl's cpp implementation for `storage.copy_()`,  which pack tensor on storage.
I solve this problem in the same way.

