### PR TITLE
Skip DNS host fix on ROCm runners

### DIFF
--- a/.github/actions/test-pytorch-binary/action.yml
+++ b/.github/actions/test-pytorch-binary/action.yml
@@ -34,8 +34,12 @@ runs:
           -w / \
           "${DOCKER_IMAGE}"
         )
-        # Propagate download.pytorch.org IP to container
-        grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" bash -c "/bin/cat >> /etc/hosts"
+
+        if [[ "${GPU_ARCH_TYPE}" != "rocm" ]]; then
+          # Propagate download.pytorch.org IP to container. This is only needed on Linux runner
+          grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" bash -c "/bin/cat >> /etc/hosts"
+        fi
+
         docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
         # Generate test script
         docker exec -t -w "${PYTORCH_ROOT}" -e OUTPUT_SCRIPT="/run.sh" "${container_name}" bash -c "bash .circleci/scripts/binary_linux_test.sh"


### PR DESCRIPTION
The quick fix in https://github.com/pytorch/pytorch/pull/100507 is only needed on Linux runners, not ROCm as the latter doesn't have the corresponding step in [setup-linux](https://github.com/pytorch/pytorch/pull/100436).  ROCm runners use `setup-rocm` action instead, and it doesn't seem to have any issue with DNS, so there is no need to add the quick fix to ROCm.

This is currently breaking ROCm binary test job in trunk, for example https://github.com/pytorch/pytorch/actions/runs/4905878029/jobs/8761271482.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport