### PR TITLE
[torch.utils.checkpoint] Separate non-reentrant impl into pre and post fwd

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -843,7 +843,6 @@ def _checkpoint_without_reentrant_pre_forward(
         # run_function, we SHOULD actually stash the cuda state here.  Unfortunately,
         # we have no way to anticipate this will happen before we run the function.
         # If they do so, we raise an error.)
-        had_device_in_fwd = False
         if device_module._initialized:
             had_device_in_fwd = True
             fwd_devices, fwd_device_states = get_device_states(*args)
@@ -905,7 +904,7 @@ def _checkpoint_without_reentrant(
     *args,
     **kwargs,
 ):
-    """Checkpointining without re-entrant autograd
+    """Checkpointing without reentrant autograd
     Args:
         function: describes what to run in the forward pass of the model or
             part of the model. It should also know how to handle the inputs
@@ -928,7 +927,9 @@ def _checkpoint_without_reentrant(
         forward_context,
         device_module,
         had_device_in_fwd,
-    ) = _checkpoint_without_reentrant_pre_forward(preserve_rng_state, context_fn, *args)
+    ) = _checkpoint_without_reentrant_pre_forward(
+        fn, preserve_rng_state, context_fn, *args, **kwargs
+    )
 
     if not should_checkpoint:
         return fn(*args, **kwargs)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -885,7 +885,7 @@ def _checkpoint_without_reentrant_pre_forward(
 def _checkpoint_without_reentrant_post_forward(
     device_module: torch.device, preserve_rng_state: bool, had_device_in_fwd: bool
 ):
-    if device_module._initialized and preserve_rng_state and not had_device_in_fwd:
+    if device_module._initialized and preserve_rng_state and not had_device_in_fwd:  # type: ignore[attr-defined]
         # Device was not initialized before running the forward, so we didn't
         # stash the device state.
         raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101650
* #101649

We'd like to separate the implementation of non reentrant checkpoint
to pre and post forward as much as possible, so that distributed composable
checkpoint API can use the pre and post forward in the pre_forward_hook and
post_forward_hook. This will help ensure distributed doesn't have to maintain a
separate checkpoint implementation that can diverge and ensures that we can get
new features such as the early stopping / nested checkpoint.

Differential Revision: [D45933439](https://our.internmc.facebook.com/intern/diff/D45933439/)