### PR TITLE
fix(docs): torch.autograd.graph.Node.register_hook can override grad_inputs, not grad_outputs

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -58,7 +58,7 @@ class Node(abc.ABC):
 
 
         The hook should not modify its argument, but it can optionally return
-        a new gradient which will be used in place of :attr:`grad_outputs`.
+        a new gradient which will be used in place of :attr:`grad_inputs`.
 
         This function returns a handle with a method ``handle.remove()``
         that removes the hook from the module.


### PR DESCRIPTION
Fixes #99165
