### PR TITLE
Fix nightly build of C++ docs

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -1,6 +1,6 @@
-sphinx==5.0.0
+sphinx==5.3.0
 #Description: This is used to generate PyTorch docs
-#Pinned versions: 5.0.0
+#Pinned versions: 5.3.0
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
@@ -18,9 +18,9 @@ tensorboard==2.13.0
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 2.13.0
 
-breathe==4.15.0
+breathe==4.34.0
 #Description: This is used to generate PyTorch C++ docs
-#Pinned versions: 4.25.0
+#Pinned versions: 4.34.0
 
 exhale==0.2.3
 #Description: This is used to generate PyTorch C++ docs

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -50,7 +50,6 @@ jobs:
     with:
       build-environment: linux-focal-py3.8-gcc7
       docker-image: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.docker-image }}
-      run-doxygen: true
 
   linux-focal-py3_8-gcc7-no-ops:
     name: linux-focal-py3.8-gcc7-no-ops

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -50,6 +50,7 @@ jobs:
     with:
       build-environment: linux-focal-py3.8-gcc7
       docker-image: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.docker-image }}
+      run-doxygen: true
 
   linux-focal-py3_8-gcc7-no-ops:
     name: linux-focal-py3.8-gcc7-no-ops


### PR DESCRIPTION
The fix is to upgrade breathe version (and sphinx accordingly), for example https://github.com/pytorch/pytorch/actions/runs/4898593997/jobs/8749163278.

```
Exception occurred:
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/breathe/renderer/sphinxrenderer.py", line 104, in DomainDirectiveFactory
    'function': (python.PyModulelevel, 'function'),
AttributeError: module 'sphinx.domains.python' has no attribute 'PyModulelevel'
```

This was missed in https://github.com/pytorch/pytorch/pull/100601 because `RUN_DOXYGEN` is only set to true in the nightly job.  Specifically, the 2 plugins `breathe` and `exhale` are only used when `RUN_DOXYGEN` is set to true https://github.com/pytorch/pytorch/blob/main/docs/cpp/source/conf.py#L37-L42

### Testing

https://github.com/pytorch/pytorch/actions/runs/4910813882/jobs/8771541636 passes with RUN_DOXYGEN set to true and C++ docs looks ok https://docs-preview.pytorch.org/100845/cppdocs/index.html