### PR TITLE
[WIP][JIT] prim::AddStatValue - mark schema as having side effects

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -357,7 +357,7 @@ RegisterOperators logging_operators(
            }
            torch::jit::logging::getLogger()->addStatValue(*key, val);
          },
-         aliasAnalysisFromSchema()),
+         aliasAnalysisConservative()),
      Operator(
          "prim::TimePoint() -> int",
          [](Stack& stack) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100269

Mark as side-effectful, because logging == side effects.