### PR TITLE
Revert D45387167: Multisect successfully blamed D45387167 for test or build failures

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -22,7 +22,8 @@ import torch._dynamo.logging
 
 # LOL if you don't remember to import this, then the op isn't registered and it hits
 # the no-op C++ kernel that i am forced to implement despite not using it
-import torch.distributed._functional_collectives as _functional_collectives
+import torch.distributed._functional_collectives
+
 
 @requires_nccl()
 class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
@@ -325,9 +326,8 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         assert same(out, correct)
 
     def test_dynamo_trace_allreduce(self):
-
         def func(inp, *, tag, ranks, group_size):
-            ar = _functional_collectives.all_reduce(inp, "sum", ranks, tag)
+            ar = torch.ops.c10d_functional.all_reduce(inp, "sum", tag, ranks, group_size)
             return ar
 
         inputs = torch.ones(4, 4, device="cuda")
@@ -336,43 +336,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         out = compiled(inputs, **self.get_world_trs())
         correct = func(inputs, **self.get_world_trs())
         assert counter.frame_count == 1
-
-        # should test more precisely, but the 2 is supposed to be (all_reduce, wait)
-        assert counter.op_count == 2
-        assert same(out, correct)
-
-    def test_dynamo_trace_all_gather_tensor(self):
-
-        def func(inp, *, tag, ranks, group_size):
-            ar = _functional_collectives.all_gather_tensor(inp, 0, ranks, tag)
-            return ar
-
-        inputs = torch.ones(4, 4, device="cuda")
-        counter = CompileCounter()
-        compiled = torch.compile(func, backend=counter)
-        out = compiled(inputs, **self.get_world_trs())
-        correct = func(inputs, **self.get_world_trs())
-        assert counter.frame_count == 1
-
-        # should test more precisely, but the 2 is supposed to be (all_reduce, wait)
-        assert counter.op_count == 2
-        assert same(out, correct)
-
-    def test_dynamo_trace_reduce_scatter_tensor(self):
-
-        def func(inp, *, tag, ranks, group_size):
-            ar = _functional_collectives.reduce_scatter_tensor(inp, "sum", 0, ranks, tag)
-            return ar
-
-        inputs = torch.ones(4, 4, device="cuda")
-        counter = CompileCounter()
-        compiled = torch.compile(func, backend=counter)
-        out = compiled(inputs, **self.get_world_trs())
-        correct = func(inputs, **self.get_world_trs())
-        assert counter.frame_count == 1
-
-        # should test more precisely, but the 2 is supposed to be (all_reduce, wait)
-        assert counter.op_count == 2
+        assert counter.op_count == 1
         assert same(out, correct)
 
     def test_backwards(self):
@@ -382,7 +346,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         However, I wanted to at least see if it was possible to support it as a design goal.
         """
         def func(inp, *, tag, ranks, group_size):
-            ar = _functional_collectives.all_reduce(inp, "sum", ranks, tag)
+            ar = torch.ops.c10d_functional.all_reduce(inp, "sum", tag, ranks, group_size)
             return ar
 
         input = torch.ones(4, 4, device="cuda", requires_grad=True)

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -108,11 +108,6 @@ def _disallowed_function_ids():
         warnings.warn,
         torch._C._dynamo.eval_frame.unsupported,
     ]
-    if torch.distributed.is_available():
-        from torch.distributed import _functional_collectives
-
-        config.skipfiles_inline_module_allowlist.add(_functional_collectives)
-
     # extract all dtypes from torch
     dtypes = [
         obj for obj in torch.__dict__.values() if isinstance(obj, type(torch.float32))
@@ -260,7 +255,6 @@ def is_allowed(obj):
     # in those cases
     if id(obj) in _disallowed_function_ids:
         return False
-
     return id(obj) in _allowed_function_ids or isinstance(
         obj,
         (torch._ops.OpOverloadPacket, torch._ops.OpOverload, torch._ops._OpNamespace),

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -4,6 +4,7 @@ import tempfile
 from os.path import abspath, dirname
 
 import torch
+
 from . import external_utils
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1,11 +1,14 @@
 import warnings
+
 import weakref
+from typing import cast, List, Tuple, Union
+
 import sys
 import torch
-import torch._dynamo.external_utils
 import torch.distributed as dist
+
 import torch.distributed.distributed_c10d as c10d
-from typing import Tuple, Union, List, cast, TYPE_CHECKING
+
 from torch.utils._pytree import tree_map_only
 
 from torch.fx.experimental.proxy_tensor import (
@@ -93,8 +96,6 @@ def _wait_and_clear_tensor(data_ptr, version):
 
 def _register_wrapper_tensor(tensor_wrapper, tensor):
     global data_ptr_to_work
-    # Note: we should NEVER try to trace this, bc it registers runtime stuff during trace.
-    # Instead, backends must call this themselves when implementing traced collectives.
     version, _ = data_ptr_to_work.get(tensor.data_ptr(), (None, None))
     if version is None:
         warnings.warn(
@@ -258,31 +259,10 @@ RANK_TYPES = Union[List[int], List[List[int]], dist.ProcessGroup, "dist._tensor.
 def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int]:
     # Cannot import on the top level to avoid circular imports
     import torch.distributed._tensor as dt
-
-    # had to define this hack _inside_ expand_group to avoid
-    # graph_break [('torch.* op returned non-Tensor int
-    # caused by 'cast_*` functions being treated as 'torch.*' ops (iiuc)
-    if TYPE_CHECKING:
-        def cast_listlistint(x):
-            return cast(List[List[int]], x)
-
-        def cast_listint(x):
-            return cast(List[int], x)
-
-    else:
-        # fake cast op for use at runtime since dynamo doesn't support real cast
-        # also, dynamo didn't like encountering 'typing' objects ()
-        # NotImplementedError: argument of type: <class 'typing._GenericAlias'>
-        def cast_listlistint(x):
-            return x
-
-        def cast_listint(x):
-            return x
-
     rankset: List[int]
     if isinstance(group, list):
         if isinstance(group[0], list):
-            nested_list = cast_listlistint(group)
+            nested_list = cast(List[List[int]], group)
             rankset = []
             group_size = -1
             for rs in nested_list:
@@ -293,7 +273,7 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int
                     )
                 group_size = len(rs)
         else:
-            rankset = cast_listint(group)
+            rankset = cast(List[int], group)
             group_size = len(rankset)
     elif isinstance(group, dist.ProcessGroup):
         rankset = dist.get_process_group_ranks(group)
@@ -322,8 +302,6 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int
     return (tag, rankset, group_size)
 
 def _are_we_tracing() -> bool:
-    if torch._dynamo.external_utils.is_compiling():
-        return True
     mode = get_innermost_proxy_mode()
     if mode is None:
         return False


### PR DESCRIPTION
Summary:
This diff is reverting D45387167
D45387167: Basic dynamo support for traceable collectives (#94440) by wconstab has been identified to be causing the following test or build failures (internal)


If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: s4ayub

Differential Revision: D45448312



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire