### PR TITLE
use Bazelisk to fetch Bazel in CI

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -80,19 +80,14 @@ function get_exit_code() {
 }
 
 function get_bazel() {
-  if [[ $(uname) == "Darwin" ]]; then
-    # download bazel version
-    retry curl https://github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-darwin-x86_64  -Lo tools/bazel
-    # verify content
-    echo '74d93848f0c9d592e341e48341c53c87e3cb304a54a2a1ee9cff3df422f0b23c  tools/bazel' | shasum -a 256 -c >/dev/null
-  else
-    # download bazel version
-    retry curl https://ossci-linux.s3.amazonaws.com/bazel-4.2.1-linux-x86_64 -o tools/bazel
-    # verify content
-    echo '1a4f3a3ce292307bceeb44f459883859c793436d564b95319aacb8af1f20557c  tools/bazel' | shasum -a 256 -c >/dev/null
-  fi
-
-  chmod +x tools/bazel
+  # Download and use the cross-platform, dependency-free Python
+  # version of Bazelisk to fetch the platform specific version of
+  # Bazel to use from .bazelversion.
+  retry curl --location --output tools/bazel \
+    https://raw.githubusercontent.com/bazelbuild/bazelisk/v1.16.0/bazelisk.py
+  shasum --algorithm=1 --check \
+    <(echo 'd4369c3d293814d3188019c9f7527a948972d9f8  tools/bazel')
+  chmod u+x tools/bazel
 }
 
 # This function is bazel specific because of the bug

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,10 +5,10 @@ load("//tools/rules:workspace.bzl", "new_patched_local_repository")
 
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-40548a2974f1aea06215272d9c2b47a14a24e556",
     patches = [
         "//:tools/rules_cc/cuda_support.patch",
     ],
+    strip_prefix = "rules_cc-40548a2974f1aea06215272d9c2b47a14a24e556",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/40548a2974f1aea06215272d9c2b47a14a24e556.tar.gz",
         "https://github.com/bazelbuild/rules_cc/archive/40548a2974f1aea06215272d9c2b47a14a24e556.tar.gz",
@@ -37,9 +37,9 @@ http_archive(
 )
 
 http_archive(
-  name = "pybind11_bazel",
-  strip_prefix = "pybind11_bazel-992381ced716ae12122360b0fbadbc3dda436dbf",
-  urls = ["https://github.com/pybind/pybind11_bazel/archive/992381ced716ae12122360b0fbadbc3dda436dbf.zip"],
+    name = "pybind11_bazel",
+    strip_prefix = "pybind11_bazel-992381ced716ae12122360b0fbadbc3dda436dbf",
+    urls = ["https://github.com/pybind/pybind11_bazel/archive/992381ced716ae12122360b0fbadbc3dda436dbf.zip"],
 )
 
 new_local_repository(
@@ -50,17 +50,17 @@ new_local_repository(
 
 http_archive(
     name = "com_github_glog",
-    strip_prefix = "glog-0.4.0",
-    urls = [
-        "https://github.com/google/glog/archive/v0.4.0.tar.gz",
-    ],
     build_file_content = """
 licenses(['notice'])
 
 load(':bazel/glog.bzl', 'glog_library')
 # TODO: figure out why enabling gflags leads to SIGSEV on the logging init
 glog_library(with_gflags=0)
-    """
+    """,
+    strip_prefix = "glog-0.4.0",
+    urls = [
+        "https://github.com/google/glog/archive/v0.4.0.tar.gz",
+    ],
 )
 
 http_archive(
@@ -110,7 +110,7 @@ new_local_repository(
     name = "fbgemm",
     build_file = "//third_party:fbgemm/BUILD.bazel",
     path = "third_party/fbgemm",
-    repo_mapping = {"@cpuinfo" : "@org_pytorch_cpuinfo"}
+    repo_mapping = {"@cpuinfo": "@org_pytorch_cpuinfo"},
 )
 
 new_local_repository(
@@ -157,11 +157,11 @@ new_local_repository(
 
 new_patched_local_repository(
     name = "tbb",
+    build_file = "//third_party:tbb.BUILD",
+    patch_strip = 1,
     patches = [
         "@//third_party:tbb.patch",
     ],
-    patch_strip = 1,
-    build_file = "//third_party:tbb.BUILD",
     path = "third_party/tbb",
 )
 
@@ -174,8 +174,8 @@ new_local_repository(
 http_archive(
     name = "mkl",
     build_file = "//third_party:mkl.BUILD",
-    strip_prefix = "lib",
     sha256 = "59154b30dd74561e90d547f9a3af26c75b6f4546210888f09c9d4db8f4bf9d4c",
+    strip_prefix = "lib",
     urls = [
         "https://anaconda.org/anaconda/mkl/2020.0/download/linux-64/mkl-2020.0-166.tar.bz2",
     ],
@@ -192,12 +192,16 @@ http_archive(
 
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
     sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")
-python_configure(name = "local_config_python", python_version="3")
+
+python_configure(
+    name = "local_config_python",
+    python_version = "3",
+)
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
@@ -237,19 +241,19 @@ local_repository(
 local_repository(
     name = "pthreadpool",
     path = "third_party/pthreadpool",
-    repo_mapping = {"@com_google_benchmark" : "@google_benchmark"}
+    repo_mapping = {"@com_google_benchmark": "@google_benchmark"},
 )
 
 local_repository(
     name = "FXdiv",
     path = "third_party/FXdiv",
-    repo_mapping = {"@com_google_benchmark" : "@google_benchmark"}
+    repo_mapping = {"@com_google_benchmark": "@google_benchmark"},
 )
 
 local_repository(
     name = "XNNPACK",
     path = "third_party/XNNPACK",
-    repo_mapping = {"@com_google_benchmark" : "@google_benchmark"}
+    repo_mapping = {"@com_google_benchmark": "@google_benchmark"},
 )
 
 local_repository(


### PR DESCRIPTION
use Bazelisk to fetch Bazel in CI

Summary:

Advantages:
1. this is cross-platform, no MacOS specific code
2. this lets us use define the version of Bazel succinctly in
   .bazelversion (already provided)

Note that this change will upgrade our version of Bazel to 6.1.1.

Test Plan: Rely on CI.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/101424).
* #101406
* #101405
* #101445
* __->__ #101424
* #101411