### PR TITLE
[Tensor Parallel] Simplify distribute for MHA

### DIFF
--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -334,24 +334,25 @@ def _parallelize_multihead_attn(
         tp_multi_head_attention.copy(module)
         module = tp_multi_head_attention
 
-    if isinstance(module, TensorParallelMultiheadAttention):  # shard TPMA
-        for n, m in module.named_children():
-            if n == "qkv":
-                # Col-wise Parallelize the qkv layer.
-                distribute_module(
-                    m,
-                    device_mesh,
-                    _colwise_parallelize_linear_fn,
-                    input_fn=parallel_style._prepare_input,  # type: ignore[arg-type, misc] # pyre-ignore[6]
-                )
-            elif n == "proj":
-                # Row-wise Parallelize the proj layer
-                distribute_module(
-                    m,
-                    device_mesh,
-                    _rowwise_parallelize_linear_fn,
-                    output_fn=parallel_style._prepare_output,  # type: ignore[arg-type, misc] # pyre-ignore[6]
-                )
+    assert isinstance(module, TensorParallelMultiheadAttention)
+    # shard TPMA
+    for n, m in module.named_children():
+        if n == "qkv":
+            # Col-wise Parallelize the qkv layer.
+            distribute_module(
+                m,
+                device_mesh,
+                _colwise_parallelize_linear_fn,
+                input_fn=parallel_style._prepare_input,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+            )
+        elif n == "proj":
+            # Row-wise Parallelize the proj layer
+            distribute_module(
+                m,
+                device_mesh,
+                _rowwise_parallelize_linear_fn,
+                output_fn=parallel_style._prepare_output,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+            )
     return module
 
 

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -334,7 +334,9 @@ def _parallelize_multihead_attn(
         tp_multi_head_attention.copy(module)
         module = tp_multi_head_attention
 
-    assert isinstance(module, TensorParallelMultiheadAttention)
+    assert isinstance(module, TensorParallelMultiheadAttention), (
+        f"Expects TensorParallelMultiheadAttention but got {type(module)}"
+    )
     # shard TPMA
     for n, m in module.named_children():
         if n == "qkv":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100046

This function is only called for nn.MHA or the custom MHA we use, and
if it is the former it is converted to the latter. So this check can actually
be an assert.

Differential Revision: [D45300396](https://our.internmc.facebook.com/intern/diff/D45300396/)