### PR TITLE
C++ CustomClass in Python: indicate which methods are not implemented

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -206,6 +206,13 @@ ValueError::ValueError(const char* format, ...) {
   va_end(fmt_args);
 }
 
+NotImplementedError::NotImplementedError(const char* format, ...) {
+  va_list fmt_args;
+  va_start(fmt_args, format);
+  msg = formatMessage(format, fmt_args);
+  va_end(fmt_args);
+}
+
 AttributeError::AttributeError(const char* format, ...) {
   va_list fmt_args;
   va_start(fmt_args, format);

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -322,6 +322,7 @@ struct ValueError : public PyTorchError {
 
 // Translates to Python NotImplementedError
 struct NotImplementedError : public PyTorchError {
+  NotImplementedError(const char* format, ...) TORCH_FORMAT_FUNC(2, 3);
   NotImplementedError() = default;
   PyObject* python_type() override {
     return PyExc_NotImplementedError;

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -953,7 +953,10 @@ void initJitScriptBindings(PyObject* module) {
           [mm_name](const Object& self, py::args args, py::kwargs kwargs) {
             auto method = self.find_method(mm_name);
             if (!method) {
-              throw NotImplementedError();
+              throw NotImplementedError(
+                "'%s' is not implemented for %s",
+                mm_name,
+                self.type()->str().c_str());
             }
             return invokeScriptMethodFromPython(
                 *method,

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -954,9 +954,9 @@ void initJitScriptBindings(PyObject* module) {
             auto method = self.find_method(mm_name);
             if (!method) {
               throw NotImplementedError(
-                "'%s' is not implemented for %s",
-                mm_name,
-                self.type()->str().c_str());
+                  "'%s' is not implemented for %s",
+                  mm_name,
+                  self.type()->str().c_str());
             }
             return invokeScriptMethodFromPython(
                 *method,


### PR DESCRIPTION
Without these changes, it can be hard to know which magic methods are not implemented on a given ScriptObject. 


before:
```py
torch.ops.load_library("somelib.so")
c = torch.classes.somelib.SomeClass()
print(len(c))
# raise NotImplementedError
```

after:
```py
torch.ops.load_library("somelib.so")
c = torch.classes.somelib.SomeClass()
print(len(c))
# raise NotImplementedError: '__len__' is not implemented for __torch__.torch.classes.somelib.SomeClass
```

------

I could not find a linked issue, if you want me to open one as well I can do this.
