### PR TITLE
Fixed issue with memory format inconsistency for interpolate op

### DIFF
--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -164,6 +164,26 @@ static C10_UNUSED std::array<int64_t, 4> upsample_2d_common_check(IntArrayRef in
   return {nbatch, channels, output_height, output_width};
 }
 
+static C10_UNUSED at::MemoryFormat upsample_2d_get_memory_format(const Tensor& input) {
+  auto memory_format = input.suggest_memory_format();
+  auto input_memory_format = (input.is_contiguous(at::MemoryFormat::ChannelsLast)) ? \
+      at::MemoryFormat::ChannelsLast : at::MemoryFormat::Contiguous;
+  if (memory_format != input_memory_format) {
+    memory_format = input_memory_format;
+  }
+  return memory_format;
+}
+
+static C10_UNUSED at::MemoryFormat upsample_3d_get_memory_format(const Tensor& input) {
+  auto memory_format = input.suggest_memory_format();
+  auto input_memory_format = (input.is_contiguous(at::MemoryFormat::ChannelsLast3d)) ? \
+      at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::Contiguous;
+  if (memory_format != input_memory_format) {
+    memory_format = input_memory_format;
+  }
+  return memory_format;
+}
+
 static C10_UNUSED
 std::array<int64_t, 5> upsample_3d_common_check(IntArrayRef input_size, IntArrayRef output_size) {
   TORCH_CHECK(

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -34,7 +34,6 @@ TORCH_META_FUNC(upsample_bicubic2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
@@ -75,7 +74,6 @@ TORCH_META_FUNC(_upsample_bicubic2d_aa) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -34,7 +34,9 @@ TORCH_META_FUNC(upsample_bicubic2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(upsample_bicubic2d_backward) (
@@ -73,7 +75,9 @@ TORCH_META_FUNC(_upsample_bicubic2d_aa) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(_upsample_bicubic2d_aa_backward) (

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -21,6 +21,8 @@
 #include <ATen/ops/upsample_bilinear2d_native.h>
 #endif
 
+#include <iostream>
+
 namespace at {
 namespace meta {
 
@@ -35,7 +37,9 @@ TORCH_META_FUNC(upsample_bilinear2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(upsample_bilinear2d_backward) (
@@ -74,7 +78,9 @@ TORCH_META_FUNC(_upsample_bilinear2d_aa) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(_upsample_bilinear2d_aa_backward) (

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -21,8 +21,6 @@
 #include <ATen/ops/upsample_bilinear2d_native.h>
 #endif
 
-#include <iostream>
-
 namespace at {
 namespace meta {
 
@@ -37,7 +35,6 @@ TORCH_META_FUNC(upsample_bilinear2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
@@ -78,7 +75,6 @@ TORCH_META_FUNC(_upsample_bilinear2d_aa) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -33,7 +33,6 @@ TORCH_META_FUNC(upsample_nearest2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
@@ -49,7 +48,6 @@ TORCH_META_FUNC(_upsample_nearest_exact2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_2d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -33,7 +33,9 @@ TORCH_META_FUNC(upsample_nearest2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(_upsample_nearest_exact2d) (
@@ -47,7 +49,9 @@ TORCH_META_FUNC(_upsample_nearest_exact2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_2d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(upsample_nearest2d_backward) (

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -36,7 +36,9 @@ TORCH_META_FUNC(upsample_nearest3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_3d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(_upsample_nearest_exact3d) (
@@ -54,7 +56,9 @@ TORCH_META_FUNC(_upsample_nearest_exact3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_3d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(upsample_nearest3d_backward) (

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -36,7 +36,6 @@ TORCH_META_FUNC(upsample_nearest3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_3d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
@@ -56,7 +55,6 @@ TORCH_META_FUNC(_upsample_nearest_exact3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_3d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -36,7 +36,6 @@ TORCH_META_FUNC(upsample_trilinear3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
   auto memory_format = native::upsample_3d_get_memory_format(input);
   set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -36,7 +36,9 @@ TORCH_META_FUNC(upsample_trilinear3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  // set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(input.suggest_memory_format()));
+  auto memory_format = native::upsample_3d_get_memory_format(input);
+  set_output_raw_strided(0, full_output_size, {}, input.options().memory_format(memory_format));
 }
 
 TORCH_META_FUNC(upsample_trilinear3d_backward) (

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -305,7 +305,7 @@ class FakeTensorTest(TestCase):
                 unsqueeze = torch.ops.aten.unsqueeze.default(arg0_1, 0)
                 out.append(torch.ops.aten.upsample_bilinear2d.default(unsqueeze, [800, 1199], False))
 
-        self.assertTrue(out[1].is_contiguous())
+        self.assertTrue(out[1].is_contiguous(memory_format=torch.channels_last))
         self.checkMetaProps(out[0], out[1])
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2158,8 +2158,8 @@ def _upsample_2d_get_memory_format(input):
             if input.is_contiguous(memory_format=torch.channels_last)
             else torch.contiguous_format
         )
-    if memory_format != input_memory_format:
-        memory_format = input_memory_format
+        if memory_format != input_memory_format:
+            memory_format = input_memory_format
 
     return memory_format
 


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/68430

Description:
- Output's memory format is not respected in interpolate op when input is squeezed/unsqueezed channels last


For example:
```python
import torch
print(torch.__version__)


def t1(x, mode, aa):
    do_squeeze = False
    if x.dim() == 3:
        do_squeeze = True
        x = x[None, ...]
    out = torch.nn.functional.interpolate(
        x, size=224, mode=mode, antialias=aa
    )
    if do_squeeze:
        out = out[0, ...]
    return out


aa = True
mode = "bilinear"
dtype = torch.uint8
mf = torch.channels_last
device = "cpu"

print("-", aa, mode, mf, device, dtype)
x = torch.randint(0, 256, size=(1, 3, 256, 256), dtype=dtype, device=device).contiguous(memory_format=mf)

x = x[0, ...]
x = x[None, ...]

y = t1(x, mode, aa)

input_mem_format = "CL" if x.is_contiguous(memory_format=torch.channels_last) else "CF"
if input_mem_format == "CF":
    assert x.is_contiguous(memory_format=torch.contiguous_format)

output_mem_format = "CL" if y.is_contiguous(memory_format=torch.channels_last) else "CF"
if output_mem_format == "CF":
    assert y.is_contiguous(memory_format=torch.contiguous_format)

if input_mem_format != output_mem_format:
    print(f"2 {mf}, {device}, {dtype}: {output_mem_format} != {input_mem_format}\n")
```
We can see have the following output on pytorch nightly:
```
2 torch.channels_last, cpu, torch.uint8: CF != CL
```

In details, memory format inconsistency comes from the strides:
```python
x = torch.ones(1, 3, 256, 256).contiguous(memory_format=torch.channels_last)
x = x[0, ...].unsqueeze(0)
assert x.stride() == (3, 1, 768, 3)  # instead of (196608, 1, 768, 3)
```

The problem essentially comes from `x.unsqueeze(0)` where new stride (i.e. stride(0)) is computed as for a tensor with channels first memory format:
https://github.com/pytorch/pytorch/blob/4582ceb2c4a7316f09afd471a97d910347d21f01/aten/src/ATen/native/TensorShape.cpp#L3136


