### PR TITLE
fix a typo in common_device_type.py

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -585,7 +585,7 @@ class PrivateUse1TestBase(DeviceTypeTestBase):
     @classmethod
     def setUpClass(cls):
         cls.device_type = torch._C._get_privateuse1_backend_name()
-        cls.divice_mod = getattr(torch, device_type, None)
+        cls.device_mod = getattr(torch, cls.device_type, None)
         assert cls.device_mod is not None, f'''torch has no module of `{cls.device_type}`, you should register
                                             a module by `torch._register_device_module`.'''
         cls.primary_device = '{device_type}:{id}'.format(device_type=cls.device_type, id=cls.device_mod.current_device())


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
In common_device_type.py the PrivateUse1TestBase class has a typo. Reference [https://github.com/pytorch/pytorch/pull/99960](url)
