### PR TITLE
Fix check-labels workflow commenting on forked PRs

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,7 +1,7 @@
 name: Check Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,8 +1,21 @@
 name: Check Labels
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches-ignore: [main]
+    paths: [.github] # To allow testing PRs that change workflows.
+
+  # We need pull_request_target to be able to post comments on PRs from forks.
+  # Only allow pull_request_target when merging to main, not some historical branch.
+  #
+  # Make sure to don't introduce explicit checking out and installing/running
+  # untrusted user code into this workflow!
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+    paths-ignore: [.github] # May be triggered together with pull_request if
+                            # the PR has files in and out of .github, it's OK.
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,11 +1,6 @@
 name: Check Labels
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches-ignore: [main]
-    paths: [.github] # To allow testing PRs that change workflows.
-
   # We need pull_request_target to be able to post comments on PRs from forks.
   # Only allow pull_request_target when merging to main, not some historical branch.
   #
@@ -14,8 +9,14 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
-    paths-ignore: [.github] # May be triggered together with pull_request if
-                            # the PR has files in and out of .github, it's OK.
+    paths-ignore: [.github]
+
+  # To allow testing PRs that change workflows.
+  # May be triggered together with pull_request_target, it's OK.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths: [.github]
+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Using `pull_request_target` allows securely passing the secrets to make comments on a forked PRs.
See more about `pull_request_target` in https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

The change was verified in https://github.com/malfet/deleteme/pull/53 - with `on pull_request` there were no "This PR needs a label" comment, with with `on pull_request_target` the comment can be posted.
