### PR TITLE
Fixed benchmark_utils.Fuzzer

### DIFF
--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -369,7 +369,7 @@ class Fuzzer:
                 ops will create reproducible Tensors.
         """
         if seed is None:
-            seed = np.random.RandomState().randint(0, 2**63)
+            seed = np.random.RandomState().randint(0, 2 ** 32 - 1, dtype=np.int64)
         self._seed = seed
         self._parameters = Fuzzer._unpack(parameters, FuzzedParameter)
         self._tensors = Fuzzer._unpack(tensors, FuzzedTensor)
@@ -392,7 +392,7 @@ class Fuzzer:
 
     def take(self, n):
         state = np.random.RandomState(self._seed)
-        torch.manual_seed(state.randint(low=0, high=2 ** 63))
+        torch.manual_seed(state.randint(low=0, high=2 ** 63, dtype=np.int64))
         for _ in range(n):
             params = self._generate(state)
             tensors = {}


### PR DESCRIPTION
Use np.randint with int64 since int32 is default on Windows.
change default seed to be between [0, 2**32-1] because that is np.random.RandomState required input

Fixes #51205


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite