### PR TITLE
Add branch change name for composite action

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -108,6 +108,8 @@ them:
   * Example: https://github.com/pytorch/pytorch/pull/77983 and https://github.com/pytorch/pytorch/pull/77986
 * A release branches should also be created in [`pytorch/xla`](https://github.com/pytorch/xla) and [`pytorch/builder`](https://github.com/pytorch/builder) repos and pinned in `pytorch/pytorch`
   * Example: https://github.com/pytorch/pytorch/pull/86290 and https://github.com/pytorch/pytorch/pull/90506
+* Update branch used in composite actions from trunk to release (for example, can be done by running `for i in .github/workflows/*.yml; do sed -i -e s#@master#@release/2.0# $i; done`
+  * Example: https://github.com/pytorch/pytorch/commit/51b42d98d696a9a474bc69f9a4c755058809542f
 
 These are examples of changes that should be made to the *default* branch after a release branch is cut
 


### PR DESCRIPTION
Mention in release runbook, that composite workflow should reference release branch rather than trunk

