### PR TITLE
[S337714] Back out "[PyTorch] Don't do extra numel() check in TensorImpl::data() (#98090)"

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1627,7 +1627,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // Computing an offset into an empty tensor would be UB, since an empty
     // tensor's storage will be nullptr, and adding a nonzero offset to nullptr
     // is UB.  So we skip the offset computation in this case.
-    if (data == nullptr) {
+    if (is_empty()) {
       return nullptr;
     }
     return data + data_type_.itemsize() * storage_offset_;


### PR DESCRIPTION
Summary:
Original commit changeset: 9875964c3b32

Original Phabricator Diff: D44586464

Reviewed By: drdarshan

Differential Revision: D45664329

