### PR TITLE
Turn on TORCH_CHECK for NT wrap_buffer

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -32,11 +32,14 @@ struct NestedTensorImpl;
 // The following functions are used to construct nested tensors from buffers and
 // metadata.
 
-inline at::Tensor wrap_buffer(
-    at::Tensor buffer,
-    at::Tensor nested_sizes) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      buffer.is_contiguous(), "Given buffer must be contiguous.");
+inline at::Tensor wrap_buffer(at::Tensor buffer, at::Tensor nested_sizes) {
+  TORCH_CHECK(
+      buffer.dim() == 1,
+      "Expected given buffer to be 1dim, but got ",
+      buffer.dim(),
+      " instead.");
+  TORCH_CHECK(
+      buffer.is_contiguous(), "Expected given buffer to be contiguous.");
   return at::detail::make_tensor<NestedTensorImpl>(
       std::move(buffer), std::move(nested_sizes));
 }


### PR DESCRIPTION
TORCH_INTERNAL_ASSERT_DEBUG_ONLY won't be enabled during non-debug builds, but for 1 dimension Tensors the check is cheap enough and not catching this can slow down development a lot.