### PR TITLE
[c10d] Recover TCPStore timeout after wait

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -92,6 +93,8 @@ class TORCH_API TCPStore : public Store {
   std::uint16_t getPort() const noexcept {
     return addr_.port;
   }
+
+  std::chrono::seconds getClientTimeout() const;
 
  private:
   int64_t incrementValueBy(const std::string& key, int64_t delta);


### PR DESCRIPTION
Summary:
It seems to be a long pending todo to recover the original timeout after the explicit wait() call. In the new store_based_barrier implementation, we give a logging timeout (https://fburl.com/code/e8b5qjv7), so we want to recover.

Plus we want to avoid keep calling setTimeout() which is setsockopt call every time.

Test Plan: unit test

Differential Revision: D45288407

