### PR TITLE
[pt2] Fix artifact logging disabling

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -123,15 +123,15 @@ def set_logs(
     dynamo=DEFAULT_LOG_LEVEL,
     aot=DEFAULT_LOG_LEVEL,
     inductor=DEFAULT_LOG_LEVEL,
-    bytecode=False,
-    aot_graphs=False,
-    aot_joint_graph=False,
-    graph=False,
-    graph_code=False,
-    guards=False,
-    recompiles=False,
-    output_code=False,
-    schedule=False,
+    bytecode=None,
+    aot_graphs=None,
+    aot_joint_graph=None,
+    graph=None,
+    graph_code=None,
+    guards=None,
+    recompiles=None,
+    output_code=None,
+    schedule=None,
     modules=None,
 ):
     """
@@ -151,10 +151,15 @@ def set_logs(
     if modules is None:
         modules = {}
 
+    def _should_enable_artifact(alias, val):
+        if val is None:
+            return not log_registry.is_off_by_default(alias)
+        return val
+
     def _set_logs(**kwargs):
         for alias, val in itertools.chain(kwargs.items(), modules.items()):
             if log_registry.is_artifact(alias):
-                if val:
+                if _should_enable_artifact(alias, val):
                     log_state.enable_artifact(alias)
             elif log_registry.is_log(alias):
                 if val not in logging._levelToName:
@@ -234,16 +239,12 @@ VERBOSITY_REGEX = (
 
 
 def configure_artifact_log(log):
-    # If the artifact is off by default, then it should only be logged when explicitly
-    # enabled; set propagate to False so that this artifact is not propagated
-    # to its ancestor logger
-    if log_registry.is_off_by_default(log.artifact_name):
-        log.propagate = False
-
     # enable artifact logging when explicitly enabled
     if log_state.is_artifact_enabled(log.artifact_name):
         log.setLevel(logging.DEBUG)
         log.propagate = True
+    else:
+        log.propagate = False
 
 
 # match a comma separated list of loggable names (whitespace allowed after commas)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100021
* __->__ #100020

Make it so you can suppress artifacts, even if their parent logger is enabled.

For example, you might expect this incantation to enable DEBUG level logging
for dynamo, but suppress bytecode output.
```
torch._logging.set_logs(
  dynamo=logging.DEBUG,
  bytecode=False,
)
```

Before this diff, setting `dynamo=logging.DEBUG` would enable `bytecode`
output, because the system wasn't distinguishing explicitly turning off an
artifact from simply leaving it unspecified.

Differential Revision: [D45290918](https://our.internmc.facebook.com/intern/diff/D45290918/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D45290918/)!