### PR TITLE
[replicate] support simpler device_id

### DIFF
--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -214,6 +214,7 @@ class ReplicateTest(MultiProcessTestCase):
         )
         self._compare_module(model, replicate_model)
 
+    @skip_if_lt_x_gpu(2)
     def test_replicate_device_id(self):
         dist.init_process_group(
             backend="gloo",

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 import weakref
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -28,7 +28,9 @@ def replicate(
     torch._C._log_api_usage_once("torch.distributed.replicate")
     if "device_id" in kwargs:
         if not isinstance(kwargs["device_id"], (int, torch.device)):
-            raise RuntimeError(f"Expected device_id to be int or torch.device, but got {type(kwargs['device_id'])}")
+            raise RuntimeError(
+                f"Expected device_id to be int or torch.device, but got {type(kwargs['device_id'])}"
+            )
     _ReplicateState(ignored_modules=ignored_modules).mark_module(module, **kwargs)
     return module
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100217
* #100216
* #100131

Allow passing in `device_id=[device]` regardless of CPU or GPU. We
modify the kwarg as needed to pass to DDP.