### PR TITLE
Use python3 instead of /usr/bin/env python3 on Windows

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
 
       - name: Uninstall PyTorch
         if: always()


### PR DESCRIPTION
I'm seeing some curious flaky failure on Windows where python3 couldn't be found in the env, for example https://github.com/pytorch/pytorch/actions/runs/4983028765/jobs/8920011406 or https://github.com/pytorch/pytorch/actions/runs/4967229128/jobs/8889106289.  On the other hand, other scripts invoked directly with python3 works fine in the same workflow.

So let's use use `python3 .github/scripts/parse_ref.py` instead.  The binary python3 is in GITHUB_PATH populated by `setup-windows` step