### PR TITLE
Support tensor.view_as(nested_tensor)

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -236,6 +236,18 @@ NestedTensorImpl::NestedTensorImpl(
   set_custom_sizes_strides(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
 }
 
+NestedTensorImpl::NestedTensorImpl(
+    c10::TensorImpl::ImplType impl_type,
+    const at::Tensor& base_tensor,
+    at::Tensor nested_sizes)
+    : NestedTensorImpl(
+          impl_type,
+          base_tensor,
+          nested_sizes,
+          construct_nested_strides(nested_sizes),
+          construct_offsets(nested_sizes)) {
+}
+
 c10::optional<int64_t> NestedTensorImpl::opt_size(int64_t d) const {
   if (C10_UNLIKELY(!opt_sizes_.has_value())) {
     // Cache the metadata to avoid recomputing it each time.

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -42,6 +42,12 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       at::Tensor nested_strides,
       at::Tensor storage_offsets);
 
+  // This constructor is used creating contiguous view tensors from nested tensors
+  explicit NestedTensorImpl(
+      c10::TensorImpl::ImplType impl_type,
+      const at::Tensor& base_tensor,
+      at::Tensor nested_sizes);
+
   // TODO: don't expose private implementation details like this; in
   // particular, resizing this tensor will mess up our dim() and
   // callers cannot fix it.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6041,6 +6041,9 @@
   variants: method
   device_check: NoCheck
   device_guard: False
+  dispatch:
+    CompositeImplicitAutograd: view_as
+    CompositeImplicitAutogradNestedTensor: view_as_nested
 
 - func: where.self(Tensor condition, Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator

--- a/aten/src/ATen/native/nested/NestedTensorShape.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorShape.cpp
@@ -1,10 +1,26 @@
-#include <ATen/NestedTensorImpl.h>
+#include <ATen/native/nested/NestedTensorUtils.h>
 
 namespace at {
 namespace native {
 Tensor view_as_nested(const Tensor& self, const Tensor& other) {
-  TORCH_CHECK(false, "LOLOLOL");
-  return self;
+  TORCH_CHECK(
+      !self.is_nested() && other.is_nested(),
+      "We currently can only view non-nested Tensors as nested Tensors. ",
+      "Expected self to not be nested and other to be nested but got ",
+      self.is_nested(),
+      " and ",
+      other.is_nested(),
+      " instead.");
+  TORCH_CHECK(self.is_contiguous(), "We currently only support contiguous Tensors for self when other is nested.");
+  TORCH_CHECK(other.is_contiguous(), "We currently can only view as contiguous nested Tensors.");
+  TORCH_CHECK(self.dim() == 1, "We currently only support 1-dim Tensors for self when other is nested. Got ", self.dim(), " instead.");
+  TORCH_CHECK(self.layout() == at::kStrided, "We currently only support strided Tensors for self when other is nested. Got ", self.layout(), " instead.");
+  TORCH_CHECK(self.numel() == other.numel(), "Expected the number of elements of self and other to match, but got ", self.numel(), " and ", other.numel(), " instead.");
+  auto other_impl = get_nested_tensor_impl(other);
+  return at::detail::make_tensor<NestedTensorImpl>(
+    c10::TensorImpl::VIEW,
+    self,
+    other_impl->get_nested_sizes().clone());
 }
-}
-}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorShape.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorShape.cpp
@@ -1,0 +1,10 @@
+#include <ATen/NestedTensorImpl.h>
+
+namespace at {
+namespace native {
+Tensor view_as_nested(const Tensor& self, const Tensor& other) {
+  TORCH_CHECK(false, "LOLOLOL");
+  return self;
+}
+}
+}

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1945,6 +1945,12 @@ class TestNestedTensorDeviceType(TestCase):
             lambda: nt1.reshape(2, -1, -1, 2, 2)
         )
 
+    @dtypes(torch.float, torch.float16, torch.double)
+    def test_view_as(self, device, dtype):
+        nt = random_nt(device, dtype, 4, (4, 4))
+        t = nt.values()
+        t.view_as(nt)
+
     @parametrize("input_dim", [3, 4])
     def test_scaled_dot_product_attention(self, device, input_dim):
 


### PR DESCRIPTION
Zero copy way of constructing a NestedTensor from a 1d contiguous buffer based on the shape of some already existing NestedTensor.