### PR TITLE
make ATen/cuda/CUDAGeneratorImpl.cpp use mutable_data_ptr

### DIFF
--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
@@ -179,7 +179,7 @@ c10::intrusive_ptr<c10::TensorImpl> CUDAGeneratorImpl::get_state() const {
   static const size_t total_size = seed_size + offset_size;
 
   auto state_tensor = at::detail::empty_cpu({(int64_t)total_size}, ScalarType::Byte, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt);
-  auto rng_state = state_tensor.data_ptr<uint8_t>();
+  auto rng_state = state_tensor.mutable_data_ptr<uint8_t>();
   auto current_seed = this->current_seed();
   auto offset = static_cast<int64_t>(this->philox_offset_per_thread()); // Note that old THCGeneratorState had offset as std::atomic<int64_t>
   memcpy(rng_state, &current_seed, seed_size);


### PR DESCRIPTION
make ATen/cuda/CUDAGeneratorImpl.cpp use mutable_data_ptr

Summary: This is correct because it's the destination of a memcpy.

Test Plan: Rely on CI.
