### PR TITLE
[quant][pt2e] remove dropout from fx quant

### DIFF
--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -441,27 +441,6 @@ def _get_embedding_op_configs() -> List[BackendPatternConfig]:
     return embedding_op_configs
 
 
-def _get_default_op_configs() -> List[BackendPatternConfig]:
-    default_op_configs: List[BackendPatternConfig] = []
-    dtype_configs = [
-        qnnpack_default_op_qint8_symmetric_dtype_config,
-        executorch_default_op_quint8_dtype_config,
-    ]
-    observation_type = ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-
-    default_ops = [
-        torch.nn.Dropout,
-        F.dropout,
-    ]
-    for op in default_ops:
-        default_op_configs.append(
-            BackendPatternConfig(op)
-            .set_observation_type(observation_type)
-            .set_dtype_configs(dtype_configs)
-        )
-
-    return default_op_configs
-
 
 # =====================
 # |  BACKEND CONFIGS  |
@@ -481,5 +460,4 @@ def get_executorch_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_bn_configs())
         .set_backend_pattern_configs(_get_cat_configs())
         .set_backend_pattern_configs(_get_embedding_op_configs())
-        .set_backend_pattern_configs(_get_default_op_configs())
     )


### PR DESCRIPTION
Summary:
Quantized Dropout after setting to eval leaves a q --> dq after dropout is removed. i.e. something like:
```
def forward(self, x):
    x = self.conv(x)
    return self.dropout(x)
```

After eval --> prepare_fx --> convert_fx gives us something like:

```
conv --> dq --> q --> dq
```

This gives us inconsistent results, such as the following failing test:

https://www.internalfb.com/intern/test/281475063425888/

Test Plan:
```
buck2 test @//mode/dev-nosan //pye/model_inventory/iobt_temporal_model:iobt_temporal_model_test -- --exact 'pye/model_inventory/iobt_temporal_model:iobt_temporal_model_test - test_executorch_e2e_output_consistency_lean_quantized (pye.model_inventory.iobt_temporal_model.IobtTemporalModelTest.IobtTemporalModelTest)' --run-disabled
File changed: fbcode//caffe2/torch/ao/quantization/backend_config/executorch.py
File changed: fbcode//pye/model_inventory/iobt_temporal_model/IobtTemporalModel.py
Buck UI: https://www.internalfb.com/buck2/248efddc-988a-409c-aa10-724e72803da9
Test UI: https://www.internalfb.com/intern/testinfra/testrun/2251799982980930
RE: reSessionID-52026a87-d16f-4125-9af6-cc0e4785d27f  Up: 12 MiB  Down: 411 MiB
Jobs completed: 50. Time elapsed: 357.1s. Cache hits: 0%. Commands: 45 (cached: 0, remote: 44, local: 1)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. 0 builds failed
```

Differential Revision: D45250152

