### PR TITLE
Fix torchinductor uint8 bug

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6142,12 +6142,12 @@ class CommonTemplate:
         self.common(fn, (torch.randn(8, 8),))
 
     def test_uint(self):
-        def fn():
-            x = torch.tensor(5, device="cuda", dtype=torch.uint8)
+        def fn(z):
+            x = torch.tensor(5, device=z.device, dtype=torch.uint8)
             y = torch.neg(x)
             return x < y
 
-        self.common(fn, ())
+        self.common(fn, (torch.randn(26),))
 
 
 @dataclasses.dataclass

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6141,7 +6141,6 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8, 8),))
 
-    @requires_cuda()
     def test_uint(self):
         def fn(z):
             x = torch.tensor(5, device=z.device, dtype=torch.uint8)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6141,6 +6141,7 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8, 8),))
 
+    @requires_cuda()
     def test_uint(self):
         def fn(z):
             x = torch.tensor(5, device=z.device, dtype=torch.uint8)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6141,6 +6141,14 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8, 8),))
 
+    def test_uint(self):
+        def fn():
+            x = torch.tensor(5, device="cuda", dtype=torch.uint8)
+            y = torch.neg(x)
+            return x < y
+
+        self.common(fn, ())
+
 
 @dataclasses.dataclass
 class TestFailure:

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -136,6 +136,7 @@ test_failures = {
     "test_views3_dynamic_shapes": TestFailure(("cpu",)),
     "test_views4_dynamic_shapes": TestFailure(("cpu",)),
     "test_zeros_dynamic_shapes": TestFailure(("cpu",)),
+    "test_uint_dynamic_shapes": TestFailure(("cpu",)),
     #
     # Failed to find for loop/triton kernel:
     #

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -616,8 +616,6 @@ class CSE:
         expr: typing.Union[str, CSEVariable],
         write=True,
         assignment=True,
-        origin_args=None,
-        name=None,
     ) -> CSEVariable:
         assert isinstance(expr, (str, CSEVariable)), type(expr)
         assert write or assignment
@@ -735,10 +733,7 @@ class Kernel(CodeGen):
             def __getattr__(name):
                 def inner(*args, **kwargs):
                     csevar = self.cse.generate(
-                        self.compute,
-                        getattr(parent_handler, name)(*args, **kwargs),
-                        origin_args=args,
-                        name=name,
+                        self.compute, getattr(parent_handler, name)(*args, **kwargs)
                     )
                     csevar.update_on_args(name, args, kwargs)
                     return csevar

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -536,12 +536,17 @@ class KernelArgs:
             live_outs.add(outer)
         return live_outs
 
+
 # PyTorch only supports uint8. Use this list for future updates.
-_uint_types = [torch.uint8, ]
+_uint_types = [
+    torch.uint8,
+]
+
 
 def _torch_uint_type_to_tl_type(dtype):
     if dtype == torch.uint8:
         return "tl.uint8"
+
 
 class CSEVariable:
     """A CSEVariable is just a name for an expression but it is useful to be able to annotate them on a backend dependent basis.
@@ -643,9 +648,11 @@ class CSE:
                 else:
                     line = f"{expr}{self.suffix}"
                 buffer.writeline(line)
-                if assignment and name == 'constant' and origin_args[1] in _uint_types:
+                if assignment and name == "constant" and origin_args[1] in _uint_types:
                     target_tl_type = _torch_uint_type_to_tl_type(origin_args[1])
-                    line = f"{self.prefix}{var} = {self.prefix}{var}.to({target_tl_type})"
+                    line = (
+                        f"{self.prefix}{var} = {self.prefix}{var}.to({target_tl_type})"
+                    )
                     buffer.writeline(line)
 
         return self.cache[cache_key]
@@ -745,7 +752,10 @@ class Kernel(CodeGen):
             def __getattr__(name):
                 def inner(*args, **kwargs):
                     csevar = self.cse.generate(
-                        self.compute, getattr(parent_handler, name)(*args, **kwargs), origin_args=args, name=name
+                        self.compute,
+                        getattr(parent_handler, name)(*args, **kwargs),
+                        origin_args=args,
+                        name=name,
                     )
                     csevar.update_on_args(name, args, kwargs)
                     return csevar

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -537,17 +537,6 @@ class KernelArgs:
         return live_outs
 
 
-# PyTorch only supports uint8. Use this list for future updates.
-_uint_types = [
-    torch.uint8,
-]
-
-
-def _torch_uint_type_to_tl_type(dtype):
-    if dtype == torch.uint8:
-        return "tl.uint8"
-
-
 class CSEVariable:
     """A CSEVariable is just a name for an expression but it is useful to be able to annotate them on a backend dependent basis.
     The backends can inherit from this class and overload the "create_cse_var" Kernel to do that.
@@ -648,12 +637,6 @@ class CSE:
                 else:
                     line = f"{expr}{self.suffix}"
                 buffer.writeline(line)
-                if assignment and name == "constant" and origin_args[1] in _uint_types:
-                    target_tl_type = _torch_uint_type_to_tl_type(origin_args[1])
-                    line = (
-                        f"{self.prefix}{var} = {self.prefix}{var}.to({target_tl_type})"
-                    )
-                    buffer.writeline(line)
 
         return self.cache[cache_key]
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -536,7 +536,7 @@ class KernelArgs:
             live_outs.add(outer)
         return live_outs
 
-# @Yueming Hao TODO: check if uint16+ exisits in torch
+# PyTorch only supports uint8. Use this list for future updates.
 _uint_types = [torch.uint8, ]
 
 def _torch_uint_type_to_tl_type(dtype):
@@ -622,7 +622,7 @@ class CSE:
         expr: typing.Union[str, CSEVariable],
         write=True,
         assignment=True,
-        args=None,
+        origin_args=None,
         name=None,
     ) -> CSEVariable:
         assert isinstance(expr, (str, CSEVariable)), type(expr)
@@ -640,12 +640,11 @@ class CSE:
                     )
                 if assignment:
                     line = f"{self.prefix}{var} = {expr}{self.suffix}"
-                        
                 else:
                     line = f"{expr}{self.suffix}"
                 buffer.writeline(line)
-                if assignment and name == 'constant' and args[1] in _uint_types:
-                    target_tl_type = _torch_uint_type_to_tl_type(args[1])
+                if assignment and name == 'constant' and origin_args[1] in _uint_types:
+                    target_tl_type = _torch_uint_type_to_tl_type(origin_args[1])
                     line = f"{self.prefix}{var} = {self.prefix}{var}.to({target_tl_type})"
                     buffer.writeline(line)
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -745,7 +745,7 @@ class Kernel(CodeGen):
             def __getattr__(name):
                 def inner(*args, **kwargs):
                     csevar = self.cse.generate(
-                        self.compute, getattr(parent_handler, name)(*args, **kwargs), args=args, name=name
+                        self.compute, getattr(parent_handler, name)(*args, **kwargs), origin_args=args, name=name
                     )
                     csevar.update_on_args(name, args, kwargs)
                     return csevar

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -170,8 +170,12 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def constant(value, dtype):
-        tmp = ops.constant_val(value)
-        return ops.to_dtype(tmp, dtype)
+        if dtype == torch.uint8:
+            tmp = ops.constant_val(value)
+            return ops.to_dtype(tmp, dtype)
+        else:
+            type_ = torch._prims_common.dtype_to_type(dtype)
+            return triton_constant(type_(value))
 
     @staticmethod
     def abs(x):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -165,9 +165,13 @@ class TritonOverrides(OpOverrides):
         return f"{x}.to({triton_compute_type(dtype)})"
 
     @staticmethod
+    def constant_val(val):
+        return triton_constant(val)
+
+    @staticmethod
     def constant(value, dtype):
-        type_ = torch._prims_common.dtype_to_type(dtype)
-        return triton_constant(type_(value))
+        tmp = ops.constant_val(value)
+        return ops.to_dtype(tmp, dtype)
 
     @staticmethod
     def abs(x):


### PR DESCRIPTION
Fixes #96604

## Issue description

When we use a constant tensor with a uint8 type, the kernel generated by torchinductor output wrong results. For example, the negative value  of `5` in uint8 will be `255`, and it is `True` that `255` is larger than `5`. However, the output result is `False` when we compare `torch.neg(5)` with `5`. It is because torchinductor bypass the data type for constant tensors and the `5` here is taken as a int32. Then, the comparison is between `-5` with `5`. 

## Solution
This PR generates an extra conversion for uint8 constant value when we use it. it does not occur on the first assignment but the access for this constant value.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire