### PR TITLE
Use `[[maybe_unused]]` in `VariableType_[0-4].cpp`

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -580,9 +580,8 @@ std::vector<std::shared_ptr<${op}>> grad_fns;
 
 SETUP_ANY_REQUIRES_GRAD = CodeTemplate(
     """\
-auto _any_requires_grad = compute_requires_grad( ${args_with_derivatives} );
+[[maybe_unused]] auto _any_requires_grad = compute_requires_grad( ${args_with_derivatives} );
 ${extra_differentiability_conditions}
-(void)_any_requires_grad;
 """
 )
 


### PR DESCRIPTION
This is kind of trivial, as per title.

Removing `(void)_any_requires_grad` and giving `[[maybe_unused]]` attribute to that variable.