### PR TITLE
move fsdp grad scaler to torch.cuda.amp

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -20,7 +20,6 @@ from torch.distributed.fsdp import (
     MixedPrecision,
     ShardingStrategy,
 )
-from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, size_based_auto_wrap_policy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
@@ -420,7 +419,7 @@ class TestFSDPMixedPrecision(FSDPTest):
                 True,
             )
             with patch_reduce_scatter(test_reduce_scatter, full_precision_param_dtype):
-                scaler = ShardedGradScaler(enabled=enable_sharded_grad_scaler)
+                scaler = torch.cuda.amp.ShardedGradScaler(enabled=enable_sharded_grad_scaler)
                 optim = torch.optim.Adam(model.parameters())
 
                 for _ in range(3):

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -419,7 +419,9 @@ class TestFSDPMixedPrecision(FSDPTest):
                 True,
             )
             with patch_reduce_scatter(test_reduce_scatter, full_precision_param_dtype):
-                scaler = torch.cuda.amp.ShardedGradScaler(enabled=enable_sharded_grad_scaler)
+                scaler = torch.cuda.amp.ShardedGradScaler(
+                    enabled=enable_sharded_grad_scaler
+                )
                 optim = torch.optim.Adam(model.parameters())
 
                 for _ in range(3):

--- a/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
+++ b/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
@@ -11,7 +11,6 @@ from torch import distributed as dist
 from torch.cuda.amp.common import amp_definitely_not_available
 from torch.distributed.fsdp import CPUOffload, MixedPrecision
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
-from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     CUDAInitMode,
@@ -71,7 +70,7 @@ class TestShardGradScaler(TestCase):
     )
     def test_grad_scaling(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
         t0 = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t1 = torch.full((1,), 8.0, dtype=torch.float32, device="cpu")
         outputs = [t1.clone(), (t0.clone(), t1.clone()), [t0.clone(), t1.clone()]]
@@ -87,7 +86,7 @@ class TestShardGradScaler(TestCase):
     )
     def test_scaling_unscaling_sparse(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
         inv_scale = torch.full((1,), 0.5, dtype=torch.float, device="cpu")
         found_inf = torch.full((1,), 0, dtype=torch.float, device="cpu")
 
@@ -132,7 +131,7 @@ class TestShardGradScaler(TestCase):
     )
     def test_inf_gradients_skip_optim_step(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
         loss = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t0 = torch.tensor([float("inf")], dtype=torch.float32, device="cpu")
         t0.grad = t0.clone()

--- a/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
+++ b/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
@@ -70,7 +70,9 @@ class TestShardGradScaler(TestCase):
     )
     def test_grad_scaling(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(
+            init_scale=2.0, process_group=pg, enabled=True
+        )
         t0 = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t1 = torch.full((1,), 8.0, dtype=torch.float32, device="cpu")
         outputs = [t1.clone(), (t0.clone(), t1.clone()), [t0.clone(), t1.clone()]]
@@ -86,7 +88,9 @@ class TestShardGradScaler(TestCase):
     )
     def test_scaling_unscaling_sparse(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(
+            init_scale=2.0, process_group=pg, enabled=True
+        )
         inv_scale = torch.full((1,), 0.5, dtype=torch.float, device="cpu")
         found_inf = torch.full((1,), 0, dtype=torch.float, device="cpu")
 
@@ -131,7 +135,9 @@ class TestShardGradScaler(TestCase):
     )
     def test_inf_gradients_skip_optim_step(self):
         pg = DummyProcessGroup(0, 1)
-        scaler = torch.cuda.amp.ShardedGradScaler(init_scale=2.0, process_group=pg, enabled=True)
+        scaler = torch.cuda.amp.ShardedGradScaler(
+            init_scale=2.0, process_group=pg, enabled=True
+        )
         loss = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
         t0 = torch.tensor([float("inf")], dtype=torch.float32, device="cpu")
         t0.grad = t0.clone()

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,3 +1,5 @@
+import torch
+
 from .flat_param import FlatParameter
 from .fully_sharded_data_parallel import (
     BackwardPrefetch,
@@ -11,3 +13,8 @@ from .fully_sharded_data_parallel import (
     ShardingStrategy,
     StateDictType,
 )
+from .sharded_grad_scaler import _ShardedGradScaler
+
+torch.cuda.amp.ShardedGradScaler = _ShardedGradScaler  # type: ignore[attr-defined]
+del torch
+del _ShardedGradScaler

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -370,5 +370,3 @@ class _ShardedGradScaler(torch.cuda.amp.GradScaler):
 
         # To prepare for next iteration, clear the data collected from optimizers this iteration.
         self._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
-
-torch.cuda.amp.ShardedGradScaler = _ShardedGradScaler

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 import torch
 import torch.distributed as dist
 from torch.cuda import FloatTensor  # type: ignore[attr-defined]
-from torch.cuda.amp.grad_scaler import _MultiDeviceReplicator, GradScaler, OptState
+from torch.cuda.amp.grad_scaler import _MultiDeviceReplicator, OptState
 from torch.distributed.distributed_c10d import ProcessGroup
 from torch.optim.sgd import SGD
 
@@ -32,7 +32,7 @@ class _GeneralMultiDeviceReplicator(_MultiDeviceReplicator):
         self._per_device_tensors: Dict[torch.device, torch.Tensor] = {}
 
 
-class ShardedGradScaler(GradScaler):
+class _ShardedGradScaler(torch.cuda.amp.GradScaler):
     """
     ShardedGradScaler helps perform gradient scaling in a shard aware manner. It extends
     functionality from GradScaler:
@@ -370,3 +370,5 @@ class ShardedGradScaler(GradScaler):
 
         # To prepare for next iteration, clear the data collected from optimizers this iteration.
         self._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
+
+torch.cuda.amp.ShardedGradScaler = _ShardedGradScaler

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -22,7 +22,6 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
     MixedPrecision,
     ShardingStrategy,
 )
-from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.distributed.fsdp.wrap import always_wrap_policy, ModuleWrapPolicy, wrap
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
@@ -932,7 +931,7 @@ class FSDPTest(MultiProcessTestCase):
         model_device = next(model.parameters()).device
         if sharded_grad_scaler_kwargs is None:
             sharded_grad_scaler_kwargs = {}
-        sharded_grad_scaler = ShardedGradScaler(
+        sharded_grad_scaler = torch.cuda.amp.ShardedGradScaler(
             enabled=enable_sharded_grad_scaler, **sharded_grad_scaler_kwargs
         )
         # use SGD with momentum instead of Adam, since Adam is scale invariant


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
For custom device with privateuse1, we also want to support FSDP, and now the `ShardedGradScaler` defined in `sharded_grad_scaler.py` is strongly coupled with cuda, so we want to move it to `torch.cuda.amp`, and then we could to define `ShardedGradScaler` in registered `custom_deivce` module by `torch.utils.rename_privateuse1_backend` for custom device.
But the `ShardedGradScaler` need distribute and other API, moving the file `sharded_grad_scaler.py` to `torch.cuda.amp` will result in circular import reference, so I just to setattr `ShardedGradScaler` to `torch.cuda.amp`

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5