### PR TITLE
[BE][DTensor] add DeviceMesh test to periodic testing list

### DIFF
--- a/.ci/pytorch/multigpu-test.sh
+++ b/.ci/pytorch/multigpu-test.sh
@@ -35,7 +35,8 @@ time python test/run_test.py --verbose -i distributed/_shard/sharded_tensor/ops/
 time python test/run_test.py --verbose -i distributed/_shard/sharded_tensor/ops/test_init
 time python test/run_test.py --verbose -i distributed/_shard/sharded_optim/test_sharded_optim
 
-# DTensor/Random Ops tests
+# DTensor tests
+time python test/run_test.py --verbose -i distributed/_tensor/test_device_mesh.py
 time python test/run_test.py --verbose -i distributed/_tensor/test_random_ops.py
 
 # DTensor/TP tests


### PR DESCRIPTION
## Why
This PR adds `test_device_mesh.py` to periodic tests because it requires more GPUs  (4/8) to run testing than the CI machine has.
 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100029

