### PR TITLE
Introduce FXGraphExtractor into torch.onnx.dynamo_export

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -79,7 +79,7 @@ most_recent_backend: Optional[CompilerFn] = None
 DONT_WRAP_FILES = {
     # For tracing into fx modules
     inspect.getsourcefile(GraphModule),
-    join(dirname(dirname(__file__)), "onnx/_internal/fx/dynamo_exporter.py"),
+    join(dirname(dirname(__file__)), "onnx/_internal/fx/dynamo_graph_extractor.py"),
 }
 
 

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import abc
-import inspect
 import io
 import logging
 from typing import (
     Any,
     Callable,
+    Dict,
     Final,
     List,
     Mapping,
@@ -16,6 +16,7 @@ from typing import (
     runtime_checkable,
     Sequence,
     Tuple,
+    Type,
     TYPE_CHECKING,
     TypeVar,
     Union,
@@ -78,7 +79,25 @@ class ExportOptions:
         self.logger = logger
 
 
-class ResolvedExportOptions:
+class ResolvedExportOptions(ExportOptions):
+    """Consolidates `ExportOptions` with default values.
+    All unspecified options from `ExportOptions` are assigned a default value.
+    This is an internal class and its API may be changed at any time without notice.
+    """
+
+    # Public attributes MUST be redefined below without ``Optional[]`` from ``ExportOptions``
+    opset_version: int
+    dynamic_shapes: bool
+    op_level_debug: bool
+    logger: logging.Logger
+
+    # Private only attributes
+    decomposition_table: Dict[torch._ops.OpOverload, Callable]
+    """Dictionary with all ATen operators supported by the exporter."""
+
+    fx_tracer: FXGraphExtractor
+    """The FXGraphExtractor instance used to extract the FX graph from the model."""
+
     @_beartype.beartype
     def __init__(self, options: Optional[ExportOptions]):
         if options is None:
@@ -96,6 +115,16 @@ class ResolvedExportOptions:
 
         self.opset_version = resolve(options.opset_version, _DEFAULT_OPSET_VERSION)
         self.dynamic_shapes = resolve(options.dynamic_shapes, False)
+        # TODO: Prevent circular dep + [onnx]script dep
+        import torch.onnx._internal.fx.dynamo_graph_extractor as dynamo_graph_extractor
+        from torch.onnx._internal.fx import (  # TODO: onnxscript is not available on Pytorch CI yet
+            function_dispatcher,
+        )
+
+        self.fx_tracer = dynamo_graph_extractor.DynamoExport()
+        self.decomposition_table = (
+            function_dispatcher._DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE
+        )
         self.op_level_debug = resolve(options.op_level_debug, False)
         self.logger = resolve(
             options.logger, lambda: logging.getLogger().getChild("torch.onnx")
@@ -410,7 +439,137 @@ class ExportOutput:
             serializer.serialize(self, destination)
 
 
-class Exporter(abc.ABC):
+class FXGraphExtractor(abc.ABC):
+    """Abstract interface for FX graph extractor engines.
+    This class isolates FX extraction logic from the rest of the export logic.
+    That allows a single ONNX exporter that can leverage different FX graphs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_adapter: InputAdapter = InputAdapter()
+        self.output_adapter: OutputAdapter = OutputAdapter()
+
+    @_beartype.beartype
+    def _export_fx_to_onnx(
+        self,
+        options: ResolvedExportOptions,
+        fx_module: torch.fx.GraphModule,
+        fx_module_args: Sequence[Any],
+    ) -> ExportOutput:
+        import torch.onnx._internal.fx.fx_exporter as fx_exporter
+        import torch.onnx._internal.fx.passes as passes
+
+        # Apply decomposition table to the input graph.
+        module = passes.Decompose(
+            fx_module,
+            options.decomposition_table,
+            enable_dynamic_axes=options.dynamic_shapes,
+        ).run(*fx_module_args)
+
+        # ONNX does not support views and mutations.
+        # Functionalize to get a semantically equivalent graph without mutations.
+        module = passes.Functionalize(
+            module, enable_dynamic_axes=options.dynamic_shapes
+        ).run(*fx_module_args)
+        # Input mutations are detected and distilled after `Functionalize` pass.
+        # Remove them since ONNX inference does not need them.
+        module = passes.RemoveInputMutation(module).run(*fx_module_args)
+
+        # Run ShapeInferenceWithFakeTensor to get static shape of nodes for op_level_debug purposes
+        # The pass added nodes with static shape into original node metadata:
+        # node.meta["static_shape"]: FakeTensor/int/float/SymInt/SynFloat
+        if options.op_level_debug:
+            module = passes.ShapeInferenceWithFakeTensor(module).run(*fx_module_args)
+
+        # We want to pass list of ints and floats to TorchScript graph correctly
+        # in _export_fx_to_ts, so we must disable FakeTensorMode. Otherwise, graph may
+        # receive FakeTensor and results runtime error. In addition, TorchScript-based
+        # ONNX exporter used in _ts_graph_to_onnx_model_in_protobuf is not compatible
+        # with FakeTensorMode.
+        with torch.utils._mode_utils.no_dispatch():
+            onnxscript_graph = passes.export_fx_to_onnxscript(module, options)
+            # ONNX does not support None inputs. During graph building, all None inputs
+            # are removed. Here we register this step to input adapter.
+            self.adapt_input(fx_exporter.RemoveNoneInputStep, fx_module_args, {})
+            # ONNX can't represent collection types (e.g., dictionary, tuple of tuple of
+            # tensor, etc), we flatten the collection and register each element as output.
+            self.output_adapter.append_step(fx_exporter.FlattenOutputStep())
+
+        # Export TorchScript graph to ONNX ModelProto.
+        onnx_model = onnxscript_graph.to_model_proto(options.opset_version)
+        return torch.onnx.ExportOutput(
+            onnx_model, self.input_adapter, self.output_adapter
+        )
+
+    def adapt_input(
+        self,
+        adapt_step_cls: Type[InputAdaptStep],
+        model_args: Sequence[Any],
+        model_kwargs: Mapping[str, Any],
+        step_init_args: Optional[Sequence[Any]] = None,
+    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
+        """Apply an input adapt step to the model args and kwargs.
+        An input adapt step object is initialized, applied and recorded as part of
+        ``self.input_adapter`.
+        Args:
+            adapt_step_cls: The input adapt step class.
+            model_args: The model args.
+            model_kwargs: The model kwargs.
+            step_init_args: The input adapt step initialization arguments.
+        Returns:
+            The adapted model args and kwargs.
+        """
+        step_init_args = step_init_args or ()
+        adapt_step = adapt_step_cls(*step_init_args)
+        self.input_adapter.append_step(adapt_step)
+        return adapt_step.apply(model_args, model_kwargs)
+
+    def adapt_output(
+        self,
+        adapt_step_cls: Type[OutputAdaptStep],
+        model_outputs: Any,
+        step_init_args: Optional[Sequence[Any]] = None,
+    ) -> Any:
+        """Apply an output adapt step to the model outputs.
+        An output adapt step object is initialized, applied and recorded as part of
+        ``self._output_adapter`.
+        Args:
+            adapt_step_cls: The output adapt step class.
+            model_outputs: The model outputs.
+            step_init_args: The input adapt step initialization arguments.
+        Returns:
+            The adapted model outputs.
+        """
+        step_init_args = step_init_args or ()
+        adapt_step = adapt_step_cls(*step_init_args)
+        self.output_adapter.append_step(adapt_step)
+        return adapt_step.apply(model_outputs)
+
+    @abc.abstractmethod
+    def generate_fx(
+        self,
+        options: ResolvedExportOptions,
+        model: Union[torch.nn.Module, Callable],
+        model_args: Sequence[Any],
+        model_kwargs: Mapping[str, Any],
+    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
+        """Analyzes user ``model`` and generates a FX graph.
+        Args:
+            options: The export options.
+            model: The user model.
+            model_args: The model's positional input arguments.
+            model_kwargs: The model's keyword input arguments.
+        Returns:
+            The generated FX Graph, and the model's adapted input arguments.
+        """
+        # By design, only torch.fx.GraphModule is needed
+        # But FXSymbolicTracer modifies model data, which will be needed
+        # to produce the ONNX proto in the next layer.
+        # TODO: Refactor after https://github.com/pytorch/pytorch/pull/98421
+        pass
+
+
+class Exporter:
     @_beartype.beartype
     def __init__(
         self,
@@ -419,33 +578,34 @@ class Exporter(abc.ABC):
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],
     ):
-        if isinstance(options, ExportOptions):
-            self.options = ResolvedExportOptions(options)
-        elif isinstance(options, ResolvedExportOptions):
+        if isinstance(options, ResolvedExportOptions):
             self.options = options
+        elif isinstance(options, ExportOptions):
+            self.options = ResolvedExportOptions(options)
         assert self.options is not None
 
         self.model = model
         self.model_args = model_args
         self.model_kwargs = model_kwargs
 
-    @abc.abstractmethod
     def export(self) -> ExportOutput:
-        pass
+        graph_module, updated_model_args = self.options.fx_tracer.generate_fx(
+            self.options, self.model, self.model_args, self.model_kwargs
+        )
+
+        # Export FX graph to ONNX ModelProto.
+        #
+        # Note that ALL kwargs are folded into constants in graph_module, so we don't pass kwargs
+        # to _export.
+        return self.options.fx_tracer._export_fx_to_onnx(
+            self.options, graph_module, updated_model_args
+        )
 
     @property
     def logger(self) -> logging.Logger:
         # options.logger will always be resolved to an instance when constructing
         assert isinstance(self.options.logger, logging.Logger)
         return self.options.logger
-
-    @property
-    def model_signature(self) -> inspect.Signature:
-        return inspect.signature(
-            self.model.forward
-            if isinstance(self.model, torch.nn.Module)
-            else self.model
-        )
 
 
 class UnsatisfiedDependencyError(RuntimeError):
@@ -533,15 +693,15 @@ def dynamo_export(
         ).save("my_model.onnx")
     """
 
-    resolved_export_options = ResolvedExportOptions(export_options)
+    resolved_export_options = (
+        export_options
+        if isinstance(export_options, ResolvedExportOptions)
+        else ResolvedExportOptions(export_options)
+    )
 
     _assert_dependencies(resolved_export_options)
 
-    # Import inside to avoid introducing the dependencies on `onnx` and `onnxscript` for
-    # this file (exporter.py).
-    from torch.onnx._internal.fx.dynamo_exporter import DynamoExporter
-
-    return DynamoExporter(
+    return Exporter(
         options=resolved_export_options,
         model=model,
         model_args=model_args,

--- a/torch/onnx/_internal/fx/function_dispatcher.py
+++ b/torch/onnx/_internal/fx/function_dispatcher.py
@@ -302,7 +302,7 @@ def _create_onnx_friendly_decomposition_table() -> (
 
 # This is a subset of PyTorch's built-in aten-to-aten decomposition. If an aten
 # op (e.g., torch.ops.aten.add.Tensor) has exporter, we exclude the op's decomposition
-# function in the _DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE.
-_DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE: Dict[
+# function in the DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE.
+DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE: Dict[
     torch._ops.OpOverload, Callable
 ] = _create_onnx_friendly_decomposition_table()

--- a/torch/onnx/_internal/fx/function_dispatcher.py
+++ b/torch/onnx/_internal/fx/function_dispatcher.py
@@ -283,7 +283,7 @@ _SYMINT_SYMFLOAT_BUILTIN_TO_EXPORTER_KEY_TABLE = {
 
 @_beartype.beartype
 def _create_onnx_friendly_decomposition_table() -> (
-    Mapping[torch._ops.OpOverload, Callable]
+    Dict[torch._ops.OpOverload, Callable]
 ):
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = {}
     for op_overload, decomp_fn in torch._decomp.decomposition_table.items():
@@ -302,5 +302,7 @@ def _create_onnx_friendly_decomposition_table() -> (
 
 # This is a subset of PyTorch's built-in aten-to-aten decomposition. If an aten
 # op (e.g., torch.ops.aten.add.Tensor) has exporter, we exclude the op's decomposition
-# function in the _ONNX_FRIENDLY_DECOMPOSITION_TABLE.
-_ONNX_FRIENDLY_DECOMPOSITION_TABLE = _create_onnx_friendly_decomposition_table()
+# function in the _DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE.
+_DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE: Dict[
+    torch._ops.OpOverload, Callable
+] = _create_onnx_friendly_decomposition_table()

--- a/torch/onnx/_internal/fx/fx_exporter.py
+++ b/torch/onnx/_internal/fx/fx_exporter.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-import abc
 import inspect
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
 
-import torch._ops
-import torch.fx
-
-import torch.onnx
-import torch.onnx._internal.fx.function_dispatcher as function_dispatcher
-import torch.onnx._internal.fx.passes as passes
-from torch.onnx._internal import _beartype, exporter
 from torch.utils import _pytree as pytree
 
 # TODO: make_fx lose stack info https://github.com/pytorch/pytorch/issues/90276
@@ -232,110 +224,3 @@ class FlattenOutputWithTreeSpecValidationStep:
                 error_message="Model outputs incompatible with the format that was exported. ",
             )
         return flattened_outputs
-
-
-class FXGraphModuleExporter(exporter.Exporter, abc.ABC):
-    _input_adapter: exporter.InputAdapter
-    _output_adapter: exporter.OutputAdapter
-
-    @property
-    def decomposition_table(self) -> Mapping[torch._ops.OpOverload, Callable]:
-        return function_dispatcher._ONNX_FRIENDLY_DECOMPOSITION_TABLE
-
-    def _apply_input_adapt_step(
-        self,
-        adapt_step_cls: Type[exporter.InputAdaptStep],
-        model_args: Sequence[Any],
-        model_kwargs: Mapping[str, Any],
-        step_init_args: Optional[Sequence[Any]] = None,
-    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
-        """Apply an input adapt step to the model args and kwargs.
-
-        An input adapt step object is initialized, applied and recorded as part of
-        ``self._input_adapter`.
-
-        Args:
-            adapt_step_cls: The input adapt step class.
-            model_args: The model args.
-            model_kwargs: The model kwargs.
-            step_init_args: The input adapt step initialization arguments.
-
-        Returns:
-            The adapted model args and kwargs.
-        """
-        step_init_args = step_init_args or ()
-        adapt_step = adapt_step_cls(*step_init_args)
-        self._input_adapter.append_step(adapt_step)
-        return adapt_step.apply(model_args, model_kwargs)
-
-    def _apply_output_adapt_step(
-        self,
-        adapt_step_cls: Type[exporter.OutputAdaptStep],
-        model_outputs: Any,
-        step_init_args: Optional[Sequence[Any]] = None,
-    ) -> Any:
-        """Apply an output adapt step to the model outputs.
-
-        An output adapt step object is initialized, applied and recorded as part of
-        ``self._output_adapter`.
-
-        Args:
-            adapt_step_cls: The output adapt step class.
-            model_outputs: The model outputs.
-            step_init_args: The input adapt step initialization arguments.
-
-        Returns:
-            The adapted model outputs.
-        """
-        step_init_args = step_init_args or ()
-        adapt_step = adapt_step_cls(*step_init_args)
-        self._output_adapter.append_step(adapt_step)
-        return adapt_step.apply(model_outputs)
-
-    @_beartype.beartype
-    def export_fx_to_onnx(
-        self,
-        fx_module: torch.fx.GraphModule,
-        fx_module_args: Sequence[Any],
-    ) -> torch.onnx.ExportOutput:
-        # Apply decomposition table to the input graph.
-        module = passes.Decompose(
-            fx_module,
-            self.decomposition_table,
-            enable_dynamic_axes=self.options.dynamic_shapes,
-        ).run(*fx_module_args)
-
-        # ONNX does not support views and mutations.
-        # Functionalize to get a semantically equivalent graph without mutations.
-        module = passes.Functionalize(
-            module, enable_dynamic_axes=self.options.dynamic_shapes
-        ).run(*fx_module_args)
-        # Input mutations are detected and distilled after `Functionalize` pass.
-        # Remove them since ONNX inference does not need them.
-        module = passes.RemoveInputMutation(module).run(*fx_module_args)
-
-        # Run ShapeInferenceWithFakeTensor to get static shape of nodes for op_level_debug purposes
-        # The pass added nodes with static shape into original node metadata:
-        # node.meta["static_shape"]: FakeTensor/int/float/SymInt/SynFloat
-        if self.options.op_level_debug:
-            module = passes.ShapeInferenceWithFakeTensor(module).run(*fx_module_args)
-
-        # We want to pass list of ints and floats to TorchScript graph correctly
-        # in _export_fx_to_ts, so we must disable FakeTensorMode. Otherwise, graph may
-        # receive FakeTensor and results runtime error. In addition, TorchScript-based
-        # ONNX exporter used in _ts_graph_to_onnx_model_in_protobuf is not compatible
-        # with FakeTensorMode.
-        with torch.utils._mode_utils.no_dispatch():
-            onnxscript_graph = passes.export_fx_to_onnxscript(module, self.options)
-            # ONNX does not support None inputs. During graph building, all None inputs
-            # are removed. Here we register this step to input adapter.
-            self._apply_input_adapt_step(RemoveNoneInputStep, fx_module_args, {})
-            # ONNX can't represent collection types (e.g., dictionary, tuple of tuple of
-            # tensor, etc), we flatten the collection and register each element as output.
-            self._output_adapter.append_step(FlattenOutputStep())
-
-        # Export TorchScript graph to ONNX ModelProto.
-        onnx_model = onnxscript_graph.to_model_proto(self.options.opset_version)
-        return torch.onnx.ExportOutput(
-            onnx_model, self._input_adapter, self._output_adapter
-        )

--- a/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
+++ b/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.fx
@@ -125,18 +125,52 @@ def _module_expansion_symbolic_trace(
 
 # TODO: Migrate to `DynamoExporter` after fake model tracing is supported.
 # Proposal at https://github.com/pytorch/pytorch/issues/95900.
-class FXSymbolicTraceExporter(fx_exporter.FXGraphModuleExporter):
+class FXSymbolicTracer(exporter.FXGraphExtractor):
+    """Generates a FX GraphModule using torch.fx.symbolic_trace API
+    Args:
+        concrete_args: Inputs to be partially specialized
+            It can be used to remove control flow or data structures.
+            For example::
+                def f(a, b):
+                    if b == True:
+                        return a
+                    else:
+                        return a*2
+            FX can typically not trace through this due to the presence of control
+            flow. However, we can use `concrete_args` to specialize on the value of
+            `b` to trace through this::
+                f = fx.symbolic_trace(f, concrete_args={'b': False})
+                assert f(3, False)  == 6
+            Note that although you can still pass in different values of `b`, they will be ignored.
+            It can also be used to eliminate data-structure handling from
+            our function. This will use pytrees to flatten your input. To avoid
+            overspecializing, pass in `fx.PH` for values that shouldn't be
+            specialized. For example::
+                def f(x):
+                    out = 0
+                    for v in x.values():
+                        out += v
+                    return out
+                f = fx.symbolic_trace(f, concrete_args={'x': {'a': fx.PH, 'b': fx.PH, 'c': fx.PH}})
+                assert f({'a': 1, 'b': 2, 'c': 4}) == 7
+    """
+
+    def __init__(self, concrete_args: Optional[Dict[str, Any]] = None):
+        super().__init__()
+        # TODO: plumb ``concrete_args`` to symbolic_trace call at ``generate_fx``
+        self.concrete_args = concrete_args
+
     @_beartype.beartype
     def _trace_into_fx_graph_via_fx_symbolic_trace(
-        self,
+        self, model, model_args, model_kwargs
     ) -> Tuple[torch.fx.GraphModule, Sequence[Any]]:
         # Bind model args and kwargs with model signature to retrieve default values
         # of unprovided arguments. These are then used to construct ``concrete_args``.
-        _, named_args = self._apply_input_adapt_step(
+        _, named_args = self.adapt_input(
             fx_exporter.BindInputStep,
-            self.model_args,
-            self.model_kwargs,
-            step_init_args=(self.model_signature,),
+            model_args,
+            model_kwargs,
+            step_init_args=(torch.onnx.utils.model_signature(model),),
         )
 
         # Create inputs to call symbolic trace (torch.fx.symbolic_trace)
@@ -154,20 +188,25 @@ class FXSymbolicTraceExporter(fx_exporter.FXGraphModuleExporter):
                 concrete_args[param_name] = param_value
 
         # Merge kwargs back into args since that is the format FX graph expects.
-        bound_args, _ = self._apply_input_adapt_step(
+        bound_args, _ = self.adapt_input(
             fx_exporter.MergeKwargsIntoArgsStep, [], named_args
         )
 
         return (
-            _module_expansion_symbolic_trace(self.model, concrete_args=concrete_args),
+            _module_expansion_symbolic_trace(model, concrete_args=concrete_args),
             bound_args,
         )
 
-    def export(self) -> torch.onnx.ExportOutput:
-        self._input_adapter = exporter.InputAdapter()
-        self._output_adapter = exporter.OutputAdapter()
-
-        graph_module, bound_args = self._trace_into_fx_graph_via_fx_symbolic_trace()
+    def generate_fx(
+        self,
+        options: exporter.ResolvedExportOptions,
+        model: Union[torch.nn.Module, Callable],
+        model_args: Sequence[Any],
+        model_kwargs: Mapping[str, Any],
+    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
+        graph_module, bound_args = self._trace_into_fx_graph_via_fx_symbolic_trace(
+            model, model_args, model_kwargs
+        )
 
         # Make sure all placeholder nodes are executed before get_attr nodes.
         # Otherwise, inputs can interleave with initializers in the final ModeoProto.graph.input.
@@ -190,8 +229,4 @@ class FXSymbolicTraceExporter(fx_exporter.FXGraphModuleExporter):
         # Finalize the graph editing.
         graph_module.recompile()
 
-        export_output = self.export_fx_to_onnx(
-            graph_module, (*bound_args, *replaced_attrs)
-        )
-
-        return export_output
+        return graph_module, (*bound_args, *replaced_attrs)  # type: ignore[return-value]

--- a/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
+++ b/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
@@ -45,7 +45,7 @@ def _onnx_function_diagnose_call_append_symbolic_source_location(
     # TODO(bowbao): Record source location of symbolic.
     # Need this separate step because normally only the source location of
     # class `onnxscript.OnnxFunction.__call__` is recorded.
-    pass
+    ...
 
 
 # TODO(bowbao): Delete this once diagnostics is introduced in onnxscript.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -12,7 +12,7 @@ from torch.onnx._internal import _beartype
 @_beartype.beartype
 def _create_tensor_proto_with_external_data(
     tensor: torch.Tensor, name: str, location: str, basepath: str
-) -> "onnx.TensorProto":
+) -> onnx.TensorProto:
     """Create a TensorProto with external data from a PyTorch tensor.
     The external data is saved to os.path.join(basepath, location).
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -57,6 +57,7 @@ __all__ = [
     "setup_onnx_logging",
     "exporter_context",
     "export",
+    "model_signature",
     "warn_on_static_input_change",
     "unpack_quantized_tensor",
     "export_to_pretty_string",
@@ -2064,3 +2065,9 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
                 else:
                     value_dict[x] = str(key) + "_dynamic_axes_" + str(i + 1)
             dynamic_axes[key] = value_dict
+
+
+def model_signature(model: Union[torch.nn.Module, Callable]) -> inspect.Signature:
+    return inspect.signature(
+        model.forward if isinstance(model, torch.nn.Module) else model
+    )


### PR DESCRIPTION
The current API architecture can be seen as 3 independent exporters as shown below. The public API `dynamo_export()` defaults to one of the 3 variants and the other 2 must be used by instantiating private classes: ![image](https://user-images.githubusercontent.com/5469809/231567368-ec899718-b7c1-4e59-b6a8-383142df245a.png)

This PR refactors the API in a way that `dynamo_export` is the only way to use the ONNX exporter. It defaults to a FX tracer based on ``torch.export``, but an internal-only idiom allows switching the FX tracer (aka `FXGraphExtractor` interface), as shown below:

![image](https://user-images.githubusercontent.com/5469809/231567495-3936362d-06de-4cfc-b752-6c2060701c08.png)

Summary of changes:

* Unifies all exporter variants under a single `dynamo_export` API
  * `ResolvedExportOptions` was expanded to allow `fx_tracer: FXGraphExtractor` to be specified, selecting which FX graph extractor to use, according to the design proposal
  * As a consequence, `torch.onnx._internal.exporter.Exporter` does not have to *internally* specialize for each type of FX API that the exporter might be used. This leads to a single `Exporter` with many `FX graph extractors`
  * Before in red, after in green: ![image](https://user-images.githubusercontent.com/5469809/232633531-4c67449b-4863-474d-9e18-78fc1d31b1bd.png)
* Input processing was moved from `Exporter` subclasses to `FXGraphExtractor` subclasses, where they are actually consumed
  * `Exporter` is a [data]class that holds export options, model and input data in a single cohesive object. Specializing it means create different exporters instead of having one exporter capable of exporting models through different options.
  * `Exporter` doesn't consume the `model_args` that caused it to specialize
* Improved the circular dependency story.
  * https://github.com/pytorch/pytorch/pull/99070 moves `import torch.onnx` to after all dynamo subcomponents, preventing `torch.onnx` to have circular depemndencies when `torch.XXXX` is imported during initialization
  * There are other points we need to improve in subsequent PRs. APIs are organized in a way that it is easy to "import too much"
* Refactored `decomposition_table` as an internal-only `ResolvedExportOptions` property.
  * Similar to input processing, this helper is not actually consumed at tyhe `Exporter` layer. This PR moves it to the layer in which it is used
* Demoted `Exporter.model_signature` to a simple standalone helper
  * There is no need to have this as a exporter method; this is a standard `inpect.signature` usage without any state

Possible next steps are:
* Decouple `passes` and `dispatching` from the cluttered `export_fx_to_onnx`
* Further integration with http://github.com/pytorch/pytorch/pull/98421/ into `FXGraphExtractor` public API + helper for unit testing
  * Some passes are changing input processing, which are not captured by the proposed input adapter

** COPILOT SUMMARY**
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bdaba31</samp>

### Summary
📝🚀🔧

<!--
1.  📝 - This emoji represents the formatting and documentation changes, such as adding an empty line, updating the `__all__` list, and improving the type annotations and docstrings.
2.  🚀 - This emoji represents the new features and enhancements, such as adding the `DynamoExport` class, supporting custom export options, and flattening HuggingFace model outputs.
3.  🔧 - This emoji represents the refactoring and restructuring changes, such as using the FX graph representation, the `io_adapter` module, and the simplified FX symbolic tracer, and renaming and reorganizing some modules and classes.
-->
This pull request refactors the ONNX exporter code to use the FX graph representation and the new `io_adapter` module for input and output adaptation. It also adds support for custom export options and flattening HuggingFace model outputs in the ONNX test framework. It updates the ONNX dynamo exporter API tests and adds a new module `torch/onnx/_internal/fx/dynamo_graph_extractor.py` for exporting FX models to ONNX with dynamo support. It fixes some type annotations, imports, and formatting issues in the ONNX exporter code.

> _The ONNX exporter got a new look_
> _With FX graph and dynamo hook_
> _It uses `io_adapter`_
> _And custom options matter_
> _For HuggingFace models and `model_signature` book_

### Walkthrough
*  Move the `fx` submodule from `torch/onnx/_internal` to `torch/onnx/_internal/fx`, and rename some of its modules ( [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL21-R26), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L25-R26), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L5-R15), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-4da17ba9e1a187bfacb65a70d6ff15f6c2a60480be8e20fc452d8984a279cd0aL3-R30))
*  Add a new module `torch/onnx/_internal/fx/dynamo_graph_extractor.py` that defines a `DynamoExport` class for generating FX graphs using the `torch._dynamo.export` API ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-078d7b8d0e4050e650fc3c15dc97a0564852191ac7b7bdc069d0b3959c5ee39aR1-R77))
*  Add a new module `torch/onnx/_internal/fx/io_adapter.py` that defines the input and output adapter classes and steps for the ONNX exporter, and a helper function to wrap models with output adapters ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L159-R192), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-4da17ba9e1a187bfacb65a70d6ff15f6c2a60480be8e20fc452d8984a279cd0aL3-R30), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-4da17ba9e1a187bfacb65a70d6ff15f6c2a60480be8e20fc452d8984a279cd0aR72-R176), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-4da17ba9e1a187bfacb65a70d6ff15f6c2a60480be8e20fc452d8984a279cd0aL237-R478))
*  Update the `ResolvedExportOptions` class in `torch/onnx/_internal/exporter.py` to inherit from the `ExportOptions` class, and to set the `fx_tracer` and `decomposition_table` attributes based on the `dynamo_graph_extractor` and `function_dispatcher` modules ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L81-R99), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862R117-R126))
*  Update the `Exporter` class in `torch/onnx/_internal/exporter.py` to remove the `export` method and add a new abstract `generate_fx` method, and to use the `fx_tracer` attribute to generate and export the FX graph ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L413-R475), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L422-R486))
*  Update the `FXSymbolicTraceExporter` class in `torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py` to be renamed to `FXSymbolicTracer`, and to inherit from `exporter.FXGraphExtractor` and implement the `generate_fx` method ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L128-R175), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L157-R219))
*  Update the `export_fx_to_onnx` method of the `FXSymbolicTracer` class to be renamed to `_export_fx_to_onnx`, and to be moved to the `exporter.FXGraphExtractor` class ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L193-R234))
*  Update the `dynamo_export` function in `torch/onnx/_internal/exporter.py` to accept and return `ResolvedExportOptions` and `Exporter` objects, respectively ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L536-R606))
*  Update the `run_test_with_fx_to_onnx_exporter_and_onnx_runtime` function in `test/onnx/onnx_test_common.py` to add a new parameter `export_options` for passing custom export options to the `torch.onnx.dynamo_export` function ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-1b38383dc1a0228a835d83bb7c4ba2d0c1bcd41297be5c6336572c525846166eR176), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-1b38383dc1a0228a835d83bb7c4ba2d0c1bcd41297be5c6336572c525846166eL216-R222))
*  Update the `test_log_sigmoid` and `_test_large_scale_exporter` tests in `test/onnx/test_fx_to_onnx_with_onnxruntime.py` to use the updated `run_test_with_fx_to_onnx_exporter_and_onnx_runtime` function and the `torch.onnx.dynamo_export` function ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL297-R301), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL682-R686), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL696-R716), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c8fa56eefd7f98fb4f9739d57df57f02ede77e28528133736010a6d06651ebcbL721-R730))
*  Update the `test_raise_on_invalid_save_argument_type` test in `test/onnx/dynamo/test_exporter_api.py` to use the `io_adapter.InputAdapter` and `io_adapter.OutputAdapter` classes instead of the `exporter.InputAdapter` and `exporter.OutputAdapter` classes ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-4545f0c15c73ebe90a875e9bee6c5ca4b6b92fb1ed0ec5560d1568e0f6339d02L139-R139))
*  Move the `model_signature` property from the `Exporter` class in `torch/onnx/_internal/exporter.py` to a standalone function in `torch/onnx/utils.py`, and update the references to it ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L432-R505), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L157-R219), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-849a5778e2dcf7f36587967273cee0bf20642e35bf4c79405111ea3417c3fb3cL54-R75))
*  Move the `UnsatisfiedDependencyError` class from the `Exporter` class in `torch/onnx/_internal/exporter.py` to the top level of the module, and update the references to it ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L442-R512))
*  Rename the `_create_onnx_friendly_decomposition_table` function and the `_ONNX_FRIENDLY_DECOMPOSITION_TABLE` dictionary in `torch/onnx/_internal/fx/function_dispatcher.py` to `_create_default_onnx_decomposition_table` and `_DEFAULT_ONNX_EXPORTER_DECOMPOSITION_TABLE`, respectively, and update the references to them ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL213-R219), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL231-R239))
*  Update the imports in `torch/onnx/_internal/fx/function_dispatcher.py` to use the `torch._ops` and `torch._decomp` modules instead of the `torch.ops` and `torch.decomp` modules, and to use aliases for accessing the `onnxscript.function_libs.torch_aten.ops` and `torch._ops` modules ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL11-R16), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL35-R156), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL160-R166), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL173-R182), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL189-R194), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL201-R204), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-549890bc593f917c4e62c4c43077340e4774c0abdf31657ced8450fdfbed3b3eL231-R239))
*  Update the `ExportOutput` class in `torch/onnx/_internal/exporter.py` to use the `InputAdapter` and `OutputAdapter` classes from `io_adapter` instead of the ones defined in the same module ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L275-R199))
*  Update the type annotations in `torch/onnx/_internal/fx/serialization.py` and `torch/onnx/_internal/exporter.py` to fix some inconsistencies ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0c7a4333620a22a5c3e5315e30272b59fb7a11b393cb42f8255070bedeb02738L15-R15), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0c7a4333620a22a5c3e5315e30272b59fb7a11b393cb42f8255070bedeb02738L83-R83), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L11-R11), [link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862R18))
*  Remove an unused import of `inspect` from `torch/onnx/_internal/exporter.py` ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-0795f54fd1f38cfbf2c4a863a4efc9f40f2ea020a2b1612605c361b8d8d35862L5))
*  Remove an unused import of `torch._dynamo` from `torch/onnx/_internal/fx/passes/shape_inference.py` ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-d38827b1f79525963c39e5c480240cd81f4edcaf8b3bd374a1c6ee2fdb28b334L7))
*  Add a comment to `torch/onnx/_internal/fx/passes/shape_inference.py` to explain why the import of `torch._dynamo` is done inside the `_run` method of the `ShapeInferenceWithFakeTensor` class ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-d38827b1f79525963c39e5c480240cd81f4edcaf8b3bd374a1c6ee2fdb28b334R32-R35))
*  Fix a typo in the docstring of the `_module_expansion_symbolic_trace` function in `torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py` ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-3eef404cb9d85216c050be153c33255ebce1170a77d8b9b17be79bcfb238c9c4L96-R98))
*  Add an empty line to `torch/onnx/__init__.py` for formatting purposes ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-c3c8c09b65c1235ca4494633c6a0aab2761a11a7653ddaf9f874bbcd91e15553R12))
*  Delete the `torch/onnx/_internal/fx/__init__.py` file ([link](https://github.com/pytorch/pytorch/pull/99940/files?diff=unified&w=0#diff-a39fa3741f027bb9717388fc922d1e846fbd43d44f2c5fbee4e8d2188a7edb85))



Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire