### PR TITLE
Reduce log output when no tests are prioritized

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -241,16 +241,19 @@ def get_reordered_tests(
         return ([], tests)
 
     # TODO: Would be great to upload these stats to RDS/Rockset!
-    test_cnt_str = pluralize(len(tests), "test")
-    print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
-    print(
-        f"Prioritized tests estimated to run up to {duration_to_str(time_savings_sec)} sooner than they would've otherwise"
-    )
+    if len(bring_to_front):
+        test_cnt_str = pluralize(len(tests), "test")
+        print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
+        print(
+            f"Prioritized tests estimated to run up to {duration_to_str(time_savings_sec)} sooner than they would've otherwise"
+        )
 
-    prioritized_test_names = [t.name for t in bring_to_front]
-    print(f"Prioritized: {prioritized_test_names}")
-    remaining_test_names = [t.name for t in the_rest]
-    print(f"The Rest: {remaining_test_names}")
+        prioritized_test_names = [t.name for t in bring_to_front]
+        print(f"Prioritized: {prioritized_test_names}")
+        remaining_test_names = [t.name for t in the_rest]
+        print(f"The Rest: {remaining_test_names}")
+    else:
+        print("Didn't find any tests to prioritize")
 
     return (bring_to_front, the_rest)
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -241,7 +241,7 @@ def get_reordered_tests(
         return ([], tests)
 
     # TODO: Would be great to upload these stats to RDS/Rockset!
-    if len(bring_to_front):
+    if bring_to_front:
         test_cnt_str = pluralize(len(tests), "test")
         print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
         print(


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 733b991</samp>

Improve test reordering output in `tools/testing/test_selections.py`. Add a check to only print reordering information when there are tests to prioritize.