### PR TITLE
[LLVM] Make changes needed for opaque pointers

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -98,6 +98,16 @@ bool& LLVMAOTWorkflow() {
 
 namespace {
 
+#if LLVM_VERSION_MAJOR >= 15
+// Address and type pair to assist in handling of opaque pointers.
+struct TypedPointer {
+  TypedPointer() = default;
+  TypedPointer(llvm::Type* t, llvm::Value* a) : type(t), addr(a) {}
+  llvm::Type* type = nullptr;
+  llvm::Value* addr = nullptr;
+};
+#endif
+
 llvm::CmpInst::Predicate llvm_comparison_predicate(
     CompareSelectOperation compare_op,
     const ScalarType& type) {
@@ -230,9 +240,13 @@ class LLVMCodeGenImpl : public IRVisitor {
 #define LLVM_TYPE_DECLARE(_1, Name) llvm::Type* Name##Ty_;
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, LLVM_TYPE_DECLARE);
 #undef LLVM_TYPE_DECLARE
-  llvm::Type* Int8PtrTy_;
-  llvm::Type* VoidTy_;
 
+#if LLVM_VERSION_MAJOR >= 15
+  llvm::Type* OpqPtrTy_;
+#else
+  llvm::Type* Int8PtrTy_;
+#endif
+  llvm::Type* VoidTy_;
   std::unordered_map<VarPtr, int> varToArg_;
   std::unordered_map<VarPtr, llvm::Value*> varToVal_;
   std::unordered_set<BufPtr> bufsExtAlloc_;
@@ -268,8 +282,15 @@ class LLVMCodeGenImpl : public IRVisitor {
   void replaceVarMapping(
       const std::vector<VarPtr>& vars,
       const std::vector<llvm::Value*>& vals);
+
+#if LLVM_VERSION_MAJOR >= 15
+  TypedPointer packFuncArgs(const std::vector<llvm::Value*>& func_args);
+  std::vector<llvm::Value*> unpackFuncArgs(TypedPointer packed, int arg_count);
+#else
   llvm::Value* packFuncArgs(const std::vector<llvm::Value*>& func_args);
   std::vector<llvm::Value*> unpackFuncArgs(llvm::Value* packed, int arg_count);
+#endif
+
   void processParallelFor(ForPtr v);
   void handleBufReuse(BufPtr buf, BufPtr buf_to_reuse);
 
@@ -328,13 +349,22 @@ class LLVMCodeGenImpl : public IRVisitor {
 
   void emitIsNan(IntrinsicsPtr v);
 
-  llvm::Value* emitUnmaskedLoad(llvm::Value* addr, llvm::Value* idx);
+  llvm::Value* emitUnmaskedLoad(
+      llvm::Type* ty,
+      llvm::Value* addr,
+      llvm::Value* idx);
   llvm::Value* emitMaskedLoad(
+      llvm::Type* ty,
       llvm::Value* addr,
       llvm::Value* idx,
       llvm::Value* mask);
-  void emitUnmaskedStore(llvm::Value* base, llvm::Value* idx, llvm::Value* val);
+  void emitUnmaskedStore(
+      llvm::Type* ty,
+      llvm::Value* base,
+      llvm::Value* idx,
+      llvm::Value* val);
   void emitMaskedStore(
+      llvm::Type* ty,
       llvm::Value* base,
       llvm::Value* idx,
       llvm::Value* mask,
@@ -462,7 +492,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
       kernel_func_name_(std::move(kernel_func_name)),
       bufsExtAlloc_(ExternalAllocBufFinder::find(stmt)) {
 #if LLVM_VERSION_MAJOR >= 15
-  context_->setOpaquePointers(false);
+  context_->setOpaquePointers(true);
 #endif
   if (!triple) {
     triple = LLVMTargetTriple();
@@ -482,9 +512,13 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   HalfTy_ = llvm::Type::getHalfTy(getContext());
   FloatTy_ = llvm::Type::getFloatTy(getContext());
   DoubleTy_ = llvm::Type::getDoubleTy(getContext());
-  Int8PtrTy_ = llvm::Type::getInt8PtrTy(getContext());
   VoidTy_ = llvm::Type::getVoidTy(getContext());
   BoolTy_ = ByteTy_;
+#if LLVM_VERSION_MAJOR >= 15
+  OpqPtrTy_ = llvm::PointerType::getUnqual(getContext());
+#else
+  Int8PtrTy_ = llvm::Type::getInt8PtrTy(getContext());
+#endif
 
   {
     std::lock_guard<std::mutex> g(llvmInitMutex);
@@ -574,6 +608,13 @@ llvm::Type* LLVMCodeGenImpl::dtypeToLLVMPtr(Dtype dtype) {
 }
 
 void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
+#if LLVM_VERSION_MAJOR >= 15
+  auto wrapper = llvm::Function::Create(
+      llvm::FunctionType::get(IntTy_, {OpqPtrTy_}, false),
+      llvm::Function::ExternalLinkage,
+      kernel_func_name_,
+      module_.get());
+#else
   auto voidPtrTy = llvm::Type::getInt8PtrTy(getContext());
   auto voidPtrPtrTy = voidPtrTy->getPointerTo();
   auto wrapper = llvm::Function::Create(
@@ -581,10 +622,28 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
       llvm::Function::ExternalLinkage,
       kernel_func_name_,
       module_.get());
+#endif
+
   auto wrapBB = llvm::BasicBlock::Create(getContext(), "wrapBB", wrapper);
   irb_.SetInsertPoint(wrapBB);
   llvm::SmallVector<llvm::Value*, 6> wrappedArgs;
   for (const auto i : c10::irange(params.size())) {
+#if LLVM_VERSION_MAJOR >= 15
+    auto argp = irb_.CreateGEP(
+        OpqPtrTy_,
+        wrapper->arg_begin(),
+        llvm::ConstantInt::getSigned(IntTy_, i));
+    if (params[i]->isPointerTy()) {
+      auto arg =
+          irb_.CreatePointerCast(irb_.CreateLoad(OpqPtrTy_, argp), params[i]);
+      wrappedArgs.push_back(arg);
+    } else {
+      auto p =
+          irb_.CreatePointerCast(irb_.CreateLoad(OpqPtrTy_, argp), OpqPtrTy_);
+      auto arg = irb_.CreateLoad(params[i], p);
+      wrappedArgs.push_back(arg);
+    }
+#else
     auto argp = irb_.CreateGEP(
         voidPtrTy,
         wrapper->arg_begin(),
@@ -601,6 +660,7 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
       auto arg = irb_.CreateLoad(p->getType()->getPointerElementType(), p);
       wrappedArgs.push_back(arg);
     }
+#endif
   }
   auto cc = irb_.CreateCall(fn_, wrappedArgs);
   irb_.CreateRet(cc);
@@ -1282,16 +1342,22 @@ void LLVMCodeGenImpl::visit(RampPtr v) {
     base = irb_.CreateAdd(base, stride);
   }
 }
-
 llvm::Value* LLVMCodeGenImpl::emitUnmaskedLoad(
+    llvm::Type* ty,
     llvm::Value* base,
     llvm::Value* idx) {
+#if LLVM_VERSION_MAJOR >= 15
+  auto addr = irb_.CreateGEP(ty, base, idx);
+  return irb_.CreateLoad(ty, addr);
+#else
   auto addr = irb_.CreateGEP(
       base->getType()->getScalarType()->getPointerElementType(), base, idx);
   return irb_.CreateLoad(addr->getType()->getPointerElementType(), addr);
+#endif
 }
 
 llvm::Value* LLVMCodeGenImpl::emitMaskedLoad(
+    llvm::Type* ty,
     llvm::Value* base,
     llvm::Value* idx,
     llvm::Value* mask) {
@@ -1306,9 +1372,16 @@ llvm::Value* LLVMCodeGenImpl::emitMaskedLoad(
 
   // Do the load
   irb_.SetInsertPoint(condblock);
+
+#if LLVM_VERSION_MAJOR >= 15
+  auto addr = irb_.CreateGEP(ty, base, idx);
+  auto load = irb_.CreateLoad(ty, addr);
+#else
   auto addr = irb_.CreateGEP(
       base->getType()->getScalarType()->getPointerElementType(), base, idx);
   auto load = irb_.CreateLoad(addr->getType()->getPointerElementType(), addr);
+#endif
+
   irb_.CreateBr(tailblock);
 
   // Merge the masked and unmasked CFG edges
@@ -1326,8 +1399,7 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
     auto base = this->value_;
     v->flat_index()->accept(this);
     auto idx = this->value_;
-
-    value_ = emitUnmaskedLoad(base, idx);
+    value_ = emitUnmaskedLoad(dtypeToLLVM(v->dtype()), base, idx);
     return;
   }
 
@@ -1364,10 +1436,15 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
       idx_ramp->base()->accept(this);
       auto first_idx = this->value_;
 
+#if LLVM_VERSION_MAJOR >= 15
+      auto addr = irb_.CreateGEP(dtypeToLLVM(v->dtype()), base, first_idx);
+#else
       auto addr = irb_.CreateGEP(
           base->getType()->getScalarType()->getPointerElementType(),
           base,
           first_idx);
+#endif
+
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(loadType, 0));
 #if LLVM_VERSION_MAJOR >= 12
@@ -1389,13 +1466,54 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
   for (int i = 0; i < v->dtype().lanes(); ++i) {
     auto sub_idx = irb_.CreateExtractElement(idx, i);
     llvm::Value* sub_load = nullptr;
-    sub_load = emitUnmaskedLoad(base, sub_idx);
+    sub_load = emitUnmaskedLoad(dtypeToLLVM(v->dtype()), base, sub_idx);
     load = irb_.CreateInsertElement(load, sub_load, i);
   }
 
   value_ = load;
 }
 
+#if LLVM_VERSION_MAJOR >= 15
+// Pack the arguments into an aggregate struct for forwarding.
+TypedPointer LLVMCodeGenImpl::packFuncArgs(
+    const std::vector<llvm::Value*>& func_args) {
+  if (func_args.empty()) {
+    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
+    return TypedPointer(
+        VoidPtrType, llvm::ConstantPointerNull::get(VoidPtrType));
+  }
+  std::vector<llvm::Type*> arg_types(func_args.size());
+  for (const auto i : c10::irange(func_args.size())) {
+    arg_types[i] = func_args[i]->getType();
+  }
+  llvm::StructType* packed_type = llvm::StructType::create(arg_types);
+  llvm::Value* zero = llvm::ConstantInt::get(IntTy_, 0);
+  llvm::Value* one = llvm::ConstantInt::get(IntTy_, 1);
+  llvm::Value* packed = irb_.CreateAlloca(packed_type, one);
+  for (const auto i : c10::irange(func_args.size())) {
+    llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
+        packed_type, packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
+    irb_.CreateStore(func_args[i], dst_ptr);
+  }
+  return TypedPointer(packed_type, packed);
+}
+
+// Unpack the aggregate struct into individual arguments.
+std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
+    TypedPointer packed,
+    int arg_count) {
+  // TODO: extract arg_count from packed.
+  std::vector<llvm::Value*> func_args(arg_count);
+  llvm::Value* zero = llvm::ConstantInt::get(IntTy_, 0);
+  for (const auto i : c10::irange(arg_count)) {
+    llvm::Type* feild_type = packed.type->getStructElementType(i);
+    llvm::Value* feild_addr = irb_.CreateInBoundsGEP(
+        packed.type, packed.addr, {zero, llvm::ConstantInt::get(IntTy_, i)});
+    func_args[i] = irb_.CreateLoad(feild_type, feild_addr);
+  }
+  return func_args;
+}
+#else
 // Pack the arguments into an aggregate struct for forwarding.
 llvm::Value* LLVMCodeGenImpl::packFuncArgs(
     const std::vector<llvm::Value*>& func_args) {
@@ -1436,6 +1554,7 @@ std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
   }
   return func_args;
 }
+#endif
 
 // Lower the parallel for-loop.
 // * Move the body into its own closure.
@@ -1467,14 +1586,24 @@ void LLVMCodeGenImpl::processParallelFor(ForPtr v) {
   }
 
   // Pack the arguments in an automatic variable for forwarding.
+#if LLVM_VERSION_MAJOR >= 15
+  TypedPointer packData = packFuncArgs(body_caller_vals);
+  llvm::Value* packed_caller_args = packData.addr;
+#else
   llvm::Value* packed_caller_args = packFuncArgs(body_caller_vals);
-
+#endif
   // Remember where we are before moving to the new function.
   llvm::BasicBlock* old_insert_block = irb_.GetInsertBlock();
 
   // Create the new body closure code.
+#if LLVM_VERSION_MAJOR >= 15
+  auto func_type =
+      llvm::FunctionType::get(VoidTy_, {LongTy_, OpqPtrTy_}, false);
+#else
   auto func_type =
       llvm::FunctionType::get(VoidTy_, {LongTy_, Int8PtrTy_}, false);
+#endif
+
   llvm::Function* func = llvm::Function::Create(
       func_type, llvm::Function::PrivateLinkage, "func", module_.get());
   auto func_body = llvm::BasicBlock::Create(getContext(), "func_body", func);
@@ -1490,7 +1619,12 @@ void LLVMCodeGenImpl::processParallelFor(ForPtr v) {
     index = irb_.CreateIntCast(
         index, dtypeToLLVM(v->var()->dtype()), v->var()->dtype().is_signed());
   }
+#if LLVM_VERSION_MAJOR >= 15
+  body_closure_args =
+      unpackFuncArgs({packData.type, packed_func_args}, body_arg_vars.size());
+#else
   body_closure_args = unpackFuncArgs(packed_func_args, body_arg_vars.size());
+#endif
   // Set the codegen to the new func.
   // TODO: this should be replaced by RAII wrappers.
   varToVal_[v->var()] = index;
@@ -1508,11 +1642,21 @@ void LLVMCodeGenImpl::processParallelFor(ForPtr v) {
 
   // Points back to the original block and generate the callee code.
   irb_.SetInsertPoint(old_insert_block);
+
+#if LLVM_VERSION_MAJOR >= 15
+  llvm::Value* packed_caller_args_ptr =
+      irb_.CreatePointerCast(packed_caller_args, OpqPtrTy_);
+  llvm::Value* func_value = irb_.CreatePointerCast(func, OpqPtrTy_);
+  llvm::FunctionType* dispatcher_fntype = llvm::FunctionType::get(
+      VoidTy_, {OpqPtrTy_, LongTy_, LongTy_, OpqPtrTy_}, false);
+#else
   llvm::Value* packed_caller_args_ptr =
       irb_.CreatePointerCast(packed_caller_args, Int8PtrTy_);
   llvm::Value* func_value = irb_.CreatePointerCast(func, Int8PtrTy_);
   llvm::FunctionType* dispatcher_fntype = llvm::FunctionType::get(
       VoidTy_, {Int8PtrTy_, LongTy_, LongTy_, Int8PtrTy_}, false);
+#endif
+
   FunctionCallee dispatcher_callee =
       module_->getOrInsertFunction("DispatchParallel", dispatcher_fntype);
   llvm::Function* dispatcher =
@@ -1602,15 +1746,22 @@ void LLVMCodeGenImpl::visit(BlockPtr v) {
 }
 
 void LLVMCodeGenImpl::emitUnmaskedStore(
+    llvm::Type* ty,
     llvm::Value* base,
     llvm::Value* idx,
     llvm::Value* val) {
+#if LLVM_VERSION_MAJOR >= 15
+  auto addr = irb_.CreateGEP(ty, base, idx);
+#else
   auto addr = irb_.CreateGEP(
       base->getType()->getScalarType()->getPointerElementType(), base, idx);
+#endif
+
   irb_.CreateStore(val, addr);
 }
 
 void LLVMCodeGenImpl::emitMaskedStore(
+    llvm::Type* ty,
     llvm::Value* base,
     llvm::Value* idx,
     llvm::Value* mask,
@@ -1625,8 +1776,14 @@ void LLVMCodeGenImpl::emitMaskedStore(
 
   // Do the store
   irb_.SetInsertPoint(condblock);
+
+#if LLVM_VERSION_MAJOR >= 15
+  auto addr = irb_.CreateGEP(ty, base, idx);
+#else
   auto addr = irb_.CreateGEP(
       base->getType()->getScalarType()->getPointerElementType(), base, idx);
+#endif
+
   irb_.CreateStore(val, addr);
   irb_.CreateBr(tailblock);
 
@@ -1643,8 +1800,7 @@ void LLVMCodeGenImpl::visit(StorePtr v) {
     v->value()->accept(this);
     auto val = this->value_;
 
-    emitUnmaskedStore(base, idx, val);
-
+    emitUnmaskedStore(dtypeToLLVM(v->value()->dtype()), base, idx, val);
     value_ = llvm::ConstantInt::get(IntTy_, 0);
     return;
   }
@@ -1662,10 +1818,16 @@ void LLVMCodeGenImpl::visit(StorePtr v) {
       idx_ramp->base()->accept(this);
       auto first_idx = value_;
 
+#if LLVM_VERSION_MAJOR >= 15
+      auto addr =
+          irb_.CreateGEP(dtypeToLLVM(v->value()->dtype()), base, first_idx);
+#else
       auto addr = irb_.CreateGEP(
           base->getType()->getScalarType()->getPointerElementType(),
           base,
           first_idx);
+#endif
+
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(val->getType(), 0));
 
@@ -1686,7 +1848,7 @@ void LLVMCodeGenImpl::visit(StorePtr v) {
   for (int i = 0; i < v->value()->dtype().lanes(); ++i) {
     auto sub_idx = irb_.CreateExtractElement(idx, i);
     auto sub_val = irb_.CreateExtractElement(val, i);
-    emitUnmaskedStore(base, sub_idx, sub_val);
+    emitUnmaskedStore(dtypeToLLVM(v->value()->dtype()), base, sub_idx, sub_val);
   }
 
   value_ = llvm::ConstantInt::get(IntTy_, 0);
@@ -2042,9 +2204,13 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   for (BufPtr b : bufs) {
     dims_num += b->dims().size();
   }
-
+#if LLVM_VERSION_MAJOR >= 15
+  llvm::Value* buf_ptrs = irb_.CreateAlloca(
+      OpqPtrTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_num));
+#else
   llvm::Value* buf_ptrs = irb_.CreateAlloca(
       Int8PtrTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_num));
+#endif
   llvm::Value* buf_ranks = irb_.CreateAlloca(
       LongTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_num));
   llvm::Value* buf_dims = irb_.CreateAlloca(
@@ -2061,11 +2227,17 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   int stride_idx = 0;
   for (BufPtr b : bufs) {
     // Store value for buf pointer
-    auto gep = irb_.CreateInBoundsGEP(
-        Int8PtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
     b->base_handle()->accept(this);
     auto buf_ptr = this->value_;
+#if LLVM_VERSION_MAJOR >= 15
+    auto gep = irb_.CreateInBoundsGEP(
+        OpqPtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
+    auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, OpqPtrTy_);
+#else
+    auto gep = irb_.CreateInBoundsGEP(
+        Int8PtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
     auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, Int8PtrTy_);
+#endif
     irb_.CreateStore(buf_void_ptr, gep);
 
     // Store dtype of the buf
@@ -2117,6 +2289,21 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
 
   // Generate the call itself
   std::string fname = v->func_name();
+#if LLVM_VERSION_MAJOR >= 15
+  FunctionCallee callee = module_->getOrInsertFunction(
+      fname,
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(getContext()), // return type
+          {LongTy_, // int64_t bufs_num
+           OpqPtrTy_, // void** buf_data
+           OpqPtrTy_, // int64_t* buf_ranks
+           OpqPtrTy_, // int64_t* buf_dims
+           OpqPtrTy_, // int64_t* buf_strides
+           OpqPtrTy_, // int64_t* buf_dtypes
+           LongTy_, // int64_t args_num
+           OpqPtrTy_}, // int64_t* extra_args
+          false)); // is var_arg
+#else
   FunctionCallee callee = module_->getOrInsertFunction(
       fname,
       llvm::FunctionType::get(
@@ -2130,6 +2317,7 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
            LongTy_, // int64_t args_num
            LongTy_->getPointerTo()}, // int64_t* extra_args
           false)); // is var_arg
+#endif
 
   auto call_ty = callee.getFunctionType();
   auto call_fn = callee.getCallee();
@@ -2174,9 +2362,15 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
   // bufs_in_size for input pointers
   // bufs_out_size for out tensors TensorImpl* to pass to nnc_aten_free to
   // release out tensors
+#if LLVM_VERSION_MAJOR >= 15
+  llvm::Value* buf_ptrs = irb_.CreateAlloca(
+      OpqPtrTy_,
+      llvm::ConstantInt::getSigned(IntTy_, bufs_in_size + 2 * bufs_out_size));
+#else
   llvm::Value* buf_ptrs = irb_.CreateAlloca(
       Int8PtrTy_,
       llvm::ConstantInt::getSigned(IntTy_, bufs_in_size + 2 * bufs_out_size));
+#endif
   // @lint-ignore CLANGTIDY
   llvm::Value* buf_ranks = irb_.CreateAlloca(
       LongTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_in_size));
@@ -2195,14 +2389,25 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
   int stride_idx = 0;
   for (const auto& b : bufs_in) {
     // Store value for buf pointer
+    b->base_handle()->accept(this);
+    auto buf_ptr = this->value_;
+
+#if LLVM_VERSION_MAJOR >= 15
+    llvm::Value* gep = irb_.CreateInBoundsGEP(
+        OpqPtrTy_,
+        buf_ptrs,
+        // @lint-ignore CLANGTIDY
+        llvm::ConstantInt::getSigned(IntTy_, bufs_out_size + i));
+    auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, OpqPtrTy_);
+#else
     llvm::Value* gep = irb_.CreateInBoundsGEP(
         Int8PtrTy_,
         buf_ptrs,
         // @lint-ignore CLANGTIDY
         llvm::ConstantInt::getSigned(IntTy_, bufs_out_size + i));
-    b->base_handle()->accept(this);
-    auto buf_ptr = this->value_;
     auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, Int8PtrTy_);
+#endif
+
     irb_.CreateStore(buf_void_ptr, gep);
 
     // Store dtype of the buf
@@ -2255,6 +2460,22 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
 
   // Generate the call itself
   std::string fname = v->func_name();
+
+#if LLVM_VERSION_MAJOR >= 15
+  FunctionCallee callee = module_->getOrInsertFunction(
+      fname,
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(getContext()), // return type
+          {LongTy_, // int64_t bufs_in_size
+           OpqPtrTy_, // void** buf_data
+           OpqPtrTy_, // int64_t* buf_ranks
+           OpqPtrTy_, // int64_t* buf_dims
+           OpqPtrTy_, // int64_t* buf_strides
+           OpqPtrTy_, // int64_t* buf_dtypes
+           LongTy_, // int64_t args_num
+           OpqPtrTy_}, // int64_t* extra_args
+          false)); // is var_arg
+#else
   FunctionCallee callee = module_->getOrInsertFunction(
       fname,
       llvm::FunctionType::get(
@@ -2268,6 +2489,7 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
            LongTy_, // int64_t args_num
            LongTy_->getPointerTo()}, // int64_t* extra_args
           false)); // is var_arg
+#endif
 
   auto call_ty = callee.getFunctionType();
   auto call_fn = callee.getCallee();
@@ -2290,10 +2512,18 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
   // @lint-ignore CLANGTIDY
   for (const auto i : c10::irange(bufs_out_size)) {
     const auto& buf_out = bufs_out[i];
+#if LLVM_VERSION_MAJOR >= 15
+    auto gep = irb_.CreateInBoundsGEP(
+        OpqPtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
+    llvm::Value* ptr = irb_.CreatePointerCast(
+        irb_.CreateLoad(OpqPtrTy_, gep), dtypeToLLVMPtr(buf_out->dtype()));
+#else
     auto gep = irb_.CreateInBoundsGEP(
         Int8PtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
     llvm::Value* ptr = irb_.CreatePointerCast(
         irb_.CreateLoad(Int8PtrTy_, gep), dtypeToLLVMPtr(buf_out->dtype()));
+#endif
+
     varToVal_[buf_out->base_handle()] = ptr;
 
     for (auto it = bufsExtAllocReuse_.find(buf_out);
@@ -2304,6 +2534,14 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
     }
     bufsExtAllocReuse_.erase(buf_out);
 
+#if LLVM_VERSION_MAJOR >= 15
+    gep = irb_.CreateInBoundsGEP(
+        OpqPtrTy_,
+        buf_ptrs,
+        // @lint-ignore CLANGTIDY
+        llvm::ConstantInt::getSigned(IntTy_, bufs_out_size + bufs_in_size + i));
+    bufsExtToFreeVal_[buf_out->base_handle()] = irb_.CreateLoad(OpqPtrTy_, gep);
+#else
     gep = irb_.CreateInBoundsGEP(
         Int8PtrTy_,
         buf_ptrs,
@@ -2311,6 +2549,7 @@ void LLVMCodeGenImpl::visit(ExternalCallWithAllocPtr v) {
         llvm::ConstantInt::getSigned(IntTy_, bufs_out_size + bufs_in_size + i));
     bufsExtToFreeVal_[buf_out->base_handle()] =
         irb_.CreateLoad(Int8PtrTy_, gep);
+#endif
   }
 
   value_ = llvm::ConstantInt::get(IntTy_, 0);
@@ -2377,16 +2616,39 @@ void LLVMCodeGenImpl::visit(FreeExtPtr v) {
   const auto& bufs = v->bufs();
   const auto bufs_num = bufs.size();
 
+#if LLVM_VERSION_MAJOR >= 15
+  llvm::Value* ptrs = irb_.CreateAlloca(
+      OpqPtrTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_num));
+#else
   llvm::Value* ptrs = irb_.CreateAlloca(
       Int8PtrTy_, llvm::ConstantInt::getSigned(IntTy_, bufs_num));
+#endif
+
   for (const auto i : c10::irange(bufs_num)) {
     const auto& buf = bufs[i];
+#if LLVM_VERSION_MAJOR >= 15
+    llvm::Value* gep = irb_.CreateInBoundsGEP(
+        OpqPtrTy_, ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
+#else
     llvm::Value* gep = irb_.CreateInBoundsGEP(
         Int8PtrTy_, ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
+#endif
+
     auto ptr = bufsExtToFreeVal_[buf->base_handle()];
     irb_.CreateStore(ptr, gep);
   }
 
+#if LLVM_VERSION_MAJOR >= 15
+  FunctionCallee callee = module_->getOrInsertFunction(
+      "nnc_aten_free",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(getContext()), // return type
+          {
+              LongTy_, // int64_t bufs_num
+              OpqPtrTy_, // void** ptrs
+          },
+          false)); // is var_arg
+#else
   FunctionCallee callee = module_->getOrInsertFunction(
       "nnc_aten_free",
       llvm::FunctionType::get(
@@ -2396,6 +2658,7 @@ void LLVMCodeGenImpl::visit(FreeExtPtr v) {
               Int8PtrTy_->getPointerTo(), // void** ptrs
           },
           false)); // is var_arg
+#endif
 
   auto call_ty = callee.getFunctionType();
   auto call_fn = callee.getCallee();


### PR DESCRIPTION
Update llvm_codegen module to use opaque pointers feature of llvm.

* Set setOpaquePointers to true for llvm context.
* Pass Type to emit\*Load and emit\*Store functions.
* Create TypedPointer struct to keep track of Value and its Type.
* Introduce OpqTy_ to be used for opaque pointer types.

cc @EikanWang @jgong5