### PR TITLE
misc. fixes to constraints warnings and errors

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1780,16 +1780,16 @@ class TestDimConstraints(TestCase):
         print(static_code)
         expected_static = '''
 def specializations(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x11, x12):
-    return (x0.size()[0] == 8 and
-    x1.size()[2] == 96 and
-    x11.size()[1] == 1 and
-    x12.size()[2] == 3 and
-    x2.size()[0] == 8 and
-    x3.size()[0] == 8 and
-    x4.size()[0] == 8 and
-    x5.size()[1] == 22 and
-    x7.size()[3] == 96 and
-    x8.size()[1] == 22)
+    assert x0.size()[0] == 8
+    assert x1.size()[2] == 96
+    assert x11.size()[1] == 1
+    assert x12.size()[2] == 3
+    assert x2.size()[0] == 8
+    assert x3.size()[0] == 8
+    assert x4.size()[0] == 8
+    assert x5.size()[1] == 22
+    assert x7.size()[3] == 96
+    assert x8.size()[1] == 22
 '''
         expected_dynamic = '''
 def specify_constraints(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x11, x12):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -855,7 +855,9 @@ def export(
         dim_constraints.solve()
         msg = dim_constraints.prettify_results(inspect.signature(f))
         if constraint_violation_error:
-            constraint_violation_error.args = (constraint_violation_error.args[0] + msg,)
+            constraint_violation_error.args = (
+                constraint_violation_error.args[0] + msg,
+            )
         else:
             log.warning(
                 "Summary of dimension constraints:%s",

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -859,7 +859,7 @@ def export(
         else:
             log.warning(
                 "Summary of dimension constraints:%s",
-                dim_constraints.prettify_results(inspect.signature(f)),
+                msg,
             )
     if constraint_violation_error:
         raise constraint_violation_error

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -27,6 +27,7 @@ from torch import _guards
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 from torch.nn.parallel.distributed import DistributedDataParallel
+
 from ..fx import GraphModule
 from .backends.registry import CompilerFn, lookup_backend
 
@@ -64,7 +65,10 @@ null_context = contextlib.nullcontext
 
 import sympy
 
-from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
+from torch.fx.experimental.symbolic_shapes import (
+    ConstraintViolationError,
+    StrictMinMaxConstraint,
+)
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -822,6 +826,7 @@ def export(
     flat_args, in_spec = pytree.tree_flatten((args, kwargs))
 
     remove_from_cache(f)
+    constraint_violation_error = None
     with patch(f"{__name__}.most_recent_backend", None), config.patch(
         summarize_dim_constraints=True,
         specialize_int=True,
@@ -838,23 +843,32 @@ def export(
             dynamic=(tracing_mode == "symbolic"),
         )(f)
         # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideffects and reject.
-        result_traced = opt_f(*args, **kwargs)
+        try:
+            result_traced = opt_f(*args, **kwargs)
+        except ConstraintViolationError as e:
+            constraint_violation_error = e
     remove_from_cache(f)
+
+    if (shape_env := getattr(fake_mode, "shape_env", None)) is not None:
+        dim_constraints = shape_env.dim_constraints
+        assert dim_constraints is not None
+        dim_constraints.solve()
+        msg = dim_constraints.prettify_results(inspect.signature(f))
+        if constraint_violation_error:
+            constraint_violation_error.args = (constraint_violation_error.args[0] + msg,)
+        else:
+            log.warning(
+                "Summary of dimension constraints:%s",
+                dim_constraints.prettify_results(inspect.signature(f)),
+            )
+    if constraint_violation_error:
+        raise constraint_violation_error
 
     assert (
         graph is not None
     ), "Failed to produce a graph during tracing. Tracing through 'f' must produce a single graph."
     assert out_guards is not None, "Failed to produce guards during tracing"
     assert fake_mode is not None
-
-    if (shape_env := getattr(fake_mode, "shape_env", None)) is not None:
-        dim_constraints = shape_env.dim_constraints
-        assert dim_constraints is not None
-        dim_constraints.solve()
-        log.warning(
-            "Summary of dimension constraints:%s",
-            dim_constraints.prettify_results(inspect.signature(f)),
-        )
 
     matched_input_elements_positions = produce_matching(flat_args, graph_captured_input)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1657,7 +1657,11 @@ class DimConstraints:
             try:
                 solution = sympy.solvers.inequalities.reduce_inequalities(exprs, s)
                 # because this is univariate, the solution is a dynamic (range) constraint
-                self._dynamic_results.add(self._dcp.doprint(solution))
+                if isinstance(solution, sympy.And):
+                    for arg in solution.args:
+                        self._dynamic_results.add(self._dcp.doprint(arg))
+                else:
+                    self._dynamic_results.add(self._dcp.doprint(solution))
             except NotImplementedError as e:
                 log.warning("Failed to reduce inequalities: %s", e)
                 for expr in exprs:
@@ -1684,20 +1688,22 @@ class DimConstraints:
         def unwrap_local_source(source_name):
             return re.sub(r"L\['(.+?)'\]", r'\1', source_name)
 
+        signature = original_signature.replace(return_annotation=inspect.Signature.empty)
+
         buf = ""
         indent = 4 * " "
         if self._static_results:
             sorted_static_results = [unwrap_local_source(res) for res in sorted(self._static_results)]
             buf += "\nThe following dimensions have been specialized and CANNOT be dynamic."
-            buf += "\nNOTE: Specializations will happen by default with `assume_static_by_default=True`."
-            buf += f"\n```\ndef specializations{str(original_signature)}:"
-            buf += f"\n{indent}return (" + f" and\n{indent}".join(sorted_static_results) + ")"
-            buf += "\n```\n"
+            buf += f"\n```\ndef specializations{str(signature)}:"
+            for result in sorted_static_results:
+                buf += f"\n{indent}assert {result}"
+            buf += f"\n```\n"
         if self._dynamic_results:
             sorted_dynamic_results = sorted(self._dynamic_results)
             buf += "\nThe following dimensions CAN be dynamic."
             buf += "\nYou can use the following code to specify the constraints they must satisfy:"
-            buf += f"\n```\ndef specify_constraints{str(original_signature)}:"
+            buf += f"\n```\ndef specify_constraints{str(signature)}:"
             buf += f"\n{indent}return ["
             for result in sorted_dynamic_results:
                 buf += f"\n{indent*2}{unwrap_local_source(result)},"
@@ -2266,8 +2272,7 @@ class ShapeEnv:
                         if isinstance(c, StrictMinMaxConstraint):
                             record_constraint_violation(c, lambda: (
                                 f"Could not validate (strict) constraint {c.render(source)} as "
-                                f"we generated a guard on this size variable: {guard_expr}.  Guard "
-                                f"was allocated at:\n{tb}"
+                                f"we generated a guard on this size variable: {guard_expr}."
                             ))
                         elif isinstance(c, RelaxedUnspecConstraint):
                             # This is fine, we allow guards here as long as it

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1698,7 +1698,7 @@ class DimConstraints:
             buf += f"\n```\ndef specializations{str(signature)}:"
             for result in sorted_static_results:
                 buf += f"\n{indent}assert {result}"
-            buf += f"\n```\n"
+            buf += "\n```\n"
         if self._dynamic_results:
             sorted_dynamic_results = sorted(self._dynamic_results)
             buf += "\nThe following dimensions CAN be dynamic."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100745
* #99993

1. Move constraint violation error after constraint discovery warning, and attach them when we have both.
2. Remove verbose internal traceback for relevant guard in constraint violation error.
3. Remove mention of `assume_static_by_default` in specialization warning.
4. Fix indenting of `specializations` body and make it assert individually instead of returning a conjunction.
5. Remove return annotation on signature used in generated `specializations` and `specify_constraints` functions.
6. Split `&` ranges because we don't support them yet.

Differential Revision: [D45619852](https://our.internmc.facebook.com/intern/diff/D45619852/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire