### PR TITLE
[export] Error when constraining on static values

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -551,7 +551,7 @@ class TestExport(TestCase):
         # There should be nonzero view nodes in the graph
         self.assertTrue(view_count > 0)
 
-    def test_export_preserve_constraints_as_metadata(self):
+    def test_export_constrain_static(self):
         def f(x, y):
             b = x.item()
             constrain_as_size(b, min=2, max=5)
@@ -565,7 +565,7 @@ class TestExport(TestCase):
         example_inputs = (x, y)
         constraints = [dynamic_dim(y, 0) >= 6, dynamic_dim(y, 0) <= 10]
         with self.assertRaisesRegex(
-            torchdynamo.exc.UserError, "Cannot constrain symbol with constraints"
+            torchdynamo.exc.UserError, "It appears that you're trying to set a constraint on a value which we evaluated to have a static value of 3. "
         ):
             export(f, example_inputs, constraints)
     

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -11,6 +11,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestExperimentalExport(TestCase):
     @unittest.skip("TypeError: <lambda>() missing 1 required positional argument")
     def test_export_simple_model_with_attr(self):
@@ -29,7 +30,6 @@ class TestExperimentalExport(TestCase):
         exported_program = do_not_use_experimental_export(mod, inp)
         self.assertEqual(exported_program.fw_module(*inp)[0], mod(*inp))
 
-    @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
     def test_export_simple_model(self):
         class Foo(torch.nn.Module):
             def __init__(self, float_val):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -565,10 +565,11 @@ class TestExport(TestCase):
         example_inputs = (x, y)
         constraints = [dynamic_dim(y, 0) >= 6, dynamic_dim(y, 0) <= 10]
         with self.assertRaisesRegex(
-            torchdynamo.exc.UserError, "It appears that you're trying to set a constraint on a value which we evaluated to have a static value of 3. "
+            torchdynamo.exc.UserError, "It appears that you're trying to set a constraint " +
+            "on a value which we evaluated to have a static value of 3. "
         ):
             export(f, example_inputs, constraints)
-    
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -894,6 +894,16 @@ def export(
                 "Summary of dimension constraints:%s",
                 msg,
             )
+
+        # Error if we have any constraints on static values
+        for k in shape_env.var_to_range.keys():
+            if isinstance(k, sympy.Integer):
+                constraint_violation_error = ConstraintViolationError(
+                    f"{shape_env.var_to_stack[k]}\n"
+                    "It appears that you're trying to set a constraint on a "
+                    f"value which we evaluated to have a static value of {k}. "
+                    f"Scroll up to see where " 
+                )
     if constraint_violation_error:
         raise constraint_violation_error
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -902,7 +902,7 @@ def export(
                     f"{shape_env.var_to_stack[k]}\n"
                     "It appears that you're trying to set a constraint on a "
                     f"value which we evaluated to have a static value of {k}. "
-                    f"Scroll up to see where " 
+                    "Scroll up to see where this constraint was set."
                 )
     if constraint_violation_error:
         raise constraint_violation_error

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -899,7 +899,7 @@ def export(
         for k in shape_env.var_to_range.keys():
             if isinstance(k, sympy.Integer):
                 constraint_violation_error = ConstraintViolationError(
-                    f"{shape_env.var_to_stack[k]}\n"
+                    f"{''.join(traceback.format_list(shape_env.var_to_stack[k]))}\n"
                     "It appears that you're trying to set a constraint on a "
                     f"value which we evaluated to have a static value of {k}. "
                     "Scroll up to see where this constraint was set."

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1838,7 +1838,7 @@ class ShapeEnv:
         # practice
         self.var_to_range: Dict["sympy.Symbol", ValueRanges] = {}
         self.var_to_sources: Dict["sympy.Symbol", List[Source]] = {}
-        self.var_to_stack: Dict["sympy.Symbol", str] = {}
+        self.var_to_stack: Dict["sympy.Symbol", traceback.StackSummary] = {}
         # Maps from sympy ints to expressions representing them
         # Populated from equality guards (i.e. a.shape[0] == b.shape[0])
         self.replacements: Dict["sympy.Symbol", "sympy.Expr"] = {}  #
@@ -2001,19 +2001,19 @@ class ShapeEnv:
 
     def create_unbacked_symfloat(self):
         symbol = sympy.Symbol(f"f{next(self.unbacked_symfloat_counter)}")
-        self.var_to_stack[symbol] = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
+        self.var_to_stack[symbol] = traceback.extract_stack()[:-1]
         self.var_to_range[symbol] = ValueRanges.unknown()
         return SymFloat(SymNode(symbol, self, float, None))
 
     def create_unbacked_symint(self):
         symbol = sympy.Symbol(f"i{next(self.unbacked_symint_counter)}", integer=True)
-        self.var_to_stack[symbol] = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
+        self.var_to_stack[symbol] = traceback.extract_stack()[:-1]
         self.var_to_range[symbol] = ValueRanges(-sys.maxsize - 1, sys.maxsize)
         return SymInt(SymNode(symbol, self, int, None))
 
     def create_unbacked_symbool(self):
         symbol = sympy.Symbol(f"i{next(self.unbacked_symint_counter)}", integer=True)
-        self.var_to_stack[symbol] = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
+        self.var_to_stack[symbol] = traceback.extract_stack()[:-1]
         self.var_to_range[symbol] = ValueRanges(0, 1)
         return SymBool(SymNode(sympy.Eq(symbol, 1), self, bool, None))
 
@@ -2648,7 +2648,8 @@ class ShapeEnv:
         # TODO: in a Dynamo context, having user code, and having the
         # name of the local, will be much better
         for s in expr.free_symbols:
-            self.log.debug("Data dependent variable '%s' allocated at:\n%s", s, self.var_to_stack[s])
+            stacktrace = ''.join(traceback.format_list(self.var_to_stack[s]))
+            self.log.debug("Data dependent variable '%s' allocated at:\n%s", s, stacktrace)
         return GuardOnDataDependentSymNode(
             "It appears that you're trying to get a value out of symbolic int/float "
             "whose value is data-dependent (and thus we do not know the true value.)  "

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -333,9 +333,7 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
             sym_integer = sympy.Integer(a)
             shape_env = fake_mode.shape_env
             shape_env.var_to_range[sym_integer] = ValueRanges(min, max)
-            shape_env.var_to_stack[sym_integer] = ''.join(
-                traceback.format_list(TracingContext.extract_stack())
-            )
+            shape_env.var_to_stack[sym_integer] = TracingContext(fake_mode).extract_stack()
 
         return
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -325,7 +325,7 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
             raise ValueRangeError(f"Invalid value {a} for range [{min}:{max}]")
 
         if (
-            (fake_mode := detect_fake_mode()) is not None and 
+            (fake_mode := detect_fake_mode()) is not None and
             getattr(fake_mode, "shape_env", None) is not None
         ):
             # If we are tracing with a fake mode then add this integer to the
@@ -342,18 +342,15 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
     if isinstance(a.node.expr, sympy.Integer):
         if not (min <= int(a.node.expr) <= max):
             raise ValueRangeError(f"Invalid value {int(a.node.expr)} for range [{min}:{max}]")
-    elif isinstance(a.node.expr, sympy.Symbol):
-        pass
-    else:
-        raise ValueRangeError("constraining non-Symbols NYI")
+        return
+    assert isinstance(a.node.expr, sympy.Symbol), "constraining non-Symbols NYI"
 
     # TODO: Shouldn't we install a guard if the symbol is backed?  Or is the
     # semantics that this is an "unchecked" assert (but it this actually
     # something useful?  Might be better to restrict only for unbacked
     # SymInt).
-    var = a.node.expr
-    r = a.node.shape_env.var_to_range[var]
-    a.node.shape_env.var_to_range[var] = ValueRanges(
+    r = a.node.shape_env.var_to_range[a.node.expr]
+    a.node.shape_env.var_to_range[a.node.expr] = ValueRanges(
         builtins.max(r.lower, min), builtins.min(r.upper, max)
     )
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -330,7 +330,7 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
         pass
     else:
         raise ValueRangeError("constraining non-Symbols NYI")
-    
+
     # TODO: Shouldn't we install a guard if the symbol is backed?  Or is the
     # semantics that this is an "unchecked" assert (but it this actually
     # something useful?  Might be better to restrict only for unbacked
@@ -338,7 +338,7 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
     if not isinstance(a, SymInt):
         if detect_fake_mode() is None:
             return
-        
+
         # If we are tracing with a fake mode then add this integer to the
         # shape_env's var_to_range
         sym_integer = sympy.Integer(a)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -344,7 +344,7 @@ def constrain_range(a, *, min: Optional[int], max: Optional[int] = None):
         sym_integer = sympy.Integer(a)
         shape_env = detect_fake_mode().shape_env
         shape_env.var_to_range[sym_integer] = ValueRanges(min, max)
-        shape_env.var_to_stack[sym_integer] = ''.join(traceback.format_list(traceback.extract_stack()[0:2]))
+        shape_env.var_to_stack[sym_integer] = ''.join(traceback.format_list(TracingContext.extract_stack()))
         return
     var = a.node.expr
     r = a.node.shape_env.var_to_range[var]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/100415 

Results in the following error:
```
Traceback (most recent call last):
  File "/scratch/angelayi/work/pytorch/test/export/test_export.py", line 572, in test_export_constrain_static
    export(f, example_inputs, constraints)
  File "/scratch/angelayi/work/pytorch/torch/_export/__init__.py", line 348, in export
    method_name_to_graph_module[compile_spec.method_name] = _export(
  File "/scratch/angelayi/work/pytorch/torch/_export/__init__.py", line 119, in _export
    raise UserError(UserErrorType.CONSTRAIN_VIOLATION, str(e))
torch._dynamo.exc.UserError:   File "/scratch/angelayi/work/pytorch/test/export/test_export.py", line 561, in f
    constrain_as_value(c, min=1, max=3)

It appears that you're trying to set a constraint on a value which we evaluated to have a static value of 3. Scroll up to see where this constraint was set.
```

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire