### PR TITLE
Update clang-tidy install in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1068,7 +1068,7 @@ To run clang-tidy locally, follow these steps:
 1. Install clang-tidy.
 We provide custom built binaries which have additional checks enabled. You can install it by running:
 ```bash
-python3 -m tools.linter.install.clang_tidy
+python3 -m tools.linter.clang_tidy.generate_build_files
 ```
 We currently only support Linux and MacOS (x86).
 


### PR DESCRIPTION
Updated clang-tidy install to reflect install command in github actions workflow https://github.com/pytorch/pytorch/blob/ce76670c6f7f64ac0f3dbe371fc64088fef47777/.github/workflows/lint.yml#L45

I was following steps to run clang-tidy and got into the above issue. I also think that the following line is outdated: https://github.com/pytorch/pytorch/blob/ce76670c6f7f64ac0f3dbe371fc64088fef47777/CONTRIBUTING.md?plain=1#L1077

 but not sure what is the right solution there as there is no `clang_tidy/requirements.txt` file.