### PR TITLE
add a cast function that suppresses -Wcast-function-type-strict

### DIFF
--- a/torch/csrc/Layout.cpp
+++ b/torch/csrc/Layout.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/unsafe_cast_function.h>
 
 #include <ATen/Layout.h>
 
@@ -35,7 +36,7 @@ PyTypeObject THPLayoutType = {
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
     nullptr, /* tp_reserved */
-    (reprfunc)THPLayout_repr, /* tp_repr */
+    torch::unsafe_cast_function<reprfunc>(THPLayout_repr), /* tp_repr */
     nullptr, /* tp_as_number */
     nullptr, /* tp_as_sequence */
     nullptr, /* tp_as_mapping */

--- a/torch/csrc/utils/pycfunction_helpers.h
+++ b/torch/csrc/utils/pycfunction_helpers.h
@@ -1,13 +1,9 @@
 #pragma once
 
-#include <c10/macros/Macros.h>
+#include <torch/csrc/utils/unsafe_cast_function.h>
 
 #include <Python.h>
 
 inline PyCFunction castPyCFunctionWithKeywords(PyCFunctionWithKeywords func) {
-  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type")
-  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type-strict")
-  return reinterpret_cast<PyCFunction>(func);
-  C10_DIAGNOSTIC_POP()
-  C10_DIAGNOSTIC_POP()
+  return torch::unsafe_cast_function<PyCFunction>(func);
 }

--- a/torch/csrc/utils/unsafe_cast_function.h
+++ b/torch/csrc/utils/unsafe_cast_function.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <type_traits>
+
+#include <c10/macros/Macros.h>
+
+namespace torch {
+
+template <typename To, typename From>
+To unsafe_cast_function(From func) {
+  static_assert(std::is_pointer_v<To>);
+  static_assert(std::is_function_v<std::remove_pointer_t<To>>);
+  static_assert(std::is_pointer_v<From>);
+  static_assert(std::is_function_v<std::remove_pointer_t<From>>);
+
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type")
+  C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wcast-function-type-strict")
+  return reinterpret_cast<To>(func);
+  C10_DIAGNOSTIC_POP()
+  C10_DIAGNOSTIC_POP()
+}
+
+} // namespace torch


### PR DESCRIPTION
add a cast function that suppresses -Wcast-function-type-strict

Summary:
These casts are a necessary evil due to the design of Python. Python
ultimately casts it back to the original type based on the flags
specified in the PyMethodDef.

Nevertheless, the new Clang flag -Wcast-function-type-strict breaks
with this.

Test Plan: Passes builds with Clang 16.

