### PR TITLE
[BE]: enable PLE error codes in ruff and fix bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ select = [
     "F",
     "SIM1",
     "W",
+    # Not included in flake8
+    "PLE",
 ]
 
 [tool.ruff.per-file-ignores]

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -451,7 +451,7 @@ class TestWith(JitTestCase):
             def __init__(self):
                 self.count = 1
 
-            def __enter__(self, incr: int):
+            def __enter__(self, incr: int):  # noqa: PLE0302
                 self.count += incr
 
             def __exit__(self, type: Any, value: Any, tb: Any):
@@ -469,7 +469,7 @@ class TestWith(JitTestCase):
             def __enter__(self):
                 self.count += 1
 
-            def __exit__(self, type: Any, value: Any):
+            def __exit__(self, type: Any, value: Any):  # noqa: PLE0302
                 pass
 
         @torch.jit.script

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1562,7 +1562,7 @@ $3 = torch._ops.aten.add.Tensor($1, $2)""")
     def test_with_nested_modes(self):
         class ErrorA(RuntimeError):
             def __init__(self, msg):
-                return super().__init__(msg)
+                super().__init__(msg)
 
         class A(TorchDispatchMode):
             def __init__(self, msg):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -888,7 +888,6 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             log.warning(
                 "can't resolve package from __spec__ or __package__, "
                 "falling back on __name__ and __path__",
-                exc_info=ImportWarning,
                 stacklevel=3,
             )
             package = self.f_globals["__name__"]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -13,6 +13,7 @@ import sys
 import traceback
 import types
 import typing
+import warnings
 import weakref
 from collections.abc import Sized
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Type
@@ -885,12 +886,12 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         elif spec is not None:
             return spec.parent
         else:
-            log.warning(
+            warnings.warn(
                 "can't resolve package from __spec__ or __package__, "
                 "falling back on __name__ and __path__",
                 ImportWarning,
                 stacklevel=3,
-            )  # type: ignore[call-arg]
+            )
             package = self.f_globals["__name__"]
             if "__path__" not in self.f_globals:
                 package = package.rpartition(".")[0]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -13,7 +13,6 @@ import sys
 import traceback
 import types
 import typing
-import warnings
 import weakref
 from collections.abc import Sized
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Type
@@ -886,10 +885,9 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         elif spec is not None:
             return spec.parent
         else:
-            warnings.warn(
+            log.warning(
                 "can't resolve package from __spec__ or __package__, "
                 "falling back on __name__ and __path__",
-                ImportWarning,
                 stacklevel=3,
             )
             package = self.f_globals["__name__"]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -888,6 +888,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             log.warning(
                 "can't resolve package from __spec__ or __package__, "
                 "falling back on __name__ and __path__",
+                exc_info=ImportWarning,
                 stacklevel=3,
             )
             package = self.f_globals["__name__"]

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -78,7 +78,7 @@ if is_available():
     rendezvous_iterator: Generator[Tuple[Store, int, int], None, None]
 
     __all__ += ["init_rpc", "BackendType", "TensorPipeRpcBackendOptions"]
-    __all__ = __all__ + api.__all__ + backend_registry.__all__
+    __all__ = __all__ + api.__all__ + backend_registry.__all__  # noqa: PLE0605
 
     def init_rpc(
         name,

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -121,7 +121,7 @@ class _lazy_property_and_property(lazy_property, property):
     * lazy_property when Distribution validate_args looks
     """
     def __init__(self, wrapped):
-        return property.__init__(self, wrapped)
+        property.__init__(self, wrapped)
 
 
 def tril_matrix_to_vec(mat, diag=0):

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -25,7 +25,7 @@ __all__ = ['set_sharing_strategy', 'get_sharing_strategy',
 from multiprocessing import *  # noqa: F403
 
 
-__all__ += multiprocessing.__all__  # type: ignore[attr-defined]
+__all__ += multiprocessing.__all__  # noqa: PLE0605 type: ignore[attr-defined]
 
 
 # This call adds a Linux specific prctl(2) wrapper function to this module.


### PR DESCRIPTION
Enables PyLint error codes implemented in ruff. These are un-opinionated static analysis checks on Python code that finds common bugs. After running all the PLE error codes that are implemented in ruff, I fixed the bugs, added a few ignores for malformed Python code that is part of our JIT test script, and finally added a few ignores for a false positive on PLE0605 and submitted an issue upstream to fix in ruff https://github.com/charliermarsh/ruff/issues/4345 . 

Common bugs found here include analysis for malformed logging format calls, bad string format calls, invalid escape sequences, and more.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire