### PR TITLE
Publicly exposing `torch.backends.cpu.get_cpu_capability()`

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -90,41 +90,40 @@ std::string get_openmp_version() {
   return ss.str();
 }
 
-static std::string used_cpu_capability() {
+std::string get_cpu_capability() {
   // It is possible that we override the cpu_capability with
   // environment variable
-  std::ostringstream ss;
-  ss << "CPU capability usage: ";
   auto capability = native::get_cpu_capability();
   switch (capability) {
 #if defined(HAVE_VSX_CPU_DEFINITION)
     case native::CPUCapability::DEFAULT:
-      ss << "DEFAULT";
-      break;
+      return "DEFAULT";
     case native::CPUCapability::VSX:
-      ss << "VSX";
-      break;
+      return "VSX";
 #elif defined(HAVE_ZVECTOR_CPU_DEFINITION)
     case native::CPUCapability::DEFAULT:
-      ss << "DEFAULT";
-      break;
+      return "DEFAULT";
     case native::CPUCapability::ZVECTOR:
-      ss << "Z VECTOR";
-      break;
+      return "Z VECTOR";
 #else
     case native::CPUCapability::DEFAULT:
-      ss << "NO AVX";
-      break;
+      return "NO AVX";
     case native::CPUCapability::AVX2:
-      ss << "AVX2";
-      break;
+      return "AVX2";
     case native::CPUCapability::AVX512:
-      ss << "AVX512";
-      break;
+      return "AVX512";
 #endif
     default:
       break;
   }
+  return "";
+}
+
+static std::string used_cpu_capability() {
+  // It is possible that we override the cpu_capability with
+  // environment variable
+  std::ostringstream ss;
+  ss << "CPU capability usage: " << get_cpu_capability();
   return ss.str();
 }
 

--- a/aten/src/ATen/Version.h
+++ b/aten/src/ATen/Version.h
@@ -13,4 +13,6 @@ TORCH_API std::string get_openmp_version();
 
 TORCH_API std::string get_cxx_flags();
 
+TORCH_API std::string get_cpu_capability();
+
 } // namespace at

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -9,6 +9,7 @@ torch.backends
 
 These backends include:
 
+- ``torch.backends.cpu``
 - ``torch.backends.cuda``
 - ``torch.backends.cudnn``
 - ``torch.backends.mps``
@@ -18,6 +19,11 @@ These backends include:
 - ``torch.backends.opt_einsum``
 - ``torch.backends.xeon``
 
+torch.backends.cpu
+^^^^^^^^^^^^^^^^^^^
+.. automodule:: torch.backends.cpu
+
+.. autofunction::  torch.backends.cpu.get_cpu_capability
 
 torch.backends.cuda
 ^^^^^^^^^^^^^^^^^^^

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7438,6 +7438,9 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_parallel_info(self):
         torch.__config__.parallel_info()
 
+    def test_get_cpu_capability(self):
+        torch.backends.cpu.get_cpu_capability()
+
     @slowTest
     def test_slow_test(self):
         # Just a smoketest to make sure our slowTest decorator works.

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -981,6 +981,7 @@ def _crash_if_aten_asan() -> _int: ...  # THPModule_crashIfATenASAN
 def _show_config() -> str: ...  # THPModule_showConfig
 def _cxx_flags() -> str: ...  # THPModule_cxxFlags
 def _parallel_info() -> str: ...  # THPModule_parallelInfo
+def _get_cpu_capability() -> str: ...  # THPModule_getCpuCapability
 def _set_backcompat_broadcast_warn(
     arg: _bool,
 ) -> None: ...  # THPModule_setBackcompatBroadcastWarn

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1393,6 +1393,7 @@ from torch import hub as hub
 from torch import random as random
 from torch import distributions as distributions
 from torch import testing as testing
+import torch.backends.cpu
 import torch.backends.cuda
 import torch.backends.mps
 import torch.backends.cudnn

--- a/torch/backends/cpu/__init__.py
+++ b/torch/backends/cpu/__init__.py
@@ -1,0 +1,17 @@
+import torch
+
+__all__ = ["get_cpu_capability", ]
+
+
+def get_cpu_capability() -> str:
+    r"""Returns cpu capability as a string value.
+
+    Possible values:
+    - "DEFAULT"
+    - "VSX"
+    - "Z VECTOR"
+    - "NO AVX"
+    - "AVX2"
+    - "AVX512"
+    """
+    return torch._C._get_cpu_capability()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -432,6 +432,14 @@ static PyObject* THPModule_parallelInfo(PyObject* module, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPModule_getCpuCapability(
+    PyObject* module,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  return THPUtils_packString(at::get_cpu_capability());
+  END_HANDLE_TH_ERRORS
+}
+
 void DLPack_Capsule_Destructor(PyObject* data) {
   if (C10_LIKELY(!PyCapsule_IsValid(data, "dltensor"))) {
     // early out, see DLPack spec: if a consuming library sets the capsule
@@ -1039,6 +1047,7 @@ static PyMethodDef TorchMethods[] = {
     {"_show_config", THPModule_showConfig, METH_NOARGS, nullptr},
     {"_cxx_flags", THPModule_cxxFlags, METH_NOARGS, nullptr},
     {"_parallel_info", THPModule_parallelInfo, METH_NOARGS, nullptr},
+    {"_get_cpu_capability", THPModule_getCpuCapability, METH_NOARGS, nullptr},
     {"_set_backcompat_broadcast_warn",
      THPModule_setBackcompatBroadcastWarn,
      METH_O,


### PR DESCRIPTION
Description:

- As suggested by Nikita, created `torch.backends.cpu` submodule and exposed `get_cpu_capability`.


- In torchvision Resize method we want to know current cpu capability in order to pick appropriate codepath depending on cpu capablities

Newly coded vectorized resize of uint8 images on AVX2 supported CPUs is now faster than older way (uint8->float->resize->uint8). However, on non-avx hardware (e.g. Mac M1) certain configs are slower using native uint8.

cc @NicolasHug 
