### PR TITLE
Enable `backward` on `_foreach_zero_`

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -909,7 +909,6 @@ class TestForeach(TestCase):
             ref = torch.zero_
 
         for sample in foreach_inputs_sample_func(1, False, False)(FakeOpInfo(), device, dtype, requires_grad=True):
-            print(f"{sample.kwargs['zero_size'] = }")
             original_inputs = sample.input
             inputs = [t.clone() for t in original_inputs]
             zeros = [torch.zeros_like(t) for t in original_inputs]

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, onlyCUDA, ops, OpDTypes)
 from torch.testing._internal.common_methods_invocations import (
     foreach_unary_op_db, foreach_binary_op_db, foreach_pointwise_op_db,
-    foreach_reduce_op_db, foreach_lerp_op_db)
+    foreach_reduce_op_db, foreach_lerp_op_db, foreach_inputs_sample_func)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, integral_types, complex_types,
     floating_types_and, floating_types, integral_types_and,
@@ -899,6 +899,32 @@ class TestForeach(TestCase):
         out1.backward(torch.ones_like(out1))
         self.assertIsNotNone(sample.input[0].grad)
         self.assertIsNone(sample.input[1].grad)
+
+    # note(crcrpar): this is clumsy but we don't have out-place `_foreach_zero` so make it a special case.
+    @dtypes(*floating_types_and(torch.half, torch.bfloat16,))
+    def test_foreach_zero(self, device, dtype):
+
+        # Needed to let sample inputs func below work.
+        class FakeOpInfo:
+            ref = torch.zero_
+
+        for sample in foreach_inputs_sample_func(1, False, False)(FakeOpInfo(), device, dtype, requires_grad=True):
+            print(f"{sample.kwargs['zero_size'] = }")
+            original_inputs = sample.input
+            inputs = [t.clone() for t in original_inputs]
+            zeros = [torch.zeros_like(t) for t in original_inputs]
+            torch._foreach_zero_(inputs)
+            # checking a function call doesn't fail is enough when `zero_size`
+            if sample.kwargs["zero_size"]:
+                continue
+            self.assertEqual(inputs, zeros)
+            self.assertTrue(all(t.grad_fn.name() == "ZeroBackward0" for t in inputs))
+            sum_of_cloned_tensors = torch.cat([t.clone().view(-1) for t in inputs]).sum()
+            grad_output = torch.rand_like(sum_of_cloned_tensors)
+            self.assertEqual(
+                torch.autograd.grad(sum_of_cloned_tensors, inputs=original_inputs, grad_outputs=(grad_output,)),
+                zeros,
+            )
 
 
 instantiate_device_type_tests(TestForeach, globals())

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -977,8 +977,6 @@ _foreach_ops_without_differentiability_info = {
     # No reference backward available as addcdiv/addcmul don't support Tensor as scaling factor.
     ("_foreach_addcdiv", "Tensor"),
     ("_foreach_addcmul", "Tensor"),
-    # FIXME(crcrpar): Let `_foreach_zero_` have backward.
-    ("_foreach_zero", ""),
 }
 
 _foreach_ops_with_different_arity = {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8474,6 +8474,13 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
     ),
+
+    ForeachFuncInfo(
+        'zero',
+        dtypes=all_types_and_complex_and(torch.bfloat16, torch.half),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
+        supports_autograd=True,
+    ),
 ]
 
 foreach_binary_op_db: List[OpInfo] = [

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -316,15 +316,13 @@ def is_reference_for_foreach(
     f: NativeFunction,
     function_schema: FunctionSchema,
 ) -> bool:
-    return (
-        f.func.name.name.base.split("_foreach_")[-1] == function_schema.name.name.base
-        and not function_schema.name.name.inplace
-        and all(
-            ref_arg.type in (arg.type, getattr(arg.type, "elem", None))
-            for arg, ref_arg in zip(
-                f.func.arguments.flat_non_out,
-                function_schema.arguments.flat_non_out,
-            )
+    return f.func.name.name.base.split("_foreach_")[
+        -1
+    ] == function_schema.name.name.base and all(
+        ref_arg.type in (arg.type, getattr(arg.type, "elem", None))
+        for arg, ref_arg in zip(
+            f.func.arguments.flat_non_out,
+            function_schema.arguments.flat_non_out,
         )
     )
 
@@ -332,8 +330,10 @@ def is_reference_for_foreach(
 # TODO(crcrpar): Avoid hard coding "Default" ideally.
 def gen_foreach_derivativeinfo(
     foreach_function: NativeFunction,
-    differentiability_infos: Dict[FunctionSchema, Dict[str, DifferentiabilityInfo]],
     functional_info_by_signature: Dict[
+        FunctionSchema, Dict[str, DifferentiabilityInfo]
+    ],
+    non_functional_info_by_signature: Dict[
         FunctionSchema, Dict[str, DifferentiabilityInfo]
     ],
     dispatch_key: str = "Default",
@@ -343,26 +343,26 @@ def gen_foreach_derivativeinfo(
     The second return value indicates whether the info is generated in this function.
     """
     ref_diff_info: Optional[DifferentiabilityInfo] = None
-    for function_schema in functional_info_by_signature:
+
+    for function_schema, diff_info in functional_info_by_signature.items():
         if not is_reference_for_foreach(foreach_function, function_schema):
             continue
-        if function_schema in differentiability_infos:
-            ref_diff_info = differentiability_infos[function_schema][dispatch_key]
-        elif (
-            function_schema.signature(strip_default=True)
-            in functional_info_by_signature
-        ):
-            ref_diff_info = functional_info_by_signature[
-                function_schema.signature(strip_default=True)
-            ][dispatch_key]
-        else:
-            raise RuntimeError(
-                "Reference `DifferentiabilityInfo` for {} not found".format(
-                    foreach_function.func
-                )
-            )
+        ref_diff_info = diff_info[dispatch_key]
         if ref_diff_info is not None:
             break
+    # note(crcrpar): It seems like `zero`'s info isn't available in functional_info_by_signature
+    # while the info of `zero_` is in non_functional_info_by_signature
+    if (
+        ref_diff_info is None
+        and foreach_function.func.kind() == SchemaKind.inplace
+        and str(foreach_function.func.name) in {"_foreach_zero_"}
+    ):
+        for function_schema, diff_info in non_functional_info_by_signature.items():
+            if not is_reference_for_foreach(foreach_function, function_schema):
+                continue
+            ref_diff_info = diff_info[dispatch_key]
+            if ref_diff_info is not None:
+                break
     if ref_diff_info is None:
         return None, False
 
@@ -534,7 +534,9 @@ Attempted to convert a derivative formula for a mutable operator
         if is_foreach_func(f):
             assert f.func not in differentiability_infos
             diff_info, is_generated = gen_foreach_derivativeinfo(
-                f, differentiability_infos, functional_info_by_signature
+                f,
+                functional_info_by_signature,
+                non_functional_info_by_signature,
             )
             if diff_info is None:
                 return None, False


### PR DESCRIPTION
Currently torchgen cannot find an appropriate `DifferentiabilityInfo` for `_foreach_zero_` because `gen_foreach_derivativeinfo` doesn't correctly make use of `functional_info_by_signature` and `differentiability_infos`, and `is_reference_for_foreach` a bit too strict to `_foreach_zero_`.

Generated code in `VariableType`
```c++
void _foreach_zero_(c10::DispatchKeySet ks, at::TensorList self) {
  auto self_ = unpack(self, "self", 0);
  [[maybe_unused]] auto _any_requires_grad = compute_requires_grad( self );

  std::vector<c10::optional<at::Tensor>> original_selfs(self.size());
  std::vector<std::shared_ptr<ZeroBackward0>> grad_fns;
  if (_any_requires_grad) {
    for (const auto& i : c10::irange( self.size() )) {
      const auto ith_requires_grad = compute_requires_grad(self[i]);
      check_inplace(self[i], ith_requires_grad);
      grad_fns.push_back([&]() -> std::shared_ptr<ZeroBackward0> {
          if (!ith_requires_grad) {
              return nullptr;
          } else {
              auto grad_fn = std::shared_ptr<ZeroBackward0>(new ZeroBackward0(), deleteNode);
              grad_fn->set_next_edges(collect_next_edges( self[i] ));
              return grad_fn;
          }
      }());
    }
  }
  #ifndef NDEBUG
  std::vector<c10::optional<Storage>> self__storage_saved(self_.size());
  for (const Tensor& tensor : self_)
    self__storage_saved.push_back(
      tensor.has_storage() ? c10::optional<Storage>(tensor.storage()) : c10::nullopt);
  std::vector<c10::intrusive_ptr<TensorImpl>> self__impl_saved(self_.size());
  for (size_t i=0; i<self_.size(); i++)
    if (self_[i].defined()) self__impl_saved[i] = self_[i].getIntrusivePtr();
  #endif
  {
    at::AutoDispatchBelowAutograd guard;
    at::redispatch::_foreach_zero_(ks & c10::after_autograd_keyset, self_);
  }
  #ifndef NDEBUG
  for (size_t i=0; i<self_.size() && !at::impl::dispatch_mode_enabled(); i++) {
    if (self__storage_saved[i].has_value() && !at::impl::tensorlist_has_dispatch(self_))
      TORCH_INTERNAL_ASSERT(self__storage_saved[i].value().is_alias_of(self_[i].storage()));
  }
  for (size_t i=0; i<self_.size() && !at::impl::dispatch_mode_enabled(); i++) {
    if (self__impl_saved[i] && !at::impl::tensorlist_has_dispatch(self_))
      TORCH_INTERNAL_ASSERT(self__impl_saved[i] == self_[i].getIntrusivePtr());
  }
  #endif
  if (!grad_fns.empty()) {
      auto differentiable_outputs = flatten_tensor_args( self );
      TORCH_INTERNAL_ASSERT(differentiable_outputs.size() == grad_fns.size());
      for (const auto& i : c10::irange(grad_fns.size())) {
          auto grad_fn = grad_fns[i];
          if (grad_fn != nullptr) {
              rebase_history(differentiable_outputs[i], grad_fns[i]);
          }
      }
  }
}
```


Rel:
- #58833 
- #96405