### PR TITLE
inductor: disable lowmem_dropout on CPU

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -97,7 +97,7 @@ if RUN_CPU:
             torch._C.has_mkldnn and torch.ops.mkldnn._is_mkldnn_bf16_supported(),
         ),
         BaseTest("test_linear_packed", "", test_cpu_repro.CPUReproTests()),
-        BaseTest("test_lowmem_dropout1"),  # None as output
+        # BaseTest("test_lowmem_dropout1"),  # None as output
         BaseTest("test_mm_views"),
         BaseTest("test_profiler_mark_wrapper_call"),
         BaseTest("test_reduction1"),  # Reduction


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/97002, we fall back bernoulli and disabled lowmem_dropout on CPU, which brings significant performance improvements for both bernoulli and dropout. 
PR https://github.com/pytorch/pytorch/pull/97931 disabled lowmem_dropout by default, thus removed the code that disabled lowmem_dropout on CPU, but unfortunately, it introduced performance regression on CUDA (https://github.com/pytorch/pytorch/issues/98614). Then https://github.com/pytorch/pytorch/pull/98631 reenabled lowmem_dropout by default. 
As a result, the performance of dropout on CPU has decreased since https://github.com/pytorch/pytorch/pull/98631. This pr re-added the code to disable lowmem_dropout on CPU.
 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100702



cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire