### PR TITLE
[ROCM] Extend try-catch mechanism for ROCM detection

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -34,7 +34,7 @@ try:
     rocm_path = subprocess.check_output(["hipconfig", "--rocmpath"]).decode("utf-8")
 except subprocess.CalledProcessError:
     print(f"Warning: hipconfig --rocmpath failed, assuming {rocm_path}")
-except (FileNotFoundError, PermissionError):
+except (FileNotFoundError, PermissionError, NotADirectoryError):
     # Do not print warning. This is okay. This file can also be imported for non-ROCm builds.
     pass
 


### PR DESCRIPTION
ROCM path detection currently relies on `hipconfig`. On some systems when calling `hipconfig` through `subprocess` python raises a `NotADirectoryError` that isn't catch at the moment. This commit adds `NotADirectoryError` to exceptions catched when calling `hipconfig`.

Fixes #98629


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport