### PR TITLE
fix _privateuse1_tag problem

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -258,8 +258,14 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             self.assertFalse(cpu_storage.is_pinned())
 
         def test_open_device_serialization():
+            self.module.set_custom_device_index(-1)
             storage = torch.UntypedStorage(4, device=torch.device('foo'))
             self.assertEqual(torch.serialization.location_tag(storage), 'foo')
+
+            self.module.set_custom_device_index(0)
+            storage = torch.UntypedStorage(4, device=torch.device('foo'))
+            self.assertEqual(torch.serialization.location_tag(storage), 'foo:0')
+
             cpu_storage = torch.empty(4, 4).storage()
             foo_storage = torch.serialization.default_restore_location(cpu_storage, 'foo:0')
             self.assertTrue(foo_storage.is_foo)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -159,7 +159,10 @@ def _meta_tag(obj):
 def _privateuse1_tag(obj):
     backend_name = torch._C._get_privateuse1_backend_name()
     if obj.device.type == backend_name:
-        return backend_name
+        if obj.device.index is None:
+            return backend_name
+        else:
+            return backend_name + ':' + str(obj.device.index)
 
 
 def _cpu_deserialize(obj, location):


### PR DESCRIPTION
Fix _privateuse1_tag bug in torch/serialization.py
Add device_index after device_type.