### PR TITLE
[caffe2] Remove inline keyword of function CUDACachingAllocator::format_size

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3525,7 +3525,7 @@ void setAllocatorSettings(const std::string& env) {
 }
 
 // Size pretty-printer
-inline std::string format_size(uint64_t size) {
+std::string format_size(uint64_t size) {
   std::ostringstream os;
   os.precision(2);
   os << std::fixed;


### PR DESCRIPTION
Summary: `CUDACachingAllocator::format_size` is used not only in CUDACachingAllocator.cpp but also in CUDAMallocAsyncAllocator.cpp. This caused a breakage when the compiler inlined the function and the linker couldn't find it when resolving symbols for CUDAMallocAsyncAllocator.cpp.

Differential Revision: D45612790

