### PR TITLE
update requirements.txt in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx==5.0.0
 # but it doesn't seem to work and hangs around idly. The initial thought is probably
 # something related to Docker setup. We can investigate this later
 sphinxcontrib.katex==0.8.6
-matplotlib==3.5.3
+matplotlib==3.6.0
 tensorboard==2.10.0
 # required to build torch.distributed.elastic.rendezvous.etcd* docs
 python-etcd==0.4.5


### PR DESCRIPTION
Fixes #101090

Local `make html` works under /docs. Not super sure how to verify doc build actually have no issue due to this update.
