### PR TITLE
[inductor][cpu] Cache for VecISA compilation results

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -144,6 +144,8 @@ def check_rocm():
 def check_dynamo(backend, device, err_msg):
     import torch
 
+    print("[liaoxuan] check dynamo: " + backend + device + err_msg)
+
     if device == "cuda" and not torch.cuda.is_available():
         print(f"CUDA not available -- skipping CUDA check on {backend} backend\n")
         return


### PR DESCRIPTION
Fixes #100378

VecISA requires compiling a testing cpp program on every new process invocation, costing nearly 1 second on startup. Here we cache for VecISA compilation results and could directly read from cache next time if it exists.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @ngimel @desertfire