### PR TITLE
[MPS] Enable `arange` for `int8` and `uint8` dtypes

### DIFF
--- a/aten/src/ATen/native/mps/TensorFactory.h
+++ b/aten/src/ATen/native/mps/TensorFactory.h
@@ -4,7 +4,9 @@
   AT_DISPATCH_SWITCH(                                                   \
       TYPE, NAME,                                                       \
       AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)              \
-      AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                \
+      AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)               \
       AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)               \
+      AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                \
       AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)              \
-      AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__))
+      AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)               \
+      AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__))

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7236,8 +7236,7 @@ class TestNLLLoss(TestCaseMPS):
             # Check that output is not all zeros or ones
             if product_version > 13.0:
                 uniq = mps_out.unique()
-                # TODO: remove cast after arange is fixed for integral types
-                self.assertEqual(uniq.to(dtype=torch.float32), torch.arange(2, device='mps', dtype=torch.float32))
+                self.assertEqual(uniq, torch.arange(2, device='mps', dtype=dtype))
             else:
                 self.assertEqual(mps_out.min().item(), 0.)
                 self.assertEqual(mps_out.max().item(), 1.)


### PR DESCRIPTION
Not sure, why it was not enabled previously.
Sort types in `AT_DISPATCH_MPS_TYPES` by group (floats first then integers) and size.
Test implicitly in `test_bernoulli`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 80c7ed7</samp>

> _`Char` and `Byte` types_
> _MPS can dispatch them now_
> _Winter of tensors_

