### PR TITLE
Remove ci: sev label and details from ci-sev.md tempalte

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -1,7 +1,6 @@
 ---
 name: "⚠️ CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
-labels: "ci: sev"
 ---
 
 > NOTE: Remember to label this issue with "`ci: sev`"
@@ -16,18 +15,6 @@ labels: "ci: sev"
 
 ## Incident timeline (all times pacific)
 *Include when the incident began, when it was detected, mitigated, root caused, and finally closed.*
-
-<details>
-<summary> Click for example </summary>
-
-e.g.
-- 10/30 7:27a incident began
-- 10/30 8:30a detected by <method>
-- 10/30 9:00 pm root caused as…
-- 10/30 9:10 pm mitigated by…
-- 10/31 10: am closed by…
-
-</details>
 
 ## User impact
 *How does this affect users of PyTorch CI?*


### PR DESCRIPTION
We don't want to add the label automatically: this way we can limit CI SEV creation to people with write permissions only.

Also remove `details` section as it's not really filled by people.

Fixes https://github.com/pytorch/pytorch/issues/100143