### PR TITLE
Fix typing for `setup_context` in `autograd`

### DIFF
--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -339,7 +339,7 @@ class _SingleLevelFunction(_C._FunctionBase, FunctionCtx, _HookMixin, metaclass=
                                   " autograd.Function.")
 
     @staticmethod
-    def setup_context(ctx: Any, inputs: Tuple[Any], output: Any) -> Any:
+    def setup_context(ctx: Any, inputs: Tuple[Any, ...], output: Any) -> Any:
         r"""There are two ways to define the forward pass of an autograd.Function.
 
         Either:


### PR DESCRIPTION
The original only matches a tuple of length 1, but it's intended to match any length.

Also, it now aligns with the docstring at L320
https://github.com/pytorch/pytorch/blob/d5cba0618aa0441af17487dd24317cd62afd0528/torch/autograd/function.py#L320