### PR TITLE
[DataLoader] Follow-up Fix: TypeVars of Sampler

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -223,8 +223,8 @@ class DataLoader(Generic[T_co]):
     __initialized = False
 
     def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
-                 shuffle: Optional[bool] = None, sampler: Union[Sampler[int], Iterable[int], None] = None,
-                 batch_sampler: Union[Sampler[List[int]], Iterable[List[int]], None] = None,
+                 shuffle: Optional[bool] = None, sampler: Union[Sampler, Iterable, None] = None,
+                 batch_sampler: Union[Sampler[List], Iterable[List], None] = None,
                  num_workers: int = 0, collate_fn: Optional[_collate_fn_t] = None,
                  pin_memory: bool = False, drop_last: bool = False,
                  timeout: float = 0, worker_init_fn: Optional[_worker_init_fn_t] = None,

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, Iterator
+from typing import TypeVar, Optional, Iterator
 
 import torch
 from . import Sampler, Dataset
@@ -7,8 +7,10 @@ import torch.distributed as dist
 
 __all__ = ["DistributedSampler", ]
 
+T_co = TypeVar('T_co', covariant=True)
 
-class DistributedSampler(Sampler[int]):
+
+class DistributedSampler(Sampler[T_co]):
     r"""Sampler that restricts data loading to a subset of the dataset.
 
     It is especially useful in conjunction with
@@ -92,7 +94,7 @@ class DistributedSampler(Sampler[int]):
         self.shuffle = shuffle
         self.seed = seed
 
-    def __iter__(self) -> Iterator[int]:
+    def __iter__(self) -> Iterator[T_co]:
         if self.shuffle:
             # deterministically shuffle based on epoch and seed
             g = torch.Generator()

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -12,7 +12,7 @@ __all__ = [
     "WeightedRandomSampler",
 ]
 
-T_co = TypeVar('T_co', int, List[int], covariant=True)
+T_co = TypeVar('T_co', covariant=True)
 
 
 class Sampler(Generic[T_co]):


### PR DESCRIPTION
API backward compatibility fixed:
https://github.com/pytorch/pytorch/pull/97338#discussion_r1169164163

Mapped Dataset can accept noninteger indices from custom Samplers.

Fixes #97338

