### PR TITLE
[inductor] add a workflow to run coordinate descent tuning in CI

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -302,6 +302,10 @@ if [[ "${TEST_CONFIG}" == *max_autotune* ]]; then
   export TORCHINDUCTOR_MAX_AUTOTUNE=1
 fi
 
+if [[ "${TEST_CONFIG}" == *coordesc_tuning* ]]; then
+  export TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=1
+fi
+
 test_perf_for_dashboard() {
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
@@ -321,6 +325,11 @@ test_perf_for_dashboard() {
       python "benchmarks/dynamo/$suite.py" \
           --accuracy --"$mode" --"$dtype" --backend "$backend" "$@" \
           --output "$TEST_REPORTS_DIR/${backend}_max_autotune_${suite}_${dtype}_${mode}_cuda_accuracy.csv"
+    elif [[ "${TEST_CONFIG}" == *coordesc_tuning* ]]; then
+      # Only run this one config for coordinate descent tuning
+      python "benchmarks/dynamo/$suite.py" \
+          --accuracy --"$mode" --"$dtype" --backend "$backend" "$@" \
+          --output "$TEST_REPORTS_DIR/${backend}_coordesc_tuning_${suite}_${dtype}_${mode}_cuda_accuracy.csv"
     else
       python "benchmarks/dynamo/$suite.py" \
           --accuracy --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs "$@" \
@@ -340,6 +349,11 @@ test_perf_for_dashboard() {
       python "benchmarks/dynamo/$suite.py" \
           --performance --cold-start-latency --"$mode" --"$dtype" --backend "$backend" "$@" \
           --output "$TEST_REPORTS_DIR/${backend}_max_autotune_${suite}_${dtype}_${mode}_cuda_performance.csv"
+    elif [[ "${TEST_CONFIG}" == *coordesc_tuning* ]]; then
+      # Only run this one config for coordinate descent tuning
+      python "benchmarks/dynamo/$suite.py" \
+          --performance --cold-start-latency --"$mode" --"$dtype" --backend "$backend" "$@" \
+          --output "$TEST_REPORTS_DIR/${backend}_coordesc_tuning_${suite}_${dtype}_${mode}_cuda_performance.csv"
     else
       python "benchmarks/dynamo/$suite.py" \
           --performance --cold-start-latency --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs "$@" \

--- a/.github/workflows/inductor-perf-coordesc.yaml
+++ b/.github/workflows/inductor-perf-coordesc.yaml
@@ -1,0 +1,43 @@
+name: inductor-A100-coordesc-tuning
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  linux-bionic-cuda11_8-py3_10-gcc7-inductor-build:
+    name: cuda11.8-py3.10-gcc7-sm80
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-bionic-cuda11.8-py3.10-gcc7-sm80
+      docker-image-name: pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7
+      cuda-arch-list: '8.0'
+      test-matrix: |
+        { include: [
+          { config: "inductor_huggingface_perf_coordesc_tuning", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf_coordesc_tuning", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf_coordesc_tuning", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 1, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 2, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 3, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 4, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 5, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf_coordesc_tuning", shard: 6, num_shards: 6, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf_coordesc_tuning", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf_coordesc_tuning", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf_coordesc_tuning", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
+        ]}
+
+  linux-bionic-cuda11_8-py3_10-gcc7-inductor-test:
+    name: cuda11.8-py3.10-gcc7-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-bionic-cuda11_8-py3_10-gcc7-inductor-build
+    with:
+      build-environment: linux-bionic-cuda11.8-py3.10-gcc7-sm80
+      docker-image: ${{ needs.linux-bionic-cuda11_8-py3_10-gcc7-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-bionic-cuda11_8-py3_10-gcc7-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 1440


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100589

I create a new workflow rather than adding stuff to max-autotune workflow. My concern is putting coordinate descent tuning in max-autotune workflow may cause the whole workflow taking too long.
