### PR TITLE
Check for pytest extensions in run_test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1523,7 +1523,7 @@ def run_tests(
 
 
 def check_pip_packages() -> None:
-    packages = ["pytest-rerunfailures", "pytest-shard", "pytest-flakefinder"]
+    packages = ["pytest-rerunfailures", "pytest-shard", "pytest-flakefinder", "pytest-xdist"]
     installed_packages = [i.key for i in pkg_resources.working_set]
     for package in packages:
         if package not in installed_packages:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from distutils.version import LooseVersion
 from typing import Any, cast, Dict, List, Optional
 
+import pkg_resources
+
 import torch
 import torch.distributed as dist
 from torch.multiprocessing import current_process, get_context
@@ -1520,7 +1522,20 @@ def run_tests(
     return failure_messages
 
 
+def check_pip_packages() -> None:
+    packages = ["pytest-rerunfailures", "pytest-shard", "pytest-flakefinder"]
+    installed_packages = [i.key for i in pkg_resources.working_set]
+    for package in packages:
+        if package not in installed_packages:
+            print(
+                f"Missing pip dependency: {package}, please run `pip install -r .ci/docker/requirements-ci.txt"
+            )
+            sys.exit(1)
+
+
 def main():
+    check_pip_packages()
+
     options = parse_args()
 
     test_directory = str(REPO_ROOT / "test")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1523,7 +1523,12 @@ def run_tests(
 
 
 def check_pip_packages() -> None:
-    packages = ["pytest-rerunfailures", "pytest-shard", "pytest-flakefinder", "pytest-xdist"]
+    packages = [
+        "pytest-rerunfailures",
+        "pytest-shard",
+        "pytest-flakefinder",
+        "pytest-xdist",
+    ]
     installed_packages = [i.key for i in pkg_resources.working_set]
     for package in packages:
         if package not in installed_packages:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1528,7 +1528,7 @@ def check_pip_packages() -> None:
     for package in packages:
         if package not in installed_packages:
             print(
-                f"Missing pip dependency: {package}, please run `pip install -r .ci/docker/requirements-ci.txt"
+                f"Missing pip dependency: {package}, please run `pip install -r .ci/docker/requirements-ci.txt`"
             )
             sys.exit(1)
 


### PR DESCRIPTION
not very elegant

checked on separate conda env that doesnt have the usual ci dependencies

the two pytest extensions at fault are pytest-rerunfailures and pytest-shard, also included pytest-flakefinder just incase

no idea if this is a good way to do this

could also check individually and add flags based on that, but was told that needing to requiring all the ci dependencies to be downloaded was also ok