### PR TITLE
DOC Fixes unpacking issue in dynamo explain docs

### DIFF
--- a/docs/source/compile/troubleshooting.rst
+++ b/docs/source/compile/troubleshooting.rst
@@ -615,8 +615,10 @@ that are encountered. Here is an example usage:
        if b.sum() < 0:
            b = b * -1
        return x * b
-   explanation, out_guards, graphs, ops_per_graph = dynamo.explain(toy_example, torch.randn(10), torch.randn(10))
-   print(explanation)
+   explanation, out_guards, graphs, ops_per_graph, break_reasons, explanation_verbose = (
+       dynamo.explain(toy_example, torch.randn(10), torch.randn(10))
+   )
+   print(explanation_verbose)
    """
    Dynamo produced 3 graphs, with 2 graph breaks and 6 ops.
     Break reasons:


### PR DESCRIPTION
This PR updates the docs to be consistent with `torch.explain` which currently returns 6 items:

https://github.com/pytorch/pytorch/blob/bfb3941ad8aaf0af159c2bec3cf1cbec1488f335/torch/_dynamo/eval_frame.py#L622-L629

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire