### PR TITLE
Make `TORCH_CHECK_GT` and friends more accessible

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -449,6 +449,33 @@ inline C10_API const char* torchCheckMsgImpl(
   }
 #endif
 
+#define TORCH_EXCEPTION_CHECK_OP(op, val1, val2, ...)  \
+  do {                                                 \
+    const auto _a684 = (val1);                         \
+    const auto _b684 = (val2);                         \
+    TORCH_CHECK(                                       \
+        _a684 op _b684,                                \
+        "Check failed: " #val1 " " #op " " #val2 " (", \
+        _a684,                                         \
+        " vs. ",                                       \
+        _b684,                                         \
+        ")",                                           \
+        ##__VA_ARGS__);                                \
+  } while (false);
+
+#define TORCH_CHECK_EQ(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(==, val1, val2, ##__VA_ARGS__)
+#define TORCH_CHECK_NE(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(!=, val1, val2, ##__VA_ARGS__)
+#define TORCH_CHECK_LE(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(<=, val1, val2, ##__VA_ARGS__)
+#define TORCH_CHECK_LT(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(<, val1, val2, ##__VA_ARGS__)
+#define TORCH_CHECK_GE(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(>=, val1, val2, ##__VA_ARGS__)
+#define TORCH_CHECK_GT(val1, val2, ...) \
+  TORCH_EXCEPTION_CHECK_OP(>, val1, val2, ##__VA_ARGS__)
+
 namespace c10 {
 namespace detail {
 

--- a/c10/util/logging_is_google_glog.h
+++ b/c10/util/logging_is_google_glog.h
@@ -50,13 +50,6 @@ INSTANTIATE_FOR_CONTAINER(set)
 #include <glog/logging.h>
 
 // Additional macros on top of glog
-#define TORCH_CHECK_EQ(val1, val2) CHECK_EQ(val1, val2)
-#define TORCH_CHECK_NE(val1, val2) CHECK_NE(val1, val2)
-#define TORCH_CHECK_LE(val1, val2) CHECK_LE(val1, val2)
-#define TORCH_CHECK_LT(val1, val2) CHECK_LT(val1, val2)
-#define TORCH_CHECK_GE(val1, val2) CHECK_GE(val1, val2)
-#define TORCH_CHECK_GT(val1, val2) CHECK_GT(val1, val2)
-
 #ifndef NDEBUG
 #define TORCH_DCHECK_EQ(val1, val2) DCHECK_EQ(val1, val2)
 #define TORCH_DCHECK_NE(val1, val2) DCHECK_NE(val1, val2)

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -140,14 +140,6 @@ static_assert(
   FATAL_IF(((val1)op(val2))) << "Check failed: " #val1 " " #op " " #val2 " (" \
                              << (val1) << " vs. " << (val2) << ") "
 
-// TORCH_CHECK_OP macro definitions
-#define TORCH_CHECK_EQ(val1, val2) TORCH_CHECK_OP(val1, val2, ==)
-#define TORCH_CHECK_NE(val1, val2) TORCH_CHECK_OP(val1, val2, !=)
-#define TORCH_CHECK_LE(val1, val2) TORCH_CHECK_OP(val1, val2, <=)
-#define TORCH_CHECK_LT(val1, val2) TORCH_CHECK_OP(val1, val2, <)
-#define TORCH_CHECK_GE(val1, val2) TORCH_CHECK_OP(val1, val2, >=)
-#define TORCH_CHECK_GT(val1, val2) TORCH_CHECK_OP(val1, val2, >)
-
 #ifndef NDEBUG
 // Debug only versions of TORCH_CHECK_OP macros.
 #define TORCH_DCHECK_EQ(val1, val2) TORCH_CHECK_OP(val1, val2, ==)

--- a/caffe2/distributed/file_store_handler.cc
+++ b/caffe2/distributed/file_store_handler.cc
@@ -55,7 +55,7 @@ FileStoreHandler::FileStoreHandler(
   auto ret = mkdir(basePath_.c_str(), 0777);
 #endif // defined(_MSC_VER)
   if (ret == -1) {
-    TORCH_CHECK_EQ(errno, EEXIST) << "mkdir: " << strerror(errno);
+    TORCH_CHECK_EQ(errno, EEXIST, "mkdir: ", strerror(errno));
   }
 }
 
@@ -71,7 +71,7 @@ std::string FileStoreHandler::realPath(const std::string& path) {
   std::array<char, PATH_MAX> buf;
   auto ret = realpath(path.c_str(), buf.data());
 #endif
-  TORCH_CHECK_EQ(buf.data(), ret) << "realpath: " << strerror(errno);
+  TORCH_CHECK_EQ(buf.data(), ret, "realpath: ", strerror(errno));
   return std::string(buf.data());
 }
 

--- a/caffe2/utils/hip/math_blas_gpu_test.cc
+++ b/caffe2/utils/hip/math_blas_gpu_test.cc
@@ -63,7 +63,7 @@ TEST(MathROCBLASTest, GemmNoTransNoTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10, i);
   }
 
   // Test Accumulate
@@ -83,7 +83,7 @@ TEST(MathROCBLASTest, GemmNoTransNoTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15, i);
   }
 
   // Test Accumulate
@@ -103,7 +103,7 @@ TEST(MathROCBLASTest, GemmNoTransNoTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20, i);
   }
 }
 
@@ -160,7 +160,7 @@ TEST(MathROCBLASTest, GemmNoTransTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10, i);
   }
 
   // Test Accumulate
@@ -180,7 +180,7 @@ TEST(MathROCBLASTest, GemmNoTransTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15, i);
   }
 
   math::Gemm<float, HIPContext>(
@@ -199,7 +199,7 @@ TEST(MathROCBLASTest, GemmNoTransTrans) {
   tensorY_host->CopyFrom(*tensorY);
   EXPECT_EQ(tensorY_host->size(), 30);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20, i);
   }
 }
 
@@ -252,7 +252,7 @@ TEST(MathROCBLASTest, GemvNoTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 10, i);
   }
 
   // Test Accumulate
@@ -269,7 +269,7 @@ TEST(MathROCBLASTest, GemvNoTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 15, i);
   }
 
   // Test Accumulate
@@ -286,7 +286,7 @@ TEST(MathROCBLASTest, GemvNoTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 20, i);
   }
 }
 
@@ -339,7 +339,7 @@ TEST(MathROCBLASTest, GemvTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 6) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 6, i);
   }
 
   // Test Accumulate
@@ -356,7 +356,7 @@ TEST(MathROCBLASTest, GemvTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 9) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 9, i);
   }
 
   // Test Accumulate
@@ -373,7 +373,7 @@ TEST(MathROCBLASTest, GemvTrans) {
   context.FinishDeviceComputation();
   tensorY_host->CopyFrom(*tensorY);
   for (int i = 0; i < tensorY_host->size(); ++i) {
-    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 12) << i;
+    TORCH_CHECK_EQ(tensorY_host->data<float>()[i], 12, i);
   }
 }
 } // namespace caffe2

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -52,7 +52,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 10, i);
   }
   // Test Accumulate
   math::Gemm<float, CPUContext>(
@@ -69,7 +69,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 15, i);
   }
   // Test Accumulate
   math::Gemm<float, CPUContext>(
@@ -86,7 +86,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 20, i);
   }
 }
 
@@ -127,7 +127,7 @@ TEST(MathTest, GemmNoTransTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 10, i);
   }
   // Test Accumulate
   math::Gemm<float, CPUContext>(
@@ -144,7 +144,7 @@ TEST(MathTest, GemmNoTransTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 15, i);
   }
   math::Gemm<float, CPUContext>(
       CblasNoTrans,
@@ -160,7 +160,7 @@ TEST(MathTest, GemmNoTransTrans) {
       &cpu_context);
   EXPECT_EQ(Y.numel(), 30);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 20, i);
   }
 }
 
@@ -322,7 +322,7 @@ TEST(MathTest, GemvNoTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 10) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 10, i);
   }
   // Test Accumulate
   math::Gemv<float, CPUContext>(
@@ -336,7 +336,7 @@ TEST(MathTest, GemvNoTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 15) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 15, i);
   }
   // Test Accumulate
   math::Gemv<float, CPUContext>(
@@ -350,7 +350,7 @@ TEST(MathTest, GemvNoTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 20) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 20, i);
   }
 }
 
@@ -388,7 +388,7 @@ TEST(MathTest, GemvTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 6) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 6, i);
   }
   // Test Accumulate
   math::Gemv<float, CPUContext>(
@@ -402,7 +402,7 @@ TEST(MathTest, GemvTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 9) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 9, i);
   }
   // Test Accumulate
   math::Gemv<float, CPUContext>(
@@ -416,7 +416,7 @@ TEST(MathTest, GemvTrans) {
       Y.mutable_data<float>(),
       &cpu_context);
   for (int i = 0; i < Y.numel(); ++i) {
-    TORCH_CHECK_EQ(Y.data<float>()[i], 12) << i;
+    TORCH_CHECK_EQ(Y.data<float>()[i], 12, i);
   }
 }
 


### PR DESCRIPTION
Summary:
These macros aren't appropriately only for tests/logging - they could be used to raise more informative exceptions anywhere in the code.

A quick regex search of PyTorch for
```
TORCH_CHECK\([^&|"]* (>=|==|<=|>|<|!=) [^&|"]*\);
```
reveals 849 places where error messages could be more informative.

These existing error messages look like:
```
TORCH_CHECK(lhs_var > rhs_var);
```
and produce the message
```
terminate called after throwing an instance of 'c10::Error'
  what():  Expected lhs_var > rhs_var to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```
while this improvement means that including `c10/util/Exception.h` allows one to write:
```
TORCH_CHECK_GT(lhs_var, rhs_var);
```
to get the more informative message (note that values are now displayed):
```
terminate called after throwing an instance of 'c10::Error'
  what():  Check failed: lhs_var > rhs_var (4 vs. 5)
Exception raised from main at test.cpp:167 (most recent call first):
```

Test Plan: Sandcastle

Differential Revision: D45453903

