### PR TITLE
Fix/skip CSE tests on Python-3.8 without `astunparse`

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5230,7 +5230,9 @@ def fn():
         return sys.version_info[:2] <= (3, 8)
 
     def _has_ast_unparse(self) -> bool:
-        return not self._is_py38() or "astunparse" in sys.modules
+        from torch._dynamo.guards import HAS_UNPARSE_FUNCTIONS
+
+        return HAS_UNPARSE_FUNCTIONS
 
     def test_guards_cse_pass_single(self):
         if not self._has_ast_unparse():

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5229,7 +5229,12 @@ def fn():
     def _is_py38(self) -> bool:
         return sys.version_info[:2] <= (3, 8)
 
+    def _has_ast_unparse(self) -> bool:
+        return not self._is_py38() or "astunparse" in sys.modules
+
     def test_guards_cse_pass_single(self):
+        if not self._has_ast_unparse():
+            raise unittest.SkipTest("Needs astunparse or Python-3.9+")
         from torch._dynamo.guards import PyExprCSEPass
 
         testcase = self.CSETestCase
@@ -5274,6 +5279,8 @@ def fn():
             self.assertEqual(expr, expected)
 
     def test_guards_cse_pass_multiple(self):
+        if not self._has_ast_unparse():
+            raise unittest.SkipTest("Needs astunparse or Python-3.9+")
         from torch._dynamo.guards import PyExprCSEPass
 
         testcase = self.CSETestCase
@@ -5383,9 +5390,7 @@ def ___make_guard_fn():
 
         if self._is_py38():
             expected = (
-                expected_38
-                if "astunparse" in sys.modules
-                else expected_38_no_astunparse
+                expected_38 if self._has_ast_unparse() else expected_38_no_astunparse
             )
         self.assertEqual(expected, pycode)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5366,8 +5366,27 @@ def ___make_guard_fn():
         return True
     return guard
 """
+        expected_38_no_astunparse = """\
+def ___make_guard_fn():
+    def guard(L):
+        if not (x[0].a < x[1].a * (3 - x[2].a)):
+            return False
+        if not (a.b.c[0].d.e + a.b.c[1].d.e * a.b.c[2].d.e > 0):
+            return False
+        if not (f(m.n[0], '0').x.y.z * f(m.n[0], '1').x.y.z * f(m.n[0], '2').x.y.z < 512):
+            return False
+        if not (self.g(a, b).k + (1 - self.g(a, b).k) <= m[0].a + self.g(a, b).k):
+            return False
+        return True
+    return guard
+"""
 
-        expected = expected_38 if self._is_py38() else expected
+        if self._is_py38():
+            expected = (
+                expected_38
+                if "astunparse" in sys.modules
+                else expected_38_no_astunparse
+            )
         self.assertEqual(expected, pycode)
 
 


### PR DESCRIPTION
If `astunparse` is not installed, following guard will be generated in `test_guard_function_builder_with_cse`:
```python
def ___make_guard_fn():
    def guard(L):
        if not (x[0].a < x[1].a * (3 - x[2].a)):
            return False
        if not (a.b.c[0].d.e + a.b.c[1].d.e * a.b.c[2].d.e > 0):
            return False
        if not (f(m.n[0], '0').x.y.z * f(m.n[0], '1').x.y.z * f(m.n[0], '2').x.y.z < 512):
            return False
        if not (self.g(a, b).k + (1 - self.g(a, b).k) <= m[0].a + self.g(a, b).k):
            return False
        return True
    return guard
```

Though, I have to say, hardcoding string comparison is pretty weird.

Also, skip `test_guards_cse_pass_[single|multiple]` if AST unparsing is missing.

Fixes failure in a test introduced by https://github.com/pytorch/pytorch/pull/98488

copilot:poem

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire