### PR TITLE
Introduce fast path in the CPU equal op

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6095,6 +6095,45 @@ class TestTorch(TestCase):
         self.assertTrue(torch.equal(x, y))
         self.assertFalse(torch.equal(z, x))
 
+        # Fast path test: tensor flags, like neg and conj
+        neg_0 = torch.tensor((1, 2, 3), dtype=torch.float)
+        neg_1 = neg_0._neg_view()
+        self.assertTrue(neg_1.is_neg())
+        self.assertEqual(neg_0.data_ptr(), neg_1.data_ptr())
+        self.assertEqual(neg_0.storage_offset(), neg_1.storage_offset())
+        self.assertEqual(neg_0.stride(), neg_1.stride())
+        self.assertEqual(neg_0.size(), neg_1.size())
+        self.assertFalse(torch.equal(neg_0, neg_1))
+        self.assertTrue(torch.equal(neg_0, neg_1._neg_view()))
+
+        conj_0 = torch.tensor([1.0 + 2.0j, 2.0 + 1.0j])
+        conj_1 = conj_0.conj()
+        self.assertTrue(conj_1.is_conj())
+        self.assertEqual(conj_0.data_ptr(), conj_1.data_ptr())
+        self.assertEqual(conj_0.storage_offset(), conj_1.storage_offset())
+        self.assertEqual(conj_0.stride(), conj_1.stride())
+        self.assertEqual(conj_0.size(), conj_1.size())
+        self.assertFalse(torch.equal(conj_0, conj_1))
+        self.assertTrue(torch.equal(conj_0, conj_1.conj()))
+
+        # Fast path test: two tensors share the same storage, but different dtype
+        s_0 = torch.rand((2, 3), dtype=torch.float)
+        s_1 = s_0.view(dtype=torch.int32)
+        self.assertEqual(s_0.data_ptr(), s_1.data_ptr())
+        self.assertEqual(s_0.storage_offset(), s_1.storage_offset())
+        self.assertEqual(s_0.stride(), s_1.stride())
+        self.assertEqual(s_0.size(), s_1.size())
+        self.assertFalse(torch.equal(s_0, s_1))
+
+        # Fast path test: two tensors share the same storage, but different strides
+        t_0 = torch.rand((2, 3), dtype=torch.float)
+        t_1 = t_0.t()
+        self.assertEqual(t_0.data_ptr(), t_1.data_ptr())
+        self.assertEqual(t_0.storage_offset(), t_1.storage_offset())
+        self.assertNotEqual(t_0.stride(), t_1.stride())
+        self.assertNotEqual(t_0.size(), t_1.size())
+        self.assertFalse(torch.equal(t_0, t_1))
+
     def test_element_size(self):
         byte = torch.ByteStorage().element_size()
         char = torch.CharStorage().element_size()


### PR DESCRIPTION
Summary: When two tensors share the same storage, and strides, and no other flags, then we should consider this tensors as equal.

Test Plan: buck2 test @//mode/opt //caffe2/test:torch -- --exact 'caffe2/test:torch - test_equal (test_torch.TestTorch)'

Differential Revision: D45282119

