### PR TITLE
[Functorch] Skip docs setup if called in optimize mode

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -887,12 +887,10 @@ exit(len(w))
 
 class TestPythonOptimizeMode(TestCase):
     def test_runs_with_optimize_flag(self):
-        script = """
-import torch
-"""
+        script = "import torch; import torch._functorch.deprecated"
         try:
             subprocess.check_output(
-                [sys.executable, '-OO', '-c', script],
+                [sys.executable, "-OO", "-c", script],
                 stderr=subprocess.STDOUT,
                 # On Windows, opening the subprocess with the default CWD makes `import torch`
                 # fail, so just set CWD to this script's directory

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -42,6 +42,9 @@ def setup_docs(functorch_api, torch_func_api=None, new_api_name=None):
     api_name = functorch_api.__name__
     if torch_func_api is None:
         torch_func_api = getattr(_impl, api_name)
+    # See https://docs.python.org/3/using/cmdline.html#cmdoption-OO
+    if torch_func_api.__doc__ is None:
+        return
 
     warning = get_warning(api_name, new_api_name)
     warning_note = "\n.. warning::\n\n" + textwrap.indent(warning, "    ")


### PR DESCRIPTION
Test plan: `python3 -OO -c "import torch._functorch.deprecated"`

Fixes https://github.com/pytorch/pytorch/issues/100680


cc @zou3519 @Chillee @samdow @soumith @kshitij12345 @janeyx99