### PR TITLE
[dynamo] Hide guard_fail_hook behind a flag to improve cache lookup time (+10% DebertaV2)

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -541,17 +541,17 @@ def speedup_experiment_fx2trt(args, model_iter_fn, model, example_inputs):
 
 
 def recompile_profiler_experiment(args, model_iter_fn, model, example_inputs):
-    prof = torch._dynamo.utils.CompileProfiler()
-    opt_model_iter_fn = torch._dynamo.optimize(prof, nopython=args.nopython)(
-        model_iter_fn
-    )
-    opt_model_iter_fn(model, example_inputs)
-    output_csv(
-        output_filename, ["model", "profiler report"], [current_name, prof.report()]
-    )
-    met = prof.get_metrics()
-    guard_failures = len(met["guard_failures"])
-    return [guard_failures]
+    with torch._dynamo.utils.CompileProfiler() as prof:
+        opt_model_iter_fn = torch._dynamo.optimize(prof, nopython=args.nopython)(
+            model_iter_fn
+        )
+        opt_model_iter_fn(model, example_inputs)
+        output_csv(
+            output_filename, ["model", "profiler report"], [current_name, prof.report()]
+        )
+        met = prof.get_metrics()
+        guard_failures = len(met["guard_failures"])
+        return [guard_failures]
 
 
 def randomize_input(inputs):

--- a/docs/source/compile/faq.rst
+++ b/docs/source/compile/faq.rst
@@ -201,14 +201,13 @@ trouble, and the profiler will accumulate statistics over this duration.
 
    from torch._dynamo.utils import CompileProfiler
 
-   prof = CompileProfiler()
-
    def my_model():
        ...
 
-   profiler_model = torch.compile(my_model, backend=prof)
-   profiler_model()
-   print(prof.report())
+   with CompileProfiler() as prof:
+       profiler_model = torch.compile(my_model, backend=prof)
+       profiler_model()
+       print(prof.report())
 
 Many of the reasons for graph breaks and excessive recompilation will be
 fixed with upcoming support for `tracing dynamic tensor

--- a/docs/source/compile/troubleshooting.rst
+++ b/docs/source/compile/troubleshooting.rst
@@ -685,14 +685,13 @@ acceptable number of recompilations for some dynamic models.
 
    from torch._dynamo.utils import CompileProfiler
 
-   prof = CompileProfiler()
-
    def my_model():
        ...
 
-   profiler_model = torch.compile(my_model, backend=prof)
-   profiler_model()
-   print(prof.report())
+   with CompileProfiler() as prof:
+       profiler_model = torch.compile(my_model, backend=prof)
+       profiler_model()
+       print(prof.report())
 
 Accuracy Debugging
 ~~~~~~~~~~~~~~~~~~

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5008,45 +5008,45 @@ def fn():
                 return input + input
 
         model = Model()
-        prof = CompileProfiler()
-        compiled = torch.compile(model, backend=prof)
-        base_checker = (
-            lambda: FileCheck()
-            .check("Torchdynamo Profiler Report")
-            .check("Graph Breaks")
-            .check("No graph breaks detected.")
-            .check("Recompilation")
-        )
-        input = torch.rand((2, 3, 4))
-        _ = compiled(input)
-        base_checker().check("No recompilation detected.").run(prof.report())
-
-        new_shape_input = torch.rand((3, 3, 4))
-        _ = compiled(new_shape_input)
-
-        # Not an exhaustive test of dynamic shapes behavior, but some sanity
-        if (
-            not torch._dynamo.config.dynamic_shapes
-            or torch._dynamo.config.assume_static_by_default
-        ):
-            base_checker().check("Recompile Reasons").check("'forward'").check(
-                "cache_size_limit to 1"
-            ).run(prof.report())
-        else:
+        with CompileProfiler() as prof:
+            compiled = torch.compile(model, backend=prof)
+            base_checker = (
+                lambda: FileCheck()
+                .check("Torchdynamo Profiler Report")
+                .check("Graph Breaks")
+                .check("No graph breaks detected.")
+                .check("Recompilation")
+            )
+            input = torch.rand((2, 3, 4))
+            _ = compiled(input)
             base_checker().check("No recompilation detected.").run(prof.report())
 
-        # Ensure correct guard fail message is selected to show to user
-        if not torch._dynamo.config.dynamic_shapes:
-            new_shape_input = torch.rand((4, 3, 4))
+            new_shape_input = torch.rand((3, 3, 4))
             _ = compiled(new_shape_input)
 
-            base_checker().check("Recompile Reasons").check("'forward'").check(
-                "tensor 'L['input']' size mismatch at index 0. expected 2, actual 3"
-            ).check(
-                "tensor 'L['input']' size mismatch at index 0. expected 3, actual 4"
-            ).run(
-                prof.report()
-            )
+            # Not an exhaustive test of dynamic shapes behavior, but some sanity
+            if (
+                not torch._dynamo.config.dynamic_shapes
+                or torch._dynamo.config.assume_static_by_default
+            ):
+                base_checker().check("Recompile Reasons").check("'forward'").check(
+                    "cache_size_limit to 1"
+                ).run(prof.report())
+            else:
+                base_checker().check("No recompilation detected.").run(prof.report())
+
+            # Ensure correct guard fail message is selected to show to user
+            if not torch._dynamo.config.dynamic_shapes:
+                new_shape_input = torch.rand((4, 3, 4))
+                _ = compiled(new_shape_input)
+
+                base_checker().check("Recompile Reasons").check("'forward'").check(
+                    "tensor 'L['input']' size mismatch at index 0. expected 2, actual 3"
+                ).check(
+                    "tensor 'L['input']' size mismatch at index 0. expected 3, actual 4"
+                ).run(
+                    prof.report()
+                )
 
     def test_guards_strip_function_call(self):
         from torch._dynamo.guards import strip_function_call

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import unittest
 import weakref
+from unittest.mock import patch
 
 import torch
 
@@ -134,6 +135,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             msg=f'Expected to find "{contains_str}" in log "{logs.records[0].getMessage()}"',
         )
 
+    @patch.object(torch._dynamo.config, "report_guard_failures", True)
     def test_verbose_tensor_check(self):
         def func(a):
             # Warning: choose a function here whose meta implementation lives
@@ -182,6 +184,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             "tensor 'L['a']' requires_grad mismatch. expected requires_grad=0",
         )
 
+    @patch.object(torch._dynamo.config, "report_guard_failures", True)
     def test_mismatched_type(self):
         a = torch.rand(3, 4, 5)
         b = torch.rand(3, 4, 5)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -219,6 +219,10 @@ allow_rnn = False
 # been seen before.
 error_on_recompile = False
 
+# reports why guards fail. Useful to identify the guards failing frequently and
+# causing recompilations.
+report_guard_failures = os.environ.get("TORCHDYNAMO_REPORT_GUARD_FAILURES") == "1"
+
 # root folder of the project
 base_dir = dirname(dirname(dirname(abspath(__file__))))
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -297,19 +297,31 @@ def convert_frame_assert(
             def format_guard_failures(code):
                 # For the common case, it's sufficient to see just the most recent failure.
                 # We could add a verbose mode if needed
-                return f"{str(guard_failures[code][-1])}"
+                return f"  reasons: {str(guard_failures[code][-1])}\n"
 
-            assert code in guard_failures, "TODO(whc) any other recompile reasons?"
-            log.warning(
-                "torch._dynamo hit config.cache_size_limit (%s)\n"
-                "   function: %s\n"
-                "   reasons:  %s\n"
-                "to diagnose recompilation issues, see %s.",
-                config.cache_size_limit,
-                format_func_info(code),
-                format_guard_failures(code),
-                troubleshooting_url,
-            )
+            if config.report_guard_failures:
+                assert code in guard_failures, "TODO(whc) any other recompile reasons?"
+
+                log.warning(
+                    "torch._dynamo hit config.cache_size_limit (%s)\n"
+                    "   function: %s\n"
+                    "   reasons:  %s\n"
+                    "to diagnose recompilation issues, see %s.",
+                    config.cache_size_limit,
+                    format_func_info(code),
+                    format_guard_failures(code),
+                    troubleshooting_url,
+                )
+            else:
+                log.warning(
+                    "torch._dynamo hit config.cache_size_limit (%s)\n"
+                    "   function: %s\n"
+                    "to diagnose recompilation issues, set env variable TORCHDYNAMO_REPORT_GUARD_FAILURES=1"
+                    " and also see %s.",
+                    config.cache_size_limit,
+                    format_func_info(code),
+                    troubleshooting_url,
+                )
             unimplemented("cache_size_limit reached")
 
         if not has_tensor_in_frame(frame):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -237,10 +237,13 @@ def convert_frame_assert(
         if code in input_codes and (
             recompiles_log.isEnabledFor(logging.DEBUG) or config.error_on_recompile
         ):
-            message = (
-                f"Recompiling function {code.co_name} in {code.co_filename}",
-                f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
-            )
+            if config.report_guard_failures:
+                message = (
+                    f"Recompiling function {code.co_name} in {code.co_filename}",
+                    f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
+                )
+            else:
+                message = f"Recompiling function {code.co_name} in {code.co_filename}"
 
             if recompiles_log.isEnabledFor(logging.DEBUG):
                 recompiles_log.debug(message)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -243,7 +243,10 @@ def convert_frame_assert(
                     f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
                 )
             else:
-                message = f"Recompiling function {code.co_name} in {code.co_filename}"
+                message = (
+                    f"Recompiling function {code.co_name} in {code.co_filename}",
+                    "set env var TORCHDYNAMO_REPORT_GUARD_FAILURES=1 to debug further",
+                )
 
             if recompiles_log.isEnabledFor(logging.DEBUG):
                 recompiles_log.debug(message)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -820,7 +820,14 @@ def ___make_guard_fn({','.join(closure_vars.keys())}):
 """
         if os.environ.get("TORCHDYNAMO_PRINT_GUARDS", None) == "1":
             print("GUARDS", code)
-        set_guard_fail_hook(guard_fail_hook)
+
+        if config.report_guard_failures:
+            # Guard fail hook is called everytime guard eval fails. For a cache
+            # lookup where there are multiple entries in the same cache line,
+            # this can lead to very high performance overhead. So, we have
+            # decided to hide this behing a config flag.
+            set_guard_fail_hook(guard_fail_hook)
+
         out: Dict[str, Any] = dict()
         exec(py_code, global_builder.scope, out)
         guard_fn = out["___make_guard_fn"](*closure_vars.values())

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -821,7 +821,7 @@ def ___make_guard_fn({','.join(closure_vars.keys())}):
         if os.environ.get("TORCHDYNAMO_PRINT_GUARDS", None) == "1":
             print("GUARDS", code)
 
-        if config.report_guard_failures:
+        if config.report_guard_failures or guard_fail_fn is not None:
             # Guard fail hook is called everytime guard eval fails. For a cache
             # lookup where there are multiple entries in the same cache line,
             # this can lead to very high performance overhead. So, we have

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1095,6 +1095,14 @@ class CompileProfiler:
                 self.op_count += 1
         return gm.forward
 
+    def __enter__(self):
+        self.old_report_guard_failure = config.report_guard_failures
+        config.report_guard_failures = True
+        return self
+
+    def __exit__(self, typ, val, traceback):
+        config.report_guard_failures = self.old_report_guard_failure
+
     def get_metrics(self):
         return {"guard_failures": guard_failures}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100599
* __->__ #100590


For TorchDynamo eager backend, DebertaV2 speedup improves from 0.77x to 0.87x. 

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire