### PR TITLE
[FSDP] Do not `sys.exit(0)` explicitly at end of unit test

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -913,7 +913,6 @@ class FSDPTest(MultiProcessTestCase):
         dist.barrier()
 
         dist.destroy_process_group()
-        sys.exit(0)
 
     def _train_for_several_steps(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100645

We are going to see if this closes https://github.com/pytorch/pytorch/issues/100641. The guess is that this might allow NCCL to be destroyed before Python finalizes, avoiding any issues with calling `pybind11::gil_scoped_release` like in [`destroy_nccl_comm`](https://github.com/pytorch/pytorch/blob/8994d9e6109c541a1d581c383e4de9ed68205d91/torch/csrc/cuda/python_nccl.cpp#L46).

Test plan:
```
CUDA_VISIBLE_DEVICES=0,7 numactl -C 2 python test/distributed/fsdp/test_fsdp_unshard_params.py -v -k test_with_grads_core --repeat 200 2>&1 | tee out
```