### PR TITLE
[c10d] Fix subprocess group handlig in scatter_object_list.

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2555,7 +2555,7 @@ def scatter_object_list(
             "Expected argument scatter_object_output_list to be a list of size at least 1."
         )
 
-    my_rank = get_rank(group)
+    my_rank = get_rank()
     pg_device = _get_pg_device(group)
     if my_rank == src:
         tensor_list, tensor_sizes = zip(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100552

scatter_object_list assumed src was a group rank while all collectives use global ranks.