### PR TITLE
[CI] Do not auto-label nightly builds PR

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,8 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    # Do not auto-label nightly builds PR
+    if: ${{ github.event.pull_request.number != 26921 }}
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
As I'm tired of removing `ciflow/trunk`/`ciflow/inductor` on those, which would fail anyway

