### PR TITLE
add new private operator copy-on-write torch._lazy_clone

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -368,6 +368,7 @@ cc_library(
         ":aten_headers",
         ":caffe2_for_aten_headers",
         ":torch_headers",
+        "//c10/core:impl/cow/try_ensure",
         "@fbgemm",
         "@ideep",
     ],

--- a/aten/src/ATen/native/_lazy_clone.cpp
+++ b/aten/src/ATen/native/_lazy_clone.cpp
@@ -1,0 +1,25 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/core/Tensor.h>
+#include <c10/core/Storage.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/core/impl/cow/try_ensure.h>
+
+namespace at::native {
+
+auto _lazy_clone(Tensor const& self) -> Tensor {
+  c10::StorageImpl* self_storage = self.storage().unsafeGetStorageImpl();
+  c10::intrusive_ptr<c10::StorageImpl> storage =
+    c10::impl::cow::try_ensure(*self_storage);
+  TORCH_CHECK(storage != nullptr);
+  auto tensor = c10::make_intrusive<c10::TensorImpl>(
+      c10::Storage(std::move(storage)),
+      self.key_set(),
+      self.dtype());
+  tensor->set_sizes_and_strides(self.sym_sizes(),
+                                self.sym_strides(),
+                                self.sym_storage_offset());
+  return Tensor(std::move(tensor));
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1163,6 +1163,13 @@
     CompositeExplicitAutograd: copysign_out
   tags: pointwise
 
+- func: _lazy_clone(Tensor self) -> Tensor
+  # Like clone, but the copy takes place lazily, only if either the
+  # input or the output are written.
+  variants: function, method
+  dispatch:
+    CompositeExplicitAutograd: _lazy_clone
+
 - func: logical_not(Tensor self) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: function, method

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1345,6 +1345,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/UpSampleTrilinear3d.cpp",
     "aten/src/ATen/native/VariableMethodStubs.cpp",
     "aten/src/ATen/native/WeightNorm.cpp",
+    "aten/src/ATen/native/_lazy_clone.cpp",
     "aten/src/ATen/native/group_norm.cpp",
     "aten/src/ATen/native/layer_norm.cpp",
     "aten/src/ATen/native/mkl/LinearAlgebra.cpp",

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -2,7 +2,20 @@
 
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <cstring>
+
 namespace c10 {
+
+DataPtr Allocator::clone(const void* data, std::size_t n) const {
+  DataPtr new_data = allocate(n);
+  copy_data(new_data.mutable_get(), data, n);
+  return new_data;
+}
+
+void Allocator::copy_data(void* dest, const void* src, std::size_t count)
+    const {
+  std::memcpy(dest, src, count);
+}
 
 static void deleteInefficientStdFunctionContext(void* ptr) {
   delete static_cast<InefficientStdFunctionContext*>(ptr);

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -4,6 +4,8 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/SymInt.h>
 #include <c10/core/impl/PyObjectSlot.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/core/impl/cow/materialize.h>
 
 #include <c10/util/intrusive_ptr.h>
 
@@ -135,6 +137,9 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   void* mutable_data() {
+    if (data_ptr_.get_deleter() == impl::cow::delete_context) {
+      impl::cow::materialize(*this);
+    }
     return data_ptr_.mutable_get();
   }
 

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -114,6 +114,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   at::DataPtr& mutable_data_ptr() {
+    maybe_materialize();
     return data_ptr_;
   }
 
@@ -122,6 +123,9 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   // Returns the previous data_ptr
+  //
+  // TODO: Does this need to trigger a copy-on-write if the returned
+  // value has a copy-on-write context?
   at::DataPtr set_data_ptr(at::DataPtr&& data_ptr) {
     at::DataPtr old_data_ptr(std::move(data_ptr_));
     data_ptr_ = std::move(data_ptr);
@@ -137,9 +141,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   void* mutable_data() {
-    if (data_ptr_.get_deleter() == impl::cow::delete_context) {
-      impl::cow::materialize(*this);
-    }
+    maybe_materialize();
     return data_ptr_.mutable_get();
   }
 
@@ -209,7 +211,24 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     return received_cuda_;
   }
 
+  /// Gets mutable access to the DataPtr without triggering a copy.
+  ///
+  /// This is *for* the copy-on-write path so that it doesn't recurse
+  /// infinitely.
+  ///
+  /// Do not use this unless you know what you're doing.
+  at::DataPtr& unsafe_mutable_data_ptr_do_not_materialize() {
+    return data_ptr_;
+  }
+
  private:
+  /// Triggers a copy if this is a copy-on-write tensor.
+  void maybe_materialize() {
+    if (data_ptr_.get_deleter() == impl::cow::delete_context) {
+      impl::cow::materialize(*this);
+    }
+  }
+
   DataPtr data_ptr_;
   SymInt size_bytes_;
   bool size_bytes_is_heap_allocated_;

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -64,7 +64,10 @@ def define_targets(rules):
                 "impl/alloc_cpu.cpp",
                 "impl/cow/*.cpp",
             ],
-        ),
+        ) + [
+            "impl/cow/materialize.cpp",
+            "impl/cow/materialize.h",
+        ],
         hdrs = rules.glob(
             [
                 "*.h",

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -121,7 +121,10 @@ def define_targets(rules):
             ":impl/cow/context",
             "//c10/util:base",
         ],
-        visibility = ["//c10/test:__pkg__"],
+        visibility = [
+            "//:__pkg__",
+            "//c10/test:__pkg__",
+        ],
     )
 
     rules.filegroup(

--- a/c10/core/impl/cow/materialize.cpp
+++ b/c10/core/impl/cow/materialize.cpp
@@ -1,0 +1,54 @@
+#include <c10/core/impl/cow/materialize.h>
+
+#include <c10/core/Allocator.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/impl/cow/context.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/util/Exception.h>
+
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace c10::impl {
+
+auto C10_API cow::materialize(StorageImpl& storage) -> void {
+  at::DataPtr& data_ptr = storage.mutable_data_ptr();
+
+  auto* ctx = data_ptr.cast_context<cow::Context>(cow::delete_context);
+  TORCH_INTERNAL_ASSERT(ctx != nullptr);
+
+  auto result = ctx->decrement_refcount();
+
+  // This must be set by each of the branches below.
+  std::optional<DataPtr> new_data_ptr;
+
+  if (std::holds_alternative<cow::Context::LastReference>(result)) {
+    // This is the only alias left on the data. If there were any
+    // racing writes, the context ensured they finished before giving
+    // us the result.
+    std::unique_ptr<void, DeleterFnPtr> data =
+        std::get<cow::Context::LastReference>(std::move(result));
+    TORCH_INTERNAL_ASSERT(data.get() == data_ptr.get());
+    new_data_ptr = DataPtr(
+        data.release(),
+        data_ptr.mutable_get(),
+        data.get_deleter(),
+        data_ptr.device());
+  } else {
+    TORCH_INTERNAL_ASSERT(
+        std::holds_alternative<cow::Context::NotLastReference>(result));
+    // We don't need to consume the result, it's just a shared lock
+    // ensuring that the data will remain while we copy it.
+    new_data_ptr = storage.allocator()->allocate(storage.nbytes());
+    std::memcpy(new_data_ptr->get(), data_ptr.get(), storage.nbytes());
+  }
+
+  TORCH_INTERNAL_ASSERT(new_data_ptr.has_value());
+  DataPtr old_data_ptr = storage.set_data_ptr(*std::move(new_data_ptr));
+  old_data_ptr.release_context(); // already deleted by decrement_refcount
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/cow/materialize.cpp
+++ b/c10/core/impl/cow/materialize.cpp
@@ -15,7 +15,7 @@
 namespace c10::impl {
 
 auto C10_API cow::materialize(StorageImpl& storage) -> void {
-  at::DataPtr& data_ptr = storage.mutable_data_ptr();
+  at::DataPtr& data_ptr = storage.unsafe_mutable_data_ptr_do_not_materialize();
 
   auto* ctx = data_ptr.cast_context<cow::Context>(cow::delete_context);
   TORCH_INTERNAL_ASSERT(ctx != nullptr);

--- a/c10/core/impl/cow/materialize.h
+++ b/c10/core/impl/cow/materialize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+struct StorageImpl;
+}; // namespace c10
+
+namespace c10 {
+namespace impl {
+namespace cow {
+
+/// Eagerly copies the data marked for lazy-copy in storage.
+///
+/// Requires: storage has a copy-on-write context.
+auto C10_API materialize(StorageImpl& storage) -> void;
+
+} // namespace cow
+} // namespace impl
+} // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3339,6 +3339,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     }
     return {r, r, &local_raw_delete, Device(DeviceType::CUDA, device)};
   }
+
   DeleterFnPtr raw_deleter() const override {
     if (forceUncachedAllocator()) {
       return &uncached_delete;
@@ -3504,6 +3505,12 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
   std::string name() override {
     return "native";
+  }
+
+ private:
+  void copy_data(void* dest, const void* src, std::size_t count) const final {
+    C10_CUDA_CHECK(
+        cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
   }
 };
 

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -19,6 +19,18 @@ def define_targets(rules):
     )
 
     rules.cc_test(
+        name = "core/impl/cow/materialize_test",
+        srcs = ["core/impl/cow/materialize_test.cpp"],
+        deps = [
+            "//c10/core:CPUAllocator",
+            "//c10/core:base",
+            "//c10/core:impl/cow/context",
+            "//c10/core:impl/cow/try_ensure",
+            "@com_google_googletest//:gtest_main",
+        ],
+    )
+
+    rules.cc_test(
         name = "core/impl/cow/try_ensure_test",
         srcs = ["core/impl/cow/try_ensure_test.cpp"],
         deps = [

--- a/c10/test/core/impl/cow/materialize_test.cpp
+++ b/c10/test/core/impl/cow/materialize_test.cpp
@@ -1,0 +1,89 @@
+#include <c10/core/CPUAllocator.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/impl/cow/context.h>
+#include <c10/core/impl/cow/deleter.h>
+#include <c10/core/impl/cow/try_ensure.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <string_view>
+
+namespace c10::impl {
+namespace {
+
+MATCHER(is_copy_on_write, "") {
+  const c10::StorageImpl& storage_impl = std::ref(arg);
+  return storage_impl.data_ptr().get_deleter() == cow::delete_context;
+}
+
+TEST(materialize_test, not_copy_on_write_context) {
+  StorageImpl storage(
+      {}, /*size_bytes=*/7, GetCPUAllocator(), /*resizable=*/false);
+  ASSERT_THAT(storage, testing::Not(is_copy_on_write()));
+
+  void const* original_data = storage.data();
+
+  // Nothing to materialize.
+  ASSERT_THAT(storage.mutable_data(), testing::Eq(original_data));
+}
+
+TEST(materialize_test, copy_on_write_single_reference) {
+  // A copy-on-write storage with only a single reference can just
+  // drop the copy-on-write context upon materialization.
+  std::unique_ptr<void, DeleterFnPtr> data(
+      new std::byte[5],
+      +[](void* bytes) { delete[] static_cast<std::byte*>(bytes); });
+  void* data_ptr = data.get();
+  StorageImpl storage(
+      {},
+      /*size_bytes=*/5,
+      at::DataPtr(
+          /*data=*/data_ptr,
+          /*ctx=*/new cow::Context(std::move(data)),
+          cow::delete_context,
+          Device(Device::Type::CPU)),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+
+  ASSERT_THAT(storage, is_copy_on_write());
+
+  ASSERT_THAT(storage.data(), testing::Eq(data_ptr));
+
+  void const* original_data = storage.data();
+
+  // Materializes storage. Only reference, so no new allocation.
+  ASSERT_THAT(storage.mutable_data(), testing::Eq(original_data));
+  // But it is no longer copy-on-write.
+  ASSERT_THAT(storage, testing::Not(is_copy_on_write()));
+}
+
+TEST(materialize_test, copy_on_write) {
+  StorageImpl original_storage(
+      {}, /*size_bytes=*/7, GetCPUAllocator(), /*resizable=*/false);
+  std::memcpy(original_storage.mutable_data(), "abcd", 5);
+  void const* original_data = original_storage.data();
+
+  auto new_storage = cow::try_ensure(original_storage);
+  ASSERT_THAT(new_storage, testing::NotNull());
+
+  auto context =
+      new_storage->data_ptr().cast_context<cow::Context>(cow::delete_context);
+  ASSERT_THAT(context, testing::NotNull());
+
+  // Materialized storage has new copy of data.
+  ASSERT_THAT(new_storage->mutable_data(), testing::Ne(original_data));
+
+  // But the original storage still has the original copy.
+  ASSERT_THAT(original_storage.data(), testing::Eq(original_data));
+
+  // But their data is the same.
+  ASSERT_THAT(
+      static_cast<char const*>(new_storage->data()),
+      testing::StrEq(static_cast<char const*>(original_storage.data())));
+}
+
+} // namespace
+} // namespace c10::impl

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -352,6 +352,7 @@ aten::_int_mm
 aten::_int_mm.out
 aten::_is_all_true
 aten::_is_any_true
+aten::_lazy_clone
 aten::_linalg_check_errors
 aten::_linalg_det
 aten::_linalg_det.result

--- a/test/test_lazy_clone.py
+++ b/test/test_lazy_clone.py
@@ -1,0 +1,16 @@
+# Owner(s): ["module: internals"]
+
+import torch
+
+
+def test_lazy_clone():
+    t = torch.tensor([[0, 1],
+                      [2, 3]], dtype=torch.int8)
+    clone = t._lazy_clone()
+    assert torch._C._storage_address(t) != torch._C._storage_address(clone)
+    assert torch._C._data_address(t) == torch._C._data_address(clone)
+    view = t.view([4])
+    assert torch._C._storage_address(t) == torch._C._storage_address(view)
+
+    t += 1  # this write causes a copy to take place
+    assert torch._C._data_address(t) != torch._C._data_address(clone)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -419,6 +419,10 @@
   self: grad
   result: auto_linear
 
+- name: _lazy_clone(Tensor self) -> Tensor
+  self: grad
+  result: auto_linear
+
 - name: _to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor
   self: _to_copy_backward(grad, self.options())
   result: _to_copy(self_t, dtype, layout, device, pin_memory, non_blocking, memory_format)

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -239,6 +239,7 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.isneginf,
             aten.isposinf,
             aten.l1_loss,
+            aten._lazy_clone,
             aten.leaky_relu,
             aten.leaky_relu_,
             aten.leaky_relu_backward,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1713,6 +1713,21 @@ Call this whenever a new thread is created in order to propagate values from
         return torch::should_allow_numbers_as_tensors(name);
       });
 
+  py_module.def(
+      "_storage_address",
+      [](const at::Tensor& tensor) {
+        return reinterpret_cast<std::intptr_t>(
+            tensor.storage().unsafeGetStorageImpl());
+      },
+      "Gets the memory address of the Tensor's StorageImpl.");
+
+  py_module.def(
+      "_data_address",
+      [](const at::Tensor& tensor) {
+        return reinterpret_cast<std::intptr_t>(tensor.storage().data());
+      },
+      "Gets the memory address of the Tensor's data pointer.");
+
   const auto& defaultGenerator = at::detail::getDefaultCPUGenerator();
   THPDefaultCPUGenerator =
       (THPGenerator*)THPGenerator_initDefaultGenerator(defaultGenerator);

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -295,6 +295,7 @@ def get_ignored_functions() -> Set[Callable]:
         Tensor._has_symbolic_sizes_strides.__get__,
         Tensor._conj,
         Tensor._conj_physical,
+        Tensor._lazy_clone,
         Tensor._neg_view,
         Tensor._is_zerotensor,
         Tensor._is_all_true,


### PR DESCRIPTION
add new private operator copy-on-write torch._lazy_clone

Summary:
This is an early access operator with some limitations. It will more
eagerly copy than desired because we haven't completed our audit
partitioning data pointer access between const_data_ptr and
mutable_data_ptr.

The idea is to add some logging when a copy is triggered to help
prioritize which operations will be audited and fixed.

Test Plan: Added a new unit test.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/100821).
* __->__ #100821
* #100820

cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh