### PR TITLE
[vulkan] Fix concat op in feature dimension

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/cat_feature.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/cat_feature.glsl
@@ -22,14 +22,17 @@ layout(set = 0, binding = 2) uniform PRECISION restrict Block {
   ivec4 out_extents;
   // input texture size (x=width,y=height,z=depth,w=unused)
   ivec4 in_extents;
-  // input tensor's batch size
-  uint batch_size;
-  // input tensor's channel size
-  uint ch_size;
-  // channel interval (total # of channels for all tensors)
-  uint ch_interval;
-  // # of channels for tensor 0 to i-1 at ith tensor
-  uint ch_size_allprior;
+  // x: size of output channel dim (values)
+  // y: size of output channel dim (texels)
+  uvec2 out_ch_info;
+  // x: size of input channel dim
+  // y: size of input channel dim up-aligned to 4
+  uvec2 in_ch_info;
+  // x: total number of channel values already appended
+  // y: offset to first channel texel being operated on
+  // z: number of channel texels being operated on
+  // w: padding
+  uvec4 appended_ch_info;
 }
 uBlock;
 
@@ -39,36 +42,47 @@ uBlock;
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
-  const ivec3 in_pos = ivec3(gl_GlobalInvocationID);
-  const uint max_src_index = uBlock.ch_size * uBlock.batch_size;
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
-  if (any(greaterThanEqual(in_pos, uBlock.in_extents.xyz))) {
+  if (any(greaterThanEqual(pos, uBlock.out_extents.xyz))) {
     return;
   }
 
-  // x and y don't change. only z and index matter
-  ivec3 out_pos = in_pos;
-  const vec4 in_tex = texelFetch(uInput, in_pos, 0);
+  // Determine the N, C indices that this invocation is writing to
+  const uint dst_n_idx = pos.z / uBlock.appended_ch_info.z;
+  const uint dst_c4_idx = (pos.z % uBlock.appended_ch_info.z) + uBlock.appended_ch_info.y;
+  uint dst_c_idx = dst_c4_idx * 4;
 
-  for (uint i = 0; i < 4; ++i) {
-    uint src_index = in_pos.z * 4 + i;
+  // Reconstruct the output write position based on the N, C indices
+  const uint dst_z_idx = dst_n_idx * uBlock.out_ch_info.y + dst_c4_idx;
+  const ivec3 write_pos = ivec3(pos.xy, dst_z_idx);
 
-    if (src_index >= max_src_index) {
-      // out of range
-      break;
+  vec4 out_tex = imageLoad(uOutput, write_pos);
+
+  const uint src_n_offset = dst_n_idx * uBlock.in_ch_info.y;
+
+  uint dst_nc_idx = dst_z_idx * 4;
+  int src_c_idx = int(dst_c_idx - uBlock.appended_ch_info.x);
+  int src_nc_idx = int(src_n_offset) + src_c_idx;
+
+  // For each element of the output, extract the corresponding value from the
+  // input
+  for (uint i = 0; i < 4; ++i, ++dst_c_idx, ++dst_nc_idx, ++src_c_idx, ++src_nc_idx) {
+    if (src_c_idx >= 0) {
+      uint src_z_idx = src_nc_idx / 4;
+
+      vec4 in_tex = texelFetch(uInput, ivec3(pos.xy, src_z_idx), 0);
+
+      uint src_offset = src_nc_idx % 4;
+      uint dst_offset = dst_nc_idx % 4;
+
+      if (src_c_idx < uBlock.in_ch_info.x) {
+        out_tex[i] = in_tex[src_offset];
+      } else {
+        out_tex[i] = 1.234;
+      }
     }
-
-    uint src_n_idx = src_index / uBlock.ch_size;
-    uint src_c_idx = src_index % uBlock.ch_size;
-
-    uint dst_nc_idx =
-        src_n_idx * uBlock.ch_interval + src_c_idx + uBlock.ch_size_allprior;
-
-    out_pos.z = int(dst_nc_idx / 4);
-    uint j = (dst_nc_idx % 4);
-
-    vec4 out_tex = imageLoad(uOutput, out_pos);
-    out_tex[j] = in_tex[i];
-    imageStore(uOutput, out_pos, out_tex);
   }
+
+  imageStore(uOutput, write_pos, out_tex);
 }

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -17,6 +17,9 @@ inline int64_t normalize_dim(int64_t d, int64_t n) {
 } // namespace
 
 Tensor cat_batch(const MaterializedITensorListRef& tensors, vTensor& v_output) {
+  (void)tensors;
+  (void)v_output;
+
   TORCH_CHECK(false, "Vulkan cat not implemented for batch dimension!");
 }
 
@@ -25,41 +28,56 @@ Tensor cat_feature(
     vTensor& v_output) {
   api::Context* const context = api::context();
 
-  int64_t ch_size_allprior = 0;
-  int64_t ch_interval = 0;
+  // Determine the channels of the output tensor
+  uint32_t ch_total = 0;
   for (const at::Tensor& tensor : tensors) {
-    ch_interval += tensor.sizes()[1];
+    ch_total += get_dim<Dim4D::Channel>(tensor);
   }
-  ch_interval = api::utils::align_up(ch_interval, INT64_C(4));
 
+  // Running counter of the number of channels already appended.
+  uint32_t ch_current = 0;
   for (const at::Tensor& tensor : tensors) {
     const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
     const vTensor& v_self = convert(self);
 
-    uint32_t in_channels = safe_downcast<uint32_t>(v_self.sizes()[1]);
-    uint32_t in_ch_aligned = api::utils::align_up(in_channels, 4u);
+    // Determine the number of channel texels that will be modified by
+    // appending this input tensor
+    uint32_t start_ch4 = ch_current / 4;
+
+    uint32_t end_ch4 =
+        api::utils::div_up(ch_current + get_dim<Dim4D::Channel>(v_self), 4u);
+
+    uint32_t ch4_range = end_ch4 - start_ch4;
+    uint32_t nc4_range = ch4_range * get_dim<Dim4D::Batch>(v_self);
 
     const struct Block final {
-      ivec3 out_extents;
+      ivec3 outExtents;
       int32_t fill0;
-      ivec3 in_extents;
+      ivec3 inExtents;
       int32_t fill1;
-      uint32_t batchSize;
-      uint32_t chSize;
-      uint32_t chInterval;
-      uint32_t chSizeAllprior;
+      uvec2 outChInfo;
+      uvec2 inChInfo;
+      uvec4 appendedChInfo;
     } block{
         api::utils::make_ivec3(v_output.extents()),
         0,
         api::utils::make_ivec3(v_self.extents()),
         0,
-        safe_downcast<uint32_t>(v_self.sizes()[0]),
-        in_ch_aligned,
-        safe_downcast<uint32_t>(ch_interval),
-        safe_downcast<uint32_t>(ch_size_allprior),
+        {
+            ch_total,
+            api::utils::div_up(ch_total, 4u),
+        },
+        {
+            get_dim<Dim4D::Channel>(v_self),
+            api::utils::align_up(get_dim<Dim4D::Channel>(v_self), 4u),
+        },
+        {
+            ch_current,
+            start_ch4,
+            ch4_range,
+            0u,
+        },
     };
-
-    ch_size_allprior += v_self.sizes()[1];
 
     api::UniformParamsBuffer params(context, block);
     api::PipelineBarrier pipeline_barrier{};
@@ -70,7 +88,11 @@ Tensor cat_feature(
         // pipeline barrier
         pipeline_barrier,
         // global work group size
-        v_self.extents(),
+        {
+            get_dim<Dim4D::Width>(v_output),
+            get_dim<Dim4D::Height>(v_output),
+            nc4_range,
+        },
         // local work group size
         adaptive_work_group_size(v_self.extents()),
         // fence handle
@@ -83,6 +105,8 @@ Tensor cat_feature(
         v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
         // params buffer
         params.buffer());
+
+    ch_current += get_dim<Dim4D::Channel>(v_self);
   }
 
   return convert(v_output);
@@ -144,6 +168,9 @@ Tensor cat_feature_mult4ch(
 }
 
 Tensor cat_width(const MaterializedITensorListRef& tensors, vTensor& v_output) {
+  (void)tensors;
+  (void)v_output;
+
   TORCH_CHECK(false, "Vulkan cat not implemented for width dimension!");
 }
 
@@ -184,11 +211,11 @@ Tensor cat_height(
 }
 
 Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
-  TORCH_CHECK(tensors.size() > 0, "Vulkan cat expects at least one tensor");
+  TORCH_CHECK(!tensors.empty(), "Vulkan cat expects at least one tensor");
 
   const int64_t dim = normalize_dim(in_dim, 4);
   auto materialized = tensors.materialize();
-  TORCH_INTERNAL_ASSERT(materialized.size() > 0, "Accessing empty array");
+  TORCH_INTERNAL_ASSERT(!materialized.empty(), "Accessing empty array");
   const at::Tensor& tensor = materialized[0];
   int64_t cat_dim_size = 0;
   bool is_mult4ch = true;
@@ -213,7 +240,7 @@ Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
   }
 
   auto result_size = tensor.sizes().vec();
-  TORCH_INTERNAL_ASSERT(result_size.size() > 0, "Accessing empty array");
+  TORCH_INTERNAL_ASSERT(!result_size.empty(), "Accessing empty array");
   result_size[dim] = cat_dim_size;
 
   vTensor v_output{api::context(), result_size, tensor.scalar_type()};


### PR DESCRIPTION
Summary: Fix a small bug in the `cat_feature` shader where an early exit path was not being taken correctly.

Test Plan:
Referring to [Pytorch Vulkan Testing Procedures](https://www.internalfb.com/intern/wiki/Pytorch_Vulkan_Backend/Development/Vulkan_Testing_Procedures/):

* Run operator unit tests on Mac and Android
* Run model inference and correctness benchmarks

Differential Revision: D45962806

