### PR TITLE
Remove torch checks from kernels

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -553,6 +553,10 @@ inline void validate_sdpa_input(
       query_.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
       "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
       query_.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead.");
+  TORCH_CHECK(
+      (key.is_nested() || value.is_nested()) || key.sym_size(-2) == value.sym_size(-2),
+      "Expected key and value to have the same sequence length, but got key.size(-2): ",
+      key.sym_size(-2), " and value.size(-2): ", value.sym_size(-2), " instead.");
   if (attn_mask_.has_value()){
     auto mask_dtype = attn_mask_->dtype();
     TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == query_.dtype(),

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -873,23 +873,18 @@ std::tuple<at::Tensor, at::Tensor> _efficient_attention_forward(
 // TODO In theory it is possible to compile with _CUDA_ARCH < 5.0 and run on a
 // machine that is >= 5.0. In practice, this is not a problem but since
 // this would avoid runtime architecture checks, we should look into it
-  TORCH_CHECK(query.dim() == 4);
-  TORCH_CHECK(key.dim() == 4);
-  TORCH_CHECK(value.dim() == 4);
 
-  // Batch sizes
-  TORCH_CHECK(query.size(0) == key.size(0));
-  TORCH_CHECK(query.size(0) == value.size(0));
-
+  // Sanity Checks
+  // We techincally check a different dim than transpose, so in theory
+  // we could have mismatch but probs should remove
   // Sequence length
+  // {
   TORCH_CHECK(key.size(1) == value.size(1));
 
   // Num heads
   TORCH_CHECK(query.size(2) == key.size(2));
   TORCH_CHECK(query.size(2) == value.size(2));
-
-  // Embedding per head
-  TORCH_CHECK(query.size(3) == key.size(3));
+  //  }
 
   int64_t max_seqlen_q = 0, max_seqlen_k=0;
   TORCH_CHECK(cu_seqlens_q.has_value() == cu_seqlens_k.has_value());

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
@@ -228,9 +228,6 @@ mha_fwd(const at::Tensor &q,         // total_q x num_heads x head_size, total_q
     TORCH_CHECK(cu_seqlens_q.dtype() == at::kInt);
     TORCH_CHECK(cu_seqlens_k.dtype() == at::kInt);
 
-    TORCH_CHECK(q.is_cuda());
-    TORCH_CHECK(k.is_cuda());
-    TORCH_CHECK(v.is_cuda());
     TORCH_CHECK(out.is_cuda());
     TORCH_CHECK(cu_seqlens_q.is_cuda());
     TORCH_CHECK(cu_seqlens_k.is_cuda());
@@ -238,7 +235,7 @@ mha_fwd(const at::Tensor &q,         // total_q x num_heads x head_size, total_q
     TORCH_CHECK(q.stride(-1) == 1);
     TORCH_CHECK(k.stride(-1) == 1);
     TORCH_CHECK(v.stride(-1) == 1);
-    TORCH_CHECK(cu_seqlens_k.is_contiguous());
+    TORCH_CHECK(cu_seqlens_q.is_contiguous());
     TORCH_CHECK(cu_seqlens_k.is_contiguous());
 
     const auto sizes = q.sizes();
@@ -248,8 +245,6 @@ mha_fwd(const at::Tensor &q,         // total_q x num_heads x head_size, total_q
     const int num_heads = sizes[H_DIM];
     const int head_size = sizes[D_DIM];
     const int total_k = k.size(TOTAL_DIM);
-    TORCH_CHECK(batch_size > 0);
-    TORCH_CHECK((head_size % 8 == 0) && (head_size <= 128));
 
     CHECK_SHAPE(q, total_q, num_heads, head_size);
     CHECK_SHAPE(k, total_k, num_heads, head_size);

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -20,6 +20,26 @@
 
 namespace sdp {
 namespace {
+/**
+* Note [SDPA Runtime Dispatch]
+* SDPA relies on a runtime dispatch mechanism to select the appropriate
+* kernel. This file contains exposes this through the `select_sdp_backend`
+* The basic structure of this function is to call `priority_order` to get a
+* list of backends to try, and then iterate through them until one succeeds.
+* Each backend defines a use_<backend> function that returns true if the
+* backend can be run with the given SDP parameters. The use_<backend> function
+* will iterate over a list of "filters" that check for specific properties of
+* the SDP parameters. If all filters pass, the backend can be used and use_<backend>
+* returns true. If any filter fails, then use_<backend> returns false.
+*
+* In order to aid in debugging, each filter takes sdp_params and a debug flag.
+* If the debug flag is set, the filter will print a warning message if it fails.
+* The behavior of select_sdp_backend is to return the first backend that
+* succeeds. If no backend is viable then it will run each use_<backend> function
+* with debug=true and return SDPBackend::error.
+*/
+
+
 // This helper function creates a constexpr std::array
 // From a compile time list of values
 template <typename V, typename... T>
@@ -562,60 +582,7 @@ bool check_use_deterministic_algorithms(sdp_params params, bool debug) {
   // Determinism is not set so we can use the kernel.
   return true;
 }
-// bool flash_forward_checks(sdp_params params, bool debug){
-//     auto dprops = at::cuda::getCurrentDeviceProperties();
-//     bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
-//     bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
-//     bool is_sm90 = dprops->major == 9 && dprops->minor == 0;
-//     TORCH_CHECK(is_sm90 || is_sm8x || is_sm75);
-//     auto q_dtype = params.query.dtype();
-//     TORCH_CHECK(q_dtype == at::kHalf || (is_sm8x && q_dtype == at::kBFloat16));
-//     TORCH_CHECK(params.key.dtype() == q_dtype);
-//     TORCH_CHECK(params.value.dtype() == q_dtype);
-//     TORCH_CHECK(out.dtype() == q_dtype);
-//     TORCH_CHECK(cu_seqlens_q.dtype() == at::kInt);
-//     TORCH_CHECK(cu_seqlens_k.dtype() == at::kInt);
-//     // This is taken care of validate_sdpa_input attention.cpp
-//     // TORCH_CHECK(q.is_cuda());
-//     // TORCH_CHECK(k.is_cuda());
-//     // TORCH_CHECK(v.is_cuda());
 
-
-
-//     // This is taken care of in check_head_dim_size
-//     // TORCH_CHECK(q.stride(-1) == 1);
-//     // TORCH_CHECK(k.stride(-1) == 1);
-//     // TORCH_CHECK(v.stride(-1) == 1);
-
-//     // These would be sanity checks
-//     TORCH_CHECK(cu_seqlens_k.is_contiguous());
-//     TORCH_CHECK(cu_seqlens_k.is_contiguous());
-//     TORCH_CHECK(out.is_cuda());
-//     TORCH_CHECK(cu_seqlens_q.is_cuda());
-//     TORCH_CHECK(cu_seqlens_k.is_cuda());
-//     CHECK_SHAPE(q, total_q, num_heads, head_size);
-//     CHECK_SHAPE(k, total_k, num_heads, head_size);
-//     CHECK_SHAPE(v, total_k, num_heads, head_size);
-//     CHECK_SHAPE(out, total_q, num_heads, head_size);
-//     CHECK_SHAPE(cu_seqlens_q, batch_size + 1);
-//     CHECK_SHAPE(cu_seqlens_k, batch_size + 1);
-
-//     const auto sizes = q.sizes();
-
-//     // We should en
-//     const int batch_size = cu_seqlens_q.numel() - 1;
-//     const int total_q = sizes[TOTAL_DIM];
-//     const int num_heads = sizes[H_DIM];
-//     const int head_size = sizes[D_DIM];
-//     const int total_k = k.size(TOTAL_DIM);
-//     // We should add this to check_shape
-//     TORCH_CHECK(batch_size > 0);
-//     // check_head_dim_size
-//     // TORCH_CHECK((head_size % 8 == 0) && (head_size <= 128));
-
-
-//     return true;
-// }
 bool use_flash_attention(sdp_params params, bool debug) {
 #ifndef USE_FLASH_ATTENTION
   TORCH_CHECK(!debug, "Torch was not compiled with flash attention.");


### PR DESCRIPTION
### Summary
Clean up redundant checks in the fused kernel impls to decrease mismatch surface