### PR TITLE
buck1 can't properly handle '/' on rule names, so fixing 'impl/cow/context' and 'core/impl/cow/context_test' build rules

### DIFF
--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -81,7 +81,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":ScalarType",
-            ":impl/cow/context",
+            ":impl_cow_context",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",
@@ -93,7 +93,7 @@ def define_targets(rules):
     )
 
     rules.cc_library(
-        name = "impl/cow/context",
+        name = "impl_cow_context",
         srcs = [
             "impl/cow/context.cpp",
             "impl/cow/deleter.cpp",

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -10,10 +10,10 @@ def define_targets(rules):
     )
 
     rules.cc_test(
-        name = "core/impl/cow/context_test",
+        name = "core_impl_cow_context_test",
         srcs = ["core/impl/cow/context_test.cpp"],
         deps = [
-            "//c10/core:impl/cow/context",
+            "//c10/core:impl_cow_context",
             "@com_google_googletest//:gtest_main",
         ],
     )


### PR DESCRIPTION
This is because PR #101510 can't be landed due to the author not have linked a github account to his internal meta account.
