### PR TITLE
Fix `merging` label removal

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -124,6 +124,10 @@ def mock_parse_args(revert: bool = False, force: bool = False) -> Any:
     return Object()
 
 
+def mock_remove_label(org: str, repo: str, pr_num: str, label: str) -> None:
+    pass
+
+
 def mock_revert(
     repo: GitRepo,
     pr: GitHubPR,
@@ -376,6 +380,7 @@ class TestTryMerge(TestCase):
 
     @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
     @mock.patch("trymerge.parse_args", return_value=mock_parse_args(False, True))
+    @mock.patch("trymerge.gh_remove_label", side_effect=mock_remove_label)
     @mock.patch("trymerge.merge", side_effect=mock_merge)
     def test_main_force(
         self, mock_merge: Any, mock_parse_args: Any, *args: Any
@@ -392,6 +397,7 @@ class TestTryMerge(TestCase):
 
     @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
     @mock.patch("trymerge.parse_args", return_value=mock_parse_args(False, False))
+    @mock.patch("trymerge.gh_remove_label", side_effect=mock_remove_label)
     @mock.patch("trymerge.merge", side_effect=mock_merge)
     def test_main_merge(self, mock_merge: Any, *args: Any) -> None:
         trymerge_main()

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1049,10 +1049,6 @@ class GitHubPR:
                 full_label = f"{label_base}X{count}"
         gh_add_labels(self.org, self.project, self.pr_num, [full_label])
 
-    def remove_label(self, label: str) -> None:
-        if self.get_labels() is not None and label in self.get_labels():
-            gh_remove_label(self.org, self.project, self.pr_num, label)
-
     def merge_into(
         self,
         repo: GitRepo,
@@ -2043,7 +2039,7 @@ def main() -> None:
         else:
             print("Missing comment ID or PR number, couldn't upload to Rockset")
     finally:
-        pr.remove_label(MERGE_IN_PROGRESS_LABEL)
+        gh_remove_label(org, project, args.pr_num, MERGE_IN_PROGRESS_LABEL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
During regular merge process, when `GitHubPR` object is created, it does not have `merging` label and when label is added it does not update existing `GitHubPR` object either

To fix the problem, call REST API wrapper `gh_remove_label` directly. Worst case that can happen, if label is already removed at this point, is that it will be printed to the stderr, which is not rendered on HUD anyway
