### PR TITLE
Make sure we get full file path for filtering in pr-sanity-check

### DIFF
--- a/.github/scripts/pr-sanity-check.sh
+++ b/.github/scripts/pr-sanity-check.sh
@@ -15,7 +15,7 @@ ancestor=$(git merge-base "${BASE}" "${HEAD}")
 echo "INFO: Checking aginst the following stats"
 (
     set -x
-    git diff --stat "$ancestor" "${HEAD}" | sed '$d' > "${TMPFILE}"
+    git diff --stat=10000 "$ancestor" "${HEAD}" | sed '$d' > "${TMPFILE}"
 )
 
 while read -r git_attribute; do


### PR DESCRIPTION
The filename get a `.../` path which makes the next diff not work for files that are too nested.
This can seen in https://github.com/pytorch/pytorch/actions/runs/4920598180/jobs/8789553971?pr=100583 for example where most files are ignored.

The detection properly works after this change.