### PR TITLE
[MPS] aten::erfinv ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -259,7 +259,7 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output) {
     auto oneTensor = [mpsGraph constantWithScalar:1.0 dataType:dataType];
     auto twoTensor = [mpsGraph constantWithScalar:2.0 dataType:dataType];
 
-    // Aprpoximation #1 for |y| <= .7
+    // Approximation #1 for |y| <= 0.7
     auto A0 = [mpsGraph constantWithScalar:0.886226899 dataType:dataType];
     auto A1 = [mpsGraph constantWithScalar:-1.645349621 dataType:dataType];
     auto A2 = [mpsGraph constantWithScalar:0.914624893 dataType:dataType];
@@ -288,7 +288,8 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output) {
                                                                              secondaryTensor:dem
                                                                                         name:nil]
                                                     name:nil];
-    // calculate 2nd approximation for |y| > 0.7
+    // Approximation #2 for |y| > 0.7
+    // #2 approximation returns absolute value so need to add sign back later
     auto C0 = [mpsGraph constantWithScalar:-1.970840454 dataType:dataType];
     auto C1 = [mpsGraph constantWithScalar:-1.624906493 dataType:dataType];
     auto C2 = [mpsGraph constantWithScalar:3.429567803 dataType:dataType];
@@ -321,7 +322,7 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output) {
                             falsePredicateTensor:x_2
                                             name:nil];
 
-    // fix infinity if input was 1
+    // Fix infinity if input was 1
     auto isOne = [mpsGraph equalWithPrimaryTensor:y_abs
                                   secondaryTensor:[mpsGraph constantWithScalar:1.0 dataType:dataType]
                                              name:nil];

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9010,6 +9010,7 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: erfinv_out
+    MPS: erfinv_out_mps
     SparseCPU, SparseCUDA: erfinv_sparse_out
     SparseCsrCPU, SparseCsrCUDA: erfinv_sparse_csr_out
   tags: pointwise

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -239,6 +239,7 @@ def mps_ops_modifier(ops):
         'eq': [torch.uint8],
         'equal': [torch.uint8],
         'erf': [torch.uint8],
+        'erfinv': [torch.uint8],
         'exp2': [torch.uint8],
         'exp': [torch.uint8],
         'expm1': [torch.uint8],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -403,7 +403,6 @@ def mps_ops_modifier(ops):
         'cumprod': None,
         'digamma': None,
         'erfc': None,
-        'erfinv': None,
         'frexp': None,
         'gcd': None,
         'geqrf': None,
@@ -7467,6 +7466,7 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 8, 3, 5), torch.expm1)
         helper((2, 8, 3, 5), torch.log)
         helper((2, 8, 3, 5), torch.cos)
+        helper((2, 8, 3, 5), torch.erfinv)
 
     def test_atan2(self):
         def helper(shape):

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -793,6 +793,7 @@ class TestUnaryUfuncs(TestCase):
             ("erfc", doubles, True, True, "cuda"),
             ("erfinv", doubles, True, True, "cpu"),
             ("erfinv", doubles, True, True, "cuda"),
+            ("erfinv", doubles, True, True, "mps"),
             ("exp", doubles, True, True, "cpu"),
             ("exp", doubles, True, True, "cuda"),
             ("exp2", doubles, True, True, "cpu"),


### PR DESCRIPTION
I've added the implementation of erfinv using the algorithm from https://github.com/pytorch/pytorch/blob/4154c8ea159fdaecc71ee9af820ac956193c875b/aten/src/ATen/native/Math.h#L152 in order for the MPS based algorithm to match the CPU automatic test.


Testing shows MPS has a decent speed up compared to CPU. 

```python
import torch
x = torch.arange(-1, 1, 1e-8) # default cpu tensor
#measure CPU compute time by calling torch.erfinv
time = %timeit -o -q torch.erfinv(x)
cpu_time = time.average
print("CPU torch.erfinv time: ", cpu_time)

x = x.to("mps")
# measure MPS compute time
time = %timeit -o -q  torch.erfinv(x)
mps_time = time.average
print("MPS torch.erfinv time: ", mps_time)
print(f"MPS torch.erfinv is {cpu_time/mps_time*100} percent faster than CPU torch.erfinv")

# compute MSE between MPS and CPU torch.erfinv
x = x.to("cpu")
print("Done convert x to cpu device")
y_cpu = torch.erfinv(x)
print("Done computing cpu torch.erfinv")
x = x.to("mps")
print("Done convert x to mps device")
y_mps = torch.erfinv(x)
print("Done computing mps torch.erfinv")

y_mps = y_mps.to("cpu")
print("computing mask")
mask = torch.isfinite(y_cpu) & torch.isfinite(y_mps.to("cpu"))
y_mps = y_mps[mask]
y_cpu = y_cpu[mask]
x = x[mask]
print
mse = torch.square(y_cpu - y_mps).mean()
print("MSE between MPS and CPU torch.erfinv: ", mse)
diff = torch.abs(y_cpu - y_mps)

print("Largest difference")
print(f"x:  {x[torch.argmax(diff)]}, y_cpu: {y_cpu[torch.argmax(diff)]}, y_mps: {y_mps[torch.argmax(diff)]} , diff = {y_cpu[torch.argmax(diff)] - y_mps[torch.argmax(diff)]}")
```
CPU torch.erfinv time:  2.6942295774279046
MPS torch.erfinv time:  0.1837057119286328
MPS torch.erfinv is 1466.600874378134 percent faster than CPU torch.erfinv
Done convert x to cpu device
Done computing cpu torch.erfinv
Done convert x to mps device
Done computing mps torch.erfinv
computing mask
MSE between MPS and CPU torch.erfinv:  tensor(4.1189e-14)
Largest difference
x:  -0.6999978423118591, y_cpu: -0.7328658699989319, y_mps: -0.7328646779060364 , diff = -1.1920928955078125e-06

Fixes #https://github.com/pytorch/pytorch/issues/86808