### PR TITLE
inductor: add dtype check before doing cpu binary fusion

### DIFF
--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -288,6 +288,7 @@ if torch._C.has_mkldnn:
         if any(
             n.args[0].meta["val"].size() != n.args[1].meta["val"].size()
             or n.args[0].meta["val"].device != n.args[1].meta["val"].device
+            or n.args[0].meta["val"].dtype != n.args[1].meta["val"].dtype
             for n in binary_nodes
         ):
             return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #101382
* #101377
* __->__ #101376



cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire