### PR TITLE
[BE] Prevent pytest from thinking this class defines any tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6019,9 +6019,9 @@ class CommonTemplate:
 
 @dataclasses.dataclass
 class TestFailure:
-    __test__: bool = False
     suffixes: Tuple[str]
     is_skip: bool = False
+    __test__: bool = False
 
 
 def copy_tests(my_cls, other_cls, suffix, test_failures=None):  # noqa: B902

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6019,6 +6019,7 @@ class CommonTemplate:
 
 @dataclasses.dataclass
 class TestFailure:
+    __test__: bool = False
     suffixes: Tuple[str]
     is_skip: bool = False
 


### PR DESCRIPTION
Fixes the error:

```
/var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6021: PytestCollectionWarning: cannot collect test class 'TestFailure' because it has a __init__ constructor (from: test/inductor/test_torchinductor.py)
  class TestFailure:
```

It does so by marking the class as not actually being a test class, despite it's name starting with `Test`.
For more details see: https://stackoverflow.com/a/72465142/21539

cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire