### PR TITLE
Logger instead of print in lr scheduler

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -196,7 +196,7 @@ class LambdaLR(LRScheduler):
             factor given an integer parameter epoch, or a list of such
             functions, one for each group in optimizer.param_groups.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -282,7 +282,7 @@ class MultiplicativeLR(LRScheduler):
             factor given an integer parameter epoch, or a list of such
             functions, one for each group in optimizer.param_groups.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -365,7 +365,7 @@ class StepLR(LRScheduler):
         gamma (float): Multiplicative factor of learning rate decay.
             Default: 0.1.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -414,7 +414,7 @@ class MultiStepLR(LRScheduler):
         gamma (float): Multiplicative factor of learning rate decay.
             Default: 0.1.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -463,7 +463,7 @@ class ConstantLR(LRScheduler):
         total_iters (int): The number of steps that the scheduler decays the learning rate.
             Default: 5.
         last_epoch (int): The index of the last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -525,7 +525,7 @@ class LinearLR(LRScheduler):
         total_iters (int): The number of iterations that multiplicative factor reaches to 1.
             Default: 5.
         last_epoch (int): The index of the last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -585,7 +585,7 @@ class ExponentialLR(LRScheduler):
         optimizer (Optimizer): Wrapped optimizer.
         gamma (float): Multiplicative factor of learning rate decay.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
     """
 
@@ -725,7 +725,7 @@ class PolynomialLR(LRScheduler):
         optimizer (Optimizer): Wrapped optimizer.
         total_iters (int): The number of steps that the scheduler decays the learning rate. Default: 5.
         power (int): The power of the polynomial. Default: 1.0.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -800,7 +800,7 @@ class CosineAnnealingLR(LRScheduler):
         T_max (int): Maximum number of iterations.
         eta_min (float): Minimum learning rate. Default: 0.
         last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
@@ -949,7 +949,7 @@ class ReduceLROnPlateau:
         eps (float): Minimal decay applied to lr. If the difference
             between new and old lr is smaller than eps, the update is
             ignored. Default: 1e-8.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -1164,7 +1164,7 @@ class CyclicLR(LRScheduler):
             number of *batches* computed, not the total number of epochs computed.
             When last_epoch=-1, the schedule is started from the beginning.
             Default: -1
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:
@@ -1358,7 +1358,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         T_mult (int, optional): A factor increases :math:`T_{i}` after a restart. Default: 1.
         eta_min (float, optional): Minimum learning rate. Default: 0.
         last_epoch (int, optional): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
@@ -1543,7 +1543,7 @@ class OneCycleLR(LRScheduler):
             number of *batches* computed, not the total number of epochs computed.
             When last_epoch=-1, the schedule is started from the beginning.
             Default: -1
-        verbose (bool): If ``True``, prints a message to stdout for
+        verbose (bool): If ``True``, logs a message with level WARNING for
             each update. Default: ``False``.
 
     Example:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -118,13 +118,11 @@ class LRScheduler:
         """
         if is_verbose:
             if epoch is None:
-                logger.warning('Adjusting learning rate'
-                      ' of group {} to {:.4e}.'.format(group, lr))
+                logger.warning('Adjusting learning rate of group %d to %.4e.', group, lr)
             else:
                 epoch_str = ("%.2f" if isinstance(epoch, float) else
                              "%.5d") % epoch
-                logger.warning('Epoch {}: adjusting learning rate'
-                      ' of group {} to {:.4e}.'.format(epoch_str, group, lr))
+                logger.warning('Epoch %s: adjusting learning rate of group %d to %.4e.', epoch_str, group, lr)
 
 
     def step(self, epoch=None):
@@ -1042,8 +1040,7 @@ class ReduceLROnPlateau:
                 if self.verbose:
                     epoch_str = ("%.2f" if isinstance(epoch, float) else
                                  "%.5d") % epoch
-                    logger.warning('Epoch {}: reducing learning rate'
-                          ' of group {} to {:.4e}.'.format(epoch_str, i, new_lr))
+                    logger.warning('Epoch %s: reducing learning rate of group %d to %.4e.', epoch_str, i, new_lr)
 
     @property
     def in_cooldown(self):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1,3 +1,4 @@
+import logging
 import types
 import math
 from torch import inf
@@ -12,6 +13,8 @@ from .optimizer import Optimizer
 __all__ = ['LambdaLR', 'MultiplicativeLR', 'StepLR', 'MultiStepLR', 'ConstantLR', 'LinearLR',
            'ExponentialLR', 'SequentialLR', 'CosineAnnealingLR', 'ChainedScheduler', 'ReduceLROnPlateau',
            'CyclicLR', 'CosineAnnealingWarmRestarts', 'OneCycleLR', 'PolynomialLR', 'LRScheduler']
+
+logger = logging.getLogger(__name__)
 
 EPOCH_DEPRECATION_WARNING = (
     "The epoch parameter in `scheduler.step()` was not necessary and is being "
@@ -115,12 +118,12 @@ class LRScheduler:
         """
         if is_verbose:
             if epoch is None:
-                print('Adjusting learning rate'
+                logger.warning('Adjusting learning rate'
                       ' of group {} to {:.4e}.'.format(group, lr))
             else:
                 epoch_str = ("%.2f" if isinstance(epoch, float) else
                              "%.5d") % epoch
-                print('Epoch {}: adjusting learning rate'
+                logger.warning('Epoch {}: adjusting learning rate'
                       ' of group {} to {:.4e}.'.format(epoch_str, group, lr))
 
 
@@ -1039,7 +1042,7 @@ class ReduceLROnPlateau:
                 if self.verbose:
                     epoch_str = ("%.2f" if isinstance(epoch, float) else
                                  "%.5d") % epoch
-                    print('Epoch {}: reducing learning rate'
+                    logger.warning('Epoch {}: reducing learning rate'
                           ' of group {} to {:.4e}.'.format(epoch_str, i, new_lr))
 
     @property


### PR DESCRIPTION
Fixes #100847

Use `logger.warning()` instead of `logger.info()` as `logger.warning()` prints to stdout by default, which best preserves the previous behavior. 

I'm not sure if the docstring change is appropriate as it might be confusing to people who are not familiar with python logging.