### PR TITLE
Translation validator for TorchDynamo guards.

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -139,23 +139,11 @@ unittest.expectedFailure(
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
 )
 
-translation_validation_xfail = [
+unittest.expectedFailure(
     # SymPy is incorrectly transforming 's0 / 6 == 0.5' into 'False'.
-    DynamicShapesReproTests.test_dynamic_shapes_float_guard_dynamic_shapes,
-
-    # 'i0 >= 0' is ignored due to its value range, but its bounds guards are not
-    # generated because 'i0' doesn't get to 'produce_guards' function.
-    DynamicShapesExportTests.test_export_preserve_constraints_as_metadata_dynamic_shapes,
-    StaticDefaultDynamicShapesExportTests.test_export_preserve_constraints_as_metadata_dynamic_shapes_static_default,
-    DynamicShapesExportTests.test_exported_graph_serialization_dynamic_shapes,
-    StaticDefaultDynamicShapesExportTests.test_exported_graph_serialization_dynamic_shapes_static_default,
-
-    # Same as above, but for Ne(s0, 1).
-    DynamicShapesHigherOrderOpTests.test_fallback_on_graph_break_complicated_dynamic_shapes,
-]
-
-for test in translation_validation_xfail:
-    unittest.expectedFailure(test)
+    # Ref: https://github.com/sympy/sympy/issues/25146
+    DynamicShapesReproTests.test_dynamic_shapes_float_guard_dynamic_shapes
+)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -58,6 +58,7 @@ def make_dynamic_cls(cls, *, static_default=False):
         cls_prefix,
         suffix,
         (config, "dynamic_shapes", True),
+        (config, "translation_validation", True),
         (config, "assume_static_by_default", static_default),
         (config, "specialize_int", static_default),
     )
@@ -137,6 +138,24 @@ unittest.expectedFailure(
     DynamicShapesNNModuleTests.test_lazy_module6_dynamic_shapes
     # RuntimeError: SymIntArrayRef expected to contain only concrete integers
 )
+
+translation_validation_xfail = [
+    # SymPy is incorrectly transforming 's0 / 6 == 0.5' into 'False'.
+    DynamicShapesReproTests.test_dynamic_shapes_float_guard_dynamic_shapes,
+
+    # 'i0 >= 0' is ignored due to its value range, but its bounds guards are not
+    # generated because 'i0' doesn't get to 'produce_guards' function.
+    DynamicShapesExportTests.test_export_preserve_constraints_as_metadata_dynamic_shapes,
+    StaticDefaultDynamicShapesExportTests.test_export_preserve_constraints_as_metadata_dynamic_shapes_static_default,
+    DynamicShapesExportTests.test_exported_graph_serialization_dynamic_shapes,
+    StaticDefaultDynamicShapesExportTests.test_exported_graph_serialization_dynamic_shapes_static_default,
+
+    # Same as above, but for Ne(s0, 1).
+    DynamicShapesHigherOrderOpTests.test_fallback_on_graph_break_complicated_dynamic_shapes,
+]
+
+for test in translation_validation_xfail:
+    unittest.expectedFailure(test)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10,6 +10,7 @@ import math
 import operator
 import os
 import sys
+import sympy
 import typing
 import unittest
 import unittest.mock as mock
@@ -40,7 +41,7 @@ from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig
 from torch.ao.quantization.quantize_fx import prepare_qat_fx
 from torch.autograd.profiler import _enable_dynamo_cache_lookup_profiler
-from torch.fx.experimental.symbolic_shapes import ConstraintViolationError
+from torch.fx.experimental.symbolic_shapes import ConstraintViolationError, FloorDiv, SympyToZ3, TranslationValidator
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_SDPA,
@@ -5102,6 +5103,138 @@ def fn():
         self.assertTrue(isinstance(compile_out, torch.Size))
         self.assertEqual(eager_out, compile_out)
 
+    def _prepare_sympy_and_z3_symbols(self):
+        import z3
+
+        # SymPy symbols.
+        s0, s1, s2 = sympy.symbols("x0 x1 x2", integer=True)
+
+        # SymPy -> Z3 symbols.
+        symbols = {sym: z3.Int(sym.name) for sym in (s0, s1, s2)}
+
+        # Z3 symbols.
+        z3_symbols = [symbols[s] for s in (s0, s1, s2)]
+
+        return (s0, s1, s2), z3_symbols, symbols
+
+    @torch._dynamo.config.patch(translation_validation=True)
+    def test_sympy_to_z3_translation(self):
+        import z3
+
+        (s0, s1, s2), (z0, z1, z2), symbols = self._prepare_sympy_and_z3_symbols()
+
+        test_cases = [
+            # Integer constants.
+            (
+                sympy.S.Zero,
+                z3.IntVal(0)
+            ),
+            (
+                sympy.S.One,
+                z3.IntVal(1)
+            ),
+            (
+                sympy.S.NegativeOne,
+                z3.IntVal(-1)
+            ),
+            (
+                sympy.Integer(2),
+                z3.IntVal(2)
+            ),
+            (
+                s0,
+                symbols[s0]
+            ),
+
+            # Arithmetic operations.
+            *[
+                (op(s0, s1), op(z0, z1))
+                for op in (
+                        operator.add,
+                        operator.mod,
+                        operator.mul,
+                        operator.pow,
+                )
+            ],
+
+            # Logical operations.
+            *[
+                (sympy_op(s0, s1), z3_op(z0, z1))
+                for sympy_op, z3_op in (
+                        (sympy.Eq, operator.eq),
+                        (sympy.Ne, operator.ne),
+                        (sympy.Lt, operator.lt),
+                        (sympy.Le, operator.le),
+                        (sympy.Gt, operator.gt),
+                        (sympy.Ge, operator.ge),
+                )
+            ],
+
+            # Other operations.
+            (
+                s0 - s1,
+                z0 + z3.IntVal(-1) * z1,
+            ),
+            (
+                s0 / s1,
+                z3.ToReal(z0) / z3.ToReal(z1),
+            ),
+            (
+                s2 % (s0 / s1),
+                z2 % z3.ToInt(z3.ToReal(z0) / z3.ToReal(z1))
+            ),
+            (
+                s2 % (s0 ** 3),
+                z2 % z3.ToInt(z0 ** 3)
+            ),
+            (
+                FloorDiv(s0, s1),
+                z3.ToInt(z3.ToReal(z0) / z3.ToReal(z1))
+            ),
+        ]
+
+        toZ3 = SympyToZ3(TranslationValidator(), symbols)
+        for sympy_expr, z3_expr in test_cases:
+            result = toZ3(sympy_expr)
+            self.assertTrue(z3_expr.eq(result), msg=f"expected: {z3_expr}. Got: {result}")
+
+    @torch._dynamo.config.patch(translation_validation=True)
+    def test_translation_validator_sat(self):
+        import z3
+
+        (s0, s1, s2), (z0, z1, z2), symbols = self._prepare_sympy_and_z3_symbols()
+
+        validator = TranslationValidator()
+        validator.add_input(s0 > 5)
+        validator.add_input(s1 / 2 > s0)
+
+        # Solutions for output is a subset of the solutions for the input.
+        validator.add_output(s0 > 20)
+        validator.add_output(s1 > s0 ** 2)
+
+        r = validator.validate()
+        self.assertEqual(r.success, True, msg=f"failed with model: {r.model}")
+        self.assertIsNone(r.model)
+        self.assertIsNone(r.failed_inputs)
+
+    @torch._dynamo.config.patch(translation_validation=True)
+    def test_translation_validator_unsat(self):
+        import z3
+
+        (s0, s1, s2), (z0, z1, z2), symbols = self._prepare_sympy_and_z3_symbols()
+
+        validator = TranslationValidator()
+        validator.add_input(s0 > 5)
+        validator.add_input(s1 / 2 > s0)
+
+        # Solutions for output is a subset of the solutions for the input.
+        validator.add_output(s0 > 20)
+        validator.add_output(s1 > s0 + 2)
+
+        r = validator.validate()
+        self.assertEqual(r.success, False, msg=f"failed with model: {r.model}")
+        self.assertIsNotNone(r.model)
+        self.assertIsNotNone(r.failed_inputs)
 
 class CustomFunc1(torch.autograd.Function):
     @staticmethod

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -230,6 +230,9 @@ base_dir = dirname(dirname(dirname(abspath(__file__))))
 # trace through numpy ndarray as tensor and try to translate numpy function to torch function.
 numpy_ndarray_as_tensor = False
 
+# Uses z3 for validating the guard optimizations transformations.
+translation_validation = False
+
 
 def is_fbcode():
     return not hasattr(torch.version, "git_version")

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -231,7 +231,7 @@ base_dir = dirname(dirname(dirname(abspath(__file__))))
 numpy_ndarray_as_tensor = False
 
 # Uses z3 for validating the guard optimizations transformations.
-translation_validation = True
+translation_validation = False
 
 
 def is_fbcode():

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -231,7 +231,7 @@ base_dir = dirname(dirname(dirname(abspath(__file__))))
 numpy_ndarray_as_tensor = False
 
 # Uses z3 for validating the guard optimizations transformations.
-translation_validation = False
+translation_validation = True
 
 
 def is_fbcode():


### PR DESCRIPTION
Follow-up from #97963.

This PR introduces a translation validator using Z3. Specifically, it answer the question whether the transformations applied to the initially generated set of guard expressions are sound.

In other words, it tries to find an assignment to the free variables such that the conjunction of the initial expressions (**_input_** expressions) yields FALSE, but the conjunction of the final expressions (_**output**_ expressions -- those actually used for building the guard function) yields TRUE. If such a case is found, it means that the applied transformations are unsound, resulting in an incorrect set of guard expressions. Otherwise, it proves that they are sound.

In Python, it would translate to something like:
```python
def check(input, output):
    if not And(input) and And(output):
        return False
    return True
```

In summary, the changes introduced are:

- Add a TorchDynamo option flag: `translation_validation` (_config.py_)
- `SympyToZ3` class: traverses SymPy expressions recursively, translating it to Z3
- `TranslationValidator` class: front-end to Z3 machinery. Actually does the check.
- Add a `validator` field to `ShapeEnv` class
- Populate the `validator` (inputs and outputs)
  - Add the expressions generated inside `evaluate_expr` as input expressions
  - Add the expressions generated inside `produce_guards` as output expressions
  - Add the expressions that reach `_set_replacement` as output expressions (specializations need to be conveyed to Z3)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire

-----

Edit: flipped the booleans when explaining the problem. As @avikchaudhuri pointed out, that paragraph was incorrectly talking about completeness, not soundness. 