### PR TITLE
Bugfix: Correctly detect test changes in PRs

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -116,8 +116,12 @@ def calculate_shards(
 
 def _query_changed_test_files() -> List[str]:
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
-    cmd = ["git", "diff", "--name-only", default_branch, "HEAD"]
-    proc = subprocess.run(cmd, capture_output=True)
+    merge_base = subprocess.run(
+        ["git", "merge-base", default_branch, "HEAD"], capture_output=True
+    )
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", merge_base, "HEAD"], capture_output=True
+    )
 
     if proc.returncode != 0:
         raise RuntimeError("Unable to get changed files")

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -116,8 +116,12 @@ def calculate_shards(
 
 def _query_changed_test_files() -> List[str]:
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
-    merge_base = subprocess.run(
-        ["git", "merge-base", default_branch, "HEAD"], capture_output=True
+    merge_base = (
+        subprocess.check_output(
+            ["git", "merge-base", default_branch, "HEAD"], capture_output=True
+        )
+        .stdout.decode()
+        .strip()
     )
     proc = subprocess.run(
         ["git", "diff", "--name-only", merge_base, "HEAD"], capture_output=True

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -117,10 +117,8 @@ def calculate_shards(
 def _query_changed_test_files() -> List[str]:
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
     merge_base = (
-        subprocess.check_output(
-            ["git", "merge-base", default_branch, "HEAD"], capture_output=True
-        )
-        .stdout.decode()
+        subprocess.check_output(["git", "merge-base", default_branch, "HEAD"])
+        .decode()
         .strip()
     )
     proc = subprocess.run(


### PR DESCRIPTION
Fixes a bug where the logic for deciding what tests have been edited by a PR would include all files that had been edited since the merge base, including files that were in main!

Now it will only consider the files that are part of the PR itself