### PR TITLE
ROCm fixes for PyT2.0

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1566,9 +1566,10 @@ make_fallback(aten.zeros.names)
 # fails accuracy on test_torch.py, and explicit fallback required to avoid warn=True on implicit
 make_fallback(aten.exponential.default, warn=False)
 
-if torch.version.hip is not None:
-    # ROCm specific fallback, perf issues are observed when registered
-    make_fallback(aten.miopen_batch_norm, warn=False)
+# ROCm specific fallback, perf issues are observed when registered
+make_fallback(aten.miopen_batch_norm, warn=False)
+
+if torch.version.hip is not None and torch.cuda.is_available():
     # tl.reduce not available yet in ROCm's version of triton
     make_fallback(aten.prod, warn=False)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1566,12 +1566,11 @@ make_fallback(aten.zeros.names)
 # fails accuracy on test_torch.py, and explicit fallback required to avoid warn=True on implicit
 make_fallback(aten.exponential.default, warn=False)
 
-if TEST_WITH_ROCM:
-    # ROCm specific fallback, perf issues are observed when registered
-    make_fallback(aten.miopen_batch_norm, warn=False)
-    # tl.reduce not available yet in ROCm's version of triton
-    make_fallback(aten.prod, warn=False)
-
+if torch.version.hip is not None:
+    # ROCm specific fallback, perf issues are observed when registered
+    make_fallback(aten.miopen_batch_norm, warn=False)
+    # tl.reduce not available yet in ROCm's version of triton
+    make_fallback(aten.prod, warn=False)
 
 @register_lowering(aten.clone)
 def clone(x, *, memory_format=0):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1572,6 +1572,7 @@ if torch.version.hip is not None:
     # tl.reduce not available yet in ROCm's version of triton
     make_fallback(aten.prod, warn=False)
 
+
 @register_lowering(aten.clone)
 def clone(x, *, memory_format=0):
     # TODO(jansel): memory format

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1566,6 +1566,12 @@ make_fallback(aten.zeros.names)
 # fails accuracy on test_torch.py, and explicit fallback required to avoid warn=True on implicit
 make_fallback(aten.exponential.default, warn=False)
 
+if TEST_WITH_ROCM:
+    # ROCm specific fallback, perf issues are observed when registered
+    make_fallback(aten.miopen_batch_norm, warn=False)
+    # tl.reduce not available yet in ROCm's version of triton
+    make_fallback(aten.prod, warn=False)
+
 
 @register_lowering(aten.clone)
 def clone(x, *, memory_format=0):

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -113,7 +113,7 @@ class CachingAutotuner(KernelInterface):
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
-        compile_meta["debug"] = compile_meta["debug"] = (
+        compile_meta["debug"] = (
             config.triton.assert_indirect_indexing and torch.version.hip is None
         )
 


### PR DESCRIPTION
This PR brings some updates and fixes in regards to PyT2.0 functionality

1 - ROCm's version of triton does not yet support tl.reduce
Until supported we are opting to revert the removal of the aten.prod make_fallback for ROCm brought in with https://github.com/pytorch/pytorch/commit/7a6c650b8150231ad81869a3d1201ba0443ecad8

This issue was found locally with the latest aten.prod UTs on ROCm
```
FAILED [0.0916s] inductor/test_torchinductor.py::CudaTests::test_prod_cuda - torch._dynamo.exc.BackendCompilerFailed: backend='compile_fx_wrapper' raised:
AttributeError: module 'triton.language' has no attribute 'reduce'
```

2 - Adds aten.miopen_batch_norm as an explicit fallback as perf issues are observed when registered as a decomposition, setting warning=False as the fallback is expected

3 - Fixes a typo and redundant assignment in _inductor/triton_heuristics.py brought in with https://github.com/pytorch/pytorch/pull/99756/commits/dd778a76103a9a0c85cc487f851160824fe6124c




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire