### PR TITLE
[export] Migrate internal verifier to subclass export/verifier

### DIFF
--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -14,10 +14,8 @@ from torch._dynamo.eval_frame import is_dynamo_supported
 
 from torch._export.verifier import (
     SpecViolationError,
-    check_valid_aten_dialect,
-    check_valid,
-    is_valid_aten_dialect,
-    is_valid,
+    Verifier,
+    ATenDialectVerifier,
 )
 
 
@@ -122,17 +120,19 @@ class VerifierTest(TestCase):
         m = ElementwiseAdd()
         egm = capture(m, (torch.randn(100), torch.randn(100)))
         # assert not throw
-        check_valid(egm)
-        self.assertTrue(is_valid(egm))
+        verifier = Verifier()
+        verifier(egm)
+        self.assertTrue(verifier.is_valid(egm))
 
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_verifier_call_module(self) -> None:
         m = FeedForwardBlock(10, 10)
         gm = torch.fx.symbolic_trace(m)
         # this would have modules that are not delegates
+        verifier = Verifier()
         with self.assertRaises(SpecViolationError):
-            check_valid(gm)
-        self.assertFalse(is_valid(gm))
+            verifier(gm)
+        self.assertFalse(verifier.is_valid(gm))
 
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_verifier_no_functional(self) -> None:
@@ -141,16 +141,18 @@ class VerifierTest(TestCase):
         for node in egm.graph.nodes:
             if node.target == torch.ops.aten.add.Tensor:
                 node.target = torch.ops.aten.add.out
+        verifier = Verifier()
         with self.assertRaises(SpecViolationError):
-            check_valid(egm)
-        self.assertFalse(is_valid(egm))
+            verifier(egm)
+        self.assertFalse(verifier.is_valid(egm))
 
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_aten_dialect(self) -> None:
         m = ElementwiseAdd()
         egm = capture(m, (torch.randn(100), torch.randn(100)))
-        check_valid_aten_dialect(egm)
-        self.assertTrue(is_valid_aten_dialect(egm))
+        verifier = ATenDialectVerifier()
+        verifier(egm)
+        self.assertTrue(verifier.is_valid(egm))
 
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_aten_wrong_mem_format(self) -> None:
@@ -167,9 +169,10 @@ class VerifierTest(TestCase):
         m = TestModel()
         egm = capture(m, (torch.randn(1, 3, 100, 100),))
         egm._apply(lambda t: t.to(memory_format=torch.channels_last))
+        verifier = ATenDialectVerifier()
         with self.assertRaises(SpecViolationError):
-            check_valid_aten_dialect(egm)
-        self.assertFalse(is_valid_aten_dialect(egm))
+            verifier(egm)
+        self.assertFalse(verifier.is_valid(egm))
 
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_aten_wrong_mem_format_buffer(self) -> None:
@@ -187,9 +190,25 @@ class VerifierTest(TestCase):
         m = TestModel()
         egm = capture(m, (torch.randn(1, 3, 100, 100),))
         egm._apply(lambda t: t.to(memory_format=torch.channels_last))
+        verifier = ATenDialectVerifier()
         with self.assertRaises(SpecViolationError):
-            check_valid_aten_dialect(egm)
-        self.assertFalse(is_valid_aten_dialect(egm))
+            verifier(egm)
+        self.assertFalse(verifier.is_valid(egm))
+
+    def test_aten_wrong_op(self) -> None:
+        class TestModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.aten._add_relu(x, x)
+
+        m = TestModel()
+        egm = torch.fx.symbolic_trace(m)
+        verifier = ATenDialectVerifier()
+        with self.assertRaises(SpecViolationError):
+            verifier(egm)
+        self.assertFalse(verifier.is_valid(egm))
 
 
 if __name__ == '__main__':

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -42,59 +42,6 @@ def _check_has_fake_tensor(node: torch.fx.Node) -> None:
 
 
 @compatibility(is_backward_compatible=False)
-def check_valid(gm: GraphModule) -> None:  # noqa: C901
-
-    for node in gm.graph.nodes:
-        # TODO(T140410192): should have fake tensor for all dialects
-        if node.op in {"call_module", "call_method"}:
-            raise SpecViolationError(
-                "call_module is not valid: got a class '{}' ".format(node.target),
-            )
-
-        if node.op == "call_function":
-            _check_has_fake_tensor(node)
-            op_name = (
-                node.target.name
-                if hasattr(node.target, "name")
-                else node.target.__name__
-            )
-            is_builtin_func = node.target in [
-                'while_loop',
-                operator.getitem,
-                'cond',
-                control_flow.cond,
-                control_flow.map,
-            ]
-            if not isinstance(node.target, OpOverload) and not is_builtin_func:
-                raise SpecViolationError(
-                    "Operator '{}' is not a registered Op".format(op_name),
-                )
-
-            # All ops functional
-            if not is_builtin_func and not is_functional(node.target):
-                raise SpecViolationError(
-                    f"operator '{op_name}' is not functional"
-                )
-
-            if isinstance(node.target, OpOverload):
-                # Check preserved metadata
-                for meta in PRESERVED_META_KEYS:
-                    if node.meta.get(meta, None) is None:
-                        raise SpecViolationError(
-                            f"node {node} is missing metadata {meta}"
-                        )
-
-
-@compatibility(is_backward_compatible=False)
-def is_valid(gm: GraphModule) -> bool:
-    try:
-        check_valid(gm)
-        return True
-    except SpecViolationError:
-        return False
-
-
-@compatibility(is_backward_compatible=False)
 def _check_tensors_are_contiguous(gm: GraphModule) -> None:
     # Tensors be of contiguous format
     for name, param in itertools.chain(gm.named_parameters(), gm.named_buffers()):
@@ -106,37 +53,91 @@ def _check_tensors_are_contiguous(gm: GraphModule) -> None:
 
 
 @compatibility(is_backward_compatible=False)
-def check_valid_aten_dialect(gm: GraphModule) -> None:
-    """Raises exception if gm is not in aten dialect.
+class Verifier:
+    def __call__(self, gm: GraphModule) -> None:
+        self.check_valid(gm)
 
-    Args:
-        gm: GraphModule
-    """
-    # need to be first valid
-    check_valid(gm)
+    @compatibility(is_backward_compatible=False)
+    def valid_builtin_funcs(self):
+        return [
+            operator.getitem,
+            control_flow.cond,
+            control_flow.map,
+        ]
 
-    # Operators be aten cannonical
-    for n in gm.graph.nodes:
-        if n.op == "call_function" and isinstance(n.target, OpOverload):
-            if (
-                torch.Tag.core not in n.target.tags  # type: ignore[attr-defined]
-                and torch.Tag.view_copy not in n.target.tags  # type: ignore[attr-defined]
-            ):
-                # NOTE(qihan): whether view_copy operators are marked as canonical is still under
-                #            discussion.
+    @compatibility(is_backward_compatible=False)
+    def check_valid_op(self, op):
+        op_name = op.name if hasattr(op, "name") else op.__name__
+
+        if not isinstance(op, OpOverload):
+            raise SpecViolationError(
+                "Operator '{}' is not a registered Op".format(op_name),
+            )
+
+        # All ops functional
+        if not is_functional(op):
+            raise SpecViolationError(
+                f"operator '{op_name}' is not functional"
+            )
+
+    @compatibility(is_backward_compatible=False)
+    def check_valid(self, gm: GraphModule) -> None:  # noqa: C901
+
+        for node in gm.graph.nodes:
+            # TODO(T140410192): should have fake tensor for all dialects
+            if node.op in {"call_module", "call_method"}:
                 raise SpecViolationError(
-                    "Operator {}.{} is not Aten Canonical.".format(
-                        n.target.__module__, n.target.__name__
-                    )
+                    "call_module is not valid: got a class '{}' ".format(node.target),
                 )
 
-    _check_tensors_are_contiguous(gm)
+            if node.op == "call_function":
+                _check_has_fake_tensor(node)
+
+                if node.target not in self.valid_builtin_funcs():
+                    self.check_valid_op(node.target)
+
+                if isinstance(node.target, OpOverload):
+                    # Check preserved metadata
+                    for meta in PRESERVED_META_KEYS:
+                        if node.meta.get(meta, None) is None:
+                            raise SpecViolationError(
+                                f"node {node} is missing metadata {meta}"
+                            )
+
+    @compatibility(is_backward_compatible=False)
+    def is_valid(self, gm: GraphModule) -> bool:
+        try:
+            self.check_valid(gm)
+            return True
+        except SpecViolationError:
+            return False
 
 
-@compatibility(is_backward_compatible=False)
-def is_valid_aten_dialect(gm: GraphModule) -> bool:
-    try:
-        check_valid_aten_dialect(gm)
-        return True
-    except SpecViolationError:
-        return False
+class ATenDialectVerifier(Verifier):
+    @compatibility(is_backward_compatible=False)
+    def check_valid_op(self, op) -> None:
+        super().check_valid_op(op)
+
+        op_name = op.name if hasattr(op, "name") else op.__name__
+
+        if not isinstance(op, OpOverload):
+            raise SpecViolationError(
+                "Operator '{}' is not a registered Op".format(op_name),
+            )
+
+        if (
+            torch.Tag.core not in op.tags  # type: ignore[attr-defined]
+            and torch.Tag.view_copy not in op.tags  # type: ignore[attr-defined]
+        ):
+            # NOTE(qihan): whether view_copy operators are marked as canonical is still under
+            #            discussion.
+            raise SpecViolationError(
+                "Operator {}.{} is not Aten Canonical.".format(
+                    op.__module__, op.__name__
+                )
+            )
+
+    @compatibility(is_backward_compatible=False)
+    def check_valid(self, gm: GraphModule) -> None:
+        super().check_valid(gm)
+        _check_tensors_are_contiguous(gm)


### PR DESCRIPTION
Summary:
Modified export/verifier.py to be easier to compose with other verifiers:

```
class SpecViolationError(Exception)

class Verifier:
    # Returns a list of valid builtin operators (ex. getitem, pyoperators)
    def valid_builtin_ops(self) -> List:
        # base class returns [getitem, cond, map]

    # Checks if a given call_function (non-builtin) operator is within the dialect. If not, it will throw a SpecViolationError.
    def check_op(self, op) -> None:
        # base class checks if the op is an OpOverload, and if the operator is functional

    # Checks if a given graph module is valid based on the dialect it is in. If not, it will throw a SpecViolationError.
    def check_valid(self, gm: GraphModule) -> None:
        # base class checks for the "val" and "stack_trace" metadata on each node

    # Returns true if the given graph module is valid
    def is_valid(self, gm: GraphModule) -> bool
```

Test Plan: CI

Differential Revision: D45416983

