### PR TITLE
Pin scikit-image and tb-nightly CI requirements

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -199,7 +199,8 @@ pygments==2.12.0
 #Pinned versions: 10.9.0
 #test that import:
 
-scikit-image==0.20.0
+scikit-image==0.19.3 ; python_version < "3.10"
+scikit-image==0.20.0 ; python_version >= "3.10"
 #Description: image processing routines
 #Pinned versions:
 #test that import: test_nn.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -81,10 +81,10 @@ mypy==0.960
 #Pinned versions: 0.960
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.6.3
+networkx==2.8.8
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.6.3 (latest version that works with Python 3.7+)
+#Pinned versions: 2.8.8
 #test that import: functorch
 
 #ninja
@@ -199,7 +199,7 @@ pygments==2.12.0
 #Pinned versions: 10.9.0
 #test that import:
 
-scikit-image
+scikit-image==0.20.0
 #Description: image processing routines
 #Pinned versions:
 #test that import: test_nn.py
@@ -224,7 +224,7 @@ scipy==1.9.3 ; python_version == "3.11"
 #Pinned versions:
 #test that import:
 
-tb-nightly
+tb-nightly==2.13.0a20230426
 #Description: TensorBoard
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
Docker build starts to fail recently, for example https://github.com/pytorch/pytorch/actions/runs/4853022561/jobs/8648730115.  I notice some packages on requirements-ci haven't been pinned yet

## Testing 

`pip install --verbose -r .ci/docker/requirements-ci.txt` locally.  I can confirm that the issue can be reproduced with Python 3.11 locally, and is fixed by this change.