### PR TITLE
Added Typechecking to input tensor in RNN

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -209,7 +209,7 @@ class RNNBase(Module):
             init.uniform_(weight, -stdv, stdv)
 
     def check_input(self, input: Tensor, batch_sizes: Optional[Tensor]) -> None:
-        if input.dtype != self._flat_weights[0].dtype:
+        if input.dtype != self._flat_weights[0].dtype and not torch.is_autocast_enabled():
             raise ValueError('input must have the type {}, got type {}'.format(
                 self._flat_weights[0].dtype, input.dtype))
         expected_input_dim = 2 if batch_sizes is not None else 3

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -209,6 +209,9 @@ class RNNBase(Module):
             init.uniform_(weight, -stdv, stdv)
 
     def check_input(self, input: Tensor, batch_sizes: Optional[Tensor]) -> None:
+        if input.dtype != self._flat_weights[0].dtype:
+            raise RuntimeError('input must have the type {}, got type {}'.format(
+                self._flat_weights[0].dtype, input.dtype))
         expected_input_dim = 2 if batch_sizes is not None else 3
         if input.dim() != expected_input_dim:
             raise RuntimeError(

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -210,7 +210,7 @@ class RNNBase(Module):
 
     def check_input(self, input: Tensor, batch_sizes: Optional[Tensor]) -> None:
         if input.dtype != self._flat_weights[0].dtype:
-            raise RuntimeError('input must have the type {}, got type {}'.format(
+            raise ValueError('input must have the type {}, got type {}'.format(
                 self._flat_weights[0].dtype, input.dtype))
         expected_input_dim = 2 if batch_sizes is not None else 3
         if input.dim() != expected_input_dim:


### PR DESCRIPTION
The input tensor of the RNN forward must be the same type as the weights.
While passing tensor of type long the error is:
    `RuntimeError: expected scalar type Long but found Float`
Which is misleading because it said to convert Something to Long, but the correct solution is to convert the input to Float (Which is the type of the weights).

The new error:
    `RuntimeError: input must have the type torch.float32, got type torch.int64`

Is correct and more verbose

Fixes #99998
