### PR TITLE
[dynamo] Disable pytest AST rewriting in test_export

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1,4 +1,9 @@
 # Owner(s): ["module: dynamo"]
+"""
+Disable pytest AST rewriting (breaks some Dyanmo tests)
+
+PYTEST_DONT_REWRITE
+"""
 import functools
 import inspect
 import math

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1,8 +1,7 @@
 # Owner(s): ["module: dynamo"]
 """
-Disable pytest AST rewriting (breaks some Dyanmo tests)
-
-PYTEST_DONT_REWRITE
+PYTEST_DONT_REWRITE (prevents pytest from rewriting assertions, which interferes
+with test_export_persist_assert)
 """
 import functools
 import inspect


### PR DESCRIPTION
pytest rewrites Python assert statements in unit tests to provide more detailed error messages. Unfortunately, this breaks some dynamo tests. Disable AST rewriting in test_export.py so that "pytest test/dynamo/test_export.py" passes.

Fixes #93449


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire