### PR TITLE
Add dummy CUDA kernel for assert_async.msg

### DIFF
--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -125,4 +125,9 @@ void _assert_async_cuda(const Tensor& self_tensor) {
   });
 }
 
+// TODO (tmanlaibaatar) Ignore assert msg for now
+void _assert_async_msg_cuda(const Tensor& self_tensor, c10::string_view assert_msg) {
+  _assert_async_cuda(self_tensor);
+}
+
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -173,6 +173,7 @@
 - func: _assert_async.msg(Tensor self, str assert_msg) -> ()
   dispatch:
     CPU: _assert_async_msg_cpu
+    CUDA: _assert_async_msg_cuda
 
 - func: _assert_tensor_metadata(Tensor a, SymInt[]? size=None, SymInt[]? stride=None, ScalarType? dtype=None) -> ()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101130

This PR doesn't actually propogate the error messages down to internal kernel implementations. Will do in a follow up PR. This op is only really meant to be used in export context and export doesn't support CUDA right now so it is safe to just ignore the assert message. This PR is for quickly unblocking https://github.com/pytorch/pytorch/pull/100791 and https://github.com/pytorch/pytorch/issues/100918