### PR TITLE
Adding serialization ID to inline container

### DIFF
--- a/c10/util/uuid.h
+++ b/c10/util/uuid.h
@@ -1,0 +1,43 @@
+#include <random>
+#include <sstream>
+
+namespace c10 {
+
+namespace uuid {
+
+static std::string generate_uuid_v4() {
+  static std::mt19937 gen(std::random_device{}());
+  static std::uniform_int_distribution<> dis_hex(0, 15);
+  static std::uniform_int_distribution<> dis_89ab(8, 11);
+
+  std::stringstream uuid;
+  int i;
+  uuid << std::hex;
+  for (i = 0; i < 8; i++) {
+    uuid << dis_hex(gen);
+  }
+  uuid << "-";
+  for (i = 0; i < 4; i++) {
+    uuid << dis_hex(gen);
+  }
+  // set the four most significant bits of the 7th byte to 0100'B, so the high
+  // nibble is "4"
+  uuid << "-4";
+  for (i = 0; i < 3; i++) {
+    uuid << dis_hex(gen);
+  }
+  uuid << "-";
+  // set the two most significant bits of the 9th byte to 10'B, so the high
+  // nibble will be one of "8", "9", "A", or "B"0
+  uuid << dis_89ab(gen);
+  for (i = 0; i < 3; i++) {
+    uuid << dis_hex(gen);
+  }
+  uuid << "-";
+  for (i = 0; i < 12; i++) {
+    uuid << dis_hex(gen);
+  };
+  return uuid.str();
+}
+} // namespace uuid
+} // namespace c10

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -93,6 +93,8 @@ typedef struct mz_zip_archive mz_zip_archive;
 namespace caffe2 {
 namespace serialize {
 
+static constexpr const char* kSerializationIdRecordName = ".data/serialization_id";
+
 class TORCH_API PyTorchStreamReader final {
  public:
   explicit PyTorchStreamReader(const std::string& file_name);
@@ -117,6 +119,9 @@ class TORCH_API PyTorchStreamReader final {
   uint64_t version() const {
     return version_;
   }
+  const std::string& serializationId() {
+    return serialization_id_;
+  }
 
   void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
     load_debug_symbol_ = should_load_debug_symbol;
@@ -137,6 +142,7 @@ class TORCH_API PyTorchStreamReader final {
   int64_t version_;
   std::mutex reader_lock_;
   bool load_debug_symbol_ = true;
+  std::string serialization_id_;
 };
 
 class TORCH_API PyTorchStreamWriter final {
@@ -164,6 +170,10 @@ class TORCH_API PyTorchStreamWriter final {
     return archive_name_;
   }
 
+  const std::string& serializationId() {
+    return serialization_id_;
+  }
+
   ~PyTorchStreamWriter();
 
  private:
@@ -177,6 +187,7 @@ class TORCH_API PyTorchStreamWriter final {
   std::string padding_;
   std::ofstream file_stream_;
   std::function<size_t(const void*, size_t)> writer_func_;
+  std::string serialization_id_;
   // This number will be updated when the model has operators
   // that have valid upgraders.
   uint64_t version_ = kMinProducedFileFormatVersion;

--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -37,6 +37,7 @@ class TestMisc(PackageTestCase):
                 ├── .data
                 │   ├── extern_modules
                 │   ├── python_version
+                │   ├── serialization_id
                 │   └── version
                 ├── main
                 │   └── main
@@ -61,6 +62,7 @@ class TestMisc(PackageTestCase):
                 ├── .data
                 │   ├── extern_modules
                 │   ├── python_version
+                │   ├── serialization_id
                 │   └── version
                 ├── main
                 │   └── main

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1349,6 +1349,7 @@ void initJITBindings(PyObject* module) {
                 name, reinterpret_cast<const char*>(data), size);
           })
       .def("archive_name", &PyTorchStreamWriter::archiveName)
+      .def("serialization_id", &PyTorchStreamWriter::serializationId)
       .def(
           "get_all_written_records",
           &PyTorchStreamWriter::getAllWrittenRecords);
@@ -1473,6 +1474,7 @@ void initJITBindings(PyObject* module) {
                     at::CPU(scalar_type).typeMeta());
             return at::Tensor(std::move(ptr));
           })
+      .def("serialization_id", &PyTorchStreamReader::serializationId)
       .def("get_all_records", [](PyTorchStreamReader& self) {
         return self.getAllRecords();
       });

--- a/torch/package/_directory_reader.py
+++ b/torch/package/_directory_reader.py
@@ -5,6 +5,8 @@ from typing import cast
 import torch
 from torch.types import Storage
 
+__serialization_id_record_name__ = ".data/serialization_id"
+
 
 # because get_storage_from_record returns a tensor!?
 class _HasStorage:
@@ -51,3 +53,11 @@ class DirectoryReader:
             if not os.path.isdir(filename):
                 files.append(filename[len(self.directory) + 1 :])
         return files
+
+    def serialization_id(
+        self,
+    ):
+        if self.has_record(__serialization_id_record_name__):
+            return self.get_record(__serialization_id_record_name__)
+        else:
+            return ""


### PR DESCRIPTION
Summary:
In order to better track models after serialization, this change writes a serialization_id as a UUID to inline container. Having this ID enables traceability of model in saving and loading events.
serialization_id is generated as a new UUID everytime serialization takes place. It can be thought of as a model snapshot identifier at the time of serialization.

Test Plan:
```
buck2 test @//mode/dev //caffe2/caffe2/serialize:inline_container_test
```

Local tests:
```
buck2 run @//mode/opt //scripts/atannous:example_pytorch_package
buck2 run @//mode/opt //scripts/atannous:example_pytorch
buck2 run @//mode/opt //scripts/atannous:example_pytorch_script
```

```
$ unzip -l output.pt
Archive:  output.pt
  Length      Date    Time    Name
---------  ---------- -----   ----
       36  00-00-1980 00:00   output/.data/serialization_id
      358  00-00-1980 00:00   output/extra/producer_info.json
       58  00-00-1980 00:00   output/data.pkl
      261  00-00-1980 00:00   output/code/__torch__.py
      326  00-00-1980 00:00   output/code/__torch__.py.debug_pkl
        4  00-00-1980 00:00   output/constants.pkl
        2  00-00-1980 00:00   output/version
---------                     -------
     1045                     7 files
```

```
unzip -p output.pt "output/.data/serialization_id"
a9f903df-cbf6-40e3-8068-68086167ec60
```

Differential Revision: D45683657

