### PR TITLE
Fixed bug in interpolate when interpolation size is larger than max

### DIFF
--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -758,11 +758,9 @@ struct HelperInterpBase {
     xsize = std::min(
         static_cast<int64_t>(center + support + 0.5 + align_corners_delta), input_size) - xmin;
 
-    if (!antialias && C10_UNLIKELY(xsize > max_interp_size)) {
-      // There are rare cases when due to precision xsize can be larger than max_interp_size by one.
-      // We have to clip the value
-      xsize = max_interp_size;
-    }
+    // There are rare cases when due to precision xsize can be larger than max_interp_size by one.
+    // We have to clip the value
+    xsize = std::clamp(xsize, static_cast<int64_t>(0), max_interp_size);
 
     int64_t j = 0;
     for (; j < xsize; j++) {

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -758,6 +758,12 @@ struct HelperInterpBase {
     xsize = std::min(
         static_cast<int64_t>(center + support + 0.5 + align_corners_delta), input_size) - xmin;
 
+    if (!antialias && C10_UNLIKELY(xsize > max_interp_size)) {
+      // There are rare cases when due to precision xsize can be larger than max_interp_size by one.
+      // We have to clip the value
+      xsize = max_interp_size;
+    }
+
     int64_t j = 0;
     for (; j < xsize; j++) {
       scalar_t w = filter_fn((j + xmin - center + 0.5 - align_corners_delta) * invscale);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9756,7 +9756,7 @@ class TestNNDeviceType(NNTestCase):
 
         output_f32 = F.interpolate(
             input_f32, size=(output_size, output_size), mode=mode, align_corners=align_corners, antialias=False
-        ).round().byte()
+        ).round().to(torch.uint8)
         output_ui8 = F.interpolate(
             input_ui8, size=(output_size, output_size), mode=mode, align_corners=align_corners, antialias=False
         )


### PR DESCRIPTION
## Description

This is a bug fix for rare cases that can happen with specific scale, antialias=False, output for a random line can be wrong. For example:
```
line 14
output uint8: [76, 78, 80, 81, 83, 85, 87, 88, 90]
expected float: [149, 152, 155, 158, 161, 164, 167, 170, 173]
diff: [-73, -74, -75, -77, -78, -79, -80, -82, -83]
opencv ref: [149 152 155 158 161 164 167 170 173]
```

It appears that for this line we have 3 weights coeff instead of 2:
```
line 13 | 351, 2                                                                                                                                                                                                                                                                                          
k: 1130 15254                                                                                                                                                                                                                                                                                        
line 14 | 378, 3                                                                                                                                                                                                                                                                                          
k: 0 16384 -6780            <-------  We should have 2 weights and not 3                                                                                                                                                                                                                                                                        
line 15 | 432, 2                                                                                                                                                                                                                                                                                          
k: 15254 1130    
```
which comes from our `_compute_weights_aa` function that is specifically used for AA=False and uint8.
```
    xmin = std::max(
        static_cast<int64_t>(center - support + 0.5 + align_corners_delta), static_cast<int64_t>(0));
    xsize = std::min(
        static_cast<int64_t>(center + support + 0.5 + align_corners_delta), input_size) - xmin;
```
```
center - support + 0.5 + align_corners_delta: 14.999999999999998
static_cast<int64_t>(center - support + 0.5 + align_corners_delta): 14
xmin -> 14

center + support + 0.5 + align_corners_delta: 17.0
static_cast<int64_t>(center + support + 0.5 + align_corners_delta): 17.0
xsize -> 17 - 14 = 3  <------ 3 instead of 2
```

For float dtype, AA=False weights and indices are computed differently due to historically first implemented.

In any case, `xsize` should not be larger than `max_interp_size`, so we decided to clip `xsize`.

Once fixed computed indices and weights are same as for float dtype code path:
```
# Option: xsize = min(xsize, max_interp_size)
Line Num | xmin, xsize

14 | 378, 2                 xmin=378 <---> xmin = i * stride = i * 3 * 9 => i = 14
k: 0 16384                  16384 = w * (1 << 14) => w = 1.0

=> i=14, w=0 and i=15, w=1
```
vs
```
Line Num | index0, index1
F32: 14 | 15, 16
F32: lambda0, lambda1: 0.999999, 9.53674e-07
```


cc @NicolasHug @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10