### PR TITLE
ASAN: fix use-after-free

### DIFF
--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -395,7 +395,9 @@ const Tensor& resize_(
     SymIntArrayRef size,
     c10::optional<MemoryFormat> optional_memory_format) {
   // Hold sizes to verify if we actually resize `self`.
-  auto org_size = self.sym_sizes();
+  // Explicitly copy data, since resizing can move original data
+  // and make references invalid.
+  auto org_size = self.sym_sizes().vec();
   {
     at::AutoDispatchBelowADInplaceOrView guard;
     at::redispatch::resize__symint(
@@ -417,7 +419,9 @@ const Tensor& resize_as_(
     const Tensor& the_template,
     c10::optional<MemoryFormat> optional_memory_format) {
   // Hold sizes to verify if we actually resize `self`.
-  auto org_size = self.sym_sizes();
+  // Explicitly copy data, since resizing can move original data
+  // and make references invalid.
+  auto org_size = self.sym_sizes().vec();
   {
     at::AutoDispatchBelowADInplaceOrView guard;
     at::redispatch::resize_as_(


### PR DESCRIPTION
When tensor is resized, reference array to it's sizes may become invalid. Make a copy in advance.

<details>
<summary>ASAN report</summary>

```
=================================================================
==1115867==ERROR: AddressSanitizer: heap-use-after-free on address 0x61000013d790 at pc 0x03ff8e7da360 bp 0x03fff53c83a0 sp 0x03fff53c8390
READ of size 8 at 0x61000013d790 thread T0
    #0 0x3ff8e7da35f in c10::SymInt::is_heap_allocated() const /home/user/pytorch/c10/core/SymInt.h:154
    #1 0x3ff8e7da35f in c10::SymInt::maybe_as_int() const /home/user/pytorch/c10/core/SymInt.h:215
    #2 0x3ff8e7d0a6d in c10::SymInt::sym_eq(c10::SymInt const&) const /home/user/pytorch/c10/core/SymInt.cpp:69
    #3 0x3ff7a9ab0bd in c10::SymInt::operator==(c10::SymInt const&) const /home/user/pytorch/c10/core/SymInt.h:177
    #4 0x3ff7a9aaedd in bool std::__equal<false>::equal<c10::SymInt const*, c10::SymInt const*>(c10::SymInt const*, c10::SymInt const*, c10::SymInt const*) /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-
v11/bits/stl_algobase.h:1162
    #5 0x3ff7a9aae4b in bool std::__equal_aux1<c10::SymInt const*, c10::SymInt const*>(c10::SymInt const*, c10::SymInt const*, c10::SymInt const*) /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/
stl_algobase.h:1211
    #6 0x3ff7a9aae05 in bool std::__equal_aux<c10::SymInt const*, c10::SymInt const*>(c10::SymInt const*, c10::SymInt const*, c10::SymInt const*) /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/s
tl_algobase.h:1219
    #7 0x3ff7a9aad97 in bool std::equal<c10::SymInt const*, c10::SymInt const*>(c10::SymInt const*, c10::SymInt const*, c10::SymInt const*) /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/stl_alg
obase.h:1556
    #8 0x3ff4b23c771 in c10::ArrayRef<c10::SymInt>::equals(c10::ArrayRef<c10::SymInt>) const /home/user/pytorch/c10/util/ArrayRef.h:188
    #9 0x3ff4cb91bc1 in bool c10::operator!=<c10::SymInt>(c10::ArrayRef<c10::SymInt>, c10::ArrayRef<c10::SymInt>) /home/user/pytorch/c10/util/ArrayRef.h:341
    #10 0x3ff6d1b57ff in torch::ADInplaceOrView::resize_(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pytorch/torch/csrc/autograd/Variab
leTypeManual.cpp:408
    #11 0x3ff6d1e59c7 in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c1
0::MemoryFormat>), &torch::ADInplaceOrView::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>
> >::operator()(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13
    #12 0x3ff6d1e59c7 in c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10:
:ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>), &torch::ADInplaceOrView::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::Sy
mInt>, c10::optional<c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::Disp
atchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:480
    #13 0x3ff51ca5129 in at::Tensor const& c10::callUnboxedKernelFunction<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(void*, c10::OperatorKernel*,
c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>&&, c10::optional<c10::MemoryFormat>&&) /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50
    #14 0x3ff51ca6e8f in at::Tensor const& c10::KernelFunction::call<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, c10::D
ispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:90
    #15 0x3ff51ca6e8f in at::Tensor const& c10::Dispatcher::redispatch<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Ten
sor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)> const&, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)
const /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:656
    #16 0x3ff5182006b in c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::redispatch(c10::DispatchKeySet, at::Tensor const&, c
10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492
    #17 0x3ff5182006b in at::_ops::resize_::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) aten/src/ATen/Operators_4.cpp:2144
    #18 0x3ff6d1d5e07 in at::redispatch::resize__symint(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) aten/src/ATen/RedispatchFunctions.h:2847
    #19 0x3ff6d1bbb67 in torch::autograd::VariableType::(anonymous namespace)::resize_(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pyto
rch/torch/csrc/autograd/VariableTypeManual.cpp:243
    #20 0x3ff6d1bd197 in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c1
0::MemoryFormat>), &torch::autograd::VariableType::(anonymous namespace)::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10
::optional<c10::MemoryFormat> > >::operator()(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pytorch/aten/src/ATen/core/boxing/impl/WrapFu
nctionIntoFunctor.h:13
    #21 0x3ff6d1bd197 in c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10:
:ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>), &torch::autograd::VariableType::(anonymous namespace)::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor
 const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::call(c
10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) /home/user/pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor
.h:480
    #22 0x3ff51ca5129 in at::Tensor const& c10::callUnboxedKernelFunction<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(void*, c10::OperatorKernel*,
c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>&&, c10::optional<c10::MemoryFormat>&&) /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50
    #23 0x3ff5181ead1 in at::Tensor const& c10::KernelFunction::call<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, c10::D
ispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:90
    #24 0x3ff5181ead1 in at::Tensor const& c10::Dispatcher::call<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Tensor co
nst& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)> const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const /home/user/pytorch/at
en/src/ATen/core/dispatch/Dispatcher.h:639
    #25 0x3ff5181ead1 in c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::call(at::Tensor const&, c10::ArrayRef<c10::SymInt>,
c10::optional<c10::MemoryFormat>) const /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:487
    #26 0x3ff5181ead1 in at::_ops::resize_::call(at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) aten/src/ATen/Operators_4.cpp:2137
    #27 0x3ff79b44fcf in at::Tensor::resize__symint(c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const aten/src/ATen/core/TensorBody.h:2452
    #28 0x3ff79a802db in torch::autograd::THPVariable_resize_(_object*, _object*, _object*)::$_0::operator()(at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const /home/us
er/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:13417
    #29 0x3ff7999f1eb in torch::autograd::THPVariable_resize_(_object*, _object*, _object*) /home/user/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:13419
    #30 0x3ffa2c9b009 in method_vectorcall_VARARGS_KEYWORDS Objects/descrobject.c:344
    #31 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #32 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #33 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #34 0x3ffa2dff7d7 in _PyEval_EvalFrameDefault Python/ceval.c:4198
    #35 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #36 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #37 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #38 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #39 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #40 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #41 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #42 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #43 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #44 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #45 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #46 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #47 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #48 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #49 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #50 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #51 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #52 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #53 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #54 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #55 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #56 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #57 0x3ffa2dff7d7 in _PyEval_EvalFrameDefault Python/ceval.c:4198
    #58 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #59 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #60 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #61 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #62 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #63 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #64 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #65 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #66 0x3ffa2dff905 in _PyEval_EvalFrameDefault Python/ceval.c:4213
    #67 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #68 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #69 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #70 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #71 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #72 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #73 0x3ffa2dff7d7 in _PyEval_EvalFrameDefault Python/ceval.c:4198
    #74 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #75 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #76 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #77 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #78 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #79 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #80 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #81 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #82 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #83 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #84 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #85 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #86 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #87 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #88 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #89 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #90 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #91 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #92 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #93 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #94 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #95 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #96 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #97 0x3ffa2c8ab9b in PyVectorcall_Call Objects/call.c:267
    #98 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #99 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #100 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #101 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #102 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #103 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #104 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #105 0x3ffa2c8a695 in _PyObject_FastCallDictTstate Objects/call.c:153
    #106 0x3ffa2c8b271 in _PyObject_Call_Prepend Objects/call.c:431
    #107 0x3ffa2d3f307 in slot_tp_call Objects/typeobject.c:7494
    #108 0x3ffa2c8a933 in _PyObject_MakeTpCall Objects/call.c:215
    #109 0x3ffa2df0081 in _PyObject_VectorcallTstate Include/cpython/abstract.h:112
    #110 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #111 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #112 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #113 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #114 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #115 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #116 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #117 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #118 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #119 0x3ffa2dff7d7 in _PyEval_EvalFrameDefault Python/ceval.c:4198
    #120 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #121 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #122 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #123 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #124 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #125 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #126 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #127 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #128 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #129 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #130 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #131 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #132 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #133 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #134 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #135 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #136 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #137 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #138 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #139 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #140 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #141 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #142 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #143 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #144 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #145 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #146 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #147 0x3ffa2c8a695 in _PyObject_FastCallDictTstate Objects/call.c:153
    #148 0x3ffa2c8b271 in _PyObject_Call_Prepend Objects/call.c:431
    #149 0x3ffa2d3f307 in slot_tp_call Objects/typeobject.c:7494
    #150 0x3ffa2c8ad17 in _PyObject_Call Objects/call.c:305
    #151 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #152 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #153 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #154 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #155 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #156 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #157 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #158 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #159 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #160 0x3ffa2dff905 in _PyEval_EvalFrameDefault Python/ceval.c:4213
    #161 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #162 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #163 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #164 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #165 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #166 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #167 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #168 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #169 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #170 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #171 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #172 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #173 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #174 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #175 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #176 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #177 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #178 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #179 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #180 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #181 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #182 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #183 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #184 0x3ffa2dff905 in _PyEval_EvalFrameDefault Python/ceval.c:4213
    #185 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #186 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #187 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #188 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #189 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #190 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #191 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #192 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #193 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #194 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #195 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #196 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #197 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #198 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #199 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #200 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #201 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #202 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #203 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #204 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #205 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #206 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #207 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #208 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #209 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #210 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #211 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #212 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #213 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #214 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #215 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #216 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #217 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #218 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #219 0x3ffa2c8a695 in _PyObject_FastCallDictTstate Objects/call.c:153
    #220 0x3ffa2c8b271 in _PyObject_Call_Prepend Objects/call.c:431
    #221 0x3ffa2d3f307 in slot_tp_call Objects/typeobject.c:7494
    #222 0x3ffa2c8a933 in _PyObject_MakeTpCall Objects/call.c:215
    #223 0x3ffa2df0081 in _PyObject_VectorcallTstate Include/cpython/abstract.h:112
    #224 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #225 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #226 0x3ffa2dffa57 in _PyEval_EvalFrameDefault Python/ceval.c:4231
    #227 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #228 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #229 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #230 0x3ffa2c8ab15 in PyVectorcall_Call Objects/call.c:255
    #231 0x3ffa2c8ac65 in _PyObject_Call Objects/call.c:290
    #232 0x3ffa2c8ada9 in PyObject_Call Objects/call.c:317
    #233 0x3ffa2e059c7 in do_call_core Python/ceval.c:5943
    #234 0x3ffa2dffd39 in _PyEval_EvalFrameDefault Python/ceval.c:4277
    #235 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #236 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #237 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #238 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #239 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #240 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #241 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #242 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #243 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #244 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #245 0x3ffa2c8e941 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #246 0x3ffa2c8eddd in method_vectorcall Objects/classobject.c:53
    #247 0x3ffa2df00a9 in _PyObject_VectorcallTstate Include/cpython/abstract.h:114
    #248 0x3ffa2df013d in PyObject_Vectorcall Include/cpython/abstract.h:123
    #249 0x3ffa2e05447 in call_function Python/ceval.c:5891
    #250 0x3ffa2dff779 in _PyEval_EvalFrameDefault Python/ceval.c:4181
    #251 0x3ffa2df052b in _PyEval_EvalFrame Include/internal/pycore_ceval.h:46
    #252 0x3ffa2e02b67 in _PyEval_Vector Python/ceval.c:5065
    #253 0x3ffa2c8aec1 in _PyFunction_Vectorcall Objects/call.c:342
    #254 0x3ffa2c8a695 in _PyObject_FastCallDictTstate Objects/call.c:153
    #255 0x3ffa2c8b271 in _PyObject_Call_Prepend Objects/call.c:431
    #256 0x3ffa2d3f307 in slot_tp_call Objects/typeobject.c:7494
    #257 0x3ffa2c8a933 in _PyObject_MakeTpCall Objects/call.c:215

0x61000013d790 is located 80 bytes inside of 192-byte region [0x61000013d740,0x61000013d800)
freed by thread T0 here:
    #0 0x3ffa3237de5 in operator delete(void*) /var/tmp/portage/sys-devel/gcc-11.3.1_p20230303/work/gcc-11-20230303/libsanitizer/asan/asan_new_delete.cpp:160
    #1 0x3ff8e7e3221 in c10::TensorImpl::~TensorImpl() /home/user/pytorch/c10/core/TensorImpl.cpp:75

previously allocated by thread T0 here:
    #0 0x3ffa323734f in operator new(unsigned long) /var/tmp/portage/sys-devel/gcc-11.3.1_p20230303/work/gcc-11-20230303/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x3ff4aeeb3d1 in c10::intrusive_ptr<c10::TensorImpl, c10::detail::intrusive_target_default_null_type<c10::TensorImpl> > c10::intrusive_ptr<c10::TensorImpl, c10::detail::intrusive_target_default_nul
l_type<c10::TensorImpl> >::make<c10::intrusive_ptr<c10::StorageImpl, c10::detail::intrusive_target_default_null_type<c10::StorageImpl> >, c10::DispatchKeySet&, caffe2::TypeMeta&>(c10::intrusive_ptr<c10::S
torageImpl, c10::detail::intrusive_target_default_null_type<c10::StorageImpl> >&&, c10::DispatchKeySet&, caffe2::TypeMeta&) /home/user/pytorch/c10/util/intrusive_ptr.h:498
    #2 0x3ff76f79e17  (/home/user/pytorch/build/lib.linux-s390x-cpython-310/torch/lib/libtorch_cpu.so+0x2fb79e17)

SUMMARY: AddressSanitizer: heap-use-after-free /home/user/pytorch/c10/core/SymInt.h:154 in c10::SymInt::is_heap_allocated() const
Shadow bytes around the buggy address:
  0x100c2000027aa0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x100c2000027ab0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x100c2000027ac0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x100c2000027ad0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x100c2000027ae0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x100c2000027af0: fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x100c2000027b00: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x100c2000027b10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100c2000027b20: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x100c2000027b30: 00 00 00 00 04 fa fa fa fa fa fa fa fa fa fa fa
  0x100c2000027b40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==1115867==ABORTING
```
</details>

<details>
<summary>Additional backtraces (not full)</summary>

Memory deallocation:
```
#0  operator delete (ptr=0x61000013d740) at /var/tmp/portage/sys-devel/gcc-11.3.1_p20230303/work/gcc-11-20230303/libsanitizer/asan/asan_new_delete.cpp:160
#1  0x000003ffa77e3222 in c10::TensorImpl::~TensorImpl (this=0x61000013d740) at /home/user/pytorch/c10/core/TensorImpl.cpp:75
#2  0x000003ff63e76e8c in c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reset_ (this=0x3ffd7ec8230) at /home/user/pytorch/c10/util/intrusive_ptr.h:291
#3  0x000003ff63e76910 in c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::~intrusive_ptr (this=0x3ffd7ec8230) at /home/user/pytorch/c10/util/intrusive_ptr.h:370
#4  0x000003ff63e67240 in at::TensorBase::~TensorBase (this=0x3ffd7ec8230) at /home/user/pytorch/aten/src/ATen/core/TensorBase.h:80
#5  0x000003ff63e85ee0 in at::Tensor::~Tensor (this=0x3ffd7ec8230) at aten/src/ATen/core/TensorBody.h:90
#6  0x000003ff63f67304 in resize__functionalization (dispatchKeySet=..., self=..., size=..., memory_format=...) at /home/user/pytorch/aten/src/ATen/FunctionalizeFallbackKernel.cpp:173
#7  0x000003ff63f89258 in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>), &(resize__functionalization(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>))>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat> > >::operator()(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>) (
    this=0x6030000390a0, args=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13
#8  c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>), &(resize__functionalization(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>))>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>) (functor=0x6030000390a0, dispatchKeySet=..., args=..., args=...,
    args=...) at /home/user/pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:480
#9  0x000003ff6aca560a in c10::callUnboxedKernelFunction<at::Tensor const&, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat> > (
    unboxed_kernel_func=0x3ff63f88a80 <c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tenso
r const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>), &(resize__functionalization(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>))>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<long>, c10::optional<c10::MemoryFormat>)>, functor=0x6030000390a0,
    dispatchKeySet=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50
#10 0x000003ff6aca715c in c10::KernelFunction::call<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> > (this=0x6210005e1b28, opHandle=...,
    dispatchKeySet=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:96
#11 c10::Dispatcher::redispatch<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)> const&, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const (
    this=0x3ff919400e0 <c10::Dispatcher::realSingleton()::_singleton>, op=..., currentDispatchKeySet=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:656
#12 0x000003ff6a82006c in c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const (
    this=0x3ff919a07e0 <at::_ops::resize_::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)::op>, currentDispatchKeySet=..., args=...,
    args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492
#13 at::_ops::resize_::redispatch (dispatchKeySet=..., self=..., size=..., memory_format=...) at /home/user/pytorch/build/aten/src/ATen/Operators_4.cpp:2144
#14 0x000003ff861d5e08 in at::redispatch::resize__symint (dispatchKeySet=..., self=..., size=..., memory_format=...) at aten/src/ATen/RedispatchFunctions.h:2847
#15 0x000003ff861b579e in torch::ADInplaceOrView::resize_ (ks=..., self=..., size=..., optional_memory_format=...) at /home/user/pytorch/torch/csrc/autograd/VariableTypeManual.cpp:401
```

Memory access:
```
#0  c10::SymInt::maybe_as_int (this=0x61000013d790) at /home/user/pytorch/c10/core/SymInt.h:215
#1  0x000003ff734d0a6e in c10::SymInt::sym_eq (this=0x61000013d790, sci=...) at /home/user/pytorch/c10/core/SymInt.cpp:69
#2  0x000003ff5f6ab0be in c10::SymInt::operator== (this=0x61000013d790, o=...) at /home/user/pytorch/c10/core/SymInt.h:177
#3  0x000003ff5f6aaede in std::__equal<false>::equal<c10::SymInt const*, c10::SymInt const*> (__first1=0x61000013d790, __last1=0x61000013d7a0, __first2=0x602000015c30)
    at /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/stl_algobase.h:1162
#4  0x000003ff5f6aae4c in std::__equal_aux1<c10::SymInt const*, c10::SymInt const*> (__first1=0x61000013d790, __last1=0x61000013d7a0, __first2=0x602000015c30)
    at /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/stl_algobase.h:1211
#5  0x000003ff5f6aae06 in std::__equal_aux<c10::SymInt const*, c10::SymInt const*> (__first1=0x61000013d790, __last1=0x61000013d7a0, __first2=0x602000015c30)
    at /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/stl_algobase.h:1219
#6  0x000003ff5f6aad98 in std::equal<c10::SymInt const*, c10::SymInt const*> (__first1=0x61000013d790, __last1=0x61000013d7a0, __first2=0x602000015c30)
    at /usr/lib/gcc/s390x-ibm-linux-gnu/11/include/g++-v11/bits/stl_algobase.h:1556
#7  0x000003ff2ff3c772 in c10::ArrayRef<c10::SymInt>::equals (this=0x3ffed7c9900, RHS=...) at /home/user/pytorch/c10/util/ArrayRef.h:188
#8  0x000003ff31891bc2 in c10::operator!=<c10::SymInt> (a1=..., a2=...) at /home/user/pytorch/c10/util/ArrayRef.h:341
#9  0x000003ff51eb5800 in torch::ADInplaceOrView::resize_ (ks=..., self=..., size=..., optional_memory_format=...) at /home/user/pytorch/torch/csrc/autograd/VariableTypeManual.cpp:408
#10 0x000003ff51ee59c8 in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c
10::MemoryFormat>), &torch::ADInplaceOrView::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>
 > >::operator()(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) (this=0x6030007dca40, args=..., args=..., args=..., args=...)
    at /home/user/pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13
#11 c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt
>, c10::optional<c10::MemoryFormat>), &torch::ADInplaceOrView::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<
c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tenso
r const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) (functor=0x6030007dca40, dispatchKeySet=..., args=..., args=..., args=...)
    at /home/user/pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:480
#12 0x000003ff369a512a in c10::callUnboxedKernelFunction<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> > (
    unboxed_kernel_func=0x3ff51ee51f0 <c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor const& (c10::DispatchKeySet, at::Tenso
r const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>), &torch::ADInplaceOrView::resize_>, at::Tensor const&, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::Ar
rayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> > >, at::Tensor const& (c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKern
el*, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>, functor=0x6030007dca40, dispatchKeySet=..., args=..., args=..., args=...)
    at /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50
#13 0x000003ff369a6e90 in c10::KernelFunction::call<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> > (this=0x6210005e1bc8, opHandle=...,
    dispatchKeySet=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:90
#14 c10::Dispatcher::redispatch<at::Tensor const&, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::Arr
ayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)> const&, c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const (
    this=0x3ff5d6400e0 <c10::Dispatcher::realSingleton()::_singleton>, op=..., currentDispatchKeySet=..., args=..., args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:656
#15 0x000003ff3652006c in c10::TypedOperatorHandle<at::Tensor const& (at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)>::redispatch(c10::DispatchKeySet, at::Tensor const&,
c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>) const (
    this=0x3ff5d6a07e0 <at::_ops::resize_::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::ArrayRef<c10::SymInt>, c10::optional<c10::MemoryFormat>)::op>, currentDispatchKeySet=..., args=...,
    args=..., args=...) at /home/user/pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492
#16 at::_ops::resize_::redispatch (dispatchKeySet=..., self=..., size=..., memory_format=...) at /home/user/pytorch/build/aten/src/ATen/Operators_4.cpp:2144
#17 0x000003ff51ed5e08 in at::redispatch::resize__symint (dispatchKeySet=..., self=..., size=..., memory_format=...) at aten/src/ATen/RedispatchFunctions.h:2847
#18 0x000003ff51ebbb68 in torch::autograd::VariableType::(anonymous namespace)::resize_ (ks=..., self=..., size=..., optional_memory_format=...)
    at /home/user/pytorch/torch/csrc/autograd/VariableTypeManual.cpp:243
```
</details>