### PR TITLE
[DataLoader] Add context to NotImplementedErrors in dataset.py

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -50,7 +50,7 @@ class Dataset(Generic[T_co]):
     """
 
     def __getitem__(self, index) -> T_co:
-        raise NotImplementedError
+        raise NotImplementedError("Subclasses of Dataset should implement __getitem__.")
 
     def __add__(self, other: 'Dataset[T_co]') -> 'ConcatDataset[T_co]':
         return ConcatDataset([self, other])
@@ -169,7 +169,7 @@ class IterableDataset(Dataset[T_co]):
         [3, 4, 5, 6]
     """
     def __iter__(self) -> Iterator[T_co]:
-        raise NotImplementedError
+        raise NotImplementedError("Subclasses of IterableDataset should implement __iter__.")
 
     def __add__(self, other: Dataset[T_co]):
         return ChainDataset([self, other])


### PR DESCRIPTION
Add helpful context message to `NotImplementedError`'s thrown by Dataset and IterableDataset, reminding users that they must implement `__getitem__`/`__iter__` in subclasses. Currently, users are presented with a bare `NotImplementedError` without describing the remedy.