### PR TITLE
Add condition in @slowTest decorator

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -21,7 +21,8 @@ torch._C._jit_set_profiling_executor(True)
 torch._C._get_graph_executor_optimize(True)
 
 from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR, \
-    enable_profiling_mode_for_profiling_tests, slowTest, skipIfTorchDynamo, TEST_WITH_ASAN
+    enable_profiling_mode_for_profiling_tests, slowTest, skipIfTorchDynamo, TEST_WITH_ASAN, \
+    slowTestIf
 from torch.testing._internal.jit_utils import JitTestCase, \
     RUN_CUDA, RUN_CUDA_HALF, RUN_CUDA_MULTI_GPU, warmup_backward, set_fusion_group_inlining, \
     clone_inputs, get_traced_sample_variant_pairs, TensorExprTestOptions, NoTracerWarnContextManager
@@ -1749,6 +1750,7 @@ class TestTEFuser(JitTestCase):
                     " ".join(["Failed:", str(dtype), op.__name__, device])
                 ) from e
 
+    @slowTestIf(TEST_WITH_ASAN)
     def test_ternary_norm_ops(self):
         def apply(fn):
             return lambda x, y, z: fn(x, y, z)
@@ -2255,6 +2257,7 @@ class TestTEFuser(JitTestCase):
         torch._C._jit_pass_inline(g)
         FileCheck().check_count("prim::If", 1, exactly=True).run(g)
 
+    @slowTestIf(TEST_WITH_ASAN)
     def test_dynamic_shapes(self):
         from functools import partial
         n = 10

--- a/third_party/nvfuser/python_tests/test_torchscript.py
+++ b/third_party/nvfuser/python_tests/test_torchscript.py
@@ -3383,6 +3383,7 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
+    @slowTest
     def test_batch_norm_impl_index_correctness(self):
         with torch.backends.cudnn.flags(enabled=True):
             batch = [2, 7, 16]

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1388,9 +1388,12 @@ def slowTest(fn):
     return wrapper
 
 
-def slowAwareTest(fn):
-    fn.__dict__['slow_test'] = True
-    return fn
+def slowTestIf(condition=True):
+    def dec(fn):
+        if condition:
+            return slowTest(fn)
+        return fn
+    return dec
 
 
 def skipCUDAMemoryLeakCheckIf(condition):


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Change slow test decorator so that it can take in a condition

Add slow tests
* test_dynamic_shapes and test_ternary_norm_ops in test_jit_fuser_te.py for asan (takes 5+ min)
* test_batch_norm_impl_index_correctness in test_jit_cuda_fuser.py (takes ~5 min)
