### PR TITLE
Fix Math Typesetting for torch.linalg.matrix_exp

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2048,10 +2048,10 @@ Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
 this function computes the **matrix exponential** of :math:`A \in \mathbb{K}^{n \times n}`, which is defined as
 
 .. math::
-    \mathrm{matrix_exp}(A) = \sum_{k=0}^\infty \frac{1}{k!}A^k \in \mathbb{K}^{n \times n}.
+    \mathrm{matrix\_exp}(A) = \sum_{k=0}^\infty \frac{1}{k!}A^k \in \mathbb{K}^{n \times n}.
 
 If the matrix :math:`A` has eigenvalues :math:`\lambda_i \in \mathbb{C}`,
-the matrix :math:`\mathrm{matrix_exp}(A)` has eigenvalues :math:`e^{\lambda_i} \in \mathbb{C}`.
+the matrix :math:`\mathrm{matrix\_exp}(A)` has eigenvalues :math:`e^{\lambda_i} \in \mathbb{C}`.
 
 Supports input of bfloat16, float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if :attr:`A` is a batch of matrices then


### PR DESCRIPTION
Fixes current the matrix_exp documentation typesetting which has an unescaped underscore.

It currently looks like this

<img width="540" alt="image" src="https://github.com/pytorch/pytorch/assets/3844846/cbff79c3-8c1a-4003-bee3-c4c97ae0e3a0">


With the fix, it looks like this
<img width="555" alt="image" src="https://github.com/pytorch/pytorch/assets/3844846/a24d9a3f-bbbd-4685-9244-2bc06872b966">

