### PR TITLE
Do not use `--extra-index-url` in testing wheels

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -95,7 +95,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
     conda install \${EXTRA_CONDA_FLAGS} -y "\$pkg" --offline
   )
 elif [[ "$PACKAGE_TYPE" != libtorch ]]; then
-  pip install "\$pkg" --extra-index-url "https://download.pytorch.org/whl/nightly/${DESIRED_CUDA}"
+  pip install "\$pkg" --index-url "https://download.pytorch.org/whl/nightly/${DESIRED_CUDA}"
   retry pip install -q numpy protobuf typing-extensions
 fi
 if [[ "$PACKAGE_TYPE" == libtorch ]]; then

--- a/scripts/install_triton_wheel.sh
+++ b/scripts/install_triton_wheel.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Updates Triton to the pinned version for this copy of PyTorch
-pip install --extra-index-url https://download.pytorch.org/whl/nightly/ "pytorch-triton==$(cat .ci/docker/triton_version.txt)+$(head -c 10 .ci/docker/ci_commit_pins/triton.txt)"
+pip install --index-url https://download.pytorch.org/whl/nightly/ "pytorch-triton==$(cat .ci/docker/triton_version.txt)+$(head -c 10 .ci/docker/ci_commit_pins/triton.txt)"


### PR DESCRIPTION
Should prevent regressions like the ones reported in  https://github.com/pytorch/pytorch/issues/100104 from sneaking undetected.

Same for `install_triton_wheel.sh` - always use packages from https://download.pytorch.org/whl/

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at deda821</samp>

> _`pip install` changed_
> _Only use PyTorch nightly_
> _Snowflake packages_
