### PR TITLE
Wrap more constraint violation cases to UserError

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4,7 +4,7 @@ import unittest
 import torch
 import torch._dynamo as torchdynamo
 from torch._dynamo.eval_frame import is_dynamo_supported
-from torch._export import _export, export
+from torch._export import _export, export, dynamic_dim
 from torch._export.trace import do_not_use_experimental_export
 from torch._export.constraints import constrain_as_size
 from torch._export.graph_module import get_export_meta
@@ -111,15 +111,28 @@ class TestDynamismExpression(TestCase):
         with self.assertRaisesRegex(torchdynamo.exc.UserError, "Unable to set min size"):
             _export(invalid_size, inp)
 
-        def invalid_input(x):
+        def invalid_input_conflict_with_inline_constraints(x):
             b = x.item()
             constrain_as_size(b, min=2, max=5)
             return torch.full((b, 1), 1)
 
         inp = (torch.tensor([6]),)
+        with self.assertRaisesRegex(torchdynamo.exc.UserError, "Invalid value 6 for range"):
+            _export(invalid_input_conflict_with_inline_constraints, inp)
 
-        with self.assertRaisesRegex(torch.utils._sympy.value_ranges.ValueRangeError, "Invalid value 6 for range"):
-            _export(invalid_input, inp)
+        def invalid_input_conflict_with_input_constraints(x):
+            return x + 1
+
+        inp = torch.zeros([3])
+        inp_constraints = [
+            dynamic_dim(inp, 0) > 5,
+        ]
+        with self.assertRaisesRegex(torchdynamo.exc.UserError, "not in range"):
+            _export(
+                invalid_input_conflict_with_input_constraints,
+                (inp,),
+                constraints=inp_constraints,
+            )
 
         def conflicting_constraints(x):
             b = x.item()
@@ -522,6 +535,22 @@ class TestExport(TestCase):
         exported_results = exported_method(*args)
 
         self.assertTrue(torch.allclose(eager_results, exported_results))
+
+    @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
+    def test_raise_user_error_when_guard_on_data_dependent_operation(self):
+        def fn_ddo(x):
+            y = x.nonzero()
+            z = y.shape[0]
+            if z > 2:
+                return x.cos()
+            else:
+                return x.sin()
+
+        with self.assertRaisesRegex(
+            torchdynamo.exc.UserError,
+            "trying to get a value out of symbolic int"
+        ):
+            _ = _export(fn_ddo, (torch.tensor([2, 3, 5]),), constraints=None)
 
 
 if __name__ == '__main__':

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -11,7 +11,10 @@ import torch
 import torch._logging
 from torch._guards import tracing
 from torch._utils_internal import signpost_event
-from torch.fx.experimental.symbolic_shapes import ConstraintViolationError
+from torch.fx.experimental.symbolic_shapes import (
+    ConstraintViolationError,
+    GuardOnDataDependentSymNode,
+)
 from torch.fx.graph_module import _forward_from_src as original_forward_from_src
 
 from . import config, exc
@@ -498,6 +501,7 @@ def _compile(
         BackendCompilerFailed,
         AssertionError,
         ConstraintViolationError,
+        GuardOnDataDependentSymNode
     ) as e:
         exception_handler(e, code, frame)
         raise

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2036,7 +2036,7 @@ class ShapeEnv:
 
             vr = self.var_to_range[sympy_expr]
             if val not in vr:
-                raise RuntimeError(f"{val} not in range [{vr.lower}, {vr.upper}]")
+                raise ConstraintViolationError(f"{val} not in range [{vr.lower}, {vr.upper}]")
 
             r = sympy_expr
         else:


### PR DESCRIPTION
Cases covered in this PR:
 - Example inputs conflict with input constraints
 - Example inputs conflict with inline constraints
 - Suggest users to use `constrain_as_*()` when trying to export with data-dependent operations

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #100939



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire