### PR TITLE
fix specify_constraints's signature when exporting model

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -786,6 +786,8 @@ def export(
     if pre_autograd:
         assert aten_graph, "pre_autograd=True can only be used when aten_graph=True"
     f = innermost_fn(f)
+    call_to_inspect = f.forward if isinstance(f, torch.nn.Module) else f
+    original_signature = inspect.signature(call_to_inspect)
 
     if functionalize and not aten_graph:
         raise UserError(
@@ -892,7 +894,7 @@ def export(
         dim_constraints = shape_env.dim_constraints
         assert dim_constraints is not None
         dim_constraints.solve()
-        msg = dim_constraints.prettify_results(inspect.signature(f))
+        msg = dim_constraints.prettify_results(original_signature)
         if constraint_violation_error:
             constraint_violation_error.args = (
                 constraint_violation_error.args[0] + msg,
@@ -1067,10 +1069,7 @@ def export(
 
     # Make dynamo graph to have same input/output spec as user code
     def argument_names(f: Callable[..., Any], *args, **kwargs) -> List[str]:
-        call_to_inspect = f.forward if isinstance(f, torch.nn.Module) else f
-
-        sig = inspect.signature(call_to_inspect)
-        fullargspec = signature_to_fullargspec(sig)
+        fullargspec = signature_to_fullargspec(original_signature)
 
         # 1. Map `args` 1-to-1 to positional arguments in original signature.
         input_strs = fullargspec.args[: len(args)]


### PR DESCRIPTION
Currently, when f is a Module, the signature should be the "forward" methods signature. For example,

```python
class Module(torch.nn.Module):
    def forward(self, x):
        return x.sin()
mod = Module()
x = torch.ones([3, 3])
torch._dynamo.export(mod, x, constraints=[dynamic_dim(x, 0)])
```
Previously, it prints following:
```python

def specify_constraints(*args, **kwargs):
    return [
        2 <= dynamic_dim(x, 0),
        2 <= dynamic_dim(x, 1),
    ]
```
After the pr, it prints:
```python
def specify_constraints(x):
    return [
        2 <= dynamic_dim(x, 0),
        2 <= dynamic_dim(x, 1),
    ]
```


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire