### PR TITLE
Do not use pickle to output config entries in repro scripts

### DIFF
--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -315,10 +315,10 @@ class MinifierTests(MinifierTestBase):
             """\
             import torch._dynamo.config
             torch._dynamo.config.cache_size_limit = 55
-            data = torch._dynamo.config.save_config()
+            config = torch._dynamo.config.codegen_config()
             torch._dynamo.config.cache_size_limit = 3
             torch._dynamo.config.repro_after = "dynamo"
-            torch._dynamo.config.load_config(data)
+            exec(config)
             assert torch._dynamo.config.cache_size_limit == 55
             assert torch._dynamo.config.repro_after == "dynamo"
         """

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -32,6 +32,7 @@ def install_config_module(module):
                 ConfigModuleInstance._bypass_keys.add(key)
             elif isinstance(value, CONFIG_TYPES):
                 config[name] = value
+                default[name] = value
                 if dest is module:
                     delattr(module, key)
             elif isinstance(value, type):
@@ -44,13 +45,21 @@ def install_config_module(module):
                 raise AssertionError(f"Unhandled config {key}={value} ({type(value)})")
 
     config = dict()
+    default = dict()
     visit(module, module, "")
     module._config = config
+    module._default = default
     module._allowed_keys = set(config.keys())
     module.__class__ = ConfigModuleInstance
 
 
 class ConfigModule(ModuleType):
+    # The default values of the configuration settings.  This can be used to
+    # determine if the config has been changed or not.
+    _default: Dict[str, Any]
+    # The actual configuration settings.  E.g., torch._dynamo.config.debug
+    # would live as "debug" in the key, and torch._inductor.config.triton.cudagraphs
+    # maps as "triton.cudagraphs"
     _config: Dict[str, Any]
     _allowed_keys: Set[str]
     _bypass_keys: Set[str]
@@ -86,6 +95,20 @@ class ConfigModule(ModuleType):
         for key in config.get("_save_config_ignore", ()):
             config.pop(key)
         return pickle.dumps(config, protocol=2)
+
+    def codegen_config(self):
+        """Convert config to Python statements that replicate current config.
+        This does NOT include config settings that are at default values.
+        """
+        lines = []
+        mod = self.__name__
+        for k, v in self._config.items():
+            if k in self._config.get("_save_config_ignore", ()):
+                continue
+            if v == self._default[k]:
+                continue
+            lines.append(f"{mod}.{k} = {v!r}")
+        return "\n".join(lines)
 
     def load_config(self, data):
         """Restore from a prior call to save_config()"""

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -228,16 +228,14 @@ def generate_config_string(*, stable_output=False):
     if stable_output:
         return "# config omitted due to stable_output=True"
 
-    return textwrap.dedent(
-        f"""\
+    return f"""\
 import torch._dynamo.config
 import torch._inductor.config
 import torch._functorch.config
-torch._dynamo.config.load_config({repr(torch._dynamo.config.save_config())})
-torch._inductor.config.load_config({repr(torch._inductor.config.save_config())})
-torch._functorch.config.load_config({repr(torch._functorch.config.save_config())})
-        """
-    )
+{torch._dynamo.config.codegen_config()}
+{torch._inductor.config.codegen_config()}
+{torch._functorch.config.codegen_config()}
+"""
 
 
 TEST_REPLACEABLE_COMMENT = "# REPLACEABLE COMMENT FOR TESTING PURPOSES"

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -27,8 +27,10 @@ class MinifierTestBase(torch._dynamo.test_case.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Comment me out to retain temporary directory
-        shutil.rmtree(cls.DEBUG_DIR)
+        if os.getenv("PYTORCH_KEEP_TMPDIR", "0") != "1":
+            shutil.rmtree(cls.DEBUG_DIR)
+        else:
+            print("test_minifier_common tmpdir kept at: {cls.DEBUG_DIR}")
         cls._exit_stack.close()
 
     # Search for the name of the first function defined in a code string.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100447
* #100324
* #100416
* #100374
* #100387
* #100357
* __->__ #100354

New output looks like:

```
torch._dynamo.config.dynamic_shapes = True
torch._dynamo.config.assume_static_by_default = False
torch._inductor.config.fallback_random = True
torch._inductor.config.triton.cudagraphs = True
```

instead of an unreadable pickle.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire