### PR TITLE
[Tensor Parallel] Add a new Colwise Parallel style when Pairwise cannot directly used

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate, Shard
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
+    ColwiseParallelNoReshard,
     make_input_replicate_1d,
     make_input_reshard_replicate,
     make_input_shard_1d,
@@ -219,6 +220,13 @@ class TensorParallelStyleTest(DTensorTestBase):
         cs = ColwiseParallel()
         self._1d_input_func_check(tensor, tensor, cs._prepare_input)
         self.assertEqual(make_output_replicate_1d, cs._prepare_output)
+
+    @with_comms
+    def test_colwise_parallel_no_reshard_style(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        cs_ns = ColwiseParallelNoReshard()
+        self._1d_input_func_check(tensor, tensor, cs_ns._prepare_input)
+        self.assertEqual(None, cs_ns._prepare_output)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -6,7 +6,7 @@ import torch.distributed as dist
 from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate, Shard
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
-    ColwiseParallelNoReshard,
+    ColwiseParallelForPairwise,
     make_input_replicate_1d,
     make_input_reshard_replicate,
     make_input_shard_1d,
@@ -15,6 +15,7 @@ from torch.distributed.tensor.parallel.style import (
     make_output_shard_1d,
     make_output_tensor,
     RowwiseParallel,
+    RowwiseParallelForPairwise,
 )
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -204,12 +205,12 @@ class TensorParallelStyleTest(DTensorTestBase):
         self._1d_input_func_check(tensor, tensor, rs._prepare_input)
         # TODO: change output test
         output, dtensor, device_mesh = self._test_prepare_output(
-            rs._prepare_input, [Shard(0)]
+            rs._prepare_output, [Shard(0)]
         )
         self.assertEqual(output, dtensor.redistribute(device_mesh, [Replicate()]))
         # test when input device_mesh is None.
         output, dtensor, device_mesh = self._test_prepare_output(
-            rs._prepare_input, [Shard(0)], None, True
+            rs._prepare_output, [Shard(0)], None, True
         )
         self.assertEqual(output, dtensor.redistribute(device_mesh, [Replicate()]))
         self._test_prepare_output_error(rs._prepare_output)
@@ -222,11 +223,20 @@ class TensorParallelStyleTest(DTensorTestBase):
         self.assertEqual(make_output_replicate_1d, cs._prepare_output)
 
     @with_comms
-    def test_colwise_parallel_no_reshard_style(self):
+    def test_colwise_parallel_for_pairwise_style(self):
         tensor = torch.rand(8, 16, device=self.device_type)
-        cs_ns = ColwiseParallelNoReshard()
-        self._1d_input_func_check(tensor, tensor, cs_ns._prepare_input)
-        self.assertEqual(None, cs_ns._prepare_output)
+        cs = ColwiseParallelForPairwise()
+        self._1d_input_func_check(tensor, tensor, cs._prepare_input)
+        self.assertEqual(None, cs._prepare_output)
+
+    @with_comms
+    def test_rowwise_parallel_for_pairwise_style(self):
+        rs = RowwiseParallelForPairwise()
+        output, dtensor, device_mesh = self._test_prepare_output(
+            rs._prepare_output, [Shard(0)]
+        )
+        self.assertEqual(output, dtensor.redistribute(device_mesh, [Replicate()]))
+        self.assertEqual(None, rs._prepare_input)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/parallel/__init__.py
+++ b/torch/distributed/tensor/parallel/__init__.py
@@ -6,6 +6,7 @@ from torch.distributed.tensor.parallel.multihead_attention_tp import (
 
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
+    ColwiseParallelNoReshard,
     make_input_replicate_1d,
     make_input_reshard_replicate,
     make_input_shard_1d,
@@ -22,6 +23,7 @@ from torch.distributed.tensor.parallel.style import (
 
 __all__ = [
     "ColwiseParallel",
+    "ColwiseParallelNoReshard",
     "PairwiseParallel",
     "PairwiseSequenceParallel",
     "ParallelStyle",

--- a/torch/distributed/tensor/parallel/__init__.py
+++ b/torch/distributed/tensor/parallel/__init__.py
@@ -6,7 +6,7 @@ from torch.distributed.tensor.parallel.multihead_attention_tp import (
 
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
-    ColwiseParallelNoReshard,
+    ColwiseParallelForPairwise,
     make_input_replicate_1d,
     make_input_reshard_replicate,
     make_input_shard_1d,
@@ -19,15 +19,17 @@ from torch.distributed.tensor.parallel.style import (
     PairwiseSequenceParallel,
     ParallelStyle,
     RowwiseParallel,
+    RowwiseParallelForPairwise,
 )
 
 __all__ = [
     "ColwiseParallel",
-    "ColwiseParallelNoReshard",
+    "ColwiseParallelForPairwise",
     "PairwiseParallel",
     "PairwiseSequenceParallel",
     "ParallelStyle",
     "RowwiseParallel",
+    "RowwiseParallelForPairwise",
     "TensorParallelMultiheadAttention",
     "make_input_replicate_1d",
     "make_input_reshard_replicate",

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -167,7 +167,7 @@ def _rowwise_parallelize_linear_fn(
 ) -> None:
     """
     This function parallelizes the input :class:`nn.Linear` module in
-    :class:`RowwiseParallel` style.
+    :class:`RowwiseParallel` or `RowwiseParallelForPairwise` style.
 
     Args:
         name (str):
@@ -198,7 +198,7 @@ def _colwise_parallelize_linear_fn(
 ) -> None:
     """
     This function parallelizes the input :class:`nn.Linear` module in
-    :class:`ColwiseParallel` or `ColwiseParallelNoReshard` style.
+    :class:`ColwiseParallel` or `ColwiseParallelForPairwise` style.
 
     Args:
         name (str):

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -18,10 +18,11 @@ from torch.distributed.tensor.parallel.multihead_attention_tp import (
 )
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
-    ColwiseParallelNoReshard,
+    ColwiseParallelForPairwise,
     PairwiseParallel,
     ParallelStyle,
     RowwiseParallel,
+    RowwiseParallelForPairwise,
 )
 
 
@@ -86,7 +87,10 @@ def parallelize_module(  # type: ignore[return]
 
     if isinstance(parallelize_plan, ParallelStyle):
         # RowwiseParallel or ColwiseParallel
-        if isinstance(parallelize_plan, (ColwiseParallel, ColwiseParallelNoReshard, RowwiseParallel)):
+        if isinstance(
+            parallelize_plan,
+            (ColwiseParallel, ColwiseParallelForPairwise, RowwiseParallel, RowwiseParallelForPairwise)
+        ):
             return _parallelize_linear(module, device_mesh, parallelize_plan)
         # PairwiseParallel
         if _is_mha_for_pairwise_parallel(module):
@@ -264,7 +268,7 @@ def _parallelize_linear(
     if device_mesh.ndim > 1:
         device_mesh = _create_1d_device_mesh(device_mesh, tp_mesh_dim)
 
-    if isinstance(parallel_style, RowwiseParallel):
+    if isinstance(parallel_style, (RowwiseParallel, RowwiseParallelForPairwise)):
         distribute_module(
             module,
             device_mesh,
@@ -272,7 +276,7 @@ def _parallelize_linear(
             input_fn=parallel_style._prepare_input,  # type: ignore[arg-type, misc] # pyre-ignore[6]
             output_fn=parallel_style._prepare_output,  # type: ignore[arg-type, misc] # pyre-ignore[6]
         )
-    elif isinstance(parallel_style, ColwiseParallel) or isinstance(parallel_style, ColwiseParallelNoReshard):
+    elif isinstance(parallel_style, (ColwiseParallel, ColwiseParallelForPairwise)):
         distribute_module(
             module,
             device_mesh,

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -15,6 +15,7 @@ __all__ = [
     "ParallelStyle",
     "RowwiseParallel",
     "ColwiseParallel",
+    "ColwiseParallelNoReshard",
     "PairwiseParallel",
     "PairwiseSequenceParallel",
     "make_input_replicate_1d",
@@ -98,6 +99,17 @@ class ColwiseParallel(ParallelStyle):
 
     def __init__(self) -> None:
         super().__init__(make_input_replicate_1d, make_output_replicate_1d)
+
+
+class ColwiseParallelNoReshard(ParallelStyle):
+    """
+    Partitioning the column of a tensor or module.
+    We assume the input to be a replicated :class:`DTensor` and output to be a sharded :class:`DTensor`.
+    We don't perform reshard for output.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(make_input_replicate_1d, None)
 
 
 @_prepare_input_validate  # type: ignore[arg-type] # pyre-ignore[56]

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -14,8 +14,9 @@ from torch.distributed.tensor.parallel._utils import (
 __all__ = [
     "ParallelStyle",
     "RowwiseParallel",
+    "RowwiseParallelForPairwise",
     "ColwiseParallel",
-    "ColwiseParallelNoReshard",
+    "ColwiseParallelForPairwise",
     "PairwiseParallel",
     "PairwiseSequenceParallel",
     "make_input_replicate_1d",
@@ -101,7 +102,7 @@ class ColwiseParallel(ParallelStyle):
         super().__init__(make_input_replicate_1d, make_output_replicate_1d)
 
 
-class ColwiseParallelNoReshard(ParallelStyle):
+class ColwiseParallelForPairwise(ParallelStyle):
     """
     Partitioning the column of a tensor or module.
     We assume the input to be a replicated :class:`DTensor` and output to be a sharded :class:`DTensor`.
@@ -110,6 +111,17 @@ class ColwiseParallelNoReshard(ParallelStyle):
 
     def __init__(self) -> None:
         super().__init__(make_input_replicate_1d, None)
+
+
+class RowwiseParallelForPairwise(ParallelStyle):
+    """
+    Partitioning the row of a module.
+    We assume the input to be a sharded :class:`DTensor` and output to be a replicated :class:`DTensor`.
+    We don't perform reshard for input.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(None, make_output_replicate_1d)
 
 
 @_prepare_input_validate  # type: ignore[arg-type] # pyre-ignore[56]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100137

Some use cases, users cannot directly `PairwiseParallelStyle` and they might need to specify colwise and rowwise separately.