### PR TITLE
Restore Vulkan tests to periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -213,3 +213,23 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
         ]}
+
+  linux-vulkan-bionic-py3_11-clang9-build:
+    name: linux-vulkan-bionic-py3.11-clang9
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-vulkan-bionic-py3.11-clang9
+      docker-image-name: pytorch-linux-bionic-py3.11-clang9
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+        ]}
+
+  linux-vulkan-bionic-py3_11-clang9-test:
+    name: linux-vulkan-bionic-py3.11-clang9
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-vulkan-bionic-py3_11-clang9-build
+    with:
+      build-environment: linux-vulkan-bionic-py3.11-clang9
+      docker-image: ${{ needs.linux-vulkan-bionic-py3_11-clang9-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-vulkan-bionic-py3_11-clang9-build.outputs.test-matrix }}

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -31,26 +31,6 @@ jobs:
           echo "Once the jobs are deemed stable enough (% red signal < 5% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
 
-  linux-vulkan-bionic-py3_11-clang9-build:
-    name: linux-vulkan-bionic-py3.11-clang9
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-vulkan-bionic-py3.11-clang9
-      docker-image-name: pytorch-linux-bionic-py3.11-clang9
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
-        ]}
-
-  linux-vulkan-bionic-py3_11-clang9-test:
-    name: linux-vulkan-bionic-py3.11-clang9
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-vulkan-bionic-py3_11-clang9-build
-    with:
-      build-environment: linux-vulkan-bionic-py3.11-clang9
-      docker-image: ${{ needs.linux-vulkan-bionic-py3_11-clang9-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-vulkan-bionic-py3_11-clang9-build.outputs.test-matrix }}
-
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-build.yml


### PR DESCRIPTION
The flaky issue has been fixed by https://github.com/pytorch/pytorch/pull/100909.  In addition, retry support for C++ is now available after https://github.com/pytorch/pytorch/pull/99956.  So it's safe to move this back from unstable now.

Per the discussion with @clee2000, it makes sense to have this as a periodic job given that this one rarely fails.  To prevent any gap here, I have created https://github.com/pytorch/test-infra/pull/4144 to add the necessary testing for Vulkan change.
