### PR TITLE
Added stub of min gcc/clang reqirements to CUDA 12.1

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,7 +88,7 @@ if sys.platform == 'win32':
     from .version import cuda as cuda_version
     import glob
     if cuda_version and all(not glob.glob(os.path.join(p, 'cudart64*.dll')) for p in dll_paths):
-        cuda_version_1 = cuda_version.replace('.', '_')
+        cuda_version_1 = str(cuda_version).replace('.', '_')
         cuda_path_var = 'CUDA_PATH_V' + cuda_version_1
         default_path = os.path.join(pfiles_path, 'NVIDIA GPU Computing Toolkit', 'CUDA', 'v' + cuda_version)
         cuda_path = os.path.join(os.getenv(cuda_path_var, default_path), 'bin')

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,7 +88,7 @@ if sys.platform == 'win32':
     from .version import cuda as cuda_version
     import glob
     if cuda_version and all(not glob.glob(os.path.join(p, 'cudart64*.dll')) for p in dll_paths):
-        cuda_version_1 = str(cuda_version).replace('.', '_')
+        cuda_version_1 = cuda_version.replace('.', '_')
         cuda_path_var = 'CUDA_PATH_V' + cuda_version_1
         default_path = os.path.join(pfiles_path, 'NVIDIA GPU Computing Toolkit', 'CUDA', 'v' + cuda_version)
         cuda_path = os.path.join(os.getenv(cuda_path_var, default_path), 'bin')

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,6 +88,8 @@ if sys.platform == 'win32':
     from .version import cuda as cuda_version
     import glob
     if cuda_version and all(not glob.glob(os.path.join(p, 'cudart64*.dll')) for p in dll_paths):
+        if type(cuda_version) is not str:
+            cuda_version = str(cuda_version)
         cuda_version_1 = cuda_version.replace('.', '_')
         cuda_path_var = 'CUDA_PATH_V' + cuda_version_1
         default_path = os.path.join(pfiles_path, 'NVIDIA GPU Computing Toolkit', 'CUDA', 'v' + cuda_version)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,8 +88,6 @@ if sys.platform == 'win32':
     from .version import cuda as cuda_version
     import glob
     if cuda_version and all(not glob.glob(os.path.join(p, 'cudart64*.dll')) for p in dll_paths):
-        if type(cuda_version) is not str:
-            cuda_version = str(cuda_version)
         cuda_version_1 = cuda_version.replace('.', '_')
         cuda_path_var = 'CUDA_PATH_V' + cuda_version_1
         default_path = os.path.join(pfiles_path, 'NVIDIA GPU Computing Toolkit', 'CUDA', 'v' + cuda_version)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -58,6 +58,7 @@ CUDA_GCC_VERSIONS: VersionMap = {
     '11.5': ((6, 0, 0), (12, 0)),
     '11.6': ((6, 0, 0), (12, 0)),
     '11.7': ((6, 0, 0), (12, 0)),
+    '12.1': ((6, 0, 0), (12, 0)), # not tested! only in nightly preview!
 }
 
 MINIMUM_CLANG_VERSION = (3, 3, 0)
@@ -69,6 +70,7 @@ CUDA_CLANG_VERSIONS: VersionMap = {
     '11.5': (MINIMUM_CLANG_VERSION, (13, 0)),
     '11.6': (MINIMUM_CLANG_VERSION, (14, 0)),
     '11.7': (MINIMUM_CLANG_VERSION, (14, 0)),
+    '12.1': (MINIMUM_CLANG_VERSION, (14, 0)), # not tested! only in nightly preview!
 }
 
 __all__ = ["get_default_build_root", "check_compiler_ok_for_platform", "get_compiler_abi_compatibility_and_version", "BuildExtension",

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -58,7 +58,6 @@ CUDA_GCC_VERSIONS: VersionMap = {
     '11.5': ((6, 0, 0), (12, 0)),
     '11.6': ((6, 0, 0), (12, 0)),
     '11.7': ((6, 0, 0), (12, 0)),
-    '12.1': ((6, 0, 0), (12, 0)), # not tested! only in nightly preview!
 }
 
 MINIMUM_CLANG_VERSION = (3, 3, 0)
@@ -70,7 +69,6 @@ CUDA_CLANG_VERSIONS: VersionMap = {
     '11.5': (MINIMUM_CLANG_VERSION, (13, 0)),
     '11.6': (MINIMUM_CLANG_VERSION, (14, 0)),
     '11.7': (MINIMUM_CLANG_VERSION, (14, 0)),
-    '12.1': (MINIMUM_CLANG_VERSION, (14, 0)), # not tested! only in nightly preview!
 }
 
 __all__ = ["get_default_build_root", "check_compiler_ok_for_platform", "get_compiler_abi_compatibility_and_version", "BuildExtension",

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -58,6 +58,7 @@ CUDA_GCC_VERSIONS: VersionMap = {
     '11.5': ((6, 0, 0), (12, 0)),
     '11.6': ((6, 0, 0), (12, 0)),
     '11.7': ((6, 0, 0), (12, 0)),
+    '12.1': ((6, 0, 0), (12, 0)),  # stub - not tested! only in nightly preview!
 }
 
 MINIMUM_CLANG_VERSION = (3, 3, 0)
@@ -69,6 +70,7 @@ CUDA_CLANG_VERSIONS: VersionMap = {
     '11.5': (MINIMUM_CLANG_VERSION, (13, 0)),
     '11.6': (MINIMUM_CLANG_VERSION, (14, 0)),
     '11.7': (MINIMUM_CLANG_VERSION, (14, 0)),
+    '12.1': (MINIMUM_CLANG_VERSION, (14, 0)),  # stub - not tested! only in nightly preview!
 }
 
 __all__ = ["get_default_build_root", "check_compiler_ok_for_platform", "get_compiler_abi_compatibility_and_version", "BuildExtension",


### PR DESCRIPTION
when patched pytorch-nightly with dirty workaround, adding in version.py materialized version of file (not template, but from site-packages) setting cuda_version = 12.1 (previously: None) new error arised -- above problem is described here in issue of pytorch:
 https://github.com/pytorch/pytorch/issues/101801

It arised when using oobabooga/one-click-installers for Windows

Short:
```
File "G:\git-jv\ai\oobabooga_one-click-installersk-installers\installer_files\env\lib\site-packages\torch\__init__.py", line 91, in <module>
cuda_version_1 = cuda_version.replace('.', '_')
AttributeError: 'float' object has no attribute 'replace'
```

Long:
```
Requirement already satisfied: mpmath>=0.19 in g:\git-jv\ai\oobabooga_one-click-installersk-installers\installer_files\env\lib\site-packages (from sympy->torch>=1.4.0->accelerate==0.18.0->-r requirements.txt (line 5)) (1.2.1)
Installing collected packages: safetensors, transformers, accelerate, datasets
  Attempting uninstall: safetensors
    Found existing installation: safetensors 0.3.1
    Uninstalling safetensors-0.3.1:
      Successfully uninstalled safetensors-0.3.1
  Attempting uninstall: transformers
    Found existing installation: transformers 4.29.1
    Uninstalling transformers-4.29.1:
      Successfully uninstalled transformers-4.29.1
  Attempting uninstall: accelerate
    Found existing installation: accelerate 0.19.0
    Uninstalling accelerate-0.19.0:
      Successfully uninstalled accelerate-0.19.0
  Attempting uninstall: datasets
    Found existing installation: datasets 2.12.0
    Uninstalling datasets-2.12.0:
      Successfully uninstalled datasets-2.12.0
Successfully installed accelerate-0.18.0 datasets-2.10.1 safetensors-0.3.0 transformers-4.28.0
Processing g:\git-jv\ai\oobabooga_one-click-installersk-installers\text-generation-webui\repositories\gptq-for-llama
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  python setup.py egg_info did not run successfully.
  exit code: 1

  [8 lines of output]
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "G:\git-jv\ai\oobabooga_one-click-installersk-installers\text-generation-webui\repositories\GPTQ-for-LLaMa\setup.py", line 2, in <module>
      from torch.utils import cpp_extension
    File "G:\git-jv\ai\oobabooga_one-click-installersk-installers\installer_files\env\lib\site-packages\torch\__init__.py", line 91, in <module>
      cuda_version_1 = cuda_version.replace('.', '_')
  AttributeError: 'float' object has no attribute 'replace'
  [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

Encountered error while generating package metadata.

See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Related issue #101801 (but not fixes it)
