### PR TITLE
[codemod] Replace hasattr with getattr in caffe2/torch/ao/quantization/stubs.py

### DIFF
--- a/torch/ao/quantization/stubs.py
+++ b/torch/ao/quantization/stubs.py
@@ -52,7 +52,7 @@ class QuantWrapper(nn.Module):
 
     def __init__(self, module):
         super().__init__()
-        qconfig = module.qconfig if hasattr(module, 'qconfig') else None
+        qconfig = getattr(module, "qconfig", None)
         self.add_module('quant', QuantStub(qconfig))
         self.add_module('dequant', DeQuantStub(qconfig))
         self.add_module('module', module)


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Test Plan: Sandcastle

Reviewed By: vkuzo

Differential Revision: D44886422

