### PR TITLE
Fix comment error in TensorIterator.cpp

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -622,7 +622,7 @@ void TensorIteratorBase::coalesce_dimensions() {
   }
 
   // We can coalesce two adjacent dimensions if either dim has size 1 or if:
-  // shape[n] * stride[n] == shape[n + 1].
+  // shape[n] * stride[n] == stride[n + 1].
   auto can_coalesce = [&](int dim0, int dim1) {
     auto shape0 = shape_[dim0];
     auto shape1 = shape_[dim1];


### PR DESCRIPTION
Fixes comment error in TensorIterator.cpp

I believe there is an error in the comment, based on the following code snippet
```c++
if (shape0 * stride[dim0] != stride[dim1]) {
        return false;
}
```
I have corrected the comment accordingly. Please let me know if any further action is required.
