### PR TITLE
Adding decorator tests

### DIFF
--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -1,0 +1,53 @@
+import unittest
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU, skipIfRocm
+from torch.testing._internal.common_utils import TestCase, run_tests, expectedFailureMeta, skipIfNoLapack, TEST_NUMPY
+
+class TestDecorators(TestCase):
+
+    @expectedFailureMeta
+    def test_expected_to_fail(self):
+        self.assertEqual(1, 2)
+
+    def run_single_test(self, test_method):
+        test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(type("TempTest", (TestDecorators,), {
+            'single_test': test_method
+        }))
+
+        class TestExecutionChecker(unittest.TestResult):
+            executed = False
+
+            def addExpectedFailure(self, test, err):
+                self.executed = True
+
+        result = TestExecutionChecker()
+        test_suite.run(result)
+        return result.executed
+
+    def test_check_failure(self):
+        # Run the test_expected_to_fail
+        result = self.run_single_test(self.test_expected_to_fail)
+
+        # Check if the test was executed and registered as expected failure
+        self.assertTrue(result)
+
+    @onlyCPU
+    def test_only_cpu(self):
+        self.assertEqual(str(self.device), 'cpu')
+
+    @skipIfRocm
+    def test_skip_if_rocm(self):
+        self.assertNotIn("rocm", str(self.device).lower())
+
+    @skipIfNoLapack
+    def test_skip_if_no_lapack(self):
+        import torch
+        self.assertTrue(torch._C.has_lapack)
+
+    @TEST_NUMPY
+    def test_test_numpy(self):
+        import numpy as np
+        self.assertIsNotNone(np)
+
+if __name__ == '__main__':
+    run_tests(
+)

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -1,5 +1,5 @@
 import unittest
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU, skipIfRocm
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyOn, skipIfRocm, dtypes
 from torch.testing._internal.common_utils import TestCase, run_tests, expectedFailureMeta, skipIfNoLapack, TEST_NUMPY
 
 class TestDecorators(TestCase):
@@ -34,6 +34,14 @@ class TestDecorators(TestCase):
     def test_only_cpu(self):
         self.assertEqual(str(self.device), 'cpu')
 
+    @onlyCUDA
+    def test_only_cuda(self):
+        self.assertIn("cuda", str(self.device).lower())
+
+    @onlyOn('cpu', 'cuda')
+    def test_only_on_cpu_or_cuda(self):
+        self.assertIn(str(self.device), ['cpu', 'cuda'])
+
     @skipIfRocm
     def test_skip_if_rocm(self):
         self.assertNotIn("rocm", str(self.device).lower())
@@ -48,6 +56,10 @@ class TestDecorators(TestCase):
         import numpy as np
         self.assertIsNotNone(np)
 
+    @dtypes(torch.float32, torch.float64)
+    def test_dtypes(self, dtype):
+        expected_dtypes = (torch.float32, torch.float64)
+        self.assertIn(dtype, expected_dtypes)
+
 if __name__ == '__main__':
-    run_tests(
-)
+    run_tests()

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -1,17 +1,30 @@
 import unittest
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyOn, skipIfRocm, dtypes
-from torch.testing._internal.common_utils import TestCase, run_tests, expectedFailureMeta, skipIfNoLapack, TEST_NUMPY
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyCPU,
+    onlyCUDA,
+    onlyOn,
+    skipIfRocm,
+    dtypes,
+)
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+    expectedFailureMeta,
+    skipIfNoLapack,
+    TEST_NUMPY,
+)
+
 
 class TestDecorators(TestCase):
-
     @expectedFailureMeta
     def test_expected_to_fail(self):
         self.assertEqual(1, 2)
 
     def run_single_test(self, test_method):
-        test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(type("TempTest", (TestDecorators,), {
-            'single_test': test_method
-        }))
+        test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(
+            type("TempTest", (TestDecorators,), {"single_test": test_method})
+        )
 
         class TestExecutionChecker(unittest.TestResult):
             executed = False
@@ -32,15 +45,15 @@ class TestDecorators(TestCase):
 
     @onlyCPU
     def test_only_cpu(self):
-        self.assertEqual(str(self.device), 'cpu')
+        self.assertEqual(str(self.device), "cpu")
 
     @onlyCUDA
     def test_only_cuda(self):
         self.assertIn("cuda", str(self.device).lower())
 
-    @onlyOn('cpu', 'cuda')
+    @onlyOn("cpu", "cuda")
     def test_only_on_cpu_or_cuda(self):
-        self.assertIn(str(self.device), ['cpu', 'cuda'])
+        self.assertIn(str(self.device), ["cpu", "cuda"])
 
     @skipIfRocm
     def test_skip_if_rocm(self):
@@ -49,11 +62,13 @@ class TestDecorators(TestCase):
     @skipIfNoLapack
     def test_skip_if_no_lapack(self):
         import torch
+
         self.assertTrue(torch._C.has_lapack)
 
     @TEST_NUMPY
     def test_test_numpy(self):
         import numpy as np
+
         self.assertIsNotNone(np)
 
     @dtypes(torch.float32, torch.float64)
@@ -61,5 +76,6 @@ class TestDecorators(TestCase):
         expected_dtypes = (torch.float32, torch.float64)
         self.assertIn(dtype, expected_dtypes)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #84972.

This PR adds a new test suite called `TestDecorators` which contains unit tests that specifically target various decorators in use within the PyTorch package, such as `expectedFailureMeta`, `onlyCPU`, `onlyCUDA`, `onlyOn`, `skipIfRocm`, `skipIfNoLapack`, `TEST_NUMPY`, and `dtypes`. The purpose of these tests is to ensure that the decorators are working as expected.

For instance, it checks whether the tests decorated with `expectedFailureMeta` are executed and registered as expected failures. It also tests the device-specific decorators for proper test execution, checks if the `skipIfRocm` and `skipIfNoLapack` decorators work as intended, and confirms that `TEST_NUMPY` and `dtypes` decorators are functional.

These tests also help address the issue observed in #84874, where tests using the `expectedFailureMeta` decorator were not being executed. By having a test suite dedicated to the proper functioning of these decorators, we minimize the risk of encountering similar issues in the future.
