### PR TITLE
Register get_cpu_capability for jit

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7445,7 +7445,12 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         torch.__config__.parallel_info()
 
     def test_get_cpu_capability(self):
+        # This method is primarily exposed for torchvision's resize
         torch.backends.cpu.get_cpu_capability()
+
+        # We have to ensure that method is torchscriptable as torchvision's resize
+        # should be torchscriptable
+        torch.jit.script(torch.backends.cpu.get_cpu_capability)
 
     @slowTest
     def test_slow_test(self):

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -457,6 +457,10 @@ RegisterOperators reg({
         "aten::set_grad_enabled(bool val) -> ()",
         [](Stack& stack) { torch::GradMode::set_enabled(pop(stack).toBool()); },
         aliasAnalysisConservative()),
+    Operator(
+        "aten::_get_cpu_capability() -> str",
+        [](Stack& stack) { push(stack, at::get_cpu_capability()); },
+        aliasAnalysisConservative()),
 });
 } // namespace
 } // namespace jit

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -95,6 +95,7 @@ _builtin_ops = [
     (torch.nn.init._no_grad_uniform_, "aten::_no_grad_uniform_"),
     (torch.nn.init._no_grad_zero_, "aten::_no_grad_zero_"),
     (torch._C._get_tracing_state, "aten::_get_tracing_state"),
+    (torch._C._get_cpu_capability, "aten::_get_cpu_capability"),
     (warnings.warn, "aten::warn"),
     (torch._VF.stft, "aten::stft"),  # type: ignore[attr-defined]
     (torch._VF.istft, "aten::istft"),  # type: ignore[attr-defined]


### PR DESCRIPTION
Description:

Context: In torchvision we ensure that functional ops are torchscriptable. Recently exposed `torch.backends.cpu.get_cpu_capability()` in https://github.com/pytorch/pytorch/pull/100164 is failing in torchvision CI
```
RuntimeError:
Python builtin <built-in function _get_cpu_capability> is currently not supported in Torchscript:
  File "/usr/local/lib/python3.10/dist-packages/torch/backends/cpu/__init__.py", line 17
    - "AVX512"
    """
    return torch._C._get_cpu_capability()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```
Ref: https://github.com/pytorch/vision/pull/7557

In this PR, `torch._C._get_cpu_capability()` is explicitly registered for JIT and tested.


cc @NicolasHug 
