### PR TITLE
Allow calling functorch transforms when their DispatchKeys are disabled

### DIFF
--- a/aten/src/ATen/functorch/ADInterpreters.cpp
+++ b/aten/src/ATen/functorch/ADInterpreters.cpp
@@ -69,8 +69,7 @@ static void autogradBasedTransformProcess(
   auto num_args = op.schema().arguments().size();
   foreachTensorInplace(*stack, stack->size() - num_args, stack->size(), maybeTransformGradWrappers);
 
-  auto exclude = keysToExcludeWhenEnteringDynamicLayer(transform_type);
-  setup_dispatch_key_tls(exclude, {});
+  setup_dispatch_key_tls(transform_type, {});
   op.callBoxed(stack);
 }
 

--- a/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
+++ b/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
@@ -15,12 +15,10 @@ static void sanityCheckNotFunctional(const c10::OperatorHandle& op, torch::jit::
 void FunctionalizeInterpreterPtr::processImpl(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
-  DispatchKeySet exclude = keysToExcludeWhenEnteringDynamicLayer(TransformType::Functionalize);
-
   // We always want to call the functionalization kernels if functionalize() is on the layer stack.
   // It's the responsibility of the functionalization kernel to no-op and redispatch
   // if none of the input tensors are functional.
-  setup_dispatch_key_tls(exclude, DispatchKeySet(DispatchKey::Functionalize));
+  setup_dispatch_key_tls(TransformType::Functionalize, DispatchKeySet(DispatchKey::Functionalize));
   auto functionalization_add_back_views = functionalizeAddBackViews();
   // We have some side-car TLS that we can set to toggle the functionaliation behavior.
   // If set, then we functionalization will only remove mutations, instead of

--- a/aten/src/ATen/functorch/Interpreter.cpp
+++ b/aten/src/ATen/functorch/Interpreter.cpp
@@ -57,10 +57,13 @@ DispatchKeySet keysToExcludeWhenEnteringDynamicLayer(TransformType key) {
   return exclude;
 }
 
-void setup_dispatch_key_tls(DispatchKeySet exclude, DispatchKeySet include) {
+void setup_dispatch_key_tls(TransformType key, DispatchKeySet also_include) {
   auto local_keyset = c10::impl::tls_local_dispatch_key_set();
-  local_keyset.excluded_ = local_keyset.excluded_ | exclude;
-  local_keyset.included_ = local_keyset.included_ | include;
+  auto to_exclude = local_keyset.excluded_;
+  to_exclude = to_exclude | keysToExcludeWhenEnteringDynamicLayer(key);
+  to_exclude = to_exclude - keysForEnteringDynamicLayer(key);
+  local_keyset.excluded_ = to_exclude;
+  local_keyset.included_ = local_keyset.included_ | also_include;
   c10::impl::_force_tls_local_dispatch_key_set(local_keyset);
 }
 

--- a/aten/src/ATen/functorch/Interpreter.h
+++ b/aten/src/ATen/functorch/Interpreter.h
@@ -201,7 +201,7 @@ std::vector<int64_t> findUnwrappedInputs(std::vector<IValue>& args, int64_t begi
 
 DispatchKeySet keysToExcludeWhenEnteringDynamicLayer(TransformType key);
 
-void setup_dispatch_key_tls(DispatchKeySet exclude, DispatchKeySet include);
+void setup_dispatch_key_tls(TransformType key, DispatchKeySet include);
 
 void sanityCheckStack(const c10::OperatorHandle& op, torch::jit::Stack* stack);
 

--- a/aten/src/ATen/functorch/VmapInterpreter.cpp
+++ b/aten/src/ATen/functorch/VmapInterpreter.cpp
@@ -6,8 +6,7 @@ namespace at { namespace functorch {
 void VmapInterpreterPtr::processImpl(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
-  DispatchKeySet exclude = keysToExcludeWhenEnteringDynamicLayer(TransformType::Vmap);
-  setup_dispatch_key_tls(exclude, DispatchKeySet(DispatchKey::FuncTorchVmapMode));
+  setup_dispatch_key_tls(TransformType::Vmap, DispatchKeySet(DispatchKey::FuncTorchVmapMode));
   op.callBoxed(stack);
 }
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -27,6 +27,7 @@ from torch.testing import make_tensor
 from torch._subclasses.fake_tensor import FakeTensorMode
 from functools import partial
 from functorch.experimental import replace_all_batch_norm_modules_
+from torch._C import ExcludeDispatchKeyGuard, DispatchKeySet, DispatchKey
 
 import functorch
 from functorch import (
@@ -3362,6 +3363,58 @@ class TestComposability(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
             jvp(g, (x,), (t,))
+
+    def test_can_use_functionalize_when_key_is_excluded(self, device):
+        def f(x):
+            y = x.clone()
+            y.sin_()
+            return y
+
+        x = torch.randn([], device=device)
+        expected = f(x)
+
+        guard = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.Functionalize))
+        try:
+            gm = make_fx(functorch.functionalize(f))(x)
+            self.assertTrue('sin_' not in gm.code)
+            self.assertEqual(gm(x), expected)
+
+            local_exclude_set = torch._C._dispatch_tls_local_exclude_set()
+            self.assertTrue(local_exclude_set.has(DispatchKey.Functionalize))
+        finally:
+            del guard
+
+    def test_can_use_vmap_when_key_is_excluded(self, device):
+        def f(x):
+            return x.sum(0)
+
+        x = torch.randn(3, device=device)
+        expected = vmap(f)(x)
+
+        guard = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.FuncTorchBatched))
+        try:
+            result = vmap(f)(x)
+            self.assertEqual(result, expected)
+            local_exclude_set = torch._C._dispatch_tls_local_exclude_set()
+            self.assertTrue(local_exclude_set.has(DispatchKey.FuncTorchBatched))
+        finally:
+            del guard
+
+    def test_can_use_grad_when_key_is_excluded(self, device):
+        def f(x):
+            return x.sin()
+
+        x = torch.randn([], device=device)
+        expected = grad(f)(x)
+
+        guard = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.Autograd))
+        try:
+            result = grad(f)(x)
+            self.assertEqual(result, expected)
+            local_exclude_set = torch._C._dispatch_tls_local_exclude_set()
+            self.assertTrue(local_exclude_set.has(DispatchKey.Autograd))
+        finally:
+            del guard
 
 
 class TestMakeFunctional(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100011

This was always the intended behavior: e.g. you should be able to call
functorch.functionalize even when DispatchKey::Functionalize is
disabled.

Test Plan:
- new tests