### PR TITLE
[cpu inductor] fix comparison ops.

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1558,6 +1558,21 @@ class CPUReproTests(TestCase):
         self.assertTrue(same(fn(x), opt_fn(x)))
         assert metrics.generated_cpp_vec_kernel_count == 1
 
+    def test_comparison_ops(self):
+        # https://github.com/pytorch/pytorch/issues/100466
+
+        comparison_ops = (torch.ge, torch.le, torch.gt, torch.lt, torch.eq, torch.ne)
+        for op in comparison_ops:
+
+            def fn(x):
+                return op(x, 0) * 4.0
+
+            metrics.reset()
+            x = torch.randn(3, 3)
+            opt_fn = torch._dynamo.optimize("inductor")(fn)
+            self.assertTrue(same(fn(x), opt_fn(x)))
+            assert metrics.generated_cpp_vec_kernel_count == 1
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -569,8 +569,11 @@ class CppVecOverrides(OpOverrides):
         return f"{a} * {a}"
 
     @staticmethod
-    def where(a, b, c):
-        return f"decltype({b})::blendv({c}, {b}, {a})"
+    def where(condition, x, y):
+        # blendv copies from first vector if MSB of condition is
+        # 0 otherwise from second vector.
+        # `condition != 0` is required to set-up mask as per above for blendv
+        return f"decltype({x})::blendv({y}, {x}, {condition} != 0)"
 
     @staticmethod
     def sign(x):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -347,27 +347,27 @@ class CppVecOverrides(OpOverrides):
 
     @staticmethod
     def eq(x, y):
-        return f"to_float_mask({x} == {y})"
+        return f"to_float_mask({x}.eq({y}))"
 
     @staticmethod
     def ne(x, y):
-        return f"to_float_mask({x} != {y})"
+        return f"to_float_mask({x}.ne({y}))"
 
     @staticmethod
     def lt(x, y):
-        return f"to_float_mask({x} < {y})"
+        return f"to_float_mask({x}.lt({y}))"
 
     @staticmethod
     def gt(x, y):
-        return f"to_float_mask({x} > {y})"
+        return f"to_float_mask({x}.gt({y}))"
 
     @staticmethod
     def le(x, y):
-        return f"to_float_mask({x} <= {y})"
+        return f"to_float_mask({x}.le({y}))"
 
     @staticmethod
     def ge(x, y):
-        return f"to_float_mask({x} >= {y})"
+        return f"to_float_mask({x}.ge({y}))"
 
     @staticmethod
     def and_(x, y):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/100466

Context (copied from https://github.com/pytorch/pytorch/issues/100466#issuecomment-1537118627):

The problem is because CPU inductor calls `>=` operator which just boils down to `_mm256_cmp_ps` which, for true, returns all bits set to 1s i.e. NaN.

https://github.com/pytorch/pytorch/blob/44caa395cb6a7f3a4efece66df4d5608aae51a64/torch/_inductor/codegen/cpp.py#L368-L370

https://github.com/pytorch/pytorch/blob/44caa395cb6a7f3a4efece66df4d5608aae51a64/aten/src/ATen/cpu/vec/vec256/vec256_float.h#L324-L326

However, we should use `ge` which handles converting this NaN to 1. Eager mode also calls into this.
https://github.com/pytorch/pytorch/blob/44caa395cb6a7f3a4efece66df4d5608aae51a64/aten/src/ATen/cpu/vec/vec256/vec256_float.h#L423-L425

NOTE: This is also true for other comparison operators.

Godbolt Repro: https://godbolt.org/z/vT7naqqKx




cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire