### PR TITLE
[inductor] Debug mode, added group/others read mode to generated output_code.py

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -7,6 +7,7 @@ import logging
 import os.path
 import pstats
 import shutil
+import stat
 import subprocess
 from typing import Any, List
 from unittest.mock import patch
@@ -380,4 +381,6 @@ class DebugFormatter:
         draw_buffers(nodes, fname=self.filename("graph_diagram.svg"))
 
     def output_code(self, filename):
-        shutil.copy(filename, self.filename("output_code.py"))
+        path = self.filename("output_code.py")
+        shutil.copy(filename, path)
+        os.chmod(path, os.stat(path).st_mode | stat.S_IRGRP | stat.S_IROTH)


### PR DESCRIPTION
Description:

- Minor improvement to `output_code.py` file generated in debug mode

Currently, generated files have the following modes:
```
ls -alh path/to/generated/files/

-rw-r--r-- 1 root root  304 May  8 13:50 fx_graph_readable.py
-rw-r--r-- 1 root root 1.5K May  8 13:50 fx_graph_runnable.py
-rw-r--r-- 1 root root  304 May  8 13:50 fx_graph_transformed.py
-rw-r--r-- 1 root root  876 May  8 13:50 ir_post_fusion.txt
-rw-r--r-- 1 root root  876 May  8 13:50 ir_pre_fusion.txt
-rw------- 1 root root 2.0K May  8 13:50 output_code.py
``` 
(created by root as code was run in docker container)

This can be a minor issue when we want to read this file with another user (e.g. outside the docker container).

This PR adds group/others read mode to generated output_code.py:
```
ls -alh path/to/generated/files/

-rw-r--r-- 1 root root  304 May  8 14:11 fx_graph_readable.py
-rw-r--r-- 1 root root 1.5K May  8 14:11 fx_graph_runnable.py
-rw-r--r-- 1 root root  304 May  8 14:11 fx_graph_transformed.py
-rw-r--r-- 1 root root  876 May  8 14:11 ir_post_fusion.txt
-rw-r--r-- 1 root root  876 May  8 14:11 ir_pre_fusion.txt
-rw-r--r-- 1 root root 2.0K May  8 14:11 output_code.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @soumith @desertfire