### PR TITLE
Work around torchdynamo import error with functional collectives

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -27,7 +27,15 @@ if _is_running_under_torch_deploy():
         """Can't import torchdynamo in torchdeploy builds currently."""
         return False
 else:
-    from torch._dynamo.external_utils import is_compiling as is_torchdynamo_compiling
+    try:
+        from torch._dynamo.external_utils import is_compiling as is_torchdynamo_compiling
+    except Exception:
+        warnings.warn(
+            "Unable to import torchdynamo util `is_torchdynamo_compiling`, so won't support torchdynamo correctly"
+        )
+
+        def is_torchdynamo_compiling():
+            return False
 
 """
 New traceable, functional collectives.


### PR DESCRIPTION
Summary:
Currently there are build configs where the torchdynamo import trips over a
strange SystemError related to some module's __dict__.items() returning NULL,
while torchdynamo tries to iterate all torch modules and process them for
its allowed functions list.

While this is hard to repro, we should be able to work around it and then fix
it properly.

Test Plan: Rely on others to test this, assuming CI passes.

Reviewed By: anijain2305

Differential Revision: D45663313

