### PR TITLE
Fix type annotation of `torch.split`

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1137,7 +1137,7 @@ def split_with_sizes(
 
 
 @register_decomposition([aten.split.Tensor, aten.unsafe_split.Tensor])
-def split(self: Tensor, split_size: int, dim: int = 0) -> List[Tensor]:
+def split(self: Tensor, split_size: int, dim: int = 0) -> Tuple[Tensor, ...]:
     input_sizes = self.shape
     dim_size = input_sizes[dim]
     if split_size == 0:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1142,7 +1142,7 @@ def split(self: Tensor, split_size: int, dim: int = 0) -> Tuple[Tensor, ...]:
     dim_size = input_sizes[dim]
     if split_size == 0:
         assert dim_size == 0
-        return [self]
+        return (self,)
     chunks = (dim_size + split_size - 1) // split_size
     chunks = guard_int(chunks)
     split_sizes = [split_size for i in range(chunks)]

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -232,8 +232,8 @@ def reshard_local_shard(
             rearrange_output_list = True
 
     # Perform autograd enabled all2all.
-    input_tensor_list = torch.split(local_tensor, input_split_sizes, dim=reshard_dim)
-    input_tensor_list = [tensor.contiguous() for tensor in input_tensor_list]
+    input_tensor_tuple = torch.split(local_tensor, input_split_sizes, dim=reshard_dim)
+    input_tensor_list = [tensor.contiguous() for tensor in input_tensor_tuple]
     output_tensor_list = all_to_all(
         output_tensor_list,
         input_tensor_list,

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -139,7 +139,7 @@ def broadcast_shapes(*shapes):
 
 def split(
     tensor: Tensor, split_size_or_sections: Union[int, List[int]], dim: int = 0
-) -> List[Tensor]:
+) -> Tuple[Tensor, ...]:
     r"""Splits the tensor into chunks. Each chunk is a view of the original tensor.
 
     If :attr:`split_size_or_sections` is an integer type, then :attr:`tensor` will

--- a/torch/fx/experimental/merge_matmul.py
+++ b/torch/fx/experimental/merge_matmul.py
@@ -29,7 +29,7 @@ def split_result_tensors(result: torch.Tensor, inputs: List[torch.Tensor]) -> Li
     else:
         splits = [x.shape[0] for x in inputs]
 
-    return torch.split(result, splits)
+    return list(torch.split(result, splits))
 
 
 def may_depend_on(a: Node, b: Node, search_depth: int = 6):

--- a/torch/fx/experimental/merge_matmul.py
+++ b/torch/fx/experimental/merge_matmul.py
@@ -6,10 +6,12 @@ from torch.fx.passes.tools_common import legalize_graph
 import itertools
 import operator
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
-def split_result_tensors(result: torch.Tensor, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+def split_result_tensors(
+    result: torch.Tensor, inputs: List[torch.Tensor]
+) -> Tuple[torch.Tensor, ...]:
     """
     A free function for use in the merge_matmul graph transformation below that
     splits the output from a merged matmul into the individual results for each
@@ -29,7 +31,7 @@ def split_result_tensors(result: torch.Tensor, inputs: List[torch.Tensor]) -> Li
     else:
         splits = [x.shape[0] for x in inputs]
 
-    return list(torch.split(result, splits))
+    return torch.split(result, splits)
 
 
 def may_depend_on(a: Node, b: Node, search_depth: int = 6):


### PR DESCRIPTION
The type annotation indicates `list` but the returned type is `tuple` 
```python
>>> import torch
>>> type(torch.arange(10).split(4))
<class 'tuple'>
```