### PR TITLE
[DataPipe] Update docstring for functional form of DataPipes

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -5,6 +5,7 @@ import itertools
 import os
 import os.path
 import pickle
+import pydoc
 import random
 import sys
 import tempfile
@@ -830,6 +831,35 @@ class TestFunctionalIterDataPipe(TestCase):
                         datapipe = dpipe(input_dp, *dp_args, **dp_kwargs)  # type: ignore[call-arg]
                     with self.assertRaises((pickle.PicklingError, AttributeError)):
                         pickle.dumps(datapipe)
+
+    def test_docstring(self):
+        """
+        Ensure functional form of IterDataPipe has the correct docstring from
+        the class form.
+
+        Regression test for https://github.com/pytorch/data/issues/792.
+        """
+        input_dp = dp.iter.IterableWrapper(range(10))
+
+        for dp_funcname in [
+            "batch",
+            "collate",
+            "concat",
+            "demux",
+            "filter",
+            "fork",
+            "map",
+            "mux",
+            "read_from_stream",
+            # "sampler",
+            "shuffle",
+            "unbatch",
+            "zip",
+        ]:
+            docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
+            assert f"(functional name: ``{dp_funcname}``)" in docstring
+            assert "Args:" in docstring
+            assert "Example:" in docstring or "Examples:" in docstring
 
     def test_iterable_wrapper_datapipe(self):
 
@@ -1893,6 +1923,28 @@ class TestFunctionalMapDataPipe(TestCase):
                         datapipe = dpipe(input_dp, *dp_args, **dp_kwargs)  # type: ignore[call-arg]
                     with self.assertRaises((pickle.PicklingError, AttributeError)):
                         pickle.dumps(datapipe)
+
+    def test_docstring(self):
+        """
+        Ensure functional form of MapDataPipe has the correct docstring from
+        the class form.
+
+        Regression test for https://github.com/pytorch/data/issues/792.
+        """
+        input_dp = dp.map.SequenceWrapper(range(10))
+
+        for dp_funcname in [
+            "batch",
+            "concat",
+            "map",
+            "shuffle",
+            # "unzip",
+            "zip",
+        ]:
+            docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
+            assert f"(functional name: ``{dp_funcname}``)" in docstring
+            assert "Args:" in docstring
+            assert "Example:" in docstring or "Examples:" in docstring
 
     def test_sequence_wrapper_datapipe(self):
         seq = list(range(10))

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1938,7 +1938,6 @@ class TestFunctionalMapDataPipe(TestCase):
             "concat",
             "map",
             "shuffle",
-            # "unzip",
             "zip",
         ]:
             docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -856,9 +856,14 @@ class TestFunctionalIterDataPipe(TestCase):
             "unbatch",
             "zip",
         ]:
-            docstring = pydoc.render_doc(
-                thing=getattr(input_dp, dp_funcname), forceload=True
-            )
+            if sys.version_info >= (3, 9):
+                docstring = pydoc.render_doc(
+                    thing=getattr(input_dp, dp_funcname), forceload=True
+                )
+            elif sys.version_info < (3, 9):
+                # pydoc works differently on Python 3.8, see
+                # https://docs.python.org/3/whatsnew/3.9.html#pydoc
+                docstring = getattr(input_dp, dp_funcname).__doc__
             try:
                 assert f"(functional name: ``{dp_funcname}``)" in docstring
             except AssertionError:

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -858,7 +858,7 @@ class TestFunctionalIterDataPipe(TestCase):
         ]:
             docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
             try:
-                assert f"(functional name: ``{dp_funcname}`` )" in docstring
+                assert f"(functional name: ``{dp_funcname}``)" in docstring
             except AssertionError:
                 print(dp_funcname)
                 print(docstring)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1948,7 +1948,14 @@ class TestFunctionalMapDataPipe(TestCase):
             "shuffle",
             "zip",
         ]:
-            docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
+            if sys.version_info >= (3, 9):
+                docstring = pydoc.render_doc(
+                    thing=getattr(input_dp, dp_funcname), forceload=True
+                )
+            elif sys.version_info < (3, 9):
+                # pydoc works differently on Python 3.8, see
+                # https://docs.python.org/3/whatsnew/3.9.html#pydoc
+                docstring = getattr(input_dp, dp_funcname).__doc__
             assert f"(functional name: ``{dp_funcname}``)" in docstring
             assert "Args:" in docstring
             assert "Example:" in docstring or "Examples:" in docstring

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -856,7 +856,9 @@ class TestFunctionalIterDataPipe(TestCase):
             "unbatch",
             "zip",
         ]:
-            docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
+            docstring = pydoc.render_doc(
+                thing=getattr(input_dp, dp_funcname), forceload=True
+            )
             try:
                 assert f"(functional name: ``{dp_funcname}``)" in docstring
             except AssertionError:

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -864,14 +864,8 @@ class TestFunctionalIterDataPipe(TestCase):
                 # pydoc works differently on Python 3.8, see
                 # https://docs.python.org/3/whatsnew/3.9.html#pydoc
                 docstring = getattr(input_dp, dp_funcname).__doc__
-            try:
-                assert f"(functional name: ``{dp_funcname}``)" in docstring
-            except AssertionError:
-                print("***Begin docstring for", dp_funcname)
-                print(docstring)
-                print("***End docstring for", dp_funcname)
-                raise ValueError(dp_funcname, "IterDataPipe docstring incorrect")
 
+            assert f"(functional name: ``{dp_funcname}``)" in docstring
             assert "Args:" in docstring
             assert "Example:" in docstring or "Examples:" in docstring
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -857,7 +857,14 @@ class TestFunctionalIterDataPipe(TestCase):
             "zip",
         ]:
             docstring = pydoc.render_doc(thing=getattr(input_dp, dp_funcname))
-            assert f"(functional name: ``{dp_funcname}``)" in docstring
+            try:
+                assert f"(functional name: ``{dp_funcname}`` )" in docstring
+            except AssertionError:
+                print(dp_funcname)
+                print(docstring)
+                print(input_dp.__doc__)
+                raise ValueError(dp_funcname, "IterDataPipe docstring incorrect")
+
             assert "Args:" in docstring
             assert "Example:" in docstring or "Examples:" in docstring
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -860,9 +860,9 @@ class TestFunctionalIterDataPipe(TestCase):
             try:
                 assert f"(functional name: ``{dp_funcname}``)" in docstring
             except AssertionError:
-                print(dp_funcname)
+                print("***Begin docstring for", dp_funcname)
                 print(docstring)
-                print(input_dp.__doc__)
+                print("***End docstring for", dp_funcname)
                 raise ValueError(dp_funcname, "IterDataPipe docstring incorrect")
 
             assert "Args:" in docstring

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -282,7 +282,7 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
 
         function = functools.partial(class_function, cls_to_register)
         functools.update_wrapper(
-            wrapper=unction, wrapped=cls_to_register, assigned=("__doc__",)
+            wrapper=function, wrapped=cls_to_register, assigned=("__doc__",)
         )
         cls.functions[function_name] = function
 

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -121,7 +121,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
             if attribute_name in _iter_deprecated_functional_names:
                 kwargs = _iter_deprecated_functional_names[attribute_name]
                 _deprecation_warning(**kwargs)
-            function = functools.partial(IterDataPipe.functions[attribute_name], self)
+            f = IterDataPipe.functions[attribute_name]
+            function = functools.partial(f, self)
+            functools.update_wrapper(wrapper=function, wrapped=f, assigned=("__doc__",))
             return function
         else:
             raise AttributeError("'{0}' object has no attribute '{1}".format(self.__class__.__name__, attribute_name))
@@ -144,7 +146,12 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
 
             return result_pipe
 
-        function = functools.partial(class_function, cls_to_register, enable_df_api_tracing)
+        function = functools.partial(
+            class_function, cls_to_register, enable_df_api_tracing
+        )
+        functools.update_wrapper(
+            wrapper=function, wrapped=cls_to_register, assigned=("__doc__",)
+        )
         cls.functions[function_name] = function
 
     def __getstate__(self):
@@ -253,7 +260,9 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
             if attribute_name in _map_deprecated_functional_names:
                 kwargs = _map_deprecated_functional_names[attribute_name]
                 _deprecation_warning(**kwargs)
-            function = functools.partial(MapDataPipe.functions[attribute_name], self)
+            f = MapDataPipe.functions[attribute_name]
+            function = functools.partial(f, self)
+            functools.update_wrapper(wrapper=function, wrapped=f, assigned=("__doc__",))
             return function
         else:
             raise AttributeError("'{0}' object has no attribute '{1}".format(self.__class__.__name__, attribute_name))
@@ -272,6 +281,9 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
             return result_pipe
 
         function = functools.partial(class_function, cls_to_register)
+        functools.update_wrapper(
+            wrapper=unction, wrapped=cls_to_register, assigned=("__doc__",)
+        )
         cls.functions[function_name] = function
 
     def __getstate__(self):


### PR DESCRIPTION
Copy the docstring from IterDataPipe and MapDataPipe classes to their functional form. Done using [`functools.update_wrapper`](https://docs.python.org/3/library/functools.html#functools.update_wrapper), xref https://stackoverflow.com/questions/6394511/python-functools-wraps-equivalent-for-classes.

See also parallel change to `.pyi` stub files at https://github.com/pytorch/pytorch/pull/100503

Fixes https://github.com/pytorch/data/issues/792 and https://github.com/weiji14/zen3geo/issues/69.