### PR TITLE
[codemod] Replace hasattr with getattr in caffe2/docs/source/notes/extending.rst

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -764,7 +764,7 @@ implementation more permissive about what operations are allowed::
           if kwargs is None:
               kwargs = {}
           metadatas = tuple(a._metadata for a in args if hasattr(a, '_metadata'))
-          args = [a._t if hasattr(a, '_t') else a for a in args]
+          args = [getattr(a, '_t', a) for a in args]
           assert len(metadatas) > 0
           ret = func(*args, **kwargs)
           return MetadataTensor(ret, metadata=metadatas[0])


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Test Plan: Sandcastle

Differential Revision: D44886464

