### PR TITLE
[Dynamo] Add unit test for explicitly calling __call__

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1610,20 +1610,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertEqual(compiled_func(inp).item(), 15)
         self.assertEqual(cc.frame_count, 1)
 
-    def test_hooks_allowed_modules(self):
-        # this test shouldn't care whether hook guards are enabled or not
-        class ToyModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.net = torch.nn.Sequential(
-                    *[torch.nn.Linear(10, 10000), torch.nn.ReLU()]
-                    + [torch.nn.Linear(10000, 5), torch.nn.ReLU()]
-                )
-
-            def forward(self, x):
-                return self.net(x)
-
-        model = ToyModel()
+    def _forward_hook_test_helper(self, model):
         forward_handles = {}
         activations = dict()
 
@@ -1649,6 +1636,35 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         print(f"Recorded Layers: {activations.keys()}\n\n")
         print(f"Expected Layers: {forward_handles.keys()}")
         self.assertTrue(activations.keys() == forward_handles.keys())
+
+    def test_hooks_allowed_modules(self):
+        # this test shouldn't care whether hook guards are enabled or not
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net = torch.nn.Sequential(
+                    *[torch.nn.Linear(10, 10000), torch.nn.ReLU()]
+                    + [torch.nn.Linear(10000, 5), torch.nn.ReLU()]
+                )
+
+            def forward(self, x):
+                return self.net(x)
+
+        model = ToyModel()
+        self._forward_hook_test_helper(model)
+
+    def test_dunder_call_explicitly(self):
+        # hooks should be triggered if explicit calling `__call__`
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10000)
+
+            def forward(self, x):
+                return self.linear.__call__(x)
+
+        model = ToyModel()
+        self._forward_hook_test_helper(model)
 
     def test_backward_hooks(self):
         # this test shouldn't care whether hook guards are enabled or not

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -288,6 +288,11 @@ class UserMethodVariable(UserFunctionVariable):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
+        # For nn.Module methods, redirecting to NNModuleVariable.call_method for optimized solution
+        # rather than simple inlining. E.g, putting `call_method` op in FX graph for `forward` method
+        # since we ensure `forward` of allowed modules can be traced by AOT safely.
+        # Note this is not only for allowed modules, as user customized modules can extend from
+        # allowed modules but using parent's `forward` method, which is also covered by this branch.
         if isinstance(self.obj, variables.NNModuleVariable):
             module_attr = getattr(self.fn, "__module__", "")
             if (


### PR DESCRIPTION
@wconstab As we discussed last Friday, I added the unit test for explicitly calling __call__ and added comment to explain why we redirecting ```UserMethodVariable.call_function``` to ```NNModuleVariable.call_method``` for a certain case. 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire