### PR TITLE
Handle multi-user case in split-cat simplification

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -401,6 +401,35 @@ class TestSplitCatFxPasses(TestCase):
 
             return cat1, stack1, relu1
 
+        def input_shuffling_multiple_output_same_ranges(x):
+            split_output = list(torch.split(x, 4, dim=1))
+            cat1 = torch.cat(
+                [torch.ones(2, 4, 32, 16)]
+                + [split_output[1], split_output[2], split_output[3]]
+                + [torch.ones(2, 4, 32, 16)],
+                dim=2,
+            )
+
+            cat2 = torch.cat(
+                [torch.ones(2, 4, 32, 16)]
+                + [split_output[1], split_output[2], split_output[3]]
+                + [torch.ones(2, 4, 32, 16)],
+                dim=2,
+            )
+            stack1 = torch.stack(
+                [
+                    torch.ones(2, 4, 32, 16),
+                    split_output[4],
+                    split_output[5],
+                    torch.ones(2, 4, 32, 16),
+                ],
+                dim=1,
+            )
+
+            relu1 = torch.relu(split_output[6])
+
+            return cat1, cat2, stack1, relu1
+
         def unequal_split_multiple_output(x):
             split_output = list(torch.split(x, [2, 4, 4, 4, 4, 4, 8, 2], dim=1))
             cat1 = torch.cat(
@@ -457,6 +486,7 @@ class TestSplitCatFxPasses(TestCase):
             (input_shuffling_dim_mismatch, 1, 1, 1, 1, 4),
             (input_shuffling_dim_mismatch_stack, 1, 1, 1, 1, 4),
             (input_shuffling_multiple_output, 1, 1, 2, 2, 3),
+            (input_shuffling_multiple_output_same_ranges, 1, 1, 3, 3, 3),
             (unequal_split_multiple_output, 1, 1, 2, 2, 3),
         ]:
             expected = fn(*args)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -578,6 +578,7 @@ getitem_split = ListOf(
             KeywordArg("split_sections"),
         ),
         Ignored(),
+        _users=MULTIPLE,
     ),
     partial=True,
 )

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -147,7 +147,7 @@ class MatchContext:
         return {
             pattern: node
             for pattern, node in self.pattern_to_node.items()
-            if pattern.has_multiple_users()
+            if pattern.has_multiple_users() and node is not None
         }
 
 


### PR DESCRIPTION
Summary: Post refactoring, previous diff had a drop in QPS gained on prod model - because of multi-user getitems. Multi user getitems can be handled by the replacer.

Differential Revision: D45893988



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire