### PR TITLE
fix indirect indexing for dimension of size 1

### DIFF
--- a/test/inductor/indirect_assert_helper.py
+++ b/test/inductor/indirect_assert_helper.py
@@ -24,10 +24,18 @@ def store(x, y, z):
 
 
 if __name__ == "__main__":
-    _, fn_name, dims, dyn_shape = sys.argv
+    _, fn_name, dims, dyn_shape, one_size = sys.argv
     assert fn_name in ("first_arg", "second_arg", "same_pm_one", "same_pp_one", "store")
+    assert one_size in ("True", "False")
+    one_size = one_size == "True"
     assert dims in ("2", "3")
-    shape_x = (3, 2, 4) if dims == "3" else (3, 2)
+    shape_x = [3, 2, 4] if dims == "3" else [3, 2]
+    if one_size:
+        print("one_size_cond", one_size)
+        assert (
+            fn_name == "first_arg"
+        )  # only testing first_arg for a special case of 1-size tensor
+        shape_x[0] = 1
     assert dyn_shape in ("True", "False")
     dynamic_shapes = dyn_shape == "True"
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6348,7 +6348,14 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             for fn, ndims, dyn_shape in itertools.product(fns, (2, 3), (True, False)):
                 proc = subprocess.Popen(
-                    [sys.executable, test_path, fn, str(ndims), str(dyn_shape)],
+                    [
+                        sys.executable,
+                        test_path,
+                        fn,
+                        str(ndims),
+                        str(dyn_shape),
+                        "False",
+                    ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 )
@@ -6358,8 +6365,21 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                         "index out of bounds" in err.decode("utf-8")
                         for err in stderr.splitlines()
                     ),
-                    f"{fn}, {ndims}, {dyn_shape}",
+                    f"{fn}, {ndims}, {dyn_shape}, False",
                 )
+            proc = subprocess.Popen(
+                [sys.executable, test_path, "first_arg", "2", "False", "True"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stderr = proc.communicate()[1]
+            self.assertTrue(
+                any(
+                    "index out of bounds" in err.decode("utf-8")
+                    for err in stderr.splitlines()
+                ),
+                "first_arg 2 False True",
+            )
 
     class RNNTest(TestCase):
         class Model(torch.nn.Module):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1813,7 +1813,10 @@ class FixedLayout(Layout):
             assert len(index) == len(self.stride) == len(self.size)
             result = self.offset
             for idx, stride, sz in zip(index, self.stride, self.size):
-                if sz != 1:
+                if sz != 1 or (
+                    isinstance(idx, sympy.Symbol)
+                    and ("tmp" in idx.name or "indirect" in idx.name)
+                ):
                     result = result + idx * stride
             return result
 


### PR DESCRIPTION
Fixes #100831, #100878

Normally when simplifying indexing we can assume that offset for a dimension of size 1 will be zero. However, with indirect indexing we still need to check if the indirect indices are within bounds, so we cannot use this simplification. 


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire