### PR TITLE
[BE] Fix flake8 B027 errors - missing abstractmethod decorator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,7 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B020,B023,B024,B026,B027,B028,B903,B904,B905,B906,B907
+    B007,B008,B017,B019,B020,B023,B024,B026,B028,B903,B904,B905,B906,B907
     # these ignores are from flake8-comprehensions; please fix!
     C407,
     # these ignores are from flake8-logging-format; please fix!

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -998,6 +998,6 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.264',
+    'ruff==0.0.265',
 ]
 is_formatter = true

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -998,6 +998,6 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.262',
+    'ruff==0.0.264',
 ]
 is_formatter = true

--- a/caffe2/python/modeling/net_modifier.py
+++ b/caffe2/python/modeling/net_modifier.py
@@ -18,10 +18,6 @@ class NetModifier(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def __init__(self):
-        pass
-
-    @abc.abstractmethod
     def modify_net(self, net, init_net=None, grad_map=None, blob_to_device=None):
         pass
 

--- a/caffe2/python/modeling/net_modifier.py
+++ b/caffe2/python/modeling/net_modifier.py
@@ -17,6 +17,7 @@ class NetModifier(metaclass=abc.ABCMeta):
         modifier(net)
     """
 
+    @abc.abstractmethod
     def __init__(self):
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ ignore = [
     "B019", "B020",
     "B023", "B024", "B026",
     "B028", # No explicit `stacklevel` keyword argument found
-    "B027", "B904", "B905",
+    "B904", "B905",
     "E402",
     "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3521,6 +3521,7 @@ def fn():
     def test_user_function_variable_supports_type_abcmeta_argument(self):
         class Foo(metaclass=abc.ABCMeta):
             @abc.abstractclassmethod
+            @abc.abstractmethod
             def read(self):
                 pass
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3521,8 +3521,7 @@ def fn():
     def test_user_function_variable_supports_type_abcmeta_argument(self):
         class Foo(metaclass=abc.ABCMeta):
             @abc.abstractclassmethod
-            @abc.abstractmethod
-            def read(self):
+            def read(self):  # noqa: B027
                 pass
 
         class Bar(Foo):

--- a/torch/ao/quantization/fx/fuse_handler.py
+++ b/torch/ao/quantization/fx/fuse_handler.py
@@ -23,6 +23,7 @@ __all__ = [
 class FuseHandler(ABC):
     """ Base handler class for the fusion patterns
     """
+    @abstractmethod
     def __init__(self, node: Node):
         pass
 

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -78,6 +78,7 @@ class _TensorLoader(ABC):
     def add(self, size: int, obj: object):
         pass
 
+    @abstractmethod
     def start_loading(self):
         pass
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -84,6 +84,7 @@ class _TensorLoader(ABC):
     def add(self, size, obj):
         pass
 
+    @abstractmethod
     def start_loading(self):
         pass
 

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -105,6 +105,7 @@ class RendezvousHandler(ABC):
         allow nodes to join the correct distributed application.
         """
 
+    @abstractmethod
     def shutdown(self) -> bool:
         """Closes all resources that were open for the rendezvous.
 

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -39,9 +39,6 @@ class _FSDPPolicy(ABC):
 
     # The motivation for this abstract base class is to hide the interface
     # expected by `_recursive_wrap()` from users (i.e. the `recurse` argument).
-    @abstractmethod
-    def __init__(self):
-        ...
 
     @property
     @abstractmethod

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -39,6 +39,7 @@ class _FSDPPolicy(ABC):
 
     # The motivation for this abstract base class is to hide the interface
     # expected by `_recursive_wrap()` from users (i.e. the `recurse` argument).
+    @abstractmethod
     def __init__(self):
         ...
 

--- a/torch/fx/passes/infra/pass_base.py
+++ b/torch/fx/passes/infra/pass_base.py
@@ -31,6 +31,7 @@ class PassBase(abc.ABC):
     the PassManager's `passes` attribute.
     """
 
+    @abc.abstractmethod
     def __init__(self) -> None:
         pass
 
@@ -55,6 +56,7 @@ class PassBase(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
     def requires(self, graph_module: GraphModule) -> None:
         """
         This function will be called before the pass is run and will check that
@@ -66,6 +68,7 @@ class PassBase(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
     def ensures(self, graph_module: GraphModule) -> None:
         """
         This function will be called after the pass is run and will check that

--- a/torch/fx/passes/infra/pass_base.py
+++ b/torch/fx/passes/infra/pass_base.py
@@ -31,10 +31,6 @@ class PassBase(abc.ABC):
     the PassManager's `passes` attribute.
     """
 
-    @abc.abstractmethod
-    def __init__(self) -> None:
-        pass
-
     def __call__(self, graph_module: GraphModule) -> Optional[PassResult]:
         """
         Runs the precondition check, the pass itself, and the postcondition check.
@@ -56,8 +52,7 @@ class PassBase(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def requires(self, graph_module: GraphModule) -> None:
+    def requires(self, graph_module: GraphModule) -> None:  # noqa: B027
         """
         This function will be called before the pass is run and will check that
         the given graph module contains the preconditions needed to run the
@@ -68,8 +63,7 @@ class PassBase(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def ensures(self, graph_module: GraphModule) -> None:
+    def ensures(self, graph_module: GraphModule) -> None:  # noqa: B027
         """
         This function will be called after the pass is run and will check that
         the given graph module contains the postconditions needed to run the

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -17,6 +17,7 @@ class BasePruningMethod(ABC):
     """
     _tensor_name: str
 
+    @abstractmethod
     def __init__(self):
         pass
 

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -17,10 +17,6 @@ class BasePruningMethod(ABC):
     """
     _tensor_name: str
 
-    @abstractmethod
-    def __init__(self):
-        pass
-
     def __call__(self, module, inputs):
         r"""Multiplies the mask (stored in ``module[name + '_mask']``)
         into the original tensor (stored in ``module[name + '_orig']``)

--- a/torch/testing/_internal/distributed/rpc/rpc_agent_test_fixture.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_agent_test_fixture.py
@@ -35,6 +35,7 @@ class RpcAgentTestFixture(ABC):
     def rpc_backend_options(self):
         pass
 
+    @abstractmethod
     def setup_fault_injection(self, faulty_messages, messages_to_delay):
         """Method used by dist_init to prepare the faulty agent.
 

--- a/torch/testing/_internal/distributed/rpc/rpc_agent_test_fixture.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_agent_test_fixture.py
@@ -35,8 +35,7 @@ class RpcAgentTestFixture(ABC):
     def rpc_backend_options(self):
         pass
 
-    @abstractmethod
-    def setup_fault_injection(self, faulty_messages, messages_to_delay):
+    def setup_fault_injection(self, faulty_messages, messages_to_delay):  # noqa: B027
         """Method used by dist_init to prepare the faulty agent.
 
         Does nothing for other agents.


### PR DESCRIPTION
Enables B027 and applies fixes by adding abstract method decorators. Autofix generated by ruff master.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire