### PR TITLE
Do not trigger lint and pull workflows when sync nightly #26921

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -87,9 +87,3 @@ runs:
 
         echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
         cat /etc/hosts
-
-    - name: Increase the stack size limit
-      shell: bash
-      run: |
-        # This is needed to avoid argument list too long when invoking Docker command for nightly jobs
-        ulimit -a

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -87,3 +87,9 @@ runs:
 
         echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
         cat /etc/hosts
+
+    - name: Increase the stack size limit
+      shell: bash
+      run: |
+        # This is needed to avoid argument list too long when invoking Docker command for nightly jobs
+        ulimit -a

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -8,6 +8,8 @@ on:
       - reopened
       - labeled
       - unlabeled
+    branches-ignore:
+      - nightly
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on:
   pull_request:
+    branches-ignore:
+      - nightly
   push:
     branches:
       - main

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -2,6 +2,8 @@ name: pull
 
 on:
   pull_request:
+    branches-ignore:
+      - nightly
   push:
     branches:
       - main


### PR DESCRIPTION
These workflows run when the nightly PR #26921 is synched and they will fail due to the large commit message saved in env variable `COMMIT_MESSAGES`, for example https://github.com/pytorch/pytorch/actions/runs/4977477882.  We don't need to run CI jobs on nightly.

The list of failing workflows is from https://hud.pytorch.org/pytorch/pytorch/commit/f3e13d956729d4fa9ce35dca5beed588c914797d
