### PR TITLE
Run C++ test_api binary directly in CI slow jobs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -581,13 +581,13 @@ test_libtorch() {
     # Wait for background download to finish
     wait
 
-    if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
+    if [[ "$BUILD_ENVIRONMENT" == *asan* || "$BUILD_ENVIRONMENT" == *slow-gradcheck* || "$TEST_CONFIG" == "slow" ]]; then
         TEST_REPORTS_DIR=test/test-reports/cpp-unittest/test_libtorch
         mkdir -p $TEST_REPORTS_DIR
 
-        # TODO: Not quite sure why these tests time out only on ASAN, probably
-        # this is due to the fact that a python executable is used and ASAN
-        # treats that differently
+        # TODO: Not quite sure why these tests time out on ASAN and SLOW, probably
+        # this is due to the fact that a python executable is used or some logic
+        # inside run_test. This test usually takes only minutes to run
         OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="${MNIST_DIR}" "$TORCH_BIN_DIR"/test_api --gtest_filter='-IMethodTest.*' --gtest_output=xml:$TEST_REPORTS_DIR/test_api.xml
         "$TORCH_BIN_DIR"/test_tensorexpr --gtest_output=xml:$TEST_REPORTS_DIR/test_tensorexpr.xml
     else


### PR DESCRIPTION
Similar to ASAN, the test starts to timeout on slow jobs such as slow gradcheck, for example https://hud.pytorch.org/pytorch/pytorch/commit/30cecc0e111e8ec391a4aab0edb8413eda594e50.  This needs to be investigated later, but it's of low priority as we can run test_api binary directly in the meantime in these jobs.