### PR TITLE
Introduce FXGraphExtractor into torch.onnx.dynamo_export

### DIFF
--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -9,9 +9,9 @@ from beartype import roar
 from torch.onnx import dynamo_export, ExportOptions, ExportOutput
 from torch.onnx._internal.exporter import (
     _DEFAULT_OPSET_VERSION,
-    _ResolvedExportOptions,
     ExportOutputSerializer,
     ProtobufExportOutputSerializer,
+    ResolvedExportOptions,
 )
 from torch.onnx._internal.fx import io_adapter
 
@@ -27,11 +27,11 @@ class SampleModel(torch.nn.Module):
 
 class TestExportOptionsAPI(common_utils.TestCase):
     def test_opset_version_default(self):
-        options = _ResolvedExportOptions(None)
+        options = ResolvedExportOptions(None)
         self.assertEquals(options.opset_version, _DEFAULT_OPSET_VERSION)
 
     def test_opset_version_explicit(self):
-        options = _ResolvedExportOptions(ExportOptions(opset_version=3000))
+        options = ResolvedExportOptions(ExportOptions(opset_version=3000))
         self.assertEquals(options.opset_version, 3000)
 
     def test_raise_on_invalid_argument_type(self):
@@ -43,26 +43,26 @@ class TestExportOptionsAPI(common_utils.TestCase):
         with self.assertRaises(expected_exception_type):
             ExportOptions(logger="DEBUG")  # type: ignore[arg-type]
         with self.assertRaises(expected_exception_type):
-            _ResolvedExportOptions(options=12)  # type: ignore[arg-type]
+            ResolvedExportOptions(options=12)  # type: ignore[arg-type]
 
     def test_dynamic_shapes_default(self):
-        options = _ResolvedExportOptions(None)
+        options = ResolvedExportOptions(None)
         self.assertFalse(options.dynamic_shapes)
 
     def test_dynamic_shapes_explicit(self):
-        options = _ResolvedExportOptions(ExportOptions(dynamic_shapes=None))
+        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=None))
         self.assertFalse(options.dynamic_shapes)
-        options = _ResolvedExportOptions(ExportOptions(dynamic_shapes=True))
+        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=True))
         self.assertTrue(options.dynamic_shapes)
-        options = _ResolvedExportOptions(ExportOptions(dynamic_shapes=False))
+        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=False))
         self.assertFalse(options.dynamic_shapes)
 
     def test_logger_default(self):
-        options = _ResolvedExportOptions(None)
+        options = ResolvedExportOptions(None)
         self.assertEquals(options.logger, logging.getLogger().getChild("torch.onnx"))
 
     def test_logger_explicit(self):
-        options = _ResolvedExportOptions(ExportOptions(logger=logging.getLogger()))
+        options = ResolvedExportOptions(ExportOptions(logger=logging.getLogger()))
         self.assertEquals(options.logger, logging.getLogger())
         self.assertNotEquals(options.logger, logging.getLogger().getChild("torch.onnx"))
 

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -6,14 +6,14 @@ import os
 import random
 import sys
 import unittest
-from typing import Mapping, Optional, Type
+from typing import Optional
 
 import numpy as np
 import packaging.version
 
 import torch
 from torch.autograd import function
-from torch.onnx._internal import diagnostics, exporter
+from torch.onnx._internal import diagnostics
 from torch.testing._internal import common_utils
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -216,35 +216,6 @@ def xfail(reason: str):
         A decorator for expecting test failure.
     """
     return unittest.expectedFailure
-
-
-def skip_fx_tracer(
-    fx_tracer_and_reason: Mapping[Optional[Type[exporter.FXGraphExtractor]], str]
-):
-    """Skip exporting test for selected FX tracers.
-
-    Args:
-        fx_tracer_and_reason: Mapping from FX tracer class to skip the test to the
-            reason for skipping.
-
-    Returns:
-        A decorator for skipping exporting test for FX tracer.
-    """
-
-    def skip_dec(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            for fx_tracer, reason in fx_tracer_and_reason.items():
-                if fx_tracer == self.fx_tracer:
-                    fx_tracer_name = fx_tracer.__name__
-                    raise unittest.SkipTest(
-                        f"Skip verify test for '{fx_tracer_name}'. {reason}"
-                    )
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
-    return skip_dec
 
 
 # skips tests for opset_versions listed in unsupported_opset_versions.

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -4,123 +4,8 @@ import copy
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 import torch.onnx
-from torch.onnx import utils as onnx_utils
 from torch.onnx._internal import exporter
 from torch.onnx._internal.fx import io_adapter as io_adapter
-
-
-class DynamoOptimizeGraphCaptureCompiler:
-    def __init__(self):
-        self.captured_graph: Optional["torch.fx.GraphModule"] = None
-        self.captured_graph_count = 0
-
-    def __call__(self, graph_module: "torch.fx.GraphModule", _):
-        assert self.captured_graph_count == 0
-        self.captured_graph = graph_module
-        self.captured_graph_count += 1
-        return graph_module
-
-
-class DynamoOptimize(exporter.FXGraphExtractor):
-    """Generates a FX GraphModule using torch.dynamo.optimize API
-    Args:
-        backend: Specify which backend compiler must be used by Torch Dynamo.
-            One of the two things:
-                - Either, a function/callable taking a torch.fx.GraphModule and
-                    example_inputs and returning a python callable that runs the
-                    graph faster.
-                    One can also provide additional context for the backend, like
-                    torch.jit.fuser("fuser2"), by setting the backend_ctx_ctor attribute.
-                    See AOTAutogradMemoryEfficientFusionWithContext for the usage.
-                - Or, a string backend name in `torch._dynamo.list_backends()`
-        nopython:  If True, graph breaks will be errors and there will be a single whole-program graph.
-        disable: If True, turn this engine into a no-op
-        dynamic: If True, turn on dynamic shapes support
-    """
-
-    def __init__(
-        self,
-        backend: Union[Callable, str] = None,
-        nopython: bool = True,
-        disable: bool = False,
-        dynamic: bool = False,
-    ):
-        super().__init__()
-        self.backend = backend or DynamoOptimizeGraphCaptureCompiler()
-        self.nopython = nopython
-        self.disable = disable
-        self.dynamic = dynamic
-
-    def generate_fx(
-        self,
-        options: exporter._ResolvedExportOptions,
-        model: Union[torch.nn.Module, Callable],
-        model_args: Sequence[Any],
-        model_kwargs: Mapping[str, Any],
-    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
-        # Fill in default values for optional args and kwargs. The goal is to preserve
-        # them as inputs in `dynamo.optimize` produced FX graph. Otherwise, they will
-        # be traced as constants.
-        _, named_args = self.adapt_input(
-            io_adapter.BindInputStep,
-            model_args,
-            model_kwargs,
-            step_init_args=(onnx_utils.model_signature(model),),
-        )
-        model_args, _ = self.adapt_input(
-            io_adapter.MergeKwargsIntoArgsStep,
-            [],
-            named_args,
-        )
-
-        # args will be converted to symbolic tensor. Let's copy to avoid side effects.
-        model_args = copy.deepcopy(model_args)
-        # Translate callable to FX graph.
-        #
-        # TODO(wechi): There are several symbolic tracing mechanisms to convert
-        # nn.Module to FX graph. We should choose the right one after they are
-        # matured.
-
-        # NOTE: Do not import at top level.
-        # Even torch/__init__.py does it internally, only
-        # Causes circular when torch._dynamo.* surfaces public facing API during `import torch`
-        import torch._dynamo
-
-        torch._dynamo.reset()
-        # TODO(titaiwang): Set `dynamic` according to `self.options.dynamic_shapes`
-        torch._dynamo.optimize(
-            self.backend,
-            nopython=self.nopython,
-            disable=self.disable,
-            dynamic=self.dynamic,
-        )(model)(*model_args)
-        torch._dynamo.reset()
-        # TODO: `self.backend.captured_graph` breaks the PyTorch Dynamo contract for compiler
-        # The contract is backend is ``Callable[gm: GraphModule, example_inputs: Any] -> Callable``
-        assert self.backend.captured_graph  # type: ignore[union-attr]
-
-        # Outputs are flattened by `dynamo.optimize`.
-        # Apply and record this output adapt step.
-        self.output_adapter.append_step(io_adapter.DynamoFlattenOutputStep())
-        # TODO: `dynamo.optimize` does not capture non computation part of the graph.
-        # Hence any tensor that is returned multiple times will only appear once
-        # in the return statement of `dynamo.optimize` traced graph. A specialized
-        # output adapter is required to map this gap between PyTorch model.
-
-        # Export FX graph to ONNX ModelProto.
-        #
-        # Apply and record the following input adapt steps.
-        # `args` and `kwargs` are merged and flattened by `dynamo.optimize`.
-        model_args, _ = self.adapt_input(
-            io_adapter.FlattenInputWithTreeSpecValidationStep, model_args, {}
-        )
-        # `None` inputs are removed by `dynamo.optimize`.
-        model_args, _ = self.adapt_input(io_adapter.RemoveNoneInputStep, model_args, {})
-        # TODO: needs additional input adapt step to remove unused arguments.
-        # `dynamo.optimize` drops unused arguments.
-        # TODO: `self.backend.captured_graph` breaks the PyTorch Dynamo contract for compiler
-        # The contract is backend is ``Callable[gm: GraphModule, example_inputs: Any] -> Callable``
-        return self.backend.captured_graph, list(model_args)  # type: ignore[return-value,union-attr]
 
 
 class DynamoExport(exporter.FXGraphExtractor):
@@ -140,7 +25,7 @@ class DynamoExport(exporter.FXGraphExtractor):
 
     def generate_fx(
         self,
-        options: exporter._ResolvedExportOptions,
+        options: exporter.ResolvedExportOptions,
         model: Union[torch.nn.Module, Callable],
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],

--- a/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
+++ b/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
@@ -201,7 +201,7 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
 
     def generate_fx(
         self,
-        options: exporter._ResolvedExportOptions,
+        options: exporter.ResolvedExportOptions,
         model: Union[torch.nn.Module, Callable],
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],

--- a/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
+++ b/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
@@ -21,7 +21,7 @@ from torch._subclasses import fake_tensor
 
 from torch.onnx import _type_utils
 from torch.onnx._internal import _beartype
-from torch.onnx._internal.exporter import _ResolvedExportOptions
+from torch.onnx._internal.exporter import ResolvedExportOptions
 from torch.onnx._internal.fx import diagnostics, function_dispatcher, op_validation
 from torch.utils import _pytree
 
@@ -324,7 +324,7 @@ def _export_fx_node_to_onnxscript(
     ],
     tracer: graph_building.TorchScriptTracingEvaluator,
     fx_module_with_metadata: torch.fx.GraphModule,
-    options: _ResolvedExportOptions,
+    options: ResolvedExportOptions,
 ):
     # Record stack trace of node in diagnostic.
     node_stack_trace = node.stack_trace
@@ -533,7 +533,7 @@ def _export_fx_node_to_onnxscript(
 @diagnostics.diagnose_call(diagnostics.rules.atenlib_fx_to_onnx)
 def export_fx_to_onnxscript(
     fx_module_with_metadata: torch.fx.GraphModule,
-    options: _ResolvedExportOptions,
+    options: ResolvedExportOptions,
 ):
     """
     Export a torch.fx.GraphModule to a TorchScript graph with ONNX symbols.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99915

The current API architecture can be seen as 3 independent exporters as shown below.
The public API `dynamo_export()` defaults to one of the 3 variants and the other 2 must be used by instantiating private classes:
![image](https://user-images.githubusercontent.com/5469809/231567368-ec899718-b7c1-4e59-b6a8-383142df245a.png)

This PR refactors the API in a way that `dynamo_export` is the only way to use the ONNX exporter.
It defaults to a FX tracer based on ``torch.export``, but an internal-only idiom allows switching the FX tracer
(aka `FXGraphExtractor` interface), as shown below:

![image](https://user-images.githubusercontent.com/5469809/231567495-3936362d-06de-4cfc-b752-6c2060701c08.png)

Summary of changes:

* Unifies all exporter variants under a single `dynamo_export` API
  * `ResolvedExportOptions` was expanded to allow `fx_tracer: FXGraphExtractor` to be specified, selecting which FX graph extractor to use, according to the design proposal
  * As a consequence, `torch.onnx._internal.exporter.Exporter` does not have to *internally* specialize for each type of FX API that the exporter might be used. This leads to a single `Exporter` with many `FX graph extractors`
  * Before in red, after in green:
![image](https://user-images.githubusercontent.com/5469809/232633531-4c67449b-4863-474d-9e18-78fc1d31b1bd.png)
* Input processing was moved from `Exporter` subclasses to `FXGraphExtractor` subclasses, where they are actually consumed
  * `Exporter` is a [data]class that holds export options, model and input data in a single cohesive object. Specializing it means create different exporters instead of having one exporter capable of exporting models through different options.
  * `Exporter` doesn't consume the `model_args` that caused it to specialize
* Improved the circular dependency story.
  * https://github.com/pytorch/pytorch/pull/99070 moves `import torch.onnx` to after all dynamo subcomponents, preventing `torch.onnx` to have circular depemndencies when `torch.XXXX` is imported during initialization
  * There are other points we need to improve in subsequent PRs. APIs are organized in a way that it is easy to "import too much"
* Refactored `decomposition_table` as an internal-only `ResolvedExportOptions` property.
  * Similar to input processing, this helper is not actually consumed at
tyhe `Exporter` layer. This PR moves it to the layer in which it is used
* Demoted `Exporter.model_signature` to a simple standalone helper
  * There is no need to have this as a exporter method; this is a standard `inpect.signature` usage without any state

Possible next steps are:
* Decouple `passes` and `dispatching` from the cluttered `export_fx_to_onnx`
* Further integration with http://github.com/pytorch/pytorch/pull/98421/ into `FXGraphExtractor` public API + helper for unit testing
  * Some passes are changing input processing, which are not captured by
the proposed input adapter

** COPILOT SUMMARY**
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 102b7b8</samp>

### Summary
🚚🗑️📝

<!--
1.  🚚 for renaming a class and updating references and annotations
2.  🗑️ for removing unused code and arguments
3.  📝 for simplifying and clarifying the code and documentation
-->
This pull request refactors and simplifies the code for exporting PyTorch models to ONNX using FX. It renames the `ResolvedExportOptions` class and updates its references and annotations in various modules and test files. It also removes unused or redundant code and imports from the ONNX exporter API and its test suite.

> _`ResolvedExportOptions`_
> _Renamed and simplified_
> _Autumn leaves of code_

### Walkthrough
*  Rename `_ResolvedExportOptions` to `ResolvedExportOptions` and update all references to it in `exporter.py`, `test_exporter_api.py`, `test_fx_to_onnx_with_onnxruntime.py`, `dynamo_graph_extractor.py`, `fx_symbolic_graph_extractor.py`, and `fx_to_onnxscript.py` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-4545f0c15c73ebe90a875e9bee6c5ca4b6b92fb1ed0ec5560d1568e0f6339d02L12-R14), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-4545f0c15c73ebe90a875e9bee6c5ca4b6b92fb1ed0ec5560d1568e0f6339d02L30-R34), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-4545f0c15c73ebe90a875e9bee6c5ca4b6b92fb1ed0ec5560d1568e0f6339d02L46-R65), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-26ce853445bf331686abb33393ee166726923ce36aa2a8de98ac7a2e3bc5a6d8L16-R16), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL945-R876), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L77-R80), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L125-R124), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L354-R348), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L455-R449), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L482-R484), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L526-R520), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L604-R599), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-078d7b8d0e4050e650fc3c15dc97a0564852191ac7b7bdc069d0b3959c5ee39aL143-R28), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L204-R204), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-cabc3e58713d6fe7ab764ade4f2692f6753402322a7b542397cad16fcc72cf4bL24-R24), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-cabc3e58713d6fe7ab764ade4f2692f6753402322a7b542397cad16fcc72cf4bL327-R327), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-cabc3e58713d6fe7ab764ade4f2692f6753402322a7b542397cad16fcc72cf4bL536-R536))
* Remove unused imports of `Mapping`, `Type`, `diagnostics`, and `exporter` from `pytorch_test_common.py` and `test_fx_to_onnx_with_onnxruntime.py` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-26ce853445bf331686abb33393ee166726923ce36aa2a8de98ac7a2e3bc5a6d8L9-R9), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-26ce853445bf331686abb33393ee166726923ce36aa2a8de98ac7a2e3bc5a6d8L16-R16), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL37-R37))
* Remove unused `decomposition_table` argument from `ExportOptions.__init__` in `exporter.py` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L71))
* Remove unused `skip_fx_tracer` decorator from `pytorch_test_common.py` and replace it with `xfail` decorator or remove it entirely from `test_fx_to_onnx_with_onnxruntime.py` depending on the expected test outcome for `DynamoExport` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-26ce853445bf331686abb33393ee166726923ce36aa2a8de98ac7a2e3bc5a6d8L221-L249), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL306-R297), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL362-R352), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL398-L402), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL439-L441), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL583-L591), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL611-R572), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL713-R665), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL777-R723), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL830-L834))
* Remove unused `fx_tracer` attribute and parameter from `TestFxToOnnxWithOnnxRuntime` class and its input values, test file name, and class name generator in `test_fx_to_onnx_with_onnxruntime.py` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL190-R191), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL232-R233), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL252-R246), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL266), [link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL283))
* Fix the call to `run_test_with_fx_to_onnx_exporter_and_onnx_runtime` in `test_fx_to_onnx_with_onnxruntime.py` to use `self` as the first argument and to wrap the additional test inputs in a tuple ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL795-R735))
* Remove unused `DynamoOptimize` class and its dependencies from `dynamo_graph_extractor.py` ([link](https://github.com/pytorch/pytorch/pull/99915/files?diff=unified&w=0#diff-078d7b8d0e4050e650fc3c15dc97a0564852191ac7b7bdc069d0b3959c5ee39aL7-R10))

