### PR TITLE
[ONNX] Simplify repeat_intereleave export for scalar-valued 'repeat'

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5212,6 +5212,18 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             dynamic_axes={"repeats_1": {0: "r"}},
         )
 
+        class DynamicFlattenModel(torch.nn.Module):
+            def forward(self, x):
+                return x.repeat_interleave(2)
+
+        x = torch.tensor([1, 2, 3])
+        self.run_test(
+            DynamicFlattenModel(),
+            x,
+            input_names=["input_1"],
+            dynamic_axes={"input_1": {0: "w"}},
+        )
+
     @skipIfUnsupportedMinOpsetVersion(13)
     def test_multiple_dynamic_repeat_interleave(self):
         class DynamicRepeatsModel(torch.nn.Module):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1261,6 +1261,40 @@ def _repeat_interleave_split_helper(g: jit_utils.GraphContext, self, reps, dim):
         split_out = split(g, self, repeats, dim, _outputs=reps)
     return split_out if reps > 1 else [split_out]
 
+@_beartype.beartype
+def _repeat_interleave_single_value_helper(g: jit_utils.GraphContext, self, repeats, dim):
+    from torch.onnx.symbolic_opset9 import unsqueeze, flatten
+
+    if not _is_tensor(repeats):
+        repeats = g.op("Constant", value_t=torch.LongTensor(repeats))
+
+    const_repeats: bool = _is_constant(repeats)
+    reps = _maybe_get_const(repeats, "t")
+
+    # Convert 'repeats' to 1-d if it is 0-d.
+    if _get_tensor_rank(repeats) == 0:
+        repeats = g.op("Reshape", repeats, g.op("Constant", value_t=torch.tensor([1])))
+
+    # Create a new dim of size 1, then resize it to be 'repeats' long, and finally collapse it.
+    unsqueezed = unsqueeze(g, self, dim+1)
+
+    # repeats_per_dim is 1 for all dims except for the new unsqueezed dim, where it has value 'repeats'.
+    if const_repeats:
+        # 'Repeats' is a constant, 'repeats_per_dim' can be a constant.
+        onehot = torch.ones(_get_tensor_rank(unsqueezed), dtype=torch.int64)
+        onehot[dim+1] = reps
+        repeats_per_dim = g.op("Constant", value_t=onehot)
+    else:
+        # 'Repeats' is a variable, 'repeats_per_dim' cannot be a constant.
+        onehot = g.op("OneHot",
+            unsqueeze(g, dim+1, 0), # indices, must be >=1-dimensional
+            g.op("Constant", value_t=torch.tensor(_get_tensor_rank(unsqueezed))), # depth
+            g.op("Concat", g.op("Constant", value_t=torch.tensor([1])), repeats, axis_i=0) # on/off values
+        )
+        repeats_per_dim = flatten(g, onehot, 0, 1)
+
+    tiled = g.op("Tile", unsqueezed, repeats_per_dim)
+    return flatten(g, tiled, dim, dim+1)
 
 @_beartype.beartype
 def _arange_cast_helper(

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1263,7 +1263,7 @@ def _repeat_interleave_split_helper(g: jit_utils.GraphContext, self, reps, dim):
 
 
 @_beartype.beartype
-def _repeat_interleave_single_value_helper(
+def _repeat_interleave_single_value_repeat_helper(
     g: jit_utils.GraphContext, self, repeats, dim
 ):
     from torch.onnx.symbolic_opset9 import flatten, unsqueeze
@@ -1278,7 +1278,7 @@ def _repeat_interleave_single_value_helper(
     if _get_tensor_rank(repeats) == 0:
         repeats = g.op("Reshape", repeats, g.op("Constant", value_t=torch.tensor([1])))
 
-    # Create a new dim of size 1, then resize it to be 'repeats' long, and finally collapse it.
+    # Create a new dim of size 1, then expand it to be 'repeats' long, and finally collapse it.
     unsqueezed = unsqueeze(g, self, dim + 1)
 
     # repeats_per_dim is 1 for all dims except for the new unsqueezed dim, where it has value 'repeats'.

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -608,7 +608,7 @@ def repeat_interleave(
         input = symbolic_helper._reshape_helper(
             g, self, g.op("Constant", value_t=torch.tensor([-1]))
         )
-        dim = 0
+        dim = torch.tensor(0, dtype=torch.int64)
     else:
         dim = symbolic_helper._maybe_get_scalar(dim)
 
@@ -639,21 +639,20 @@ def repeat_interleave(
         if input_size is None:
             output_sizes[idx], input_sizes[idx] = 0, -1
 
+    # Check if all indices should be repeated the same number of times.
+    if repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1):
+        return symbolic_helper._repeat_interleave_single_value_helper(g, self, repeats, dim)
+
     cond_dynamic_repeats = repeats_dim == 1 and repeats_sizes[0] is None
     # If input size is dynamic or repeats vector is dynamic
     if output_sizes[dim] == 0 or cond_dynamic_repeats:
         reps = symbolic_helper._size_helper(g, input, dim)
         reps = opset11.unsqueeze(g, reps, 0)
-        # Check if repeats vector is a single integer value
-        # or a single dimension tensor with non-dynamic values
-        if repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1):
-            if not symbolic_helper._is_tensor(repeats):
-                repeats = g.op("Constant", value_t=torch.LongTensor(repeats))
-            repeats = g.op("Expand", repeats, reps)
+
         # Check if repeats is dynamic
         # As repeats is dynamic, we use a where node as a substitute for the if statement
         # If repests_dim = 1, expand repeats otherwise use original tensor
-        elif cond_dynamic_repeats:
+        if cond_dynamic_repeats:
             repeat_dim = symbolic_helper._size_helper(
                 g, repeats, g.op("Constant", value_t=torch.LongTensor([0]))
             )

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -641,7 +641,9 @@ def repeat_interleave(
 
     # Check if all indices should be repeated the same number of times.
     if repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1):
-        return symbolic_helper._repeat_interleave_single_value_helper(g, self, repeats, dim)
+        return symbolic_helper._repeat_interleave_single_value_helper(
+            g, self, repeats, dim
+        )
 
     cond_dynamic_repeats = repeats_dim == 1 and repeats_sizes[0] is None
     # If input size is dynamic or repeats vector is dynamic

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -641,7 +641,7 @@ def repeat_interleave(
 
     # Check if all indices should be repeated the same number of times.
     if repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1):
-        return symbolic_helper._repeat_interleave_single_value_helper(
+        return symbolic_helper._repeat_interleave_single_value_repeat_helper(
             g, self, repeats, dim
         )
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4252,7 +4252,7 @@ def repeat_interleave(
         input = symbolic_helper._reshape_helper(
             g, self, g.op("Constant", value_t=torch.tensor([-1]))
         )
-        dim = 0
+        dim = torch.tensor(0, dtype=torch.int64)
     else:
         dim = symbolic_helper._maybe_get_scalar(dim)
 
@@ -4275,6 +4275,10 @@ def repeat_interleave(
             input,
         )
 
+    # Handle cases where dim is negative
+    if dim < 0:
+        dim += len(input_sizes)
+
     input_sizes_temp = input_sizes.copy()
     for idx, input_size in enumerate(input_sizes):
         if input_size is None:
@@ -4282,8 +4286,6 @@ def repeat_interleave(
 
     # Cases where repeats is an int or single value tensor
     if repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1):
-        if not symbolic_helper._is_tensor(repeats):
-            repeats = g.op("Constant", value_t=torch.LongTensor(repeats))
         if input_sizes[dim] == 0:
             return symbolic_helper._onnx_opset_unsupported_detailed(
                 "repeat_interleave",
@@ -4292,11 +4294,7 @@ def repeat_interleave(
                 "Unsupported along dimension with unknown input size",
                 self,
             )
-        else:
-            reps = input_sizes[dim]
-            repeats = expand(
-                g, repeats, g.op("Constant", value_t=torch.tensor([reps])), None
-            )
+        return symbolic_helper._repeat_interleave_single_value_helper(g, self, repeats, dim)
 
     # Cases where repeats is a 1 dim Tensor
     elif repeats_dim == 1:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4294,7 +4294,7 @@ def repeat_interleave(
                 "Unsupported along dimension with unknown input size",
                 self,
             )
-        return symbolic_helper._repeat_interleave_single_value_helper(
+        return symbolic_helper._repeat_interleave_single_value_repeat_helper(
             g, self, repeats, dim
         )
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4294,7 +4294,9 @@ def repeat_interleave(
                 "Unsupported along dimension with unknown input size",
                 self,
             )
-        return symbolic_helper._repeat_interleave_single_value_helper(g, self, repeats, dim)
+        return symbolic_helper._repeat_interleave_single_value_helper(
+            g, self, repeats, dim
+        )
 
     # Cases where repeats is a 1 dim Tensor
     elif repeats_dim == 1:


### PR DESCRIPTION
This PR simplifies the ONNX export of torch.repeat_interleave when 'repeat' is a scalar value (so each index in the input is repeated the same number of times). (Issue #100438)

Here is a before/after of a simple model export:
```python
# Model + export code
import torch

class RepeatInterleaveModel(torch.nn.Module):
    def forward(self, x):
        return x.repeat_interleave(2, dim=-1)

args = (torch.rand((2, 2, 16)),)
model = RepeatInterleaveModel()
torch.onnx.export(model, args, "repeat_interleave.onnx", opset_version=17)
``` 

**Before (static shapes)**
![repeat_interleave onnx(1)](https://user-images.githubusercontent.com/46343317/236014996-00726832-1e76-4fb4-950d-4b54cc5cc20c.png)

-----
**Before (dynamic shapes, second graph is Loop body)**
<p float="left">
  <img src="https://user-images.githubusercontent.com/46343317/236029895-20b0ae0a-240f-466d-bb01-e619ec5967ad.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/46343317/236029915-e67b808a-029b-4997-bc05-1ce59eec409a.png" width="47%" /> 
</p>

-----
**After (for both static and dynamic shapes)**
<img src="https://user-images.githubusercontent.com/46343317/236015235-633811cb-09a2-435d-a293-1b2bcb7dea50.png" width="66%" />

-----

This PR also fixes a bug where the exporter throws an expection when the input has dynamic shapes and the 'dim' parameter is not specified to torch.repeat_interleave. Also adds a new testcase to cover this. (Issue #100429)

Fixes #100438 and #100429
