### PR TITLE
Back out "Add global boolean for controlling whether to record concrete shapes or not"

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1213,21 +1213,6 @@ RecordQueue::getRecords(
   return {out, std::move(trace)};
 }
 
-namespace {
-std::atomic<bool>& record_concrete_inputs_enabled() {
-  static std::atomic<bool> val{true};
-  return val;
-}
-} // namespace
-
-bool get_record_concrete_inputs_enabled() {
-  return record_concrete_inputs_enabled();
-}
-
-void set_record_concrete_inputs_enabled(bool val) {
-  record_concrete_inputs_enabled() = val;
-}
-
 } // namespace impl
 } // namespace profiler
 } // namespace torch

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -604,9 +604,6 @@ class TORCH_API RecordQueue {
   std::unique_ptr<python_tracer::PythonTracerBase> python_tracer_;
 };
 
-TORCH_API bool get_record_concrete_inputs_enabled();
-TORCH_API void set_record_concrete_inputs_enabled(bool);
-
 } // namespace impl
 } // namespace profiler
 } // namespace torch


### PR DESCRIPTION
Summary:
Causes an internal test to time out.

Original commit changeset: 27f2f86090a1

Original Phabricator Diff: D45680162

Test Plan: Ran the internal test and verified that it passes now

Differential Revision: D45802043

