### PR TITLE
Create public interface for torch.jit

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -62,6 +62,34 @@ from torch.jit._fuser import optimized_execution, fuser, last_executed_optimized
 from torch.jit._freeze import freeze, optimize_for_inference, run_frozen_optimizations
 from torch.jit._ir_utils import _InsertPoint
 
+__all__ = [
+    'Attribute',
+    'CompilationUnit',
+    'Error',
+    'Future',
+    'ScriptFunction',
+    'ScriptModule',
+    'annotate',
+    'enable_onednn_fusion',
+    'export_opnames',
+    'fork',
+    'freeze',
+    'ignore',
+    'isinstance',
+    'load',
+    'onednn_fusion_enabled',
+    'optimize_for_inference',
+    'save',
+    'script',
+    'script_if_tracing',
+    'set_fusion_strategy',
+    'strict_fusion',
+    'trace',
+    'trace_module',
+    'unused',
+    'wait'
+]
+
 # For backwards compatibility
 _fork = fork
 _wait = wait


### PR DESCRIPTION
Fixes #92240; this adds all variables in `torch/jit/__init__.py` that also have docs page to `__all__`: https://pytorch.org/docs/stable/jit.html

As stated in the tracking issue, this solves pyright errors like this:

```python
import torch

def foo(x, y):
    return 2 * x + y

traced_foo = torch.jit.trace(foo, (torch.rand(3), torch.rand(3)))  # error: "trace" is not exported from module "torch.jit" (reportPrivateImportUsage)

```