### PR TITLE
Use the symint version of computeStorageNbytes within get_nbytes.

### DIFF
--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -83,6 +83,7 @@ static c10::SymInt get_nbytes(const Tensor& value) {
     if (value.key_set().has(c10::DispatchKey::Python)) {
       return value.storage().sym_nbytes();
     }
+    return at::detail::computeStorageNbytes(value.sym_sizes(), value.sym_strides(), value.dtype().itemsize(), value.sym_storage_offset());
   }
   // XLA storage objects also do not properly track nbytes.
   return at::detail::computeStorageNbytes(value.sizes(), value.strides(), value.dtype().itemsize(), value.storage_offset());

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -83,6 +83,9 @@ static c10::SymInt get_nbytes(const Tensor& value) {
     if (value.key_set().has(c10::DispatchKey::Python)) {
       return value.storage().sym_nbytes();
     }
+    // TODO(vanbasten23): force fail to find out where I can add a test for my
+    // change. Should remove the TORCH_CHECK before merging the PR.
+    TORCH_CHECK(false, "fails right before calling symint version of computeStorageNbytes")
     return at::detail::computeStorageNbytes(value.sym_sizes(), value.sym_strides(), value.dtype().itemsize(), value.sym_storage_offset());
   }
   // XLA storage objects also do not properly track nbytes.

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -80,6 +80,11 @@ static c10::SymInt get_nbytes(const Tensor& value) {
     // and lazy tensor (LTC/XLA).
     // LTC hasn't implemented SymInt support yet though
     // Once it does, we should remove this check.
+
+    // TODO(vanbasten23): force fail to find out where I can add a test for my
+    // change. Should remove the TORCH_CHECK before merging the PR.
+    TORCH_CHECK(false, "fails right before calling symint version of computeStorageNbytes")
+
     if (value.key_set().has(c10::DispatchKey::Python)) {
       return value.storage().sym_nbytes();
     }

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -80,17 +80,9 @@ static c10::SymInt get_nbytes(const Tensor& value) {
     // and lazy tensor (LTC/XLA).
     // LTC hasn't implemented SymInt support yet though
     // Once it does, we should remove this check.
-
-    // TODO(vanbasten23): force fail to find out where I can add a test for my
-    // change. Should remove the TORCH_CHECK before merging the PR.
-    TORCH_CHECK(false, "fails right before calling symint version of computeStorageNbytes")
-
     if (value.key_set().has(c10::DispatchKey::Python)) {
       return value.storage().sym_nbytes();
     }
-    // TODO(vanbasten23): force fail to find out where I can add a test for my
-    // change. Should remove the TORCH_CHECK before merging the PR.
-    TORCH_CHECK(false, "fails right before calling symint version of computeStorageNbytes")
     return at::detail::computeStorageNbytes(value.sym_sizes(), value.sym_strides(), value.dtype().itemsize(), value.sym_storage_offset());
   }
   // XLA storage objects also do not properly track nbytes.


### PR DESCRIPTION
Fixes [#ISSUE_NUMBER](https://github.com/pytorch/xla/pull/4998) according to [comment](https://github.com/pytorch/xla/pull/4998#issuecomment-1550232063).

This change is needed to make sure calling tensor.sizes() will error if the tensor has dynamic dimension in pytorch/xla.