### PR TITLE
[inductor] added TORCH_CHECK before indirect loads and stores

### DIFF
--- a/test/inductor/indirect_assert_helper.py
+++ b/test/inductor/indirect_assert_helper.py
@@ -24,20 +24,21 @@ def store(x, y, z):
 
 
 if __name__ == "__main__":
-    _, fn_name, dims, dyn_shape = sys.argv
+    _, fn_name, dims, dyn_shape, device = sys.argv
     assert fn_name in ("first_arg", "second_arg", "same_pm_one", "same_pp_one", "store")
     assert dims in ("2", "3")
+    assert device in ("cpu", "cuda")
     shape_x = (3, 2, 4) if dims == "3" else (3, 2)
     assert dyn_shape in ("True", "False")
     dynamic_shapes = dyn_shape == "True"
 
-    x = torch.randn(shape_x, device="cuda")
-    y = torch.arange(4, device="cuda")
+    x = torch.randn(shape_x, device=device)
+    y = torch.arange(4, device=device)
     fn = vars()[fn_name]
     fn = torch.compile(dynamic=dynamic_shapes)(fn)
     if fn_name == "store":
         shape = (y.numel(),) + x.shape[2:]
-        z = torch.randn(shape, device="cuda")
+        z = torch.randn(shape, device=device)
         fn(x, y, z)
     else:
         fn(x, y)


### PR DESCRIPTION
Fixes #100343

Description:
- Added `gen_assert_indirect_indexing` method to `cpp.py` and refactored the common part
- Adapted exising triton test for cpu

Note: `TORCH_CHECK` throws an exception and thus execution is stopped with "Aborted (core dumped)" message.

<details>
<summary>
Typical traceback for index out of bounds failure
</summary>

```
terminate called after throwing an instance of 'c10::Error'
  what():  index out of bounds: 0 <= tmp0 < 20
Exception raised from kernel at /tmp/torchinductor_root/tk/ctkbvuo5hvvdwoxz7qijfh7twlspvwnypr2rwv24s73p5zfoahqy.cpp:12 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x7f91e71bc6ac in /pytorch/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, char const*) + 0x84 (0x7f91e7175572 in /pytorch/torch/lib/libc10.so)
frame #2: <unknown function> + 0x1753 (0x7f91d0c38753 in /tmp/torchinductor_root/tk/ctkbvuo5hvvdwoxz7qijfh7twlspvwnypr2rwv24s73p5zfoahqy.so)
frame #3: <unknown function> + 0x6ff5 (0x7f92279e1ff5 in /usr/lib/x86_64-linux-gnu/libffi.so.7)
frame #4: <unknown function> + 0x640a (0x7f92279e140a in /usr/lib/x86_64-linux-gnu/libffi.so.7)
frame #5: _ctypes_callproc + 0x5b6 (0x7f92279fa306 in /usr/lib/python3.8/lib-dynload/_ctypes.cpython-38-x86_64-linux-gnu.so)
frame #6: <unknown function> + 0x139dc (0x7f92279fa9dc in /usr/lib/python3.8/lib-dynload/_ctypes.cpython-38-x86_64-linux-gnu.so)
<omitting python frames>
frame #32: <unknown function> + 0x784c0c (0x7f91f9c52c0c in /pytorch/torch/lib/libtorch_python.so)
frame #36: <unknown function> + 0x7849e0 (0x7f91f9c529e0 in /pytorch/torch/lib/libtorch_python.so)
frame #45: python() [0x67d9b1]
frame #46: python() [0x67da2f]
frame #47: python() [0x67dad1]
frame #51: __libc_start_main + 0xf3 (0x7f9227ed8083 in /usr/lib/x86_64-linux-gnu/libc.so.6)

Aborted (core dumped)
```

</details>

We may want to catch such exceptions and transform it into python RuntimeError ?



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @soumith @desertfire @Valentine233 