### PR TITLE
[Reland] Initial version of Dynamo capture for HigherOrderOperator

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -7,6 +7,7 @@ try:
         test_ctx_manager,
         test_export,
         test_functions,
+        test_higher_order_ops,
         test_misc,
         test_modules,
         test_repros,
@@ -16,6 +17,7 @@ except ImportError:
     import test_ctx_manager
     import test_export
     import test_functions
+    import test_higher_order_ops
     import test_misc
     import test_modules
     import test_repros
@@ -79,6 +81,7 @@ tests = [
     test_modules.NNModuleTests,
     test_export.ExportTests,
     test_subgraphs.SubGraphTests,
+    test_higher_order_ops.HigherOrderOpTests,
 ]
 for test in tests:
     make_dynamic_cls(test)

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1,0 +1,423 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+
+import torch._dynamo.test_case
+from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend
+from torch._dynamo.utils import counters
+from torch._ops import wrap
+
+
+# Equivalent to backend="eager", but also records graphs that
+# we can assert on
+class EagerAndRecordGraphs:
+    def __init__(self):
+        self.graphs = []
+
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+        self.graphs.append(gm)
+        return gm
+
+
+global_var = torch.randn(3)
+global_num = 3.14
+
+
+def find_first_node(gm, func):
+    for node in gm.graph.nodes:
+        if node.target is func:
+            return node
+    return None
+
+
+def op_count(gm):
+    result = 0
+    for node in gm.graph.nodes:
+        if "call" in node.op:
+            result += 1
+    return result
+
+
+class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
+    def _test_wrap_simple(self, func, args, expected_num_wrap_args, expected_opcount=1):
+        # Given a `func` that has a single call to `wrap`,
+        # we check that:
+        # - there are no graph breaks
+        # - eager vs torch.compile has the same result
+        # - after dynamo capture, the wrap has the expected number of args
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        expected = func(*args)
+        result = torch.compile(func, fullgraph=True, backend=cnt)(*args)
+
+        self.assertEqual(result, expected)
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, expected_opcount)
+
+        self.assertEqual(len(backend.graphs), 1)
+        wrap_node = find_first_node(backend.graphs[0], wrap)
+        self.assertEqual(len(wrap_node.args), expected_num_wrap_args)
+
+    def test_no_freevars(self):
+        def f(x):
+            return wrap(lambda x: torch.sin(x), x)
+
+        x = torch.randn(3)
+        self._test_wrap_simple(f, (x,), 2)
+
+    def test_capture_untracked_global(self):
+        def f(x):
+            return wrap(lambda x: x + global_var, x)
+
+        x = torch.randn(3)
+        self._test_wrap_simple(f, (x,), 3)
+
+    def test_capture_untracked_global_nested(self):
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def f(x):
+            return wrap(lambda x: wrap(lambda x: x + global_var, x), x)
+
+        x = torch.randn(3)
+        result = f(x)
+
+        self.assertEqual(result, x + global_var)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 1)
+
+        self.assertEqual(len(backend.graphs), 1)
+        wrap_node = find_first_node(backend.graphs[0], wrap)
+        self.assertTrue(len(wrap_node.args), 3)
+
+        body_function = getattr(backend.graphs[0], wrap_node.args[0].name)
+        self.assertEqual(op_count(body_function), 1)
+        inner_wrap_node = find_first_node(body_function, wrap)
+        self.assertTrue(len(inner_wrap_node.args), 3)
+
+    def test_capture_untracked_nonlocal(self):
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        def f(x, y):
+            def g(x):
+                return wrap(lambda x: x + y, x)
+
+            self._test_wrap_simple(g, (x,), 3)
+            return g(x)
+
+        f(x, y)
+
+    def test_capture_tracked(self):
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        def f(x, y):
+            return wrap(lambda x: x + y, x)
+
+        self._test_wrap_simple(f, (x, y), 3)
+
+    def test_inlined_functions(self):
+        def g(x, y):
+            return x + y
+
+        def f(x, y):
+            return wrap(lambda x: g(x, y), x)
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+        self._test_wrap_simple(f, (x, y), 3)
+
+    def test_capture_value_created_in_subgraph(self):
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        def inner(x, y):
+            z = x + y
+            return wrap(lambda x: wrap(lambda x: x + z, x), x)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def f(x, y):
+            return wrap(inner, x, y)
+
+        result = f(x, y)
+
+        self.assertEqual(result, x + y + x)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 1)
+        self.assertEqual(len(backend.graphs), 1)
+
+        # No changes to args of outer wrap
+        gm = backend.graphs[0]
+        wrap_node = find_first_node(gm, wrap)
+        self.assertTrue(len(wrap_node.args), 3)
+
+        # z was lifted to arg of inner wrap
+        body_function = getattr(gm, wrap_node.args[0].name)
+        # addition + wrap
+        self.assertEqual(op_count(body_function), 2)
+        inner_wrap_node = find_first_node(body_function, wrap)
+        self.assertTrue(len(inner_wrap_node.args), 3)
+
+        # Innermost body function: z was also lifted to arg
+        body_function = getattr(body_function, inner_wrap_node.args[0].name)
+        self.assertEqual(op_count(body_function), 1)
+        inner_wrap_node = find_first_node(body_function, wrap)
+        self.assertTrue(len(inner_wrap_node.args), 3)
+
+    def test_capture_global_num(self):
+        def f(x):
+            return wrap(lambda x: x + global_num, x)
+
+        x = torch.zeros([])
+        # Numbers don't get lifted, so args is still 2.
+        self._test_wrap_simple(f, (x,), 2)
+
+    def test_capture_global_num_adds_guard(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            return wrap(lambda x: x + global_num, x)
+
+        global global_num
+        x = torch.zeros([])
+        result = f(x)
+        self.assertEqual(result, x + global_num)
+
+        global_num = torch.randn([]).item()
+        result = f(x)
+        self.assertEqual(result, x + global_num)
+
+    def test_capture_input_num(self):
+        def f(x, y):
+            return wrap(lambda x: x + y, x)
+
+        x = torch.zeros([])
+        y = 3.14
+        # Numbers don't get lifted, so args is still 2.
+        self._test_wrap_simple(f, (x, y), 2)
+
+    # TODO: Ideally we would error out if there are any new live side
+    # effects (for example, if the body function mutates a global variable).
+    # I don't know how to detect this in a robust way, because it conflicts with
+    # benign side effects like storing and loading cells that is necessary for
+    # capturing variables.
+    @unittest.expectedFailure
+    def test_side_effect_in_body(self):
+        counters.clear()
+        backend = EagerAndRecordGraphs()
+
+        x = torch.randn([])
+        y = torch.randn([])
+
+        def inner(x):
+            nonlocal y
+            y = x
+            return x.clone()
+
+        @torch.compile(backend=backend)
+        def f(x):
+            return wrap(inner, x)
+
+        f(x)
+        self.assertEqual(y, x)
+        self.assertEqual(
+            dict(counters["graph_break"]),
+            {"side effects in HigherOrderOperator body": 1},
+        )
+
+    def test_fallback_on_graph_break_simple(self):
+        # In the future, there should be a per-HigherOrderOperator switch
+        # on whether or not to fallback or raise a loud error.
+        # For now we just fallback by default.
+        cnt = CompileCounter()
+        x = torch.randn([])
+
+        def inner(x):
+            y = x.sin()
+            torch._dynamo.graph_break()
+            z = y.sin()
+            return z
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            return wrap(inner, x)
+
+        result = f(x)
+        self.assertEqual(result, inner(x))
+        # It's unclear if this is correct: dynamo graph breaks on wrap but
+        # then interposes on wrap.__call__, which invokes fn(*args),
+        # leading to two graphs being compiled
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_fallback_on_graph_break_complicated(self):
+        cnt = CompileCounter()
+        x = torch.randn([])
+
+        def inner(x):
+            y = x.sin()
+            y = y * global_var
+            torch._dynamo.graph_break()
+            z = y.sin()
+            return z
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            x = x.clone()
+            result = wrap(inner, x)
+            return result.clone()
+
+        result = f(x)
+        self.assertEqual(result, inner(x))
+        # It's unclear if this is correct: dynamo graph breaks on wrap but
+        # then interposes on wrap.__call__, which invokes fn(*args),
+        # leading to four graphs being compiled: clone, sin, sin, clone
+        self.assertEqual(cnt.frame_count, 4)
+
+    def test_fallback_on_modules(self):
+        # We can likely support this in the future, I just don't want to deal
+        # with it right now
+        counters.clear()
+        cnt = CompileCounter()
+        mod = torch.nn.Linear(3, 3)
+        x = torch.randn(3, 3)
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            return wrap(lambda x: mod(x), x)
+
+        result = f(x)
+
+        self.assertEqual(result, mod(x))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(
+            dict(counters["graph_break"]),
+            {"Invoking an nn.Module inside HigherOrderOperator": 1},
+        )
+
+    def test_fallback_on_non_single_tensor_output(self):
+        # We can likely support this in the future, I just don't want to deal
+        # with it right now
+        counters.clear()
+        cnt = CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            return wrap(lambda x: (x.sin(), x.cos()), x)
+
+        x = torch.randn(2, 3)
+        result = f(x)
+
+        self.assertEqual(result, (x.sin(), x.cos()))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(
+            dict(counters["graph_break"]),
+            {"HigherOrderOperator with body with non single Tensor output": 1},
+        )
+
+    def test_fallback_on_non_tensor_inputs(self):
+        # We can likely support this in the future, I just don't want to deal
+        # with it right now
+        counters.clear()
+        cnt = CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            return wrap(lambda x, y: x + y, x, 193)
+
+        x = torch.randn(2, 3)
+        result = f(x)
+
+        self.assertEqual(result, x + 193)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(
+            dict(counters["graph_break"]),
+            {"HigherOrderOperator with body that accepts non-Tensors as input": 1},
+        )
+
+    def test_access_module_attr(self):
+        # We can likely support this in the future, I just don't want to deal
+        # with it right now
+        counters.clear()
+        cnt = CompileCounter()
+        mod = torch.nn.Linear(3, 3)
+        x = torch.randn(3, 3)
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            y = mod(x)
+            return wrap(lambda y: y - mod.bias, y)
+
+        result = f(x)
+        self.assertEqual(result, mod(x) - mod.bias)
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(
+            dict(counters["graph_break"]),
+            {"accessing attribute of nn.Module inside HigherOrderOperator": 1},
+        )
+
+    def test_make_closure(self):
+        def f(x, y):
+            def g(x):
+                return x + y
+
+            return g(x)
+
+        def h(x, y):
+            return wrap(f, x, y)
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+        self._test_wrap_simple(h, (x, y), 3)
+
+    def test_capture_numpy_number(self):
+        import numpy as np
+
+        y = np.float32(1.0)
+
+        def f(x):
+            return wrap(lambda x: x + y, x)
+
+        x = torch.randn(3)
+        # np.number are lifted to graph inputs
+        self._test_wrap_simple(f, (x,), 3)
+
+    @torch._dynamo.config.patch(specialize_int=False, dynamic_shapes=True)
+    def test_capture_uncommon_int(self):
+        y = 328
+
+        def f(x):
+            return wrap(lambda x: x + y, x)
+
+        x = torch.randn(3)
+        # Under this specific config, uncommon ints are lifted to graph inputs.
+        self._test_wrap_simple(f, (x,), 3)
+
+    def test_freevars_as_inputs_to_wrap(self):
+        y = torch.randn(3)
+
+        def f(x):
+            return wrap(lambda x, y: x + y, x, y)
+
+        x = torch.randn(3)
+        self._test_wrap_simple(f, (x,), 3)
+
+    def test_lift_tensor_constant(self):
+        def f(x):
+            y = torch.tensor(1.0)
+            return wrap(lambda x: x + y, x)
+
+        x = torch.randn(3)
+        self._test_wrap_simple(f, (x,), 3, expected_opcount=2)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6,7 +6,7 @@ import torch
 import torch._dynamo.test_case
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend
 from torch._dynamo.utils import counters
-from torch._ops import wrap
+from torch._higher_order_ops.wrap import wrap
 
 
 # Equivalent to backend="eager", but also records graphs that

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import copy
 import functools
 import itertools
@@ -18,6 +19,7 @@ import torch._guards
 import torch._logging
 
 import torch.nn
+import torch.utils._pytree as pytree
 from torch import fx
 from torch._guards import (
     Checkpointable,
@@ -190,6 +192,11 @@ class OutputGraph(Checkpointable[OutputGraphState]):
     """
     Wrapper class to hold outputs of InstructionTranslator.  Mainly the
     generated fx.Graph.
+
+    OutputGraph is 1:1 with a frame being processed. Each frame is associated
+    with some root InstructionTranslator. When user code calls a function,
+    we construct a InliningInstructionTranslator that continues to write into
+    the root InstructionTranslator's OutputGraph.
     """
 
     def __init__(
@@ -290,8 +297,11 @@ class OutputGraph(Checkpointable[OutputGraphState]):
     def real_value_cache(self):
         return self.current_tracer.real_value_cache
 
-    def create_graph_input(self, *args, **kwargs):
-        return self.current_tracer.create_graph_input(*args, **kwargs)
+    # If you are here, and you're looking for create_graph_input,
+    # to avoid ambiguity, please call one of the following:
+    # - self.current_tracer.create_graph_input
+    # - self.root_tracer.create_graph_input
+    # See NOTE [HigherOrderOperator tracing design] for more context.
 
     def create_proxy(self, *args, **kwargs):
         return self.current_tracer.create_proxy(*args, **kwargs)
@@ -302,8 +312,14 @@ class OutputGraph(Checkpointable[OutputGraphState]):
     def remove_node(self, *args, **kwargs):
         return self.current_tracer.remove_node(*args, **kwargs)
 
-    def create_arg(self, *args, **kwargs):
-        return self.current_tracer.create_arg(*args, **kwargs)
+    @contextlib.contextmanager
+    def new_subtracer(self):
+        try:
+            tracer = SubgraphTracer(self, parent=self.current_tracer)
+            self.tracers.append(tracer)
+            yield tracer
+        finally:
+            self.tracers.pop()
 
     @property
     def output(self):
@@ -400,7 +416,9 @@ class OutputGraph(Checkpointable[OutputGraphState]):
                 return
             # TODO: don't readd symint if we already have it in graph
             # (this is harmless because we do remove the unused ones later)
-            proxy = self.create_graph_input(str(s.node.expr), torch.SymInt, before=True)
+            proxy = self.root_tracer.create_graph_input(
+                str(s.node.expr), torch.SymInt, before=True
+            )
             proxy.node.meta["grapharg"] = GraphArg(
                 prop(arg.source),
                 s,
@@ -464,6 +482,10 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         assert not isinstance(source, ParamBufferSource)
 
         if isinstance(target, torch.Tensor):
+            if len(self.tracers) > 1:
+                unimplemented(
+                    "accessing attribute of nn.Module inside HigherOrderOperator"
+                )
             if not is_constant_source(source):
                 options["guards"].add(source.make_guard(GuardBuilder.TENSOR_MATCH))
 
@@ -758,7 +780,10 @@ class OutputGraph(Checkpointable[OutputGraphState]):
             self.guards.update(output.guards)
 
         self.create_node(
-            "output", "output", (self.create_arg(tuple(x.as_proxy() for x in rv)),), {}
+            "output",
+            "output",
+            (self.current_tracer.create_arg(tuple(x.as_proxy() for x in rv)),),
+            {},
         )
         self.remove_unused_graphargs()
         ncalls = count_calls(self.graph)
@@ -932,7 +957,7 @@ class SubgraphTracer(fx.Tracer):
     compiling and executing the graph.
     """
 
-    def __init__(self, output_graph):
+    def __init__(self, output_graph, parent=None):
         super(SubgraphTracer, self).__init__()
         self.output_graph = weakref.proxy(output_graph)
         self.graph = torch.fx.Graph()
@@ -942,6 +967,18 @@ class SubgraphTracer(fx.Tracer):
         self.input_name_to_proxy: OrderedDict[str, fx.Proxy] = collections.OrderedDict()
         # Node => computed real value (see utils.get_real_value)
         self.real_value_cache: Dict[fx.Node, torch.Tensor] = {}
+
+        # SubgraphTracers can be nested. See NOTE [HigherOrderOperator tracing design]
+        self.parent = parent
+        # A list of proxies that exist in the graph being traced. We use this
+        # list to determine that, when tracing the body function of a HigherOrderOperator,
+        # if a new proxy is actually a free variable.
+        self.seen_proxies = set({})
+        # A list of previously free variables that we lifted to being inputs
+        # of the graph. If we are tracing a HigherOrderOperator's body_fn,
+        # then we need to keep track of this so we can rewrite the
+        # HigherOrderOperator call using the traced body_fn.
+        self.lifted_freevars = set({})
 
     def create_proxy(
         self,
@@ -953,6 +990,53 @@ class SubgraphTracer(fx.Tracer):
         type_expr=None,
         proxy_factory_fn=None,
     ):
+        # NOTE: [Nested SubgraphTracer and free_variable handling]
+        # --------------------------------------------------------
+        # Read NOTE [HigherOrderOperator tracing design] first.
+        #
+        # Let's say we're in the middle of introspecting the body of a possibly
+        # nested HigherOrderOperator, and we see a free variable.
+        #
+        # There are two cases:
+        # 1. We see a free variable that is already tracked by Dynamo.
+        # 2. We see a free variable that has not been tracked by Dynamo
+        #
+        # In case 1, we call `lift_tracked_freevar_to_input` (below)
+        # which will lift the freevar to be an input of this subgraph
+        # and also recursively lift it to be an input on the parent(s).
+        #
+        # In case 2, before the call to `create_proxy`, the InstructionTranslator
+        # will see the freevar when it gets loaded by Python bytecode.
+        # E.g. for Python 3.11 the bytecodes that may do this are LOAD_DEREF or
+        # LOAD_GLOBAL.
+        # There, the InstructionTranslator asks Dynamo to begin tracking the
+        # freevar by building a new Variable.
+        # Building a new Variable automatically lifts the freevar to be an
+        # input of the root SubgraphTracer.
+        #
+        # The implications for the code below are:
+        # - We will always be in Case 1 when we get to this code.
+        # - Any "free variable" we encounter here is guaranteed to already be
+        #   bound, that is, it is either a graph input of the root graph, or
+        #   some local variable of the root graph or a subgraph.
+        # - The additional work we need to do here is *only* that we need to
+        #   lift this free variable into inputs (recursively) of each nested
+        #   higher-order-op subgraph until we hit the subgraph where the free
+        #   variable is bound
+        if self.parent is not None:
+            flat_args, _ = pytree.tree_flatten(args)
+            for arg in flat_args:
+                if not isinstance(arg, torch.fx.Proxy):
+                    # Is a constant
+                    continue
+                if arg in self.seen_proxies:
+                    continue
+                if not hasattr(arg, "node"):
+                    continue
+                if arg.node.name in self.input_name_to_proxy:
+                    continue
+                self.lift_tracked_freevar_to_input(arg)
+
         rv = super().create_proxy(
             kind, target, args, kwargs, name, type_expr, proxy_factory_fn
         )
@@ -967,6 +1051,8 @@ class SubgraphTracer(fx.Tracer):
         if kind in {"call_function", "call_method"}:
             rv.node.meta["source_fn"] = target
         elif kind == "call_module":
+            if self.parent is not None:
+                unimplemented("Invoking an nn.Module inside HigherOrderOperator")
             # For modules we store the class
             rv.node.meta["source_fn"] = rv.node.meta["nn_module_stack"][target][1]
 
@@ -981,6 +1067,7 @@ class SubgraphTracer(fx.Tracer):
         msgs = traceback.StackSummary.from_list(frame_summaries).format()  # type: ignore[arg-type]
         rv.node.stack_trace = "".join(msgs)
 
+        self.seen_proxies.add(rv)
         return rv
 
     def create_node(self, *args, **kwargs):
@@ -1027,3 +1114,57 @@ class SubgraphTracer(fx.Tracer):
             else:
                 self.input_name_to_proxy[name] = proxy
             return proxy
+
+    def is_name_bound(self, name):
+        if name in self.input_name_to_proxy:
+            return True
+        for proxy in self.seen_proxies:
+            if proxy.node.name == name:
+                return True
+        return False
+
+    # See NOTE: [Nested SubgraphTracer and free_variable handling] for more details
+    def lift_tracked_freevar_to_input(self, proxy):
+        # You're doing something wrong if we are the root SubgraphTracer because
+        # Dynamo adds tensors to graph inputs before creating a proxy for them.
+        assert (
+            self.parent is not None
+        ), "lift_tracked_freevar_to_input on root SubgraphTracer"
+        self.create_graph_input(proxy.node.name)
+        self.lifted_freevars.add(proxy)
+        if self.parent is not None and not self.parent.is_name_bound(proxy.node.name):
+            self.parent.lift_tracked_freevar_to_input(proxy)
+
+
+# NOTE: [HigherOrderOperator tracing design]
+# Ignoring HigherOrderOperators for a moment,
+# OutputGraph represents the graph being built by Dynamo that may be compiled
+# and executed. It holds a root SubgraphTracer where the FX graph is built.
+#
+# HigherOrderOperators are operators that take functions as their arguments.
+# When Dynamo encounters a HigherOrderOperator, then it attempts to introspect
+# the function passed to it (call this the "body function"), capture it into a
+# GraphModule, and rewrite the call to the HigherOrderOperator to use the
+# GraphModule.
+#
+# The way we handle the capture of body functions is through having
+# (possibly nested) SubgraphTracers, one per body function.
+#
+# Mechanically, we do the introspection by:
+# - Creating a new SubgraphTracer via OutputGraph.new_subtracer
+# - Executing the body function.
+# This constructs the graph of the body function in the new SubgraphTracer
+# while modifying the state of the OutputGraph. For example:
+# - the OutputGraph can receive new GraphArgs (if we discover any new
+#   untracked Tensors)
+# - side effects from the body function get accumulated into
+#   OutputGraph.side_effects
+# - guards produced by the body function get accumulated into OutputGraph.guards
+#
+# The traced function has some special properties that make it easier for us
+# to transform later down the line:
+# - we lift all free variables to being inputs.
+#
+# If the introspection fails (due to the existence of graph breaks), then
+# we roll back the current OutputGraph state and graph break on the
+# HigherOrderOperator.

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -788,7 +788,15 @@ class VariableBuilder:
         if is_duplicate_tensor:
             return self.tx.output.input_source_to_var[source]
 
-        tensor_proxy = self.tx.output.create_graph_input(
+        # tx.output has multiple tracers if we're introspecting HigherOrderOperator.
+        # When we've discovered an untracked tensor, then we actually need
+        # to get Dynamo to track the tensor (which is what this function does)
+        # and put it as a graph input on the root tracer. Later on,
+        # if the input is actually used in the body of the HigherOrderOperator,
+        # then the relevant SubgraphTracer will lift it to being an input of
+        # the subgraph.
+        # See NOTE [HigherOrderOperator tracing design] for more details.
+        tensor_proxy = self.tx.output.root_tracer.create_graph_input(
             re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(value)
         )
         tensor_variable = wrap_fx_proxy(
@@ -886,7 +894,7 @@ class VariableBuilder:
             if isinstance(wrapped_value, torch.Tensor):
                 options.update({"raw_value": value})
 
-            proxy = self.tx.output.create_graph_input(
+            proxy = self.tx.output.root_tracer.create_graph_input(
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(wrapped_value)
             )
 

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -1,0 +1,13 @@
+from torch._ops import HigherOrderOperator
+
+# Used for testing the HigherOrderOperator mechanism
+class Wrap(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("wrap")
+
+    def __call__(self, func, *args):
+        result = func(*args)
+        return result
+
+
+wrap = Wrap()

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -788,17 +788,5 @@ class _Ops(types.ModuleType):
         self.loaded_libraries.add(path)
 
 
-class Wrap(HigherOrderOperator):
-    def __init__(self):
-        super().__init__("wrap")
-
-    def __call__(self, func, *args):
-        result = func(*args)
-        return result
-
-
-wrap = Wrap()
-
-
 # The ops "namespace"
 ops = _Ops()

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -788,5 +788,17 @@ class _Ops(types.ModuleType):
         self.loaded_libraries.add(path)
 
 
+class Wrap(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("wrap")
+
+    def __call__(self, func, *args):
+        result = func(*args)
+        return result
+
+
+wrap = Wrap()
+
+
 # The ops "namespace"
 ops = _Ops()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #100544

Original PR #99988

The problem was that we added `wrap` to torch._ops which actually puts
it on `torch.ops.wrap` which is a namespace that can be open-registered
to. The fix is that we now shove `wrap` into a new file

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire