### PR TITLE
suppress `-Wcast-function-type-strict` when casting to PyCFunction

### DIFF
--- a/torch/csrc/utils/pycfunction_helpers.h
+++ b/torch/csrc/utils/pycfunction_helpers.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
+
 #include <Python.h>
 
 inline PyCFunction castPyCFunctionWithKeywords(PyCFunctionWithKeywords func) {
-  // NOLINTNEXTLINE(modernize-redundant-void-arg)
-  return (PyCFunction)(void (*)(void))func;
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type")
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type-strict")
+  return reinterpret_cast<PyCFunction>(func);
+  C10_DIAGNOSTIC_POP()
+  C10_DIAGNOSTIC_POP()
 }


### PR DESCRIPTION
suppress `-Wcast-function-type-strict` when casting to PyCFunction

Summary:
These casts are a necessary evil due to the design of Python. Python
ultimately casts it back to the original type based on the flags
specified in the `PyMethodDef`.

Nevertheless, the new Clang flag `-Wcast-function-type-strict` breaks
with this.

While here, convert the cast to a `reinterpret_cast`.

Test Plan: Should be a no-op. Rely on CI.
