### PR TITLE
[ET selective build] SelectiveBuilder.et_compute_selected_specialized_kernels

### DIFF
--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -107,8 +107,7 @@ class SelectiveBuilder:
         for k, v in kernel_metadata_dict.items():
             kernel_metadata[str(k)] = [str(dtype) for dtype in v]
 
-        # TODO(T149265497): Need to parse the et kernel metadata
-        et_kernel_metadata: Dict[str, List[List[str]]] = {}
+        et_kernel_metadata = data.get("et_kernel_metadata", {})
 
         custom_classes = data.get("custom_classes", [])
         assert isinstance(custom_classes, Iterable)


### PR DESCRIPTION
Summary:
For all specialized kernels (dtype/dim-order combo) recorded in selective_build.yaml, we include the corresponding specialized kernel from the available specialized kernels (format to be specified, assuming it's a `(dtype, dim-order)` tuple). We return a bool array for whether the corresponding kernel is selected.

If the available specialized kernels cannot cover all usages, we return an empty list. We need to use fallback kernel then.

Test Plan: `buck test xplat/caffe2/tools:test_torchgen_executorch`

Reviewed By: larryliu0820

Differential Revision: D45593556

