### PR TITLE
Update public_api to remove duplicated `randn_like`

### DIFF
--- a/functorch/op_analysis/public_api
+++ b/functorch/op_analysis/public_api
@@ -387,7 +387,6 @@ randint
 randint_like
 randn
 randn_like
-randn_like
 random_
 randperm
 range


### PR DESCRIPTION
Remove duplicated `randn_like` in `functorch/op_analysis`