### PR TITLE
[dynamo] Guard on nn.Module dicts and type

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_training.csv
@@ -4,7 +4,7 @@ LearningToPaint,pass,8
 Super_SloMo,pass,8
 alexnet,pass,8
 attention_is_all_you_need_pytorch,pass,8
-basic_gnn_edgecnn,pass,23
+basic_gnn_edgecnn,pass,25
 basic_gnn_gcn,pass,14
 basic_gnn_gin,pass,8
 basic_gnn_sage,pass,8
@@ -19,7 +19,7 @@ hf_Bert,pass,7
 hf_Bert_large,pass,7
 hf_DistilBert,pass,7
 hf_GPT2,pass,7
-hf_Reformer,pass,47
+hf_Reformer,pass,50
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,8
 llama,fail_accuracy,9

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_training.csv
@@ -19,7 +19,7 @@ hf_Bert,pass,7
 hf_Bert_large,pass,7
 hf_DistilBert,pass,7
 hf_GPT2,pass,7
-hf_Reformer,pass,46
+hf_Reformer,pass,47
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,8
 llama,fail_accuracy,9

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -9,7 +9,7 @@ basic_gnn_edgecnn,pass,0
 basic_gnn_gcn,pass,6
 basic_gnn_gin,pass,0
 basic_gnn_sage,pass,0
-cm3leon_generate,pass,67
+cm3leon_generate,pass,68
 dcgan,pass,0
 dlrm,pass,0
 doctr_det_predictor,pass,4
@@ -59,5 +59,5 @@ timm_vision_transformer_large,pass_due_to_skip,0
 timm_vovnet,pass,0
 tts_angular,pass,2
 vgg16,pass,0
-vision_maskrcnn,pass,124
+vision_maskrcnn,pass,126
 yolov3,pass,2

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -19,7 +19,7 @@ hf_Bert,pass,7
 hf_Bert_large,pass,7
 hf_DistilBert,pass,7
 hf_GPT2,pass,7
-hf_Reformer,pass,66
+hf_Reformer,pass,67
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,8
 llama,fail_accuracy,9

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -4,7 +4,7 @@ LearningToPaint,pass,8
 Super_SloMo,pass,8
 alexnet,pass,8
 attention_is_all_you_need_pytorch,pass,8
-basic_gnn_edgecnn,pass,23
+basic_gnn_edgecnn,pass,25
 basic_gnn_gcn,pass,14
 basic_gnn_gin,pass,8
 basic_gnn_sage,pass,8
@@ -19,7 +19,7 @@ hf_Bert,pass,7
 hf_Bert_large,pass,7
 hf_DistilBert,pass,7
 hf_GPT2,pass,7
-hf_Reformer,pass,67
+hf_Reformer,pass,70
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,8
 llama,fail_accuracy,9
@@ -49,5 +49,5 @@ timm_vision_transformer_large,pass_due_to_skip,0
 timm_vovnet,pass,8
 tts_angular,pass,10
 vgg16,pass,8
-vision_maskrcnn,fail_accuracy,167
+vision_maskrcnn,fail_accuracy,169
 yolov3,pass,10

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1567,6 +1567,10 @@ class BenchmarkRunner:
 
         # Cast the model to float16/float32 as necessary
         model, example_inputs = self.maybe_cast(model, example_inputs)
+
+        if not hasattr(model, name):
+            model.name = name
+
         self.init_optimizer(name, current_device, model.parameters())
         with self.pick_grad(name, self.args.training):
             ok, total = Stats.reset_counters()
@@ -1618,8 +1622,6 @@ class BenchmarkRunner:
                     f"{ok:3}/{total:3} +{frames_third_pass} frames {compilation_time:3.0f}s"
                 )
 
-            if not hasattr(model, name):
-                model.name = name
             results.append(experiment(model, example_inputs, **experiment_kwargs))
             return " ".join(map(str, results))
 

--- a/docs/source/compile/nn-module.rst
+++ b/docs/source/compile/nn-module.rst
@@ -3,6 +3,8 @@ PyTorch 2.0 NNModule Support
 
 **Author**: `Will Constable <https://github.com/wconstab>`_
 
+TODO: update this!!!
+
 `torch.compile` has special handling for torch.nn.Module objects, tracing them differently than it traces
 arbitrary python classes, with the intent of producing faster code by making assumptions about the structure.
 

--- a/docs/source/compile/nn-module.rst
+++ b/docs/source/compile/nn-module.rst
@@ -1,21 +1,16 @@
-PyTorch 2.0 NNModule Support
-============================
+PyTorch 2.0 nn.Module Support
+=============================
 
 **Author**: `Will Constable <https://github.com/wconstab>`_
-
-TODO: update this!!!
 
 `torch.compile` has special handling for torch.nn.Module objects, tracing them differently than it traces
 arbitrary python classes, with the intent of producing faster code by making assumptions about the structure.
 
 This doc describes some of the tradeoffs or edge cases that come up due to this specialization.
 
-NNModule Hooks Support
-----------------------
-Previously, `torch.compile` had no support for hooks on nn.Modules, and if hooks were registered
-they would simply be ignored in the compiled program. Indeed many users do not
-use nn.Module hooks at all, or only use them for debug workflows, but there are valid use cases
-for composing nn.Module hooks with `torch.compile`.
+`nn.Module` Hooks Support
+-------------------------
+`torch.compile` now has partial support for forward and backward hooks on nn.Modules.
 
 Hooks that are orchestrated via nn.Module.__call__ implementation include `_forward_pre_hooks`,
 `forward_hooks`, `_backward_pre_hooks`, and `_backward_hooks`, and will be referred to as 'call hooks'.
@@ -27,11 +22,11 @@ unsupported by `torch.compile`.
 `nn.Module.__call__` Hooks Usage and limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 By default, `torch.compile` will trace the contents of `nn.Module.__call__` which means it will encounter
-and run forward/pre-forward hooks.  If you install hooks before calling `torch.compile` and then do not remove
-or alter the hooks later, your use case should be supported by default.
+and run forward/pre-forward hooks. `torch.compile` installs guards that detect added and removed hooks,
+and will trigger a recompilation if the forward/pre-forward hooks change.
 
 Backward/Pre-backward hooks are generally also supported, with similar caveats: currently graph-breaks in dynamo
-occur when accessing backward_hooks dicts, which is probably avoiable with some work.  Graph-breaks also impact the
+occur when accessing backward_hooks dicts, which is probably avoidable with some work.  Graph-breaks also impact the
 timing of firing backward hooks, since graph-segments are run as autograd-functions which produce all their grads at
 the same time.  Assuming it were possible for dynamo to not graph-break on the presence of backward-hooks, we would
 still expect the backward hooks for a series of modules to all fire together after the whole compiled graph's backward
@@ -42,17 +37,6 @@ ran.
 by allowing them to be called opaquely in the dynamo graph instead of traced into by dynamo.  For such modules, hooks
 currently trigger a graph-break so that the affected modules run outside of dynamo.  Depending on the model, this could
 introduce a significant performance regression, and additional work is required to improve this support.
-
-**skip_nnmodule_hook_guards**
-By default, `torch._dynamo.config.skip_nnmodule_hook_guards` is set to True, meaning no guards will be installed
-on each nn.Module hook dictionary, improving runtime by reducing guard execution time, at the cost of not noticing
-if any hook dict is changed after compilation.
-
-If you want to be able to remove or modify hooks after compilation and have `torch.compile` react appropriately
-(by recompiling), then you need to set `skip_nnmodule_hook_guards=False` and expect a runtime penalty for the added
-guards.
-
-TODO: confirm if backward/pre_backward hooks are working or not and document accordingly
 
 state_dict Hooks
 ~~~~~~~~~~~~~~~~

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1508,7 +1508,6 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             )
         )
 
-    @patch.object(torch._dynamo.config, "skip_nnmodule_hook_guards", False)
     def test_hooks_outer(self):
         class TestModule(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1141,8 +1141,8 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             out1 = m(data)
 
         out_post = m(data)
-        self.assertEqual(cnt.frame_count, 1)
-        self.assertEqual(cnt.op_count, 1)
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.op_count, 2)
         self.assertTrue(torch._dynamo.testing.same(pre, opt_pre))
         self.assertTrue(torch._dynamo.testing.same(out1, out_post))
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1132,6 +1132,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         module_dict = torch.nn.ModuleDict({"cat": torch.nn.Conv2d(1, 1, 1)})
         pre = m(data)
         cnt.clear()
+        torch._dynamo.reset()
 
         with torch._dynamo.optimize(cnt, nopython=False):
             opt_pre = m(data)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -201,11 +201,6 @@ optimize_ddp = True
 # Whether to skip guarding on FSDP-managed modules
 skip_fsdp_guards = True
 
-# Make dynamo skip guarding on hooks on nn modules
-# Note: unsafe: if your model actually has hooks and you remove them, or doesn't and  you add them,
-# dynamo will not notice and will execute whichever version you first compiled.
-skip_nnmodule_hook_guards = True
-
 # If True, raises exception if TorchDynamo is called with a context manager
 raise_on_ctx_manager_usage = True
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -38,7 +38,6 @@ from torch.utils.weak import WeakIdRef
 
 from . import config, convert_frame, mutation_guard
 from .eval_frame import set_guard_error_hook, set_guard_fail_hook
-from .exc import unimplemented
 from .types import GuardedCode, GuardFail, GuardFn  # noqa: F401
 from .utils import (
     dict_const_keys,
@@ -860,7 +859,8 @@ class CheckFunctionManager:
                 and "__defaults__" not in guard.name
                 and "__kwdefaults__" not in guard.name
                 and (config.skip_nnmodule_hook_guards or "hooks" not in guard.name)
-                and guard.create_fn is not GuardBuilder.NN_MODULE  # Force-enable NN_MODULE checks for now
+                # Force-enable NN_MODULE checks for now
+                and guard.create_fn is not GuardBuilder.NN_MODULE
             ):
                 continue
             guard.create(local_builder, global_builder)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -369,19 +369,14 @@ class GuardBuilder(GuardBuilderBase):
             self.EQUALS_MATCH(guard)
 
     def NN_MODULE(self, guard: Guard):
-        self.ID_MATCH(guard)
         ref = self.arg_ref(guard)
         val = self.get(guard.name)
-
-        def setup_guard():
-            assert istype(val.training, bool)
-            self.code.append(f"{ref}.training == {val.training}")
-
-        if hasattr(val, "training"):
-            # There are cases where a monkeypatched object has a guard made between __new__ and __init__
-            setup_guard()
-        else:
-            unimplemented(f"Guard setup for uninitialized class {type(val)}")
+        # The module guard checks for modifications to the Module's type, __dict__,
+        # and various nested OrderedDicts, such as _parameters, _buffers, and _modules.
+        # This subsumes the check for Module.training.
+        g = torch._C._dynamo.guards.nn_module_guard(val)
+        name = self.check_fn_manager.add_extra_closure_var("__nn_module_guard", g)
+        self._produce_guard_code(guard, [f"{name}()"])
 
     def FUNCTION_MATCH(self, guard: Guard):
         """things like torch.add and user defined functions"""
@@ -816,6 +811,7 @@ class CheckFunctionManager:
         self.valid = True
         self._weakrefs: List["ReferenceType[object]"] = []
         self._seen_ids: Set[int] = set()
+        self._extra_closure_vars: Dict[str, object] = {}
         self.output_graph = output_graph
 
         # Note: right overrides left
@@ -864,6 +860,7 @@ class CheckFunctionManager:
                 and "__defaults__" not in guard.name
                 and "__kwdefaults__" not in guard.name
                 and (config.skip_nnmodule_hook_guards or "hooks" not in guard.name)
+                and guard.create_fn is not GuardBuilder.NN_MODULE  # Force-enable NN_MODULE checks for now
             ):
                 continue
             guard.create(local_builder, global_builder)
@@ -975,6 +972,7 @@ class CheckFunctionManager:
             + list(SYMPY_INTERP.items())
         )
         closure_vars.update(CLOSURE_VARS)
+        closure_vars.update(self._extra_closure_vars)
 
         unique_code_parts = list(unique(code_parts))
         make_guard_fn_args = ", ".join(closure_vars.keys())
@@ -1016,6 +1014,14 @@ class CheckFunctionManager:
         except TypeError:
             pass  # cannot weakref bool object
         return id(obj)
+
+    def add_extra_closure_var(self, name_hint, obj):
+        idx = 0
+        while f"{name_hint}_{idx}" in self._extra_closure_vars:
+            idx += 1
+        name = f"{name_hint}_{idx}"
+        self._extra_closure_vars[name] = obj
+        return name
 
 
 def build_guard_function(code_parts, closure_args) -> Tuple[str, str]:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -382,7 +382,7 @@ class GuardBuilder(GuardBuilderBase):
             # For now, we skip installing the guard.
             return
         name = self.check_fn_manager.add_extra_closure_var("__nn_module_guard", g)
-        self._produce_guard_code(guard, [f"{name}()"])
+        self._produce_guard_code(guard, [f"{name}({ref})"])
 
     def FUNCTION_MATCH(self, guard: Guard):
         """things like torch.add and user defined functions"""

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -38,6 +38,7 @@ from torch.utils.weak import WeakIdRef
 
 from . import config, convert_frame, mutation_guard
 from .eval_frame import set_guard_error_hook, set_guard_fail_hook
+from .exc import unimplemented
 from .types import GuardedCode, GuardFail, GuardFn  # noqa: F401
 from .utils import (
     dict_const_keys,
@@ -373,6 +374,8 @@ class GuardBuilder(GuardBuilderBase):
         # The module guard checks for modifications to the Module's type, __dict__,
         # and various nested OrderedDicts, such as _parameters, _buffers, and _modules.
         # This subsumes the check for Module.training.
+        if not hasattr(val, "training"):
+            unimplemented(f"Guard setup for uninitialized class {type(val)}")
         try:
             g = torch._C._dynamo.guards.nn_module_guard(val)
         except AttributeError:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -868,8 +868,7 @@ class CheckFunctionManager:
                 # TODO: we could make use of 'DefaultsSource' and offer a .guard.is_defaults() API
                 and "__defaults__" not in guard.name
                 and "__kwdefaults__" not in guard.name
-                and (config.skip_nnmodule_hook_guards or "hooks" not in guard.name)
-                # Force-enable NN_MODULE checks for now
+                # Force-enable NN_MODULE checks
                 and guard.create_fn is not GuardBuilder.NN_MODULE
             ):
                 continue

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -568,15 +568,6 @@ class OutputGraph(Checkpointable[OutputGraphState]):
 
         elif isinstance(target, torch.nn.Module):
             assert isinstance(target, torch.nn.Module)
-            if nnmodule_has_hooks(target, check_forward_hooks=True):
-                torch._logging.warning_once(
-                    log,
-                    "nn.Module forward/_pre hooks are only partially supported, and were detected in your model. "
-                    "In particular, if you do not change/remove hooks after calling .compile(), you can disregard this "
-                    "warning, and otherwise you may need to set torch._dynamo.config.skip_nnmodule_hook_guards=False "
-                    "to ensure recompiling after changing hooks."
-                    f"{nnmodule_doc_url_msg} ",
-                )
             if nnmodule_has_hooks(
                 target, check_backward_hooks=True, check_state_dict_hooks=True
             ):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2011,9 +2011,10 @@ class InstructionTranslator(InstructionTranslatorBase):
                     ]
                     self.output.guards.update(index_guards)
 
-            # Additionally, we need to add guards for self, if it is a NNModule.
-            # The outer invocation of Module.__call__ is a use of "self" that's not seen
-            # by the tracer.
+            # Additionally, we need to add guards for self, if it is a NNModule. The
+            # outer invocation of Module.__call__ is a use of "self" that's not seen
+            # by the tracer. Practically, this is useful for catching modifications
+            # to the module's hooks that would otherwise be missed.
             if "self" in self.symbolic_locals:
                 val = self.symbolic_locals["self"]
                 if isinstance(val, NNModuleVariable):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2011,6 +2011,15 @@ class InstructionTranslator(InstructionTranslatorBase):
                     ]
                     self.output.guards.update(index_guards)
 
+            # Additionally, we need to add guards for self, if it is a NNModule.
+            # The outer invocation of Module.__call__ is a use of "self" that's not seen
+            # by the tracer.
+            if "self" in self.symbolic_locals:
+                val = self.symbolic_locals["self"]
+                if isinstance(val, NNModuleVariable):
+                    local_guards = VariableTracker.propagate(val)["guards"]
+                    self.output.guards.update(local_guards)
+
             self._freevars_ids = dict()
             for name in self.code_options["co_freevars"]:
                 if name in f_locals:

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1,5 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <torch/csrc/dynamo/guards.h>
+#include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/extension.h>
 #include <sstream>

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -504,9 +504,13 @@ static PyObject* NNModuleGuard_call(
     Py_RETURN_FALSE;
   }
 
-  if (Py_TYPE(mod)->tp_version_tag != guard->version_tag) {
-    Py_RETURN_FALSE;
-  }
+  // TODO(sgross): temporarily disable tp_version_tag check due to
+  // torch.fx._symbolic_trace patching __getattr__ and __call__.  Modifying
+  // those attributes on the class changes the tp_version_tag, invalidating
+  // the guard.
+  // if (Py_TYPE(mod)->tp_version_tag != guard->version_tag) {
+  //   Py_RETURN_FALSE;
+  // }
 
   // NOTE: we must check the dict version tag before we check the attributes,
   // because the attributes may be dead references if the dict has been updated.

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -500,11 +500,12 @@ static PyObject* NNModuleGuard_call(
   NNModuleGuard* guard = (NNModuleGuard*)callable;
 
   if (PyTuple_GET_SIZE(args) != 1) {
-    PyErr_SetString(PyExc_TypeError, "NNModuleGuardType: expected one argument");
+    PyErr_SetString(
+        PyExc_TypeError, "NNModuleGuardType: expected one argument");
     return NULL;
   }
 
-  PyObject *mod = PyTuple_GET_ITEM(args, 0);
+  PyObject* mod = PyTuple_GET_ITEM(args, 0);
   if (guard->mod != mod) {
     Py_RETURN_FALSE;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -465,21 +465,20 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
 }
 
 typedef struct {
-  PyDictObject *dict;  // borrowed reference
+  PyDictObject* dict; // borrowed reference
   uint64_t dict_version_tag;
 } AttrTag;
 
 static const char* module_guard_attrs[] = {
-  "_parameters",
-  "_buffers",
-  "_modules",
-  "_forward_hooks",
-  "_forward_pre_hooks",
+    "_parameters",
+    "_buffers",
+    "_modules",
+    "_forward_hooks",
+    "_forward_pre_hooks",
 };
 
 typedef struct {
-  PyObject_HEAD
-  PyObject *wr;
+  PyObject_HEAD PyObject* wr;
   unsigned int version_tag;
   uint64_t dict_version_tag;
   AttrTag attr_tags[sizeof(module_guard_attrs) / sizeof(module_guard_attrs[0])];
@@ -494,8 +493,11 @@ static PyTypeObject NNModuleGuardType = {
     // NOLINTNEXTLINE
     PyVarObject_HEAD_INIT(NULL, 0)};
 
-static PyObject* NNModuleGuard_call(PyObject *callable, PyObject *args, PyObject *kwargs) {
-  NNModuleGuard *guard = (NNModuleGuard *)callable;
+static PyObject* NNModuleGuard_call(
+    PyObject* callable,
+    PyObject* args,
+    PyObject* kwargs) {
+  NNModuleGuard* guard = (NNModuleGuard*)callable;
 
   PyObject* mod = PyWeakref_GetObject(guard->wr);
   if (mod == NULL) {
@@ -524,7 +526,8 @@ static PyObject* NNModuleGuard_call(PyObject *callable, PyObject *args, PyObject
 }
 
 static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
-  NNModuleGuard *guard = (NNModuleGuard *)NNModuleGuardType.tp_alloc(&NNModuleGuardType, 0);
+  NNModuleGuard* guard =
+      (NNModuleGuard*)NNModuleGuardType.tp_alloc(&NNModuleGuardType, 0);
   if (guard == NULL) {
     return NULL;
   }
@@ -535,7 +538,7 @@ static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
     return NULL;
   }
 
-  PyObject *dict = PyObject_GenericGetDict(obj, NULL);
+  PyObject* dict = PyObject_GenericGetDict(obj, NULL);
   if (dict == NULL) {
     Py_DECREF(guard);
     return NULL;
@@ -545,7 +548,7 @@ static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
   Py_ssize_t idx = 0;
   for (const char* attr : module_guard_attrs) {
     auto& tag = guard->attr_tags[idx];
-    PyObject *attr_obj = PyDict_GetItemString(dict, attr);
+    PyObject* attr_obj = PyDict_GetItemString(dict, attr);
     if (attr_obj == NULL) {
       Py_DECREF(dict);
       Py_DECREF(guard);
@@ -561,7 +564,7 @@ static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
   if (Py_TYPE(obj)->tp_version_tag == 0) {
     // The tp_version_tag may be lazily set on attribute access. If we don't
     // have a valid tag, perform a property lookup to force the tag to be set.
-    PyObject *tmp = PyObject_GetAttrString(obj, "__dict__");
+    PyObject* tmp = PyObject_GetAttrString(obj, "__dict__");
     if (tmp == NULL) {
       Py_DECREF(guard);
       return NULL;
@@ -575,7 +578,7 @@ static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
     PyErr_SetString(PyExc_ValueError, "object has no version tag");
     return NULL;
   }
-  return (PyObject *)guard;
+  return (PyObject*)guard;
 }
 
 static PyMethodDef _methods[] = {
@@ -630,7 +633,8 @@ PyObject* torch_c_dynamo_guards_init() {
     return NULL;
   }
 
-  if (PyModule_AddObject(m, "NNModuleGuardType", Py_NewRef(&NNModuleGuardType)) < 0) {
+  if (PyModule_AddObject(
+          m, "NNModuleGuardType", Py_NewRef(&NNModuleGuardType)) < 0) {
     Py_DECREF(&NNModuleGuardType);
     Py_DECREF(m);
     return NULL;

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -475,6 +475,8 @@ static const char* module_guard_attrs[] = {
     "_modules",
     "_forward_hooks",
     "_forward_pre_hooks",
+    "_backward_hooks",
+    "_backward_pre_hooks",
 };
 
 typedef struct {


### PR DESCRIPTION
(WIP)

The NN_MODULE guard now subsumes guards on Module attributes. The check_fn will fail if the module attributes are changed (such as Module.training), parameters, submodules, and buffers are added or removed, and if fields are changed on the type itself.

This gives up specificity in the guard check -- if any field is changed the check_fn fails -- for faster overall checks.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov @soumith @desertfire