### PR TITLE
No need to run Windows binary build for every PR

### DIFF
--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -90,7 +90,6 @@ def isGreen(commit: str, results: List[Dict[str, Any]]) -> Tuple[bool, str]:
         "trunk": False,
         "lint": False,
         "linux-binary": False,
-        "windows-binary": False,
     }
 
     for check in workflow_checks:

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -244,7 +244,7 @@ WINDOWS_BINARY_SMOKE_WORKFLOWS = [
         ),
         branches="main",
         ciflow_config=CIFlowConfig(
-            unstable=True,
+            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -259,7 +259,7 @@ WINDOWS_BINARY_SMOKE_WORKFLOWS = [
         ),
         branches="main",
         ciflow_config=CIFlowConfig(
-            unstable=True,
+            isolated_workflow=True,
         ),
     ),
 ]

--- a/.github/scripts/test_fetch_latest_green_commit.py
+++ b/.github/scripts/test_fetch_latest_green_commit.py
@@ -140,7 +140,7 @@ class TestPrintCommits(TestCase):
         self.assertFalse(result[0])
         self.assertEqual(
             result[1],
-            "missing required workflows: pull, trunk, lint, linux-binary, windows-binary",
+            "missing required workflows: pull, trunk, lint, linux-binary",
         )
 
 

--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'ciflow/unstable/*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'ciflow/unstable/*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Per the discussion with @malfet , there is no need to run Windows binary build for every PR. We will keep it running in trunk (on push) though just in case.

This also moves the workflow back from unstable after the symlink copy fix in https://github.com/pytorch/builder/commit/860d444515fa2bee44dfac16385702f7abb8a4e0

Another data point to back this up is the high correlation between Windows binaries debug and release build v.s. Windows CPU CI job.  The numbers are:

* `libtorch-cpu-shared-with-deps-debug` and `win-vs2019-cpu-py3` has 0.95 correlation
* `libtorch-cpu-shared-with-deps-release` and `win-vs2019-cpu-py3` has the same 0.95 correlation

The rest is noise, eh?