### PR TITLE
Forward fix lint failure from #100661

### DIFF
--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -64,7 +64,7 @@ struct TORCH_API MPSHooksInterface {
   virtual void setMemoryFraction(double /*ratio*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  
+
   #undef FAIL_MPSHOOKS_FUNC
 };
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/100661 breaks lint check, but it's just some empty spaces, so ... forward fixing