### PR TITLE
Support runtime assertion for inline constraints

### DIFF
--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -4,12 +4,14 @@ import unittest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch._dynamo.eval_frame import is_dynamo_supported
-from torch._export import export, dynamic_dim
+from torch._export import _export, export, dynamic_dim
+from torch._export.constraints import constrain_as_value
 from torch._export.passes import (
     AddRuntimeAssertionsForConstraintsPass,
     ConstPropPass,
     ReplaceBrokenOpsWithFunctionalOpsPass,
 )
+from functorch.experimental.control_flow import cond
 
 
 def count_call_function(graph: torch.fx.Graph, target: torch.ops.OpOverload) -> int:
@@ -209,6 +211,102 @@ class TestPasses(TestCase):
         eager_result_for_1_size = M().forward(torch.zeros(4, 2, 3), torch.ones(5, 5, 5))
 
         self.assertEqual(gm_result_for_1_size, eager_result_for_1_size)
+
+
+    def test_runtime_assert_inline_constraints_for_item(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                b = x.item()
+                constrain_as_value(b, min=2, max=5)
+                return b
+
+        x = torch.tensor([2])
+        mod = M()
+        gm = _export(mod, (x,))
+
+        pass_result = AddRuntimeAssertionsForConstraintsPass()(gm)
+        new_gm = pass_result.graph_module
+        self.assertTrue(pass_result.modified)
+
+        num_assert = count_call_function(new_gm.graph, torch.ops.aten._assert_async.msg)
+        num_scalar_tensor = count_call_function(new_gm.graph, torch.ops.aten.scalar_tensor.default)
+        # 1 constraint for shape of x, 2 constraints for b
+        self.assertEqual(num_assert, 3)
+        self.assertEqual(num_scalar_tensor, 3)
+
+        with self.assertRaisesRegex(RuntimeError, r"_local_scalar_dense_default is outside of inline constraint \[2, 5\]."):
+            new_gm(torch.tensor([6]))
+
+        new_inp = torch.tensor([5])
+        self.assertEqual(mod(new_inp), new_gm(new_inp))
+
+
+    def test_runtime_assert_inline_constraints_for_nonzero(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                b = x.nonzero()
+                constrain_as_value(b.shape[0], min=3, max=5)
+                return b
+
+        x = torch.tensor([2, 1, 2, 3, 5, 0])
+
+        mod = M()
+        gm = _export(mod, (x,), constraints=[dynamic_dim(x, 0) >= 2])
+
+        pass_result = AddRuntimeAssertionsForConstraintsPass()(gm)
+        new_gm = pass_result.graph_module
+        self.assertTrue(pass_result.modified)
+        num_assert = count_call_function(new_gm.graph, torch.ops.aten._assert_async.msg)
+        num_scalar_tensor = count_call_function(new_gm.graph, torch.ops.aten.scalar_tensor.default)
+
+        # 2 constraints for b
+        self.assertEqual(num_assert, 2)
+        self.assertEqual(num_scalar_tensor, 2)
+
+        new_gm.print_readable()
+        with self.assertRaisesRegex(RuntimeError, r"nonzero_default.shape\[0\] is outside of inline constraint \[3, 5\]."):
+            new_gm(torch.tensor([1, 1, 0, 0, 0]))
+
+        with self.assertRaisesRegex(RuntimeError, r"nonzero_default.shape\[0\] is outside of inline constraint \[3, 5\]."):
+            new_gm(torch.ones(6))
+
+        new_inp = torch.tensor([1, 1, 1, 1])
+        self.assertEqual(mod(new_inp), new_gm(new_inp))
+
+    # FIXME: support control flow operators for the pass
+    @unittest.expectedFailure
+    def test_runtime_assert_inline_constraints_for_cond(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x, y):
+                def true_fn(x, y):
+                    b = x.item()
+                    constrain_as_value(b, min=2, max=5)
+                    return x
+
+                def false_fn(x, y):
+                    c = y.item()
+                    constrain_as_value(c, min=2, max=5)
+                    return y
+
+                ret = cond(pred, true_fn, false_fn, [x, y])
+                return ret
+
+        x = torch.tensor([2])
+        y = torch.tensor([5])
+        mod = M()
+        gm = _export(mod, (torch.tensor(True), x, y))
+
+        _ = AddRuntimeAssertionsForConstraintsPass()(gm)
+
 
 
 if __name__ == '__main__':

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -836,7 +836,6 @@ def export(
 
     fake_mode = None
     example_inputs = []
-    var_to_range_map = {}
 
     def dynamo_normalization_capturing_compiler(
         gm: torch.fx.GraphModule, inner_example_inputs
@@ -847,11 +846,9 @@ def export(
         ), "Tried to emit a second graph during export. Tracing through 'f' must produce a single graph."
         graph = gm
 
-        nonlocal fake_mode, example_inputs, var_to_range_map
+        nonlocal fake_mode, example_inputs
         fake_mode = _guards.detect_fake_mode(inner_example_inputs)
         example_inputs = inner_example_inputs
-        if fake_mode and fake_mode.shape_env:
-            var_to_range_map = fake_mode.shape_env.var_to_range
 
         def result_capturing_wrapper(*graph_inputs):
             nonlocal graph_captured_result
@@ -1019,13 +1016,22 @@ def export(
         if constraints
         else None
     )
-    new_graph.meta["inline_constraints"] = {
-        node.meta["val"].node.expr: var_to_range_map[node.meta["val"].node.expr]
-        for node in new_graph.graph.nodes
-        if node.op != "placeholder" and "val" in node.meta
-        # Find constraints frome unbacked symints
-        and re.match(r"^i\d+$", str(node.meta["val"]))
-    }
+
+    if (shape_env := getattr(fake_mode, "shape_env", None)) is not None:
+        dim_constraints = shape_env.dim_constraints
+        assert dim_constraints is not None
+        dim_constraints.solve()
+        log.warning(
+            "Summary of dimension constraints:%s",
+            dim_constraints.prettify_results(inspect.signature(f)),
+        )
+
+        # Inline constraints added by users correspond to unbacked symbols in shape_env,
+        new_graph.meta["inline_constraints"] = {
+            k: v
+            for k, v in shape_env.var_to_range.items()
+            if re.match(r"^[if]\d+$", str(k))
+        }
 
     def signature_to_fullargspec(sig: inspect.Signature):
         # Get a list of Parameter objects from the Signature object

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -1,4 +1,5 @@
 from collections import defaultdict, namedtuple
+from functools import partial
 from typing import Dict, List, Tuple, Optional
 
 import math
@@ -19,6 +20,16 @@ __all__ = ["AddRuntimeAssertionsForConstraintsPass"]
 
 ConstraintSpec = namedtuple("ConstraintSpec", ["constraint_dim", "min_val", "max_val"])
 
+# Convert simple sympy Integers into concrete int to
+# insert into graph
+def _convert_to_int(val):
+    if val == sympy.oo:
+        return math.inf
+    if isinstance(val, sympy.Integer):
+        return int(val)
+    raise RuntimeError(
+        "Export constraints cannot be non-integer expressions"
+    )
 
 class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
     def __init__(self) -> None:
@@ -32,16 +43,6 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         if constraints is None:
             return constraints_id_to_constraint
 
-        # Convert simple sympy Integers into concrete int to
-        # insert into graph
-        def _convert_to_int(val):
-            if val == sympy.oo:
-                return math.inf
-            if isinstance(val, sympy.Integer):
-                return int(val)
-            raise RuntimeError(
-                "Export constraints cannot be non-integer expressions"
-            )
 
         constraint_id_to_dim: Dict[int, Dict[int, List[Tuple[int, int]]]] = defaultdict(
             lambda: defaultdict(list)
@@ -76,6 +77,7 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         assert isinstance(self.current_gm, torch.fx.GraphModule)
         self.constraints = self._process_constraints(get_export_meta(self.current_gm).input_shape_constraints)
         self.example_inputs = pytree.tree_flatten(get_export_meta(self.current_gm).example_inputs)[0]
+        self.inline_constraints = get_export_meta(self.current_gm).inline_constraints
         return super().call(graph_module)
 
     def _insert_specialized_shapes_assert(self, arg, dims, current_inp):
@@ -86,25 +88,25 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
                 f"Input #{self.input_tracker}'s dimension #{dim} size is "
                 f"specialized at {shapes[dim]}"
             )
-            dim_node = self.call_operator(
+            dim_node = super().call_operator(
                 torch.ops.aten.sym_size,
                 (arg, dim),
                 {},
                 NodeMetadata({}),
             )
-            eq = self.call_operator(
+            eq = super().call_operator(
                 operator.eq,
                 (dim_node, shapes[dim]),
                 {},
                 NodeMetadata({}),
             )
-            tensor_eq = self.call_operator(
+            tensor_eq = super().call_operator(
                 torch.ops.aten.scalar_tensor.default,
                 (eq,),
                 {},
                 NodeMetadata({}),
             )
-            self.call_operator(
+            super().call_operator(
                 torch.ops.aten._assert_async.msg,
                 (tensor_eq, assert_msg),
                 {},
@@ -131,7 +133,7 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         # x[1] == x[0])
         for constraint in constraints:
             constrained_dims.add(constraint.constraint_dim)
-            dim = self.call_operator(
+            dim = super().call_operator(
                 torch.ops.aten.sym_size,
                 (arg, constraint.constraint_dim),
                 {},
@@ -147,45 +149,7 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
             # 1. if we can generalize to N < 2, not add any assertion saying N >= 2
             # 2. If we can't generalize to N < 2, add an assertion saying N >= 2
             # Above can be achieved via a seperate pass.
-            if constraint.min_val > 2:
-                ge = self.call_operator(
-                    operator.ge,
-                    (dim, constraint.min_val),
-                    {},
-                    NodeMetadata({}),
-                )
-                tensor_ge = self.call_operator(
-                    torch.ops.aten.scalar_tensor.default,
-                    (ge,),
-                    {},
-                    NodeMetadata({}),
-                )
-                self.call_operator(
-                    torch.ops.aten._assert_async.msg,
-                    (tensor_ge, assert_msg),
-                    {},
-                    NodeMetadata({}),
-                )
-
-            if constraint.max_val < math.inf:
-                le = self.call_operator(
-                    operator.le,
-                    (dim, constraint.max_val),
-                    {},
-                    NodeMetadata({}),
-                )
-                tensor_le = self.call_operator(
-                    torch.ops.aten.scalar_tensor.default,
-                    (le,),
-                    {},
-                    NodeMetadata({}),
-                )
-                self.call_operator(
-                    torch.ops.aten._assert_async.msg,
-                    (tensor_le, assert_msg),
-                    {},
-                    NodeMetadata({}),
-                )
+            self._assert_constraint(dim, constraint.min_val, constraint.max_val, assert_msg, low_threshold=2)
 
         specialized_dims = all_dims - constrained_dims
         # Make all non-constrained dims to be static
@@ -194,4 +158,67 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         # TODO Add relational constraints
         self.input_tracker += 1
         return arg
-    # TODO implement adding inline constraints as assertion
+
+
+    def _assert_constraint(self, proxy, lower, upper, assert_msg, low_threshold=2):
+        if lower > low_threshold:
+            self._insert_assert_async(operator.ge, proxy, lower, assert_msg)
+
+        if upper < math.inf:
+            self._insert_assert_async(operator.le, proxy, upper, assert_msg)
+
+    def _insert_assert_async(self, operator, l, r, assert_msg):
+        cmp = super().call_operator(operator, (l, r), {}, NodeMetadata({}))
+        cmp_tensor = super().call_operator(torch.ops.aten.scalar_tensor.default, (cmp,), {}, NodeMetadata({}))
+        super().call_operator(
+            torch.ops.aten._assert_async.msg,
+            (cmp_tensor, assert_msg),
+            {},
+            NodeMetadata({}),
+        )
+
+    def call_operator(self, op, args, kwargs, meta) -> ProxyValue:
+        ret = super().call_operator(op, args, kwargs, meta)
+        if "val" in meta:
+            val = meta["val"]
+
+            # In general, we may have to deal the case such as: ret[1].shape[0].
+            # We need first find out what symbols require assertion, then we need to follow the path
+            # from ret to the symbol, construct the proxies along the way and construct the messages
+            # piece-wise at the same time.
+            #
+            # We use post-order traversal to collect all the proxies callbacks needed, construct
+            # the error message callbacks, and at the top-level traversal tree we execute all the callbacks.
+            # We need the callbacks because, in order to call the function to create a proxy for shape[0], we
+            # need the proxy for shape, which further requries the proxy for ret[1], etc.
+            def add_assertions(val):
+                call_backs = []
+                messages = []
+                if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+                    expr = val.node._expr
+                    if expr in self.inline_constraints:
+                        constraint = self.inline_constraints[expr]
+                        lower = _convert_to_int(constraint.lower)
+                        upper = _convert_to_int(constraint.upper)
+                        assert_msg = f" is outside of inline constraint [{lower}, {upper}]."
+                        call_backs.append(partial(self._assert_constraint, lower=lower, upper=upper, low_threshold=-1))
+                        messages.append(assert_msg)
+                elif isinstance(val, torch.Tensor):
+                    for i, sym in enumerate(val.shape):
+                        cbs, msgs = add_assertions(sym)
+                        for cb, msg in zip(cbs, msgs):
+                            def sym_size_cb(proxy, assert_msg, dim):
+                                dim_proxy = super(AddRuntimeAssertionsForConstraintsPass, self).call_operator(
+                                    torch.ops.aten.sym_size,
+                                    (proxy, dim),
+                                    {},
+                                    NodeMetadata({}),
+                                )
+                                cb(proxy=dim_proxy, assert_msg=assert_msg)
+                            call_backs.append(partial(sym_size_cb, dim=i))
+                            messages.append(f".shape[{i}]" + msg)
+                return call_backs, messages
+            callbacks, messages = add_assertions(val)
+            for cb, msg in zip(callbacks, messages):
+                cb(proxy=ret, assert_msg=f"{ret.node}" + msg)
+        return ret

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -328,7 +328,6 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
         if not (min <= int(a.node.expr) <= max):
             raise ValueRangeError(f"Invalid value {int(a.node.expr)} for range [{min}:{max}]")
         return
-    # TODO: Turn this into a runtime assert too
     assert isinstance(a.node.expr, sympy.Symbol), "constraining non-Symbols NYI"
     # TODO: Shouldn't we install a guard if the symbol is backed?  Or is the
     # semantics that this is an "unchecked" assert (but it this actually


### PR DESCRIPTION
This pr does the following:
1. previously, inline constraints is not properly set for tensor output data-dependent ops such as a.nonzero because of its return value is not symint. This pr just uses all the unbacked symbols i.e.those start with "i"/"f" in create_unbacked_sym* functions. Note that these symbols are guaranteed to be a super set of inline user constraints.

2. add inline assertions support by checking.

Currently, it only deal with tensor, SymInt, SymFloat, SymBool output data-dependent ops and ignore the rest. It's good enough for now as we only have a limited number of data-dependent ops (.item and .nonzero are explicitly tested).

The examples for graph that is added assertions is shown below:

```
class ExportGraphModule(torch.nn.Module):
    def forward(self, x):
        arg0: i64[s0], = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
        nonzero_default: i64[i0, 1] = torch.ops.aten.nonzero.default(arg0);  arg0 = None
        return pytree.tree_unflatten([nonzero_default], self._out_spec)
        
class GraphModule(torch.nn.Module):
    def forward(self, x):
        arg0: i64[s0], = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
        sym_size: Sym(s0) = torch.ops.aten.sym_size(arg0, 0)
        nonzero_default: i64[i1, 1] = torch.ops.aten.nonzero.default(arg0);  arg0 = None
        sym_size_1: Sym(i1) = torch.ops.aten.sym_size(nonzero_default, 0)
        ge: Sym(i1 >= 3) = sym_size_1 >= 3
        scalar_tensor_default: f32[] = torch.ops.aten.scalar_tensor.default(ge);  ge = None
        _assert_async_msg = torch.ops.aten._assert_async.msg(scalar_tensor_default, 'nonzero_default.shape[0] is outside of inline constraint [3, 5].');  scalar_tensor_default = None
        le: Sym(i1 <= 5) = sym_size_1 <= 5;  sym_size_1 = None
        scalar_tensor_default_1: f32[] = torch.ops.aten.scalar_tensor.default(le);  le = None
        _assert_async_msg_1 = torch.ops.aten._assert_async.msg(scalar_tensor_default_1, 'nonzero_default.shape[0] is outside of inline constraint [3, 5].');  scalar_tensor_default_1 = None
        return pytree.tree_unflatten([nonzero_default], self._out_spec)
```

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire