### PR TITLE
[ET selective build] add kernel metadata section to selective_build.yaml

### DIFF
--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -39,6 +39,10 @@ class SelectiveBuilder:
     # of the kernel function implementation itself.
     kernel_metadata: Dict[str, List[str]]
 
+    # ExecuTorch only. A dictionary of kernel tag -> list of (list of input
+    # dtypes for tensor-like input args).
+    et_kernel_metadata: Dict[str, List[List[str]]]
+
     # A set of all the custom torch bind classes used by the selected models
     # Stored as a set internally to remove duplicates proactively, but written
     # as a list to yamls
@@ -67,6 +71,7 @@ class SelectiveBuilder:
             "debug_info",
             "operators",
             "kernel_metadata",
+            "et_kernel_metadata",
             "custom_classes",
             "build_features",
         }
@@ -101,6 +106,9 @@ class SelectiveBuilder:
         for k, v in kernel_metadata_dict.items():
             kernel_metadata[str(k)] = [str(dtype) for dtype in v]
 
+        # TODO(T149265497): Need to parse the et kernel metadata
+        et_kernel_metadata: Dict[str, List[List[str]]] = {}
+
         custom_classes = data.get("custom_classes", [])
         custom_classes = set(custom_classes)  # type: ignore[arg-type]
 
@@ -115,6 +123,7 @@ class SelectiveBuilder:
             debug_info,
             operators,
             kernel_metadata,
+            et_kernel_metadata,
             custom_classes,  # type: ignore[arg-type]
             build_features,  # type: ignore[arg-type]
             include_all_non_op_selectives,
@@ -263,6 +272,8 @@ def combine_selective_builders(
     debug_info = merge_debug_info(lhs._debug_info, rhs._debug_info)
     operators = merge_operator_dicts(lhs.operators, rhs.operators)
     kernel_metadata = merge_kernel_metadata(lhs.kernel_metadata, rhs.kernel_metadata)
+    # TODO(T149265497): Need to parse the et kernel metadata
+    et_kernel_metadata: Dict[str, List[List[str]]] = {}
     include_all_non_op_selectives = (
         lhs.include_all_non_op_selectives or rhs.include_all_non_op_selectives
     )
@@ -273,6 +284,7 @@ def combine_selective_builders(
         debug_info,
         operators,
         kernel_metadata,
+        et_kernel_metadata,
         custom_classes,
         build_features,
         include_all_non_op_selectives,


### PR DESCRIPTION
Summary:
For each op, we have a List[List[dtype;dim-order]]:
  - the inner list contains the `dtype;dim-order` info for each arg if we have a Tensor/TensorList/OptionalTensorList
  - the outer list contains different occurances of dtype/dim-order combinations for that op in the program

Example:
```
et_kernel_metadata:
  aten::add.out:
    # A list of different dtype/dim-order combinations used in model
    - # Each contains the list of args of Tensor dtype and dim order if applicable
      - FLOAT;0,1
      - FLOAT;0,1
      - NON_TENSOR_ARG
      - FLOAT;0,1
      - FLOAT;0,1
    -
      - INT;0,1
      - INT;0,1
      - NON_TENSOR_ARG
      - INT;0,1
      - INT;0,1
  aten::mul.out:
    - - FLOAT;0,1
      - FLOAT;0,1
      - FLOAT;0,1
      - FLOAT;0,1
```

We don't have the arg name so far; we need to parse the schema (functions.yaml) to get that info.  We depend on the order of args from that file.

Test Plan: `buck run fbcode//executorch/codegen/tools:test_gen_oplist_real_model`

Differential Revision: D45551409

