### PR TITLE
[CI][MPS] Actually make grid_sampler_2d available

### DIFF
--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -86,7 +86,11 @@ void grid_sampler_2d_mps_impl(Tensor& output,
                                         relativeCoordinates:FALSE
                                                alignCorners:align_corners
                                                 paddingMode:paddingMode
+#if defined(__MAC_13_2)
                                         nearestRoundingMode:MPSGraphResizeNearestRoundingModeRoundToEven
+#else
+                                        nearestRoundingMode:(MPSGraphResizeNearestRoundingMode)4L
+#endif
                                               constantValue:0.0f
                                                        name:nil];
       } else {

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -19,7 +19,6 @@ void grid_sampler_2d_mps_impl(Tensor& output,
                               int64_t padding_mode,
                               bool align_corners) {
 // Grid Sampler support has been added in macOS 13.1
-#if defined(__MAC_13_2)
   using namespace mps;
   check_grid_sampler_common(input, grid);
   check_grid_sampler_2d(input, grid);
@@ -121,7 +120,6 @@ void grid_sampler_2d_mps_impl(Tensor& output,
 
     runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
-#endif // defined(__MAC_13_2)
 }
 } // namespace mps
 
@@ -130,13 +128,7 @@ Tensor grid_sampler_2d_mps(const Tensor& input,
                            int64_t interpolation_mode,
                            int64_t padding_mode,
                            bool align_corners) {
-#if defined(__MAC_13_2)
-  bool xcode_sdk_13_2_or_higher = true;
-#else
-  bool xcode_sdk_13_2_or_higher = false;
-#endif
-
-  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS) || !xcode_sdk_13_2_or_higher) {
+  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS)) {
     TORCH_WARN_ONCE("MPS: grid_sampler_2d op is supported natively starting from macOS 13.1. ",
                     "Falling back on CPU. This may have performance implications.");
 

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -18,7 +18,7 @@ void grid_sampler_2d_mps_impl(Tensor& output,
                               int64_t interpolation_mode,
                               int64_t padding_mode,
                               bool align_corners) {
-// Grid Sampler support has been added in macOS 13.1
+  // Grid Sampler support has been added in macOS 13.2
   using namespace mps;
   check_grid_sampler_common(input, grid);
   check_grid_sampler_2d(input, grid);
@@ -129,7 +129,7 @@ Tensor grid_sampler_2d_mps(const Tensor& input,
                            int64_t padding_mode,
                            bool align_corners) {
   if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS)) {
-    TORCH_WARN_ONCE("MPS: grid_sampler_2d op is supported natively starting from macOS 13.1. ",
+    TORCH_WARN_ONCE("MPS: grid_sampler_2d op is supported natively starting from macOS 13.2. ",
                     "Falling back on CPU. This may have performance implications.");
 
     return at::grid_sampler_2d(input.to("cpu"), grid.to("cpu"), interpolation_mode, padding_mode, align_corners)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -333,10 +333,12 @@ def mps_ops_modifier(ops):
         'masked.cumsum': [torch.int64],
     }
 
-    MACOS_13_3_XFAILLIST = {
-        # before macOS 13.3 it falls back to cpu and pass the forward pass
+    MACOS_AFTER_13_1_XFAILLIST = {
+        # before macOS 13.2 it falls back to cpu and pass the forward pass
         'grid_sampler_2d': [torch.float32],  # Unsupported Border padding mode
+    }
 
+    MACOS_13_3_XFAILLIST = {
         # Failure due to precision issue for fp16
         # on both cpu and mps there are test cases that might produce inf result
         # 'nn.functional.pairwise_distance': [torch.float16],
@@ -732,6 +734,11 @@ def mps_ops_modifier(ops):
             addDecorator(op, DecorateInfo(
                          unittest.expectedFailure,
                          dtypes=MACOS_BEFORE_13_3_XFAILLIST[key]))
+
+        if key in MACOS_AFTER_13_1_XFAILLIST and torch.backends.mps.is_macos13_or_newer(2):
+            addDecorator(op, DecorateInfo(
+                         unittest.expectedFailure,
+                         dtypes=MACOS_AFTER_13_1_XFAILLIST[key]))
 
         if key in MACOS_13_3_XFAILLIST and (product_version >= 13.3):
             addDecorator(op, DecorateInfo(


### PR DESCRIPTION
In CI older MacOS SDK can be used to compile the binary, so add guard for availability of `MPSGraphResizeNearestRoundingModeRoundToEven` enum value.
MPS feature availability checks are deliberately done at runtime (by using `is_macos_13_or_newer` and forward-declaring methods in `MPSGraphVenturaOps.h`) rather than at compile time (by using `#ifdef`s).

Modify error message and XFAIL condition in `test_mps.py` to fail test due to missing conditional on macOS-13.2 or newer.
