### PR TITLE
[CUDA] Switch to `at::empty` in `max_pool3d_with_indices_backward_cuda`

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -636,7 +636,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("max_pool3d_with_indices_backward_cuda");
-  auto gradInput = at::zeros_like(input, input.suggest_memory_format());
+  auto gradInput = at::empty(input.sizes(), input.options());
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,


### PR DESCRIPTION
Looks like there's an extraneous call to `at::zero` as `gradInput` will always be zero'd by `max_pool3d_with_indices_backward_out_cuda_template`.

CC @ptrblck @ngimel 

cc @ngimel