### PR TITLE
Inductor cpp wrapper: support sympy.Expr as input

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -85,7 +85,7 @@ if RUN_CPU:
         BaseTest("test_bmm1"),
         BaseTest("test_bmm2"),
         BaseTest("test_cat"),  # alias
-        BaseTest("test_dtype_sympy_expr"),  # buffer reuse
+        BaseTest("test_dtype_sympy_expr"),
         BaseTest("test_embedding_bag"),  # test default FallbackKernel
         BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_int_div", "", test_cpu_repro.CPUReproTests()),

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -85,6 +85,7 @@ if RUN_CPU:
         BaseTest("test_bmm1"),
         BaseTest("test_bmm2"),
         BaseTest("test_cat"),  # alias
+        BaseTest("test_dtype_sympy_expr"),  # buffer reuse
         BaseTest("test_embedding_bag"),  # test default FallbackKernel
         BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_int_div", "", test_cpu_repro.CPUReproTests()),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5006,6 +5006,24 @@ class CommonTemplate:
             torch._inductor.metrics.generated_kernel_count, expected_kernel
         )
 
+    @torch._dynamo.config.patch(dynamic_shapes=True)
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_dtype_sympy_expr(self):
+        torch._inductor.metrics.disable_cpp_wrapper = 0
+
+        @torch._dynamo.optimize_assert("inductor")
+        def fn(a):
+            y = a[..., :-1, :].contiguous()
+            return y
+
+        result = fn(torch.randn([1, 2, 16, 4]).requires_grad_())
+        result.sum().backward()
+
+        expected_disable_cpp_wrapper = 0
+        self.assertEqual(
+            torch._inductor.metrics.disable_cpp_wrapper, expected_disable_cpp_wrapper
+        )
+
     @config.patch({"triton.cudagraphs": False})
     def test_lowmem_dropout1(self):
         n = 100000

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -17,6 +17,7 @@ from .. import metrics
 from ..utils import (
     DeferredLineBase,
     free_symbol_startswith,
+    get_sympy_Expr_dtype,
     IndentedBuffer,
     sympy_dot,
     sympy_subs,
@@ -434,10 +435,7 @@ class KernelArgs:
         buffer_types = {x.get_name(): x.get_dtype() for x in V.graph.buffers}
         for name, val in V.graph.graph_inputs.items():
             if isinstance(val, sympy.Expr):
-                if val.is_integer:
-                    buffer_types[name] = torch.int64
-                else:
-                    buffer_types[name] = torch.float64
+                buffer_types[name] = get_sympy_Expr_dtype(val)
             else:
                 buffer_types[name] = val.get_dtype()
         buffer_types.update(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -77,7 +77,7 @@ def supported_dtype_of_cpp_wrapper(dtype, cuda):
 def may_get_constant_buffer_dtype(constant_buffer):
     assert isinstance(
         constant_buffer, (sympy.Symbol, sympy.Expr, sympy.core.numbers.Integer)
-    ), "get_constant_buffer_dtype only supports input of sympy.Symbol or sympy.core.numbers.Integer"
+    ), "get_constant_buffer_dtype only supports input of sympy.Symbol, sympy.Expr or sympy.core.numbers.Integer"
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -46,6 +46,7 @@ from .utils import (
     convert_shape_to_inductor,
     gather_origins,
     get_dtype_size,
+    get_sympy_Expr_dtype,
     sympy_product,
 )
 from .virtualized import V
@@ -81,10 +82,7 @@ def may_get_constant_buffer_dtype(constant_buffer):
         return torch.int64
 
     if isinstance(constant_buffer, sympy.Expr):
-        if constant_buffer.is_integer:
-            return torch.int64
-        else:
-            return torch.float64
+        return get_sympy_Expr_dtype(constant_buffer)
 
     if constant_buffer.is_integer:
         return torch.int64

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -23,7 +23,7 @@ from torch.utils._mode_utils import no_dispatch
 
 from .._dynamo import config as dynamo_config
 
-from . import config, ir
+from . import config, ir, metrics
 from .codegen.wrapper import CppWrapperCodeGen, CudaWrapperCodeGen, WrapperCodeGen
 from .exc import (
     LoweringException,
@@ -75,10 +75,17 @@ def supported_dtype_of_cpp_wrapper(dtype, cuda):
 
 def may_get_constant_buffer_dtype(constant_buffer):
     assert isinstance(
-        constant_buffer, (sympy.Symbol, sympy.core.numbers.Integer)
+        constant_buffer, (sympy.Symbol, sympy.Expr, sympy.core.numbers.Integer)
     ), "get_constant_buffer_dtype only supports input of sympy.Symbol or sympy.core.numbers.Integer"
     if isinstance(constant_buffer, sympy.core.numbers.Integer):
         return torch.int64
+
+    if isinstance(constant_buffer, sympy.Expr):
+        if constant_buffer.is_integer:
+            return torch.int64
+        else:
+            return torch.float64
+
     if constant_buffer.is_integer:
         return torch.int64
     elif constant_buffer.is_float:
@@ -263,6 +270,7 @@ class GraphLowering(torch.fx.Interpreter):
         return super().run(*args)
 
     def disable_cpp_wrapper(self, cond):
+        metrics.disable_cpp_wrapper += 1
         self.cpp_wrapper = False
         log.debug("Set cpp_wrapper to False due to %s", cond)
 
@@ -625,7 +633,9 @@ class GraphLowering(torch.fx.Interpreter):
             dtype = None
             if isinstance(value, TensorBox):
                 dtype = value.get_dtype()
-            elif isinstance(value, (sympy.Symbol, sympy.core.numbers.Integer)):
+            elif isinstance(
+                value, (sympy.Symbol, sympy.Expr, sympy.core.numbers.Integer)
+            ):
                 dtype = may_get_constant_buffer_dtype(value)
 
             if not supported_dtype_of_cpp_wrapper(dtype, self.cuda):

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -10,6 +10,9 @@ ir_nodes_pre_fusion = 0
 # counters for tracking to_dtype inserted
 cpp_to_dtype_count = 0
 
+# counters for tracking cpp_wrapper disabled
+disable_cpp_wrapper = 0
+
 
 # reset all counters
 def reset():
@@ -18,6 +21,7 @@ def reset():
     global num_bytes_accessed, nodes_num_elem
     global ir_nodes_pre_fusion
     global cpp_to_dtype_count
+    global disable_cpp_wrapper
 
     generated_kernel_count = 0
     generated_cpp_vec_kernel_count = 0
@@ -25,3 +29,4 @@ def reset():
     nodes_num_elem.clear()
     ir_nodes_pre_fusion = 0
     cpp_to_dtype_count = 0
+    disable_cpp_wrapper = 0

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -895,7 +895,9 @@ def is_cpu_device(inputs):
 
 
 def get_sympy_Expr_dtype(val):
-    assert isinstance(val, sympy.Expr)
+    assert isinstance(
+        val, sympy.Expr
+    ), "only support sympy.Expr as input to get_sympy_Expr_dtype"
     if val.is_integer:
         return torch.int64
     else:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -894,6 +894,14 @@ def is_cpu_device(inputs):
     )
 
 
+def get_sympy_Expr_dtype(val):
+    assert isinstance(val, sympy.Expr)
+    if val.is_integer:
+        return torch.int64
+    else:
+        return torch.float64
+
+
 @contextlib.contextmanager
 def maybe_profile(should_profile, *args, **kwargs):
     if should_profile:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -894,7 +894,7 @@ def is_cpu_device(inputs):
     )
 
 
-def get_sympy_Expr_dtype(val):
+def get_sympy_Expr_dtype(val : sympy.Expr) -> torch.dtype:
     assert isinstance(
         val, sympy.Expr
     ), "only support sympy.Expr as input to get_sympy_Expr_dtype"

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -894,7 +894,7 @@ def is_cpu_device(inputs):
     )
 
 
-def get_sympy_Expr_dtype(val : sympy.Expr) -> torch.dtype:
+def get_sympy_Expr_dtype(val: sympy.Expr) -> torch.dtype:
     assert isinstance(
         val, sympy.Expr
     ), "only support sympy.Expr as input to get_sympy_Expr_dtype"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101257

Leverage the logic in https://github.com/pytorch/pytorch/pull/95533 to get the `dtype` of `sympy.Expr` and support it as graph input in the cpp wrapper.


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire