### PR TITLE
[WIP] Don't `import functorch` inside inductor

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 
-from functorch.compile import min_cut_rematerialization_partition
+from torch._functorch.partitioners import min_cut_rematerialization_partition
 
 import torch._dynamo.config as dynamo_config
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #101802

We have some internal problems with the functorch target where it is not
automatically included with the torch target. This PR is a quick
short-term fix that excises the dependency on `import functorch` from
PyTorch so that you can use `torch.compile` without needing to be able
to `import functorch`.

Test Plan:
- CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire