### PR TITLE
add an adapter to replace casting to reprfunc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1567,7 +1567,7 @@ cc_library(
         exclude = [
             "torch/csrc/*/generated/*.h",
         ] + torch_cuda_headers,
-    ) + GENERATED_AUTOGRAD_CPP + [":version_h"],
+    ) + GENERATED_AUTOGRAD_CPP + [":version_h"] + ["//torch/csrc/utils:hdrs"],
     includes = [
         "third_party/kineto/libkineto/include",
         "torch/csrc",
@@ -1581,6 +1581,7 @@ cc_library(
         ":aten_headers",
         ":caffe2_headers",
         "//c10",
+        "//torch/csrc/utils:reprfunc",
         "@com_github_google_flatbuffers//:flatbuffers",
         "@local_config_python//:python_headers",
         "@onnx",
@@ -1620,7 +1621,8 @@ cc_library(
             "torch/csrc/cuda/nccl.cpp",
             "torch/csrc/distributed/c10d/quantization/quantization_gpu.cu",
         ],
-    )) + torch_sources,
+    )) + torch_sources + ["//torch/csrc/utils:srcs"],
+    hdrs = ["//torch/csrc/utils:hdrs"],
     copts = TORCH_COPTS,
     defines = [
         "CAFFE2_NIGHTLY_VERSION=20200115",

--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 //#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/utils/python_compat.h>
+#include <torch/csrc/utils/reprfunc.h>
 #include <torch/csrc/Export.h>
 #include <ATen/functorch/BatchedTensorImpl.h>
 #include <ATen/functorch/DynamicLayer.h>
@@ -305,7 +306,7 @@ PyTypeObject Dim::Type = {
     0,                              /* tp_getattr */
     0,                              /* tp_setattr */
     0,                              /* tp_as_async */
-    (reprfunc)Dim_repr,           /* tp_repr */
+    TORCH_AS_REPRFUNC(Dim_repr),    /* tp_repr */
     0,                 /* tp_as_number */
     0,                              /* tp_as_sequence */
     0,                              /* tp_as_mapping */
@@ -520,15 +521,15 @@ PyMappingMethods DimList_mapping = {
 
 PyTypeObject DimList::Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_C.DimList",               /* tp_name */
-    sizeof(DimList),               /* tp_basicsize */
-    0,                              /* tp_itemsize */
-    DimList::dealloc_stub,      /* tp_dealloc */
-    0,                              /* tp_vectorcall_offset */
-    0,                              /* tp_getattr */
-    0,                              /* tp_setattr */
-    0,                              /* tp_as_async */
-    (reprfunc)DimList_repr,           /* tp_repr */
+    "_C.DimList",                    /* tp_name */
+    sizeof(DimList),                 /* tp_basicsize */
+    0,                               /* tp_itemsize */
+    DimList::dealloc_stub,           /* tp_dealloc */
+    0,                               /* tp_vectorcall_offset */
+    0,                               /* tp_getattr */
+    0,                               /* tp_setattr */
+    0,                               /* tp_as_async */
+    TORCH_AS_REPRFUNC(DimList_repr), /* tp_repr */
     0,                 /* tp_as_number */
     &DimList_seq,                 /* tp_as_sequence */
     &DimList_mapping,             /* tp_as_mapping */

--- a/test/cpp/torch/utils/BUILD
+++ b/test/cpp/torch/utils/BUILD
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "reprfunc_test",
+    srcs = ["reprfunc_test.cpp"],
+    deps = [
+        "//torch/csrc/utils:reprfunc",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_python//:python_embed",
+    ],
+)

--- a/test/cpp/torch/utils/reprfunc_test.cpp
+++ b/test/cpp/torch/utils/reprfunc_test.cpp
@@ -1,0 +1,67 @@
+#include <torch/csrc/utils/reprfunc.h>
+
+#include <Python.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <string_view>
+
+namespace torch {
+
+// Simple type to create a reprfunc from.
+class PyType {
+ public:
+  explicit PyType(std::string repr) : repr_(std::move(repr)) {}
+
+  static auto repr_impl(PyType* self) -> PyObject* {
+    return PyUnicode_FromStringAndSize(
+        self->repr_.data(), self->repr_.length());
+  }
+
+  auto repr() const -> std::string_view {
+    return repr_;
+  }
+
+ private:
+  std::string repr_;
+};
+
+namespace {
+
+// Gets a std::string_view from a PyObject.
+std::string_view as_string_view(PyObject* obj) {
+  assert(PyUnicode_Check(obj));
+  const char* data = PyUnicode_AsUTF8(obj);
+  assert(data != nullptr);
+  return std::string_view(data);
+}
+
+// Matcher that verifies a PyObject is equivalent to a string.
+MATCHER_P(EqPyString, want, "") {
+  std::string_view got = as_string_view(arg);
+  *result_listener << "i.e. " << got;
+  return got == want;
+}
+
+TEST(reprfunc_test, adapter) {
+  reprfunc func = as_reprfunc<PyType, &PyType::repr_impl>();
+
+  PyType self("PyType('value')");
+  auto obj = reinterpret_cast<PyObject const&>(self);
+
+  ASSERT_THAT(func(&obj), EqPyString(self.repr()));
+}
+
+TEST(reprfunc_test, adapter_macro) {
+  reprfunc func = TORCH_AS_REPRFUNC(&PyType::repr_impl);
+
+  PyType self("PyType('value')");
+  auto obj = reinterpret_cast<PyObject const&>(self);
+
+  ASSERT_THAT(func(&obj), EqPyString(self.repr()));
+}
+
+} // namespace
+} // namespace torch

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -721,7 +721,7 @@ PyTypeObject* get_{name}_namedtuple() {{
     static PyStructSequence_Desc desc = {{ "torch.return_types.{name}", nullptr, NamedTuple_fields, {len(fieldnames)} }};
     if (!is_initialized) {{
         PyStructSequence_InitType(&{typename}, &desc);
-        {typename}.tp_repr = (reprfunc)torch::utils::returned_structseq_repr;
+        {typename}.tp_repr = TORCH_AS_REPRFUNC(torch::utils::returned_structseq_repr);
         is_initialized = true;
     }}
     return &{typename};

--- a/tools/autograd/templates/python_return_types.cpp
+++ b/tools/autograd/templates/python_return_types.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "torch/csrc/autograd/python_return_types.h"
+#include "torch/csrc/utils/reprfunc.h"
 #include "torch/csrc/utils/structseq.h"
 #include "torch/csrc/Exceptions.h"
 

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 
 #include <ATen/Device.h>
 #include <c10/util/Exception.h>
@@ -226,7 +227,7 @@ PyTypeObject THPDeviceType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPDevice_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPDevice_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */
@@ -237,7 +238,7 @@ PyTypeObject THPDeviceType = {
     // this later, so for now, don't actually implement this
     // THPDevice_call, /* tp_call */
     nullptr, /* tp_call */
-    (reprfunc)THPDevice_str, /* tp_str */
+    TORCH_AS_REPRFUNC(THPDevice_str), /* tp_str */
     nullptr, /* tp_getattro */
     nullptr, /* tp_setattro */
     nullptr, /* tp_as_buffer */

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 #include <torch/csrc/utils/tensor_dtypes.h>
 #include <torch/csrc/utils/tensor_types.h>
 #include <cstring>
@@ -90,7 +91,7 @@ PyTypeObject THPDtypeType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPDtype_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPDtype_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */

--- a/torch/csrc/Layout.cpp
+++ b/torch/csrc/Layout.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 
 #include <ATen/Layout.h>
 
@@ -35,7 +36,7 @@ PyTypeObject THPLayoutType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPLayout_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPLayout_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */

--- a/torch/csrc/MemoryFormat.cpp
+++ b/torch/csrc/MemoryFormat.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 
 #include <c10/core/MemoryFormat.h>
 
@@ -48,7 +49,7 @@ PyTypeObject THPMemoryFormatType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPMemoryFormat_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPMemoryFormat_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */

--- a/torch/csrc/QScheme.cpp
+++ b/torch/csrc/QScheme.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 
 #include <c10/core/QScheme.h>
 
@@ -47,7 +48,7 @@ PyTypeObject THPQSchemeType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPQScheme_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPQScheme_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_tuples.h>
+#include <torch/csrc/utils/reprfunc.h>
 #include <string>
 
 #include <torch/csrc/autograd/python_variable.h>
@@ -236,7 +237,7 @@ PyTypeObject THPSizeType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPSize_repr, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPSize_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     &THPSize_as_sequence, /* tp_as_sequence */
     &THPSize_as_mapping, /* tp_as_mapping */

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/reprfunc.h>
 #include <torch/csrc/utils/tensor_dtypes.h>
 
 #include <c10/util/Exception.h>
@@ -259,13 +260,13 @@ PyTypeObject THPFInfoType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPFInfo_str, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPFInfo_str), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */
     nullptr, /* tp_hash  */
     nullptr, /* tp_call */
-    (reprfunc)THPFInfo_str, /* tp_str */
+    TORCH_AS_REPRFUNC(THPFInfo_str), /* tp_str */
     nullptr, /* tp_getattro */
     nullptr, /* tp_setattro */
     nullptr, /* tp_as_buffer */
@@ -312,13 +313,13 @@ PyTypeObject THPIInfoType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPIInfo_str, /* tp_repr */
+    TORCH_AS_REPRFUNC(THPIInfo_str), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */
     nullptr, /* tp_hash  */
     nullptr, /* tp_call */
-    (reprfunc)THPIInfo_str, /* tp_str */
+    TORCH_AS_REPRFUNC(THPIInfo_str), /* tp_str */
     nullptr, /* tp_getattro */
     nullptr, /* tp_setattro */
     nullptr, /* tp_as_buffer */

--- a/torch/csrc/utils/BUILD.bazel
+++ b/torch/csrc/utils/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "reprfunc",
+    hdrs = ["reprfunc.h"],
+    visibility = [
+        "//:__pkg__",
+        "//test/cpp/torch/utils:__pkg__",
+    ],
+    deps = ["@local_config_python//:python_headers"],
+
+)
+
+filegroup(
+    name = "hdrs",
+    srcs = glob(["*.h"], exclude=[
+        "reprfunc.h",
+    ]),
+    visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["*.cpp"]),
+    visibility = ["//:__pkg__"],
+)

--- a/torch/csrc/utils/reprfunc.h
+++ b/torch/csrc/utils/reprfunc.h
@@ -1,0 +1,96 @@
+/// Type-safe-ish utilities for defining __repr__ on Python types.
+///
+/// The classic Python way of handling this is c-style casts
+/// transmuting one function type to another. This is very sketchy and
+/// violates a modern Clang warning "-Wcast-function-type-strict". A
+/// somewhat less sketchy approach is to preserve the function
+/// signature and provide adapters that reinterpret_cast arguments as
+/// necessary. This is more principled, but isn't fully type-safe
+/// since nothing prevents you from giving Python an adapter that
+/// takes the wrong argument.
+
+#pragma once
+
+#include <Python.h>
+
+#include <string>
+#include <type_traits>
+
+/// Adapts an existing type-safe function to the reprfunc signature.
+///
+/// This is provided as an alternative to using torch::as_reprfunc()
+/// directly. The advantage of the macro is that the type of the
+/// object is inferred.
+///
+/// @example
+/// ```
+/// PyTypeObject type = {
+///   ...
+///   /*tp_basicsize=*/sizeof(CppType)
+///   // Note that it is very important that you put the + in front of
+///   // the lambda, and also that the lambda is stateless. This is a
+///   // technical requirement of the design of this feature.
+///   /*tp_reprfunc=*/TORCH_AS_REPRFUNC(CppType_repr);
+/// };
+/// ```
+#define TORCH_AS_REPRFUNC(func) \
+  ::torch::as_reprfunc<decltype(::torch::detail::get_self((func))), (func)>()
+
+namespace torch::detail {
+
+/// Typed alias of a reprfunc.
+template <typename Self>
+using ReprFunc = PyObject* (*)(Self* self);
+
+} // namespace torch::detail
+
+namespace torch {
+
+/// Adapts an existing type-safe function to the reprfunc signature.
+///
+/// This is available if you prefer redundantly specifying the type of
+/// the object to the ickiness of a macro.
+///
+/// @example
+/// ```
+/// PyTypeObject type = {
+///   ...
+///   /*tp_basicsize=*/sizeof(CppType)
+///   // Note that it is very important that you put the + in front of
+///   // the lambda, and also that the lambda is stateless. This is a
+///   // technical requirement of the design of this feature.
+///   /*tp_reprfunc=*/torch::as_reprfunc<CppType, CppType_repr>();
+/// };
+/// ```
+///
+/// Note that in C++ 20, we will be able to infer the type using
+/// "template <auto impl>" and the macro will no longer provide any
+/// value.
+template <typename Self, detail::ReprFunc<Self> impl>
+reprfunc as_reprfunc();
+
+} // namespace torch
+
+// The rest of the file is implementation details. Review at your own peril.
+
+namespace torch::detail {
+
+// Extracts the object type of a ReprFunc.
+//
+// Example:
+//   using Self = decltype(get_self(some_typed_reprfunc));
+template <typename Self>
+Self get_self(ReprFunc<Self> func) {
+  return std::declval<Self>();
+}
+
+} // namespace torch::detail
+
+namespace torch {
+
+template <typename Self, detail::ReprFunc<Self> impl>
+reprfunc as_reprfunc() {
+  return +[](PyObject* self) { return impl(reinterpret_cast<Self*>(self)); };
+}
+
+} // namespace torch


### PR DESCRIPTION
add an adapter to replace casting to reprfunc

Summary:
The Python design of its binding layer is sketchy from a C++
perspective and relies on unsafe casts of function pointers. This is
getting flagged by a new warning `-Wcast-function-type-strict` in a
new version of Clang. A less sketchy but still type-unsafe thing to do
is to preserve the signature, but add an adapter that casts the
arguments as necessary.

This is better because it narrows the scope of the type unsafety, and
in the long-run, enables the creation of a broader scope of
type-safety coupled to the entire Python object. More concretely, we
could create a Python adapter around an entire C++ class and have
typesafe fields for repr, getters, etc. Since we would give this as
entire, internally type-safe, unit to Python, we would eliminate the
scope for user error and only allow type violations if our library or
Python's had errors.

Test Plan: Rely on CI.
