### PR TITLE
handle new param from torch.compile (Inductor pattern matcher), enable_log

### DIFF
--- a/torch/distributed/_spmd/aot_function_patch.py
+++ b/torch/distributed/_spmd/aot_function_patch.py
@@ -21,6 +21,7 @@ def patched_aot_function(
     num_params_buffers: int = 0,
     keep_inference_input_mutations: bool = False,
     pre_compile_fn: Optional[Callable[..., object]] = None,
+    enable_log: bool = False,
 ) -> Callable[..., object]:
     """
     NOTE: rationale for patch.


### PR DESCRIPTION
This PR puts a placeholder param handler for a new param being passed in from Inductor, enable log.  
Fixes this error below, where I've been unable to run torch.compile on NanoGPT due to this error:

~~~
File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/_inductor/fx_passes/fuse_attention.py", line 219, in _sfdp_init
    register_replacement(
  File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/_inductor/pattern_matcher.py", line 658, in register_replacement
    search_gm = trace_fn(search_fn, example_inputs)
  File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/envs/pytorch/lib/python3.9/site-packages/torch/_inductor/pattern_matcher.py", line 828, in training_graph
    aot_function(
torch._dynamo.exc.BackendCompilerFailed: backend='compile_fn' raised:
TypeError: patched_aot_function() got an unexpected keyword argument 'enable_log'
~~~


