### PR TITLE
Add missing smooth_l1_loss_backward decomposition

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -36,6 +36,7 @@ inductor_decompositions = get_decompositions(
         aten.tril_indices,
         aten.triu_indices,
         aten.unsafe_split,
+        aten.smooth_l1_loss_backward,
     ]
 )
 decompositions = {**core_aten_decompositions(), **inductor_decompositions}


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/99429 and  https://github.com/pytorch/pytorch/pull/100242, forward fixing an issue introduced by https://github.com/pytorch/pytorch/pull/99429

Fix based on the error message:
```
There is a decomposition available for aten.smooth_l1_loss_backward.default in torch._decomp.get_decompositions(). 
Please add this operator to the `decompositions` list in torch._inductor.decompositions
```

Fixes https://github.com/pytorch/pytorch/issues/100280

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire