### PR TITLE
Manually resolve download.pytorch.org to IPv4

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -9,6 +9,13 @@ set -ex
 echo "Environment variables:"
 env
 
+# Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+# Print the configurations
+sysctl -a 2>/dev/null | grep disable_ipv6
+
 TORCH_INSTALL_DIR=$(python -c "import site; print(site.getsitepackages()[0])")/torch
 TORCH_BIN_DIR="$TORCH_INSTALL_DIR"/bin
 TORCH_LIB_DIR="$TORCH_INSTALL_DIR"/lib

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -9,14 +9,6 @@ set -ex
 echo "Environment variables:"
 env
 
-# TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400.
-# Cleaning this up once the issue is fixed
-sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
-sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
-
-# Print the configurations
-sysctl -a 2>/dev/null | grep disable_ipv6
-
 TORCH_INSTALL_DIR=$(python -c "import site; print(site.getsitepackages()[0])")/torch
 TORCH_BIN_DIR="$TORCH_INSTALL_DIR"/bin
 TORCH_LIB_DIR="$TORCH_INSTALL_DIR"/lib

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -9,7 +9,8 @@ set -ex
 echo "Environment variables:"
 env
 
-# Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400
+# TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400.
+# Cleaning this up once the issue is fixed
 sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
 sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -68,7 +68,7 @@ runs:
         # TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400,
         # cleaning this up once the issue is fixed. There are more than one resolved IP here, the last
         # one is returned at random
-        RESOLVED_IP=$(dig -4 +short "${PT_DOMAIN}"  | tail -n1)
+        RESOLVED_IP=$(dig -4 +short "${PT_DOMAIN}" | tail -n1)
 
         if [ -z "${RESOLVED_IP}" ]; then
           echo "Couldn't resolve ${PT_DOMAIN}, exiting..."

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -81,4 +81,4 @@ runs:
         fi
 
         echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
-        host "${PT_DOMAIN}"
+        cat /etc/hosts

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -56,3 +56,13 @@ runs:
       run: |
         env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
         env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+
+    - name: Disable IPv6
+      shell: bash
+      run: |
+        # Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400
+        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+        # Print the configurations
+        sysctl -a 2>/dev/null | grep disable_ipv6

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -56,13 +56,3 @@ runs:
       run: |
         env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
         env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
-
-    - name: Disable IPv6
-      shell: bash
-      run: |
-        # Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400
-        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
-        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
-
-        # Print the configurations
-        sysctl -a 2>/dev/null | grep disable_ipv6

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -78,7 +78,7 @@ runs:
         if grep -r "${PT_DOMAIN}" /etc/hosts; then
           # Clean up any old records first
           sudo sed -i "/${PT_DOMAIN}/d" /etc/hosts
-          echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
         fi
 
+        echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
         host "${PT_DOMAIN}"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -56,3 +56,15 @@ runs:
       run: |
         env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
         env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+
+    - name: Disable IPv6
+      shell: bash
+      run: |
+        # TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400,
+        # cleaning this up once the issue is fixed. Note that doing this step inside Docker container
+        # would also apply the same configuration to the host itself
+        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+        # Print the configurations
+        sysctl -a 2>/dev/null | grep disable_ipv6

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -57,14 +57,28 @@ runs:
         env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
         env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
 
-    - name: Disable IPv6
+    - name: Manually resolve download.pytorch.org
       shell: bash
+      continue-on-error: true
       run: |
-        # TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400,
-        # cleaning this up once the issue is fixed. Note that doing this step inside Docker container
-        # would also apply the same configuration to the host itself
-        sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
-        sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+        set +e
+        set -x
 
-        # Print the configurations
-        sysctl -a 2>/dev/null | grep disable_ipv6
+        PT_DOMAIN=download.pytorch.org
+        # TODO: Flaky access to download.pytorch.org https://github.com/pytorch/pytorch/issues/100400,
+        # cleaning this up once the issue is fixed. There are more than one resolved IP here, the last
+        # one is returned at random
+        RESOLVED_IP=$(dig -4 +short "${PT_DOMAIN}"  | tail -n1)
+
+        if [ -z "${RESOLVED_IP}" ]; then
+          echo "Couldn't resolve ${PT_DOMAIN}, exiting..."
+          exit 1
+        fi
+
+        if grep -r "${PT_DOMAIN}" /etc/hosts; then
+          # Clean up any old records first
+          sudo sed -i "/${PT_DOMAIN}/d" /etc/hosts
+          echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
+        fi
+
+        host "${PT_DOMAIN}"


### PR DESCRIPTION
This is an attempt to address https://github.com/pytorch/pytorch/issues/100400 by using only IPV4 when accessing the domain.

I kind of want to ignore AAAA records from DNS instead, but couldn't find an easy way to do so.  https://www.cloudflare.com/learning/dns/dns-records/dns-aaaa-record doc mentions this

```
Like A records, AAAA records enable client devices to learn the IP address for a domain name. The client device can then connect with and load the website.

AAAA records are only used when a domain has an IPv6 address in addition to an IPv4 address, and when the client device in question is configured to use IPv6
```
