### PR TITLE
[Security] Move mergebot workflows in its own env

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -8,6 +8,7 @@ jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}
     runs-on: linux.20_04.4x
+    environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -8,6 +8,7 @@ jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
     runs-on: linux.20_04.4x
+    environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   do_rebase:
     runs-on: ubuntu-20.04
+    environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   do_update_viablestrict:
     runs-on: ubuntu-20.04
+    environment: mergebot
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -91,8 +91,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN}}
-          MERGEBOT_TOKEN: ${{ secrets.MERGEBOT_TOKEN}}
         run: |
           curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit
           curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PYTORCHBOT_TOKEN" https://api.github.com/rate_limit
-          curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $MERGEBOT_TOKEN" https://api.github.com/rate_limit


### PR DESCRIPTION
TODO: Move pin update workflows to use separate bot
