### PR TITLE
[functorch] fix UB in interpreter stack

### DIFF
--- a/aten/src/ATen/functorch/DynamicLayer.cpp
+++ b/aten/src/ATen/functorch/DynamicLayer.cpp
@@ -468,11 +468,12 @@ restoreLocalDispatchKeySetRAII(const c10::impl::LocalDispatchKeySet& key_set) {
 // right now grad_special_case as a bool is sufficient because this is the only special case for grad. If we need to add
 // more special cases, it's more scalable to add an enum to know which op we're looking at without looking at the schema
 static void dynamicLayerBack(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool grad_special_case) {
-  auto& layer = dynamicLayerStackAccessor().back();
-  auto restore_guard = restoreLocalDispatchKeySetRAII(layer.interpreter().getSavedLocalDispatchKeySet());
+  auto restore_guard = restoreLocalDispatchKeySetRAII(
+      dynamicLayerStackAccessor().back().interpreter().getSavedLocalDispatchKeySet());
   WithoutTop guard;
 
-  layer.interpreter().sendToNextInterpreter(op, stack, grad_special_case);
+  // WithoutTop stores the popped DynamicLayer object.
+  guard.layer_.interpreter().sendToNextInterpreter(op, stack, grad_special_case);
 }
 
 // used for functions that have aliasing operations but should be treated like they're out of place (i.e. lift_fresh)

--- a/aten/src/ATen/functorch/Interpreter.cpp
+++ b/aten/src/ATen/functorch/Interpreter.cpp
@@ -106,12 +106,16 @@ void sanityCheckStack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
 #define INTERPRETER_DISPATCH(type, method) \
   switch (key()) { \
     case TransformType::Vmap: \
+      TORCH_INTERNAL_ASSERT(c10::holds_alternative<VmapInterpreterMeta>(this->meta()));\
       return VmapInterpreterPtr(this). method; \
     case TransformType::Grad: \
+      TORCH_INTERNAL_ASSERT(c10::holds_alternative<GradInterpreterMeta>(this->meta()));\
       return GradInterpreterPtr(this). method; \
     case TransformType::Jvp: \
+      TORCH_INTERNAL_ASSERT(c10::holds_alternative<JvpInterpreterMeta>(this->meta()));\
       return JvpInterpreterPtr(this). method; \
     case TransformType::Functionalize: \
+      TORCH_INTERNAL_ASSERT(c10::holds_alternative<FunctionalizeInterpreterMeta>(this->meta()));\
       return FunctionalizeInterpreterPtr(this). method; \
     default: \
       TORCH_INTERNAL_ASSERT(false, "Unrecognized transform"); \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #101568

The UB was:
- We grab a reference to the last element in the interpreter stack
(DynamicLayerStack)
- Then, we pop the last element in the interpreter stack
- Finally, we continue to use the reference to the last element.

The fix is to stop using that reference and instead use the popped
element.

Test Plan:
- It's difficult to write a test for this PR so I didn't
- Patched in https://github.com/pytorch/pytorch/pull/101409 and verified
that this PR fixes the bad_variant_access it was experiencing under
clang compilers.

cc @Chillee @samdow @kshitij12345 @janeyx99