### PR TITLE
Include yaml as PyTorch runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1007,6 +1007,7 @@ def main():
         'networkx',
         'jinja2',
         'fsspec',
+        'yaml',
     ]
 
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -1007,7 +1007,7 @@ def main():
         'networkx',
         'jinja2',
         'fsspec',
-        'yaml',
+        'pyyaml',
     ]
 
     extras_require = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100166

The context behind this change is:
- We're adding a new custom operator API to PyTorch (#99439).
- This depends on `torchgen`, which is included as a part of PyTorch
- `torchgen` depends on the `yaml` project, which is not included as a
runtime dependency
- #99439 breaks the binary CI tests because it needs yaml

There are workarounds I can do, like refactor what I need from torchgen
to not import yaml. But the cleaner solution, because we do ship
torchgen with PyTorch, is to actually include yaml as a runtime
dependency.

Putting up this PR for discussion.