### PR TITLE
Introduce aggressive merge to `CapabilityPartitioner`

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -231,8 +231,7 @@ class TestPartitionFunctions:
     def forward17(a, b, c, d):
         a0 = a + b
         a1 = c + d
-        out = torch.stack([a0, a1])
-        return out
+        return (a0, a1)
 
 # A mock OperatorSupport class, where only operator.add is supported
 class MockOperatorSupport(OperatorSupport):

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -39,6 +39,7 @@ class CapabilityBasedPartitioner:
                  allows_single_node_partition: bool = False,
                  non_compute_ops: Optional[Sequence[str]] = None,
                  allowed_single_node_partition_ops: Optional[Sequence[str]] = None,
+                 aggressive_merge: Optional[bool] = False,
                  ) -> None:
         self.graph_module = graph_module
         self.operator_support = operator_support
@@ -49,6 +50,7 @@ class CapabilityBasedPartitioner:
             if allowed_single_node_partition_ops is not None
             else []
         )
+        self.aggressive_merge = aggressive_merge
 
     def __is_node_supported(self, node: Node) -> bool:
         return (
@@ -164,6 +166,18 @@ class CapabilityBasedPartitioner:
                     # it doesn't create cyclic dependency in the graph, otherwise,
                     # this is a no-op
                     maybe_merge_partition(self_id, other_id)
+
+        # merge the candidates aggressively
+        if self.aggressive_merge:
+            merge_candidates_list = list(set(assignment.values()))
+            while True:
+                size = len(merge_candidates_list)
+                self_id = merge_candidates_list[0]
+                for other_id in merge_candidates_list[1:]:
+                    maybe_merge_partition(self_id, other_id)
+                new_size = len(merge_candidates_list)
+                if new_size == size:
+                    break
 
         # post processing to re-assign "getitem" nodes into upstream partition
         logger.debug("Reassigning getitem nodes to its producer node's partition...")


### PR DESCRIPTION
With the old partitioner, suppose `add` is supported, the following code
```python
def fn(a, b, c, d):
    x = a + b # add
    y = c + d # add_1
    return (x, y)

traced = symbolic_trace(fn)
partitioner = CapabilityBasedPartitioner(traced, supported_ops, allows_single_node_partition=True)
partitions = partitioner.propose_partitions()
```
results in the partitions `[[add], [add_1]]`. However, since these two partitions do not depend on each other, they can be aggressively merged into a single partition `[[add, add_1]]` without causing any issues. This PR introduces a new feature that allows such aggressive merging by introducing an option `aggressive_merge` to the Partitioner class.
