### PR TITLE
BE changes for tryrebase.py

### DIFF
--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -44,7 +44,7 @@ class TestRebase(TestCase):
         mocked_run_git.assert_has_calls(calls)
         self.assertIn(
             f"Successfully rebased `master` onto `{MAIN_BRANCH}`",
-            mocked_post_comment.call_args[0][3]
+            mocked_post_comment.call_args[0][3],
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
@@ -75,7 +75,7 @@ class TestRebase(TestCase):
         mocked_run_git.assert_has_calls(calls)
         self.assertIn(
             f"Successfully rebased `master` onto `{VIABLE_STRICT_BRANCH}`",
-            mocked_post_comment.call_args[0][3]
+            mocked_post_comment.call_args[0][3],
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
@@ -106,7 +106,7 @@ class TestRebase(TestCase):
         mocked_run_git.assert_has_calls(calls)
         self.assertIn(
             "Tried to rebase and push PR #31093, but it was already up to date",
-            mocked_post_comment.call_args[0][3]
+            mocked_post_comment.call_args[0][3],
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -11,6 +11,10 @@ def mocked_rev_parse(branch: str) -> str:
     return branch
 
 
+MAIN_BRANCH = "refs/remotes/origin/main"
+VIABLE_STRICT_BRANCH = "refs/remotes/origin/viable/strict"
+
+
 class TestRebase(TestCase):
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
     @mock.patch("gitutils.GitRepo._run_git")
@@ -26,10 +30,10 @@ class TestRebase(TestCase):
         "Tests rebase successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, "main")
+        rebase_onto(pr, repo, MAIN_BRANCH)
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", "refs/remotes/origin/main", "pull/31093/head"),
+            mock.call("rebase", MAIN_BRANCH, "pull/31093/head"),
             mock.call(
                 "push",
                 "-f",
@@ -38,9 +42,9 @@ class TestRebase(TestCase):
             ),
         ]
         mocked_run_git.assert_has_calls(calls)
-        self.assertTrue(
-            "Successfully rebased `master` onto `refs/remotes/origin/main`"
-            in mocked_post_comment.call_args[0][3]
+        self.assertIn(
+            f"Successfully rebased `master` onto `{MAIN_BRANCH}`",
+            mocked_post_comment.call_args[0][3]
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
@@ -57,10 +61,10 @@ class TestRebase(TestCase):
         "Tests rebase to viable/strict successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, "viable/strict", False)
+        rebase_onto(pr, repo, VIABLE_STRICT_BRANCH, False)
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", "refs/remotes/origin/viable/strict", "pull/31093/head"),
+            mock.call("rebase", VIABLE_STRICT_BRANCH, "pull/31093/head"),
             mock.call(
                 "push",
                 "-f",
@@ -69,9 +73,9 @@ class TestRebase(TestCase):
             ),
         ]
         mocked_run_git.assert_has_calls(calls)
-        self.assertTrue(
-            "Successfully rebased `master` onto `refs/remotes/origin/viable/strict`"
-            in mocked_post_comment.call_args[0][3]
+        self.assertIn(
+            f"Successfully rebased `master` onto `{VIABLE_STRICT_BRANCH}`",
+            mocked_post_comment.call_args[0][3]
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
@@ -88,10 +92,10 @@ class TestRebase(TestCase):
         "Tests branch already up to date"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, "main")
+        rebase_onto(pr, repo, MAIN_BRANCH)
         calls = [
             mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
-            mock.call("rebase", "refs/remotes/origin/main", "pull/31093/head"),
+            mock.call("rebase", MAIN_BRANCH, "pull/31093/head"),
             mock.call(
                 "push",
                 "-f",
@@ -100,9 +104,9 @@ class TestRebase(TestCase):
             ),
         ]
         mocked_run_git.assert_has_calls(calls)
-        self.assertTrue(
-            "Tried to rebase and push PR #31093, but it was already up to date"
-            in mocked_post_comment.call_args[0][3]
+        self.assertIn(
+            "Tried to rebase and push PR #31093, but it was already up to date",
+            mocked_post_comment.call_args[0][3]
         )
 
     @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
@@ -120,9 +124,9 @@ class TestRebase(TestCase):
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
         with self.assertRaisesRegex(Exception, "same sha as the target branch"):
-            rebase_onto(pr, repo, "main")
+            rebase_onto(pr, repo, MAIN_BRANCH)
         with self.assertRaisesRegex(Exception, "same sha as the target branch"):
-            rebase_ghstack_onto(pr, repo, "main")
+            rebase_ghstack_onto(pr, repo, MAIN_BRANCH)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
+import contextlib
 import os
 import re
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Generator
 
 from github_utils import gh_post_pr_comment as gh_post_comment
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
@@ -30,7 +31,6 @@ def rebase_onto(
     pr: GitHubPR, repo: GitRepo, onto_branch: str, dry_run: bool = False
 ) -> None:
     branch = f"pull/{pr.pr_num}/head"
-    onto_branch = f"refs/remotes/origin/{onto_branch}"
     remote_url = f"https://github.com/{pr.info['headRepository']['nameWithOwner']}.git"
     refspec = f"{branch}:{pr.head_ref()}"
 
@@ -75,7 +75,6 @@ def rebase_ghstack_onto(
     ):
         subprocess.run([sys.executable, "-m", "pip", "install", "ghstack"])
     orig_ref = f"{re.sub(r'/head$', '/orig', pr.head_ref())}"
-    onto_branch = f"refs/remotes/origin/{onto_branch}"
 
     repo.fetch(orig_ref, orig_ref)
     repo._run_git("rebase", onto_branch, orig_ref)
@@ -159,6 +158,20 @@ def rebase_ghstack_onto(
             )
 
 
+@contextlib.contextmanager
+def git_config_guard(repo: GitRepo) -> Generator[None, None, None]:
+    """Restores user.name and user.email global properties after context is finished"""
+    user_email = repo._run_git("config", "user.email")
+    user_name = repo._run_git("config", "user.name")
+    try:
+        yield
+    finally:
+        if user_email:
+            repo._run_git("config", "--global", "user.email", user_email)
+        if user_name:
+            repo._run_git("config", "--global", "user.name", user_name)
+
+
 def main() -> None:
     args = parse_args()
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name(), debug=True)
@@ -166,6 +179,7 @@ def main() -> None:
 
     pr = GitHubPR(org, project, args.pr_num)
     onto_branch = args.branch if args.branch else pr.default_branch()
+    onto_branch = f"refs/remotes/{repo.remote}/{onto_branch}"
 
     msg = "@pytorchbot successfully started a rebase job."
     msg += f" Check the current status [here]({os.getenv('GH_RUN_URL')})"
@@ -182,15 +196,9 @@ def main() -> None:
         return
 
     try:
-        email = name = ""
-
         if pr.is_ghstack_pr():
-            # Check the configured name and email. If they are available, store them so that
-            # we can put them back after rebasing here
-            email = repo._run_git("config", "user.email")
-            name = repo._run_git("config", "user.name")
-
-            rebase_ghstack_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+            with git_config_guard(repo):
+                rebase_ghstack_onto(pr, repo, onto_branch, dry_run=args.dry_run)
         else:
             rebase_onto(pr, repo, onto_branch, dry_run=args.dry_run)
 
@@ -200,13 +208,6 @@ def main() -> None:
         if run_url is not None:
             msg += f"\nRaised by {run_url}"
         gh_post_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
-
-    finally:
-        if email:
-            repo._run_git("config", "--global", "user.email", email)
-
-        if name:
-            repo._run_git("config", "--global", "user.name", name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #101504
* __->__ #101503

- Use context manager rather than explicit ```try: finally:```

- Add `ref/remotes` prefix to `onto_branch` in `main` rather than in
`rebase_onto` functions

- Define `MAIN_BRANCH` and `VIABLE_STRICT_BRANCH` constants in tests.
- Replace `self.assertTrue(x in y)` with `self.assertIn(x, y)`