### PR TITLE
Use a stable ordering for saved values in functorch.default_partition

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -251,8 +251,8 @@ def default_partition(
                     saved_sym_nodes.append(user)
             else:
                 saved_values.append(node)
-    saved_values = list(set(saved_values))
-    saved_sym_nodes = list(set(saved_sym_nodes))
+    saved_values = list({k: None for k in saved_values}.keys())
+    saved_sym_nodes = list({k: None for k in saved_sym_nodes}.keys())
 
     return _extract_fwd_bwd_modules(joint_module, saved_values, saved_sym_nodes=saved_sym_nodes, num_fwd_outputs=num_fwd_outputs)
 


### PR DESCRIPTION
Previously, due to the use of the Python set data structure, the ordering of saved values (and how they would appear in the graph) was unstable and changed across runs, making it hard to debug downstream applications. Here we use a dict (with insertion-ordering semantics) to deduplicate values in a way that preserves ordering