### PR TITLE
Add UUID in _CudaDeviceProperties

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1608,6 +1608,7 @@ class _CudaDeviceProperties:
     is_integrated: _int
     is_multi_gpu_board: _int
     max_threads_per_multi_processor: _int
+    uuid: str
 
 # Defined in torch/csrc/cuda/python_comm.cpp
 def _broadcast(tensor: Tensor, devices: List[_int]) -> List[Tensor]: ...

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -887,13 +887,14 @@ static void registerCudaDeviceProperties(PyObject* module) {
       .def_readonly(
           "max_threads_per_multi_processor",
           &cudaDeviceProp::maxThreadsPerMultiProcessor)
+      .def_readonly("uuid", &cudaDeviceProp::uuid)
       .def("__repr__", [](const cudaDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_CudaDeviceProperties(name='" << prop.name
                << "', major=" << prop.major << ", minor=" << prop.minor
                << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
                << "MB, multi_processor_count=" << prop.multiProcessorCount
-               << ")";
+               << ", uuid=" << prop.uuid.bytes << ")";
         return stream.str();
       });
 

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -2186,6 +2186,10 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             ("hipDeviceAttributeMax", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED),
         ),
         (
+            "CU_DEVICE_ATTRIBUTE_UUID",
+            ("hipDeviceAttributeUuid", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED),
+        ),
+        (
             "CU_POINTER_ATTRIBUTE_CONTEXT",
             ("hipPointerAttributeContext", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED),
         ),
@@ -4259,6 +4263,10 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         (
             "cudaDevAttrMultiProcessorCount",
             ("hipDeviceAttributeMultiprocessorCount", CONV_TYPE, API_RUNTIME),
+        ),
+        (
+            "cudaDevAttrUUID",
+            ("hipDeviceAttributeUuid", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED),
         ),
         (
             "cudaDevAttrKernelExecTimeout",


### PR DESCRIPTION
Summary:
Make uuid in _CudaDeviceProperties visible.

References: [Nvidia doc: cudaDeviceProp::uuid](https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1626c20637498c7be1381db55a6261308)

Fix: #99903 

Test Plan: Please see GitHub tests

Differential Revision: D45262005

