### PR TITLE
use mutable_data_ptr for PhiloxCudaState

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -71,7 +71,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/) {
   offset_extragraph_ = at::empty({1}, options);
 
   seed_extragraph_.fill_(int64_t(gen->current_seed()));
-  gen->capture_prologue(seed_extragraph_.data_ptr<int64_t>(), offset_extragraph_.mutable_data_ptr<int64_t>());
+  gen->capture_prologue(seed_extragraph_.mutable_data_ptr<int64_t>(), offset_extragraph_.mutable_data_ptr<int64_t>());
 
   auto stream = at::cuda::getCurrentCUDAStream();
 


### PR DESCRIPTION
use mutable_data_ptr for PhiloxCudaState

Summary: This is an RNG, it needs to be mutable.

Test Plan: Rely on CI.
