### PR TITLE
[spmd] enable fully_shard fused_adam test

### DIFF
--- a/test/distributed/_spmd/test_data_parallel.py
+++ b/test/distributed/_spmd/test_data_parallel.py
@@ -216,6 +216,23 @@ class TestDataParallel(DTensorTestBase):
             mod, ddp_mod, opt, ddp_opt, train_batch, train_step, "fully_shard"
         )
 
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_fully_shard_adam_fused(self):
+        mod = SimpleMLP().cuda(self.rank)
+        opt = torch.optim.Adam(mod.parameters(), lr=0.1, fused=True)
+
+        train_batch = (
+            torch.randn(128, 50).to(self.rank),
+            torch.randn(128, 8).to(self.rank),
+        )
+
+        ddp_mod = DDP(deepcopy(mod), device_ids=[self.rank])
+        ddp_opt = torch.optim.Adam(ddp_mod.parameters(), lr=0.1, fused=True)
+
+        self._test_data_parallel(
+            mod, ddp_mod, opt, ddp_opt, train_batch, train_step, "fully_shard"
+        )
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99964
* #99901
* #99900
* #99899
* __->__ #99898
* #99374
* #99489
* #99436
* #99897

This PR enables fully_shard fused adam tests with some additional tweaks
about how to handle scalar tensor. Now we treat scalar tensors as if
it's just a scalar value, we don't distribute it as there's no need to
shard a scalar tensor