### PR TITLE
remove default lower bound in dynamic_dim suggestions

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1794,7 +1794,7 @@ def specializations(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x11, x12):
         expected_dynamic = '''
 def specify_constraints(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x11, x12):
     return [
-        2 <= dynamic_dim(x6, 1),
+        dynamic_dim(x6, 1),
         dynamic_dim(x10, 1) == dynamic_dim(x6, 1),
         dynamic_dim(x9, 1) == dynamic_dim(x6, 1),
     ]

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1722,6 +1722,9 @@ class DimConstraints:
         def unwrap_local_source(source_name):
             return re.sub(r"L\['(.+?)'\]", r'\1', source_name)
 
+        def remove_default_lower_bound(dc):
+            return re.sub(r"2 <= dynamic_dim(.+)", r"dynamic_dim\1", dc)
+
         signature = original_signature.replace(return_annotation=inspect.Signature.empty)
 
         buf = ""
@@ -1740,7 +1743,7 @@ class DimConstraints:
             buf += f"\n```\ndef specify_constraints{str(signature)}:"
             buf += f"\n{indent}return ["
             for result in sorted_dynamic_results:
-                buf += f"\n{indent*2}{unwrap_local_source(result)},"
+                buf += f"\n{indent*2}{remove_default_lower_bound(unwrap_local_source(result))},"
             buf += f"\n{indent}]\n```\n"
         return buf
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1722,6 +1722,8 @@ class DimConstraints:
         def unwrap_local_source(source_name):
             return re.sub(r"L\['(.+?)'\]", r'\1', source_name)
 
+        # Instead of 2 <= dynamic_dim(...) simply suggest dynamic_dim(...).
+        # There is no change in behavior since 2 is the default lower bound.
         def remove_default_lower_bound(dc):
             return re.sub(r"2 <= dynamic_dim(.+)", r"dynamic_dim\1", dc)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101636

So instead of `2 <= dynamic_dim(x, 0)` simply suggest `dynamic_dim(x, 0)`. This has exactly the same effect.

Differential Revision: [D45933273](https://our.internmc.facebook.com/intern/diff/D45933273/)