### PR TITLE
[ONNX] Don't duplicate model weights in ONNX export

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -110,9 +110,10 @@ class ONNXTracedModule(torch.nn.Module):
 
             trace_inputs = _unflatten(in_args, in_desc)
 
-            ret_inputs.append(
-                tuple(x.clone(memory_format=torch.preserve_format) for x in args)
-            )
+            if self._return_inputs:
+                ret_inputs.append(
+                    tuple(x.clone(memory_format=torch.preserve_format) for x in args)
+                )
             if self._return_inputs_states:
                 inputs_states.append(_unflatten(in_args, in_desc))
             outs.append(self.inner(*trace_inputs))


### PR DESCRIPTION
This commit partially fixes an issue where the ONNX exporter always requires about 2x memory than the model size. The `ONNXTracedModule` class uses a copy of the original weights only when `return_inputs=True`, so this commit makes sure the weights are cloned only in that case.

As a side note, I don't think the exporter is ever called with `return_inputs=True`, so maybe this is just some old code that can be removed.

Partially fixes #61263. There are still other places in the exporter which use more memory than they need to. For example, during the shape inference step many intermediate tensors are computed and saved until shape inference on the model is complete. I am working on a fix for that, but that optimization is independent of this one and can be done in a separate PR.
