### PR TITLE
[CUDA] Switch to `at::empty_like` in `adaptive_avg_pool3d_backward_cuda`

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -15,7 +15,7 @@
 #include <ATen/ops/adaptive_avg_pool3d_backward_native.h>
 #include <ATen/ops/adaptive_avg_pool3d_native.h>
 #include <ATen/ops/empty.h>
-#include <ATen/ops/zeros_like.h>
+#include <ATen/ops/empty_like.h>
 #endif
 
 #include <ATen/native/AdaptivePooling.h>
@@ -537,7 +537,7 @@ Tensor adaptive_avg_pool3d_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("adaptive_avg_pool3d_backward_cuda");
-  auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto gradInput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   adaptive_avg_pool3d_backward_out_cuda_template(gradInput, gradOutput_, input);
   return gradInput;
 }

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -636,7 +636,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("max_pool3d_with_indices_backward_cuda");
-  auto gradInput = at::empty_like(input, MemoryFormat::Preserve);
+  auto gradInput = at::empty(input, input.options());
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -635,7 +635,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("max_pool3d_with_indices_backward_cuda");
-  auto gradInput = at::empty(input, input.options());
+  auto gradInput = at::empty(input.sizes(), input.options());
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -21,7 +21,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/max_pool3d_with_indices_native.h>
 #include <ATen/ops/max_pool3d_with_indices_backward_native.h>
-#include <ATen/ops/zeros_like.h>
+#include <ATen/ops/empty_like.h>
 #endif
 
 namespace at::native {
@@ -636,7 +636,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("max_pool3d_with_indices_backward_cuda");
-  auto gradInput = at::empty(input.sizes(), input.options());
+  auto gradInput = at::empty_like(input);
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -636,7 +636,7 @@ Tensor max_pool3d_with_indices_backward_cuda(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("max_pool3d_with_indices_backward_cuda");
-  auto gradInput = at::empty_like(input);
+  auto gradInput = at::empty_like(input, MemoryFormat::Preserve);
   max_pool3d_with_indices_backward_out_cuda_template(
     gradInput,
     gradOutput,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -21,7 +21,6 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/max_pool3d_with_indices_native.h>
 #include <ATen/ops/max_pool3d_with_indices_backward_native.h>
-#include <ATen/ops/empty_like.h>
 #endif
 
 namespace at::native {


### PR DESCRIPTION
Same as #100138, `gradInput` is already zero'd out. Also clean up includes after #100138.

CC @ngimel @ptrblck 

cc @ngimel