### PR TITLE
[dtensor] Relax condition for _split_tensor()

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -1,8 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 
+from numpy.testing import assert_array_equal
+
 import torch
 import torch.nn.functional as F
+import torch.distributed as dist
+
 from torch.distributed._tensor import DeviceMesh, distribute_tensor, DTensor
 from torch.distributed._tensor.placement_types import _Partial, Replicate, Shard
 from torch.distributed.tensor.parallel import PairwiseParallel, parallelize_module
@@ -525,6 +529,68 @@ class DTensorMeshTest(DTensorTestBase):
         self.sub_mesh_assert_equal(
             mesh.mesh, torch.ones(4, 3), torch.tensor([]), sharded_again.to_local()
         )
+
+
+class TestDTensorPlacementTypes(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
+    def _create_tensor(self, size):
+        # Keep everything deterministic.
+        torch.manual_seed(0)
+        tensor = torch.rand(size)
+        if torch.cuda.is_available():
+            return tensor.cuda()
+        else:
+            return tensor
+
+    @with_comms
+    def test_split_tensor(self) -> None:
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        shard_placement = Shard(0)
+
+        for size in range(2):
+            tensor = self._create_tensor(size)
+            if size == 0:
+                with self.assertRaisesRegex(
+                    Exception,
+                    "Tensor size along dim0 is 0. There is nothing to be sharded.",
+                ):
+                    _, _ = shard_placement._split_tensor(
+                        tensor,
+                        mesh.size(),
+                        with_padding=True,
+                        contiguous=True,
+                    )
+            else:
+                splitted_tensor_list, pad_sizes = shard_placement._split_tensor(
+                    tensor,
+                    mesh.size(),
+                    with_padding=True,
+                    contiguous=True,
+                )
+                expected_pad_sizes = [
+                    0 if idx < size else 1
+                    for idx, _ in enumerate(range(dist.get_world_size()))
+                ]
+                assert_array_equal(expected_pad_sizes, pad_sizes)
+
+                unpadded_list = [
+                    shard_placement._unpad_tensor(tensor, pad_sizes[i])
+                    if pad_sizes[i] > 0
+                    else tensor
+                    for i, tensor in enumerate(splitted_tensor_list)
+                ]
+                expected_is_tensor_empty = [
+                    False if idx < size else True
+                    for idx, _ in enumerate(range(dist.get_world_size()))
+                ]
+                is_tensor_empty = [
+                    False if unpadded_tensor.numel() > 0 else True
+                    for unpadded_tensor in unpadded_list
+                ]
+                assert_array_equal(expected_is_tensor_empty, is_tensor_empty)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -550,7 +550,7 @@ class TestDTensorPlacementTypes(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         shard_placement = Shard(0)
 
-        for size in range(2):
+        for size in range(8):
             tensor = self._create_tensor(size)
             if size == 0:
                 with self.assertRaisesRegex(

--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -1,11 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 
-from numpy.testing import assert_array_equal
-
 import torch
-import torch.nn.functional as F
 import torch.distributed as dist
+import torch.nn.functional as F
+from numpy.testing import assert_array_equal
 
 from torch.distributed._tensor import DeviceMesh, distribute_tensor, DTensor
 from torch.distributed._tensor.placement_types import _Partial, Replicate, Shard

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -50,6 +50,9 @@ class Shard(Placement):
         assert (
             self.dim <= tensor.ndim
         ), f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
+        assert (
+            tensor.size(self.dim) > 0
+        ), f"Tensor size along dim{self.dim} is 0. There is nothing to be sharded."
 
         # chunk tensor over dimension `dim` into n slices with padding if necessary
         tensor_list = list(torch.chunk(tensor, num_chunks, dim=self.dim))

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -50,10 +50,6 @@ class Shard(Placement):
         assert (
             self.dim <= tensor.ndim
         ), f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
-        assert (
-            tensor.size(self.dim) >= num_chunks
-        ), f"Tensors to be sharded on dim {self.dim} must be at least as large as "
-        f"the number of devices in that dimension {num_chunks}"
 
         # chunk tensor over dimension `dim` into n slices with padding if necessary
         tensor_list = list(torch.chunk(tensor, num_chunks, dim=self.dim))


### PR DESCRIPTION
When tensor.size(self.dim) < num_chunks, we will fill empty chunk with empty tensor (https://github.com/pytorch/pytorch/pull/98722). Therefore, we no longer needs this assert. 

For example, when sharding a tensor with 1 element on 2 ranks along dim 0, results would be as follows:
```
rank:0, dtensor:DTensor(local_tensor=tensor([0.4963], device='cuda:0'), device_mesh=DeviceMesh:([0, 1]), placements=[Shard(dim=0)])
rank:1, dtensor:DTensor(local_tensor=tensor([], device='cuda:1'), device_mesh=DeviceMesh:([0, 1]), placements=[Shard(dim=0)])
```