### PR TITLE
[PG Wrapper] Enhance error msg

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -33,7 +33,7 @@ struct CollectiveFingerPrint {
   std::vector<std::vector<int64_t>> tensor_sizes_;
   int sequence_number_;
 
-  explicit CollectiveFingerPrint(
+  CollectiveFingerPrint(
       OpType op_type,
       const std::vector<at::Tensor>& input_tensors,
       int sequence_number)
@@ -53,11 +53,13 @@ struct CollectiveFingerPrint {
   // Constructor for the data received from deserialized fingerprint
   CollectiveFingerPrint(
       OpType op_type,
+      size_t num_tensors,
       std::vector<int8_t> tensor_dtypes,
       std::vector<int8_t> tensor_device_types,
       std::vector<std::vector<int64_t>> tensor_sizes,
       int sequence_number)
       : op_type_(op_type),
+        num_tensors_(num_tensors),
         tensor_dtypes_(std::move(tensor_dtypes)),
         tensor_device_types_(std::move(tensor_device_types)),
         tensor_sizes_(std::move(tensor_sizes)),
@@ -97,12 +99,12 @@ struct CollectiveFingerPrint {
     // 1. OpType
     optype = OpType(serialized_tensor[index].item<int>());
     index++;
-
+    int num_tensors = 0;
     if (index < serialized_tensor.size(0)) {
       seq = serialized_tensor[index].item<int64_t>();
       index++;
       // 2. Num tensors
-      int num_tensors = serialized_tensor[index].item<int>();
+      num_tensors = serialized_tensor[index].item<int>();
       index++;
       dtypes.reserve(num_tensors);
       device_types.reserve(num_tensors);
@@ -133,7 +135,8 @@ struct CollectiveFingerPrint {
         sizes.push_back(shapeVec);
       }
     }
-    return CollectiveFingerPrint(optype, dtypes, device_types, sizes, seq);
+    return CollectiveFingerPrint(
+        optype, num_tensors, dtypes, device_types, sizes, seq);
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100214
* __->__ #100213

Previously, the mismatch report would not give the full details of the
collective running on the mismatched rank, it would look something like:

```
Detected mismatch between collectives on ranks. Rank 26 is running collective: CollectiveFingerPrint(SequenceNumber=683057617, OpType=BROADCAST, TensorShape=[1], TensorDtypes=Long, TensorDeviceTypes=TensorOptions(dtype=float (default), device=cpu, layout=Strided (default), requires_grad=false (default), pinned_memory=false (default), memory_format=(nullopt))), but Rank 1 is running collective: CollectiveFingerPrint(SequenceNumber=513876813OpType=BROADCAST).
```

i.e. Rank 1 is missing more details such as the shape, type etc.


This was due to `num_tensors` field not being populated, which operator<<
checks to determine whether to print additional information such as the tensor
shape.

Adding this field gives a better error:

```
Detected mismatch between collectives on ranks. Rank 0 is run     ning collective: CollectiveFingerPrint(SequenceNumber=1564312518, OpType=ALLREDUCE     , TensorShape=[20, 10], TensorDtypes=Float, TensorDeviceTypes=TensorOptions(dtype=     float (default), device=cpu, layout=Strided (default), requires_grad=false (defaul     t), pinned_memory=false (default), memory_format=(nullopt))), but Rank 1 is runnin     g collective: CollectiveFingerPrint(SequenceNumber=1564312518, OpType=REDUCE, Tens     orShape=[20, 10], TensorDtypes=Float, TensorDeviceTypes=TensorOptions(dtype=float      (default), device=cpu, layout=Strided (default), requires_grad=false (default), pi     nned_memory=false (default), memory_format=(nullopt))).
```

Differential Revision: [D45372325](https://our.internmc.facebook.com/intern/diff/D45372325/)