### PR TITLE
fix bug in trace model when out-operator has more than one output

### DIFF
--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -138,6 +138,16 @@ class TestTracer(JitTestCase):
         jit_f2 = torch.jit.trace(f2, x)
         assert f2(x) == jit_f2(x)  # fails
 
+    def test_trace_out_operator_with_two_output(self):
+        example_input = torch.rand(2, 8)
+        out_1, out_2 = torch.cummax(example_input, 1)
+
+        def run_cummax(example_input, out_1, out_2):
+            output_1, output_2 = torch.cummax(example_input, 1, out=(out_1, out_2))
+            return output_1, output_2
+
+        trace_model = torch.jit.trace(run_cummax, (example_input, out_1, out_2))
+
     def test_trace_namedtuple(self):
         Point = namedtuple('point', ['x', 'y'])
 

--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -175,8 +175,12 @@ def format_trace_inputs(f: NativeFunction) -> str:
     if f.func.is_out_fn():
         # for *_out functions, handle the result argument differently for inplace/outplace.
         # For inplace: just add the input to the end to confirm with the JIT schema
-        inplace = [ADD_TRACE_INPUT.substitute(name=f.func.arguments.out[i].name,
-            input=f.func.arguments.out[i].name) for i in range(num_out_args)]
+        inplace = [
+            ADD_TRACE_INPUT.substitute(
+                name=f.func.arguments.out[i].name, input=f.func.arguments.out[i].name
+            )
+            for i in range(num_out_args)
+        ]
 
         # for outplace: do nothing, except if the function is a factory.
         # Factories are a bit special because their out-of-place overloads

--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -222,7 +222,7 @@ def format_trace_inputs(f: NativeFunction) -> str:
                 SELECT.substitute(
                     cond="tracer_state->force_outplace",
                     true="\n".join(outplace),
-                    false=inplace,
+                    false="\n".join(inplace),
                 )
             ],
         )

--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -165,9 +165,8 @@ def format_trace_inputs(f: NativeFunction) -> str:
         # *_out functions take the result as a separate argument, but we don't want to
         # trace that argument directly. Instead, we trace its TensorOptions.
         # So first, we need to remove the out argument from the list of arguments to trace.
-        # TODO: byte-for-byte compatible with old codegen behavior - it's incorrect to assume
-        # there is only one output argument.
-        args = args[:-1]
+        num_out_args = len(f.func.arguments.out)
+        args = args[:-num_out_args]
 
     trace_inputs = itertools.chain.from_iterable(
         dispatch_trace_input(arg) for arg in args
@@ -176,8 +175,8 @@ def format_trace_inputs(f: NativeFunction) -> str:
     if f.func.is_out_fn():
         # for *_out functions, handle the result argument differently for inplace/outplace.
         # For inplace: just add the input to the end to confirm with the JIT schema
-        name = f.func.arguments.out[0].name  # TODO: old codegen behavior - should fix
-        inplace = ADD_TRACE_INPUT.substitute(name=name, input=name)
+        inplace = [ADD_TRACE_INPUT.substitute(name=f.func.arguments.out[i].name,
+            input=f.func.arguments.out[i].name) for i in range(num_out_args)]
 
         # for outplace: do nothing, except if the function is a factory.
         # Factories are a bit special because their out-of-place overloads


### PR DESCRIPTION
Fixes #https://github.com/pytorch/pytorch/issues/101960
when I trace a func to run out-operator has more than one output, I got the error. This is because the situation when the output of the out operator is greater than 1 is not handled.
```
def test_trace_out_operator_with_two_output():
    example_input = torch.rand(2, 8)
    out_1, out_2 = torch.cummax(example_input, 1)

    def run_cummax(example_input, out_1, out_2):
        output_1, output_2 = torch.cummax(example_input, 1, out=(out_1, out_2))
        return output_1, output_2

    trace_model = torch.jit.trace(run_cummax, (example_input, out_1, out_2))

and the error info:

    raise TracingCheckError(
torch.jit._trace.TracingCheckError: Tracing failed sanity checks!
encountered an exception while running the trace with test inputs
```

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel