### PR TITLE
[MPS] Export check for 13.3 to `is_macos13_or_newer`

### DIFF
--- a/aten/src/ATen/mps/MPSHooks.cpp
+++ b/aten/src/ATen/mps/MPSHooks.cpp
@@ -27,7 +27,7 @@ bool MPSHooks::isOnMacOS13orNewer(unsigned minor) const {
     case 2:
       return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
     case 3:
-      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);      
+      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
     default:
       TORCH_WARN("Can't check whether running on 13.",minor,"+ returning one for 13.3+");
       return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);

--- a/aten/src/ATen/mps/MPSHooks.cpp
+++ b/aten/src/ATen/mps/MPSHooks.cpp
@@ -26,9 +26,11 @@ bool MPSHooks::isOnMacOS13orNewer(unsigned minor) const {
       return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_1_PLUS);
     case 2:
       return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
+    case 3:
+      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);      
     default:
-      TORCH_WARN("Can't check whether running on 13.",minor,"+ returning one for 13.2+");
-      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
+      TORCH_WARN("Can't check whether running on 13.",minor,"+ returning one for 13.3+");
+      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   }
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b420550</samp>

Updated `isOnMacOS13orNewer` function in `MPSHooks.cpp` to handle macOS 13.3. This fixes a bug with MPS on this version of macOS.

