### PR TITLE
[MPS] Rename metalIndexingFunction to metalIndexingPSO

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -66,7 +66,7 @@ class TORCH_API MPSDevice {
    */
   bool isMacOS13Plus(MacOSVersion version) const;
 
-  MTLComputePipelineState_t metalIndexingFunction(const std::string &kernel);
+  MTLComputePipelineState_t metalIndexingPSO(const std::string &kernel);
   MTLLibrary_t getMetalIndexingLibrary();
 
   ~MPSDevice();

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -48,7 +48,7 @@ id<MTLLibrary> MPSDevice::getMetalIndexingLibrary() {
   return _mtl_indexing_library;
 }
 
-id<MTLComputePipelineState> MPSDevice::metalIndexingFunction(const std::string& kernel) {
+id<MTLComputePipelineState> MPSDevice::metalIndexingPSO(const std::string& kernel) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(_mtl_device);
   NSError* error = nil;
   static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -199,7 +199,7 @@ void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name) {
       }
 
       id<MTLComputePipelineState> kernelDataOffsetsPSO =
-          MPSDevice::getInstance()->metalIndexingFunction("kernel_index_offsets");
+          MPSDevice::getInstance()->metalIndexingPSO("kernel_index_offsets");
       id<MTLBuffer> kernelDataOffsets = [[device newBufferWithLength:numThreads * sizeof(simd_uint3)
                                                              options:0] autorelease];
       TORCH_CHECK(

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -157,7 +157,7 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
       }
 
       id<MTLComputePipelineState> kernelDataOffsetsPSO =
-          MPSDevice::getInstance()->metalIndexingFunction("kernel_index_offsets");
+          MPSDevice::getInstance()->metalIndexingPSO("kernel_index_offsets");
       id<MTLBuffer> kernelDataOffsets = [[device newBufferWithLength:numThreads * sizeof(simd_uint3)
                                                              options:0] autorelease];
       TORCH_CHECK(

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -80,7 +80,7 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
       MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       id<MTLComputePipelineState> kernelDataOffsetsPSO =
-          MPSDevice::getInstance()->metalIndexingFunction("kernel_index_offsets");
+          MPSDevice::getInstance()->metalIndexingPSO("kernel_index_offsets");
       id<MTLBuffer> kernelDataOffsets =
           (id<MTLBuffer>)getIMPSAllocator()->allocate(numThreads * sizeof(simd_uint3)).get();
       TORCH_CHECK(
@@ -106,7 +106,7 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
       id<MTLBuffer> indexAB = nil;
 #if defined(__MAC_13_0)
       if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_0_PLUS)) {
-        indexSelectPSO = MPSDevice::getInstance()->metalIndexingFunction(indexFunction);
+        indexSelectPSO = MPSDevice::getInstance()->metalIndexingPSO(indexFunction);
         size_t argumentBufferLength = sizeof(uint64_t) * num_indices;
         indexAB = [[device newBufferWithLength:argumentBufferLength options:0] autorelease];
         uint64_t* indexABContents = (uint64_t*)(indexAB.contents);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101156

Rename to reflect its return type.

cc @DenisVieriu97