### PR TITLE
put third_party/ittapi/ in .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# We do not use this library in our Bazel build. It contains an
+# infinitely recursing symlink that makes Bazel very unhappy.
+third_party/ittapi/


### PR DESCRIPTION
put third_party/ittapi/ in .bazelignore

Summary:
Bazel fails when recursing into this directory because it has a
symlink that infinitely recurses. We don't use this library in Bazel,
so it's safe to just ignore its existence.

Test Plan: Verified with `bazel query //...`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/101364).
* #101406
* #101405
* __->__ #101364

cc @malfet @seemethere