### PR TITLE
Allow C++ custom class to define __repr__ and use it from Python

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4130,7 +4130,11 @@ def foo(x):
                 return torch.relu(x)
 
         f = torch.jit.script(Foo())
-        self.assertEqual('ScriptObject', str(f._c))
+
+        str_f = str(f._c)
+        self.assertTrue(str_f.startswith('ScriptObject'))
+        self.assertTrue('__torch__.' in str_f)
+        self.assertTrue('.Foo' in str_f)
 
     def test_jitter_bug(self):
         @torch.jit.script

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -936,7 +936,7 @@ void initJitScriptBindings(PyObject* module) {
       [](const Object& self, py::args args, py::kwargs kwargs) -> py::object {
         auto method = self.find_method("__str__");
         if (!method) {
-          return py::str("ScriptObject");
+          return py::str("ScriptObject <" + self.type()->str() + ">");
         }
         return invokeScriptMethodFromPython(
             *method,

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -648,7 +648,7 @@ static py::dict _jit_debug_module_iterators(Module& module) {
   return result;
 }
 
-static constexpr std::array<const char*, 47> magic_method_names = {
+static constexpr std::array<const char*, 48> magic_method_names = {
     "__lt__",      "__le__",      "__eq__",        "__ne__",
     "__ge__",      "__gt__",      "__not__",       "__abs__",
     "__add__",     "__and__",     "__floordiv__",  "__index__",
@@ -660,7 +660,7 @@ static constexpr std::array<const char*, 47> magic_method_names = {
     "__iand__",    "__iconcat__", "__ifloordiv__", "__ilshift__",
     "__imod__",    "__imul__",    "__imatmul__",   "__ior__",
     "__ipow__",    "__irshift__", "__isub__",      "__itruediv__",
-    "__ixor__",    "__str__",     "__len__",
+    "__ixor__",    "__str__",     "__len__",       "__repr__",
 };
 
 struct DeepCopyMemoTable {
@@ -925,24 +925,43 @@ void initJitScriptBindings(PyObject* module) {
         return self.setter_func;
       });
 
-  // Special case __str__ to make sure we can print Objects/Modules
-  // regardless of if the user defined a __str__
+  // Special case __str__ and __repr__ to make sure we can print Objects/Modules
+  // regardless of if the user defined __str__/__repr__
   using MagicMethodImplType = std::function<py::object(
       const Object& self, py::args args, py::kwargs kwargs)>;
-  std::unordered_map<std::string, MagicMethodImplType> special_magic_methods{
-      {"__str__",
-       [](const Object& self, py::args args, py::kwargs kwargs) -> py::object {
-         auto method = self.find_method("__str__");
-         if (!method) {
-           return py::str("ScriptObject");
-         }
-         return invokeScriptMethodFromPython(
-             *method,
-             // NOLINTNEXTLINE(performance-move-const-arg)
-             std::move(args),
-             // NOLINTNEXTLINE(performance-move-const-arg)
-             std::move(kwargs));
-       }}};
+
+  std::unordered_map<std::string, MagicMethodImplType> special_magic_methods;
+  special_magic_methods.emplace(
+      "__str__",
+      [](const Object& self, py::args args, py::kwargs kwargs) -> py::object {
+        auto method = self.find_method("__str__");
+        if (!method) {
+          return py::str("ScriptObject");
+        }
+        return invokeScriptMethodFromPython(
+            *method,
+            // NOLINTNEXTLINE(performance-move-const-arg)
+            std::move(args),
+            // NOLINTNEXTLINE(performance-move-const-arg)
+            std::move(kwargs));
+      });
+
+  special_magic_methods.emplace(
+      "__repr__",
+      [](const Object& self, py::args args, py::kwargs kwargs) -> py::object {
+        auto method = self.find_method("__repr__");
+        if (!method) {
+          std::stringstream ss;
+          ss << std::hex << static_cast<const void*>(&self);
+          return py::str("<torch.ScriptObject object at " + ss.str() + ">");
+        }
+        return invokeScriptMethodFromPython(
+            *method,
+            // NOLINTNEXTLINE(performance-move-const-arg)
+            std::move(args),
+            // NOLINTNEXTLINE(performance-move-const-arg)
+            std::move(kwargs));
+      });
 
   for (const char* mm_name : magic_method_names) {
     if (special_magic_methods.count(mm_name)) {


### PR DESCRIPTION
When handling custom classes from Python, it is nice to be able to specify how they are displayed to the user.

Out of the two standard functions to do this, only `__str__` could be implemented in C++. This PR add `__repr__` to the allowlist of magic methods. 

The second commit tweaks the default output of `__str__` to make it more informative, but I can remove the change if you want.
