### PR TITLE
Populate download.pytorch.org IP to container

### DIFF
--- a/.github/actions/test-pytorch-binary/action.yml
+++ b/.github/actions/test-pytorch-binary/action.yml
@@ -28,6 +28,7 @@ runs:
           -e SKIP_ALL_TESTS \
           --tty \
           --detach \
+          -v "/etc/hosts:/etc/hosts:ro" \
           -v "${GITHUB_WORKSPACE}/pytorch:/pytorch" \
           -v "${GITHUB_WORKSPACE}/builder:/builder" \
           -v "${RUNNER_TEMP}/artifacts:/final_pkgs" \

--- a/.github/actions/test-pytorch-binary/action.yml
+++ b/.github/actions/test-pytorch-binary/action.yml
@@ -28,13 +28,14 @@ runs:
           -e SKIP_ALL_TESTS \
           --tty \
           --detach \
-          -v "/etc/hosts:/etc/hosts:ro" \
           -v "${GITHUB_WORKSPACE}/pytorch:/pytorch" \
           -v "${GITHUB_WORKSPACE}/builder:/builder" \
           -v "${RUNNER_TEMP}/artifacts:/final_pkgs" \
           -w / \
           "${DOCKER_IMAGE}"
         )
+        # Propagate download.pytorch.org IP to container
+        grep download.pytorch.org /etc/hosts | docker exec -i ${container_name} sudo bash -c "/bin/cat >> /etc/hosts"
         docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
         # Generate test script
         docker exec -t -w "${PYTORCH_ROOT}" -e OUTPUT_SCRIPT="/run.sh" "${container_name}" bash -c "bash .circleci/scripts/binary_linux_test.sh"

--- a/.github/actions/test-pytorch-binary/action.yml
+++ b/.github/actions/test-pytorch-binary/action.yml
@@ -35,7 +35,7 @@ runs:
           "${DOCKER_IMAGE}"
         )
         # Propagate download.pytorch.org IP to container
-        grep download.pytorch.org /etc/hosts | docker exec -i ${container_name} sudo bash -c "/bin/cat >> /etc/hosts"
+        grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" sudo bash -c "/bin/cat >> /etc/hosts"
         docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
         # Generate test script
         docker exec -t -w "${PYTORCH_ROOT}" -e OUTPUT_SCRIPT="/run.sh" "${container_name}" bash -c "bash .circleci/scripts/binary_linux_test.sh"

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -210,7 +210,7 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           # Propagate download.pytorch.org IP to container
-          grep download.pytorch.org /etc/hosts | docker exec -i ${container_name} sudo bash -c "/bin/cat >> /etc/hosts"
+          grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" sudo bash -c "/bin/cat >> /etc/hosts"
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -167,6 +167,7 @@ jobs:
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
+          # Mount /etc/hosts into the container to propagate all shortcuts
           # shellcheck disable=SC2086,SC2090
           container_name=$(docker run \
             ${GPU_FLAG:-} \
@@ -205,12 +206,11 @@ jobs:
             --detach \
             --name="${container_name}" \
             --user jenkins \
+            -v "/etc/hosts:/etc/hosts:ro" \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          # Copy /etc/hosts that contains download.pytorch.org ipv4 int container
-          docker cp /etc/hosts ${container_name}:/etc/
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -167,7 +167,6 @@ jobs:
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
-          # Mount /etc/hosts into the container to propagate all shortcuts
           # shellcheck disable=SC2086,SC2090
           container_name=$(docker run \
             ${GPU_FLAG:-} \
@@ -206,11 +205,12 @@ jobs:
             --detach \
             --name="${container_name}" \
             --user jenkins \
-            -v "/etc/hosts:/etc/hosts:ro" \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
+          # Propagate download.pytorch.org IP to container
+          grep download.pytorch.org /etc/hosts | docker exec -i ${container_name} sudo bash -c "/bin/cat >> /etc/hosts"
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -209,6 +209,8 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
+          # Copy /etc/hosts that contains download.pytorch.org ipv4 int container
+          docker cp /etc/hosts ${container_name}:/etc/
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 


### PR DESCRIPTION
Follow up after https://github.com/pytorch/pytorch/pull/100436 to disable download.pytorch.org access over ipv6 access problems.

Why not copy `/etc/hosts` from host to the container? Because it would break container ip resolution in distributed tests, that relies on `socket.gethostbyname(socket.gethostname())` to work.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 756d0b1</samp>

Propagate `download.pytorch.org` IP address to docker containers in `test-pytorch-binary` action and workflow. This fixes DNS issues when downloading PyTorch binaries inside the containers.