### PR TITLE
Disable core dumping on ROCm UT workflows

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -176,7 +176,7 @@ jobs:
             -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
-            --ulimit stack=10485760:83886080 \
+            --ulimit core=0 \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \
             --shm-size="8g" \

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -176,6 +176,7 @@ jobs:
             -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --ulimit stack=10485760:83886080 \
             --ulimit core=0 \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \


### PR DESCRIPTION
Recently an issue was observed on PyTorch CI in which the ROCm nodes were running out of space due to out of control core dumping.
https://github.com/pytorch/pytorch/issues/99578

To mitigate this issue we have proposed to disable core dumping on the ROCm workers with the `--ulimit core=0` flag in the docker run command in `_rocm-test.yml` 
https://stackoverflow.com/questions/58704192/how-to-disable-core-file-dumps-in-docker-container/59611557#59611557

Before this change
```
ulimit -a
core file size          (blocks, -c) unlimited
```

After this change
```
ulimit -a
core file size          (blocks, -c) 0
```



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport