### PR TITLE
Add support for list copy in dynamo export

### DIFF
--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -295,6 +295,14 @@ class ListVariable(BaseListVariable):
                 items[key.as_python_constant()] = value
             result = ListVariable(items, regen_guards=False, **options)
             return tx.replace_all(self, result)
+        elif name == "copy":
+            # List copy() doesn't have args and kwargs
+            assert not kwargs
+            assert not args
+            items = list(self.items)
+            return ListVariable(
+                items, regen_guards=False, mutable_local=MutableLocal(), **options
+            )
         else:
             return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
Summary:
Issue:
`torch._dynamo.exc.Unsupported: call_method ListVariable() copy [] {}`

Fix:
Add `copy()` to "method_call" to _dynamo/variables/lists.py

Take it over from #98184. To unblock a meta internal model onboarding to ExecuTorch. 

Differential Revision: D45592416



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire