### PR TITLE
explicitly check or discard cudaGetLastError return value

### DIFF
--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -98,7 +98,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
       C10_CUDA_CHECK(err);
     } else {
       // ignore and clear the error if not ready
-      cudaGetLastError();
+      (void)cudaGetLastError();
     }
 
     return false;

--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -310,7 +310,7 @@ class CUDAHostAllocator {
         auto& event = processed->first;
         cudaError_t err = cudaEventQuery(*event);
         if (err == cudaErrorNotReady) {
-          cudaGetLastError();
+          (void)cudaGetLastError(); // clear CUDA error
           // push the event onto the back of the queue if it's not
           // ready. TODO: do we need some debouncing logic to avoid allocating
           // threads repeatedly spinning on an event?

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -140,14 +140,14 @@ bool CUDAHooks::isPinnedPtr(const void* data) const {
   cudaError_t err = cudaPointerGetAttributes(&attr, const_cast<void*>(data));
 #if !defined(USE_ROCM)
   if (err == cudaErrorInvalidValue) {
-    cudaGetLastError();
+    (void)cudaGetLastError(); // clear CUDA error
     return false;
   }
   AT_CUDA_CHECK(err);
 #else
   // HIP throws hipErrorUnknown here
   if (err != cudaSuccess) {
-    cudaGetLastError();
+    (void)cudaGetLastError(); // clear HIP error
     return false;
   }
 #endif

--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -196,7 +196,7 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
     if (err != hipErrorNotReady) C10_HIP_CHECK(err);
     else {
       // ignore and clear the error if not ready
-      hipGetLastError();
+      (void)hipGetLastError();
     }
     return (err == hipSuccess);
   }

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -401,7 +401,7 @@ void launch_masked_scatter_kernel(
               }
               return a;
             });
-        cudaGetLastError();
+        AT_CUDA_CHECK(cudaGetLastError());
       });
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -387,7 +387,7 @@ void generate_and_filter_plans(const cudnnHandle_t handle, cudnn_frontend::Opera
       break;
     } catch (c10::OutOfMemoryError &e) {
       max_workspace_size /= 2;
-      cudaGetLastError(); // clear CUDA error
+      (void)cudaGetLastError(); // clear CUDA error
       remove_invalid = true;
     }
   }
@@ -494,7 +494,7 @@ void try_plans(cudnn_frontend::executionPlans_t& plans, const CacheKey& key, con
       return;
     } catch (cudnn_frontend::cudnnException &e) {} catch (CuDNNError &e) {}
       catch (c10::OutOfMemoryError &e) {
-        cudaGetLastError(); // clear CUDA error
+        (void)cudaGetLastError(); // clear CUDA error
     }
   }
   TORCH_CHECK(false, "FIND was unable to find an engine to execute this computation");
@@ -508,7 +508,7 @@ void try_plans_fused(cudnn_frontend::executionPlans_t& plans, const CacheKeyFuse
       return;
     } catch (cudnn_frontend::cudnnException &e) {} catch (CuDNNError &e) {}
       catch (c10::OutOfMemoryError &e) {
-        cudaGetLastError(); // clear CUDA error
+        (void)cudaGetLastError(); // clear CUDA error
     }
   }
   TORCH_CHECK(false, "FIND was unable to find an engine to execute this computation");
@@ -529,7 +529,7 @@ bool try_configs(cudnn_frontend::EngineConfigList& configs, const std::string& o
       return true;
     } catch (cudnn_frontend::cudnnException &e) {} catch(CuDNNError &e) {}
       catch (c10::OutOfMemoryError &e) {
-        cudaGetLastError(); // clear CUDA error
+        (void)cudaGetLastError(); // clear CUDA error
     }
   }
   return false;
@@ -550,7 +550,7 @@ bool try_configs_fused(cudnn_frontend::EngineConfigList& configs, const std::str
       return true;
     } catch (cudnn_frontend::cudnnException &e) {} catch(CuDNNError &e) {}
       catch (c10::OutOfMemoryError &e) {
-        cudaGetLastError(); // clear CUDA error
+        (void)cudaGetLastError(); // clear CUDA error
     }
   }
   return false;
@@ -570,7 +570,7 @@ void run_single_conv(const cudnnBackendDescriptorType_t operation,
       run_conv_plan(handle, x, y, w, *search);
       return;
     } catch(c10::OutOfMemoryError &e) {
-      cudaGetLastError(); // clear CUDA error
+      (void)cudaGetLastError(); // clear CUDA error
     }
   }
   if (!benchmark) {
@@ -615,7 +615,7 @@ void run_fused_conv(const Tensor& x, const Tensor& y, const Tensor& w, const Ten
       run_conv_plan_fused(handle, x, y, w, z, b, *search);
       return;
     } catch(c10::OutOfMemoryError &e) {
-      cudaGetLastError(); // clear CUDA error
+      (void)cudaGetLastError(); // clear CUDA error
     }
   }
   if (!benchmark) {

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -154,7 +154,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
     for (int j = 0; j < 16; j++) {
       b1 = reinterpret_cast<double *>(reinterpret_cast<char *>(buffer1) + i);
       b2 = reinterpret_cast<double *>(reinterpret_cast<char *>(buffer2) + j);
-      cudaGetLastError();
+      (void)cudaGetLastError();
       cudaDeviceSynchronize();
       vectorized_copy<double, 4><<<1, num_threads()>>>(b2, b1);
       cudaDeviceSynchronize();

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2700,7 +2700,7 @@ class DeviceCachingAllocator {
           // to catch the exception, free some stuff in their script, and
           // attempt the allocation again. In this case, we can also forgive and
           // clear CUDA's internal error state.
-          cudaGetLastError();
+          (void)cudaGetLastError();
         } else {
           // If the error's unrelated to memory allocation, we should throw
           // immediately.
@@ -3026,7 +3026,7 @@ class DeviceCachingAllocator {
         cudaError_t err = C10_CUDA_ERROR_HANDLED(cudaEventQuery(*event));
         if (err == cudaErrorNotReady) {
           // ignore and clear the error if not ready
-          cudaGetLastError();
+          (void)cudaGetLastError();
           // Return the ownership of the Event (unique ptr)
           e.first = std::move(event);
           break;
@@ -3419,7 +3419,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     cudaError_t err = cudaDeviceEnablePeerAccess(dev_to_access, 0);
     if (err == cudaErrorPeerAccessAlreadyEnabled) {
       // ignore and clear the error if access was already enabled
-      cudaGetLastError();
+      (void)cudaGetLastError();
     } else {
       C10_CUDA_CHECK(err);
     }

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -362,7 +362,7 @@ void mallocAsync(void** devPtr, int device, size_t size, cudaStream_t stream) {
     // OOM exception, free some stuff on the script side, and retry the
     // allocation. This aligns with the behavior of alloc_block in
     // CUDACachingAllocator.cpp.
-    cudaGetLastError();
+    (void)cudaGetLastError(); // clear CUDA error
     size_t device_free;
     size_t device_total;
     C10_CUDA_CHECK(cudaMemGetInfo(&device_free, &device_total));
@@ -563,7 +563,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
         *maxWorkspaceGuess = guess;
         return;
       } else if (err == cudaErrorMemoryAllocation) {
-        cudaGetLastError(); // clear CUDA error
+        (void)cudaGetLastError(); // clear CUDA error
         guess >>= 1; // quick and dirty: try half the size next iteration
       } else {
         C10_CUDA_CHECK(err);

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -297,7 +297,7 @@ void CUDAPluggableAllocator::enablePeerAccess(int dev, int dev_to_access) {
   cudaError_t err = cudaDeviceEnablePeerAccess(dev_to_access, 0);
   if (err == cudaErrorPeerAccessAlreadyEnabled) {
     // ignore and clear the error if access was already enabled
-    cudaGetLastError();
+    (void)cudaGetLastError();
   } else {
     C10_CUDA_CHECK(err);
   }


### PR DESCRIPTION
cudaGetLastError and hipGetLastError will clear any error value within CUDA and HIP, respectively. This is often done on purpose to clear benign errors. Discarding the return value should be indicated by casting to void and a nearby comment. This silences warnings from HIP:

warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]

Performing an audit of pytorch sources found one use of cudaGetLastError that was incorrectly ignored in IndexKernel.cu.
