### PR TITLE
Add cooperative_groups header to cuda_to_hip_mappings.py

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -604,6 +604,7 @@ CUDA_INCLUDE_MAP = collections.OrderedDict(
             "cuda_texture_types.h",
             ("hip/hip_texture_types.h", CONV_INCLUDE, API_RUNTIME),
         ),
+        ("cooperative_groups.h", ("hip/hip_cooperative_groups.h", CONV_INCLUDE, API_RUNTIME)),
         ("vector_types.h", ("hip/hip_vector_types.h", CONV_INCLUDE, API_RUNTIME)),
         ("cublas.h", ("rocblas.h" if rocm_version < (5, 2, 0) else "rocblas/rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),
         ("cublas_v2.h", ("rocblas.h" if rocm_version < (5, 2, 0) else "rocblas/rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),


### PR DESCRIPTION
This PR is to add hip/hip_cooperative_groups.h to avoid the hipify errors. 

cc: @jithunnair-amd 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo