### PR TITLE
[ONNX] Refactor Input/Output Adapter

### DIFF
--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -7,7 +7,7 @@ import onnx
 import torch
 from beartype import roar
 from torch.onnx import dynamo_export, ExportOptions, ExportOutput
-from torch.onnx._internal import exporter
+from torch.onnx._internal import exporter, io_adapter
 from torch.onnx._internal.diagnostics import infra
 from torch.onnx._internal.exporter import (
     _DEFAULT_OPSET_VERSION,
@@ -154,8 +154,8 @@ class TestDynamoExportAPI(common_utils.TestCase):
             ExportOutput(torch.nn.Linear(2, 3))  # type: ignore[arg-type]
         export_output = ExportOutput(
             onnx.ModelProto(),
-            exporter.InputAdapter(),
-            exporter.OutputAdapter(),
+            io_adapter.InputAdapter(),
+            io_adapter.OutputAdapter(),
             infra.DiagnosticContext("test", "1.0"),
         )
         with self.assertRaises(roar.BeartypeException):

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -315,6 +315,12 @@ def run_ort(
         ort_model, providers=["CPUExecutionProvider"]
     )
     input_names = [ort_input.name for ort_input in session.get_inputs()]
+
+    if len(input_names) != len(pytorch_inputs):
+        raise AssertionError(
+            f"Expected {len(input_names)} inputs, got {len(pytorch_inputs)}"
+        )
+
     return session.run(
         None, {k: v.cpu().numpy() for k, v in zip(input_names, pytorch_inputs)}
     )

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -315,11 +315,6 @@ def run_ort(
         ort_model, providers=["CPUExecutionProvider"]
     )
     input_names = [ort_input.name for ort_input in session.get_inputs()]
-
-    if len(input_names) != len(pytorch_inputs):
-        raise AssertionError(
-            f"Expected {len(input_names)} inputs, got {len(pytorch_inputs)}"
-        )
     return session.run(
         None, {k: v.cpu().numpy() for k, v in zip(input_names, pytorch_inputs)}
     )

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -755,6 +755,10 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             )
             # ORT outputs.
             args_not_none = export_output.adapt_torch_inputs_to_onnx(*args)
+
+            # Drop Parameters and buffers added by fx_serialization.save_model_with_external_data
+            args_not_none = args_not_none[: len(args) - len(kwargs)]
+
             ort_outputs = onnx_test_common.run_ort(
                 os.path.join(tmp_folder, onnx_model_location),
                 args_not_none,

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -9,7 +9,6 @@ from typing import (
     Callable,
     Dict,
     Final,
-    List,
     Mapping,
     Optional,
     Protocol,
@@ -25,7 +24,7 @@ from typing import (
 import torch
 import torch._ops
 
-from torch.onnx._internal import _beartype
+from torch.onnx._internal import _beartype, io_adapter
 from torch.onnx._internal.diagnostics import infra
 
 # We can only import onnx from this module in a type-checking context to ensure that
@@ -214,129 +213,20 @@ class ProtobufExportOutputSerializer:
         destination.write(export_output.model_proto.SerializeToString())
 
 
-# TODO(bowbao): Add diagnostics for IO adapters.
-@runtime_checkable
-class InputAdaptStep(Protocol):
-    """A protocol that defines a step in the input adapting process.
-
-    The input adapting process is a sequence of steps that are applied to the
-    PyTorch model inputs to transform them into the inputs format expected by the
-    exported ONNX model. Each step takes the PyTorch model inputs as arguments and
-    returns the transformed inputs.
-
-    This serves as a base formalized construct for the transformation done to model
-    input signature by any individual component in the exporter.
-    """
-
-    def apply(
-        self, model_args: Sequence[Any], model_kwargs: Mapping[str, Any]
-    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
-        ...
-
-
-class InputAdapter:
-    """A class that adapts the PyTorch model inputs to exported ONNX model inputs format."""
-
-    _input_adapt_steps: List[InputAdaptStep]
-
-    def __init__(self, input_adapt_steps: Optional[List[InputAdaptStep]] = None):
-        self._input_adapt_steps = input_adapt_steps or []
-
-    @_beartype.beartype
-    def append_step(self, step: InputAdaptStep) -> None:
-        """Appends a step to the input adapt steps.
-
-        Args:
-            step: The step to append.
-        """
-        self._input_adapt_steps.append(step)
-
-    @_beartype.beartype
-    def apply(
-        self, *model_args, **model_kwargs
-    ) -> Sequence[Union[int, float, bool, torch.Tensor]]:
-        """Converts the PyTorch model inputs to exported ONNX model inputs format.
-
-        Args:
-            model_args: The PyTorch model inputs.
-            model_kwargs: The PyTorch model keyword inputs.
-
-        Returns:
-            A sequence of tensors converted from PyTorch model inputs.
-        """
-        args: Sequence[Any] = model_args
-        kwargs: Mapping[str, Any] = model_kwargs
-        for step in self._input_adapt_steps:
-            args, kwargs = step.apply(args, kwargs)
-        assert not kwargs
-        return args
-
-
-@runtime_checkable
-class OutputAdaptStep(Protocol):
-    """A protocol that defines a step in the output adapting process.
-
-    The output adapting process is a sequence of steps that are applied to the
-    PyTorch model outputs to transform them into the outputs format produced by the
-    exported ONNX model. Each step takes the PyTorch model outputs as arguments and
-    returns the transformed outputs.
-
-    This serves as a base formalized construct for the transformation done to model
-    output signature by any individual component in the exporter.
-    """
-
-    def apply(self, model_outputs: Any) -> Any:
-        ...
-
-
-class OutputAdapter:
-    """A class that adapts the PyTorch model outputs to exported ONNX model outputs format."""
-
-    _output_adapt_steps: List[OutputAdaptStep]
-
-    def __init__(self, output_adapt_steps: Optional[List[OutputAdaptStep]] = None):
-        self._output_adapt_steps = output_adapt_steps or []
-
-    @_beartype.beartype
-    def append_step(self, step: OutputAdaptStep) -> None:
-        """Appends a step to the output format steps.
-
-        Args:
-            step: The step to append.
-        """
-        self._output_adapt_steps.append(step)
-
-    @_beartype.beartype
-    def apply(
-        self, model_outputs: Any
-    ) -> Sequence[Union[torch.Tensor, int, float, bool]]:
-        """Converts the PyTorch model outputs to exported ONNX model outputs format.
-
-        Args:
-            model_outputs: The PyTorch model outputs.
-
-        Returns:
-            PyTorch model outputs in exported ONNX model outputs format.
-        """
-        for step in self._output_adapt_steps:
-            model_outputs = step.apply(model_outputs)
-        return model_outputs
-
-
 class ExportOutput:
     """An in-memory representation of a PyTorch model that has been exported to ONNX."""
 
     _model_proto: Final[onnx.ModelProto]
-    _input_adapter: Final[InputAdapter]
-    _output_adapter: Final[OutputAdapter]
+    _input_adapter: Final[io_adapter.InputAdapter]
+    _output_adapter: Final[io_adapter.OutputAdapter]
     _diagnostic_context: Final[infra.DiagnosticContext]
 
     @_beartype.beartype
     def __init__(
         self,
         model_proto: onnx.ModelProto,
-        input_adapter: InputAdapter,
-        output_adapter: OutputAdapter,
+        input_adapter: io_adapter.InputAdapter,
+        output_adapter: io_adapter.OutputAdapter,
         diagnostic_context: infra.DiagnosticContext,
     ):
         self._model_proto = model_proto
@@ -490,8 +380,8 @@ class FXGraphExtractor(abc.ABC):
 
     def __init__(self) -> None:
         super().__init__()
-        self.input_adapter: InputAdapter = InputAdapter()
-        self.output_adapter: OutputAdapter = OutputAdapter()
+        self.input_adapter: io_adapter.InputAdapter = io_adapter.InputAdapter()
+        self.output_adapter: io_adapter.OutputAdapter = io_adapter.OutputAdapter()
 
     @_beartype.beartype
     def _export_fx_to_onnx(
@@ -501,7 +391,6 @@ class FXGraphExtractor(abc.ABC):
         fx_module_args: Sequence[Any],
     ) -> ExportOutput:
         # TODO: Import here to prevent circular dependency
-        import torch.onnx._internal.fx.fx_exporter as fx_exporter
         import torch.onnx._internal.fx.passes as passes
 
         diagnostic_context = options.diagnostic_context
@@ -544,13 +433,15 @@ class FXGraphExtractor(abc.ABC):
             )
             # ONNX does not support None inputs. During graph building, all None inputs
             # are removed. Here we register this step to input adapter.
-            self.adapt_input(fx_exporter.RemoveNoneInputStep, fx_module_args, {})
+            self.input_adapter.append_step(io_adapter.RemoveNoneInputStep())
+
             # NOTE: temp workaround for https://github.com/pytorch/pytorch/issues/99534
             # Dynamo doesn't support non-tensor inputs.
-            self.adapt_input(fx_exporter.RemoveNonTensorInputStep, fx_module_args, {})
+            self.input_adapter.append_step(io_adapter.RemoveNoRemoveNonTensorInputStepneInputStep())
+
             # ONNX can't represent collection types (e.g., dictionary, tuple of tuple of
             # tensor, etc), we flatten the collection and register each element as output.
-            self.output_adapter.append_step(fx_exporter.FlattenOutputStep())
+            self.output_adapter.append_step(io_adapter.FlattenOutputStep())
 
         # Export TorchScript graph to ONNX ModelProto.
         onnx_model = onnxscript_graph.to_model_proto(options.opset_version)
@@ -561,50 +452,6 @@ class FXGraphExtractor(abc.ABC):
             options.diagnostic_context,
         )
 
-    def adapt_input(
-        self,
-        adapt_step_cls: Type[InputAdaptStep],
-        model_args: Sequence[Any],
-        model_kwargs: Mapping[str, Any],
-        step_init_args: Optional[Sequence[Any]] = None,
-    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
-        """Apply an input adapt step to the model args and kwargs.
-        An input adapt step object is initialized, applied and recorded as part of
-        ``self.input_adapter`.
-        Args:
-            adapt_step_cls: The input adapt step class.
-            model_args: The model args.
-            model_kwargs: The model kwargs.
-            step_init_args: The input adapt step initialization arguments.
-        Returns:
-            The adapted model args and kwargs.
-        """
-        step_init_args = step_init_args or ()
-        adapt_step = adapt_step_cls(*step_init_args)
-        self.input_adapter.append_step(adapt_step)
-        return adapt_step.apply(model_args, model_kwargs)
-
-    def adapt_output(
-        self,
-        adapt_step_cls: Type[OutputAdaptStep],
-        model_outputs: Any,
-        step_init_args: Optional[Sequence[Any]] = None,
-    ) -> Any:
-        """Apply an output adapt step to the model outputs.
-        An output adapt step object is initialized, applied and recorded as part of
-        ``self._output_adapter`.
-        Args:
-            adapt_step_cls: The output adapt step class.
-            model_outputs: The model outputs.
-            step_init_args: The input adapt step initialization arguments.
-        Returns:
-            The adapted model outputs.
-        """
-        step_init_args = step_init_args or ()
-        adapt_step = adapt_step_cls(*step_init_args)
-        self.output_adapter.append_step(adapt_step)
-        return adapt_step.apply(model_outputs)
-
     @abc.abstractmethod
     def generate_fx(
         self,
@@ -612,7 +459,7 @@ class FXGraphExtractor(abc.ABC):
         model: Union[torch.nn.Module, Callable],
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],
-    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
+    ) -> torch.fx.GraphModule:
         """Analyzes user ``model`` and generates a FX graph.
         Args:
             options: The export options.
@@ -620,7 +467,7 @@ class FXGraphExtractor(abc.ABC):
             model_args: The model's positional input arguments.
             model_kwargs: The model's keyword input arguments.
         Returns:
-            The generated FX Graph, and the model's adapted input arguments.
+            The generated FX Graph.
         """
         # By design, only torch.fx.GraphModule is needed
         # But FXSymbolicTracer modifies model data, which will be needed
@@ -646,8 +493,13 @@ class Exporter:
         self.model_kwargs = model_kwargs
 
     def export(self) -> ExportOutput:
-        graph_module, updated_model_args = self.options.fx_tracer.generate_fx(
+        graph_module = self.options.fx_tracer.generate_fx(
             self.options, self.model, self.model_args, self.model_kwargs
+        )
+
+        updated_model_args = self.options.fx_tracer.input_adapter.apply(
+            *self.model_args,
+            **self.model_kwargs
         )
 
         # Export FX graph to ONNX ModelProto.

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -435,7 +435,7 @@ class FXGraphExtractor(abc.ABC):
 
             # NOTE: temp workaround for https://github.com/pytorch/pytorch/issues/99534
             # Dynamo doesn't support non-tensor inputs.
-            self.input_adapter.append_step(io_adapter.RemoveNoRemoveNonTensorInputStepneInputStep())
+            self.input_adapter.append_step(io_adapter.RemoveNonTensorInputStep())
 
             # ONNX can't represent collection types (e.g., dictionary, tuple of tuple of
             # tensor, etc), we flatten the collection and register each element as output.

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -14,8 +14,6 @@ from typing import (
     Protocol,
     runtime_checkable,
     Sequence,
-    Tuple,
-    Type,
     TYPE_CHECKING,
     TypeVar,
     Union,
@@ -469,10 +467,6 @@ class FXGraphExtractor(abc.ABC):
         Returns:
             The generated FX Graph.
         """
-        # By design, only torch.fx.GraphModule is needed
-        # But FXSymbolicTracer modifies model data, which will be needed
-        # to produce the ONNX proto in the next layer.
-        # TODO: Refactor after https://github.com/pytorch/pytorch/pull/98421
         ...
 
 
@@ -498,8 +492,7 @@ class Exporter:
         )
 
         updated_model_args = self.options.fx_tracer.input_adapter.apply(
-            *self.model_args,
-            **self.model_kwargs
+            *self.model_args, **self.model_kwargs
         )
 
         # Export FX graph to ONNX ModelProto.

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -195,5 +195,7 @@ class DynamoExport(exporter.FXGraphExtractor):
         torch._dynamo.reset()
 
         # Export FX graph to ONNX ModelProto.
-        self.input_adapter.append_step(io_adapter.FlattenInputWithTreeSpecValidationStep())
+        self.input_adapter.append_step(
+            io_adapter.FlattenInputWithTreeSpecValidationStep()
+        )
         return graph_module  # type: ignore[return-value]

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -19,8 +19,7 @@ from typing import (
 import torch._dynamo
 import torch.fx
 import torch.onnx
-from torch.onnx._internal import _beartype, exporter
-from torch.onnx._internal.fx import fx_exporter
+from torch.onnx._internal import _beartype, exporter, io_adapter
 from torch.utils import _pytree as pytree
 
 
@@ -98,10 +97,10 @@ class _PyTreeExtensionContext:
             )
 
 
-class DynamoFlattenOutputStep(fx_exporter.FlattenOutputStep):
+class DynamoFlattenOutputStep(io_adapter.FlattenOutputStep):
     """Flatten nested collection and custom python types and return a flat list of elements.
 
-    Extended from :class:`fx_exporter.FlattenOutputStep` to support flattening arbitrary
+    Extended from :class:`io_adapter.FlattenOutputStep` to support flattening arbitrary
     types via pytree extension. By default this supports many common user defined python
     types such as :class:`ModelOutput` from HuggingFace transformers.
 
@@ -171,7 +170,7 @@ class DynamoExport(exporter.FXGraphExtractor):
         model: Union[torch.nn.Module, Callable],
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],
-    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
+    ) -> torch.fx.GraphModule:
         # args will be converted to symbolic tensor. Let's copy to avoid side effects.
         args = copy.deepcopy(model_args)
         kwargs = copy.deepcopy(model_kwargs)
@@ -196,10 +195,5 @@ class DynamoExport(exporter.FXGraphExtractor):
         torch._dynamo.reset()
 
         # Export FX graph to ONNX ModelProto.
-        #
-        # `args` and `kwargs` are merged and flattened by `dynamo.export`.
-        # Apply and record this input adapt step.
-        merged_args, _ = self.adapt_input(
-            fx_exporter.FlattenInputWithTreeSpecValidationStep, args, kwargs
-        )
-        return graph_module, merged_args  # type: ignore[return-value]
+        self.input_adapter.append_step(io_adapter.FlattenInputWithTreeSpecValidationStep())
+        return graph_module  # type: ignore[return-value]

--- a/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
+++ b/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
@@ -165,7 +165,9 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
     ) -> torch.fx.GraphModule:
         # Bind model args and kwargs with model signature to retrieve default values
         # of unprovided arguments. These are then used to construct ``concrete_args``.
-        bind_input_step = io_adapter.BindInputStep(torch.onnx.utils.model_signature(model))
+        bind_input_step = io_adapter.BindInputStep(
+            torch.onnx.utils.model_signature(model)
+        )
         self.input_adapter.append_step(bind_input_step)
         _, named_args = bind_input_step.apply(model_args, model_kwargs)
 
@@ -218,7 +220,9 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
         )
         graph_module = replace_get_attr_with_placeholder_pass.run()
         replaced_attrs = replace_get_attr_with_placeholder_pass.replaced_attrs
-        append_extra_input_step = io_adapter.AppendPositionalsIntoArgsStep(replaced_attrs)
+        append_extra_input_step = io_adapter.AppendPositionalsIntoArgsStep(
+            replaced_attrs
+        )
         self.input_adapter.append_step(append_extra_input_step)
         # Move all newly created placeholder nodes to the front of the graph.
         graph_module = passes.MovePlaceholderToFront(

--- a/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
+++ b/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
@@ -220,7 +220,7 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
         )
         graph_module = replace_get_attr_with_placeholder_pass.run()
         replaced_attrs = replace_get_attr_with_placeholder_pass.replaced_attrs
-        append_extra_input_step = io_adapter.AppendPositionalsIntoArgsStep(
+        append_extra_input_step = io_adapter.LiftParametersAndBuffersIntoArgsStep(
             replaced_attrs
         )
         self.input_adapter.append_step(append_extra_input_step)

--- a/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
+++ b/torch/onnx/_internal/fx/fx_symbolic_graph_extractor.py
@@ -8,9 +8,8 @@ import torch
 import torch.fx
 import torch.onnx
 
-import torch.onnx._internal.fx.fx_exporter as fx_exporter
 import torch.onnx._internal.fx.passes as passes
-from torch.onnx._internal import _beartype, exporter
+from torch.onnx._internal import _beartype, exporter, io_adapter
 
 # Functions directly wrapped to produce torch.fx.Proxy so that symbolic
 # data can flow through those functions. Python functions (e.g., `torch.arange`)
@@ -163,15 +162,12 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
     @_beartype.beartype
     def _trace_into_fx_graph_via_fx_symbolic_trace(
         self, model, model_args, model_kwargs
-    ) -> Tuple[torch.fx.GraphModule, Sequence[Any]]:
+    ) -> torch.fx.GraphModule:
         # Bind model args and kwargs with model signature to retrieve default values
         # of unprovided arguments. These are then used to construct ``concrete_args``.
-        _, named_args = self.adapt_input(
-            fx_exporter.BindInputStep,
-            model_args,
-            model_kwargs,
-            step_init_args=(torch.onnx.utils.model_signature(model),),
-        )
+        bind_input_step = io_adapter.BindInputStep(torch.onnx.utils.model_signature(model))
+        self.input_adapter.append_step(bind_input_step)
+        _, named_args = bind_input_step.apply(model_args, model_kwargs)
 
         # Create inputs to call symbolic trace (torch.fx.symbolic_trace)
         # Example content of concrete_args:
@@ -188,14 +184,9 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
                 concrete_args[param_name] = param_value
 
         # Merge kwargs back into args since that is the format FX graph expects.
-        bound_args, _ = self.adapt_input(
-            fx_exporter.MergeKwargsIntoArgsStep, [], named_args
-        )
-
-        return (
-            _module_expansion_symbolic_trace(model, concrete_args=concrete_args),
-            bound_args,
-        )
+        merge_kwargs_step = io_adapter.MergeKwargsIntoArgsStep()
+        self.input_adapter.append_step(merge_kwargs_step)
+        return _module_expansion_symbolic_trace(model, concrete_args=concrete_args)
 
     def generate_fx(
         self,
@@ -203,9 +194,9 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
         model: Union[torch.nn.Module, Callable],
         model_args: Sequence[Any],
         model_kwargs: Mapping[str, Any],
-    ) -> Tuple[torch.fx.GraphModule, Tuple[Any]]:
+    ) -> torch.fx.GraphModule:
         diagnostic_context = options.diagnostic_context
-        graph_module, bound_args = self._trace_into_fx_graph_via_fx_symbolic_trace(
+        graph_module = self._trace_into_fx_graph_via_fx_symbolic_trace(
             model, model_args, model_kwargs
         )
 
@@ -227,6 +218,8 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
         )
         graph_module = replace_get_attr_with_placeholder_pass.run()
         replaced_attrs = replace_get_attr_with_placeholder_pass.replaced_attrs
+        append_extra_input_step = io_adapter.AppendPositionalsIntoArgsStep(replaced_attrs)
+        self.input_adapter.append_step(append_extra_input_step)
         # Move all newly created placeholder nodes to the front of the graph.
         graph_module = passes.MovePlaceholderToFront(
             diagnostic_context, graph_module
@@ -234,4 +227,4 @@ class FXSymbolicTracer(exporter.FXGraphExtractor):
         # Finalize the graph editing.
         graph_module.recompile()
 
-        return graph_module, (*bound_args, *replaced_attrs)  # type: ignore[return-value]
+        return graph_module

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -60,7 +60,7 @@ class InputAdapter:
     @_beartype.beartype
     def apply(
         self, *model_args, **model_kwargs
-    ) -> Sequence[Union[int, float, bool, "torch.Tensor"]]:
+    ) -> Sequence[Union[int, float, bool, "torch.Tensor", None]]:
         """Converts the PyTorch model inputs to exported ONNX model inputs format.
 
         Args:

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+
 from typing import (
     Any,
     Callable,
@@ -12,11 +14,14 @@ from typing import (
     Tuple,
     Union,
 )
+
+import torch
+
 from torch.onnx._internal import _beartype
-import inspect
 from torch.utils import _pytree as pytree
 
 # TODO(bowbao): Add diagnostics for IO adapters.
+
 
 @runtime_checkable
 class InputAdaptStep(Protocol):
@@ -121,6 +126,7 @@ class OutputAdapter:
             model_outputs = step.apply(model_outputs)
         return model_outputs
 
+
 # TODO: make_fx lose stack info https://github.com/pytorch/pytorch/issues/90276
 
 
@@ -218,6 +224,7 @@ class MergeKwargsIntoArgsStep:
         """
         return tuple(model_args) + tuple(model_kwargs.values()), {}
 
+
 class AppendPositionalsIntoArgsStep:
     """Merge the input kwargs into the input args."""
 
@@ -236,7 +243,8 @@ class AppendPositionalsIntoArgsStep:
         Returns:
             A tuple of the model args and kwargs, plus all extra appended inputs.
         """
-        return tuple(model_args + self.inputs), tuple(model_kwargs.values())
+        return tuple(model_args + self.inputs), model_kwargs
+
 
 class RemoveNoneInputStep:
     """Remove `None` from arguments.

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -243,7 +243,7 @@ class AppendPositionalsIntoArgsStep:
         Returns:
             A tuple of the model args and kwargs, plus all extra appended inputs.
         """
-        return tuple(model_args + self.inputs), model_kwargs
+        return (*model_args, *self.inputs), model_kwargs
 
 
 class RemoveNoneInputStep:

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -225,8 +225,8 @@ class MergeKwargsIntoArgsStep:
         return tuple(model_args) + tuple(model_kwargs.values()), {}
 
 
-class AppendPositionalsIntoArgsStep:
-    """Merge the input kwargs into the input args."""
+class LiftParametersAndBuffersIntoArgsStep:
+    """Append parameters and buffers to model's positional argument list."""
 
     def __init__(self, inputs: Tuple["torch.Tensor", ...]) -> None:
         self.inputs = inputs
@@ -234,14 +234,14 @@ class AppendPositionalsIntoArgsStep:
     def apply(
         self, model_args: Sequence[Any], model_kwargs: Mapping[str, Any]
     ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
-        """Merge the input kwargs into the input args.
+        """Append model's parameters and buffers into its input.
 
         Args:
             model_args: The model args.
             model_kwargs: The model kwargs.
 
         Returns:
-            A tuple of the model args and kwargs, plus all extra appended inputs.
+            A tuple of the model args + appended inputs and kwargs.
         """
         return (*model_args, *self.inputs), model_kwargs
 

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -1,9 +1,125 @@
 from __future__ import annotations
 
+from typing import (
+    Any,
+    Callable,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    Sequence,
+    Tuple,
+    Union,
+)
+from torch.onnx._internal import _beartype
 import inspect
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
-
 from torch.utils import _pytree as pytree
+
+# TODO(bowbao): Add diagnostics for IO adapters.
+
+@runtime_checkable
+class InputAdaptStep(Protocol):
+    """A protocol that defines a step in the input adapting process.
+
+    The input adapting process is a sequence of steps that are applied to the
+    PyTorch model inputs to transform them into the inputs format expected by the
+    exported ONNX model. Each step takes the PyTorch model inputs as arguments and
+    returns the transformed inputs.
+
+    This serves as a base formalized construct for the transformation done to model
+    input signature by any individual component in the exporter.
+    """
+
+    def apply(
+        self, model_args: Sequence[Any], model_kwargs: Mapping[str, Any]
+    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
+        ...
+
+
+class InputAdapter:
+    """A class that adapts the PyTorch model inputs to exported ONNX model inputs format."""
+
+    def __init__(self, steps: Optional[List[InputAdaptStep]] = None):
+        self._steps = steps or []
+
+    @_beartype.beartype
+    def append_step(self, step: InputAdaptStep) -> None:
+        """Appends a step to the input adapt steps.
+
+        Args:
+            step: The step to append.
+        """
+        self._steps.append(step)
+
+    @_beartype.beartype
+    def apply(
+        self, *model_args, **model_kwargs
+    ) -> Sequence[Union[int, float, bool, "torch.Tensor"]]:
+        """Converts the PyTorch model inputs to exported ONNX model inputs format.
+
+        Args:
+            model_args: The PyTorch model inputs.
+            model_kwargs: The PyTorch model keyword inputs.
+
+        Returns:
+            A sequence of tensors converted from PyTorch model inputs.
+        """
+        args: Sequence[Any] = model_args
+        kwargs: Mapping[str, Any] = model_kwargs
+        for step in self._steps:
+            args, kwargs = step.apply(args, kwargs)
+        assert not kwargs
+        return args
+
+
+@runtime_checkable
+class OutputAdaptStep(Protocol):
+    """A protocol that defines a step in the output adapting process.
+
+    The output adapting process is a sequence of steps that are applied to the
+    PyTorch model outputs to transform them into the outputs format produced by the
+    exported ONNX model. Each step takes the PyTorch model outputs as arguments and
+    returns the transformed outputs.
+
+    This serves as a base formalized construct for the transformation done to model
+    output signature by any individual component in the exporter.
+    """
+
+    def apply(self, model_outputs: Any) -> Any:
+        ...
+
+
+class OutputAdapter:
+    """A class that adapts the PyTorch model outputs to exported ONNX model outputs format."""
+
+    def __init__(self, steps: Optional[List[OutputAdaptStep]] = None):
+        self._steps = steps or []
+
+    @_beartype.beartype
+    def append_step(self, step: OutputAdaptStep) -> None:
+        """Appends a step to the output format steps.
+
+        Args:
+            step: The step to append.
+        """
+        self._steps.append(step)
+
+    @_beartype.beartype
+    def apply(
+        self, model_outputs: Any
+    ) -> Sequence[Union["torch.Tensor", int, float, bool]]:
+        """Converts the PyTorch model outputs to exported ONNX model outputs format.
+
+        Args:
+            model_outputs: The PyTorch model outputs.
+
+        Returns:
+            PyTorch model outputs in exported ONNX model outputs format.
+        """
+        for step in self._steps:
+            model_outputs = step.apply(model_outputs)
+        return model_outputs
 
 # TODO: make_fx lose stack info https://github.com/pytorch/pytorch/issues/90276
 
@@ -102,6 +218,25 @@ class MergeKwargsIntoArgsStep:
         """
         return tuple(model_args) + tuple(model_kwargs.values()), {}
 
+class AppendPositionalsIntoArgsStep:
+    """Merge the input kwargs into the input args."""
+
+    def __init__(self, inputs: Tuple["torch.Tensor", ...]) -> None:
+        self.inputs = inputs
+
+    def apply(
+        self, model_args: Sequence[Any], model_kwargs: Mapping[str, Any]
+    ) -> Tuple[Sequence[Any], Mapping[str, Any]]:
+        """Merge the input kwargs into the input args.
+
+        Args:
+            model_args: The model args.
+            model_kwargs: The model kwargs.
+
+        Returns:
+            A tuple of the model args and kwargs, plus all extra appended inputs.
+        """
+        return tuple(model_args + self.inputs), tuple(model_kwargs.values())
 
 class RemoveNoneInputStep:
     """Remove `None` from arguments.


### PR DESCRIPTION
This PR refactors how InputAdapter and OutputAdapter is used throughout the exporter.

During refactoring, API issues with passes (torch.onnx._internal.fx._pass.Transform) were identified and should be tackled on another API. In short, some passes can modify the input/output of the model and the input/output adapter must be in sync with such change, otherwise, the adapters will not reflect the actual model input/output. The first instance of this issue was with `ReplaceGetAttrWithPlaceholder` pass that adds new inputs to the model. In order to work this around, a new input adapt step to append new inputs (generated by the pass) was introduced. That resulted in the number of inputs of the ONNX model to mismatch the numer of inputs of the pytorch model, though.


Follow up on https://github.com/pytorch/pytorch/pull/98421