### PR TITLE
inductor(CPU): don't do binary fusion if binary's inputs are same tensor

### DIFF
--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -291,6 +291,9 @@ if torch._C.has_mkldnn:
             for n in binary_nodes
         ):
             return False
+        # check args[0] and args[1] is not same
+        if any(n.args[0] == n.args[1] for n in binary_nodes):
+            return False
         return True
 
     def _is_valid_computation_binary(computation_op, binary_op, other_index=None):
@@ -314,9 +317,6 @@ if torch._C.has_mkldnn:
                 n.args[other_index].op in ["placeholder", "output"]
                 for n in binary_nodes
             ):
-                return False
-            # check args[0] and args[1] is not same
-            if any(n.args[0] == n.args[1] for n in binary_nodes):
                 return False
             return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100844
* __->__ #100843


This PR will fix https://github.com/pytorch/pytorch/issues/100802.

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire