### PR TITLE
add runtime assertions for inline constraints.

### DIFF
--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -7,11 +7,13 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch._export import _export
 from torch._export import dynamic_dim
+from torch._export.constraints import constrain_as_value
 from torch._export.passes import (
     AddRuntimeAssertionsForConstraintsPass,
     ConstPropPass,
     ReplaceBrokenOpsWithFunctionalOpsPass,
 )
+from functorch.experimental.control_flow import cond
 
 
 def count_call_function(graph: torch.fx.Graph, target: torch.ops.OpOverload) -> int:
@@ -211,6 +213,98 @@ class TestPasses(TestCase):
         eager_result_for_1_size = M().forward(torch.zeros(4, 2, 3), torch.ones(5, 5, 5))
 
         self.assertEqual(gm_result_for_1_size, eager_result_for_1_size)
+
+    def test_runtime_assert_inline_constraints_for_item(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                b = x.item()
+                constrain_as_value(b, min=2, max=5)
+                return b
+
+        x = torch.tensor([2])
+        mod = M()
+        gm = _export(mod, (x,))
+
+        pass_result = AddRuntimeAssertionsForConstraintsPass()(gm)
+        new_gm = pass_result.graph_module
+        self.assertTrue(pass_result.modified)
+
+        num_assert = count_call_function(new_gm.graph, torch.ops.aten._assert_async.msg)
+        num_scalar_tensor = count_call_function(new_gm.graph, torch.ops.aten.scalar_tensor.default)
+        # 1 constraint for shape of x, 2 constraints for b
+        self.assertEqual(num_assert, 3)
+        self.assertEqual(num_scalar_tensor, 3)
+
+        with self.assertRaisesRegex(RuntimeError, r"^_local_scalar_dense_default.*\[2, 5\].$"):
+            new_gm(torch.tensor([6]))
+
+        new_inp = torch.tensor([5])
+        self.assertEqual(mod(new_inp), new_gm(new_inp))
+
+
+    def test_runtime_assert_inline_constraints_for_nonzero(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                b = x.nonzero()
+                constrain_as_value(b.shape[0], min=3, max=5)
+                return b
+
+        x = torch.tensor([2, 1, 2, 3, 5, 0])
+
+        mod = M()
+        gm = _export(mod, (x,), constraints=[dynamic_dim(x, 0) >= 2])
+
+        pass_result = AddRuntimeAssertionsForConstraintsPass()(gm)
+        new_gm = pass_result.graph_module
+        self.assertTrue(pass_result.modified)
+        num_assert = count_call_function(new_gm.graph, torch.ops.aten._assert_async.msg)
+        num_scalar_tensor = count_call_function(new_gm.graph, torch.ops.aten.scalar_tensor.default)
+
+        # 2 constraints for b
+        self.assertEqual(num_assert, 2)
+        self.assertEqual(num_scalar_tensor, 2)
+
+        with self.assertRaisesRegex(RuntimeError, r"^nonzero_default.shape\[0\].*\[3, 5\].$"):
+            new_gm(torch.tensor([1, 1, 0, 0, 0]))
+
+        with self.assertRaisesRegex(RuntimeError, r"^nonzero_default.shape\[0\].*\[3, 5\].$"):
+            new_gm(torch.ones(6))
+
+        new_inp = torch.tensor([1, 1, 1, 1])
+        self.assertEqual(mod(new_inp), new_gm(new_inp))
+
+    @unittest.expectedFailure
+    def test_runtime_assert_inline_constraints_for_cond(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x, y):
+                def true_fn(x, y):
+                    b = x.item()
+                    constrain_as_value(b, min=2, max=5)
+                    return x
+
+                def false_fn(x, y):
+                    c = y.item()
+                    constrain_as_value(c, min=2, max=5)
+                    return y
+
+                ret = cond(pred, true_fn, false_fn, [x, y])
+                return ret
+
+        x = torch.tensor([2])
+        y = torch.tensor([5])
+        mod = M()
+        gm = _export(mod, (torch.tensor(True), x, y))
+
+        pass_result = AddRuntimeAssertionsForConstraintsPass()(gm)
 
 
 if __name__ == '__main__':

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -791,7 +791,6 @@ def export(
 
     fake_mode = None
     example_inputs = []
-    var_to_range_map = {}
 
     def dynamo_normalization_capturing_compiler(
         gm: torch.fx.GraphModule, inner_example_inputs
@@ -802,11 +801,9 @@ def export(
         ), "Tried to emit a second graph during export. Tracing through 'f' must produce a single graph."
         graph = gm
 
-        nonlocal fake_mode, example_inputs, var_to_range_map
+        nonlocal fake_mode, example_inputs
         fake_mode = _guards.detect_fake_mode(inner_example_inputs)
         example_inputs = inner_example_inputs
-        if fake_mode and fake_mode.shape_env:
-            var_to_range_map = fake_mode.shape_env.var_to_range
 
         def result_capturing_wrapper(*graph_inputs):
             nonlocal graph_captured_result
@@ -846,15 +843,6 @@ def export(
     ), "Failed to produce a graph during tracing. Tracing through 'f' must produce a single graph."
     assert out_guards is not None, "Failed to produce guards during tracing"
     assert fake_mode is not None
-
-    if (shape_env := getattr(fake_mode, "shape_env", None)) is not None:
-        dim_constraints = shape_env.dim_constraints
-        assert dim_constraints is not None
-        dim_constraints.solve()
-        log.warning(
-            "Summary of dimension constraints:%s",
-            dim_constraints.prettify_results(inspect.signature(f)),
-        )
 
     matched_input_elements_positions = produce_matching(flat_args, graph_captured_input)
 
@@ -930,15 +918,22 @@ def export(
     new_graph.meta["input_shape_constraints"] = (
         [constraint.serializable_spec for constraint in constraints]
         if constraints
-        else None
+        else []
     )
-    new_graph.meta["inline_constraints"] = {
-        node.meta["val"].node.expr: var_to_range_map[node.meta["val"].node.expr]
-        for node in new_graph.graph.nodes
-        if node.op != "placeholder" and "val" in node.meta
-        # Find constraints frome unbacked symints
-        and re.match(r"^i\d+$", str(node.meta["val"]))
-    }
+
+    if (shape_env := getattr(fake_mode, "shape_env", None)) is not None:
+        dim_constraints = shape_env.dim_constraints
+        assert dim_constraints is not None
+        dim_constraints.solve()
+        log.warning(
+            "Summary of dimension constraints:%s",
+            dim_constraints.prettify_results(inspect.signature(f)),
+        )
+
+        # Inline constraints added by users correspond to unbacked symbols in shape_env,
+        new_graph.meta["inline_constraints"] = {
+            k: v for k, v in shape_env.var_to_range.items() if re.match(r"^[if]\d+$", str(k))
+        }
 
     def signature_to_fullargspec(sig: inspect.Signature):
         # Get a list of Parameter objects from the Signature object

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -328,7 +328,6 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
         if not (min <= int(a.node.expr) <= max):
             raise ValueRangeError(f"Invalid value {int(a.node.expr)} for range [{min}:{max}]")
         return
-    # TODO: Turn this into a runtime assert too
     assert isinstance(a.node.expr, sympy.Symbol), "constraining non-Symbols NYI"
     # TODO: Shouldn't we install a guard if the symbol is backed?  Or is the
     # semantics that this is an "unchecked" assert (but it this actually


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100948
* __->__ #100947
* #100247

This pr does the following:
1. previously, inline constraints is not properly set for tensor output data-dependent ops such as a.nonzero because of its return value is not symint. This pr just uses all the unbacked symbols i.e.those start with i/f in create_unbacked_sym* functions. Note that it's guaranteed to be a super set of user constraints only if we forbid users to call constrian_as_size/value for symbols that is backed. But it doesn't seem to have such a mechanism now.

2. add inline assertions support by checking whether the symbols of the output is in inline_constraints or not. It only creates fx node and assertion messages for constrianed symbols.

Currently, it only deal with tensor, SymInt, SymFloat, SymBool output and ignore the rest. It's good enough for now as we only have a limited number of data-dependent ops (.item and .nonzero are explictly tested).

```
class ExportGraphModule(torch.nn.Module):
    def forward(self, x):
        arg0: i64[s0], = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
        nonzero_default: i64[i0, 1] = torch.ops.aten.nonzero.default(arg0);  arg0 = None
        return pytree.tree_unflatten([nonzero_default], self._out_spec)

class GraphModule(torch.nn.Module):
    def forward(self, x):
        arg0: i64[s0], = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
        sym_size: Sym(s0) = torch.ops.aten.sym_size(arg0, 0)
        nonzero_default: i64[i1, 1] = torch.ops.aten.nonzero.default(arg0);  arg0 = None
        sym_size_1: Sym(i1) = torch.ops.aten.sym_size(nonzero_default, 0)
        ge: Sym(i1 >= 3) = sym_size_1 >= 3
        scalar_tensor_default: f32[] = torch.ops.aten.scalar_tensor.default(ge);  ge = None
        _assert_async_msg = torch.ops.aten._assert_async.msg(scalar_tensor_default, 'nonzero_default.shape[0] is outside of inline constraint [3, 5].');  scalar_tensor_default = None
        le: Sym(i1 <= 5) = sym_size_1 <= 5;  sym_size_1 = None
        scalar_tensor_default_1: f32[] = torch.ops.aten.scalar_tensor.default(le);  le = None
        _assert_async_msg_1 = torch.ops.aten._assert_async.msg(scalar_tensor_default_1, 'nonzero_default.shape[0] is outside of inline constraint [3, 5].');  scalar_tensor_default_1 = None
        return pytree.tree_unflatten([nonzero_default], self._out_spec)
```

Differential Revision: [D45549837](https://our.internmc.facebook.com/intern/diff/D45549837/)