### PR TITLE
[dynamo] Remove redundant recompile call

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -752,7 +752,6 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         self.real_value_cache.clear()
 
         gm = fx.GraphModule(root, self.graph)
-        gm.recompile()
         gm.compile_subgraph_reason = self.compile_subgraph_reason
         name = unique_id("__compiled_fn")
 


### PR DESCRIPTION
A single call to the `GraphModule.recompile` function occurs after the `GraphModule` has been constructed.
https://github.com/pytorch/pytorch/blob/62f9189d9d6ad1578c1bfddd17d45dc132e4b9b6/torch/_dynamo/output_graph.py#L754-L755

However, the recompile function has already been called once during construction, so this call should be redundant.
```
call stack:
  recompile, graph_module.py:644
  graph, graph_module.py:411
  __setattr__, module.py:1674
  __init__, graph_module.py:370
  compile_and_call_fx_graph, output_graph.py:754
  ...
```

So maybe it can be deleted.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire