### PR TITLE
[dtensor] remove assertions about submesh checks

### DIFF
--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -12,7 +12,9 @@ def compute_local_shape(
     Compute the shape of a local shard of the given DTensor on its current
     coordinate of the mesh.
     """
-    if mesh.get_coordinate() is None:
+    my_coordinate = mesh.get_coordinate()
+
+    if my_coordinate is None:
         # if rank not in the mesh, return empty shape
         return ()
     else:
@@ -20,8 +22,6 @@ def compute_local_shape(
         ndim = len(global_shape)
         for idx, placement in enumerate(placements):
             mesh_dim_size = mesh.size(idx)
-            my_coordinate = mesh.get_coordinate()
-            assert my_coordinate is not None, "Rank not part of mesh!"
             if isinstance(placement, Shard):
                 shard_dim = placement.dim
                 assert (
@@ -44,7 +44,9 @@ def compute_local_offset(
     global rank. This is mostly used by distributed checkpointing to know the
     exact offsets of the local shard.
     """
-    if mesh.get_coordinate() is None:
+    my_coordinate = mesh.get_coordinate()
+
+    if my_coordinate is None:
         # if rank not in the mesh, return empty offset
         return ()
     else:
@@ -53,8 +55,6 @@ def compute_local_offset(
 
         for idx, placement in enumerate(placements):
             mesh_dim_size = mesh.size(idx)
-            my_coordinate = mesh.get_coordinate()
-            assert my_coordinate is not None, "Rank not part of mesh!"
             if isinstance(placement, Shard):
                 shard_dim = placement.dim
                 assert shard_dim < len(

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -184,11 +184,11 @@ class Shard(Placement):
         """
         my_coordinate = mesh.get_coordinate()
         num_chunks = mesh.size(dim=mesh_dim)
-        # TODO: what should happen if rank is not in the mesh?
-        # see issue https://github.com/pytorch/tau/pull/492
-        assert (
-            my_coordinate is not None
-        ), "Rank if not part of mesh"  # TODO: figure out behavior here
+
+        if my_coordinate is None:
+            # if rank is not part of mesh, we simply return local_tensor,
+            # which should be an empty tensor
+            return tensor
 
         is_padded = tensor.size(self.dim) % num_chunks != 0
         if is_padded:
@@ -219,11 +219,11 @@ class Shard(Placement):
         my_coordinate = mesh.get_coordinate()
         num_chunks = mesh.size(dim=mesh_dim)
 
-        # TODO: what should happen if rank is not in the mesh?
-        # see issue https://github.com/pytorch/tau/pull/492
-        assert (
-            my_coordinate is not None
-        ), "Rank if not part of mesh"  # TODO: figure out behavior here
+        if my_coordinate is None:
+            # if rank is not part of mesh, we simply return local_tensor,
+            # which should be an empty tensor
+            return local_tensor
+
         # check if it needs to pad input tensor before all_gather
         full_chunk_size = (size[self.dim] + num_chunks - 1) // num_chunks
         chunk_sizes = [

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -88,11 +88,11 @@ def _redistribute_with_local_tensor(
     for i, (current, target) in sorted_placements:
         my_coordinate = device_mesh.get_coordinate()
         num_chunks = device_mesh.size(dim=i)
-        # TODO: what should happen if rank is not in the mesh?
-        # see issue https://github.com/pytorch/tau/pull/492
-        assert (
-            my_coordinate is not None
-        ), "Rank if not part of mesh"  # TODO: figure out behavior here
+
+        if my_coordinate is None:
+            # if rank is not part of mesh, we simply return local_tensor,
+            # which should be an empty tensor
+            return local_tensor
 
         if current == target:
             # short cut, just use the original local tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101229
* #101202

This PR removes assertions from submesh checks to directly return local
tensor, this is so that all the other APIs can work with submesh