### PR TITLE
dynamo: fix the issue of aten.expand when the source and expaned size are all symbolic size

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -45,6 +45,8 @@ from torch._prims_common.wrappers import (
     out_wrapper,
 )
 
+from torch.fx.experimental.symbolic_shapes import guard_int
+
 # Experimental module containing prototype Python references for existing
 #   PyTorch operations.
 
@@ -2791,11 +2793,12 @@ def expand(a: Tensor, *shape) -> Tensor:
     for idx, x in enumerate(a.shape):
         offset_idx = idx + offset
         requested_length = shape[offset_idx]
+        requested_length = guard_int(requested_length)
+        x = guard_int(x)
         check(
             requested_length == x or x == 1 or requested_length == -1,
             lambda: f"expand: attempting to expand a dimension of length {x}!",
         )
-
         shape_[offset_idx] = requested_length if requested_length != -1 else x
 
     # At this point shape must be valid


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101173

For the dynamic shape of TIMM eca_halonext26ts model(```python -m torch.backends.xeon.run_cpu --node_id 0 benchmarks/dynamo/timm_models.py --performance --float32 -dcpu --inference -n5 --inductor --dynamic-shapes --only eca_halonext26ts```), there meets an error when calling ```aten.expand``` when src and the expanded size are all symbolic size:
```
Traceback (most recent call last):
  File "/home/xiaobing/pytorch-offical/torch/_dynamo/utils.py", line 1309, in run_node
    return node.target(*args, **kwargs)
  File "/home/xiaobing/pytorch-offical/torch/_decomp/decompositions.py", line 3270, in matmul
    tensor2_expanded = tensor2.expand(tensor2_expand_size).reshape(
  File "/home/xiaobing/pytorch-offical/torch/utils/_stats.py", line 20, in wrapper
    return fn(*args, **kwargs)
  File "/home/xiaobing/pytorch-offical/torch/_subclasses/fake_tensor.py", line 1105, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
  File "/home/xiaobing/pytorch-offical/torch/_subclasses/fake_tensor.py", line 1269, in dispatch
    return decomposition_table[func](*args, **kwargs)
  File "/home/xiaobing/pytorch-offical/torch/_refs/__init__.py", line 2799, in expand
    check(
  File "/home/xiaobing/pytorch-offical/torch/_prims_common/__init__.py", line 1648, in check
    raise exc_type(s())
RuntimeError: expand: attempting to expand a dimension of length 8*s0!
```
the src size is ```8*s0```, the expanded size is ```((s0*(((s2 - 1)//16))**2 + 2*s0*(((s2 - 1)//16)) + s0)//(8*(((((s2 - 1)//16) + 1)//8))**2))```.

This PR will try to fix it.

cc @ezyang