### PR TITLE
Avoid cond prefix when naming subgraph of HigherOrderOperators

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: dynamo"]
 import unittest
 
+import functorch.experimental.control_flow as control_flow
+
 import torch
 
 import torch._dynamo.test_case
@@ -171,6 +173,107 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(op_count(body_function), 1)
         inner_wrap_node = find_first_node(body_function, wrap)
         self.assertTrue(len(inner_wrap_node.args), 3)
+
+    def test_map_subgraph_name_is_valid(self):
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        xs = torch.randn(2, 3, 3)
+        y = torch.randn(3)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def map_f(xs, y):
+            def inner(x, y):
+                def inner2(x, y):
+                    return x + y
+
+                return control_flow.map(inner2, x, y)
+
+            return control_flow.map(inner, xs, y)
+
+        result = map_f(xs, y)
+        self.assertEqual(result, xs + y)
+
+        map_gm = backend.graphs[0]
+        name_set = set()
+        for name, _ in map_gm.named_modules():
+            name_set.add(name)
+        self.assertEqual(name_set, {"", "map_body_0.map_body_0", "map_body_0"})
+
+    def test_cond_subgraph_name_is_valid(self):
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        pred = torch.tensor(True)
+        pred2 = torch.tensor(False)
+        xs = torch.randn(2, 3, 3)
+        y = torch.randn(3, 3)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def cond_f(pred, pred2, x, y):
+            def true_fn(pred2, x, y):
+                return x + y
+
+            def false_fn(pred2, x, y):
+                def true_fn2(x, y):
+                    return x.sin() - y.cos()
+
+                def false_fn2(x, y):
+                    return x.cos() - y.sin()
+
+                return control_flow.cond(pred2, true_fn2, false_fn2, [x, y])
+
+            return control_flow.cond(pred, true_fn, false_fn, [pred2, x, y])
+
+        result = cond_f(pred, pred2, xs, y)
+        self.assertEqual(result, xs + y)
+
+        cond_gm = backend.graphs[0]
+        name_set = set()
+        for name, _ in cond_gm.named_modules():
+            name_set.add(name)
+        self.assertEqual(
+            name_set,
+            {
+                "",
+                "cond_true_0",
+                "cond_false_0",
+                "cond_false_0.cond_false_0",
+                "cond_false_0.cond_true_0",
+            },
+        )
+
+    def test_wrap_subgraph_name_is_valid(self):
+        backend = EagerAndRecordGraphs()
+        cnt = CompileCounterWithBackend(backend)
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+
+        def inner(x, y):
+            z = x + y
+            return wrap(lambda x: wrap(lambda x: x + z, x), x)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def f(x, y):
+            return wrap(inner, x, y)
+
+        result = f(x, y)
+
+        self.assertEqual(result, x + y + x)
+        wrap_gm = backend.graphs[0]
+        names = set()
+        for mod_name, _ in wrap_gm.named_modules():
+            names.add(mod_name)
+        self.assertEqual(
+            names,
+            {
+                "",
+                "wrap_body_2",
+                "wrap_body_2.wrap_body_1",
+                "wrap_body_2.wrap_body_1.wrap_body_0",
+            },
+        )
 
     def test_capture_global_num(self):
         def f(x):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -768,7 +768,7 @@ class TorchHigherOrderOperator(VariableTracker):
             next_name = None
             i = 0
             while not next_name:
-                candidate = f"cond_{name}_{i}"
+                candidate = f"{name}_{i}"
                 if candidate in tx.output.nn_modules:
                     i += 1
                 else:
@@ -1052,11 +1052,11 @@ class TorchHigherOrderOperator(VariableTracker):
             )
 
             true_name = add_subgraph(
-                "true",
+                "cond_true",
                 torch.fx.GraphModule(true_nn_modules_context.nn_modules, true_graph),
             )
             false_name = add_subgraph(
-                "false",
+                "cond_false",
                 torch.fx.GraphModule(false_nn_modules_context.nn_modules, false_graph),
             )
 
@@ -1122,7 +1122,7 @@ class TorchHigherOrderOperator(VariableTracker):
             )
 
             body_name = add_subgraph(
-                "body",
+                "map_body",
                 torch.fx.GraphModule(body_nn_modules_context.nn_modules, body_graph),
             )
 
@@ -1169,7 +1169,7 @@ class TorchHigherOrderOperator(VariableTracker):
             )
 
             body_name = add_subgraph(
-                "body", torch.fx.GraphModule(tx.output.nn_modules, body_graph)
+                "wrap_body", torch.fx.GraphModule(tx.output.nn_modules, body_graph)
             )
             body_node = make_attr(body_name)
             p_args = (


### PR DESCRIPTION
Fixes the issue in  #100278: HigherOrderOperator body functions should not all be named "cond_body".

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire