### PR TITLE
make it configurable whether to print warning info when override the operator

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -150,9 +150,7 @@ OperatorEntry::AnnotatedKernelContainerIterator OperatorEntry::registerKernel(
     // Suppress the warning for Meta key as we are overriding C++ meta functions with python meta functions
     // for some ops
     if (dispatch_key != DispatchKey::Meta) {
-      if (check_opname_in_allowlist(name_)) {
-        ;
-      } else {
+      if (!check_opname_in_allowlist(name_)) {
         TORCH_WARN_ONCE("Warning only once for all operators,  other operators may also be overrided.\n",
               "  Overriding a previously registered kernel for the same operator and the same dispatch key\n",
               "  operator: ", (schema_.has_value() ? toString(schema_->schema) : toString(name_)), "\n",

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -620,5 +620,15 @@ std::string OperatorEntry::dumpState() const {
   return oss.str();
 }
 
+std::unordered_set<c10::OperatorName>& get_opname_override_allowlist() {
+  static std::unordered_set<c10::OperatorName> opname_array;
+  return opname_array;
+}
+
+bool check_opname_in_allowlist(const c10::OperatorName& name) {
+  auto opname_array = get_opname_override_allowlist();
+  return opname_array.count(name) > 0;
+}
+
 }
 }

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -150,14 +150,18 @@ OperatorEntry::AnnotatedKernelContainerIterator OperatorEntry::registerKernel(
     // Suppress the warning for Meta key as we are overriding C++ meta functions with python meta functions
     // for some ops
     if (dispatch_key != DispatchKey::Meta) {
-      TORCH_WARN_ONCE("Warning only once for all operators,  other operators may also be overrided.\n",
-            "  Overriding a previously registered kernel for the same operator and the same dispatch key\n",
-            "  operator: ", (schema_.has_value() ? toString(schema_->schema) : toString(name_)), "\n",
-            "    ", (this->schema_.has_value() ? this->schema_->debug : "no debug info"), "\n",
-            "  dispatch key: ", toString(dispatch_key), "\n",
-            "  previous kernel: ", (cpp_signature_.has_value() ? cpp_signature_->debug : (sym_cpp_signature_.has_value() ? sym_cpp_signature_->debug : "no debug info")), "\n",
-            "       new kernel: ", debug
-      );
+      if (check_opname_in_allowlist(name_)) {
+        ;
+      } else {
+        TORCH_WARN_ONCE("Warning only once for all operators,  other operators may also be overrided.\n",
+              "  Overriding a previously registered kernel for the same operator and the same dispatch key\n",
+              "  operator: ", (schema_.has_value() ? toString(schema_->schema) : toString(name_)), "\n",
+              "    ", (this->schema_.has_value() ? this->schema_->debug : "no debug info"), "\n",
+              "  dispatch key: ", toString(dispatch_key), "\n",
+              "  previous kernel: ", (cpp_signature_.has_value() ? cpp_signature_->debug : (sym_cpp_signature_.has_value() ? sym_cpp_signature_->debug : "no debug info")), "\n",
+              "       new kernel: ", debug
+        );
+      }
     }
   }
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -305,5 +305,14 @@ private:
   const AnnotatedKernel* getKernelForDispatchKey(DispatchKey dispatch_key) const;
 };
 
+std::unordered_set<c10::string_view>& get_opname_override_allowlist() {
+  static std::unordered_set<c10::string_view> opname_array;
+  return opname_array;
+}
+
+bool check_opname_in_allowlist(c10::string_view) {
+  auto opname_array = get_opname_allow_override();
+  return opname_array.count(string_view) > 0;
+}
 } // namespace impl
 } // namespace c10

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -305,14 +305,9 @@ private:
   const AnnotatedKernel* getKernelForDispatchKey(DispatchKey dispatch_key) const;
 };
 
-std::unordered_set<c10::string_view>& get_opname_override_allowlist() {
-  static std::unordered_set<c10::string_view> opname_array;
-  return opname_array;
-}
+TORCH_API std::unordered_set<c10::OperatorName>& get_opname_override_allowlist();
 
-bool check_opname_in_allowlist(c10::string_view) {
-  auto opname_array = get_opname_allow_override();
-  return opname_array.count(string_view) > 0;
-}
+TORCH_API bool check_opname_in_allowlist(const c10::OperatorName& name);
+
 } // namespace impl
 } // namespace c10


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1、for custom device, we have to override some operators such as `has_compatible_shallow_copy_type`. so there will be some warning infos. And there will be too much warning infos if we run script with DDP. So I added a list to configure the list of operators. When the operator we override is in this list, no warning information will be output.

cc @bdhirsh 