### PR TITLE
Don't change filelock log level by default

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -61,7 +61,6 @@ def _compile_end():
 
 
 log = logging.getLogger(__name__)
-logging.getLogger("filelock").setLevel(logging.DEBUG if config.debug else logging.INFO)
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99991

Fixes https://github.com/pytorch/pytorch/issues/99730

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire