### PR TITLE
[PoC] Dynamo to emit nn.Module boundary metadata

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -857,6 +857,10 @@ def export(
                 arg.node.meta["val"] = self.current_node.meta["val"]
             if "tensor_dict" in self.current_node.meta:
                 arg.node.meta["tensor_dict"] = self.current_node.meta["tensor_dict"]
+            if "nn_module_boundary" in self.current_node.meta:
+                arg.node.meta["nn_module_boundary"] = self.current_node.meta[
+                    "nn_module_boundary"
+                ]
             return arg
 
         def output(self, target, args, kwargs):

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -138,7 +138,7 @@ class TracerBase:
                 node.stack_trace = stack_trace
             # Explicitly set the stack_trace, nn_module_stack and source_fn on the node.meta
             # If other meta fields are needed, they can be added here
-            copy_meta_fields = ["nn_module_stack", "source_fn", "original_aten"]
+            copy_meta_fields = ["nn_module_stack", "source_fn", "original_aten", "nn_module_boundary"]
             for field in copy_meta_fields:
                 if field in current_meta:
                     node.meta[field] = current_meta[field]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100140

The end goal is to be able to capture nn.Module calls as subgraphs. This PR
is an exploratory effort to enrich the metadata emitted from dynamo. Together
with `node.meta["nn_module_stack"]` to provide the boundary of nn.Module calls
for downstream analysis.

Example:

```python
import torch
import torch._dynamo
from torch import nn
import tabulate


class SubModule(nn.Module):
    def forward(self, x, y):
        return x + y


class MNISTModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(1, 32, 3, 1, bias=True)
        self.conv2 = nn.Conv2d(32, 64, 3, 2, bias=True)
        self.fc1 = nn.Linear(9216, 128, bias=True)
        self.fc2 = nn.Linear(128, 10, bias=True)
        self.extra = SubModule()

    def forward(self, tensor_x: torch.Tensor):
        tensor_x = self.conv1(tensor_x)
        tensor_x = torch.sigmoid(tensor_x)
        tensor_x = self.conv2(tensor_x)
        tensor_x = torch.sigmoid(tensor_x)
        tensor_x = torch.flatten(tensor_x, 1)
        tensor_x = self.fc1(tensor_x)
        tensor_x = torch.sigmoid(tensor_x)
        output = self.fc2(tensor_x)
        return self.extra(output, output)


gm, _ = torch._dynamo.export(
    MNISTModel(), torch.rand((64, 1, 28, 28), dtype=torch.float32)
)
node_specs = [
    [
        node,
        tuple(node.meta.get("nn_module_stack", {}).keys()),
        node.meta.get("nn_module_boundary", None),
    ]
    for node in gm.graph.nodes
]
print(
    tabulate.tabulate(
        node_specs, headers=["node", "nn_module_stack", "nn_module_boundary"]
    )
)
```
Outputing
```
node             nn_module_stack       nn_module_boundary
---------------  --------------------  ---------------------------------------------------------------------------------------------------
arg0             ()                    {'nn_module_input': {'L__self___conv1': [0]}}
l__self___conv1  ('L__self___conv1',)  {'nn_module_output': {'L__self___conv1': ['output']}}
sigmoid          ()                    {'nn_module_input': {'L__self___conv2': [0]}}
l__self___conv2  ('L__self___conv2',)  {'nn_module_output': {'L__self___conv2': ['output']}}
sigmoid_1        ()
flatten          ()                    {'nn_module_input': {'L__self___fc1': [0]}}
l__self___fc1    ('L__self___fc1',)    {'nn_module_output': {'L__self___fc1': ['output']}}
sigmoid_2        ()                    {'nn_module_input': {'L__self___fc2': [0]}}
l__self___fc2    ('L__self___fc2',)    {'nn_module_output': {'L__self___fc2': ['output']}, 'nn_module_input': {'L__self___extra': [1, 2]}}
add              ('L__self___extra',)  {'nn_module_output': {'L__self___extra': ['output']}}
output           ()
```

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @soumith @desertfire