### PR TITLE
add missing include on <stdexcept> from Registry.h

### DIFF
--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
add missing include on <stdexcept> from Registry.h

Summary: This throws std::runtime_error in the header.

Test Plan: Rely on CI.
