### PR TITLE
Optimize split-split pass

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -159,13 +159,9 @@ def merge_splits(
                 continue
             old_getitem = first_split_num_to_user[split_num]
             if split_num != next_split_index:
-                with graph.inserting_after(new_split):
-                    new_getitem = graph.call_function(
-                        operator.getitem, args=(new_split, new_split_num)
-                    )
+                old_getitem.update_arg(0, new_split)
+                old_getitem.update_arg(1, new_split_num)
                 new_split_num += 1
-                new_getitem.meta.update(old_getitem.meta)
-                old_getitem.replace_all_uses_with(new_getitem)
             else:
                 next_split_num_to_user = {
                     user.args[1]: user for user in node.users.keys()
@@ -181,7 +177,8 @@ def merge_splits(
                     next_getitem.replace_all_uses_with(new_getitem)
                     to_remove.append(next_getitem)
                 to_remove.append(node)
-            to_remove.append(old_getitem)
+                to_remove.append(old_getitem)
+
         to_remove.append(first_split)
     for node in to_remove:
         graph.erase_node(node)


### PR DESCRIPTION
Summary:
Previously, we were replacing all getitems of a split - even the ones not affected by the pattern. For large split nodes, this was inefficient.

For instance, on an internal ads model - split-split pass took ~1100s. This is down to ~18s after this optimization

Test Plan:
* Compiled and tested on internal model (compilation time down by ~1100s)
* CI tests

Differential Revision: D45698034



cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire