### PR TITLE
Add pass to normalize torch.ops.fb.equally_split

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -13,6 +13,9 @@ class TestSplitCatFxPasses(TestCase):
         def arg_only(x):
             return [torch.relu(s) for s in torch.split(x, 2, 1)]
 
+        def arg_only_dim0(x):
+            return [torch.relu(s) for s in torch.split(x, 2, 0)]
+
         def kwarg1(x):
             return [torch.relu(s) for s in torch.split(x, 2, dim=1)]
 
@@ -56,6 +59,7 @@ class TestSplitCatFxPasses(TestCase):
         ]
         for fn, expected_split_norm_count in [
             (arg_only, 1),
+            (arg_only_dim0, 1),
             (kwarg1, 1),
             (kwarg2, 1),
             (kwarg3, 1),

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -33,6 +33,11 @@ def lazy_init():
     if config.split_cat_fx_passes:
         _split_cat_init()
 
+    if config.is_fbcode():
+        from .fb.split_cat import _split_cat_init as _fb_split_cat_init
+
+        _fb_split_cat_init()
+
 
 def pre_grad_passes(gm, example_inputs):
     """


### PR DESCRIPTION
Summary: This adds a fb-only pass to normalize torch.ops.fb.equally_split

Test Plan: CI tests (FB + OSS)

Reviewed By: jansel

Differential Revision: D45198465



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire