### PR TITLE
Prevent Triton from getting eagerly imported when importing torch._inductor

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -190,9 +190,10 @@ class WrapperCodeGen(CodeGen):
     Generate outer wrapper in Python that calls the kernels.
     """
 
-    def __init__(self):
+    def __init__(self, cuda=False):
         super().__init__()
         self._names_iter = count()
+        self.cuda = cuda
         self.header = IndentedBuffer()
         self.prefix = IndentedBuffer()
         self.wrapper_call = IndentedBuffer()
@@ -260,7 +261,7 @@ class WrapperCodeGen(CodeGen):
             """
         )
 
-        if has_triton():
+        if self.cuda and has_triton():
             self.header.splice(
                 """
                 import triton
@@ -733,7 +734,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
     """
 
     def __init__(self):
-        super().__init__()
+        super().__init__(cuda=False)
         self.declare = "auto "
         self.ending = ";"
         self.open_bracket = "{"
@@ -745,7 +746,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.size = "sizes()"
         self.stride = "strides()"
         self.call_func_name = "inductor_entry_cpp"
-        self.cuda = False
         self.supports_intermediate_hooks = False
 
     def seed(self):
@@ -1005,10 +1005,9 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
     """
 
     def __init__(self):
-        super().__init__()
+        super().__init__(cuda=True)
         self.kernel_callsite_id = count()
         self.arg_var_id = count()
-        self.cuda = True
 
     def write_prefix(self):
         self.prefix.splice(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -633,7 +633,7 @@ class GraphLowering(torch.fx.Interpreter):
                 )
                 return
 
-        self.wrapper_code = WrapperCodeGen(cuda=self.cuda)
+        self.wrapper_code = WrapperCodeGen()
 
     def codegen(self):
         from .scheduler import Scheduler

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -633,7 +633,7 @@ class GraphLowering(torch.fx.Interpreter):
                 )
                 return
 
-        self.wrapper_code = WrapperCodeGen()
+        self.wrapper_code = WrapperCodeGen(cuda=self.cuda)
 
     def codegen(self):
         from .scheduler import Scheduler

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -896,7 +896,14 @@ class AlgorithmSelectorCache(PersistentCache):
         )
 
 
-autotune_select_algorithm = AlgorithmSelectorCache()
+_ALGORITHM_SELECTOR_CACHE = None
+
+
+def autotune_select_algorithm(*args, **kwargs):
+    global _ALGORITHM_SELECTOR_CACHE
+    if _ALGORITHM_SELECTOR_CACHE is None:
+        _ALGORITHM_SELECTOR_CACHE = AlgorithmSelectorCache()
+    return _ALGORITHM_SELECTOR_CACHE(*args, **kwargs)
 
 
 def realize_inputs(*args):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -32,31 +32,35 @@ log = logging.getLogger(__name__)
 VarRanges = Dict[sympy.Expr, sympy.Expr]
 
 
-try:
-    from triton.testing import do_bench as triton_do_bench
+def do_bench(*args, **kwargs):
+    @functools.lru_cache(None)
+    def load_triton():
+        try:
+            # NB: Lazily load triton, as importing triton is slow
+            # see https://github.com/openai/triton/issues/1599
+            from triton.testing import do_bench as triton_do_bench
+        except ImportError:
+            raise NotImplementedError("requires Triton")
 
-    # triton PR https://github.com/openai/triton/pull/1513 change the
-    # quantile fields name from 'percentiles' to 'quantiles'
-    # and change the default value from (0.5, 0.2, 0.8) to None.
-    # This may break inductor since a caller expects a tuple may get a item.
-    #
-    # Add a wrapper to maintain the same behavior for inductor.
-    # Maybe we should have own implementation of this function?
-    quantile_field_name = (
-        "quantiles"
-        if inspect.signature(triton_do_bench).parameters.get("quantiles") is not None
-        else "percentiles"
-    )
+        # triton PR https://github.com/openai/triton/pull/1513 change the
+        # quantile fields name from 'percentiles' to 'quantiles'
+        # and change the default value from (0.5, 0.2, 0.8) to None.
+        # This may break inductor since a caller expects a tuple may get a item.
+        #
+        # Add a wrapper to maintain the same behavior for inductor.
+        # Maybe we should have own implementation of this function?
+        return triton_do_bench, (
+            "quantiles"
+            if inspect.signature(triton_do_bench).parameters.get("quantiles")
+            is not None
+            else "percentiles"
+        )
 
-    def do_bench(*args, **kwargs):
-        if quantile_field_name not in kwargs:
-            kwargs[quantile_field_name] = (0.5, 0.2, 0.8)
-        return triton_do_bench(*args, **kwargs)[0]
+    triton_do_bench, quantile_field_name = load_triton()
 
-except ImportError:
-
-    def do_bench(*args, **kwargs):
-        raise NotImplementedError("requires Triton")
+    if quantile_field_name not in kwargs:
+        kwargs[quantile_field_name] = (0.5, 0.2, 0.8)
+    return triton_do_bench(*args, **kwargs)[0]
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100447
* #100324
* #100416
* __->__ #100374
* #100387
* #100357
* #100354

This makes 'import torch._inductor.utils' go from 3.5s to 2.1s

See also https://github.com/openai/triton/issues/1599

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire