### PR TITLE
Add aten.smooth_l1_loss_backward to core_aten_decompositions

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -299,6 +299,7 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.silu_backward,
             aten.sinc,
             aten.slice_backward,
+            aten.smooth_l1_loss_backward,
             aten.soft_margin_loss,
             aten.soft_margin_loss_backward,
             aten._softmax,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100267

Summary: https://github.com/pytorch/pytorch/pull/100242 didn't cover all
test failures