### PR TITLE
[Dynamo] Fix constructing lazy submodule inside of lazy module's initialize_parameters

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -127,6 +127,11 @@ unittest.expectedFailure(
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
 )
 
+unittest.expectedFailure(
+    DynamicShapesNNModuleTests.test_lazy_module6_dynamic_shapes
+    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
+)
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1274,7 +1274,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         res = opt_m(x)
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
-    
+
     def test_lazy_module_no_cls_to_become(self):
         # make sure super() works in the case where cls_to_become is None
         m = LazyChildModuleNoClsToBecome()

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -553,7 +553,18 @@ class LazyModuleWithListInput(torch.nn.Module):
         return self.layer(input[:-1])
 
 
-<<<<<<< HEAD
+class LazyModuleWithLazySubmodule(LazyModuleMixin, torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def initialize_parameters(self, input):
+        with torch.no_grad():
+            self.layer = LazyLayerWithListInput()
+
+    def forward(self, x):
+        return self.layer(x)
+
+
 class LazyParentModule(LazyModuleMixin, torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -571,18 +582,6 @@ class LazyChildModuleNoClsToBecome(LazyParentModule):
 
     def initialize_parameters(self, input):
         self._val = torch.nn.Parameter(torch.ones(2, 2))
-=======
-class LazyModuleWithLazySubmodule(LazyModuleMixin, torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def initialize_parameters(self, input):
-        with torch.no_grad():
-            self.layer = LazyLayerWithListInput()
-
-    def forward(self, x):
-        return self.layer(x)
->>>>>>> [Dynamo] Fix constructing lazy submodule inside of lazy module's initialize_parameters
 
 
 def requires_grad1(module: torch.nn.Module, recurse: bool = False) -> bool:
@@ -1271,6 +1270,15 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         # Test new lazy submodule in lazy module's initialize_parameters
         m = LazyModuleWithLazySubmodule()
         x = [torch.rand([5, 5])] * 3
+        opt_m = torch._dynamo.optimize("eager", nopython=True)(m)
+        res = opt_m(x)
+        ref = m(x)
+        self.assertTrue(torch.allclose(ref, res))
+    
+    def test_lazy_module_no_cls_to_become(self):
+        # make sure super() works in the case where cls_to_become is None
+        m = LazyChildModuleNoClsToBecome()
+        x = torch.rand(2, 2)
         opt_m = torch._dynamo.optimize("eager", nopython=True)(m)
         res = opt_m(x)
         ref = m(x)

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -553,6 +553,7 @@ class LazyModuleWithListInput(torch.nn.Module):
         return self.layer(input[:-1])
 
 
+<<<<<<< HEAD
 class LazyParentModule(LazyModuleMixin, torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -570,6 +571,18 @@ class LazyChildModuleNoClsToBecome(LazyParentModule):
 
     def initialize_parameters(self, input):
         self._val = torch.nn.Parameter(torch.ones(2, 2))
+=======
+class LazyModuleWithLazySubmodule(LazyModuleMixin, torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def initialize_parameters(self, input):
+        with torch.no_grad():
+            self.layer = LazyLayerWithListInput()
+
+    def forward(self, x):
+        return self.layer(x)
+>>>>>>> [Dynamo] Fix constructing lazy submodule inside of lazy module's initialize_parameters
 
 
 def requires_grad1(module: torch.nn.Module, recurse: bool = False) -> bool:
@@ -1254,10 +1267,10 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    def test_lazy_module_no_cls_to_become(self):
-        # make sure super() works in the case where cls_to_become is None
-        m = LazyChildModuleNoClsToBecome()
-        x = torch.rand(2, 2)
+    def test_lazy_module6(self):
+        # Test new lazy submodule in lazy module's initialize_parameters
+        m = LazyModuleWithLazySubmodule()
+        x = [torch.rand([5, 5])] * 3
         opt_m = torch._dynamo.optimize("eager", nopython=True)(m)
         res = opt_m(x)
         ref = m(x)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -110,7 +110,7 @@ class OptimizedModule(torch.nn.Module):
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
 
         if hasattr(self._orig_mod, "_initialize_hook"):
-            self.__call__ = self._call_lazy_check
+            self.forward = self._call_lazy_check
 
     def __getstate__(self):
         state = dict(self.__dict__)
@@ -135,7 +135,7 @@ class OptimizedModule(torch.nn.Module):
             # to avoid treating it as lazy on subsequent recompile.
             assert len(kwargs) == 0
             self._orig_mod._infer_parameters(self._orig_mod, args)
-        return super().__call__(*args, **kwargs)
+        return self.dynamo_ctx(self._orig_mod.__call__)(*args, **kwargs)
 
 
 def remove_from_cache(f):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -136,7 +136,7 @@ class OptimizedModule(torch.nn.Module):
             # to avoid treating it as lazy on subsequent recompile.
             assert len(kwargs) == 0
             self._orig_mod._infer_parameters(self._orig_mod, args)
-        return self.dynamo_ctx(self._orig_mod.__call__)(*args, **kwargs)
+        return self._forward(*args, **kwargs)
 
 
 def remove_from_cache(f):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -110,6 +110,7 @@ class OptimizedModule(torch.nn.Module):
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
 
         if hasattr(self._orig_mod, "_initialize_hook"):
+            self._forward = self.forward
             self.forward = self._call_lazy_check
 
     def __getstate__(self):

--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -4,7 +4,7 @@ import weakref
 import torch.nn
 from torch.nn import Module
 
-from .utils import ExactWeakKeyDictionary
+from .utils import ExactWeakKeyDictionary, is_lazy_module
 
 
 class MutationTracker:
@@ -85,6 +85,8 @@ def is_dynamic_nn_module(obj):
     """Check for nn.Modules() created dynamically or mutated"""
     if hasattr(obj, "torchdynamo_force_dynamic"):
         return obj.torchdynamo_force_dynamic
+    if is_lazy_module(obj):
+        return False
     dyn = GenerationTracker.dynamic_classes.get(type(obj)) or GenerationTracker.check(
         obj
     )


### PR DESCRIPTION
This PR fixed two issues:
* Constructing lazy submodule inside of lazy module's ```initialize_parameters``` - don't unspecialized module if it's lazy.
* Fixes #100001


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire