### PR TITLE
remove casts to `getter` in python_cpp_function.h

### DIFF
--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -124,13 +124,14 @@ void THPCppFunction_dealloc(PyObject* self) {
 
 } // namespace
 
-PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook) {
-  const auto num_next = self->cdata->num_outputs();
+PyObject* THPCppFunction_next_functions(PyObject* self, void* _unused) {
+  auto cdata = reinterpret_cast<const THPCppFunction*>(self)->cdata;
+  const auto num_next = cdata->num_outputs();
   THPObjectPtr py_functions(PyTuple_New(num_next));
   if (!py_functions)
     return nullptr;
   for (const auto i : c10::irange(num_next)) {
-    auto& c_tuple = self->cdata->next_edge(i);
+    auto& c_tuple = cdata->next_edge(i);
     THPObjectPtr tuple(PyTuple_New(2));
     if (!tuple)
       return nullptr;
@@ -147,15 +148,17 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook) {
   return py_functions.release();
 }
 
-PyObject* THPCppFunction_metadata(THPCppFunction* self, void* _unused) {
+PyObject* THPCppFunction_metadata(PyObject* self, void* _unused) {
   auto* metadata =
-      static_cast<PyAnomalyMetadata*>(self->cdata->metadata())->dict();
+      static_cast<PyAnomalyMetadata*>(
+          reinterpret_cast<THPCppFunction*>(self)->cdata->metadata())
+          ->dict();
 
   Py_XINCREF(metadata);
   return metadata;
 }
 
-PyObject* THPCppFunction_requires_grad(THPCppFunction* self, void* unused) {
+PyObject* THPCppFunction_requires_grad(PyObject* self, void* unused) {
   Py_RETURN_TRUE;
 }
 

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -49,23 +49,22 @@ PyObject* CppFunction_pynew(
 
 #define THP_FUNCTION_DEFAULT_PROPERTIES                                   \
   {(char*)"next_functions",                                               \
-   (getter)THPCppFunction_next_functions,                                 \
+   THPCppFunction_next_functions,                                         \
    nullptr,                                                               \
    nullptr,                                                               \
    nullptr},                                                              \
       {(char*)"requires_grad",                                            \
-       (getter)THPCppFunction_requires_grad,                              \
+       THPCppFunction_requires_grad,                                      \
        nullptr,                                                           \
        nullptr,                                                           \
        nullptr},                                                          \
   {                                                                       \
-    (char*)"metadata", (getter)THPCppFunction_metadata, nullptr, nullptr, \
-        nullptr                                                           \
+    (char*)"metadata", THPCppFunction_metadata, nullptr, nullptr, nullptr \
   }
 
-PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook);
-PyObject* THPCppFunction_metadata(THPCppFunction* self, void* _unused);
-PyObject* THPCppFunction_requires_grad(THPCppFunction* self, void* _unused);
+PyObject* THPCppFunction_next_functions(PyObject* self, void* _unused);
+PyObject* THPCppFunction_metadata(PyObject* self, void* _unused);
+PyObject* THPCppFunction_requires_grad(PyObject* self, void* _unused);
 PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var);
 PyObject* THPCppFunction_register_hook(PyObject* self, PyObject* hook);
 PyObject* THPCppFunction_register_prehook(PyObject* self, PyObject* hook);


### PR DESCRIPTION
remove casts to `getter` in python_cpp_function.h

Summary:
These were triggering the warning `-Wcast-function-type-strict` and
breaking the build on my machine.

Test Plan: Rely on CI.


cc @ezyang @albanD @zou3519 @gqchen @pearu @nikitaved @soulitzer @Lezcano @Varal7