### PR TITLE
Remove MacOS workflow step to disable XProtect

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -83,26 +83,6 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Disable XProtect and MDS
-        continue-on-error: true
-        run: |
-          # Like Windows Defender, XProtect could interfere with the test
-          set +e
-          set -x
-
-          SERVICES=(
-            "com.apple.XProtect.daemon.scan"
-            "com.apple.XprotectFramework.PluginService"
-            "com.apple.XprotectFramework.scan"
-            "com.apple.metadata.mds"
-            "com.apple.metadata.mds.index"
-          )
-          # 13.x calls it XProtect.daemon.scan while 12.x calls it XprotectFramework.scan
-          for SERVICE in "${SERVICES[@]}"; do
-            sudo launchctl stop "${SERVICE}"
-            sudo launchctl disable "system/${SERVICE}"
-          done
-
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -81,26 +81,6 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Disable XProtect and MDS
-        continue-on-error: true
-        run: |
-          # Like Windows Defender, XProtect could interfere with the test
-          set +e
-          set -x
-
-          SERVICES=(
-            "com.apple.XProtect.daemon.scan"
-            "com.apple.XprotectFramework.PluginService"
-            "com.apple.XprotectFramework.scan"
-            "com.apple.metadata.mds"
-            "com.apple.metadata.mds.index"
-          )
-          # 13.x calls it XProtect.daemon.scan while 12.x calls it XprotectFramework.scan
-          for SERVICE in "${SERVICES[@]}"; do
-            sudo launchctl stop "${SERVICE}"
-            sudo launchctl disable "system/${SERVICE}"
-          done
-
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:


### PR DESCRIPTION
I added this few weeks back trying to fix the flaky dependencies missing on MacOS in https://github.com/pytorch/pytorch/pull/99506.  But I think this step is not really needed.  More importantly, it starts to hang on MacOS 13, for example https://github.com/pytorch/pytorch/actions/runs/4889081518/jobs/8727397905.  The reason is unclear, but this should be removed nonetheless.
