### PR TITLE
[inductor] Prevent reusing aliased buffers if aliases still have uses

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1818,7 +1818,7 @@ class CommonTemplate:
         def fn(x, y):
             x = 2 * x
             y = 2 * y
-            c = torch.cat([x, y], dim = -1)
+            c = torch.cat([x, y], dim=-1)
             d = 1 + c
             m = torch.mm(d, d)
             return m[:, :2] + x

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1814,6 +1814,17 @@ class CommonTemplate:
             self.assertFalse("= as_strided(" in code)
             self.assertEqual(run(*v), mod(*v))
 
+    def test_aliased_buffer_reuse(self):
+        def fn(x, y):
+            x = 2 * x
+            y = 2 * y
+            c = torch.cat([x, y], dim = -1)
+            d = 1 + c
+            m = torch.mm(d, d)
+            return m[:, :2] + x
+
+        self.common(fn, (torch.randn(4, 2), torch.randn(4, 2)), check_lowp=False)
+
     def test_view_detach(self):
         def fn(a):
             return a[0].detach()

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -270,6 +270,7 @@ test_failures = {
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
     # test_roi_align uses torchvision, which doesn't work with dynamic shapes
     "test_roi_align_dynamic_shapes": TestFailure(("cpu", "cuda")),
+    "test_aliased_buffer_reuse_dynamic_shapes": TestFailure(("cpu",))
 }
 
 

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -270,7 +270,7 @@ test_failures = {
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
     # test_roi_align uses torchvision, which doesn't work with dynamic shapes
     "test_roi_align_dynamic_shapes": TestFailure(("cpu", "cuda")),
-    "test_aliased_buffer_reuse_dynamic_shapes": TestFailure(("cpu",))
+    "test_aliased_buffer_reuse_dynamic_shapes": TestFailure(("cpu",)),
 }
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -677,6 +677,10 @@ class WrapperCodeGen(CodeGen):
     def codegen_free(self, buffer):
         name = buffer.get_name()
 
+        if not config.allow_buffer_reuse:
+            self.writeline(self.make_buffer_free(buffer))
+            return
+
         # can be freed but not reused
         if isinstance(buffer, ir.InputBuffer):
             self.writeline(self.make_buffer_free(buffer))

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -30,6 +30,9 @@ pick_loop_orders = True
 # generate inplace computations
 inplace_buffers = True
 
+# allow reusing buffers for more efficient memory use
+allow_buffer_reuse = True
+
 # codegen benchmark harness
 benchmark_harness = True
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -534,7 +534,7 @@ class FusedSchedulerNode(BaseSchedulerNode):
     @cache_on_self
     def used_or_aliased_buffer_names(self) -> Set[str]:
         return functools.reduce(
-            set.union, [x.used_or_aliased_buffer_names() for x in self.snodes]
+            set.union, (x.used_or_aliased_buffer_names() for x in self.snodes)
         )
 
     def get_nodes(self) -> List[BaseSchedulerNode]:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -141,7 +141,6 @@ class BaseSchedulerNode:
                     used_names.add(layout.view.data.get_name())
         return used_names
 
-
     def prune_deps(self):
         self.unmet_dependencies = {
             dep
@@ -532,8 +531,9 @@ class FusedSchedulerNode(BaseSchedulerNode):
 
     @cache_on_self
     def used_or_aliased_buffer_names(self) -> Set[str]:
-        return functools.reduce(set.union, [x.used_or_aliased_buffer_names() for x in self.snodes])
-
+        return functools.reduce(
+            set.union, [x.used_or_aliased_buffer_names() for x in self.snodes]
+        )
 
     def get_nodes(self) -> List[BaseSchedulerNode]:
         return self.snodes

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -137,6 +137,8 @@ class BaseSchedulerNode:
             used_names.add(dep.name)
             if V.graph.name_to_buffer.get(dep.name):
                 layout = V.graph.name_to_buffer[dep.name].get_layout()
+                # needed to avoid deallocating aliased buffer
+                # if there are still uses of aliases ahead
                 if isinstance(layout, ir.AliasedLayout):
                     used_names.add(layout.view.data.get_name())
         return used_names

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -131,6 +131,17 @@ class BaseSchedulerNode:
             for dep in itertools.chain(self.read_writes.reads, self.read_writes.writes)
         }
 
+    def used_or_aliased_buffer_names(self) -> Set[str]:
+        used_names = set()
+        for dep in itertools.chain(self.read_writes.reads, self.read_writes.writes):
+            used_names.add(dep.name)
+            if V.graph.name_to_buffer.get(dep.name):
+                layout = V.graph.name_to_buffer[dep.name].get_layout()
+                if isinstance(layout, ir.AliasedLayout):
+                    used_names.add(layout.view.data.get_name())
+        return used_names
+
+
     def prune_deps(self):
         self.unmet_dependencies = {
             dep
@@ -518,6 +529,11 @@ class FusedSchedulerNode(BaseSchedulerNode):
     @cache_on_self
     def used_buffer_names(self) -> Set[str]:
         return functools.reduce(set.union, [x.used_buffer_names() for x in self.snodes])
+
+    @cache_on_self
+    def used_or_aliased_buffer_names(self) -> Set[str]:
+        return functools.reduce(set.union, [x.used_or_aliased_buffer_names() for x in self.snodes])
+
 
     def get_nodes(self) -> List[BaseSchedulerNode]:
         return self.snodes
@@ -1079,7 +1095,7 @@ class Scheduler:
             future_used_buffers.add(node_name)
 
         for node in reversed(self.nodes):
-            used_buffers = node.used_buffer_names()
+            used_buffers = node.used_or_aliased_buffer_names()
             used_buffers = {self.mutation_real_name.get(k, k) for k in used_buffers}
             node.last_usage = used_buffers - future_used_buffers
             future_used_buffers.update(used_buffers)


### PR DESCRIPTION
Fixes #100314
In dependencies, we should track not only immediately used buffer, but also aliased buffers that point to it, otherwise we can reuse and overwrite the buffer while there are still pending uses. 



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire