### PR TITLE
[PT2E][Quant] Use subgraph matcher annotate linear pattern

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: quantization"]
 import copy
 import operator
+import unittest
 from typing import List
 
 import torch
@@ -42,6 +43,8 @@ from torch.testing._internal.common_quantization import (
 )
 from torch.testing._internal.common_quantized import override_quantized_engine
 
+
+from torch.ao.quantization.quantize_fx import _convert_to_reference_decomposed_fx
 
 @skipIfNoQNNPACK
 class TestQuantizePT2E(QuantizationTestCase):
@@ -161,6 +164,202 @@ class TestQuantizePT2E(QuantizationTestCase):
         self.checkGraphModuleNodes(
             m, expected_node_list=node_list, expected_node_occurrence=node_occurrence
         )
+
+    def test_qnnpack_quantizer_linear(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(8, 16, bias=False)
+                self.linear2 = torch.nn.Linear(16, 8)
+
+            def forward(self, x):
+                return self.linear2(self.linear1(x))
+
+        import torch.ao.quantization._pt2e.quantizer.qnnpack_quantizer as qq
+
+        quantizer = QNNPackQuantizer()
+        operator_config = qq.get_symmetric_quantization_config(is_per_channel=True)
+        quantizer.set_global(operator_config)
+        m_eager = M().eval()
+
+        # Test with 2d inputs
+        example_inputs_2d = (torch.randn(9, 8),)
+        example_inputs_3d = (torch.randn(9, 10, 8),)
+        example_inputs_4d = (torch.randn(9, 10, 11, 8),)
+        for example_inputs in [example_inputs_2d, example_inputs_3d, example_inputs_4d]:
+            # program capture
+            m = m_eager
+            m, guards = torchdynamo.export(
+                m,
+                *copy.deepcopy(example_inputs),
+                aten_graph=True,
+                tracing_mode="real",
+            )
+
+            m = prepare_pt2e_quantizer(m, quantizer)
+            # Calibrate
+            m(*example_inputs)
+            m = convert_pt2e(m)
+            pt2_quant_output = m(*example_inputs)
+            node_occurrence = {
+                # input and output are using quantize_per_tensor and weight is using quantize_per_channel
+                ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 3,
+                ns.call_function(
+                    torch.ops.quantized_decomposed.dequantize_per_tensor
+                ): 3,
+                ns.call_function(
+                    torch.ops.quantized_decomposed.quantize_per_channel
+                ): 2,
+                ns.call_function(
+                    torch.ops.quantized_decomposed.dequantize_per_channel
+                ): 2,
+            }
+            self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
+            qconfig = default_per_channel_symmetric_qnnpack_qconfig
+            qconfig_mapping = QConfigMapping().set_global(qconfig)
+            backend_config = get_qnnpack_backend_config()
+            m_copy = copy.deepcopy(m_eager)
+            m_fx = prepare_fx(
+                m_copy, qconfig_mapping, example_inputs, backend_config=backend_config
+            )
+            m_fx(*example_inputs)
+            m_fx = _convert_to_reference_decomposed_fx(
+                m_fx, backend_config=backend_config
+            )
+            m_fx, _ = torchdynamo.export(
+                m_fx,
+                *copy.deepcopy(example_inputs),
+                aten_graph=True,
+                tracing_mode="real",
+            )
+            fx_quant_output = m_fx(*example_inputs)
+            self.assertTrue(torch.allclose(fx_quant_output, pt2_quant_output))
+
+    def test_qnnpack_quantizer_conv_linear_no_permute(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, 3)
+                self.linear1 = torch.nn.Linear(64, 8, bias=False)
+                self.linear2 = torch.nn.Linear(8, 8)
+
+            def forward(self, x):
+                conv_out = self.conv(x)
+                reshape_out = torch.reshape(conv_out, (2, 64))
+                return self.linear2(self.linear1(reshape_out))
+
+        import torch.ao.quantization._pt2e.quantizer.qnnpack_quantizer as qq
+
+        quantizer = QNNPackQuantizer()
+        operator_config = qq.get_symmetric_quantization_config(is_per_channel=True)
+        quantizer.set_global(operator_config)
+        m_eager = M().eval()
+
+        # Test with 2d inputs
+        example_inputs = (torch.randn(2, 3, 4, 4),)
+        # program capture
+        m = m_eager
+        m, guards = torchdynamo.export(
+            m,
+            *copy.deepcopy(example_inputs),
+            aten_graph=True,
+            tracing_mode="real",
+        )
+
+        m = prepare_pt2e_quantizer(m, quantizer)
+        # Calibrate
+        m(*example_inputs)
+        m = convert_pt2e(m)
+        pt2_quant_output = m(*example_inputs)
+        node_occurrence = {
+            # input and output are using quantize_per_tensor and weight is using quantize_per_channel
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 5,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor): 5,
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_channel): 3,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_channel): 3,
+        }
+        self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
+        qconfig = default_per_channel_symmetric_qnnpack_qconfig
+        qconfig_mapping = QConfigMapping().set_global(qconfig)
+        backend_config = get_qnnpack_backend_config()
+        m_copy = copy.deepcopy(m_eager)
+        m_fx = prepare_fx(
+            m_copy, qconfig_mapping, example_inputs, backend_config=backend_config
+        )
+        m_fx(*example_inputs)
+        m_fx = _convert_to_reference_decomposed_fx(m_fx, backend_config=backend_config)
+        fx_quant_output = m_fx(*example_inputs)
+        self.assertTrue(torch.allclose(fx_quant_output, pt2_quant_output))
+
+    @unittest.skip(
+        "Skip due to linear traces into a different pattern. See test comment."
+    )
+    def test_qnnpack_quantizer_conv_linear(self):
+        """
+        This test fails because linear decompositon changes due to the presence of
+        permute node. In the below linear 1 is decomposed as
+        %t_default : [#users=1] = call_function[target=torch.ops.aten.t.default](args = (%_param_constant2,), kwargs = {})
+        %clone_default : [#users=1] = call_function[target=torch.ops.aten.clone.default](args = (%permute_default,), kwargs = {memory_format: torch.contiguous_format})  # noqa: B950
+        %_unsafe_view_default : [#users=1] = call_function[target=torch.ops.aten._unsafe_view.default](args = (%clone_default, [8, 16]), kwargs = {})  # noqa: B950
+        %mm_default : [#users=1] = call_function[target=torch.ops.aten.mm.default](args = (%_unsafe_view_default, %t_default), kwargs = {})  # noqa: B950
+        %view_default : [#users=1] = call_function[target=torch.ops.aten.view.default](args = (%mm_default, [2, 2, 2, 8]), kwargs = {})  # noqa: B950
+
+        Note the presence of cline and unsafe_view. This is due to permute
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, 3)
+                self.linear1 = torch.nn.Linear(16, 8, bias=False)
+                self.linear2 = torch.nn.Linear(8, 8)
+
+            def forward(self, x):
+                conv_out = self.conv(x)
+                permute_out = torch.permute(conv_out, (0, 2, 3, 1))
+                return self.linear2(self.linear1(permute_out))
+
+        import torch.ao.quantization._pt2e.quantizer.qnnpack_quantizer as qq
+
+        quantizer = QNNPackQuantizer()
+        operator_config = qq.get_symmetric_quantization_config(is_per_channel=True)
+        quantizer.set_global(operator_config)
+        m_eager = M().eval()
+
+        # Test with 2d inputs
+        example_inputs = (torch.randn(2, 3, 4, 4),)
+        # program capture
+        m = m_eager
+        m, guards = torchdynamo.export(
+            m,
+            *copy.deepcopy(example_inputs),
+            aten_graph=True,
+            tracing_mode="real",
+        )
+
+        m = prepare_pt2e_quantizer(m, quantizer)
+        # Calibrate
+        m(*example_inputs)
+        m = convert_pt2e(m)
+        pt2_quant_output = m(*example_inputs)
+        node_occurrence = {
+            # input and output are using quantize_per_tensor and weight is using quantize_per_channel
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 3,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor): 3,
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_channel): 2,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_channel): 2,
+        }
+        self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
+        qconfig = default_per_channel_symmetric_qnnpack_qconfig
+        qconfig_mapping = QConfigMapping().set_global(qconfig)
+        backend_config = get_qnnpack_backend_config()
+        m_copy = copy.deepcopy(m)
+        m_fx = prepare_fx(
+            m_copy, qconfig_mapping, example_inputs, backend_config=backend_config
+        )
+        m_fx = convert_to_reference_fx(m_fx, backend_config=backend_config)
+        fx_quant_output = m_fx(*example_inputs)
+        self.assertTrue(torch.allclose(fx_quant_output, pt2_quant_output))
 
     def test_qnnpack_quantizer_obs_sharing_ops(self):
         class M(torch.nn.Module):
@@ -417,5 +616,11 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 compute_sqnr(after_prepare_result, after_prepare_result_fx),
                 torch.tensor(float("inf")),
             )
-            self.assertEqual(after_quant_result, after_quant_result_fx)
-            self.assertTrue(compute_sqnr(after_quant_result, after_quant_result_fx) == torch.tensor(float("inf")))
+            # there are slight differences after convert due to different implementations
+            # of quant/dequant
+            self.assertTrue(
+                torch.max(after_quant_result - after_quant_result_fx) < 1e-1
+            )
+            self.assertTrue(
+                compute_sqnr(after_quant_result, after_quant_result_fx) > 35
+            )

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -129,6 +129,7 @@ FILENAME_ALLOWLIST |= {torch.optim._functional.__file__}
 # `torch.ao.quantization._pt2e`, which interferes with memory profiling
 FILENAME_ALLOWLIST |= {
     _module_dir(torch) + "ao/quantization/_pt2e/qat_utils.py",
+    _module_dir(torch) + "ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py",
 }
 
 

--- a/torch/ao/quantization/_pt2e/prepare.py
+++ b/torch/ao/quantization/_pt2e/prepare.py
@@ -95,9 +95,13 @@ def prepare(
 
     for node in nodes_before_observation:
 
-        if node.op == "placeholder":
-            pass
-        elif node.op in ("call_module", "call_method", "call_function"):
+        if node.op in (
+            "placeholder",
+            "call_module",
+            "call_method",
+            "call_function",
+            "get_attr",
+        ):
             _maybe_insert_input_and_output_observers_for_node(node, model)
         elif node.op == "output":
             named_modules = dict(model.named_modules(remove_duplicate=False))

--- a/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
@@ -6,6 +6,7 @@ import operator
 from typing import Callable, Dict, List, Optional, Set
 
 import torch
+import torch._dynamo as torchdynamo
 import torch.nn.functional as F
 
 from torch.ao.quantization._pt2e.quantizer.utils import (
@@ -16,6 +17,8 @@ from torch.ao.quantization._pt2e.quantizer.utils import (
 
 from torch.ao.quantization.observer import PlaceholderObserver
 from torch.fx import Node
+
+from torch.fx.passes.utils.matcher_utils import InternalMatch, SubgraphMatcher
 
 from .quantizer import (
     OperatorConfig,
@@ -31,6 +34,41 @@ __all__ = [
 ]
 
 _QUANT_CONFIG_TO_ANNOTATOR = {}
+
+
+def _mark_nodes_as_annotated(nodes: List[Node]):
+    for node in nodes:
+        if node is not None:
+            if "target_dtype_info" not in node.meta:
+                node.meta["target_dtype_info"] = {
+                    "input_act_obs_or_fq_ctr": None,
+                    "output_act_obs_or_fq_ctr": None,
+                    "weight_obs_or_fq_ctr": None,
+                    "bias_obs_or_fq_ctr": None,
+                    "_annotated": True,
+                }
+            node.meta["target_dtype_info"]["_annotated"] = True
+
+
+def _get_dynamo_graph(function: Callable, inputs) -> torch.fx.Graph:
+    gm, _ = torchdynamo.export(function, *inputs, aten_graph=True)
+    gm.graph.eliminate_dead_code()
+    return gm.graph
+
+
+def _get_linear_patterns(input_size: List[int]):
+    in_channels = input_size[-1]
+    out_channels = 8  # hard coding but this should not matter
+    weight = torch.ones((out_channels, in_channels))
+    bias = torch.ones((out_channels,))
+    act = torch.ones(input_size)
+
+    def linear_op(act, weight, bias=None):
+        return F.linear(act, weight, bias)
+
+    pattern_w_bias = _get_dynamo_graph(linear_op, (act, weight, bias))
+    pattern_wo_bias = _get_dynamo_graph(linear_op, (act, weight))
+    return [pattern_w_bias, pattern_wo_bias]
 
 
 def register_annotator(quantization_configs: List[QuantizationConfig]):
@@ -206,6 +244,7 @@ class QNNPackQuantizer(Quantizer):
         # and fusion operator patterns (conv - relu) can get matched before single operator pattern (conv)
         # and we will mark the matched node with "_annoated" so fusion operator pattern
         # can take precedence over single operator pattern in this way
+        self._annotate_linear(model, config)
         for node in reversed(model.graph.nodes):
             # one improvement is to register node annotators for each
             # supported op type.
@@ -213,7 +252,6 @@ class QNNPackQuantizer(Quantizer):
                 self._annotate_conv2d_bn(node, config)
             self._annotate_conv2d_relu(node, config)
             self._annotate_conv2d(node, config)
-            self._annotate_linear(node, config)
             self._annotate_maxpool2d(node, config)
             self._annotate_add_relu(node, config)
             self._annotate_add(node, config)
@@ -340,45 +378,88 @@ class QNNPackQuantizer(Quantizer):
         }
 
     def _annotate_linear(
-        self, node: Node, quantization_config: QuantizationConfig
+        self, gm: torch.fx.GraphModule, quantization_config: QuantizationConfig
     ) -> None:
-        addmm_node = node
-        if (
-            addmm_node.op != "call_function"
-            or addmm_node.target != torch.ops.aten.addmm.default
-        ):
-            return
-        view_node = addmm_node.args[1]
-        assert isinstance(view_node, Node)
-        if (
-            view_node.op != "call_function"
-            or view_node.target != torch.ops.aten.view.default
-        ):
-            return
-        t_node = addmm_node.args[2]
-        assert isinstance(t_node, Node)
-        if t_node.op != "call_function" or t_node.target != torch.ops.aten.t.default:
-            return
-        if _is_annotated([addmm_node, view_node, t_node]):
-            return
+        graph = gm.graph
+        patterns = []
+        """
+        Annotate linear nodes:
+        This is done by tracing linear patterns for various input shapes that give
+        distinct pattern graph.
+        Order matters here since without that we get overlapping matches, resulting
+        in wrong annotations.
+        We will really plan to move this as graph matching utils supported by compiler/core team.
+        More details can be found here: (put doc link)
+        """
+        patterns.extend(_get_linear_patterns([8, 8, 8, 8]))
+        patterns.extend(_get_linear_patterns([8, 8, 8]))
+        patterns.extend(_get_linear_patterns([8, 8]))
+        matches: List[InternalMatch] = []
+        for pattern in patterns:
+            subgraph_matcher = SubgraphMatcher(pattern, ignore_literals=True)
+            matches.extend(subgraph_matcher.match(graph))
+        for match in matches:
+            weight_or_bias = []
+            act_node = None
+            if len(match.returning_nodes) != 1:
+                raise ValueError("Linear pattern must have only one returning node")
+            output_node = match.returning_nodes[0]
+            for ph in match.placeholder_nodes:
+                if ph.op == "get_attr":
+                    weight_or_bias.append(ph)
+                else:
+                    act_node = ph
+            weight_node = None
+            bias_node = None
+            for ph in weight_or_bias:
+                weight_or_bias = getattr(gm, ph.target)  # type: ignore[arg-type]
+                if weight_or_bias.ndim == 2:  # type: ignore[attr-defined]
+                    weight_node = ph
+                if weight_or_bias.ndim == 1:  # type: ignore[attr-defined]
+                    bias_node = ph
 
-        # bias and output act
-        addmm_node.meta["target_dtype_info"] = {
-            "bias_obs_or_fq_ctr": get_bias_obs_or_fq_ctr(quantization_config),
-            "output_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(quantization_config),
-            "bias_index": 0,
-            "_annotated": True,
-        }
-        # input act
-        view_node.meta["target_dtype_info"] = {
-            "input_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(quantization_config),
-            "_annotated": True,
-        }
-        # weight
-        t_node.meta["target_dtype_info"] = {
-            "input_act_obs_or_fq_ctr": get_weight_obs_or_fq_ctr(quantization_config),
-            "_annotated": True,
-        }
+            # bias and output act
+            if _is_annotated([act_node]) is False:  # type: ignore[list-item]
+                act_node.meta["target_dtype_info"] = {  # type: ignore[union-attr]
+                    "input_act_obs_or_fq_ctr": None,
+                    "output_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(
+                        quantization_config
+                    ),
+                    "weight_obs_or_fq_ctr": None,
+                    "bias_obs_or_fq_ctr": None,
+                    "_annotated": True,
+                }
+            if bias_node and _is_annotated([bias_node]) is False:
+                bias_node.meta["target_dtype_info"] = {
+                    "input_act_obs_or_fq_ctr": None,
+                    "output_act_obs_or_fq_ctr": get_bias_obs_or_fq_ctr(
+                        quantization_config
+                    ),
+                    "weight_obs_or_fq_ctr": None,
+                    "bias_obs_or_fq_ctr": None,
+                    "_annotated": True,
+                }
+            if _is_annotated([weight_node]) is False:  # type: ignore[list-item]
+                weight_node.meta["target_dtype_info"] = {  # type: ignore[union-attr]
+                    "input_act_obs_or_fq_ctr": None,
+                    "output_act_obs_or_fq_ctr": get_weight_obs_or_fq_ctr(
+                        quantization_config
+                    ),
+                    "weight_obs_or_fq_ctr": None,
+                    "bias_obs_or_fq_ctr": None,
+                    "_annotated": True,
+                }
+            if _is_annotated([output_node]) is False:
+                output_node.meta["target_dtype_info"] = {
+                    "input_act_obs_or_fq_ctr": None,
+                    "output_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(
+                        quantization_config
+                    ),
+                    "weight_obs_or_fq_ctr": None,
+                    "bias_obs_or_fq_ctr": None,
+                    "_annotated": True,
+                }
+            _mark_nodes_as_annotated(list(match.nodes_map.values()))
 
     # TODO: move to `_pt2e/_propagate_annotation.py` after we have
     # decided on the how we want to use pattern matching for annotation


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100566
* #100265

This diff adds subgraph matcher for pattern matching. Furthermore, we also move
annotations for the matched subgraph in a way that only input and output nodes
of the matched subgraph have quantization related valid annotations.

Differential Revision: [D45535539](https://our.internmc.facebook.com/intern/diff/D45535539/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire