### PR TITLE
[ONNX] add cast operator after reduce to match desired dtype

### DIFF
--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -441,18 +441,16 @@ def _reduce_with_dtype(onnx_op, name):
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
                 dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
-                self = g.op(
-                    "Cast", self, to_i=dtype_onnx
-                )
+                self = g.op("Cast", self, to_i=dtype_onnx)
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self)
             if dtype_onnx is not None:
-                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(
+                    result
+                ).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
-                    result = g.op(
-                        "Cast", result, to_i=dtype_onnx
-                    )
+                    result = g.op("Cast", result, to_i=dtype_onnx)
             return result
 
         @symbolic_helper.parse_args("v", "v", "i", "none")
@@ -462,18 +460,16 @@ def _reduce_with_dtype(onnx_op, name):
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
                 dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
-                self = g.op(
-                    "Cast", self, to_i=dtype_onnx
-                )
+                self = g.op("Cast", self, to_i=dtype_onnx)
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self, dim, keepdim)
             if dtype_onnx is not None:
-                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(
+                    result
+                ).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
-                    result = g.op(
-                        "Cast", result, to_i=dtype_onnx
-                    )
+                    result = g.op("Cast", result, to_i=dtype_onnx)
             return result
 
         return reduce_nodim, reduce_dim

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -472,7 +472,7 @@ def _reduce_with_dtype(onnx_op, name):
                 result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
-                        "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
+                        "Cast", result, to_i=dtype_onnx
                     )
             return result
 

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -448,8 +448,7 @@ def _reduce_with_dtype(onnx_op, name):
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self)
             if dtype_onnx is not None:
-                result_dtype_scalar = result.type().scalarType()
-                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
                         "Cast", result, to_i=dtype_onnx
@@ -470,8 +469,7 @@ def _reduce_with_dtype(onnx_op, name):
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self, dim, keepdim)
             if dtype_onnx is not None:
-                result_dtype_scalar = result.type().scalarType()
-                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
                         "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -446,7 +446,7 @@ def _reduce_with_dtype(onnx_op, name):
                 )
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
-            result =  symbolic(g, self)
+            result = symbolic(g, self)
             if dtype_onnx is not None:
                 result_dtype_scalar = result.type().scalarType()
                 result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
@@ -476,7 +476,7 @@ def _reduce_with_dtype(onnx_op, name):
                     result = g.op(
                         "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
                     )
-            return result            
+            return result
 
         return reduce_nodim, reduce_dim
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -843,20 +843,23 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
         @symbolic_helper.quantized_args(True)
         @symbolic_helper.parse_args("v", "none")
         def reduce_nodim(g, self, dtype):
-            original_dtype = self.type().scalarType()
+            dtype_onnx = None
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
+                dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
                 self = g.op(
-                    "Cast", self, to_i=_type_utils.JitScalarType(dtype).onnx_type()
+                    "Cast", self, to_i=dtype_onnx
                 )
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result =  symbolic(g, self)
-            result_type = result.type().scalarType()
-            if result_type != original_dtype:
-                result = g.op(
-                    "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
-                )
+            if dtype_onnx is not None:
+                result_dtype_scalar = result.type().scalarType()
+                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                if result_dtype_onnx != dtype_onnx:
+                    result = g.op(
+                        "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
+                    )
             return result
 
 
@@ -865,20 +868,23 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
         @symbolic_helper.quantized_args(True)
         @symbolic_helper.parse_args("v", dim_desc, "i", "none")  # type: ignore[arg-type]
         def reduce_dim(g, self, dim, keepdim, dtype):
-            original_dtype = self.type().scalarType()
+            dtype_onnx = None
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
+                dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
                 self = g.op(
-                    "Cast", self, to_i=_type_utils.JitScalarType(dtype).onnx_type()
+                    "Cast", self, to_i=dtype_onnx
                 )
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result =  symbolic(g, self, dim, keepdim)
-            result_type = result.type().scalarType()
-            if result_type != original_dtype:
-                result = g.op(
-                    "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
-                )
+            if dtype_onnx is not None:
+                result_dtype_scalar = result.type().scalarType()
+                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                if result_dtype_onnx != dtype_onnx:
+                    result = g.op(
+                        "Cast", result, to_i=dtype_onnx
+                    )
             return result
 
         return reduce_nodim, reduce_dim

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -857,7 +857,7 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
                 result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
-                        "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
+                        "Cast", result, to_i=dtype_onnx
                     )
             return result
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -852,7 +852,7 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
                 )
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
-            result =  symbolic(g, self)
+            result = symbolic(g, self)
             if dtype_onnx is not None:
                 result_dtype_scalar = result.type().scalarType()
                 result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
@@ -877,7 +877,7 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
                 )
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
-            result =  symbolic(g, self, dim, keepdim)
+            result = symbolic(g, self, dim, keepdim)
             if dtype_onnx is not None:
                 result_dtype_scalar = result.type().scalarType()
                 result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -854,8 +854,7 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self)
             if dtype_onnx is not None:
-                result_dtype_scalar = result.type().scalarType()
-                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
                         "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
@@ -879,8 +878,7 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self, dim, keepdim)
             if dtype_onnx is not None:
-                result_dtype_scalar = result.type().scalarType()
-                result_dtype_onnx = _type_utils.JitScalarType._from_name(result_dtype_scalar).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
                     result = g.op(
                         "Cast", result, to_i=dtype_onnx

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -876,7 +876,6 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
             result =  symbolic(g, self, dim, keepdim)
             result_type = result.type().scalarType()
             if result_type != original_dtype:
-                # cast back to the dtype requested if result type is diffrent
                 result = g.op(
                     "Cast", result, to_i=_type_utils.JitScalarType(dtype).onnx_type()
                 )

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -847,20 +847,17 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
                 dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
-                self = g.op(
-                    "Cast", self, to_i=dtype_onnx
-                )
+                self = g.op("Cast", self, to_i=dtype_onnx)
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self)
             if dtype_onnx is not None:
-                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(
+                    result
+                ).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
-                    result = g.op(
-                        "Cast", result, to_i=dtype_onnx
-                    )
+                    result = g.op("Cast", result, to_i=dtype_onnx)
             return result
-
 
         dim_desc = "is" if allow_multi_dim_support else "i"
 
@@ -871,18 +868,16 @@ def _reduce_with_dtype(onnx_op: str, name: str, allow_multi_dim_support: bool = 
             if dtype.node().kind() == "onnx::Constant":
                 dtype = symbolic_helper._get_const(dtype, "i", "dtype")
                 dtype_onnx = _type_utils.JitScalarType(dtype).onnx_type()
-                self = g.op(
-                    "Cast", self, to_i=dtype_onnx
-                )
+                self = g.op("Cast", self, to_i=dtype_onnx)
             elif dtype.node().kind() != "prim::Constant":
                 return symbolic_helper._unimplemented(name, "dtype", dtype)
             result = symbolic(g, self, dim, keepdim)
             if dtype_onnx is not None:
-                result_dtype_onnx = _type_utils.JitScalarType.from_value(result).onnx_type()
+                result_dtype_onnx = _type_utils.JitScalarType.from_value(
+                    result
+                ).onnx_type()
                 if result_dtype_onnx != dtype_onnx:
-                    result = g.op(
-                        "Cast", result, to_i=dtype_onnx
-                    )
+                    result = g.op("Cast", result, to_i=dtype_onnx)
             return result
 
         return reduce_nodim, reduce_dim


### PR DESCRIPTION
This PR conditionally inserts a cast operator after a reduction operation  to match the specified dtype in the exported ONNX model.  The code changes affect **opset9**, and **opset13**.

I understand there's an [automatic upcast to int64](https://github.com/pytorch/pytorch/blob/c91a41fd6827f076224477913b1c09d20a887935/torch/onnx/symbolic_opset9.py#L783) before reduction most likely to prevent overflow so I left that alone and only conditionally add casting back to desired dtype.

## Test int32
```
import torch
import onnx
a = torch.tensor([10, 20, 30, 80], dtype=torch.int32)
def test():
    class SumInt32(torch.nn.Module):
        def forward(self, a):
            return torch.sum(a, dtype=torch.int32)

    sumi = SumInt32().eval()
    assert sumi(a).dtype == torch.int32
    print("Torch model output type matches input type")

    torch.onnx.export(sumi, (a), "/tmp/sumi_int32.onnx", opset_version=12)
    model = onnx.load("/tmp/sumi_int32.onnx")

    assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.INT32
    print("ONNX model output type matches input type")
test()
```
![sumi_int32 onnx](https://user-images.githubusercontent.com/10516699/236499220-59b64821-5807-4f69-b0e2-90ae34280e03.png)


## Test int64

```
import onnx
import torch

a = torch.tensor([10, 20, 30, 80], dtype=torch.int64)


def test():
    class SumInt64(torch.nn.Module):
        def forward(self, a):
            return torch.sum(a, dtype=torch.int64)

    sumi = SumInt64().eval()
    assert sumi(a).dtype == torch.int64
    print("Torch model output type matches input type")
    torch.onnx.export(sumi, (a), "/tmp/sumi_int64.onnx", opset_version=12)
    model = onnx.load("/tmp/sumi_int64.onnx")
    assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.INT64
    print("ONNX model output type matches input type")


test()

```
![sum_int64 onnx](https://user-images.githubusercontent.com/10516699/236422133-15f9cda3-242f-46da-9b23-c2e920f27078.png)


Fixes https://github.com/pytorch/pytorch/issues/100097
