### PR TITLE
[c10d] Add is_available for custom backend.

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1600,6 +1600,10 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             dist.Backend._plugins["DUMMY"].creator_fn,
             PythonProcessGroupExtensionTest.create_dummy
         )
+        self.assertEqual(
+            hasattr(dist, "is_dummy_available") and dist.is_dummy_available(),
+            True
+        )
 
     def test_backend_config(self):
         dist.Backend.register_backend(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -276,6 +276,8 @@ class Backend:
             Backend.backend_capability[name.lower()] = devices
 
         Backend._plugins[name.upper()] = Backend._BackendPlugin(func, extended_api)
+        # Add torch.distributed.is_custombackend_available() functional
+        setattr(torch.distributed, f'is_{name.lower()}_available', lambda : True)
 
 class BackendConfig:
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Add is_available for custom backend to torch.distribtued, e.g. torch.distributed.is_dummy_available().