### PR TITLE
fix precision error in constraint solver

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -877,6 +877,21 @@ class TestDimConstraints(TestCase):
         solution = reduce_inequalities(exprs, s).as_set()
         self.assertEqual(solution, {8})
 
+    def test_precision(self):
+        from sympy import Eq, Ne, Symbol
+        from torch.fx.experimental.symbolic_shapes import DimConstraints
+
+        x = Symbol("x", positive=True, integer=True)
+        y = Symbol("y", positive=True, integer=True)
+        var_to_val = {x: 296, y: 1155}
+
+        dim_constraints = DimConstraints({}, var_to_val)
+        dim_constraints.add(Eq(x / y, 0.256277056277056))
+        with self.assertRaisesRegex(AssertionError, "Ne(x/y, 296/1155) is inconsistent!"):
+            dim_constraints.add(Ne(x / y, 0.256277056277056))
+        dim_constraints.solve()
+        self.assertEqual(dim_constraints._dynamic_results, set())
+
     def test_dim_constraints_solve_full(self):
         from sympy import Eq, Integer, Mod, Ne, Symbol
         from torch._dynamo.source import LocalSource, TensorProperty, TensorPropertySource

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -887,7 +887,7 @@ class TestDimConstraints(TestCase):
 
         dim_constraints = DimConstraints({}, var_to_val)
         dim_constraints.add(Eq(x / y, 0.256277056277056))
-        with self.assertRaisesRegex(AssertionError, "Ne\(x/y, 296/1155\) is inconsistent!"):
+        with self.assertRaisesRegex(AssertionError, "Ne\\(x/y, 296/1155\\) is inconsistent!"):
             dim_constraints.add(Ne(x / y, 0.256277056277056))
         dim_constraints.solve()
         self.assertEqual(dim_constraints._dynamic_results, set())

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -887,7 +887,7 @@ class TestDimConstraints(TestCase):
 
         dim_constraints = DimConstraints({}, var_to_val)
         dim_constraints.add(Eq(x / y, 0.256277056277056))
-        with self.assertRaisesRegex(AssertionError, "Ne(x/y, 296/1155) is inconsistent!"):
+        with self.assertRaisesRegex(AssertionError, "Ne\(x/y, 296/1155\) is inconsistent!"):
             dim_constraints.add(Ne(x / y, 0.256277056277056))
         dim_constraints.solve()
         self.assertEqual(dim_constraints._dynamic_results, set())

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1592,7 +1592,7 @@ class DimConstraints:
             # with their concrete values, we might end up comparing floats. Thus
             # we approximate floats with rationals using concrete values as hints.
             constants = [self._var_to_val[s] for s in free_symbols]
-            expr = type(expr)(*[sympy.nsimplify(arg, constants) for arg in expr.args])
+            expr = type(expr)(*(sympy.nsimplify(arg, constants) for arg in expr.args))
         if expr == sympy.true:
             return
         # `expr` should be consistent with concrete values

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1585,12 +1585,20 @@ class DimConstraints:
         return expr
 
     def add(self, expr):
+        free_symbols = expr.free_symbols
+        if isinstance(expr, sympy.Rel):
+            # It is possible that `expr` will fail the consistency check below
+            # because of precision errors, i.e., on substituting its free symbols
+            # with their concrete values, we might end up comparing floats. Thus
+            # we approximate floats with rationals using concrete values as hints.
+            constants = [self._var_to_val[s] for s in free_symbols]
+            expr = type(expr)(*[sympy.nsimplify(arg, constants) for arg in expr.args])
         if expr == sympy.true:
             return
+        # `expr` should be consistent with concrete values
         orig_expr = expr
         orig_reduced = orig_expr.subs(self._var_to_val)
         assert orig_reduced != sympy.false, f"{orig_expr} is inconsistent!"
-        free_symbols = expr.free_symbols
         assert free_symbols, f"Did not expect constraint with no free variables: {expr}"
         if len(free_symbols) > 1:
             # multivariate: record and move on


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101307

When adding guards to the constraint solver, we check that they are consistent, i.e., they do not simplify to false when their free symbols are substituted with the corresponding concrete values.

However this check may "spuriously" fail because it doesn't take into account precision errors when comparing floats. Since the symbols involved are all positive integers, we try to approximate floats in the guards with rationals, providing concrete values as hints: `sympy.nsimplify` does the job.

As an alternative approach, we considered using `sympy.evalf` to compare with reduced precision. But we did not pursue it because
* the choice of what is a good reduced precision feels arbitrary (`sympy` uses `1e15` by default);
* more importantly, there is no guarantee that we will not encounter the same problem when solving downstream.

Differential Revision: [D45826951](https://our.internmc.facebook.com/intern/diff/D45826951/)