### PR TITLE
Remove IS_CI check from inductor lowering

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -22,7 +22,6 @@ from torch._prims_common import (
     type_to_dtype,
 )
 from torch.fx.experimental.symbolic_shapes import magic_methods, method_to_operator
-from torch.testing._internal.common_utils import IS_CI
 from torch.utils._pytree import tree_flatten
 from .._dynamo.utils import import_submodule
 
@@ -1103,11 +1102,9 @@ def make_fallback(kernel, layout_constraint=None, warn=True):
     assert (
         kernel not in decompositions
     ), f"both a fallback and a decomp for same kernel: {kernel}"
-    if get_decompositions([kernel]) and warn and IS_CI:
+    if get_decompositions([kernel]) and warn:
         # Note: 'warn' is holdover from when this was a warning, but for ops that previously
-        # set warn=False we do not want a CI error.
-        # Ignore the 'suppress errors' configs in CI, as this particular warning happens on startup anyway and is not
-        # likely to be triggered preferentially on one CI config over another.
+        # set warn=False we do not want an error.
         if torch._dynamo.config.suppress_errors:
             torch._dynamo.config.suppress_errors = False
             log.warning(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99995

The IS_CI check was designed to only put a hard error in CI and not bother users.

The warning that predates the hard error was bothering users becuase
 1- it was not actionable for the users
 2- it was introduced by changes made by other devs adding decomps

Making it a hard error closes the loop for the devs adding decomps, forcing action
at that time.  In this regime, users shouldn't see the warning unless they also
added a decomp.

It's still possible users would hit this warning on an implicit fallback if we did not
test that op in our CI at all.  This seems relatively low risk.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire