### PR TITLE
disableing quantizing gradient in 8bw

### DIFF
--- a/torch/csrc/quantized/quantized_backward.cpp
+++ b/torch/csrc/quantized/quantized_backward.cpp
@@ -79,58 +79,11 @@ class PackedLinearWeightDynamicBackward
       // Per Channel quantizer does not support transpose.
       // Manual transpose is necessary
       original_weight = original_weight.dequantize();
-#if 1
-      // Enable Kernel backend for quantized backpropagaiton matrix
-      // multiplication
-      original_weight = at::permute(original_weight, {1, 0});
-      // Take advantage of QNNPACK for matrix multiplication
-      // Per channel scales & zero point computation
-      // Sources :
-      // https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/observer.py#L350-L353
-      auto [amin, amax] = at::aminmax(original_weight, /*dim* = */ 1);
-      // QInt8 type signed quantization
-      auto qmax = 127;
-      auto qmin = -128;
-      // Clamp with some epsilon number, so that value does not go below zero
-      auto epsilon = 1e-9;
-      auto new_scales = (amax - amin) / float(qmax - qmin);
-      new_scales = at::clamp(new_scales, epsilon);
-      auto new_zero_point =
-          qmin - at::round(amin / new_scales).toType(c10::kInt);
-      new_zero_point = at::clamp(new_zero_point, qmin, qmax);
-      // TO-DO (BUGBUG)
-      // Backend kernel is designed for inference, tightly coded for output
-      // channel. For mathematical correctness, we should enable to run kernel
-      // with input channel axis after transpose. As workaround, we are simply
-      // either exploring per tensor quantization or per channel quantization
-      // with axis = 0
-      original_weight = at::quantize_per_channel(
-          original_weight,
-          new_scales,
-          new_zero_point,
-          /*axis = 1 for transpose, but we are forcing it to non-transposed case
-             due to above issue*/
-          0,
-          c10::kQInt8);
-#endif
     } else {
       TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
     }
-#if 0
-    // Pure FP32 computation, useful for debugging purpose
+    // Compute gradient in FP32
     auto dLdX1 = torch::matmul(grad_output0, original_weight);
-#else
-    // Take advantage of QNNPACK for matrix multiplication
-    static auto op = at::Dispatcher::singleton()
-                         .findSchemaOrThrow("quantized::linear_prepack", "")
-                         .typed<c10::intrusive_ptr<LinearPackedParamsBase>(
-                             at::Tensor, c10::optional<at::Tensor>)>();
-    auto prepacked_weight = op.call(original_weight, nullopt);
-
-    auto dLdX1 =
-        prepacked_weight->apply_dynamic(grad_output0.toType(c10::kFloat));
-#endif
-
     auto input_grad0 = dLdX1 * input_scale;
     return {input_grad0, torch::Tensor(), torch::Tensor()};
   }


### PR DESCRIPTION
Summary:
Quantizing a *gradient* is not applicable to complex ASR model.

Gradient in INT8
f438266519
Gradient in FP32
f438109197
Clearly two WER shows the limitation with quantizing a gradient.

As of now, we are okay with simply enabling quantized backpropagation but computing gradient in FP32.
It already saves a memory due to model size.

Test Plan: Signals

Differential Revision: D45965552

