### PR TITLE
[exportdb] Change case ids to case names for UserErrors.

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -13,7 +13,7 @@ if is_fbcode():
     from torch.fb.exportdb.logging import exportdb_error_message
 else:
 
-    def exportdb_error_message(ref_case_id):
+    def exportdb_error_message(case_name):
         return ""
 
 
@@ -108,17 +108,18 @@ class UserErrorType(Enum):
 
 
 class UserError(Unsupported):
-    def __init__(self, error_type: UserErrorType, msg, ref_case_id=None):
+    def __init__(self, error_type: UserErrorType, msg, case_name=None):
         """
         Type of errors that would be valid in Eager, but not supported in TorchDynamo.
         The error message should tell user about next actions.
 
         error_type: Type of user error
         msg: Actionable error message
+        case_name: (Optional) Unique name (snake case) for the usage example in exportdb.
         """
-        if ref_case_id is not None:
-            assert isinstance(ref_case_id, int)
-            msg += exportdb_error_message(ref_case_id)
+        if case_name is not None:
+            assert isinstance(case_name, str)
+            msg += exportdb_error_message(case_name)
         super().__init__(msg)
         self.error_type = error_type
         self.message = msg

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -887,7 +887,7 @@ class TorchHigherOrderOperator(VariableTracker):
                         f"at {code.co_filename}:{code.co_firstlineno} because "
                         f"it closes over variables {closure_vars}. Please rewrite "
                         f"'{code.co_name}' to take {closure_vars} as additional args.",
-                        ref_case_id=26,
+                        case_name="cond_closed_over_variable",
                     )
 
             # Setup the subgraph we're going to capture into


### PR DESCRIPTION
Associate UserErrors with the unique case name instead of the
case ids, because in practice they work similarly but names are more
meaningful to use and remember.

Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire