### PR TITLE
inductor: fallback ConvTranspose when output_padding is big

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -133,6 +133,32 @@ class CPUReproTests(TestCase):
 
     @unittest.skipIf(not torch._C.has_mkldnn, "MKLDNN is not enabled")
     @patch("torch.cuda.is_available", lambda: False)
+    def test_unsupported_conv_transpose(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv_transpose = torch.nn.ConvTranspose2d(
+                    3, 6, 3, stride=1, padding=1, output_padding=1
+                )
+
+            def forward(self, input_tensor):
+                x = self.conv_transpose(input_tensor)
+                output = torch.tanh(x)
+                return output
+
+        input = torch.randn(1, 3, 28, 28)
+        m = Model().eval()
+
+        with torch.no_grad():
+            compiled_m = torch.compile(m)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "output padding must be smaller than either stride or dilation",
+            ):
+                compiled_m(input)
+
+    @unittest.skipIf(not torch._C.has_mkldnn, "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
     def test_conv_used_from_multiple_places(self):
         class M(torch.nn.Module):
             def __init__(self, conv_in_channel, conv_out_channel) -> None:

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -446,30 +446,6 @@ class TestPaternMatcher(TestCase):
         include_ops = ["mkldnn._convolution_pointwise_.binary"]
         self._test_code_common(mod, (input,), include_ops, [])
 
-    def test_unsupported_conv_transpose(self):
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv_transpose = torch.nn.ConvTranspose2d(
-                    3, 6, 3, stride=1, padding=1, output_padding=1
-                )
-
-            def forward(self, input_tensor):
-                x = self.conv_transpose(input_tensor)
-                output = torch.tanh(x)
-                return output
-
-        input = torch.randn(1, 3, 28, 28)
-        m = Model().eval()
-
-        with torch.no_grad():
-            compiled_m = torch.compile(m)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "output padding must be smaller than either stride or dilation",
-            ):
-                compiled_m(input)
-
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CPU and torch._C.has_mkldnn:

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -20,6 +20,7 @@ def is_group_depthwise_conv_transpose(m):
     )
 
 
+# Port from: aten/src/ATen/native/Convolution.cpp:is_output_padding_big
 def is_output_padding_big(m):
     is_big = False
     for i in range(len(m.output_padding)):

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -20,6 +20,13 @@ def is_group_depthwise_conv_transpose(m):
     )
 
 
+def is_output_padding_big(m):
+    is_big = False
+    for i in range(len(m.output_padding)):
+        is_big |= (m.output_padding[i] >= m.stride[i])
+    return is_big
+
+
 class PackedConv2d(nn.Conv2d):
     def __init__(
         self,
@@ -314,6 +321,7 @@ def pack_module(gm: torch.fx.GraphModule):
                     or dynamo_config.dynamic_shapes
                     or len(node.args) > 1
                     or len(node.kwargs) > 0
+                    or is_output_padding_big(cur_module)
                 ):
                     continue
                 new_module = computation_op_packed_map[type(cur_module)](

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -23,7 +23,7 @@ def is_group_depthwise_conv_transpose(m):
 def is_output_padding_big(m):
     is_big = False
     for i in range(len(m.output_padding)):
-        is_big |= (m.output_padding[i] >= m.stride[i])
+        is_big |= m.output_padding[i] >= m.stride[i]
     return is_big
 
 

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -315,7 +315,9 @@ def pack_module(gm: torch.fx.GraphModule):
                     or len(node.args) > 1
                     or len(node.kwargs) > 0
                     or any(
-                        output_padding >= stride
+                        not isinstance(output_padding, int)
+                        or not isinstance(stride, int)
+                        or output_padding >= stride
                         for output_padding, stride in zip(
                             cur_module.output_padding, cur_module.stride
                         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100846


Fixes https://github.com/pytorch/pytorch/issues/100225.

Do not use mkldnn when `output_padding` is big to align the behavior with eager mode:
https://github.com/pytorch/pytorch/blob/7d0e4e2aa843ef5d73646f5b304914d2b65db93c/aten/src/ATen/native/Convolution.cpp#L500-L507

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire