### PR TITLE
[fbcode/caffe2] Make fmt formatter methods const

### DIFF
--- a/torch/csrc/distributed/c10d/error.h
+++ b/torch/csrc/distributed/c10d/error.h
@@ -15,12 +15,13 @@ namespace fmt {
 
 template <>
 struct formatter<std::error_category> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) {
+  constexpr decltype(auto) parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const std::error_category& cat, FormatContext& ctx) {
+  decltype(auto) format(const std::error_category& cat, FormatContext& ctx)
+      const {
     if (std::strcmp(cat.name(), "generic") == 0) {
       return format_to(ctx.out(), "errno");
     } else {
@@ -31,12 +32,12 @@ struct formatter<std::error_category> {
 
 template <>
 struct formatter<std::error_code> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) {
+  constexpr decltype(auto) parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const std::error_code& err, FormatContext& ctx) {
+  decltype(auto) format(const std::error_code& err, FormatContext& ctx) const {
     return format_to(
         ctx.out(), "({}: {} - {})", err.category(), err.value(), err.message());
   }

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -189,12 +189,12 @@ namespace fmt {
 
 template <>
 struct formatter<::addrinfo> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) {
+  constexpr decltype(auto) parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  decltype(auto) format(const ::addrinfo& addr, FormatContext& ctx) {
+  decltype(auto) format(const ::addrinfo& addr, FormatContext& ctx) const {
     char host[NI_MAXHOST], port[NI_MAXSERV]; // NOLINT
 
     int r = ::getnameinfo(
@@ -219,14 +219,14 @@ struct formatter<::addrinfo> {
 
 template <>
 struct formatter<c10d::detail::SocketImpl> {
-  constexpr decltype(auto) parse(format_parse_context& ctx) {
+  constexpr decltype(auto) parse(format_parse_context& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
   decltype(auto) format(
       const c10d::detail::SocketImpl& socket,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     ::sockaddr_storage addr_s{};
 
     auto addr_ptr = reinterpret_cast<::sockaddr*>(&addr_s);


### PR DESCRIPTION
Summary:
Staging an update to the latest fmt version triggered lots of build errors due to non-`const` methods on custom formatters. This fixes the `format()` methods to be `const` as they don't mutate any state anyway, as well as `parse()` methods that don't need to mutate internal state. This mitigates many future build errors.

Updates were identified and executed by using regular expression search/replacements such as:
`(constexpr auto parse\(ParseContext& [^)]*\)) \{` -> `$1 const {`
`(constexpr auto parse\(ParseContext& [^)]*\)) ->` -> `$1 const ->`
`(auto format\(.*, FormatContext& [^)]*\)) \{` -> `$1 const {`
`(auto format\(.*, FormatContext& [^)]*\)) ->` -> `$1 const ->`

Any changes to third-party code was then reverted. Some small changes detected from subsequent build errors were then applied.

Test Plan: CI

Differential Revision: D45463620

