### PR TITLE
[codemod] Replace hasattr with getattr in caffe2/torch/jit/_trace.py

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -329,7 +329,7 @@ def _check_trace(
             for name, data in inputs.items():
                 copied_dict[name] = _clone_inputs(data)
             check_mod = torch.jit.trace_module(
-                func.__self__ if hasattr(func, "__self__") else func,
+                getattr(func, "__self__", func),
                 copied_dict,
                 check_trace=False,
                 strict=strict,


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Test Plan: Sandcastle

Differential Revision: D44886479

