### PR TITLE
[spmd] expose input_batch_dim to DataParallelMode

### DIFF
--- a/torch/distributed/_spmd/data_parallel.py
+++ b/torch/distributed/_spmd/data_parallel.py
@@ -840,6 +840,7 @@ def partition_data_parallel(
     kwargs: Dict[str, Any],
     mesh: DeviceMesh,
     parallel_style: DataParallelStyle,
+    input_batch_dim: int,
 ) -> GraphModule:
     """
     The entry point function to partition the graph to data parallel
@@ -856,7 +857,7 @@ def partition_data_parallel(
 
     # 1. First build up data parallel strategies for the whole graph
     strategy_map = build_data_parallel_strategies(
-        graph, num_params_buffers, num_states, mesh=mesh
+        graph, num_params_buffers, num_states, mesh=mesh, batch_dim=input_batch_dim
     )
 
     # 2. Next we mark the data parallel strategy for each node base on

--- a/torch/distributed/_spmd/parallel_mode.py
+++ b/torch/distributed/_spmd/parallel_mode.py
@@ -60,6 +60,7 @@ class DataParallel(ParallelMode):
     def __init__(
         self,
         parallel_style: str = "replicate",
+        input_batch_dim: int = 0,
         custom_passes: Optional[Callable[[GraphModule], GraphModule]] = None,
     ):
         """
@@ -71,6 +72,8 @@ class DataParallel(ParallelMode):
         Args:
             parallel_style (str): parallel style to use. Currently supports
                 "replicate", "fully_shard", and "default".
+            input_batch_dim (int): the batch dimension of the input tensor.
+                 default: 0
             custom_passes (Callable[[GraphModule], GraphModule], optional):
                 A custom callable that overrides the default graph transformation
                 and optimization passes.
@@ -84,6 +87,8 @@ class DataParallel(ParallelMode):
             self.parallel_style = DataParallelStyle.DEFAULT
         else:
             raise RuntimeError(f"Unknown parallel style: {parallel_style}")
+
+        self.input_batch_dim = input_batch_dim
 
         if custom_passes is not None:
             self._gm_passes: Callable[[GraphModule], GraphModule] = custom_passes
@@ -114,6 +119,7 @@ class DataParallel(ParallelMode):
             kwargs,
             mesh,
             self.parallel_style,
+            self.input_batch_dim,
         )
         return gm
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #99964
* #99901
* #99900
* __->__ #99899
* #99898
* #99374
* #99489
* #99436
* #99897

This PR exposes the input batch dim to the DataParallelMode so that
we could have explicit control of which input dim is batch dim