### PR TITLE
[GHF][BE] Memoize `read_flaky_rule

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1189,7 +1189,7 @@ def read_merge_rules(
             rc = yaml.safe_load(fp)
         return [MergeRule(**x) for x in rc]
 
- 
+
 @lru_cache(maxsize=None)
 def read_flaky_rules() -> List[FlakyRule]:
     # NOTE: This is currently hardcoded, can be extended to do per repo rules

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1189,7 +1189,8 @@ def read_merge_rules(
             rc = yaml.safe_load(fp)
         return [MergeRule(**x) for x in rc]
 
-
+ 
+@lru_cache(maxsize=None)
 def read_flaky_rules() -> List[FlakyRule]:
     # NOTE: This is currently hardcoded, can be extended to do per repo rules
     FLAKY_RULES_URL = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/flaky-rules.json"


### PR DESCRIPTION
Added caching to `read_flaky_rules`, as it's called several times during the merge process and every call incurs network access. Also, one should not expect flaky rules to change while PR is landed.