### PR TITLE
[reland][quant][pt2e] Change input act annotation to a map and allow dynamic quantization for non zeroth argument (#101005)

### DIFF
--- a/torch/ao/quantization/_pt2e/prepare.py
+++ b/torch/ao/quantization/_pt2e/prepare.py
@@ -1,7 +1,11 @@
 import torch
 from torch._subclasses import FakeTensor
 from torch.ao.quantization.fx.prepare import (
-    _maybe_insert_input_observers_for_node,
+    _needs_obs_or_fq,
+    _get_arg_as_input_act_obs_or_fq_ctr,
+    _get_output_act_obs_or_fq_ctr,
+    _get_dtype_and_is_dynamic,
+    _insert_observer,
     _maybe_insert_output_observer_for_node,
     _is_observer_in_same_graph,
     _maybe_make_input_output_share_observers,
@@ -9,12 +13,134 @@ from torch.ao.quantization.fx.prepare import (
     _maybe_insert_observers_before_graph_output,
     _save_state
 )
-from torch.fx import GraphModule
-from torch.fx import Node
+from torch.fx import (
+    GraphModule,
+    Node,
+)
+from torch.fx.node import Argument
 
 from torch.ao.quantization import QConfigMapping
+from torch.ao.quantization.qconfig import QConfigAny
 from torch.ao.quantization.fx.custom_config import PrepareCustomConfig
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union, Any
+
+def _maybe_insert_input_observer_for_arg_or_kwarg(
+    node: Union[Node, Any],
+    arg: Argument,
+    qconfig: QConfigAny,
+    model: torch.nn.Module,
+    named_modules: Dict[str, torch.nn.Module],
+) -> Argument:
+    """
+    Given a `node` and an `arg`, inserts an input observer between
+    `node` and `arg` if necessary.
+    """
+    # for ops such as torch.cat([x0, x1]),
+    # traverse through the list
+    if isinstance(arg, (list, tuple)):
+        new_arg_to_return = []
+        for inner_arg in arg:
+            new_inner_arg = _maybe_insert_input_observer_for_arg_or_kwarg(
+                node, inner_arg, qconfig, model, named_modules,
+            )
+            new_arg_to_return.append(new_inner_arg)
+        return type(arg)(new_arg_to_return)
+
+    if not isinstance(arg, Node):
+        return arg
+    assert isinstance(arg, Node)
+    # default (no observer)
+    new_arg = arg
+
+    # TODO: we are assuming "target_dtype_info" exists here, maybe
+    # a default value also need to be provided here
+    target_dtype_info = node.meta["target_dtype_info"]
+    # for nodes that doesn't have `reuse_input_obs_or_fq` configured,
+    # we'll default to False, this makes configuring this field optional for users
+    reuse_input_obs_or_fq = target_dtype_info.get("reuse_input_obs_or_fq", False)
+    arg_as_input_act_obs_or_fq_ctr = _get_arg_as_input_act_obs_or_fq_ctr(arg, node, named_modules)
+    act_post_process_ctr = arg_as_input_act_obs_or_fq_ctr
+
+    arg_as_output_act_obs_or_fq_ctr = _get_output_act_obs_or_fq_ctr(arg, named_modules)
+    arg_as_output_target_dtype, arg_as_output_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_output_act_obs_or_fq_ctr)
+    arg_as_input_target_dtype, arg_as_input_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_input_act_obs_or_fq_ctr)
+
+
+    needs_obs_or_fq = _needs_obs_or_fq(
+        arg_as_output_target_dtype,
+        arg_as_output_target_is_dynamic,
+        arg_as_input_target_dtype,
+        arg_as_input_target_is_dynamic,
+        reuse_input_obs_or_fq,
+        True,  # set is_zeroth_arg to True so that non-zeroth arg can be observed for
+               # dynamic quantization as well
+    )
+
+    if needs_obs_or_fq:
+
+        new_obs_mod = act_post_process_ctr()
+        existing_obs_node = None
+
+        # Before using the new observer, check if an observer
+        # of the correct type already exists. If it does, use it.
+        # This prevents duplicate observer insertions if a node is
+        # used by multiple nodes.
+        # TODO: this is looking into how the value is used in the future
+        # we should remove this
+        # removing this means we insert one observer for each use, even if they
+        # have the same dtype, we can have an extra pass that removes the extra observers
+        for maybe_obs_node, _ in arg.users.items():
+            if maybe_obs_node.op == 'call_module':
+                maybe_obs_mod = named_modules[maybe_obs_node.target]  # type: ignore[index]
+                if (
+                    type(maybe_obs_mod) == type(new_obs_mod) and
+                    maybe_obs_mod.dtype == arg_as_input_target_dtype
+                ):
+                    existing_obs_node = maybe_obs_node
+                    break
+
+        if existing_obs_node is None:
+            new_obs_node = _insert_observer(
+                arg, new_obs_mod, model, named_modules, model.graph)  # type: ignore[arg-type]
+            # override this arg to be the observed arg
+            new_arg = new_obs_node
+        else:
+            new_arg = existing_obs_node
+
+    return new_arg
+
+def _maybe_insert_input_observers_for_node(
+    node: Node,
+    qconfig: QConfigAny,
+    model: torch.nn.Module,
+    named_modules: Dict[str, torch.nn.Module],
+) -> None:
+    """
+    If needed, inserts observers to the input args and kwargs of `node`.
+    Note: modifies `node` inplace.
+
+    For example, if cur_node needs an observer after prev_node, we change from
+
+      prev_node -> cur_node
+
+    To
+
+      prev_node -> obs -> cur_node
+
+    """
+    # Look through every input arg.  If that arg's target dtype does not
+    # match the current node's target dtype, insert an observer.
+    new_args = []
+    for arg in node.args:
+        new_arg = _maybe_insert_input_observer_for_arg_or_kwarg(
+            node, arg, qconfig, model, named_modules,
+        )
+        new_args.append(new_arg)
+
+    assert len(node.kwargs) == 0, " expecting kwargs for aten op IR to be empty"
+
+    # assign the new args to the node, inplace
+    node.args = tuple(new_args)
 
 def _maybe_insert_input_and_output_observers_for_node(
     node: Node,
@@ -43,10 +169,6 @@ def _maybe_insert_input_and_output_observers_for_node(
         None,  # qconfig
         model,
         named_modules,
-        model.graph,
-        None,  # qhandler
-        PrepareCustomConfig(),
-        None,  # backend_config
     )
 
     # this returns the new observer node if it was needed

--- a/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
@@ -406,14 +406,15 @@ class QNNPackQuantizer(Quantizer):
         if _is_annotated([relu_node, conv_node]):
             return
 
+        input_node = conv_node.args[0]
+        weight_node = conv_node.args[1]
+        bias_node = conv_node.args[2]
         conv_node.meta["target_dtype_info"] = {
-            "input_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(quantization_config),
-            "weight_obs_or_fq_ctr": get_weight_obs_or_fq_ctr(quantization_config),
-            "bias_obs_or_fq_ctr": get_bias_obs_or_fq_ctr(quantization_config),
-            # TODO: validation of weight_index must be set if weight_obs_or_fq_ctr is set
-            "weight_index": 1,
-            # TODO: validation of bias_index must be set if bias_obs_or_fq_ctr is set
-            "bias_index": 2,
+            "input_act_obs_or_fq_ctr_map": {
+                input_node: get_act_obs_or_fq_ctr(quantization_config),
+                weight_node: get_weight_obs_or_fq_ctr(quantization_config),
+                bias_node: get_bias_obs_or_fq_ctr(quantization_config),
+            },
             "_annotated": True,
         }
         relu_node.meta["target_dtype_info"] = {
@@ -433,15 +434,17 @@ class QNNPackQuantizer(Quantizer):
         # skip annotation if it is already annotated
         if _is_annotated([conv_node]):
             return
+
+        input_node = conv_node.args[0]
+        weight_node = conv_node.args[1]
+        bias_node = conv_node.args[2]
         conv_node.meta["target_dtype_info"] = {
-            "input_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(quantization_config),
-            "weight_obs_or_fq_ctr": get_weight_obs_or_fq_ctr(quantization_config),
-            "bias_obs_or_fq_ctr": get_bias_obs_or_fq_ctr(quantization_config),
+            "input_act_obs_or_fq_ctr_map": {
+                input_node: get_act_obs_or_fq_ctr(quantization_config),
+                weight_node: get_weight_obs_or_fq_ctr(quantization_config),
+                bias_node: get_bias_obs_or_fq_ctr(quantization_config),
+            },
             "output_act_obs_or_fq_ctr": get_act_obs_or_fq_ctr(quantization_config),
-            # TODO: validation of weight_index must be set if weight_obs_or_fq_ctr is set
-            "weight_index": 1,
-            # TODO: validation of bias_index must be set if bias_obs_or_fq_ctr is set
-            "bias_index": 2,
             "_annotated": True,
         }
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/101005

Previously the node annotation looks like the following:
```
node.meta["..."] = {
    "input_act_obs_or_fq_ctr": ...,
    "weight_obs_or_fq_ctr": ...,
    "weight_index": 1,
}
```
Basically we need specifiy the index for weight and also have a separate key for weight config, in this PR we changed that to:
```
node.meta["..."] = {
    "input_act_obs_or_fq_ctr_map": {input_node: ..., weight_node: ...},
}
```
This can support specifying the observer/fake quant constructor for any argument of the node

Test Plan: buck2 test @//mode/opt //caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_resnet18_with_quantizer_api (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2EModels)'

Differential Revision: D45719781

