### PR TITLE
[inductor] Make codecache file permissions less restrictive

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import sysconfig
@@ -233,6 +234,18 @@ def write_atomic(path: str, source_code: str):
     fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path))
     with os.fdopen(fd, "w") as f:
         f.write(source_code)
+
+    # mkstemp only gives permission to the creating user, reset to default
+    os.chmod(
+        tmp_path,
+        # User
+        stat.S_IRUSR | stat.S_IWUSR |
+        # Group
+        stat.S_IRGRP | stat.S_IWGRP |
+        # Other
+        stat.S_IROTH,
+    )
+    # rename atomically
     os.rename(tmp_path, path)
 
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -233,9 +233,8 @@ def write(source_code, ext, extra=""):
 def write_atomic(path: str, source_code: str):
     # Write into temporary file first to avoid conflicts between threads
     # Avoid using a named temporary file, as those have restricted permissions
-    salt = f"{os.getpid()}.{threading.get_ident()}"
     path = pathlib.Path(path)
-    tmp_path = path.parent / f".{path.name}.{salt}.tmp"
+    tmp_path = path.parent / f".{os.getpid()}.{threading.get_ident()}.tmp"
     with tmp_path.open("w") as f:
         f.write(source_code)
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -229,22 +229,23 @@ def write(source_code, ext, extra=""):
     return basename, path
 
 
-def write_atomic(path: str, source_code: str):
+def get_umask():
+    # os.umask sets-and-gets, so we need to restore the previous value
+    mask = os.umask(0o666)
+    os.umask(mask)
+    return mask
+
+
+def write_atomic(path: str, source_code: str, mode=0o666):
     # use a temp file for thread safety
     fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path))
     with os.fdopen(fd, "w") as f:
         f.write(source_code)
 
-    # mkstemp only gives permission to the creating user, reset to default
-    os.chmod(
-        tmp_path,
-        # User
-        stat.S_IRUSR | stat.S_IWUSR |
-        # Group
-        stat.S_IRGRP | stat.S_IWGRP |
-        # Other
-        stat.S_IROTH,
-    )
+    # set file permissions
+    masked_mode = mode & ~get_umask()
+    os.chmod(tmp_path, masked_mode)
+
     # rename atomically
     os.rename(tmp_path, path)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100870

`tempfile.mkstemp` always creates the file `0o600` permissions, so
only the current user can access it. Instead, this salts the original
filename with the pid and thread id to avoid conflicts between
temporary files.

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire