### PR TITLE
[DataLoader] `__getitems__` added to description of Dataset API and better supported within `Subset`

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -300,7 +300,7 @@ class Subset(Dataset[T_co]):
 
         # add batched sampling support when parent dataset supports it.
         # see torch.utils.data._utils.fetch._MapDatasetFetcher
-        if hasattr(dataset, "__getitems__") and dataset.__getitems__:
+        if hasattr(dataset, "__getitems__") and dataset.__getitems__:  # type: ignore[attr-defined]
             self.__getitems__ = self._getitems
 
     def __getitem__(self, idx):
@@ -312,7 +312,7 @@ class Subset(Dataset[T_co]):
         return len(self.indices)
 
     def _getitems(self, idx):
-        return self.dataset.__getitems__([self.indices[i] for i in idx])
+        return self.dataset.__getitems__([self.indices[i] for i in idx])  # type: ignore[attr-defined]
 
 
 def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -301,7 +301,7 @@ class Subset(Dataset[T_co]):
         # add batched sampling support when parent dataset supports it.
         # see torch.utils.data._utils.fetch._MapDatasetFetcher
         if hasattr(dataset, "__getitems__") and dataset.__getitems__:
-            self.__getitems__ = self.__getitem__
+            self.__getitems__ = self._getitems
 
     def __getitem__(self, idx):
         if isinstance(idx, list):
@@ -310,6 +310,9 @@ class Subset(Dataset[T_co]):
 
     def __len__(self):
         return len(self.indices)
+
+    def _getitems(self, idx):
+        return self.dataset.__getitems__([self.indices[i] for i in idx])
 
 
 def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -300,7 +300,7 @@ class Subset(Dataset[T_co]):
 
         # add batched sampling support when parent dataset supports it.
         # see torch.utils.data._utils.fetch._MapDatasetFetcher
-        if hasattr(dataset, "__getitems__") and dataset.__getitems__:  # type: ignore[attr-defined]
+        if getattr(dataset, "__getitems__", None):
             self.__getitems__ = self._getitems
 
     def __getitem__(self, idx):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -42,7 +42,7 @@ class Dataset(Generic[T_co]):
     :meth:`__len__`, which is expected to return the size of the dataset by many
     :class:`~torch.utils.data.Sampler` implementations and the default options
     of :class:`~torch.utils.data.DataLoader`. Subclasses could also
-    optionally overwrite :meth:`__getitems__`, for speedup batched samples
+    optionally implement :meth:`__getitems__`, for speedup batched samples
     loading. This method accepts list of indices of samples of batch and returns
     list of samples.
 

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -306,7 +306,7 @@ class Subset(Dataset[T_co]):
     def __getitems__(self, indices: List[int]) -> List[T_co]:
         # add batched sampling support when parent dataset supports it.
         # see torch.utils.data._utils.fetch._MapDatasetFetcher
-        if hasattr(self.dataset, "__getitems__") and self.dataset.__getitems__:
+        if callable(getattr(self.dataset, "__getitems__", None)):
             return self.dataset.__getitems__([self.indices[idx] for idx in indices])  # type: ignore[attr-defined]
         else:
             return [self.dataset[self.indices[idx]] for idx in indices]


### PR DESCRIPTION
DataLoader supports batched loading from Mapped Datasets.

This is the fetcher's implementation of auto-detection of batch loading support.

torch.utils.data._utils.fetch._MapDatasetFetcher
```
class _MapDatasetFetcher(_BaseDatasetFetcher):
    def fetch(self, possibly_batched_index):
        if self.auto_collation:
            if hasattr(self.dataset, "__getitems__") and self.dataset.__getitems__:
                data = self.dataset.__getitems__(possibly_batched_index)
            else:
                data = [self.dataset[idx] for idx in possibly_batched_index]
```

Description of Dataset API now shows this feature.

Additionally, Subset dataset now supports `__getitems__` if parent dataset supports it.