### PR TITLE
Speed up minifier tests by applying some configs that speed things up.

### DIFF
--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -17,10 +17,11 @@ class MinifierTests(MinifierTestBase):
     # Generates code that patches CppOverrides/TritonOverrides.
     def _gen_codegen_fn_patch_code(self, device, bug_type):
         assert bug_type in ("compile_error", "runtime_error", "accuracy")
-        if device == "cpu":
-            return f"torch._inductor.config.cpp.inject_relu_bug_TESTING_ONLY = {bug_type!r}"
-        else:
-            return f"torch._inductor.config.triton.inject_relu_bug_TESTING_ONLY = {bug_type!r}"
+        return f"""\
+{torch._dynamo.config.codegen_config()}
+{torch._inductor.config.codegen_config()}
+torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_TESTING_ONLY = {bug_type!r}
+"""
 
     # Test that compile and accuracy errors after aot can be repro'd (both CPU and CUDA)
     def _test_after_aot(self, device, bug_type, repro_level):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -28,7 +28,6 @@ import torch
 from torch._inductor import config, cuda_properties, exc
 from torch._inductor.utils import developer_warning
 from torch.hub import _Faketqdm, tqdm
-from torch.utils import cpp_extension
 
 if config.is_fbcode():
     from torch._inductor.fb.logging import global_cache_log
@@ -358,6 +357,9 @@ cdll.LoadLibrary("__lib_path__")
 
     @functools.lru_cache(None)
     def __bool__(self):
+        if config.cpp.vec_isa_ok is not None:
+            return config.cpp.vec_isa_ok
+
         key, input_path = write(VecISA._avx_code, "cpp")
         from filelock import FileLock
 
@@ -495,6 +497,8 @@ def use_custom_generated_macros():
 def get_include_and_linking_paths(
     include_pytorch=False, vec_isa: VecISA = invalid_vec_isa, cuda=False
 ):
+    from torch.utils import cpp_extension
+
     macros = ""
     if sys.platform == "linux" and (
         include_pytorch

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -215,6 +215,10 @@ class cpp:
     # Valid values: "compile_error", "runtime_error", "accuracy"
     inject_relu_bug_TESTING_ONLY = None
 
+    # If None, autodetect whether or not AVX512/AVX2 can be used.  Otherwise,
+    # force usage as specified, without testing.
+    vec_isa_ok = None
+
 
 # config specific to codegen/triton.py
 class triton:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100447
* #100324
* #100416
* #100374
* __->__ #100387
* #100357
* #100354

Previously, test_after_aot_cpu_compile_error took 101s.  After this
patch, it only takes 46s, a more than 2x speedup.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire