### PR TITLE
Improve docstring of binary_cross_entropy_with_logits

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3165,7 +3165,7 @@ def binary_cross_entropy_with_logits(
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
         pos_weight (Tensor, optional): a weight of positive examples.
-                Must be a vector with length equal to the number of classes.
+                If provided it's repeated to match input tensor shape.
 
     Examples::
 


### PR DESCRIPTION
The current docstring says that parameter `pos_weight` must have length equal to the number of classes, but there are always two classes for binary cross entropy. It seems that the parameter can have length either 1, or the length of input/target.
