### PR TITLE
Disable Autograd when calling RecordFunction callbacks

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -536,6 +536,8 @@ RecordFunction::RecordFunction(StepCallbacks&& step_callbacks)
 }
 
 void RecordFunction::runStartCallbacks() {
+  at::AutoFwGradMode fw_grad_mode(false);
+  at::AutoGradMode grad_mode(false);
   for (const auto i : c10::irange(step_callbacks_.callbacks_.size())) {
     tryRunCallback</*is_start=*/true>(
         step_callbacks_.callbacks_[i], *this, ctx_[i]);
@@ -544,6 +546,8 @@ void RecordFunction::runStartCallbacks() {
 }
 
 void RecordFunction::end() {
+  at::AutoFwGradMode fw_grad_mode(false);
+  at::AutoGradMode grad_mode(false);
   if (called_start_callbacks_) {
     for (const auto i : c10::irange(step_callbacks_.callbacks_.size())) {
       tryRunCallback</*is_start=*/false>(

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -894,11 +894,12 @@ static std::unordered_set<std::string> ts_output_names;
 
 std::unique_ptr<at::ObserverContext> tracedInputsCallback(
     const RecordFunction& fn) {
+  TORCH_CHECK(!at::GradMode::is_enabled());
+  TORCH_CHECK(!c10::AutogradState::get_tls_state().get_fw_grad_mode());
   if (fn.scope() == RecordScope::FUNCTION) {
     auto inputs = fn.inputs();
     std::vector<std::vector<int64_t>> sizes;
     for (const auto& input : inputs) {
-      TORCH_CHECK(!at::GradMode::is_enabled());
       if (input.isTensor()) {
         sizes.push_back(input.toTensor().sizes().vec());
       } else if (input.isScalar()) {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -898,6 +898,7 @@ std::unique_ptr<at::ObserverContext> tracedInputsCallback(
     auto inputs = fn.inputs();
     std::vector<std::vector<int64_t>> sizes;
     for (const auto& input : inputs) {
+      TORCH_CHECK(!at::GradMode::is_enabled());
       if (input.isTensor()) {
         sizes.push_back(input.toTensor().sizes().vec());
       } else if (input.isScalar()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100727
* #100551
* #100274

This PR disables autograd for all callbacks that are registered to RecordFunction. 

Context: RecordFunction interposes before autograd in at least a couple places: custom Function, detach{,_}'s VariableTypeManual (why?) and calls arbitrary user-defined callbacks that can be registered via "addGlobalCallback" (for example, to log infs/nans to scuba). 

Issue: if any callbacks call torch operations, it may result in tensors being saved for backward (potentially problematic in the case of non-reentrant checkpointing even if the graph/saved tensors are expected to die immediately). 

Proposed solution: RecordFunction should be primarily used for profiling + logging, so it should probably live below autograd, but since actually moving where RecordFunction is called will take more work, this PR is a good stop gap solution.

Alternatives:
- putting the guard on the specific callback rather than disabling autograd (safer)

Another detail:
- we could use the dispatch below autograd guard instead
