### PR TITLE
[pt2] Add some helper function for SymIntVector

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -467,6 +467,10 @@ bool IValue::isIntList() const {
   return isListOf<c10::IntType>();
 }
 
+bool IValue::isSymIntList() const {
+  return isListOf<c10::SymIntType>();
+}
+
 bool IValue::isBoolList() const {
   return isListOf<c10::BoolType>();
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -667,9 +667,11 @@ public:
 
   // IntList
   bool isIntList() const;
+  bool isSymIntList() const;
   c10::List<int64_t> toIntList() &&;
   c10::List<int64_t> toIntList() const&;
   std::vector<int64_t> toIntVector() const;
+  std::vector<c10::SymInt> toSymIntVector() const;
   at::DimVector toDimVector() const;
 
   // ConstantString

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1964,6 +1964,14 @@ inline std::vector<int64_t> IValue::toIntVector() const {
   return createVectorFromList<int64_t>(
       static_cast<const c10::detail::ListImpl*>(payload.u.as_intrusive_ptr));
 }
+inline std::vector<c10::SymInt> IValue::toSymIntVector() const {
+  AT_ASSERT(isSymIntList() || isIntList(), "Expected SymIntList or IntList but got ", tagKind());
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      payload.u.as_intrusive_ptr != c10::UndefinedTensorImpl::singleton(),
+      "called toSymIntVector on null intrusive_ptr IValue");
+  return createVectorFromList<c10::SymInt>(
+      static_cast<const c10::detail::ListImpl*>(payload.u.as_intrusive_ptr));
+}
 inline at::DimVector IValue::toDimVector() const {
   AT_ASSERT(isIntList(), "Expected IntList but got ", tagKind());
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(


### PR DESCRIPTION
Summary: To SymInt-ify some fbgemm kernels https://github.com/pytorch/FBGEMM/blob/f4c83b4fb362683c19afd71c5083ea6615e1d601/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp#L109, we need to provide a toSymIntVector helper function in pytorch

Test Plan: Run fbgemm op + torch.compile to make sure the symbolic shape is produced.

Differential Revision: D45724091

