### PR TITLE
catching the correct exception

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -562,7 +562,7 @@ def _store_based_barrier(rank, store, group_name, rendezvous_count, timeout, log
             # the status of the group or time out officially, throwing runtime error
             store.wait([last_worker_key], logging_interval)
             break
-        except RuntimeError as e:
+        except Exception as e:
             worker_count = store.add(store_key, 0)
             # Print status periodically to keep track.
             logger.info(


### PR DESCRIPTION
Summary
------------

Somehow in `distributed_c10d.py`,  `StoreHandlerTimeoutError` is not getting converted to `RuntimeException`.
Instead of catching `RuntimeException`, we are not catching the correct exception so no conversion is necessary.

We are seeing the following line in the runs:

```
torch.fb.rendezvous.zeus_lib.StoreHandlerTimeoutError: [fbcode/caffe2/caffe2/fb/distribute/lib/ZeusStoreHandler.cpp:237]
Wait timeout for name(s): default_pg/store_based_barrier_key:1:last_worker
```

But if you look carefully in the code, this exception should be caught in `caffe2/torch/distributed/distributed_c10d.py:496` as `RuntimeError`. 

Somehow the `StoreHandlerTimeoutError` is not getting caught as such. This could be due to loading multiple, replicated definitions of the error in pybindings, the code is peppered with these or some other reason. 

Again, we are catching the direct error instead of its base class.
the code is linking with `caffe2/torch/distributed/elastic/rendezvous/fb/zeus.cpp` which also defines the `ZeusStoreHandlerError` but does not define it as `RuntimeError` which may be the source of the trouble as the initialization of pybind is nondeterministic. The correct definition is in `fbcode/caffe2/torch/fb/rendezvous/zeus.cpp`

Test Plan
--------------
Regular tests & multiple tests of 
```
$ flow-cli clone f431528892 --run-as-secure-group ai_user_understanding
```

for various flows

Differential Revision: D45323074

