### PR TITLE
[MPS] Fix unary ops over sparse-mapped tensors

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -313,6 +313,15 @@ MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
      ", downcasting to a smaller data type (int32/float32). Native support for int64 has been added in macOS 13.3.");   \
   }
 
+/**
+ * Computes number of elements one needs to transfer to preserve all the elements
+ */
+size_t compute_strided_size(const at::Tensor& t);
+
+inline bool is_strided_contiguous(const at::Tensor& t) {
+  return compute_strided_size(t) == static_cast<size_t>(t.numel());
+}
+
 } // namespace mps
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -314,12 +314,15 @@ MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
   }
 
 /**
- * Computes number of elements one needs to transfer to preserve all the elements
+ * Returns distance from lowest to highest element offset in given tensor.
  */
-size_t compute_strided_size(const at::Tensor& t);
+size_t compute_storage_numel_distance(const at::Tensor& t);
 
-inline bool is_strided_contiguous(const at::Tensor& t) {
-  return compute_strided_size(t) == static_cast<size_t>(t.numel());
+/**
+ * Checks whether tensor is mapped to a contiguous area in the storage.
+ */
+inline bool is_dense_in_storage(const at::Tensor& t) {
+  return compute_storage_numel_distance(t) == static_cast<size_t>(t.numel());
 }
 
 } // namespace mps

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -13,6 +13,21 @@
 
 namespace at::native::mps {
 
+/**
+ * Computes number of elements one needs to transfer to preserve all the elements
+ */
+size_t compute_strided_size(const at::Tensor& t) {
+  size_t rc = 1;
+  if (t.numel() == 0) {
+    return 0;
+  }
+  for (const auto i : c10::irange(t.dim())) {
+    assert(t.size(i) > 0);
+    rc += (t.size(i) - 1) * t.stride(i);
+  }
+  return rc;
+}
+
 void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results) {
   mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE);
 }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -14,9 +14,9 @@
 namespace at::native::mps {
 
 /**
- * Computes number of elements one needs to transfer to preserve all the elements
+ * Computes distance from lowest to highest element offset in given tensor.
  */
-size_t compute_strided_size(const at::Tensor& t) {
+size_t compute_storage_numel_distance(const at::Tensor& t) {
   size_t rc = 1;
   if (t.numel() == 0) {
     return 0;

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -20,24 +20,6 @@ void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedB
   return (void*)alignedAddress;
 }
 
-/**
- * Computes number of elements one needs to transfer to preserve all the elements
- */
-size_t compute_strided_size(const at::Tensor& t) {
-  size_t rc = 1;
-  if (t.numel() == 0) {
-    return 0;
-  }
-  for (const auto i : c10::irange(t.dim())) {
-    assert(t.size(i) > 0);
-    rc += (t.size(i) - 1) * t.stride(i);
-  }
-  return rc;
-}
-
-bool is_strided_contiguous(const at::Tensor& t) {
-  return compute_strided_size(t) == static_cast<size_t>(t.numel());
-}
 
 // Copy sourceBuffer into destBuffer, casting sourceBuffer to src.scalar_type().
 // The shapes and dtypes are taken from dst and src, but their storage pointers are not used.

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -20,7 +20,6 @@ void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedB
   return (void*)alignedAddress;
 }
 
-
 // Copy sourceBuffer into destBuffer, casting sourceBuffer to src.scalar_type().
 // The shapes and dtypes are taken from dst and src, but their storage pointers are not used.
 void copy_cast_mps(at::Tensor& dst,

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -90,7 +90,6 @@ void unary_op(const Tensor& self,
       self_ = self;
     }
 
-
     bool gatherTensorData = true;
     // NS: This check is wrong and needs to be fixed, as it would produce wrong results for transposed outputs
     // See https://github.com/pytorch/pytorch/issues/100764

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -1,5 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -80,13 +81,26 @@ void unary_op(const Tensor& self,
       newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
     });
 
+    // If self is not a sparse-contiguous, create a dense output-like representation
+    at::Tensor self_;
+    if (!is_strided_contiguous(self)) {
+      self_ = at::empty_like(output);
+      mps::mps_copy_(self_, self, false);
+    } else {
+      self_ = self;
+    }
+
+
     bool gatherTensorData = true;
+    // NS: This check is wrong and needs to be fixed, as it would produce wrong results for transposed outputs
+    // See https://github.com/pytorch/pytorch/issues/100764
+
     if (!output.is_contiguous() || output.is_view()) {
       gatherTensorData = false;
     }
 
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, /*mpsShape=*/nullptr, gatherTensorData);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, /*mpsShape=*/nullptr, false);
+    auto selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self_, /*mpsShape=*/nullptr, gatherTensorData);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, /*mpsShape=*/nullptr, false);
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =
         @{selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData()};
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -81,9 +81,9 @@ void unary_op(const Tensor& self,
       newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
     });
 
-    // If self is not a sparse-contiguous, create a dense output-like representation
+    // If self is densely mapped in storage, create a dense output-like representation
     at::Tensor self_;
-    if (!is_strided_contiguous(self)) {
+    if (!is_dense_in_storage(self)) {
       self_ = at::empty_like(output);
       mps::mps_copy_(self_, self, false);
     } else {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6620,6 +6620,14 @@ class TestNLLLoss(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
+    def test_neg_strided_input(self):
+        # See https://github.com/pytorch/pytorch/issues/98074#issuecomment-1496088337
+        x = torch.arange(18.0, device='mps').reshape(2, 3, 3)
+        y = x.permute(1, 0, 2)[..., 1]
+        z = y + y.neg()
+        self.assertEqual(z.abs().max().item(), 0.0)
+
+
     # Test index add
     def test_index_add(self):
         def helper(shape, dim, index, source_shape, alpha, x_dtype=torch.float32, idx_dtype=torch.int32):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6627,7 +6627,6 @@ class TestNLLLoss(TestCaseMPS):
         z = y + y.neg()
         self.assertEqual(z.abs().max().item(), 0.0)
 
-
     # Test index add
     def test_index_add(self):
         def helper(shape, dim, index, source_shape, alpha, x_dtype=torch.float32, idx_dtype=torch.int32):


### PR DESCRIPTION
If input tensor is backed by a sparse view, create a dense copy before running unary op, otherwise op will be applied against the wrong elements. 
Introduce `is_dense_in_storage` that returns true if tensor/view are mapped to a dense area in  the tensor storage. 
Add unit test to validate the fix.

Fixes https://github.com/pytorch/pytorch/issues/98074