### PR TITLE
Prioritize modified tests when running on `main`

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -126,8 +126,21 @@ def _query_changed_test_files() -> List[str]:
         .decode()
         .strip()
     )
+
+    head = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"])
+        .decode()
+        .strip()
+    )
+
+    base_commit = merge_base
+
+    if base_commit == head:
+        # We are on the default branch, so check for changes since the last commit
+        base_commit = "HEAD^"
+
     proc = subprocess.run(
-        ["git", "diff", "--name-only", merge_base, "HEAD"], capture_output=True
+        ["git", "diff", "--name-only", base_commit, "HEAD"], capture_output=True
     )
 
     if proc.returncode != 0:

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -127,14 +127,9 @@ def _query_changed_test_files() -> List[str]:
         .strip()
     )
 
-    head = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"])
-        .decode()
-        .strip()
-    )
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
 
     base_commit = merge_base
-
     if base_commit == head:
         # We are on the default branch, so check for changes since the last commit
         base_commit = "HEAD^"


### PR DESCRIPTION
If a PR modifies a test, prioritize running that test on the default branch so that we get the test signal faster

Fixes https://github.com/pytorch/pytorch/issues/101617