### PR TITLE
Fix HigherOrderOperator.name() implementation

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -252,7 +252,7 @@ class HigherOrderOperator(OperatorBase):
         return self.dispatch(dispatch_key_set.highestPriorityTypeId(), *args, **kwargs)
 
     def name(self):
-        return self.name
+        return self._name
 
 
 def _to_flat_tuple(args, kwargs):


### PR DESCRIPTION
Summary: `name()` returned `self.name` instead of `self._name`, causing it to return a pointer to the called function itself instead of the string value.

Test Plan: CI

Differential Revision: D45238160

