### PR TITLE
Add is_xpu to torch type

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4481,6 +4481,17 @@ else:
         self.assertEqual(torch.FloatTensor(5).to(device).is_signed(), True)
         self.assertEqual(torch.HalfTensor(10).to(device).is_signed(), True)
 
+    def test_tensor_type(slef):
+        for t in torch._tensor_classes:
+            if 'cuda' in t.__module__:
+                self.assertEqual(t.is_cuda, True)
+            else:
+                self.assertEqual(t.is_cuda, False)
+            if 'xpu' in t.__module__:
+                self.assertEqual(t.is_xpu, True)
+            else:
+                self.assertEqual(t.is_xpu, False)
+
     # Note - reports a leak of 512 bytes on CUDA device 1
     @deviceCountAtLeast(2)
     @skipCUDAMemoryLeakCheckIf(True)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4481,7 +4481,7 @@ else:
         self.assertEqual(torch.FloatTensor(5).to(device).is_signed(), True)
         self.assertEqual(torch.HalfTensor(10).to(device).is_signed(), True)
 
-    def test_tensor_type(slef):
+    def test_tensor_type(self):
         for t in torch._tensor_classes:
             if 'cuda' in t.__module__:
                 self.assertEqual(t.is_cuda, True)

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -36,6 +36,7 @@ struct PyTensorType {
   THPDtype* dtype;
   THPLayout* layout;
   bool is_cuda;
+  bool is_xpu;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   char name[64];
   int backend;
@@ -134,6 +135,14 @@ static PyObject* Tensor_is_cuda(PyTensorType* self, void* unused) {
   }
 }
 
+static PyObject* Tensor_is_xpu(PyTensorType* self, void* unused) {
+  if (self->is_xpu) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 static PyObject* Tensor_is_sparse(PyTensorType* self, void* unused) {
   if (self->layout->layout == at::Layout::Strided) {
     Py_RETURN_FALSE;
@@ -162,6 +171,7 @@ static struct PyGetSetDef metaclass_properties[] = {
     {"dtype", (getter)Tensor_dtype, nullptr, nullptr, nullptr},
     {"layout", (getter)Tensor_layout, nullptr, nullptr, nullptr},
     {"is_cuda", (getter)Tensor_is_cuda, nullptr, nullptr, nullptr},
+    {"is_xpu", (getter)Tensor_is_xpu, nullptr, nullptr, nullptr},
     {"is_sparse", (getter)Tensor_is_sparse, nullptr, nullptr, nullptr},
     {"is_sparse_csr", (getter)Tensor_is_sparse_csr, nullptr, nullptr, nullptr},
     {nullptr}};
@@ -255,6 +265,8 @@ static void set_type(
   type_obj.dtype = torch::getTHPDtype(scalarType);
   type_obj.is_cuda =
       (backend == at::Backend::CUDA || backend == at::Backend::SparseCUDA);
+  type_obj.is_xpu =
+      (backend == at::Backend::XPU || backend == at::Backend::SparseXPU);
 }
 
 static void set_name(PyTensorType& type_obj, const std::string& name) {


### PR DESCRIPTION
# Motivate 
Without this PR:
```python
>>>import torch
>>>torch.IntTensor.is_cuda
False
>>>torch.IntTensor.is_xpu
<attribute 'is_xpu' of 'torch._C._TensorBase' objects>
```

With this PR:
```python
>>>import torch
>>>torch.IntTensor.is_xpu
False
```
Align to CUDA, some customer code use is_xpu to check the backend. Without this PR, the check is always True which result in an unexpected behavior
