### PR TITLE
[caffe2] Fix build

### DIFF
--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -81,7 +81,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":ScalarType",
-            ":impl/cow/context",
+            ":impl_cow_context",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",
@@ -93,7 +93,7 @@ def define_targets(rules):
     )
 
     rules.cc_library(
-        name = "impl/cow/context",
+        name = "impl_cow_context",
         srcs = [
             "impl/cow/context.cpp",
             "impl/cow/deleter.cpp",

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -10,10 +10,10 @@ def define_targets(rules):
     )
 
     rules.cc_test(
-        name = "core/impl/cow/context_test",
+        name = "core_impl_cow_context_test",
         srcs = ["core/impl/cow/context_test.cpp"],
         deps = [
-            "//c10/core:impl/cow/context",
+            "//c10/core:impl_cow_context",
             "@com_google_googletest//:gtest_main",
         ],
     )


### PR DESCRIPTION
Summary: Build rules with `/` in their name are ambiguous and can refer to either subdirectories, or just a file with / in the name

Reviewed By: malfet

Differential Revision: D45900387

