### PR TITLE
[functorch] make disable_proxy_modes_tracing work for map and cond

### DIFF
--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -138,8 +138,10 @@ def inner(pred, true_fn, false_fn, operands):
     mode = _get_current_dispatch_mode()
     assert (mode is not None), "Mode should always be enabled for python fallback key"
     with _pop_mode_temporarily() as mode:
-        res = trace_cond(mode, cond, pred, true_fn, false_fn, operands)
-    return res
+        if mode.enable_tracing:
+            return trace_cond(mode, cond, pred, true_fn, false_fn, operands)
+        else:
+            return cond(pred, true_fn, false_fn, operands)
 
 
 @cond.py_impl(FakeTensorMode)

--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -82,9 +82,10 @@ def map_proxy_torch_dispatch_mode(f, xs, *args):
     mode = _get_current_dispatch_mode()
     assert (mode is not None), "Mode should always be enabled for python fallback key"
     with _pop_mode_temporarily() as mode:
-        res = trace_map(mode, map, f, xs, *args)
-    return res
-
+        if mode.enable_tracing:
+            return trace_map(mode, map, f, xs, *args)
+        else:
+            return map(f, xs, *args)
 
 @map.py_impl(FakeTensorMode)
 def map_fake_tensor_mode(f, xs, *args):


### PR DESCRIPTION
This pr makes map and cond respect disable_proxy_modes_tracing. Before that, even if we call diable_proxy_modes_tracing, control flow operators will still get traced.