### PR TITLE
Fix get_reordered_tests in run_test.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1233,7 +1233,7 @@ def can_run_in_pytest(test):
     return os.getenv("PYTORCH_TEST_DO_NOT_USE_PYTEST", "0") == "0"
 
 
-def get_selected_tests(options):
+def get_selected_tests(options) -> List[ShardedTest]:
     selected_tests = options.include
 
     # filter if there's JIT only and distributed only test options

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -114,7 +114,7 @@ def calculate_shards(
 
 
 def _query_changed_test_files() -> List[str]:
-    default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'master')}"
+    default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
     cmd = ["git", "diff", "--name-only", default_branch, "HEAD"]
     proc = subprocess.run(cmd, capture_output=True)
 
@@ -126,7 +126,7 @@ def _query_changed_test_files() -> List[str]:
     return lines
 
 
-def get_reordered_tests(tests: List[str]) -> List[str]:
+def get_reordered_tests(tests: List[ShardedTest]) -> List[ShardedTest]:
     """
     Get the reordered test filename list based on github PR history or git changed file.
     We prioritize running test files that were changed.
@@ -151,7 +151,7 @@ def get_reordered_tests(tests: List[str]) -> List[str]:
     the_rest = []
 
     for test in tests:
-        if test in prioritized_tests:
+        if test.name in prioritized_tests:
             bring_to_front.append(test)
         else:
             the_rest.append(test)


### PR DESCRIPTION
i think get_reordered_tests broken since master -> main switch

add typing for some functions

checked for `prioritized` in the logs

limited testing because I only care about one very small part of the log thats near the beginning 
