### PR TITLE
[torchgen] accept scalars for unary `SymInt` arrays

### DIFF
--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -951,6 +951,9 @@ def argument_type_str_pyi(t: Type) -> str:
             )
         elif str(t.elem) == "float":
             ret = "Sequence[_float]"
+        elif str(t.elem) == "SymInt" and t.size == 1:
+            elem = argument_type_str_pyi(t.elem)
+            ret = f"Union[{elem}, Sequence[{elem}]]"
         else:
             elem = argument_type_str_pyi(t.elem)
             ret = f"Sequence[{elem}]"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #99921

Fixes https://github.com/pytorch/pytorch/issues/99907