### PR TITLE
[ROCm] Limiting the NUM_PROCS to 8 while UT testing

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -24,7 +24,8 @@ if os.path.exists("/opt/rocm") and not IS_MEM_LEAK_CHECK:
             if " gfx" in line:
                 count += 1
         assert count > 0  # there must be at least 1 GPU
-        NUM_PROCS = count
+        # Limiting to 8 GPUs(PROCS)
+        NUM_PROCS = 8 if count > 8 else count
     except subprocess.CalledProcessError as e:
         # The safe default for ROCm GHA runners is to run tests serially.
         NUM_PROCS = 1


### PR DESCRIPTION
- Few AMD machines have >8 GPUs so limiting the NUM_PARALLEL_PROCS to 8, so number of test shards are also max 8
- Parallelizing for >8 is limited by memory.


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport