### PR TITLE
implement a function to materialize a copy-on-write storage

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -2,7 +2,20 @@
 
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <cstring>
+
 namespace c10 {
+
+DataPtr Allocator::clone(const void* data, std::size_t n) const {
+  DataPtr new_data = allocate(n);
+  copy_data(new_data.mutable_get(), data, n);
+  return new_data;
+}
+
+void Allocator::copy_data(void* dest, const void* src, std::size_t count)
+    const {
+  std::memcpy(dest, src, count);
+}
 
 static void deleteInefficientStdFunctionContext(void* ptr) {
   delete static_cast<InefficientStdFunctionContext*>(ptr);

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -4,6 +4,8 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/SymInt.h>
 #include <c10/core/impl/PyObjectSlot.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/core/impl/cow/materialize.h>
 
 #include <c10/util/intrusive_ptr.h>
 
@@ -135,6 +137,9 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   void* mutable_data() {
+    if (data_ptr_.get_deleter() == impl::cow::delete_context) {
+      impl::cow::materialize(*this);
+    }
     return data_ptr_.mutable_get();
   }
 

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -64,7 +64,10 @@ def define_targets(rules):
                 "impl/alloc_cpu.cpp",
                 "impl/cow/*.cpp",
             ],
-        ),
+        ) + [
+            "impl/cow/materialize.cpp",
+            "impl/cow/materialize.h",
+        ],
         hdrs = rules.glob(
             [
                 "*.h",

--- a/c10/core/impl/cow/materialize.cpp
+++ b/c10/core/impl/cow/materialize.cpp
@@ -1,0 +1,54 @@
+#include <c10/core/impl/cow/materialize.h>
+
+#include <c10/core/Allocator.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/impl/cow/context.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/util/Exception.h>
+
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace c10::impl {
+
+auto C10_API cow::materialize(StorageImpl& storage) -> void {
+  at::DataPtr& data_ptr = storage.mutable_data_ptr();
+
+  auto* ctx = data_ptr.cast_context<cow::Context>(cow::delete_context);
+  TORCH_INTERNAL_ASSERT(ctx != nullptr);
+
+  auto result = ctx->decrement_refcount();
+
+  // This must be set by each of the branches below.
+  std::optional<DataPtr> new_data_ptr;
+
+  if (std::holds_alternative<cow::Context::LastReference>(result)) {
+    // This is the only alias left on the data. If there were any
+    // racing writes, the context ensured they finished before giving
+    // us the result.
+    std::unique_ptr<void, DeleterFnPtr> data =
+        std::get<cow::Context::LastReference>(std::move(result));
+    TORCH_INTERNAL_ASSERT(data.get() == data_ptr.get());
+    new_data_ptr = DataPtr(
+        data.release(),
+        data_ptr.mutable_get(),
+        data.get_deleter(),
+        data_ptr.device());
+  } else {
+    TORCH_INTERNAL_ASSERT(
+        std::holds_alternative<cow::Context::NotLastReference>(result));
+    // We don't need to consume the result, it's just a shared lock
+    // ensuring that the data will remain while we copy it.
+    new_data_ptr = storage.allocator()->allocate(storage.nbytes());
+    std::memcpy(new_data_ptr->get(), data_ptr.get(), storage.nbytes());
+  }
+
+  TORCH_INTERNAL_ASSERT(new_data_ptr.has_value());
+  DataPtr old_data_ptr = storage.set_data_ptr(*std::move(new_data_ptr));
+  old_data_ptr.release_context(); // already deleted by decrement_refcount
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/cow/materialize.h
+++ b/c10/core/impl/cow/materialize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+struct StorageImpl;
+}; // namespace c10
+
+namespace c10 {
+namespace impl {
+namespace cow {
+
+/// Eagerly copies the data marked for lazy-copy in storage.
+///
+/// Requires: storage has a copy-on-write context.
+auto C10_API materialize(StorageImpl& storage) -> void;
+
+} // namespace cow
+} // namespace impl
+} // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3339,6 +3339,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     }
     return {r, r, &local_raw_delete, Device(DeviceType::CUDA, device)};
   }
+
   DeleterFnPtr raw_deleter() const override {
     if (forceUncachedAllocator()) {
       return &uncached_delete;
@@ -3504,6 +3505,12 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
   std::string name() override {
     return "native";
+  }
+
+ private:
+  void copy_data(void* dest, const void* src, std::size_t count) const final {
+    C10_CUDA_CHECK(
+        cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
   }
 };
 

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -19,6 +19,18 @@ def define_targets(rules):
     )
 
     rules.cc_test(
+        name = "core/impl/cow/materialize_test",
+        srcs = ["core/impl/cow/materialize_test.cpp"],
+        deps = [
+            "//c10/core:CPUAllocator",
+            "//c10/core:base",
+            "//c10/core:impl/cow/context",
+            "//c10/core:impl/cow/try_ensure",
+            "@com_google_googletest//:gtest_main",
+        ],
+    )
+
+    rules.cc_test(
         name = "core/impl/cow/try_ensure_test",
         srcs = ["core/impl/cow/try_ensure_test.cpp"],
         deps = [

--- a/c10/test/core/impl/cow/materialize_test.cpp
+++ b/c10/test/core/impl/cow/materialize_test.cpp
@@ -1,0 +1,89 @@
+#include <c10/core/CPUAllocator.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/impl/cow/context.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/core/impl/cow/try_ensure.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <string_view>
+
+namespace c10::impl {
+namespace {
+
+MATCHER(is_copy_on_write, "") {
+  const c10::StorageImpl& storage_impl = std::ref(arg);
+  return storage_impl.data_ptr().get_deleter() == cow::delete_context;
+}
+
+TEST(materialize_test, not_copy_on_write_context) {
+  StorageImpl storage(
+      {}, /*size_bytes=*/7, GetCPUAllocator(), /*resizable=*/false);
+  ASSERT_THAT(storage, testing::Not(is_copy_on_write()));
+
+  void const* original_data = storage.data();
+
+  // Nothing to materialize.
+  ASSERT_THAT(storage.mutable_data(), testing::Eq(original_data));
+}
+
+TEST(materialize_test, copy_on_write_single_reference) {
+  // A copy-on-write storage with only a single reference can just
+  // drop the copy-on-write context upon materialization.
+  std::unique_ptr<void, DeleterFnPtr> data(
+      new std::byte[5],
+      +[](void* bytes) { delete[] static_cast<std::byte*>(bytes); });
+  void* data_ptr = data.get();
+  StorageImpl storage(
+      {},
+      /*size_bytes=*/5,
+      at::DataPtr(
+          /*data=*/data_ptr,
+          /*ctx=*/new cow::Context(std::move(data)),
+          cow::delete_context,
+          Device(Device::Type::CPU)),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+
+  ASSERT_THAT(storage, is_copy_on_write());
+
+  ASSERT_THAT(storage.data(), testing::Eq(data_ptr));
+
+  void const* original_data = storage.data();
+
+  // Materializes storage. Only reference, so no new allocation.
+  ASSERT_THAT(storage.mutable_data(), testing::Eq(original_data));
+  // But it is no longer copy-on-write.
+  ASSERT_THAT(storage, testing::Not(is_copy_on_write()));
+}
+
+TEST(materialize_test, copy_on_write) {
+  StorageImpl original_storage(
+      {}, /*size_bytes=*/7, GetCPUAllocator(), /*resizable=*/false);
+  std::memcpy(original_storage.mutable_data(), "abcd", 5);
+  void const* original_data = original_storage.data();
+
+  auto new_storage = cow::try_ensure(original_storage);
+  ASSERT_THAT(new_storage, testing::NotNull());
+
+  auto context =
+      new_storage->data_ptr().cast_context<cow::Context>(cow::delete_context);
+  ASSERT_THAT(context, testing::NotNull());
+
+  // Materialized storage has new copy of data.
+  ASSERT_THAT(new_storage->mutable_data(), testing::Ne(original_data));
+
+  // But the original storage still has the original copy.
+  ASSERT_THAT(original_storage.data(), testing::Eq(original_data));
+
+  // But their data is the same.
+  ASSERT_THAT(
+      static_cast<char const*>(new_storage->data()),
+      testing::StrEq(static_cast<char const*>(original_storage.data())));
+}
+
+} // namespace
+} // namespace c10::impl


### PR DESCRIPTION
implement a function to materialize a copy-on-write storage

Summary:
This is triggered if the storage is copy-on-write whenever mutable
access to a DataPtr is given.

Test Plan: 100% code coverage

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/100820).
* #100821
* __->__ #100820

cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh