### PR TITLE
[inductor] enable multi-threaded compilation in fbcode

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -150,12 +150,12 @@ def decide_compile_threads():
     Here are the precedence to decide compile_threads
     1. User can override it by TORCHINDUCTOR_COMPILE_THREADS.  One may want to disable async compiling by
        setting this to 1 to make pdb happy.
-    2. Set to 1 if it's win32 platform or it's a fbcode build
+    2. Set to 1 if it's win32 platform
     3. decide by the number of CPU cores
     """
     if "TORCHINDUCTOR_COMPILE_THREADS" in os.environ:
         return int(os.environ["TORCHINDUCTOR_COMPILE_THREADS"])
-    elif sys.platform == "win32" or is_fbcode():
+    elif sys.platform == "win32":
         return 1
     else:
         return min(


### PR DESCRIPTION
Summary: update `decide_compile_threads` in inductor config to enable multi-threaded compilation for fbcode

Test Plan: sandcastle + oss

Differential Revision: D45790151



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @soumith @desertfire