### PR TITLE
Stop importing torch._inductor.overrides in repro script

### DIFF
--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -442,8 +442,6 @@ def save_graph_repro(
             sync_line = "torch.cuda.synchronize() # Ensures that segfaults are surfaced"
             break
 
-    if "inductor" in compiler_name:
-        fd.write("import torch._inductor.overrides\n")
     fd.write(
         generate_compiler_repro_string(
             gm, args, stable_output=stable_output, save_dir=save_dir


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100350

This prevents inductor threads from initializing which cost
10s startup latency.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire