### PR TITLE
Set assume_static_by_default to True in Dynamo config

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -108,6 +108,7 @@ def _export(
             tracing_mode="symbolic",
             decomposition_table=DECOMP_TABLE,
             constraints=constraints,
+            assume_static_by_default=True,
         )
 
     flat_args, in_spec = pytree.tree_flatten(args)


### PR DESCRIPTION
We expect fine grained dynamic shape enabled at all times, which means that a dimension is assumed to be static unless user explicitly says otherwise.

Differential Revision: D45473365

