### PR TITLE
ci: win cpu test -> trunk, cuda test -> periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -209,3 +209,30 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
         ]}
+
+  win-vs2019-cuda11_7-py3-build:
+    name: win-vs2019-cuda11.7-py3
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2019-cuda11.7-py3
+      cuda-version: "11.7"
+      sync-tag: win-cuda-build
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 2, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 3, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 4, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 5, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
+        ]}
+
+  win-vs2019-cuda11_7-py3-test:
+    name: win-vs2019-cuda11.7-py3
+    uses: ./.github/workflows/_win-test.yml
+    needs: win-vs2019-cuda11_7-py3-build
+    with:
+      build-environment: win-vs2019-cuda11.7-py3
+      cuda-version: "11.7"
+      test-matrix: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.test-matrix }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -209,30 +209,3 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
         ]}
-
-  win-vs2019-cuda11_7-py3-build:
-    name: win-vs2019-cuda11.7-py3
-    uses: ./.github/workflows/_win-build.yml
-    with:
-      build-environment: win-vs2019-cuda11.7-py3
-      cuda-version: "11.7"
-      sync-tag: win-cuda-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
-        ]}
-
-  win-vs2019-cuda11_7-py3-test:
-    name: win-vs2019-cuda11.7-py3
-    uses: ./.github/workflows/_win-test.yml
-    needs: win-vs2019-cuda11_7-py3-build
-    with:
-      build-environment: win-vs2019-cuda11.7-py3
-      cuda-version: "11.7"
-      test-matrix: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.test-matrix }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -269,34 +269,6 @@ jobs:
           { config: "default", shard: 3, num_shards: 3, runner: "windows.4xlarge" },
         ]}
 
-  win-vs2019-cpu-py3-test:
-    name: win-vs2019-cpu-py3
-    uses: ./.github/workflows/_win-test.yml
-    needs: win-vs2019-cpu-py3-build
-    with:
-      build-environment: win-vs2019-cpu-py3
-      cuda-version: cpu
-      test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}
-
-  win-vs2019-cuda11_7-py3-build:
-    if: github.event_name == 'pull_request'
-    name: win-vs2019-cuda11.7-py3
-    uses: ./.github/workflows/_win-build.yml
-    with:
-      build-environment: win-vs2019-cuda11.7-py3
-      cuda-version: "11.7"
-      sync-tag: win-cuda-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
-        ]}
-
   linux-bionic-cpu-py3_10-gcc7-bazel-test:
     name: linux-bionic-cpu-py3.10-gcc7-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -134,29 +134,24 @@ jobs:
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
       arch: arm64
 
-  win-vs2019-cuda11_7-py3-build:
-    name: win-vs2019-cuda11.7-py3
+  win-vs2019-cpu-py3-build:
+    name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-build.yml
     with:
-      build-environment: win-vs2019-cuda11.7-py3
-      cuda-version: "11.7"
-      sync-tag: win-cuda-build
+      build-environment: win-vs2019-cpu-py3
+      cuda-version: cpu
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
-          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
+          { config: "default", shard: 1, num_shards: 3, runner: "windows.4xlarge" },
+          { config: "default", shard: 2, num_shards: 3, runner: "windows.4xlarge" },
+          { config: "default", shard: 3, num_shards: 3, runner: "windows.4xlarge" },
         ]}
 
-  win-vs2019-cuda11_7-py3-test:
-    name: win-vs2019-cuda11.7-py3
+  win-vs2019-cpu-py3-test:
+    name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-test.yml
-    needs: win-vs2019-cuda11_7-py3-build
+    needs: win-vs2019-cpu-py3-build
     with:
-      build-environment: win-vs2019-cuda11.7-py3
-      cuda-version: "11.7"
-      test-matrix: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.test-matrix }}
+      build-environment: win-vs2019-cpu-py3
+      cuda-version: cpu
+      test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -155,3 +155,21 @@ jobs:
       build-environment: win-vs2019-cpu-py3
       cuda-version: cpu
       test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}
+
+  win-vs2019-cuda11_7-py3-build:
+    name: win-vs2019-cuda11.7-py3
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2019-cuda11.7-py3
+      cuda-version: "11.7"
+      sync-tag: win-cuda-build
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 2, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 3, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 4, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 5, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
+        ]}


### PR DESCRIPTION
Bumps windows CPU tests to trunk.yml (retaining build in pull.yml), this
also bumps the cuda tests to periodic.yml (retaining build in
trunk.yml).

Hopefully this change will rein in windows spending on AWS since it is
currently our costliest platform (in terms of dollar amount / hours used)

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht