### PR TITLE
Benchmark with batch size refresher

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1317,6 +1317,8 @@ class BenchmarkRunner:
                     batch_size,
                 )
                 self.model_iter_fn(model, example_inputs)
+                #optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+                #optimized_model_iter_fn(model, example_inputs)
                 return batch_size
             except RuntimeError as e:
                 error_str = str(e)
@@ -2035,6 +2037,19 @@ def parse_args(args=None):
         default=1,
         help="Set per-process GPU memory fraction (limit) for reducing usable size and reproducing OOMs",
     )
+    
+    parser.add_argument(
+        "--find-batch-sizes",
+        action="store_true",
+        help="finds the largest batch size that could fit on GPUs",
+    )
+    
+    parser.add_argument(
+        "--find-all-batch-sizes",
+        action="store_true",
+        help="finds the largest batch size that could fit on GPUs",
+    )
+
     group_fuser = parser.add_mutually_exclusive_group()
     # --nvfuser is now the default, keep the option to not break scripts
     group_fuser.add_argument("--nvfuser", action="store_true", help=argparse.SUPPRESS)
@@ -2112,11 +2127,6 @@ def parse_args(args=None):
         "--recompile_profiler",
         action="store_true",
         help="Run the dynamo recompilation profiler on each model.",
-    )
-    group.add_argument(
-        "--find-batch-sizes",
-        action="store_true",
-        help="finds the largest batch size that could fit on GPUs",
     )
 
     mode_group = parser.add_mutually_exclusive_group(required=True)

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -607,8 +607,8 @@ def refresh_model_names_and_batch_sizes():
 
 def huggingface_main():
     # Code to refresh model names and batch sizes
-    # if "--find-batch-sizes" not in sys.argv:
-    #     refresh_model_names_and_batch_sizes()
+    if ("--find-all-batch-sizes" in sys.argv) and ("--only" not in '\t'.join(sys.argv)) and ("--accuracy" not in sys.argv):
+        refresh_model_names_and_batch_sizes()
     logging.basicConfig(level=logging.WARNING)
     warnings.filterwarnings("ignore")
     main(HuggingfaceRunner())

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -316,6 +316,13 @@ def parse_args():
         help="batch size for benchmarking",
     )
     parser.add_argument(
+        "--find-all-batch-sizes",
+        "--find_all_batch_sizes",
+        action="store_true",
+        default=False,
+        help="find batch size to fit GPU, and then run benchmarking for all models",
+    )
+    parser.add_argument(
         "--threads",
         "-t",
         type=int,
@@ -421,6 +428,9 @@ def generate_commands(args, dtypes, suites, devices, compilers, output_dir):
                     cmd = f"{cmd} {base_cmd} {args.extra_args} --no-skip --dashboard"
                     skip_tests_str = get_skip_tests(suite)
                     cmd = f"{cmd} {skip_tests_str}"
+                    
+                    if args.find_all_batch_sizes:
+                        cmd = f"{cmd} --find-all-batch-sizes"
 
                     if args.log_operator_inputs:
                         cmd = f"{cmd} --log-operator-inputs"

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -37,8 +37,11 @@ def read_models_and_batch_sizes():
         lines = fh.readlines()
         lines = [line.rstrip() for line in lines]
         for line in lines:
-            if line:
+            if "," in line:
                 model_name, batch_size = line.split(",")
+                TIMM_MODELS[model_name] = int(batch_size)
+            if " " in line:
+                model_name, batch_size = line.split(" ")
                 TIMM_MODELS[model_name] = int(batch_size)
         
     return TIMM_MODELS


### PR DESCRIPTION
Fixes #100637. User can add a flag `--find-all-batch-sizes` to `python benchmarks/dynamo/runner.py` call to refresh the model names list with the optimal batch size that fit the current GPU, and then run the benchmark. 

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire