### PR TITLE
Fix loading of OrderedDict with LibTorch

### DIFF
--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -152,6 +152,28 @@ TEST(SerializationTest, TypeTags) {
   }
 }
 
+TEST(SerializationTest, SaveStateDict) {
+
+  // Requires the state_dict that should have been written in tests_setup.py
+  // Refer: SaveStateDict in test/cpp/jit/tests_setup.py
+  std::ifstream file("state_dict.pt", std::ios::binary);
+  std::vector<char> data((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+  auto dict = torch::pickle_load(data).toGenericDict();
+
+  for (auto& el: dict) {
+    auto key = el.key().toStringRef();
+    auto ten = el.value().toTensor();
+    if (key == "weight") {
+      ASSERT_TRUE(ten.eq(2.0).all().item().toBool());
+    } else if (key == "bias") {
+      ASSERT_TRUE(ten.eq(3.0).all().item().toBool());
+    } else {
+      ASSERT_TRUE(false);
+    }
+  }
+}
+
 TEST(SerializationTest, TestJitStream_CUDA) {
   torch::jit::Module model;
   std::vector<torch::jit::IValue> inputs;

--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -153,15 +153,14 @@ TEST(SerializationTest, TypeTags) {
 }
 
 TEST(SerializationTest, SaveStateDict) {
-
   // Requires the state_dict that should have been written in tests_setup.py
   // Refer: SaveStateDict in test/cpp/jit/tests_setup.py
   std::ifstream file("state_dict.pt", std::ios::binary);
-  std::vector<char> data((std::istreambuf_iterator<char>(file)),
-                         std::istreambuf_iterator<char>());
+  std::vector<char> data(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   auto dict = torch::pickle_load(data).toGenericDict();
 
-  for (auto& el: dict) {
+  for (auto& el : dict) {
     auto key = el.key().toStringRef();
     auto ten = el.value().toTensor();
     if (key == "weight") {

--- a/test/cpp/jit/tests_setup.py
+++ b/test/cpp/jit/tests_setup.py
@@ -57,7 +57,7 @@ class SaveStateDict(FileSetup):
         model = torch.nn.Linear(10, 10)
         torch.nn.init.constant_(model.weight, 2.0)
         torch.nn.init.constant_(model.bias, 3.0)
-        
+
         torch.save(model.state_dict(), self.path, _use_new_zipfile_serialization=True)
 
 # See testTorchSaveError in test/cpp/jit/tests.h for usage

--- a/test/cpp/jit/tests_setup.py
+++ b/test/cpp/jit/tests_setup.py
@@ -50,6 +50,15 @@ class SerializationInterop(FileSetup):
 
         torch.save(value, self.path, _use_new_zipfile_serialization=True)
 
+class SaveStateDict(FileSetup):
+    path = 'state_dict.pt'
+
+    def setup(self):
+        model = torch.nn.Linear(10, 10)
+        torch.nn.init.constant_(model.weight, 2.0)
+        torch.nn.init.constant_(model.bias, 3.0)
+        
+        torch.save(model.state_dict(), self.path, _use_new_zipfile_serialization=True)
 
 # See testTorchSaveError in test/cpp/jit/tests.h for usage
 class TorchSaveError(FileSetup):
@@ -93,6 +102,7 @@ tests = [
     EvalModeForLoadedModule(),
     SerializationInterop(),
     TorchSaveError(),
+    SaveStateDict(),
     TorchSaveJitStream_CUDA()
 ]
 

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -511,7 +511,7 @@ PickleOpCode Unpickler::readInstruction() {
           "Parsing error: stack_ contains ",
           stack_.size(),
           " elements, at least 2 expected");
-      
+
       // In the OrderedDict case, the id has already been materialized
       // and added to the stack, thus there's no <functor_idx> but a Dict
       // there, in this case we can just pop the functor args and break.
@@ -622,7 +622,7 @@ PickleOpCode Unpickler::readInstruction() {
           (dict_pos < stack_size) && (key_pos < stack_size) &&
               (val_pos < stack_size),
           "Parsing error: attempted out-of-bounds access while processing SETITEM opcode");
-      
+
       auto dict = stack_.at(dict_pos).toGenericDict();
       dict.insert_or_assign(stack_.at(key_pos), stack_.at(val_pos));
       stack_.erase(stack_.begin() + (key_pos), stack_.end());
@@ -769,9 +769,9 @@ void Unpickler::readGlobal(
     // Python's model.state_dict() is an OrderedDict, but this is not used
     // for model loading.
     globals_.emplace_back([this] {
-        // The OrderedDict becomes a GenericDict. The inputs which are in stack.back()
-        // are fully ignored, but they are empty anyways.
-        stack_.back() = c10::impl::GenericDict(AnyType::get(), AnyType::get());
+      // The OrderedDict becomes a GenericDict. The inputs which are in
+      // stack.back() are fully ignored, but they are empty anyways.
+      stack_.back() = c10::impl::GenericDict(AnyType::get(), AnyType::get());
     });
   } else if (module_name == "torch" && class_name == "device") {
     globals_.emplace_back([this] {

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -511,6 +511,17 @@ PickleOpCode Unpickler::readInstruction() {
           "Parsing error: stack_ contains ",
           stack_.size(),
           " elements, at least 2 expected");
+      
+      // In the OrderedDict case, the id has already been materialized
+      // and added to the stack, thus there's no <functor_idx> but a Dict
+      // there, in this case we can just pop the functor args and break.
+      // The functor args in this case contain some other metadata like
+      // '{_metadata: {: {version: 1}}}' which seem to be safe to ignore.
+      if (stack_.at(stack_.size() - 2).isGenericDict()) {
+        stack_.pop_back();
+        break;
+      }
+
       std::swap(*(stack_.end() - 2), *(stack_.end() - 1));
       size_t idx = stack_.back().toInt();
       stack_.pop_back();
@@ -611,7 +622,7 @@ PickleOpCode Unpickler::readInstruction() {
           (dict_pos < stack_size) && (key_pos < stack_size) &&
               (val_pos < stack_size),
           "Parsing error: attempted out-of-bounds access while processing SETITEM opcode");
-
+      
       auto dict = stack_.at(dict_pos).toGenericDict();
       dict.insert_or_assign(stack_.at(key_pos), stack_.at(val_pos));
       stack_.erase(stack_.begin() + (key_pos), stack_.end());
@@ -647,6 +658,7 @@ void Unpickler::readGlobal(
       TORCH_CHECK(false, "INVALID VALUES")
     }
   }
+
   // TODO [unpickler refactor] __main__ isn't used by the pickler anymore, this
   // is only here for bc-compatibility reasons
   if (module_name == "__main__") {
@@ -754,11 +766,12 @@ void Unpickler::readGlobal(
   } else if (module_name == "collections" && class_name == "OrderedDict") {
     // collections.OrderedDict is used in tensor serialization for a tensor's
     // backward hooks (but they are not actually saved with this Pickler)
+    // Python's model.state_dict() is an OrderedDict, but this is not used
+    // for model loading.
     globals_.emplace_back([this] {
-      // drop the Tuple that was argument to OrderedDict, and replace it
-      // with None OrderedDicts only appear in tensor deserialization and
-      // their value is never used
-      stack_.back() = IValue();
+        // The OrderedDict becomes a GenericDict. The inputs which are in stack.back()
+        // are fully ignored, but they are empty anyways.
+        stack_.back() = c10::impl::GenericDict(AnyType::get(), AnyType::get());
     });
   } else if (module_name == "torch" && class_name == "device") {
     globals_.emplace_back([this] {


### PR DESCRIPTION
Fixes #100741
This PR re-adds changes from #100743 that was reverted, trying to fix the test case so it's more portable.

