### PR TITLE
Pin lintrunner mypy to 1.2.0

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -149,7 +149,7 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'numpy==1.23.1',
     'expecttest==0.1.3',
-    'mypy==0.960',
+    'mypy==1.2.0',
     'types-requests==2.27.25',
     'types-PyYAML==6.0.7',
     'types-tabulate==0.8.8',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100098

Fixes https://github.com/pytorch/pytorch/issues/99562

I have verified that on a local machine upgrading my mypy to 1.2.0 from
the current pin fixes that issue, though I haven't root caused it.
Submitting this PR as an easy fix.