### PR TITLE
Fix frequent "warning C4141: 'dllimport': used more than once"

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -295,7 +295,6 @@ inline c10::SymInt multiply_integers(Iter begin, Iter end) {
   C10_API RetTy operator%(scalar_t a, const SymInt& b);
 
 #define DECLARE_SYMINT_OP(scalar_t, RetTy)              \
-  C10_API                                               \
   C10_API RetTy operator+(const SymInt& a, scalar_t b); \
   C10_API RetTy operator-(const SymInt& a, scalar_t b); \
   C10_API RetTy operator*(const SymInt& a, scalar_t b); \


### PR DESCRIPTION
This was introduced recently for MSVC builds.
