### PR TITLE
[Profiler] Fix HTML plot output for profiler export_memory_timeline

### DIFF
--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -1059,7 +1059,13 @@ class MemoryProfileTimeline:
 
         with open(tmpfile.name, 'rb') as tmp:
             encoded = b64encode(tmp.read()).decode('utf-8')
-            html = 'GPU Memory Timeline HTML' + '<img src=\'data:image/png;base64,{}\'>'.format(encoded)
+            html = """<html>
+<head><meta charset="utf-8" /><title>GPU Memory Timeline HTML</title></head>
+<body>
+  <img src=\'data:image/png;base64,{}\'>
+</body>
+</html>""".format(encoded)
+
             with open(path, 'w') as f:
                 f.write(html)
         remove(tmpfile.name)


### PR DESCRIPTION
Summary: Wrap the PNG image of the memory plot inside of an HTML body, so that the file can be easily opened or embedding in other frontends.

Test Plan:
CI Tests

# Ran locally on Resnet50:
{F988498243}
{F988498789}
https://www.internalfb.com/manifold/explorer/trace_stats/tree/749163530321413/tmpj3ifzs7r.pt.memorytl.html

Differential Revision: D45827509

Pulled By: aaronenyeshi

