### PR TITLE
Fix `recursive_store` for smaller elementSize

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3031,11 +3031,11 @@ def forward(self, x):
     def test_byte_tensor_does_not_crash(self):
         # See https://github.com/pytorch/pytorch/issues/100455
         def func(text):
-            tensor = torch.ByteTensor(list(bytes(text, 'utf8')))
+            tensor = torch.ByteTensor(list(bytes(text, "utf8")))
             return tensor + tensor
 
-        text = "".join(chr(a%90+40) for a in range(111))
-        opt_func = torch._dynamo.optimize("eager",dynamic=True)(func)
+        text = "".join(chr(a % 90 + 40) for a in range(111))
+        opt_func = torch._dynamo.optimize("eager", dynamic=True)(func)
         for i in [99, 100]:
             input = text[:i]
             opt_func(input)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3028,6 +3028,18 @@ def forward(self, x):
                 aten_graph=True,
             )
 
+    def test_byte_tensor_does_not_crash(self):
+        # See https://github.com/pytorch/pytorch/issues/100455
+        def func(text):
+            tensor = torch.ByteTensor(list(bytes(text, 'utf8')))
+            return tensor + tensor
+
+        text = "".join(chr(a%90+40) for a in range(111))
+        opt_func = torch._dynamo.optimize("eager",dynamic=True)(func)
+        for i in [99, 100]:
+            input = text[:i]
+            opt_func(input)
+
     def test_export_defaults_ok(self):
         class DynamicSliceExportMod(torch.nn.Module):
             def forward(self, x):

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -217,7 +217,13 @@ void recursive_store(
     if (is_symint) {
       auto new_obj = py::reinterpret_borrow<py::object>(obj);
       auto val = new_obj.cast<c10::SymInt>();
-      *(int64_t*)data = val.guard_int(__FILE__, __LINE__);
+      switch (elementSize) {
+        case 8: *(int64_t*)data = val.guard_int(__FILE__, __LINE__); break;
+        case 4: *(int32_t*)data = val.guard_int(__FILE__, __LINE__); break;
+        case 2: *(int16_t*)data = val.guard_int(__FILE__, __LINE__); break;
+        case 1: *(int8_t*)data = val.guard_int(__FILE__, __LINE__); break;
+        default: TORCH_CHECK(false, "Unexpected elementSize ", elementSize);
+      }
       return;
     }
     torch::utils::store_scalar(data, scalarType, obj);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -218,11 +218,20 @@ void recursive_store(
       auto new_obj = py::reinterpret_borrow<py::object>(obj);
       auto val = new_obj.cast<c10::SymInt>();
       switch (elementSize) {
-        case 8: *(int64_t*)data = val.guard_int(__FILE__, __LINE__); break;
-        case 4: *(int32_t*)data = val.guard_int(__FILE__, __LINE__); break;
-        case 2: *(int16_t*)data = val.guard_int(__FILE__, __LINE__); break;
-        case 1: *(int8_t*)data = val.guard_int(__FILE__, __LINE__); break;
-        default: TORCH_CHECK(false, "Unexpected elementSize ", elementSize);
+        case 8:
+          *(int64_t*)data = val.guard_int(__FILE__, __LINE__);
+          break;
+        case 4:
+          *(int32_t*)data = val.guard_int(__FILE__, __LINE__);
+          break;
+        case 2:
+          *(int16_t*)data = val.guard_int(__FILE__, __LINE__);
+          break;
+        case 1:
+          *(int8_t*)data = val.guard_int(__FILE__, __LINE__);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected elementSize ", elementSize);
       }
       return;
     }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -217,18 +217,19 @@ void recursive_store(
     if (is_symint) {
       auto new_obj = py::reinterpret_borrow<py::object>(obj);
       auto val = new_obj.cast<c10::SymInt>();
+      const auto int_val = val.guard_int(__FILE__, __LINE__);
       switch (elementSize) {
         case 8:
-          *(int64_t*)data = val.guard_int(__FILE__, __LINE__);
+          *reinterpret_cast<int64_t*>(data) = int_val;
           break;
         case 4:
-          *(int32_t*)data = val.guard_int(__FILE__, __LINE__);
+          *reinterpret_cast<int32_t*>(data) = static_cast<int32_t>(int_val);
           break;
         case 2:
-          *(int16_t*)data = val.guard_int(__FILE__, __LINE__);
+          *reinterpret_cast<int16_t*>(data) = static_cast<int16_t>(int_val);
           break;
         case 1:
-          *(int8_t*)data = val.guard_int(__FILE__, __LINE__);
+          *reinterpret_cast<int8_t*>(data) = static_cast<int8_t>(int_val);
           break;
         default:
           TORCH_CHECK(false, "Unexpected elementSize ", elementSize);


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cbc54f</samp>

Add support for symbolic integers of different sizes in `tensor_new.cpp`. Use a switch statement to cast them to the appropriate fixed-width integer type. 

Fixes crash reported in https://github.com/pytorch/pytorch/issues/100455


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire