### PR TITLE
[dynamo] don't use LazyModuleMixin.cls_to_become if it is None

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1260,7 +1260,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-
     def test_call_fn_with_non_const_inputs_safe(self):
         class ModuleSpecialFwd(torch.nn.Module):
             def __init__(self):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -279,7 +279,8 @@ class NNModuleVariable(VariableTracker):
 
             if is_lazy:
                 # The module type will change after it is called
-                self.module_type = mod.cls_to_become
+                if mod.cls_to_become is not None:
+                    self.module_type = mod.cls_to_become
 
                 # The pre-hook runs to initialize the module shapes, then deletes itself.  After this,
                 # the module is more or less not lazy and can be treated as a normal module regardless of
@@ -685,7 +686,8 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
 
         # see comment on lazy module handling in NNModuleVariable.call_function for context
         if is_lazy_module(mod):
-            self.value_type = mod.cls_to_become
+            if mod.cls_to_become is not None:
+                self.value_type = mod.cls_to_become
             initialize_lazy_module(tx, mod, args, kwargs)
 
         name = "__call__"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #99943

**TL;DR**: This PR fixes handling for lazy modules where `cls_to_become is None`. In those cases, we should leave the type of the lazy module as the old value.

**Details**:
Lazy modules are intended to be initialized at execution; some of them are also supposed to switch to a different type after they have been initialized. However, not all are supposed to switch; see this logic from `nn/modules/lazy.py`

```python
    def _infer_parameters(self, ...):
        ...
        if module.cls_to_become is not None:
            module.__class__ = module.cls_to_become
```

i.e., we should leave the module type as the old value if `module.cls_to_become is None`. This PR updates dynamo's handling to match this behavior.

Test `test_lazy_module_no_cls_to_become` added to `test/dynamo/test_module.py`.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire

Differential Revision: [D45253698](https://our.internmc.facebook.com/intern/diff/D45253698)