### PR TITLE
[profiler] replace record_concrete_inputs_enabled interface with callback instead of boolean

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1214,18 +1214,18 @@ RecordQueue::getRecords(
 }
 
 namespace {
-std::atomic<bool>& record_concrete_inputs_enabled() {
-  static std::atomic<bool> val{true};
-  return val;
+std::function<bool()>& record_concrete_inputs_enabled_fn() {
+  static std::function<bool()> fn = []() { return true; };
+  return fn;
 }
 } // namespace
 
 bool get_record_concrete_inputs_enabled() {
-  return record_concrete_inputs_enabled();
+  return record_concrete_inputs_enabled_fn()();
 }
 
-void set_record_concrete_inputs_enabled(bool val) {
-  record_concrete_inputs_enabled() = val;
+void set_record_concrete_inputs_enabled_fn(std::function<bool()> fn) {
+  record_concrete_inputs_enabled_fn() = std::move(fn);
 }
 
 } // namespace impl

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -605,7 +605,7 @@ class TORCH_API RecordQueue {
 };
 
 TORCH_API bool get_record_concrete_inputs_enabled();
-TORCH_API void set_record_concrete_inputs_enabled(bool);
+TORCH_API void set_record_concrete_inputs_enabled_fn(std::function<bool()>);
 
 } // namespace impl
 } // namespace profiler


### PR DESCRIPTION
Summary: This allows an internal use case to register a callback that can vary over time instead of being a static value over the lifetime of the program.

Test Plan: ran the test listed above ^^.

Differential Revision: D45805139

