### PR TITLE
[Inductor] Using PythonPrinter for SymInt arguments codegen for FallbackKernal

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -28,7 +28,7 @@ from torch._prims_common import (
     make_channels_last_strides_for,
     make_contiguous_strides_for,
 )
-from torch.fx.experimental.symbolic_shapes import FloorDiv
+from torch.fx.experimental.symbolic_shapes import FloorDiv, SymTypes
 
 from . import config, dependencies
 from .codegen.common import index_prevent_reordering
@@ -3128,6 +3128,8 @@ class FallbackKernel(ExternKernelAlloc):
         V.graph.warn_fallback(self.kernel)
 
     def codegen_args(self):
+        from torch._inductor.codegen.wrapper import pexpr
+
         @dataclasses.dataclass
         class Shim:
             ref: Any
@@ -3138,8 +3140,14 @@ class FallbackKernel(ExternKernelAlloc):
         def gen_kwarg(k, v):
             return f"{k}={repr(v)}"
 
+        def get_pexpr(x):
+            if isinstance(x, SymTypes):
+                return pexpr(sympy.expand(repr(x)))
+            else:
+                return repr(x)
+
         tensor_args = [Shim(x.codegen_reference()) for x in self.inputs]
-        constant_args = [Shim(repr(x)) for x in self.constant_args]
+        constant_args = [Shim(get_pexpr(x)) for x in self.constant_args]
         args, kwargs = self.unflatten_args(tensor_args, constant_args)
         return list(map(repr, args)) + [gen_kwarg(k, v) for k, v in kwargs.items()]
 


### PR DESCRIPTION
Fixes Meta internal user case.

Repro:
```
import torch
import torch._inductor

torch._inductor.config.disable_cpp_codegen = True

@torch.compile(backend="inductor", dynamic=True)
def func(input: torch.Tensor) -> torch.Tensor:
    n = input.size(-1)
    output = input + int(n * 0.2) + 1
    return output, input + 1


print(func(torch.rand(5, device="cpu")))
print(func(torch.rand(10, device="cpu")))
```

Error:
```
Traceback (most recent call last):
  File "/scratch/ybliang/work/repos/debug/debug7.py", line 20, in <module>
    print(func(torch.rand(10, device="cpu")))
  File "/scratch/ybliang/work/repos/pytorch/torch/_dynamo/eval_frame.py", line 280, in _fn
    return fn(*args, **kwargs)
  File "/scratch/ybliang/work/repos/debug/debug7.py", line 12, in func
    @torch.compile(backend="inductor", dynamic=True)
  File "/scratch/ybliang/work/repos/pytorch/torch/_dynamo/eval_frame.py", line 280, in _fn
    return fn(*args, **kwargs)
  File "/scratch/ybliang/work/repos/pytorch/torch/_dynamo/external_utils.py", line 17, in inner
    return fn(*args, **kwargs)
  File "/scratch/ybliang/work/repos/pytorch/torch/_functorch/aot_autograd.py", line 3346, in forward
    return compiled_fn(full_args)
  File "/scratch/ybliang/work/repos/pytorch/torch/_functorch/aot_autograd.py", line 1260, in g
    return f(*args)
  File "/scratch/ybliang/work/repos/pytorch/torch/_functorch/aot_autograd.py", line 2210, in runtime_wrapper
    all_outs = call_func_with_args(
  File "/scratch/ybliang/work/repos/pytorch/torch/_functorch/aot_autograd.py", line 1285, in call_func_with_args
    out = normalize_as_list(f(args))
  File "/scratch/ybliang/work/repos/pytorch/torch/_functorch/aot_autograd.py", line 1372, in rng_functionalization_wrapper
    return compiled_fw(args)
  File "/tmp/torchinductor_ybliang/od/codk4bo4oqmjiec35zlz2rsildcix33lsxpdcy7pi6p4nvdrofpu.py", line 27, in call
    buf0 = torch.ops.aten.add.Tensor(arg1_1, floor(0.2*s0))
NameError: name 'floor' is not defined
```

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire