### PR TITLE
Run dynamo tests in parallel

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1235,7 +1235,6 @@ def must_serial(file: str) -> bool:
     return (
         os.getenv("PYTORCH_TEST_RUN_EVERYTHING_IN_SERIAL", "0") == "1"
         or "distributed" in os.getenv("TEST_CONFIG", "")
-        or "dynamo" in os.getenv("TEST_CONFIG", "")
         or "distributed" in file
         or file in CUSTOM_HANDLERS
         or file in RUN_PARALLEL_BLOCKLIST


### PR DESCRIPTION
cuts off ~30 min per shard 
(2 shards and 2 python versions so 2 hours total)