### PR TITLE
torch.utils.checkpoint warns if user does not pass use_reentrant explicitly

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5621,6 +5621,23 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(Exception, "only supported when use_reentrant=False"):
             out = checkpoint(lambda x: x.sin(), x, use_reentrant=True, context_fn=context_fn)
 
+    def test_checkpoint_warns_if_use_reentrant_not_passed_explcitly(self):
+        a = torch.randn(1, requires_grad=True)
+
+        # Passing explicitly should not warn
+        with warnings.catch_warnings(record=True) as w:
+            checkpoint(lambda x: x, a, use_reentrant=False)
+        self.assertEqual(len(w), 0)
+
+        # Not passing explicitly warns
+        with warnings.catch_warnings(record=True) as w:
+            checkpoint(lambda x: x, a)
+        self.assertEqual(len(w), 1)
+        self.assertIn(
+            "please pass in use_reentrant=True or use_reentrant=False explicitly",
+            str(w[0].message)
+        )
+
     def test_access_saved_tensor_twice_without_recomputation_works(self):
         count = [0]
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -172,7 +172,7 @@ def noop_context_fn():
 def checkpoint(
     function,
     *args,
-    use_reentrant: bool = True,
+    use_reentrant: Optional[bool] = None,
     context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
     **kwargs
 ):
@@ -271,6 +271,15 @@ def checkpoint(
     Returns:
         Output of running :attr:`function` on :attr:`*args`
     """
+    if use_reentrant is None:
+        warnings.warn(
+            "torch.utils.checkpoint: please pass in use_reentrant=True or "
+            "use_reentrant=False explicitly. The default value of use_reentrant "
+            "will be updated to be False in the future. To maintain current "
+            "behavior, pass use_reentrant=True. It is recommended that you use "
+            "use_reentrant=False. Refer to docs for more details on the "
+            "differences between the two variants.")
+        use_reentrant = True
     # Hack to mix *args with **kwargs in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
     if kwargs and use_reentrant:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100551
* #100274

Now that we have updated all internal callsites, per https://fb.workplace.com/groups/pytorch.oss.dev/permalink/1635183750239493/ we should raise a warning when use_reentrant is not explicitly passed for 2.1

Deprecation note:
- Not passing in use_reentrant explicitly is now deprecated and will raise a warning. In the future the default value of use-reentrant will be False. To preserve the existing behavior you can pass in use_reentrant=True. It is recommended that you use use_reentrant=False.