### PR TITLE
relax restriction on cond branches calling closed functions

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -844,6 +844,12 @@ class TorchHigherOrderOperator(VariableTracker):
                     for var in f.closure.items
                     if isinstance(var, ClosureVariable) and var.name != "self"
                 ]
+                scope = {**tx.symbolic_locals, **tx.symbolic_globals}
+                closure_vars = [
+                    name
+                    for name in closure_vars
+                    if not isinstance(scope[name], (UserFunctionVariable, NestedUserFunctionVariable))
+                ]
                 if closure_vars:
                     code = f.get_code()
                     raise torch._dynamo.exc.UserError(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -848,7 +848,9 @@ class TorchHigherOrderOperator(VariableTracker):
                 closure_vars = [
                     name
                     for name in closure_vars
-                    if not isinstance(scope[name], (UserFunctionVariable, NestedUserFunctionVariable))
+                    if not isinstance(
+                        scope[name], (UserFunctionVariable, NestedUserFunctionVariable)
+                    )
                 ]
                 if closure_vars:
                     code = f.get_code()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100013

As of https://github.com/pytorch/pytorch/pull/99367 we error when cond branches look up closed vars. The suggested fix is to add these closed vars as args to the branches.

However, while this works for tensor vars (and also primitive vars by explicit wrapping), this is impossible to do for function vars. Moreover, function vars are OK because we trace through them. So relaxing this restriction for function vars is a strict win.

Differential Revision: [D45287893](https://our.internmc.facebook.com/intern/diff/D45287893/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire