### PR TITLE
[c10d] Scalable PG initiation.

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1345,6 +1345,76 @@ class AbstractCommTest:
         dist.all_gather(tensor_list_c, tensor)
         dist.all_gather(tensor_list_c, tensor_c)
 
+
+# Variant of AbstractCommTest that expects world size of 4
+class AbstractLargeCommTest(object):
+    @property
+    def op_timeout_sec(self):
+        return 1
+
+    @property
+    def world_size(self):
+        return 4
+
+    @property
+    def device(self):
+        raise RuntimeError("Implement me")
+
+    def _test_new_group_local_sync(self, backend):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend,
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        rank = dist.get_rank()
+        ranks_in = [rank, (rank + 2) % self.world_size]
+        ranks_out = [i for i in range(self.world_size) if i not in ranks_in]
+        self.assertIn(rank, ranks_in)
+        self.assertNotIn(rank, ranks_out)
+
+        self.assertIsNone(dist.new_group(ranks=ranks_out, use_local_synchronization=True))
+
+        new_pg = dist.new_group(ranks=ranks_in, use_local_synchronization=True)
+        self.assertIsInstance(new_pg, dist.ProcessGroup)
+
+        # PTD sorts ranks before creating the PG, so [3, 1] actually gets assigned ranks [1, 0]
+        ranks_in.sort()
+        self.assertEqual(dist.get_group_rank(new_pg, rank), ranks_in.index(rank))
+        self.assertEqual(
+            ranks_in,
+            dist.get_process_group_ranks(new_pg),
+            f"expecting {ranks_in} but got {dist.get_process_group_ranks(new_pg)}"
+        )
+
+    def _test_new_group_local_sync_sanity_check(self, backend):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend,
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        rank = dist.get_rank()
+
+        # split the world in 2 PGs
+        rank = dist.get_rank()
+        pg_idx = rank // 2
+        ranks_in = [pg_idx * 2, pg_idx * 2 + 1]
+        new_pg = dist.new_group(ranks=ranks_in, use_local_synchronization=True)
+
+        input_tensor = torch.tensor([pg_idx, rank], device=self.device)
+        output_tensor_list = [torch.tensor([-1, -1], device=self.device,) for _ in range(new_pg.size())]
+        dist.all_gather(output_tensor_list, input_tensor, group=new_pg)
+
+        expected = [
+            torch.tensor([pg_idx, ranks_in[0]], device=self.device),
+            torch.tensor([pg_idx, ranks_in[1]], device=self.device)
+        ]
+        self.assertEqual(output_tensor_list, expected)
+
+
 class CommTest(AbstractCommTest, MultiProcessTestCase):
     def setUp(self):
         super().setUp()

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2487,6 +2487,30 @@ class CompilerTest(test_c10d_common.CompilerTest):
             torch.ones(2, 2, device=self.rank) * self.rank
         )
 
+class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase):
+    def setUp(self):
+        super(LargeCommTest, self).setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super(LargeCommTest, self).tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    @requires_gloo()
+    def test_new_group_local_sync(self):
+        self._test_new_group_local_sync(backend="gloo")
+
+    @requires_gloo()
+    def test_new_group_local_sync_sanity_check(self):
+        self._test_new_group_local_sync_sanity_check(backend="gloo")
+
 if __name__ == "__main__":
     assert (
         not torch.cuda._initialized

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2,6 +2,7 @@ import itertools
 import collections.abc
 import contextlib
 import functools
+import hashlib
 import io
 import logging
 import os
@@ -468,18 +469,18 @@ def _get_pg_device(group: ProcessGroup):
     return torch.device("cpu")
 
 
-def _store_based_barrier(rank, store, timeout, logging_interval=timedelta(seconds=10)):
+def _store_based_barrier(rank, store, group_name, rendezvous_count, timeout, logging_interval=timedelta(seconds=10)):
     """
     Barrier based on store which is used for synchronizing processes after
     ``init_process_group`` or ``new_group``. Intended to be used only with
     those two methods and is not a generic alternative to ``barrier()``.
     """
-    store_key = f"{STORE_BASED_BARRIER_PREFIX}:{_world.group_count}"
+    store_key = f"{STORE_BASED_BARRIER_PREFIX}:{group_name}"
     store.add(store_key, 1)
     logger.info("Added key: %s to store for rank: %s", store_key, rank)
 
     # Now wait for all workers to check in with the store.
-    world_size = get_world_size()
+    world_size = rendezvous_count
     worker_count = store.add(store_key, 0)
 
     last_worker_key = f"{store_key}:last_worker"
@@ -868,7 +869,7 @@ def init_process_group(
             For ``ucc``, blocking wait is supported similar to NCCL. However,
             async error handling is done differently since with UCC we have
             progress thread and not watch-dog thread.
-        group_name (str, optional, deprecated): Group name.
+        group_name (str, optional, deprecated): Group name. This argument is ignored
         pg_options (ProcessGroupOptions, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. As of now, the only
@@ -916,6 +917,12 @@ def init_process_group(
     else:
         backend = Backend("undefined")
 
+    """
+    Group name is not visible to users unless they access
+    internals of c10d. This means we can ignore the value
+    they provide as it not exposed in a public way.
+    """
+    group_name = _process_group_name([], use_hashed_name=False)
     if backend == Backend.MPI:
         if world_size != -1 or rank != -1:
             warnings.warn(
@@ -924,7 +931,7 @@ def init_process_group(
                 "MPI runtime.".format(world_size, rank)
             )
 
-        default_pg = _new_process_group_helper(
+        default_pg, _ = _new_process_group_helper(
             -1, -1, [], backend, None, group_name=group_name, timeout=timeout
         )
         _update_default_pg(default_pg)
@@ -941,7 +948,7 @@ def init_process_group(
             # different systems (e.g. RPC) in case the store is multi-tenant.
             store = PrefixStore("default_pg", store)
 
-        default_pg = _new_process_group_helper(
+        default_pg, _ = _new_process_group_helper(
             world_size,
             rank,
             [],
@@ -966,7 +973,7 @@ def init_process_group(
     else:
         # Use store based barrier here since barrier() used a bunch of
         # default devices and messes up NCCL internal state.
-        _store_based_barrier(rank, store, timeout)
+        _store_based_barrier(rank, store, group_name, world_size, timeout)
 
 
 def _new_process_group_helper(
@@ -991,10 +998,6 @@ def _new_process_group_helper(
     """
     global _world
 
-    if not group_name:
-        group_name = str(_world.group_count)
-        _world.group_count = _world.group_count + 1
-
     if group_name in _world.pg_names.values():
         raise RuntimeError(
             "The specified group name has already been "
@@ -1010,7 +1013,8 @@ def _new_process_group_helper(
         # creating with the same tag and rank set results in the same underlying PG
         existing_group = _find_pg_by_ranks_and_tag(pg_tag, global_ranks_in_group)
         if existing_group:
-            return existing_group
+            _, prefix_store = _world.pg_map[existing_group]
+            return existing_group, prefix_store
 
     # The list of group ranks is empty if we're creating the default group.
     is_default_group = len(global_ranks_in_group) == 0
@@ -1020,7 +1024,7 @@ def _new_process_group_helper(
     if not is_default_group:
         global_rank = _get_default_group().rank()
         if global_rank not in global_ranks_in_group:
-            return GroupMember.NON_GROUP_MEMBER
+            return GroupMember.NON_GROUP_MEMBER, None
 
     prefix_store = PrefixStore(f"{group_name}/", store)
     base_pg_options = ProcessGroup.Options(backend=str(backend))
@@ -1152,7 +1156,7 @@ def _new_process_group_helper(
 
     _world.tags_to_pg.setdefault(pg_tag, []).append(pg)
     _world.pg_to_tag[pg] = pg_tag
-    return pg
+    return pg, prefix_store
 
 def destroy_process_group(group: Optional[ProcessGroup] = None):
     """
@@ -3479,7 +3483,28 @@ def _create_process_group_wrapper(
     wrapped_pg = _ProcessGroupWrapper(wrapped_pg, helper_pg)
     return wrapped_pg
 
-def new_group(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=None):
+
+def _process_group_name(ranks, use_hashed_name):
+    global _world
+    if use_hashed_name:
+        pg_name = hashlib.sha1(bytes("_".join(map(str, ranks)), "utf-8")).hexdigest()
+        while pg_name in _world.pg_names:
+            pg_name = hashlib.sha1(bytes(pg_name + "_", "utf-8")).hexdigest()
+    else:
+        pg_name = str(_world.group_count)
+        _world.group_count += 1
+    return pg_name
+
+def _get_backend_from_str(backend: Optional[str] = None) -> Backend:
+    # Default to the same backend as the global process group
+    #  if backend is not specified.
+    if not backend:
+        backend = get_backend(_get_default_group())
+    return Backend(backend)
+
+
+
+def new_group(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=None, use_local_synchronization=False):
     """
     Creates a new distributed group.
 
@@ -3533,13 +3558,34 @@ def new_group(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=N
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
             process group can pick up high priority cuda streams.
+        use_local_synchronization (bool, optional): perform a group-local
+            barrier at the end of the process group creation. This is different
+            in that non-member ranks don't need to call into API and don't
+            join the barrier.
 
     Returns:
-        A handle of distributed group that can be given to collective calls.
-    """
-    return _new_group_with_tag(ranks, timeout, backend, pg_options)
+        A handle of distributed group that can be given to collective calls or None if the rank is not part of ``ranks``.
 
-def _new_group_with_tag(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=None, pg_tag=None):
+    N.B. use_local_synchronization doesn't work with MPI.
+
+    N.B. While use_local_synchronization=True can be significantly faster with larger
+    clusters and small process groups, care must be taken since it changes cluster behavior
+    as non-member ranks don't join the group barrier().
+
+    N.B. use_local_synchronization=True can lead to deadlocks when each rank creates
+    multiple overlaping process groups. To avoid that, make sure all ranks follow the
+    same global creation order.
+    """
+    return _new_group_with_tag(ranks, timeout, backend, pg_options, None, use_local_synchronization=use_local_synchronization)
+
+def _new_group_with_tag(
+    ranks=None,
+    timeout=default_pg_timeout,
+    backend=None,
+    pg_options=None,
+    pg_tag=None,
+    use_local_synchronization=False
+):
     """
     This is a variant of ``new_group`` that exposes tag creation.
 
@@ -3557,6 +3603,13 @@ def _new_group_with_tag(ranks=None, timeout=default_pg_timeout, backend=None, pg
     # if the backend is not specified.
     if not backend:
         backend = default_backend
+    backend = Backend(backend)
+    if use_local_synchronization:
+        # MPI backend doesn't have have a way for us to perform a partial sync
+        if backend == Backend.MPI:
+            raise RuntimeError("MPI backend doesn't support use_local_synchronization=True")
+        if ranks is not None and get_rank() not in ranks:
+            return None
 
     # checks the input ranks
     if ranks is not None:
@@ -3584,15 +3637,16 @@ def _new_group_with_tag(ranks=None, timeout=default_pg_timeout, backend=None, pg
         group_world_size = global_world_size
         group_rank = global_rank
 
-    backend = Backend(backend)
+    group_name = _process_group_name(ranks, use_hashed_name=use_local_synchronization)
 
     with record_function(f"## process_group:init with ranks: {ranks}"):
-        pg = _new_process_group_helper(
+        pg, pg_store = _new_process_group_helper(
             group_world_size,
             group_rank,
             ranks,
             backend,
             default_store,
+            group_name=group_name,
             pg_options=pg_options,
             timeout=timeout,
             pg_tag=pg_tag
@@ -3610,9 +3664,12 @@ def _new_group_with_tag(ranks=None, timeout=default_pg_timeout, backend=None, pg
         # MPI doesn't have store.
         barrier()
     else:
+        barrier_store = pg_store if use_local_synchronization else default_store
+        world_size = len(ranks) if use_local_synchronization else get_world_size()
+
         # Use store based barrier here since barrier() used a bunch of
         # default devices and messes up NCCL internal state.
-        _store_based_barrier(global_rank, default_store, timeout)
+        _store_based_barrier(global_rank, barrier_store, group_name, world_size, timeout)
 
     return pg
 


### PR DESCRIPTION
Add use_local_synchronization argument to new_group.

When this argument is True, is change new_group to do a store_barrier only on the ranks that are park of the group and not the whole cluster.

This addressess both scalability and composability problems associated with new_group.

Fixes #81291.

This is relanding #84224
As part of the original PR I did a quick benchmark of creating 3 PGs per rank using both functions and perf is the following:

new_group use_local_synchronization=False:
| World Size | Time (in secs) |
| --- | ----------- |
| 4 | 0.12 |
| 8 | 0.25 |
| 16 | 0.51 |
| 32 | 0.87 |
| 64 | 1.50 |
| 128 | 2.87 |

new_group use_local_synchronization=True:
| World Size | Time (in secs) |
| --- | ----------- |
| 4 | 0.05 |
| 8 | 0.04 |
| 16 | 0.03 |
| 32 | 0.03 |
| 64 | 0.04 |
| 128 | 0.04 |

Scaling for `use_local_synchronization=False` is sub linear because the number of process groups created as a multiple of world_size decreases as we go up. It's 6 with world_size 4 and 192 with world_size 128.

Scaling for `use_local_synchronization=True` is constant as the number of store barriers executed per rank remains constant at 3.

Setup:

1 AWS host, backend gloo.

