### PR TITLE
Remove CUDA 11.6 note from complex docs

### DIFF
--- a/docs/source/complex_numbers.rst
+++ b/docs/source/complex_numbers.rst
@@ -3,9 +3,6 @@
 Complex Numbers
 ===============
 
-.. note:: When using complex numbers, use Pytorch with CUDA 11.6 downloaded via pip wheel as described in
-   `Get Started <https://pytorch.org/get-started/locally/>`__ and select the CUDA 11.6 pip package.
-
 Complex numbers are numbers that can be expressed in the form :math:`a + bj`, where a and b are real numbers,
 and *j* is called the imaginary unit, which satisfies the equation :math:`j^2 = -1`. Complex numbers frequently occur in mathematics and
 engineering, especially in topics like signal processing. Traditionally many users and libraries (e.g., TorchAudio) have


### PR DESCRIPTION
Removes note in the complex docs pointing to the CUDA 11.6 wheels introduced in https://github.com/pytorch/pytorch/pull/80363.
Background: this warning was added via https://github.com/pytorch/pytorch/issues/79876 which pointed out a slow compilation time in 11.3. The 11.6 pip wheels were thus recommended but are not build anymore as our current support is 11.7, 11.8 (and 12.1 experimental in nightlies).

The note is confusing users as it doesn't explain why 11.6 is needed.
Reference: https://discuss.pytorch.org/t/complex-numbers-cuda-11-6-documentation-warning/178588/1
