### PR TITLE
[codemod] Replace hasattr with getattr in caffe2/test/distributed/fsdp/test_fsdp_optim_state.py

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -383,7 +383,7 @@ class TestFSDPOptimState(FSDPTest):
         ``num_iters``-many times, and returns the per-iteration losses."""
         torch.manual_seed(0)  # set seed for determinism
         losses = []
-        module = model.module if hasattr(model, "module") else model
+        module = getattr(model, "module", model)
         for _ in range(num_iters):
             optim.zero_grad()
             inp = module.get_input(device)


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Test Plan: Sandcastle

Differential Revision: D44886500

