### PR TITLE
Stop loading functorch._C unless torchdim is needed

### DIFF
--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import torch
-from . import _C
 
 # Top-level APIs. Please think carefully before adding something to the
 # top-level namespace:

--- a/functorch/dim/__init__.py
+++ b/functorch/dim/__init__.py
@@ -4,6 +4,7 @@ import inspect
 import dis
 from .tree_map import tree_flatten, tree_map
 from .wrap_type import wrap_type
+import functorch._C
 from functorch._C import dim as _C
 _C._patch_tensor_class()
 dims, DimList, dimlists = _C.dims, _C.DimList, _C.dimlists


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100491

Just a small optimization. This PR changes it so that import of
functorch.dim ends up loading functorch._C (which is entirely composed
of torchdim APIs)

Test Plan:
- existing tests