### PR TITLE
[MPS] aten::erfinv metal kernel ops

### DIFF
--- a/aten/src/ATen/native/mps/UnaryConstants.h
+++ b/aten/src/ATen/native/mps/UnaryConstants.h
@@ -1,11 +1,24 @@
 #pragma once
 
 struct ErfinvConstant {
-  float a[4] = { 0.886226899, -1.645349621, 0.914624893, -0.140543331 };
-  float b[4] = { -2.118377725, 1.442710462, -0.329097515, 0.012229801 };
-  float c[4] = { -1.970840454, -1.624906493, 3.429567803, 1.641345311 };
-  float d[2] = { 3.543889200, 1.637067800 };
+  float a[4];
+  float b[4];
+  float c[4];
+  float d[2];
+  constexpr ErfinvConstant(
+    float a0, float a1, float a2, float a3,
+    float b0, float b1, float b2, float b3,
+    float c0, float c1, float c2, float c3,
+    float d0, float d1)
+    :a{a0, a1, a2, a3}, b{b0, b1, b2, b3}, c{c0, c1, c2, c3}, d{d0, d1} {}
 };
+
+constexpr ErfinvConstant erfinv_constant(
+  0.886226899, -1.645349621, 0.914624893, -0.140543331,
+  -2.118377725, 1.442710462, -0.329097515, 0.012229801,
+  -1.970840454, -1.624906493, 3.429567803, 1.641345311,
+  3.543889200, 1.637067800
+);
 
 const char* UNARY_KERNEL_TEMPLATE = R"METAL(
 #include <metal_stdlib>

--- a/aten/src/ATen/native/mps/UnaryConstants.h
+++ b/aten/src/ATen/native/mps/UnaryConstants.h
@@ -1,0 +1,58 @@
+#pragma once
+
+struct ErfinvConstant {
+  float a[4] = { 0.886226899, -1.645349621, 0.914624893, -0.140543331 };
+  float b[4] = { -2.118377725, 1.442710462, -0.329097515, 0.012229801 };
+  float c[4] = { -1.970840454, -1.624906493, 3.429567803, 1.641345311 };
+  float d[2] = { 3.543889200, 1.637067800 };
+};
+
+const char* UNARY_KERNEL_TEMPLATE = R"METAL(
+#include <metal_stdlib>
+using namespace metal;
+
+struct ErfinvConstant {{
+  float a[4];
+  float b[4];
+  float c[4];
+  float d[2];
+
+}};
+
+kernel void erfinv_mps_kernel( device {0} *output [[buffer(0)]],
+                            device {1} *input [[buffer(1)]],
+                            constant ErfinvConstant& uniforms [[buffer(2)]],
+                            uint index [[thread_position_in_grid]]) {{
+
+  constant const float *a = uniforms.a;
+  constant const float *b = uniforms.b;
+  constant const float *c = uniforms.c;
+  constant const float *d = uniforms.d;
+  float y = input[index];
+  float x, z, num, dem; /*working variables */
+  /* coefficients in rational expansion */
+
+  float y_abs = abs(y);
+  if(y_abs > 1.0f){{
+    output[index] = NAN;
+    return;
+  }}
+  if(y_abs == 1.0f){{
+    output[index] = copysign(INFINITY, y);
+    return;
+  }}
+  if(y_abs <= 0.7f) {{
+    z = y * y;
+    num = (((a[3]*z + a[2])*z + a[1])*z + a[0]);
+    dem = ((((b[3]*z + b[2])*z + b[1])*z +b[0]) * z + 1.0f);
+    x = y * num / dem;
+  }}
+  else{{
+    z = sqrt(-1.0f*log((1.0-y_abs)/2.0));
+    num = ((c[3]*z + c[2])*z + c[1]) * z + c[0];
+    dem = (d[1]*z + d[0])*z + 1.0f;
+    x = copysign(num, y) / dem;
+  }}
+
+  output[index] = x;
+}})METAL";

--- a/aten/src/ATen/native/mps/UnaryConstants.h
+++ b/aten/src/ATen/native/mps/UnaryConstants.h
@@ -1,25 +1,5 @@
 #pragma once
 
-struct ErfinvConstant {
-  float a[4];
-  float b[4];
-  float c[4];
-  float d[2];
-  constexpr ErfinvConstant(
-    float a0, float a1, float a2, float a3,
-    float b0, float b1, float b2, float b3,
-    float c0, float c1, float c2, float c3,
-    float d0, float d1)
-    :a{a0, a1, a2, a3}, b{b0, b1, b2, b3}, c{c0, c1, c2, c3}, d{d0, d1} {}
-};
-
-constexpr ErfinvConstant erfinv_constant(
-  0.886226899, -1.645349621, 0.914624893, -0.140543331,
-  -2.118377725, 1.442710462, -0.329097515, 0.012229801,
-  -1.970840454, -1.624906493, 3.429567803, 1.641345311,
-  3.543889200, 1.637067800
-);
-
 const char* UNARY_KERNEL_TEMPLATE = R"METAL(
 #include <metal_stdlib>
 using namespace metal;
@@ -29,18 +9,24 @@ struct ErfinvConstant {{
   float b[4];
   float c[4];
   float d[2];
-
 }};
+
+constant ErfinvConstant erfinv_constant = {{
+  {{0.886226899, -1.645349621, 0.914624893, -0.140543331}},
+  {{-2.118377725, 1.442710462, -0.329097515, 0.012229801}},
+  {{-1.970840454, -1.624906493, 3.429567803, 1.641345311}},
+  {{3.543889200, 1.637067800}}
+}};
+
 
 kernel void erfinv_mps_kernel( device {0} *output [[buffer(0)]],
                             device {1} *input [[buffer(1)]],
-                            constant ErfinvConstant& uniforms [[buffer(2)]],
                             uint index [[thread_position_in_grid]]) {{
 
-  constant const float *a = uniforms.a;
-  constant const float *b = uniforms.b;
-  constant const float *c = uniforms.c;
-  constant const float *d = uniforms.d;
+  constant const float *a = erfinv_constant.a;
+  constant const float *b = erfinv_constant.b;
+  constant const float *c = erfinv_constant.c;
+  constant const float *d = erfinv_constant.d;
   float y = input[index];
   float x, z, num, dem; /*working variables */
   /* coefficients in rational expansion */

--- a/aten/src/ATen/native/mps/UnaryConstants.h
+++ b/aten/src/ATen/native/mps/UnaryConstants.h
@@ -4,29 +4,15 @@ const char* UNARY_KERNEL_TEMPLATE = R"METAL(
 #include <metal_stdlib>
 using namespace metal;
 
-struct ErfinvConstant {{
-  float a[4];
-  float b[4];
-  float c[4];
-  float d[2];
-}};
-
-constant ErfinvConstant erfinv_constant = {{
-  {{0.886226899, -1.645349621, 0.914624893, -0.140543331}},
-  {{-2.118377725, 1.442710462, -0.329097515, 0.012229801}},
-  {{-1.970840454, -1.624906493, 3.429567803, 1.641345311}},
-  {{3.543889200, 1.637067800}}
-}};
-
+constant float a[4] = {{0.886226899, -1.645349621, 0.914624893, -0.140543331}};
+constant float b[4] = {{-2.118377725, 1.442710462, -0.329097515, 0.012229801}};
+constant float c[4] = {{-1.970840454, -1.624906493, 3.429567803, 1.641345311}};
+constant float d[2] = {{3.543889200, 1.637067800}};
 
 kernel void erfinv_mps_kernel( device {0} *output [[buffer(0)]],
                             device {1} *input [[buffer(1)]],
                             uint index [[thread_position_in_grid]]) {{
 
-  constant const float *a = erfinv_constant.a;
-  constant const float *b = erfinv_constant.b;
-  constant const float *c = erfinv_constant.c;
-  constant const float *d = erfinv_constant.d;
   float y = input[index];
   float x, z, num, dem; /*working variables */
   /* coefficients in rational expansion */

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -1,0 +1,146 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/UnaryOps.h>
+#include <ATen/native/mps/UnaryConstants.h>
+#include <torch/mps.h>
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/erfinv_native.h>
+#endif
+
+#include <fmt/format.h>
+
+namespace at::native {
+const std::string& getMetalType(const c10::ScalarType& t) {
+  // Mapping from c10::ScalarType to integral type that can be used for unary ops
+  static std::unordered_map<c10::ScalarType, std::string> scalar_to_metal_type = {
+      {c10::ScalarType::Half, "half"},
+      {c10::ScalarType::Float, "float"},
+      {c10::ScalarType::Long, "long"},
+      {c10::ScalarType::Int, "int"},
+      {c10::ScalarType::Short, "short"},
+      {c10::ScalarType::Bool, "bool"},
+      {c10::ScalarType::Char, "int8_t"},
+  };
+
+  auto it = scalar_to_metal_type.find(t);
+  TORCH_CHECK(it != scalar_to_metal_type.end(), "Unsupported type ", t);
+  return it->second;
+}
+
+const std::string& getMetalType(const Tensor& t) {
+  return getMetalType(t.scalar_type());
+}
+
+const std::string& getMetalType(const c10::Scalar& s) {
+  return getMetalType(s.type());
+}
+static inline id<MTLBuffer> getMTLBufferStorage(const Tensor& tensor) {
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
+static id<MTLLibrary> compileUnaryOpsLibrary(id<MTLDevice> device, const std::string& t1, const std::string& t2) {
+  auto key = t1 + t2;
+  static std::unordered_map<std::string, id<MTLLibrary>> libMap;
+  auto it = libMap.find(key);
+  if (it != libMap.end()) {
+    return it->second;
+  }
+  NSError* error = nil;
+  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
+  [options setLanguageVersion:MTLLanguageVersion2_3];
+  auto rc =
+      [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(UNARY_KERNEL_TEMPLATE, t1, t2).c_str()]
+                           options:options
+                             error:&error];
+  TORCH_CHECK(rc != nil && error == nil, "Failed to compile library: ", [[error localizedDescription] UTF8String]);
+  libMap[key] = rc;
+  return rc;
+}
+
+static id<MTLComputePipelineState> getCPLState(id<MTLDevice> device,
+                                               const std::string& t1,
+                                               const std::string& t2,
+                                               const std::string& fname) {
+  auto key = t1 + t2 + fname;
+  static std::unordered_map<std::string, id<MTLComputePipelineState>> cplMap;
+  auto it = cplMap.find(key);
+  if (it != cplMap.end()) {
+    return it->second;
+  }
+  NSError* error = nil;
+  auto library = compileUnaryOpsLibrary(device, t1, t2);
+  id<MTLFunction> func = [library newFunctionWithName:[NSString stringWithUTF8String:fname.c_str()]];
+  TORCH_CHECK(func != nil, "Can't get function ", fname);
+  auto rc = [device newComputePipelineStateWithFunction:func error:&error];
+  TORCH_CHECK(
+      rc != nil && error == nil, "Failed to construct pipeline state: ", [[error localizedDescription] UTF8String]);
+  cplMap[key] = rc;
+  return rc;
+}
+
+TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
+  // handle erfinv ops using metal kernel
+  // erfinv algorithm ported from aten/src/ATen/native/Math.h
+  // https://github.com/pytorch/pytorch/blob/4154c8ea159fdaecc71ee9af820ac956193c875b/aten/src/ATen/native/Math.h#L152
+
+  TORCH_CHECK(self.scalar_type() != ScalarType::Double, "MPS does not support erfinv op with scalar type: Double");
+
+  Tensor outputTensor = output_;
+  bool needs_output_copy = false;
+  uint32_t length = output_.numel();
+  if (length == 0) {
+    return;
+  }
+  using namespace torch::mps;
+  @autoreleasepool {
+    Tensor inputTensor = self;
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    id<MTLComputePipelineState> cplState =
+        getCPLState(device, getMetalType(outputTensor), getMetalType(self), "erfinv_mps_kernel");
+
+    if (!self.is_contiguous()) {
+      inputTensor = inputTensor.contiguous();
+      outputTensor = outputTensor.contiguous();
+      needs_output_copy = true;
+      // calling continguous triggers a command encoder so need to commit it
+      torch::mps::commit();
+    }
+
+    // Get a reference of the MPSStream MTLCommandBuffer.
+    id<MTLCommandBuffer> commandBuffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(commandBuffer, "Failed to retrieve command buffer reference");
+    dispatch_queue_t serialQueue = torch::mps::get_dispatch_queue();
+    dispatch_sync(serialQueue, ^() {
+      id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+      id<MTLBuffer> outBuf = getMTLBufferStorage(outputTensor);
+      id<MTLBuffer> inputBuf = getMTLBufferStorage(inputTensor);
+
+      [computeEncoder setComputePipelineState:cplState];
+      [computeEncoder setBuffer:outBuf offset:0 atIndex:0];
+      [computeEncoder setBuffer:inputBuf offset:0 atIndex:1];
+      // Set uniform buffer for the erfinv kernel polynomial constants
+      struct ErfinvConstant uniforms;
+      id<MTLBuffer> constantBuffer = [device newBufferWithLength:sizeof(ErfinvConstant)
+                                                         options:MTLResourceStorageModePrivate];
+      memcpy([constantBuffer contents], &uniforms, sizeof(ErfinvConstant));
+      [computeEncoder setBuffer:constantBuffer offset:0 atIndex:2];
+
+      MTLSize gridSize = MTLSizeMake(length, 1, 1);
+      uint32_t maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
+
+      NSUInteger threadsPerGroupSize = std::min(maxThreadsPerGroup, length);
+      MTLSize threadGroupSize = MTLSizeMake(threadsPerGroupSize, 1, 1);
+      [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
+      [computeEncoder endEncoding];
+      torch::mps::commit();
+    });
+  }
+  torch::mps::synchronize();
+  if (needs_output_copy) {
+    output_.copy_(outputTensor);
+  }
+}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -1,10 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/DispatchStub.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/UnaryConstants.h>
-#include <torch/mps.h>
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -128,7 +126,6 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
       getMPSProfiler().endProfileKernel(cplState);
     });
   }
-  torch::mps::synchronize();
   if (needs_output_copy) {
     output_.copy_(outputTensor);
   }

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -23,6 +23,7 @@ const std::string& getMetalType(const c10::ScalarType& t) {
       {c10::ScalarType::Short, "short"},
       {c10::ScalarType::Bool, "bool"},
       {c10::ScalarType::Char, "int8_t"},
+      {c10::ScalarType::Byte, "uint8_t"},
   };
 
   auto it = scalar_to_metal_type.find(t);

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -122,7 +122,7 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
       [computeEncoder setBuffer:inputBuf offset:0 atIndex:1];
 
       id<MTLBuffer> erfinvConstants = [device newBufferWithLength:sizeof(ErfinvConstant)
-                                                         options:MTLResourceStorageModePrivate];
+                                                          options:MTLResourceStorageModePrivate];
       memcpy([erfinvConstants contents], &erfinv_constant, sizeof(ErfinvConstant));
       [computeEncoder setBuffer:erfinvConstants offset:0 atIndex:2];
 

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -121,10 +121,10 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
       [computeEncoder setBuffer:outBuf offset:0 atIndex:0];
       [computeEncoder setBuffer:inputBuf offset:0 atIndex:1];
 
-      id<MTLBuffer> erfinvConstants = [device newBufferWithLength:sizeof(ErfinvConstant)
-                                                          options:MTLResourceStorageModePrivate];
-      memcpy([erfinvConstants contents], &erfinv_constant, sizeof(ErfinvConstant));
-      [computeEncoder setBuffer:erfinvConstants offset:0 atIndex:2];
+      id<MTLBuffer> erfinvConstant = [device newBufferWithLength:sizeof(ErfinvConstant)
+                                                         options:MTLResourceStorageModePrivate];
+      memcpy([erfinvConstant contents], &erfinv_constant, sizeof(ErfinvConstant));
+      [computeEncoder setBuffer:erfinvConstant offset:0 atIndex:2];
 
       MTLSize gridSize = MTLSizeMake(length, 1, 1);
       uint32_t maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -121,11 +121,6 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
       [computeEncoder setBuffer:outBuf offset:0 atIndex:0];
       [computeEncoder setBuffer:inputBuf offset:0 atIndex:1];
 
-      id<MTLBuffer> erfinvConstant = [device newBufferWithLength:sizeof(ErfinvConstant)
-                                                         options:MTLResourceStorageModePrivate];
-      memcpy([erfinvConstant contents], &erfinv_constant, sizeof(ErfinvConstant));
-      [computeEncoder setBuffer:erfinvConstant offset:0 atIndex:2];
-
       MTLSize gridSize = MTLSizeMake(length, 1, 1);
       uint32_t maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9124,6 +9124,7 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: erfinv_out
+    MPS: erfinv_out_mps
     SparseCPU, SparseCUDA: erfinv_sparse_out
     SparseCsrCPU, SparseCsrCUDA: erfinv_sparse_csr_out
   tags: pointwise

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -245,6 +245,7 @@ def mps_ops_modifier(ops):
         'eq': [torch.uint8],
         'equal': [torch.uint8],
         'erf': [torch.uint8],
+        'erfinv': [torch.uint8],
         'exp2': [torch.uint8],
         'exp': [torch.uint8],
         'expm1': [torch.uint8],
@@ -408,7 +409,6 @@ def mps_ops_modifier(ops):
         'cumprod': None,
         'digamma': None,
         'erfc': None,
-        'erfinv': None,
         'frexp': None,
         'gcd': None,
         'geqrf': None,
@@ -7549,6 +7549,8 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 8, 3, 5), torch.expm1)
         helper((2, 8, 3, 5), torch.log)
         helper((2, 8, 3, 5), torch.cos)
+        helper((2, 8, 3, 5), torch.erfinv)
+
 
     def test_non_dense_in_storage_unary_ops(self):
         def helper(op):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -245,7 +245,6 @@ def mps_ops_modifier(ops):
         'eq': [torch.uint8],
         'equal': [torch.uint8],
         'erf': [torch.uint8],
-        'erfinv': [torch.uint8],
         'exp2': [torch.uint8],
         'exp': [torch.uint8],
         'expm1': [torch.uint8],


### PR DESCRIPTION
I've added the implementation of erfinv using the algorithm from https://github.com/pytorch/pytorch/blob/4154c8ea159fdaecc71ee9af820ac956193c875b/aten/src/ATen/native/Math.h#L152 in order for the MPS based algorithm to match the CPU automatic test. This PR is using the new metal api calls from https://github.com/pytorch/pytorch/pull/100661


Testing shows MPS has a decent speed up (270x) compared to CPU on tensor size of 100 mil elements.
```
import torch
x = torch.arange(-1, 1, 1e-8) # default cpu tensor
#measure CPU compute time by calling torch.erfinv
time = %timeit -o -q -r 5 torch.erfinv(x)
cpu_time = time.average
print("CPU torch.erfinv time: ", cpu_time)
x = x.to("mps")
# measure MPS compute time
time = %timeit -o -q -r 5 torch.erfinv(x)
mps_time = time.average
print("MPS torch.erfinv time: ", mps_time)
print(f"MPS torch.erfinv is {cpu_time/mps_time*100} percent faster than CPU torch.erfinv")

# compute MSE between MPS and CPU torch.erfinv
x = x.to("cpu")
y_cpu = torch.erfinv(x)
x = x.to("mps")
y_mps = torch.erfinv(x)
y_mps = y_mps.to("cpu")
mask = torch.isfinite(y_cpu) & torch.isfinite(y_mps.to("cpu"))
y_mps = y_mps[mask]
y_cpu = y_cpu[mask]
x = x[mask]
print(f"length of y_mps: {len(y_mps)}, length of y_cpu: {len(y_cpu)}, length of x: {len(x)}")
mse = torch.square(y_cpu - y_mps).mean()
print("MSE between MPS and CPU torch.erfinv: ", mse)
diff = torch.abs(y_cpu - y_mps)
print("Largest difference")
print(f"x:  {x[torch.argmax(diff)]}, y_cpu: {y_cpu[torch.argmax(diff)]}, y_mps: {y_mps[torch.argmax(diff)]} , diff = {y_cpu[torch.argmax(diff)] - y_mps[torch.argmax(diff)]}")
```
CPU torch.erfinv time:  2.654937833400254
MPS torch.erfinv time:  0.009831255332002912
MPS torch.erfinv is 27005.07456822776 percent faster than CPU torch.erfinv
length of y_mps: 199999992, length of y_cpu: 199999992, length of x: 199999992
MSE between MPS and CPU torch.erfinv:  tensor(4.2339e-14)
Largest difference
x:  -0.9999980330467224, y_cpu: -3.363569736480713, y_mps: -3.3635685443878174 , diff = -1.1920928955078125e-06


Fixes #https://github.com/pytorch/pytorch/issues/86808
