### PR TITLE
Initialize view_replay_enabled_ in the AutogradState ctor

### DIFF
--- a/c10/core/AutogradState.h
+++ b/c10/core/AutogradState.h
@@ -18,7 +18,8 @@ struct C10_API AutogradState {
       : grad_mode_(grad_mode),
         inference_mode_(inference_mode),
         fw_grad_mode_(fw_grad_mode),
-        multithreading_enabled_(multithreading_enabled) {}
+        multithreading_enabled_(multithreading_enabled),
+        view_replay_enabled_(false) {}
 
   void set_grad_mode(bool enabled) {
     grad_mode_ = enabled;


### PR DESCRIPTION
Cruise uses [clang static analyzer](https://clang-analyzer.llvm.org/) internally.
In the v2.0.0 release of PyTorch it found this problem

```
In file included from external/pytorch/aten/src/ATen/ATen.h:7:
In file included from external/pytorch/aten/src/ATen/Context.h:3:
In file included from external/pytorch/aten/src/ATen/CPUGeneratorImpl.h:3:
In file included from external/pytorch/aten/src/ATen/core/Generator.h:22:
In file included from external/pytorch/c10/core/GeneratorImpl.h:8:
In file included from external/pytorch/c10/core/TensorImpl.h:6:
external/pytorch/c10/core/InferenceMode.h:58:5: warning: Passed-by-value struct argument contains uninitialized data (e.g., field: 'view_replay_enabled_')
    AutogradState::set_tls_state(AutogradState(
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

In other words, the value of `view_replay_enabled_` could be initialized which may lead to subtle bugs later on.

This PR addresses the warning by explicitly initializing it to `false`.
