### PR TITLE
Support expandable_segments:True in fbcode for caching allocator

### DIFF
--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -19,7 +19,7 @@ def define_targets(rules):
                 "CUDAMacros.h",
             ],
         ),
-        defines = ["USE_CUDA"],
+        defines = ["USE_CUDA", "PYTORCH_C10_DRIVER_API_SUPPORTED"],
         linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         target_compatible_with = rules.requires_cuda_enabled(),


### PR DESCRIPTION
Summary: Now that expandable_segments has been merged from OSS, we can enable it in the internal build. It still defaults to off, so this should not change any behavior changes in the allocator unless the flag is explicitly set.

Test Plan: waitforsandcastle


