### PR TITLE
[CUDA][DLPack] Handle legacy default streams for DLPack conversion

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -148,8 +148,8 @@ class TestTorchDlPack(TestCase):
     @onlyCUDA
     @skipCUDAIfRocm
     def test_dlpack_convert_default_stream(self, device):
-        x = torch.zeros(2**30, device=device)
         torch.cuda.default_stream().synchronize()
+        x = torch.zeros(2**30, device=device)
         self.assertTrue(torch.cuda.default_stream().query())
         d = x.__dlpack__(1)
         # check that the default stream has work (a pending cudaStreamWaitEvent)

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -152,7 +152,7 @@ class TestTorchDlPack(TestCase):
         torch.cuda.default_stream().synchronize()
         self.assertTrue(torch.cuda.default_stream().query())
         d = x.__dlpack__(1)
-        # check that the default stream has work
+        # check that the default stream has work (a pending cudaStreamWaitEvent)
         self.assertFalse(torch.cuda.default_stream().query())
 
     @skipMeta

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -149,7 +149,8 @@ class TestTorchDlPack(TestCase):
     @skipCUDAIfRocm
     def test_dlpack_convert_default_stream(self, device):
         torch.cuda.default_stream().synchronize()
-        x = torch.zeros(2**30, device=device)
+        x = torch.zeros(1, device=device)
+        torch.cuda._sleep(2**20)
         self.assertTrue(torch.cuda.default_stream().query())
         d = x.__dlpack__(1)
         # check that the default stream has work (a pending cudaStreamWaitEvent)


### PR DESCRIPTION
It seems that some legacy default stream logic (e.g., present in https://github.com/pytorch/pytorch/blob/a8ff647e4233625d5f5840d46c93b00471c18fe8/torch/utils/dlpack.py#L114 ) is not handled on the potential receiving end in `torch/_tensor.py`.

Open to suggestions on how to make the test case less clunky, as this was the combination we arrived at after discovering flakiness in alternate versions.

Thanks to Olga Andreeva for surfacing this issue and providing a repro.

CC @Aidyn-A @ngimel 

cc @ngimel