### PR TITLE
Refactor is_causal detection into subroutine and clarify doc strings that is_causal is a hint

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3813,7 +3813,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         encoder_input_shape = correct_encoder_input_shape
         decoder_input_shape = correct_decoder_input_shape
         wrong_tgt_mask_size = tgt_len + 1
-        test(encoder_input_shape, decoder_input_shape, tgt_mask_len=wrong_tgt_mask_size, raises=True)
+        test(encoder_input_shape, decoder_input_shape, tgt_mask_len=wrong_tgt_mask_size)
 
         # Incorrect memory_mask
         encoder_input_shape = correct_encoder_input_shape

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -650,8 +650,9 @@ class TestTransformers(NNTestCase):
         d_model = 3
         layer = torch.nn.TransformerEncoderLayer(d_model, 1, 6, batch_first=True)
         layer.eval()
-        x = torch.randn(1, 5, d_model)
+        x = torch.randn(1, 5, d_model) # float
         unmasked_output = layer(x)
+        # double
         mask = torch.nn.Transformer.generate_square_subsequent_mask(x.size(1))
         is_causal_output = layer(x, src_mask=mask, is_causal=True)
         masked_output = layer(x, src_mask=mask)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5210,12 +5210,19 @@ def multi_head_attention_forward(
         target_type=query.dtype
     )
 
-    if is_causal and attn_mask is None:
-        raise RuntimeError(
-            "Need attn_mask if specifying the is_causal hint. "
-            "You may use the Transformer module method "
-            "`generate_square_subsequent_mask` to create this mask."
-        )
+    if is_causal:
+        if attn_mask is None:
+            raise RuntimeError(
+                "Need attn_mask if specifying the is_causal hint. "
+                "You may use the Transformer module method "
+                "`generate_square_subsequent_mask` to create this mask."
+            )
+        else:
+            print(f"attn_mask size {attn_mask.size()}")
+            print(f"src len {src_len}")
+            print(f"tgt len {tgt_len}")
+            print(f"emd_dim {embed_dim}")
+            # check attn_mask vs input size
 
     if is_causal and key_padding_mask is None and not need_weights:
         # when we have a kpm or need weights, we need attn_mask

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1079,6 +1079,9 @@ class MultiheadAttention(Module):
             corresponding position is not allowed to attend. For a float mask, the mask values will be added to
             the attention weight.
             If both attn_mask and key_padding_mask are supplied, their types should match.
+        average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
+            heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
+            effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
         is_causal: If specified, applies a causal mask as attention mask.
             Default: ``False``.
             Warning:
@@ -1086,9 +1089,6 @@ class MultiheadAttention(Module):
             causal mask. Providing incorrect hints can result in
             incorrect execution, including forward and backward
             compatibility.
-        average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
-            heads. Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an
-            effect when ``need_weights=True``. Default: ``True`` (i.e. average weights across heads)
 
     Outputs:
         - **attn_output** - Attention outputs of shape :math:`(L, E)` when input is unbatched,

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1712,6 +1712,23 @@ def module_inputs_torch_nn_TransformerEncoderLayer(module_info, device, dtype, r
     return samples
 
 
+def module_inputs_torch_nn_TransformerDecoder(module_info, device, dtype, requires_grad, training, **kwargs):
+    # Reuse the TransformerDecoderLayer samples since the forward args are the same.
+    for layer_module_input in module_inputs_torch_nn_TransformerDecoderLayer(
+            None, device, dtype, requires_grad, training):
+        # Construct a TransformerDecoderLayer object to pass to TransformerDecoder.
+        l_args, l_kwargs = (layer_module_input.constructor_input.args,
+                            layer_module_input.constructor_input.kwargs)
+        decoder_layer = torch.nn.TransformerDecoderLayer(*l_args, **l_kwargs)
+        num_layers = 2
+        forward_input = layer_module_input.forward_input
+        yield ModuleInput(
+            constructor_input=FunctionInput(decoder_layer, num_layers),
+            forward_input=forward_input,
+            desc=layer_module_input.desc
+        )
+
+
 def module_inputs_torch_nn_TransformerDecoderLayer(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -2848,6 +2865,16 @@ module_db: List[ModuleInfo] = [
                skips=(
                    # No channels_last support for TransformerEncoderLayer currently.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),
+                   DecorateInfo(skipIfMps, 'TestModule', dtypes=[torch.float64]),)
+               ),
+    ModuleInfo(torch.nn.TransformerDecoder,
+               module_inputs_func=module_inputs_torch_nn_TransformerDecoder,
+               skips=(
+                   # No channels_last support for TransformerDecoderLayer currently.
+                   DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),
+                   # Doesn't support device / dtype kwargs directly because it is just a
+                   # container of TransformerDecoderLayers.
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_factory_kwargs'),
                    DecorateInfo(skipIfMps, 'TestModule', dtypes=[torch.float64]),)
                ),
     ModuleInfo(torch.nn.TransformerDecoderLayer,


### PR DESCRIPTION
Summary:
* Clarify documentation that is_causal is a hint
* Refactor by putting is_causal detection in a separate utility function

Split from janEbert's
"Implement is_causal API for Transformer #98327"

Differential Revision: D45628308

