### PR TITLE
Add Batch Rule for aten::native_dropout_backward

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesRandomness.cpp
+++ b/aten/src/ATen/functorch/BatchRulesRandomness.cpp
@@ -478,6 +478,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchVmapMode, m) {
   UNARY_POINTWISE_RANDOM_LEADING_FLOAT(normal, float_Tensor);
 
   m.impl("native_dropout", native_dropout_batching_rule); // needs special casing because cuda version doesn't call bernoulli
+  // native_dropout_backward uses a decomposition for its batch rule
 
   UNARY_POINTWISE_RANDOM(_standard_gamma);
   UNARY_POINTWISE_RANDOM(_sample_dirichlet);

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -944,7 +944,7 @@ def col2im(
     return output
 
 
-@register_decomposition(aten.native_dropout_backward)
+@register_decomposition(aten.native_dropout_backward.default)
 def native_dropout_backward(grad_output: Tensor, mask: Tensor, scale: float):
     # According to the CUDA kernel implementation we should have this test;
     # but it seems to fail tests!

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -247,6 +247,7 @@ def lazy_load_decompositions():
     _register_python_decomposition_vmap(torch.ops.aten.smooth_l1_loss_backward.default)
     _register_python_decomposition_vmap(torch.ops.aten.huber_loss_backward.default)
     _register_python_decomposition_vmap(torch.ops.aten.addr.default)
+    _register_python_decomposition_vmap(torch.ops.aten.native_dropout_backward.default)
 
 # vmap(func)(inputs) wraps all Tensor inputs to be batched in BatchedTensors,
 # sends those into func, and then unwraps the output BatchedTensors. Operations


### PR DESCRIPTION
Summary: Add batch rule for ` aten::native_dropout_backward`

Fix: #100801 

Test Plan: Please see GitHub pipelines.

Differential Revision: D45640369

