### PR TITLE
Train Step Compile [1/3] basic fwd/bwd only

### DIFF
--- a/test/dynamo/test_train_step.py
+++ b/test/dynamo/test_train_step.py
@@ -1,0 +1,171 @@
+# Owner(s): ["module: dynamo"]
+
+import torch
+
+import torch._dynamo
+import torch._dynamo.backends.ipex
+import torch._dynamo.test_case
+from torch._dynamo.backends.train_step import (
+    _compile_train_step,
+    _train_step_compiler,
+    _train_step_eager,
+    _train_step_inductor,
+)
+from torch._dynamo.testing import same
+
+
+class Seq(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.Sequential(
+            torch.nn.Linear(10, 10),
+            torch.nn.ReLU(),
+            torch.nn.Linear(10, 10),
+            torch.nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+
+def init_weights(m):
+    if isinstance(m, torch.nn.Linear):
+        torch.nn.init.xavier_uniform_(m.weight)
+        m.bias.data.fill_(0.01)
+
+
+class TestCompileTrainStep(torch._dynamo.test_case.TestCase):
+    def test_no_optimizer(self):
+        def train_step(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        model = Seq()
+        model.apply(init_weights)
+        inputs = [torch.randn((128, 10))]
+
+        correct_loss = train_step(model, inputs)
+
+        opt_train_step = _compile_train_step(train_step, backend=_train_step_eager)
+        opt_loss = opt_train_step(model, inputs)
+
+        self.assertTrue(same(correct_loss, opt_loss))
+
+    def test_dynamo_safety_checks(self):
+        """Since dynamo train_step compile traces .backward() call, it's imperative that no .grad_fn exists
+        for inputs to the train_step graph, otherwise their backwards will incorrectly be traced
+        """
+
+        def train_step(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        opt_model = Seq()
+        opt_model.apply(init_weights)
+
+        # Cause the inputs to the model to have grad_fn
+        pre_inputs = torch.randn((128, 10))
+        pre_input_layer = torch.nn.Linear(10, 10)
+        inputs = [
+            pre_input_layer(pre_inputs),
+        ]
+        opt_train_step = _compile_train_step(train_step, backend=_train_step_eager)
+
+        with self.assertRaisesRegex(AssertionError, r"an input tensor has a grad_fn"):
+            opt_train_step(opt_model, inputs)
+
+        def train_step_multi_backward(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward()
+            # ok, not a real double backward, but either way would cause the same assert to fire
+            loss.backward()
+            return loss
+
+        inputs = [
+            torch.randn((128, 10)),
+        ]
+        opt_train_step = _compile_train_step(
+            train_step_multi_backward, backend=_train_step_eager
+        )
+        with self.assertRaisesRegex(AssertionError, r"multiple \.backward\(\) calls"):
+            opt_train_step(opt_model, inputs)
+
+        def train_step_backward_args(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward(loss)
+
+        opt_train_step = _compile_train_step(
+            train_step_backward_args, backend=_train_step_eager
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError, r"\.backward\(\) call with non-empty args"
+        ):
+            opt_train_step(opt_model, inputs)
+
+    def test_custom_backend(self):
+        def train_step(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        opt_model = Seq()
+        opt_model.apply(init_weights)
+        inputs = [torch.randn((128, 10))]
+
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("eager")
+        train_step_cnt = _train_step_compiler(cnt)
+        opt_train_step = _compile_train_step(train_step, backend=train_step_cnt)
+
+        loss = []
+        for _ in range(10):
+            opt_loss = opt_train_step(opt_model, inputs)
+            loss.append(opt_loss)
+            # no-op until optimizer is added
+            # if step > 0:
+            #     # in practice, this model loss goes 684, 458, 264, 125, ... so this check should not be too noisy
+            #     self.assertTrue(loss[-2] > loss[-1])
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 37)
+
+    def test_inductor_backend(self):
+        def train_step(model, inputs):
+            out = model(*inputs)
+            loss = out.sum()
+            loss.backward()
+            return loss
+
+        opt_model = Seq()
+        opt_model.apply(init_weights)
+        inputs = [torch.randn((128, 10))]
+
+        torch._dynamo.reset()
+        ind_train_step = _compile_train_step(train_step, backend=_train_step_inductor)
+
+        loss = []
+        for _ in range(10):
+            ind_loss = ind_train_step(opt_model, inputs)
+            loss.append(ind_loss)
+            # no-op until optimizer is added
+            # if step > 0:
+            #     self.assertTrue(loss[-2] > loss[-1])
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(
+            RuntimeError, r"_compile_train_step does not support inductor"
+        ):
+            ind_train_step = _compile_train_step(train_step, backend="inductor")
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/backends/is_train_step.py
+++ b/torch/_dynamo/backends/is_train_step.py
@@ -1,0 +1,10 @@
+class TrainStepCompiler:
+    def __init__(self, compile_fn):
+        self.compile_fn = compile_fn
+
+    def __call__(self, *args, **kwargs):
+        return self.compile_fn(*args, **kwargs)
+
+
+def _is_train_step_compiler(compiler_fn):
+    return isinstance(compiler_fn, TrainStepCompiler)

--- a/torch/_dynamo/backends/train_step.py
+++ b/torch/_dynamo/backends/train_step.py
@@ -1,0 +1,197 @@
+import builtins
+import logging
+from typing import Callable, Dict, List, Optional, Union
+
+import torch
+import torch.utils._pytree as pytree
+from torch import _C, fx
+from torch._dynamo.backends.registry import lookup_backend
+from torch._guards import detect_fake_mode, TracingContext
+from torch._inductor.compile_fx import compile_fx_inner
+
+from torch._inductor.decomposition import select_decomp_table
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.func import functionalize
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.nn.utils import stateless
+from .is_train_step import TrainStepCompiler
+
+log = logging.getLogger(__name__)
+
+
+def _compile_train_step(
+    train_step_fn: Callable,
+    *,
+    dynamic: builtins.bool = False,
+    backend: Union[str, Callable] = "inductor",
+    options: Optional[Dict[str, Union[str, builtins.int, builtins.bool]]] = None,
+    disable: builtins.bool = False,
+) -> Callable:
+    """
+    Compiles a whole train step function, without graph-breaking on .backward().
+
+    EXPERIMENTAL: both how the API is constructed and how it behaves are experimental and subject to change.
+
+    Limitations:
+    - No optimizer support yet
+    - All inputs to the train_step fn (whether args/kwargs or globals) must not have .grad_fn set, meaning
+      you may not use these tensors in gradient-requiring operations outside of the compiled region
+
+    _compile_train_step args are copied from `torch.compile` so see those docs for more info.
+    - note: fullgraph=True is implied
+
+    Example:
+
+        from torch._dynamo.backends._train_step import _compile_train_step
+
+        def train_step(model, inputs):
+            ...
+
+        opt_train_step = _compile_train_step(train_step, ...)
+    """
+    _C._log_api_usage_once("torch._dynamo.backends.train_step._compile_train_step")
+
+    import torch._dynamo
+
+    if not _is_train_step_compiler(backend):
+        raise RuntimeError(
+            f"_compile_train_step does not support {backend}, which is not wrapped in TrainStepCompiler."
+            " If you want to make a new TrainStepCompiler backend, ensure your backend does not call aot_autograd,"
+            " and wrap it in TrainStepCompiler."
+        )
+
+    return torch._dynamo.optimize(
+        backend=backend, nopython=True, dynamic=dynamic, disable=disable
+    )(train_step_fn)
+
+
+def _train_step_compiler(backend_compile_fn):
+    """Note [Train Step Compile]
+
+    Usually, torch.compile() allows graph-breaks and compiles pairs of forward (+backward) by
+    extracting sections of forward from python programs and using AotAutograd to produce corresponding
+    chunks of backwards, tying it back together with an AotFunction.
+
+    Instead, TrainStepCompiler assumes the user compiles a full train_step function complete with calls to
+    .backward(), and zero_grad().  It additionally requires no graph-breaks.
+
+    Args:
+        backend_compile_fn (callable): A dynamo compiler function, to be invoked to compile each subgraph.
+    """
+    is_inductor = backend_compile_fn is compile_fx_inner
+    backend_decomps = select_decomp_table() if is_inductor else None
+
+    def _compile_fn(mod: fx.GraphModule, real_inputs: List[torch.Tensor]):
+        """
+        Step 1: Assert inputs (from user) are already Fake, and user their FakeTensorMode
+                (created by dynamo) to fakeify the module's parameters
+        """
+        assert (
+            torch.is_grad_enabled()
+        ), "Expected grad enabled when calling train_step_compile"
+        torch._dynamo.utils.assert_no_fake_params_or_buffers(mod)
+        assert len(real_inputs) > 0, "Expected at least one input"
+        fake_mode = detect_fake_mode()
+
+        tc = TracingContext.train_step_context(assert_if_missing=True)
+        assert isinstance(fake_mode, FakeTensorMode), "Expected a valid FakeTensorMode"
+
+        def fakeify_inputs(flat_args):
+            already_fake = {}
+
+            def convert(idx, x):
+                # todo: do we expect symint inputs?
+                assert isinstance(x, torch.Tensor)
+                if x not in already_fake:
+                    # Since we do have duplicate names from dynamo refering to the same tensor,
+                    # ensure that we never make more than one faketensor for a given real tensor!
+                    already_fake[x] = fake_mode.from_tensor(x, static_shapes=False)
+                return already_fake[x]
+
+            return [convert(idx, x) for idx, x in enumerate(flat_args)]
+
+        params = {
+            **dict(mod.named_parameters()),
+            **dict(mod.named_buffers()),
+        }
+        params_flat, params_spec = pytree.tree_flatten(params)
+        params_len = len(params_flat)
+        fake_params_flat = fakeify_inputs(params_flat)
+        fake_inputs = fakeify_inputs(real_inputs)
+
+        log.debug("\n---original graph---\n%s\n\n", mod.graph)
+
+        def functional_call(*lifted_args, **kwargs):
+            """Call the dynamo graphmodule in a functional way safe for tracing
+            (lifts module parameters and optimizer states as inputs)
+            """
+            _params = lifted_args[:params_len]
+            _params_dict = pytree.tree_unflatten(_params, params_spec)
+            _user_args = lifted_args[params_len:]
+            with stateless._reparametrize_module(mod, _params_dict):
+                out = mod(*_user_args, **kwargs)
+
+            if not isinstance(out, (tuple, list)):
+                raise RuntimeError(
+                    "Graph output must be a tuple() to avoid pytree processing of the ouputs."
+                )
+            return out
+
+        """
+        Step 1: Warm up the optimizer(s) (if present).
+        """
+        # TODO support optimizers
+        full_fake_args = fake_params_flat + fake_inputs
+
+        """
+        Step 2: Trace the full graph, invoking backend-specific decomps.
+                Expand the .backward() and .step/.zero_grad calls into aten ops.
+        """
+        with fake_mode:
+            fx_g = make_fx(functional_call, decomposition_table=backend_decomps)(
+                *full_fake_args
+            )
+        log.debug("\n---functional_call graph---\n%s\n\n", fx_g.graph)
+
+        """
+        Step 3: Functionalize the resulting flattend graph, producing code with copy_ ops
+                as an epilogue for any inplace/mutating ops such as optimizer update.
+        """
+        with fake_mode, torch.inference_mode():
+            # We need to disable grad, since we will be inplace-updating leaf nodes (optimizer acting on params)
+            functional_fx_g = make_fx(functionalize(fx_g))(*full_fake_args)
+            log.debug("\n---functionalized graph---\n%s\n\n", functional_fx_g.graph)
+
+        """
+        Step 4: Call the user compiler. This user compiler must be aware/capable of supporting a full train graph,
+                and should not attempt to call AOTAutograd internally.
+        """
+        with torch.inference_mode():
+            backend_fx_g = backend_compile_fn(functional_fx_g, full_fake_args)
+
+        """
+        Step 5: Reverse the calling-convention change we made above with _reparametrize_module,
+                and return a function that accepts the arguments as originally provided by dynamo.
+        """
+
+        def call_without_params(*runtime_args):
+            with torch.inference_mode():
+                # See note above about disabling grad
+                # TODO can this divergence be unified?
+                _args = params_flat + list(runtime_args)
+                if is_inductor:
+                    return backend_fx_g(_args)
+                else:
+                    return backend_fx_g(*_args)
+
+        return call_without_params
+
+    return TrainStepCompiler(_compile_fn)
+
+
+_train_step_inductor = _train_step_compiler(compile_fx_inner)
+_train_step_eager = _train_step_compiler(lookup_backend("eager"))
+
+
+def _is_train_step_compiler(compiler_fn: Callable):
+    return isinstance(compiler_fn, TrainStepCompiler)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -32,6 +32,7 @@ from . import (
     variables,
 )
 from .allowed_functions import is_allowed, is_builtin_callable, is_builtin_constant
+from .backends.is_train_step import _is_train_step_compiler
 from .bytecode_analysis import get_indexof, JUMP_OPNAMES, livevars_analysis
 from .bytecode_transformation import (
     cleaned_instructions,
@@ -1946,6 +1947,9 @@ class InstructionTranslator(InstructionTranslatorBase):
         # as soon as we create the tracing context we should keep it active, so any calls
         # into dynamo apis can rely on finding it
         with tracing(self.output.tracing_context):
+            if _is_train_step_compiler(compiler_fn):
+                TracingContext.trace_train_step()
+
             self.one_graph: bool = one_graph
             self.export = export
             self.mutated_closure_cell_contents = mutated_closure_cell_contents

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1209,6 +1209,13 @@ def get_fake_value(node, tx):
     args = tree_map(fake_wrapper, args)
     kwargs = tree_map(fake_wrapper, kwargs)
 
+    # TODO(whc) can I avoid having these hacks here?
+    if op == "call_method" and node.target == "backward":
+        # We don't want to run .backward() during dynamo tracing even if under a fake mode, since
+        # it may affect the state of the autograd system and we must preserve it for later tracing.
+        # The actual return type here is None anyway (from .backward()) so no need to run it to find out.
+        return None
+
     nnmodule = None
     if op == "call_method" and len(args) > 0 and isinstance(args[0], torch.nn.Module):
         # If the first argument is nn.Module, should copy to fake mode.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds infra to wrap compilers in TrainStepCompiler and logic to dynamo
to behave specially (e.g. allowing .backward() to not graph-break)
when using such compilers.

Integrates some state with TracingContext, useful for both asserting
only one call to .backard() as well as groundwork for optimizer support
in following PR.

Checks various assumptions about the user trainstep function:
 - only one call to .backward() - double backwards is uncommon, and
   initial users of train step compile are expected to be satisfied
   without it.  Not sure if it would be feasible to support.
 - only supported backends are allowed
 - fullgraph (nopython) is required when train_step_compiling

Separated PRs for easier review, but this is of minimal utility
on its own without optimizer support.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire