### PR TITLE
inductor: enhance conv+binary fusion path test for cpu path

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -4,6 +4,7 @@ import itertools
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import counters
+from torch._inductor.utils import run_and_get_code
 from torch.nn import functional as F
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_CPU
@@ -90,6 +91,21 @@ class TestPaternMatcher(TestCase):
                 counters["inductor"]["pattern_matcher_nodes"],
                 matcher_nodes,
             )
+
+    def _test_code_common(
+        self, mod, inputs, include_ops, exclude_ops, atol=1e-5, rtol=1.3e-6
+    ):
+        with torch.no_grad():
+            clone_inputs = self._clone_inputs(inputs)
+            expected = mod(*inputs)
+            actual, (source_code,) = run_and_get_code(
+                torch.compile(mod, fullgraph=True), *clone_inputs
+            )
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+            for op in include_ops:
+                self.assertIn(op, source_code)
+            for op in exclude_ops:
+                self.assertNotIn(op, source_code)
 
     def test_conv2d_unary(self):
         class M(torch.nn.Module):
@@ -327,6 +343,108 @@ class TestPaternMatcher(TestCase):
             mod = Model().eval()
             v = torch.randn(1, 3, 28, 28)
             self._test_common(mod, (v,), 0, 0)
+
+    def test_conv2d_binary_inplace_fusion_pass(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1
+                )
+
+            def forward(self, x, other):
+                conv_out = self.conv(x)
+                return torch.add(conv_out, other.relu())
+
+        inputs = [
+            torch.randn(1, 3, 28, 28).to(memory_format=torch.channels_last),
+            torch.randn(1, 32, 28, 28).to(memory_format=torch.channels_last),
+        ]
+        mod = Model().to(memory_format=torch.channels_last).eval()
+        include_ops = ["mkldnn._convolution_pointwise_.binary"]
+        exclude_ops = ["mkldnn._convolution_pointwise.binary"]
+        self._test_code_common(mod, inputs, include_ops, exclude_ops)
+
+    def test_conv2d_binary_inplace_fusion_failed(self):
+        # Write buffer is graph input, we can't fuse inplace.
+        class Model_v1(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1
+                )
+
+            def forward(self, x, other):
+                conv_out = self.conv(x)
+                return torch.add(conv_out, other)
+
+        # Write buffer is a alias tensor, we can't fuse inplace.
+        class Model_v2(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1
+                )
+
+            def forward(self, x, other):
+                conv_out = self.conv(x)
+                return torch.add(conv_out, other[1:2, :, :, :]), other
+
+        input = torch.randn(1, 3, 28, 28).to(memory_format=torch.channels_last)
+        others = [
+            torch.randn(1, 32, 28, 28).to(memory_format=torch.channels_last),
+            torch.randn(2, 32, 28, 28).to(memory_format=torch.channels_last),
+        ]
+        mod_v1 = Model_v1().to(memory_format=torch.channels_last).eval()
+        mod_v2 = Model_v2().to(memory_format=torch.channels_last).eval()
+        include_ops = ["mkldnn._convolution_pointwise.binary"]
+        exclude_ops = ["mkldnn._convolution_pointwise_.binary"]
+        for other, mod in zip(others, [mod_v1, mod_v2]):
+            self._test_code_common(mod, (input, other), include_ops, exclude_ops)
+
+    def test_conv2d_binary_fusion_failed(self):
+        # we dones't support alpha !=1 or othe has different size with conv's output.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1
+                )
+
+            def forward(self, x, other, alpha):
+                conv_out = self.conv(x)
+                return torch.add(conv_out, other, alpha=alpha)
+
+        input = torch.randn(1, 3, 28, 28).to(memory_format=torch.channels_last)
+        others = [
+            torch.randn(1, 32, 28, 28).to(memory_format=torch.channels_last),
+            torch.randn(32, 28, 28),
+        ]
+        mod = Model().to(memory_format=torch.channels_last).eval()
+        include_ops = ["mkldnn._convolution_pointwise"]
+        exclude_ops = [
+            "mkldnn._convolution_pointwise.binary",
+            "mkldnn._convolution_pointwise_.binary",
+        ]
+
+        for other, alpha in zip(others, [0.1, 1.0]):
+            self._test_code_common(mod, (input, other, alpha), include_ops, exclude_ops)
+
+    def test_reproduce_99842_issue(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1)
+
+        def forward(self, input_tensor):
+            x = self.conv(input_tensor)
+            x = F.relu(x + torch.ones(x.size()))
+            return x
+
+        input = torch.randn(1, 3, 14, 14)
+        mod = Model().eval()
+        include_ops = ["mkldnn._convolution_pointwise_.binary"]
+        self._test_code_common(mod, (input, other, alpha), include_ops, [])
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -436,15 +436,15 @@ class TestPaternMatcher(TestCase):
                 super(Model, self).__init__()
                 self.conv = torch.nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1)
 
-        def forward(self, input_tensor):
-            x = self.conv(input_tensor)
-            x = F.relu(x + torch.ones(x.size()))
-            return x
+            def forward(self, input_tensor):
+                x = self.conv(input_tensor)
+                x = F.relu(x + torch.ones(x.size()))
+                return x
 
         input = torch.randn(1, 3, 14, 14)
         mod = Model().eval()
         include_ops = ["mkldnn._convolution_pointwise_.binary"]
-        self._test_code_common(mod, (input, other, alpha), include_ops, [])
+        self._test_code_common(mod, (input,), include_ops, [])
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -366,7 +366,7 @@ class TestPaternMatcher(TestCase):
         self._test_code_common(mod, inputs, include_ops, exclude_ops)
 
     def test_conv2d_binary_inplace_fusion_failed(self):
-        # Write buffer is graph input, we can't fuse inplace.
+        # Written buffer is graph input, we can't fuse inplace.
         class Model_v1(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -378,7 +378,7 @@ class TestPaternMatcher(TestCase):
                 conv_out = self.conv(x)
                 return torch.add(conv_out, other)
 
-        # Write buffer is a alias tensor, we can't fuse inplace.
+        # Written buffer is an alias tensor, we can't fuse inplace.
         class Model_v2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -403,7 +403,7 @@ class TestPaternMatcher(TestCase):
             self._test_code_common(mod, (input, other), include_ops, exclude_ops)
 
     def test_conv2d_binary_fusion_failed(self):
-        # we dones't support alpha !=1 or othe has different size with conv's output.
+        # we don't support alpha !=1 case or other has different size with conv's output.
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -285,9 +285,6 @@ if torch._C.has_mkldnn:
             for n in binary_nodes
         ):
             return False
-        # check args[0] and args[1] is not same
-        if any(n.args[0] == n.args[1] for n in binary_nodes):
-            return False
         if any(
             n.args[0].meta["val"].size() != n.args[1].meta["val"].size()
             or n.args[0].meta["val"].device != n.args[1].meta["val"].device
@@ -318,6 +315,9 @@ if torch._C.has_mkldnn:
                 for n in binary_nodes
             ):
                 return False
+            # check args[0] and args[1] is not same
+            if any(n.args[0] == n.args[1] for n in binary_nodes):
+                return False
             return True
 
         return fn
@@ -327,15 +327,14 @@ if torch._C.has_mkldnn:
         computation_op,
         binary_op,
         fusion_op,
-        check_fn=_is_valid_computation_binary,
         unary_attr=None,
-        other_index=None,
     ):
         @register_lowering_pattern(
-            pattern, extra_check=check_fn(computation_op, binary_op, other_index)
+            pattern, extra_check=_is_valid_computation_binary(computation_op, binary_op)
         )
         def fn(match, *args, **kwargs):
             other = kwargs.get("other")
+            assert isinstance(other, ir.TensorBox)
             binary_attr = _binary_attr[binary_op]
             args_list = list(args)
             computation_args = [args_list[0], other] + args_list[1:-3] + [binary_attr]
@@ -350,6 +349,49 @@ if torch._C.has_mkldnn:
                 else:
                     computation_args += [1.0, None, [], None]
             return L[fusion_op](*computation_args)
+
+        return fn
+
+    def _register_binary_unary_inplace_fusion_lowering(
+        pattern,
+        computation_op,
+        binary_op,
+        inplace_fusion_op,
+        outplace_fusion_op,
+        unary_attr=None,
+        other_index=None,
+    ):
+        @register_lowering_pattern(
+            pattern,
+            extra_check=_is_valid_computation_binary_inplace(
+                computation_op, binary_op, other_index
+            ),
+        )
+        def fn(match, *args, **kwargs):
+            other = kwargs.get("other")
+            assert isinstance(other, ir.TensorBox)
+            binary_attr = _binary_attr[binary_op]
+            args_list = list(args)
+            computation_args = [args_list[0], other] + args_list[1:-3] + [binary_attr]
+            if len(args_list) > 6:
+                if unary_attr is not None:
+                    computation_args += [
+                        1.0,
+                        unary_attr.op_name,
+                        unary_attr.scalars_attr,
+                        unary_attr.algorithm_attr,
+                    ]
+                else:
+                    computation_args += [1.0, None, [], None]
+            # Make sure the other is not a alias or mutation(fx side doesn't has such info).
+            other.realize()
+            can_be_inplace = not (
+                isinstance(other.data, ir.ReinterpretView)
+                or isinstance(other.get_layout(), (ir.MutationLayout, ir.AliasedLayout))
+            )
+            if not can_be_inplace:
+                return L[outplace_fusion_op](*computation_args)
+            return L[inplace_fusion_op](*computation_args)
 
         return fn
 
@@ -404,46 +446,47 @@ if torch._C.has_mkldnn:
 
     def _register_inplace_fusion():
         binary_ops = [aten.add, ops.add]
-        fusion_op = mkldnn._convolution_pointwise_.binary
+        inplace_fusion_op = mkldnn._convolution_pointwise_.binary
+        outplace_fusion_op = mkldnn._convolution_pointwise.binary
         computation_call = _computation_user_1[0]
         computation_op = computation_ops[0]
         for binary_op in binary_ops:
             binary_v1 = _binary_fusion_v1(computation_call, binary_op)
             binary_unary_v1 = _combined_fusion(binary_v1, aten.relu)
-            _register_binary_unary_fusion_lowering(
+            _register_binary_unary_inplace_fusion_lowering(
                 binary_unary_v1,
                 computation_op,
                 binary_op,
-                fusion_op,
-                check_fn=_is_valid_computation_binary_inplace,
+                inplace_fusion_op,
+                outplace_fusion_op,
                 other_index=0,
                 unary_attr=UnaryAttr("relu"),
             )
-            _register_binary_unary_fusion_lowering(
+            _register_binary_unary_inplace_fusion_lowering(
                 binary_v1,
                 computation_op,
                 binary_op,
-                fusion_op,
-                check_fn=_is_valid_computation_binary_inplace,
+                inplace_fusion_op,
+                outplace_fusion_op,
                 other_index=0,
             )
             binary_v2 = _binary_fusion_v2(computation_call, binary_op)
             binary_unary_v2 = _combined_fusion(binary_v2, aten.relu)
-            _register_binary_unary_fusion_lowering(
+            _register_binary_unary_inplace_fusion_lowering(
                 binary_unary_v2,
                 computation_op,
                 binary_op,
-                fusion_op,
-                check_fn=_is_valid_computation_binary_inplace,
+                inplace_fusion_op,
+                outplace_fusion_op,
                 other_index=1,
                 unary_attr=UnaryAttr("relu"),
             )
-            _register_binary_unary_fusion_lowering(
+            _register_binary_unary_inplace_fusion_lowering(
                 binary_v2,
                 computation_op,
                 binary_op,
-                fusion_op,
-                check_fn=_is_valid_computation_binary_inplace,
+                inplace_fusion_op,
+                outplace_fusion_op,
                 other_index=1,
             )
 

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -352,7 +352,7 @@ if torch._C.has_mkldnn:
 
         return fn
 
-    def _register_binary_unary_inplace_fusion_lowering(
+    def _register_binary_unary_maybe_inplace_fusion_lowering(
         pattern,
         computation_op,
         binary_op,
@@ -453,7 +453,7 @@ if torch._C.has_mkldnn:
         for binary_op in binary_ops:
             binary_v1 = _binary_fusion_v1(computation_call, binary_op)
             binary_unary_v1 = _combined_fusion(binary_v1, aten.relu)
-            _register_binary_unary_inplace_fusion_lowering(
+            _register_binary_unary_maybe_inplace_fusion_lowering(
                 binary_unary_v1,
                 computation_op,
                 binary_op,
@@ -462,7 +462,7 @@ if torch._C.has_mkldnn:
                 other_index=0,
                 unary_attr=UnaryAttr("relu"),
             )
-            _register_binary_unary_inplace_fusion_lowering(
+            _register_binary_unary_maybe_inplace_fusion_lowering(
                 binary_v1,
                 computation_op,
                 binary_op,
@@ -472,7 +472,7 @@ if torch._C.has_mkldnn:
             )
             binary_v2 = _binary_fusion_v2(computation_call, binary_op)
             binary_unary_v2 = _combined_fusion(binary_v2, aten.relu)
-            _register_binary_unary_inplace_fusion_lowering(
+            _register_binary_unary_maybe_inplace_fusion_lowering(
                 binary_unary_v2,
                 computation_op,
                 binary_op,
@@ -481,7 +481,7 @@ if torch._C.has_mkldnn:
                 other_index=1,
                 unary_attr=UnaryAttr("relu"),
             )
-            _register_binary_unary_inplace_fusion_lowering(
+            _register_binary_unary_maybe_inplace_fusion_lowering(
                 binary_v2,
                 computation_op,
                 binary_op,

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -383,7 +383,7 @@ if torch._C.has_mkldnn:
                     ]
                 else:
                     computation_args += [1.0, None, [], None]
-            # Make sure the other is not a alias or mutation(fx side doesn't has such info).
+            # Make sure the other is not an alias or mutation(fx side doesn't has such info).
             other.realize()
             can_be_inplace = not (
                 isinstance(other.data, ir.ReinterpretView)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3468,10 +3468,15 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
         unary_algorithm: Optional[str],
     ):
         kernel = "torch.ops.mkldnn._convolution_pointwise_.binary"
-        (inputs, constant_args, _, _) = _prepare_convolution_fusion_create(
+        (
+            inputs,
+            constant_args,
+            _,
+            req_stride_order,
+        ) = _prepare_convolution_fusion_create(
             cls, x, weight, bias, padding_, stride_, dilation_, groups
         )
-        other = cls.realize_input(other)
+        other = cls.require_stride_order(other, req_stride_order)
         V.graph.realize_users_of(other.get_name())
         inputs.insert(1, other)
         constant_args = constant_args + [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100058
* #100057

The motivations for this PR are:

1. Add negative/positive testing for conv+binary fusion path.
2. Add alias check for in-place fusion path: if the write buffer is an alias tensor, we will lower the out-place path(one test is also added).
3. Fix https://github.com/pytorch/pytorch/issues/99842.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire