### PR TITLE
[inductor] Fix bug where a node gets erased twice

### DIFF
--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -76,7 +76,8 @@ class Match:
 
     def erase_nodes(self, graph: torch.fx.Graph):
         for n in reversed(self.nodes):
-            graph.erase_node(n)
+            if not n._erased:
+                graph.erase_node(n)
 
     def output_nodes(self):
         return [

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -868,6 +868,10 @@ class Graph:
             raise RuntimeError(f'Tried to erase Node {to_erase} but it still had {len(to_erase.users)} '
                                f'users in the graph: {to_erase.users}!')
 
+        if to_erase._erased:
+            warnings.warn(f"erase_node() on an already erased node: %s", to_erase)
+            return
+
         to_erase._remove_from_list()
         to_erase._erased = True  # iterators may retain handles to erased nodes
         self._len -= 1

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -867,9 +867,8 @@ class Graph:
         if len(to_erase.users) > 0:
             raise RuntimeError(f'Tried to erase Node {to_erase} but it still had {len(to_erase.users)} '
                                f'users in the graph: {to_erase.users}!')
-
         if to_erase._erased:
-            warnings.warn(f"erase_node() on an already erased node: %s", to_erase)
+            warnings.warn(f"erase_node({to_erase}) on an already erased node")
             return
 
         to_erase._remove_from_list()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100848

Fixes #100806

The underlying bug is if you erase an FX node twice, everything runs without error, but `len(graph.nodes)` reports the incorrect value.

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire