### PR TITLE
Fix device normalization of automatically generate methods for custom backends. 

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -232,6 +232,11 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             z1 = z1.cpu()
             self.assertFalse(self.module.custom_add_called())
             self.assertFalse(z1.is_foo)
+            z1 = z1.foo(device="foo:0", non_blocking=False)
+            self.assertFalse(self.module.custom_add_called())
+            self.assertTrue(z1.is_foo)
+            with self.assertRaisesRegex(RuntimeError, "Invalid device"):
+                z1.foo(device="cuda:0", non_blocking=False)
             # check UntypedStorage
             y = torch.empty(4, 4)
             z2 = y.untyped_storage()

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -235,7 +235,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             z1 = z1.foo(device="foo:0", non_blocking=False)
             self.assertFalse(self.module.custom_add_called())
             self.assertTrue(z1.is_foo)
-            with self.assertRaisesRegex(RuntimeError, "Invalid device"):
+            with self.assertRaisesRegex(ValueError, "Invalid device"):
                 z1.foo(device="cuda:0", non_blocking=False)
             # check UntypedStorage
             y = torch.empty(4, 4)

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -235,7 +235,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             z1 = z1.foo(device="foo:0", non_blocking=False)
             self.assertFalse(self.module.custom_add_called())
             self.assertTrue(z1.is_foo)
-            with self.assertRaisesRegex(ValueError, "Invalid device"):
+            with self.assertRaisesRegex(RuntimeError, "Invalid device"):
                 z1.foo(device="cuda:0", non_blocking=False)
             # check UntypedStorage
             y = torch.empty(4, 4)

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -110,6 +110,7 @@ def _normalization_device(custom_backend_name: str, device: Optional[Union[int, 
             device_idx = _get_current_device_index()
         else:
             device_idx = device.index
+    # if isinstance(device, int), we can take the index number directly
     else:
         device_idx = device
     return device_idx

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -96,18 +96,20 @@ def _normalization_device(custom_backend_name: str, device: Optional[Union[int, 
             return 0
 
     if device is None:
-        device_idx = _get_current_device_index()
-    elif isinstance(device, torch.device):
+        return _get_current_device_index()
+    # if isinstance(device, str), this means that the parameter passed in is in the string format "foo:0"
+    # convert str object to torch.device object, and then process it uniformly
+    elif isinstance(device, str):
+        device = torch.device(device)
+
+    # variable devcie can only be torch.device type or int type
+    if isinstance(device, torch.device):
         if device.type != custom_backend_name:
             raise RuntimeError(f"Invalid device, must be {custom_backend_name} device")
         elif device.index is None:
             device_idx = _get_current_device_index()
         else:
             device_idx = device.index
-    # if isinstance(device, str), this means that the parameter passed in is in the string format "foo:0"
-    elif isinstance(device, str):
-        device_idx = torch.device(device).index
-    # if isinstance(device, int), we can take the index number directly
     else:
         device_idx = device
     return device_idx

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -85,7 +85,7 @@ def _check_register_once(module, attr):
         raise RuntimeError(f"The custom device module of {module} has already been registered with {attr}")
 
 
-def _normalization_device(custom_backend_name: str, device: Optional[Union[int, torch.device]] = None) -> int:
+def _normalization_device(custom_backend_name: str, device: Optional[Union[int, str, torch.device]] = None) -> int:
     def _get_current_device_index():
         _get_device_index = "current_device"
         if hasattr(torch, custom_backend_name) and \
@@ -104,6 +104,12 @@ def _normalization_device(custom_backend_name: str, device: Optional[Union[int, 
             device_idx = _get_current_device_index()
         else:
             device_idx = device.index
+    # if isinstance(device, str), this means that the parameter passed in is in the string format "foo:0"
+    elif isinstance(device, str):
+        if device.split(":")[0] == custom_backend_name:
+            device_idx = int(device.split(":")[-1])
+        else:
+            raise RuntimeError(f"Invalid device, must be {custom_backend_name} device")
     # if isinstance(device, int), we can take the index number directly
     else:
         device_idx = device

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -106,10 +106,7 @@ def _normalization_device(custom_backend_name: str, device: Optional[Union[int, 
             device_idx = device.index
     # if isinstance(device, str), this means that the parameter passed in is in the string format "foo:0"
     elif isinstance(device, str):
-        if device.split(":")[0] == custom_backend_name:
-            device_idx = int(device.split(":")[-1])
-        else:
-            raise ValueError(f"Invalid device, must be {custom_backend_name} device")
+        device_idx = torch.device(device).index
     # if isinstance(device, int), we can take the index number directly
     else:
         device_idx = device

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -109,7 +109,7 @@ def _normalization_device(custom_backend_name: str, device: Optional[Union[int, 
         if device.split(":")[0] == custom_backend_name:
             device_idx = int(device.split(":")[-1])
         else:
-            raise RuntimeError(f"Invalid device, must be {custom_backend_name} device")
+            raise ValueError(f"Invalid device, must be {custom_backend_name} device")
     # if isinstance(device, int), we can take the index number directly
     else:
         device_idx = device


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Fix the problem of error handling when the device input parameter adopts string type, Align capabilities.

`foo_storage = torch.DoubleStorage(4).foo(device="foo:0, non_blocking=False")`


cc @bdhirsh