### PR TITLE
inductor(CPU): skip weight packing when autocast is enabled

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -131,6 +131,16 @@ class CPUReproTests(TestCase):
                     (v,),
                 )
 
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_conv2d_autocast(self):
+        v = torch.randn(1, 3, 28, 18, dtype=torch.float32)
+        mod = torch.nn.Sequential(torch.nn.Conv2d(3, 64, 3, 3)).eval()
+        with torch.no_grad(), torch.cpu.amp.autocast():
+            self.common(
+                mod,
+                (v,),
+            )
+
     @unittest.skipIf(not torch._C.has_mkldnn, "MKLDNN is not enabled")
     @patch("torch.cuda.is_available", lambda: False)
     def test_conv_used_from_multiple_places(self):

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -248,8 +248,8 @@ def mkldnn_fuse_fx(gm: torch.fx.GraphModule, example_inputs):
         if isinstance(example_input, torch.Tensor)
     )
 
-    # make sure the autograd is disabled.
-    if torch.is_grad_enabled():
+    # make sure the autograd and autocast are disabled.
+    if torch.is_grad_enabled() or torch.is_autocast_cpu_enabled():
         return gm
     if not (torch.backends.mkldnn.enabled and torch.backends.mkldnn.is_available()):
         return gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100844
* #100843

Currently, the packed op doesn't support autocast and the packing path happened before AOTAutograd, which changes the default autocast behavior. Now, we disable the packing path, and the bfloat16 packing path can work after we move this path after AOTAutograd(I will do it after https://github.com/pytorch/pytorch/pull/100652 is done).


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire