### PR TITLE
Revert D45446149: Multisect successfully blamed D45446149 for test or build failures

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1312,11 +1312,6 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 static void addmm_impl_cpu_(
     Tensor &result, const Tensor &self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);
-
-  TORCH_CHECK(
-    m1.dtype() == m2.dtype(),
-    "expected m1 and m2 to have the same dtype, but got: ", m1.dtype(), " != ", m2.dtype()
-  )
   // Array access is faster than .size(n) and .stride(n)
   const auto self_sizes = self.sizes();
   auto m1_strides = m1.strides();

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -151,10 +151,6 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   // preflights a check to try to avoid actually needing to call
   // expand().
   TORCH_CHECK(mat1.dim() == 2 && mat2.dim() == 2, "tensors must be 2-D");
-  TORCH_CHECK(
-    mat1.dtype() == mat2.dtype(),
-    "expected mat1 and mat2 to have the same dtype, but got: ", mat1.dtype(), " != ", mat2.dtype()
-  )
 
   TensorArg args[]{{result, "out", 0}, {self, "self", 1}, {mat1, "mat1", 2}, {mat2, "mat2", 3}};
   checkAllSameGPU(__func__, args);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5833,13 +5833,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertEqual(torch.bmm(t_b(Ab_conj), Bb_, out=out_b), torch.bmm(t_b(Ab_conj_physical), Bb_, out=out_b))
 
     @onlyNativeDeviceTypes
-    def test_mm_empty_inputs_mixed_dtype_errors(self, device):
-        a = torch.randint(0, 10, [1, 10], dtype=torch.int16, device=device)
-        b = torch.randn(10, 20, dtype=torch.float32, device=device)
-        with self.assertRaisesRegex(RuntimeError, "expected .* and .* to have the same dtype, but got:"):
-            torch.mm(a, b)
-
-    @onlyNativeDeviceTypes
     @dtypes(torch.float32, torch.float64)
     def test_strided_mm_bmm(self, device, dtype):
         # Tests strided view case with stride smaller than corresponding dimension size


### PR DESCRIPTION
Summary:
This diff is reverting D45446149
D45446149: Check inputs have same dtype in addmm_impl_cpu_ even if input has zero numel (#100274) by soulitzer has been identified to be causing the following test or build failures:

Tests affected:
- [caffe2/torch/fb/model_transform/splitting/tests:utils_test - test_maybe_fix_dtype_errors (caffe2.torch.fb.model_transform.splitting.tests.utils_test.UtilsTest)](https://www.internalfb.com/intern/test/844425018399076/)

Here's the Multisect link:
https://www.internalfb.com/multisect/1972447
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: soulitzer

Differential Revision: D45471651

