### PR TITLE
Support expandable_segments:True in fbcode for caching allocator

### DIFF
--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -19,7 +19,7 @@ def define_targets(rules):
                 "CUDAMacros.h",
             ],
         ),
-        defines = ["USE_CUDA"],
+        defines = ["USE_CUDA", "PYTORCH_C10_DRIVER_API_SUPPORTED"],
         linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         target_compatible_with = rules.requires_cuda_enabled(),

--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -1,4 +1,4 @@
-def define_targets(rules):
+def define_targets(rules, extra_defines=[]):
     rules.cc_library(
         name = "cuda",
         srcs = rules.glob(
@@ -19,7 +19,7 @@ def define_targets(rules):
                 "CUDAMacros.h",
             ],
         ),
-        defines = ["USE_CUDA", "PYTORCH_C10_DRIVER_API_SUPPORTED"],
+        defines = ["USE_CUDA"] + extra_defines,
         linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         target_compatible_with = rules.requires_cuda_enabled(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100184

Now that expandable_segments has been merged from OSS, we can enable it in the internal build. It still defaults to off, so this should not change any behavior changes in the allocator unless the flag is explicitly set.

Differential Revision: [D45249535](https://our.internmc.facebook.com/intern/diff/D45249535/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D45249535/)!