### PR TITLE
[MPS] Fix bernoulli for int types

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7227,6 +7227,13 @@ class TestNLLLoss(TestCaseMPS):
         mps_out = torch.bernoulli(all_ones)
         self.assertEqual(mps_out, all_ones)
 
+        # Check it works for different dtypes
+        for dtype in [torch.float16, torch.int8, torch.int32, torch.int16, torch.int64]:
+            mps_out = torch.zeros(shape, device='mps', dtype=dtype).bernoulli(0.5)
+            self.assertEqual(mps_out.min().item(), 0.)
+            self.assertEqual(mps_out.max().item(), 1.)
+
+
     def test_mps_generator(self):
         # explicit manual seeding by creating an MPS Generator
         g_mps = torch.Generator(device='mps')


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 069fd23</samp>

This pull request enhances the MPS implementation of random operations in `Distributions.mm` and adds more dtype tests for the bernoulli distribution in `test_mps.py`. This improves the performance, correctness, and usability of the MPS backend for PyTorch. 

Fixes https://github.com/pytorch/pytorch/issues/100717

