### PR TITLE
[quant][pt2e] Support conv bn fusion in convert step for QAT flow

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1284,6 +1284,7 @@ def get_fake_value(node, tx):
             unimplemented("guard on data-dependent symbolic int/float")
         elif isinstance(cause, torch.utils._sympy.value_ranges.ValueRangeError):
             raise UserError(UserErrorType.CONSTRAIN_VIOLATION, e.args[0]) from e
+        # why don't we print the exception here?
         raise TorchRuntimeError() from e
 
 

--- a/torch/ao/quantization/_pt2e/utils.py
+++ b/torch/ao/quantization/_pt2e/utils.py
@@ -1,5 +1,8 @@
 import torch
-from torch.fx import GraphModule
+from torch.fx import (
+    GraphModule,
+    Node,
+)
 from torch.nn.utils.fusion import fuse_conv_bn_weights
 # TODO[jerryzh168]: move this to a more general util function
 from torch.ao.quantization.fx.prepare import (
@@ -15,68 +18,94 @@ def _get_tensor_constant_from_node(node, m):
     assert node.op == "get_attr"
     return getattr(m, node.target)
 
+def _get_all_arguments(orig_args, orig_kwargs, args_schema):
+    all_args = []
+    for i, schema in enumerate(args_schema):
+        if schema.name in orig_kwargs:
+            all_args.append(orig_kwargs[schema.name])
+        elif not schema.kwarg_only and i < len(orig_args):
+            all_args.append(orig_args[i])
+        else:
+            all_args.append(schema.default_value)
+    return all_args
+
+def _fold_bn_weights_into_conv_node(
+    conv_node: Node,
+    conv_weight_node: Node,
+    conv_bias_node: Node,
+    bn_node: Node,
+    m: GraphModule
+) -> None:
+    # conv weight
+    conv_w = _get_tensor_constant_from_node(conv_weight_node, m)
+    # conv bias
+    conv_b = _get_tensor_constant_from_node(conv_bias_node, m)
+    transpose = conv_node.args[6]
+
+    bn_args_schema = bn_node.target._schema.arguments  # type: ignore[union-attr]
+    bn_args = _get_all_arguments(bn_node.args, bn_node.kwargs, bn_args_schema)
+
+    # bn weight
+    bn_w = _get_tensor_constant_from_node(bn_args[1], m)
+    # bn bias
+    bn_b = _get_tensor_constant_from_node(bn_args[2], m)
+    # bn running mean
+    bn_rm = _get_tensor_constant_from_node(bn_args[3], m)
+    # bn running variance
+    bn_rv = _get_tensor_constant_from_node(bn_args[4], m)
+    bn_eps = bn_args[6]
+
+    fused_weight, fused_bias = fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=transpose)
+
+    # update the weight and bias for conv
+    conv_args = list(conv_node.args)
+    # calling data since the fused_weight and fused_bias are nn.Parameter
+    weight_attr_name = conv_weight_node.target
+    setattr(m, weight_attr_name, fused_weight)  # type: ignore[arg-type]
+    if conv_bias_node is not None:
+        bias_attr_name = conv_bias_node.target
+    else:
+        bias_attr_name = weight_attr_name + "_bias"
+        with m.graph.inserting_before(conv_node):
+            get_bias_node = m.graph.get_attr(bias_attr_name)
+        # NOTE: here we assume the bias of conv is not quantized!
+        conv_args[2] = get_bias_node
+    setattr(m, bias_attr_name, fused_bias)  # type: ignore[arg-type]
+    conv_node.args = tuple(conv_args)
+
+    # native_batch_norm has 3 outputs, we expect getitem calls on the output
+    # and we want to replace the uses of getitem 0 with the output of conv
+    #
+    # Before:
+    # conv -> bn - (first output) -> users1
+    #          \ - (second output) -> users2
+    #          \ - (third output) -> users3
+    # After:
+    # conv -> (first output) -> users1
+    #       bn -
+    #          \ - (second output) -> users2
+    #          \ - (third output) -> users3
+    # if users2 and users3 are empty then bn will be removed through dead code elimination
+
+    for user in bn_node.users:
+        if user.op != "call_function" or user.target != operator.getitem or user.args[1] != 0:
+            continue
+        user.replace_all_uses_with(conv_node)
+
 # fuse conv bn weights, inplace modification of the graph_module and graph
 def _fuse_conv_bn_(m: GraphModule) -> None:
     for n in m.graph.nodes:
         if n.op != "call_function" or n.target != torch.ops.aten._native_batch_norm_legit_no_training.default:
             continue
-        bn_op = n
-        n = bn_op.args[0]
+        bn_node = n
+        n = bn_node.args[0]
         if n.op != "call_function" or n.target != torch.ops.aten.convolution.default:
             continue
-        conv_op = n
+        conv_node = n
+        conv_weight_node = conv_node.args[1]
+        conv_bias_node = conv_node.args[2]
+        _fold_bn_weights_into_conv_node(conv_node, conv_weight_node, conv_bias_node, bn_node, m)
 
-        # conv weight
-        conv_w = _get_tensor_constant_from_node(conv_op.args[1], m)
-        # conv bias
-        conv_b = _get_tensor_constant_from_node(conv_op.args[2], m)
-        transpose = conv_op.args[6]
-
-        # bn weight
-        bn_w = _get_tensor_constant_from_node(bn_op.args[1], m)
-        # bn bias
-        bn_b = _get_tensor_constant_from_node(bn_op.args[2], m)
-        # bn running mean
-        bn_rm = _get_tensor_constant_from_node(bn_op.args[3], m)
-        # bn running variance
-        bn_rv = _get_tensor_constant_from_node(bn_op.args[4], m)
-        bn_eps = bn_op.args[6]
-
-        fused_weight, fused_bias = fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=transpose)
-
-        # update the weight and bias for conv
-        conv_args = list(conv_op.args)
-        # calling data since the fused_weight and fused_bias are nn.Parameter
-        weight_attr_name = conv_args[1].target
-        setattr(m, weight_attr_name, fused_weight)
-        if conv_args[2] is not None:
-            bias_attr_name = conv_args[2].target
-        else:
-            bias_attr_name = weight_attr_name + "_bias"
-            with m.graph.inserting_before(conv_op):
-                get_bias_node = m.graph.get_attr(bias_attr_name)
-            conv_args[2] = get_bias_node
-        setattr(m, bias_attr_name, fused_bias)
-        conv_op.args = tuple(conv_args)
-
-        # native_batch_norm has 3 outputs, we expect getitem calls on the output
-        # and we want to replace the uses of getitem 0 with the output of conv
-        #
-        # Before:
-        # conv -> bn - (first output) -> users1
-        #          \ - (second output) -> users2
-        #          \ - (third output) -> users3
-        # After:
-        # conv -> (first output) -> users1
-        #       bn -
-        #          \ - (second output) -> users2
-        #          \ - (third output) -> users3
-        # if users2 and users3 are empty then bn will be removed through dead code elimination
-
-        for user in bn_op.users:
-            if user.op != "call_function" or user.target != operator.getitem or user.args[1] != 0:
-                continue
-            user.replace_all_uses_with(conv_op)
     m.graph.eliminate_dead_code()
     m.recompile()
 

--- a/torch/ao/quantization/_quantize_pt2e.py
+++ b/torch/ao/quantization/_quantize_pt2e.py
@@ -2,7 +2,10 @@ from torch.fx import GraphModule
 
 from ._pt2e.prepare import prepare
 from ._pt2e._propagate_annotation import propagate_annotation
-from ._pt2e.qat_utils import _fuse_conv_bn_qat
+from ._pt2e.qat_utils import (
+    _fuse_conv_bn_qat,
+    _fold_conv_bn_qat,
+)
 from ._pt2e.utils import (
     _get_node_name_to_scope,
     _fuse_conv_bn_,
@@ -81,4 +84,6 @@ def prepare_qat_pt2e_quantizer(
 def convert_pt2e(
     model: GraphModule
 ):
-    return _convert_to_reference_decomposed_fx(model)
+    model = _convert_to_reference_decomposed_fx(model)  # type: ignore[assignment]
+    model = _fold_conv_bn_qat(model)
+    return model

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -222,6 +222,7 @@ def _replace_pattern(
     pattern: Union[Callable, GraphModule],
     replacement: Union[Callable, GraphModule],
     match_filters: List[Callable[["InternalMatch", Graph, Graph], bool]] = None,  # type: ignore[name-defined]
+    ignore_literals: bool = False,
 ) -> List[ReplacedPatterns]:
 
     from torch.fx.passes.utils.matcher_utils import SubgraphMatcher, InternalMatch
@@ -243,7 +244,7 @@ def _replace_pattern(
         replacement_graph = symbolic_trace(replacement).graph
 
     matcher = SubgraphMatcher(pattern_graph, match_output=False, match_placeholder=False,
-                              remove_overlapping_matches=True)
+                              remove_overlapping_matches=True, ignore_literals=ignore_literals)
     _matches: List[InternalMatch] = matcher.match(original_graph)
 
     # Filter out matches that don't match the filter


### PR DESCRIPTION
Summary:
This PR adds support for folding bn weights into conv for QAT flow, this is equivalent
to the QAT branch of `from_float` in eager mode quantized conv module: https://github.com/pytorch/pytorch/blob/main/torch/ao/nn/quantized/modules/conv.py#L223

Items that needs followup:
* there are some workaround I did because quantize_per_tensor is using float/int args and dynamo does not support these args, need to fix after we change the quantized model representation and also change these args to Tensor

Test Plan: buck2 test @//mode/opt //caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_convert_qat_conv_bn_fusion (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2E)'

Reviewed By: andrewor14

Differential Revision: D45344281



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire