### PR TITLE
File level rerun changes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -255,6 +255,6 @@ class StepcurrentPlugin:
             return f"stepcurrent: {self.report_status}"
         return None
 
-    def pytest_runtest_logreport(self, report: TestReport) -> None:
-        self.lastrun = report.nodeid
+    def pytest_runtest_protocol(self, item, nextitem) -> None:
+        self.lastrun = item.nodeid
         self.cache.set(self.directory, self.lastrun)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -545,10 +545,7 @@ def run_test(
     os.close(log_fd)
 
     command = (launcher_cmd or []) + executable + argv
-    should_file_rerun = (
-        "--subprocess" not in command
-        and not RERUN_DISABLED_TESTS
-    )
+    should_file_rerun = "--subprocess" not in command and not RERUN_DISABLED_TESTS
     timeout = THRESHOLD * 3 if should_file_rerun else None
     print_to_stderr("Executing {} ... [{}]".format(command, datetime.now()))
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -548,8 +548,6 @@ def run_test(
     should_file_rerun = (
         "--subprocess" not in command
         and not RERUN_DISABLED_TESTS
-        and isinstance(test_module, ShardedTest)
-        and test_module.time is not None
     )
     timeout = THRESHOLD * 3 if should_file_rerun else None
     print_to_stderr("Executing {} ... [{}]".format(command, datetime.now()))

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -560,7 +560,7 @@ def run_test(
             stderr=f,
             env=env,
             timeout=timeout,
-            retries=1 if should_file_rerun else 0,
+            retries=2 if should_file_rerun else 0,
         )
 
         # Pytest return code 5 means no test is collected. This is needed


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
* change hook so that test still gets saved in --sc when fails in test setup (caused an off by 1 error due to setup being called before the logreport hook)
* allow reruns for all tests now that --sc is used
* increase number of reruns now that --sc is used