### PR TITLE
[pytorch] add Vulkan support for the `t` and `transpose` operators for 2d, 3d and 4d tensors

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Transpose.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Transpose.cpp
@@ -1,0 +1,147 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor transpose_4d(
+    const Tensor& input_arg,
+    const uvec4& in_size,
+    const uvec4& out_size,
+    const uvec4& out_dims,
+    vTensor& v_output) {
+  api::Context* const context = api::context();
+
+  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const vTensor& v_self = convert(input);
+
+  uint32_t out_channels = out_size.data[1u];
+  uint32_t in_channels = in_size.data[1u];
+
+  uint32_t out_c_aligned = api::utils::align_up(out_channels, 4u);
+  uint32_t in_c_aligned = api::utils::align_up(in_channels, 4u);
+
+  const struct Block final {
+    ivec3 out_extents;
+    int32_t fill0;
+    ivec3 in_extents;
+    int32_t fill1;
+    uvec4 out_tensor_size;
+    uvec4 in_tensor_size;
+    uvec4 out_ndims;
+    uvec2 ch_info;
+  } block{
+      api::utils::make_ivec3(v_output.extents()),
+      0,
+      api::utils::make_ivec3(v_self.extents()),
+      0,
+      out_size,
+      in_size,
+      out_dims,
+      {out_c_aligned, in_c_aligned},
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      VK_KERNEL(permute_4d),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      // params buffer
+      params.buffer());
+
+  return convert(v_output);
+}
+
+Tensor transpose(const Tensor& self, int64_t index0, int64_t index1) {
+  TORCH_CHECK(
+      self.dim() <= 4,
+      "Vulkan transpose only supports tensors <= 4 dimensions");
+
+  auto nDims = safe_downcast<uint32_t>(self.dim());
+  uvec4 in_size{1u, 1u, 1u, 1u}, out_size{1u, 1u, 1u, 1u};
+  uvec4 out_dims{0u, 1u, 2u, 3u};
+
+  auto oldSizes = self.sizes();
+  DimVector newSizes(nDims);
+  auto new_index0 = safe_downcast<uint32_t>(maybe_wrap_dim(index0, nDims));
+  auto new_index1 = safe_downcast<uint32_t>(maybe_wrap_dim(index1, nDims));
+  if (new_index0 == new_index1) {
+    return self.detach();
+  }
+
+  // generalize input and output into 4D tensor, e.g. input is 3d of shape [2,
+  // 3, 4] by padding at the batch dim, input becomes 4d with in_size = [1, 2,
+  // 3, 4]
+  for (const auto i : c10::irange(nDims)) {
+    in_size.data[(4u - nDims) + i] = self.sizes()[i];
+    out_size.data[(4u - nDims) + i] = self.sizes()[i];
+    newSizes[i] = oldSizes[i];
+  }
+
+  // get the size of the output by swapping the size of input at index0 and
+  // index1 continue with the example above, if index0 = 0, index1 = 2, then
+  // output is of size out_size = [1, 4, 3, 2].
+  // Note: indices are shifted by (4u - nDims) since input is generalized into
+  // 4d.
+  out_size.data[(4u - nDims) + new_index0] =
+      in_size.data[(4u - nDims) + new_index1];
+  out_size.data[(4u - nDims) + new_index1] =
+      in_size.data[(4u - nDims) + new_index0];
+
+  // get the desired ordering of dimensions, again we shift by (4u - nDims).
+  // Using the example above, out_dims = [0, 3, 2, 1]
+  auto temp_dim = out_dims.data[(4u - nDims) + new_index0];
+  out_dims.data[(4u - nDims) + new_index0] =
+      out_dims.data[(4u - nDims) + new_index1];
+  out_dims.data[(4u - nDims) + new_index1] = temp_dim;
+
+  // get the size of the output by swapping sizes of the input. Continue with
+  // the example, newSizes = [1, 4, 3, 2]
+  newSizes[new_index0] = oldSizes[new_index1];
+  newSizes[new_index1] = oldSizes[new_index0];
+
+  vTensor v_output{api::context(), newSizes, self.scalar_type()};
+
+  return transpose_4d(self, in_size, out_size, out_dims, v_output);
+}
+
+Tensor t(const Tensor& self) {
+  TORCH_CHECK(self.dim() <= 2, "t() only supports tensors <= 2 dimensions");
+  return transpose(self.detach(), 0, self.dim() < 2 ? 0 : 1);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::t"), TORCH_FN(t));
+  m.impl(TORCH_SELECTIVE_NAME("aten::transpose.int"), TORCH_FN(transpose));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3384,6 +3384,160 @@ TEST_F(VulkanAPITest, unsqueeze_dim2) {
   test_unsqueeze({111, 222}, -1);
 }
 
+void test_t(const at::IntArrayRef input_shape) {
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = at::t(in_cpu);
+
+  const auto in_vulkan = in_cpu.vulkan();
+  const auto out_vulkan = at::t(in_vulkan);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, transpose_t_1d) {
+  test_t({7});
+}
+
+TEST_F(VulkanAPITest, transpose_t_2d_small) {
+  test_t({1, 1});
+}
+
+TEST_F(VulkanAPITest, transpose_t_2d_medium) {
+  test_t({7, 5});
+}
+
+TEST_F(VulkanAPITest, transpose_t_2d_large) {
+  test_t({53, 117});
+}
+
+void test_transpose(const at::IntArrayRef input_shape, int64_t index0, int64_t index1) {
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = at::transpose(in_cpu, index0, index1);
+
+  const auto in_vulkan = in_cpu.vulkan();
+  const auto out_vulkan = at::transpose(in_vulkan, index0, index1);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, transpose_2d_height_and_width_small) {
+  test_transpose({1, 1}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_2d_height_and_width_medium) {
+  test_transpose({7, 5}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_2d_height_and_width_large) {
+  test_transpose({53, 117}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_2d_height_and_height_large) {
+  test_transpose({53, 117}, 0, 0);
+}
+
+TEST_F(VulkanAPITest, transpose_2d_width_and_width_large) {
+  test_transpose({53, 117}, 1, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_height_and_width_small) {
+  test_transpose({1, 1, 1}, 1, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_height_and_width_medium) {
+  test_transpose({3, 2, 5}, 1, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_height_and_width_large) {
+  test_transpose({100, 1, 144}, 1, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_width_and_width_large) {
+  test_transpose({100, 1, 144}, 2, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_width_small) {
+  test_transpose({1, 1, 1}, 0, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_width_medium) {
+  test_transpose({3, 2, 5}, 0, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_width_large) {
+  test_transpose({113, 1, 141}, 0, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_depth_large) {
+  test_transpose({113, 2, 131}, 0, 0);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_height_small) {
+  test_transpose({1, 1, 1}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_height_medium) {
+  test_transpose({3, 7, 5}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_depth_and_height_large) {
+  test_transpose({113, 141, 1}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_3d_height_and_height_large) {
+  test_transpose({101, 1, 141}, 1, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_batch_and_batch_large) {
+  test_transpose({7, 51, 41, 3}, 0, 0);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_depth_and_depth_large) {
+  test_transpose({7, 51, 41, 3}, 1, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_height_and_height_large) {
+  test_transpose({7, 51, 41, 3}, 2, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_width_and_width_large) {
+  test_transpose({7, 51, 41, 3}, 3, 3);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_batch_and_depth_large) {
+  test_transpose({7, 51, 41, 3}, 0, 1);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_batch_and_height_large) {
+  test_transpose({7, 51, 41, 3}, 0, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_batch_and_width_large) {
+  test_transpose({7, 51, 41, 3}, 0, 3);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_depth_and_height_large) {
+  test_transpose({7, 51, 41, 3}, 1, 2);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_depth_and_width_large) {
+  test_transpose({7, 51, 41, 3}, 1, 3);
+}
+
+TEST_F(VulkanAPITest, transpose_4d_height_and_width_large) {
+  test_transpose({7, 51, 41, 3}, 2, 3);
+}
+
 TEST_F(VulkanAPITest, upsample_nearest2d) {
   const auto in_cpu = at::rand({1, 2, 2, 3}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   const auto out_cpu = at::upsample_nearest2d(in_cpu, {4, 6});


### PR DESCRIPTION
Summary:
Use the existing permute shader to implement the following two operators for Vulkan backend
- `aten::transpose` The behavior of the operator is shown in https://pytorch.org/docs/stable/generated/torch.transpose.html.
- `aten::t` The behavior of the operator is shown in https://pytorch.org/docs/stable/generated/torch.t.html#torch.t. 1d tensors are returned as is. When input is a 2d tensor this is equivalent to `aten::transpose(input, 0, 1)`.

Test Plan:
At local repo of fbsource on MacBook, run `buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1`
- Full test results P739033174.
- `aten::t` and `aten::tranpose` related results shown below
```
(base) luwei@luwei-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1

[... other tests ...]

[ RUN      ] VulkanAPITest.transpose_t_1d
[       OK ] VulkanAPITest.transpose_t_1d (0 ms)
[ RUN      ] VulkanAPITest.transpose_t_2d_small
[       OK ] VulkanAPITest.transpose_t_2d_small (1 ms)
[ RUN      ] VulkanAPITest.transpose_t_2d_medium
[       OK ] VulkanAPITest.transpose_t_2d_medium (0 ms)
[ RUN      ] VulkanAPITest.transpose_t_2d_large
[       OK ] VulkanAPITest.transpose_t_2d_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_2d_height_and_width_small
[       OK ] VulkanAPITest.transpose_2d_height_and_width_small (0 ms)
[ RUN      ] VulkanAPITest.transpose_2d_height_and_width_medium
[       OK ] VulkanAPITest.transpose_2d_height_and_width_medium (0 ms)
[ RUN      ] VulkanAPITest.transpose_2d_height_and_width_large
[       OK ] VulkanAPITest.transpose_2d_height_and_width_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_2d_height_and_height_large
[       OK ] VulkanAPITest.transpose_2d_height_and_height_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_2d_width_and_width_large
[       OK ] VulkanAPITest.transpose_2d_width_and_width_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_height_and_width_small
[       OK ] VulkanAPITest.transpose_3d_height_and_width_small (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_height_and_width_medium
[       OK ] VulkanAPITest.transpose_3d_height_and_width_medium (1 ms)
[ RUN      ] VulkanAPITest.transpose_3d_height_and_width_large
[       OK ] VulkanAPITest.transpose_3d_height_and_width_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_3d_width_and_width_large
[       OK ] VulkanAPITest.transpose_3d_width_and_width_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_width_small
[       OK ] VulkanAPITest.transpose_3d_depth_and_width_small (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_width_medium
[       OK ] VulkanAPITest.transpose_3d_depth_and_width_medium (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_width_large
[       OK ] VulkanAPITest.transpose_3d_depth_and_width_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_depth_large
[       OK ] VulkanAPITest.transpose_3d_depth_and_depth_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_height_small
[       OK ] VulkanAPITest.transpose_3d_depth_and_height_small (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_height_medium
[       OK ] VulkanAPITest.transpose_3d_depth_and_height_medium (0 ms)
[ RUN      ] VulkanAPITest.transpose_3d_depth_and_height_large
[       OK ] VulkanAPITest.transpose_3d_depth_and_height_large (2 ms)
[ RUN      ] VulkanAPITest.transpose_3d_height_and_height_large
[       OK ] VulkanAPITest.transpose_3d_height_and_height_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_4d_batch_and_batch_large
[       OK ] VulkanAPITest.transpose_4d_batch_and_batch_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_4d_depth_and_depth_large
[       OK ] VulkanAPITest.transpose_4d_depth_and_depth_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_4d_height_and_height_large
[       OK ] VulkanAPITest.transpose_4d_height_and_height_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_4d_width_and_width_large
[       OK ] VulkanAPITest.transpose_4d_width_and_width_large (0 ms)
[ RUN      ] VulkanAPITest.transpose_4d_batch_and_depth_large
[       OK ] VulkanAPITest.transpose_4d_batch_and_depth_large (1 ms)
[ RUN      ] VulkanAPITest.transpose_4d_batch_and_height_large
[       OK ] VulkanAPITest.transpose_4d_batch_and_height_large (2 ms)
[ RUN      ] VulkanAPITest.transpose_4d_batch_and_width_large
[       OK ] VulkanAPITest.transpose_4d_batch_and_width_large (2 ms)
[ RUN      ] VulkanAPITest.transpose_4d_depth_and_height_large
[       OK ] VulkanAPITest.transpose_4d_depth_and_height_large (2 ms)
[ RUN      ] VulkanAPITest.transpose_4d_depth_and_width_large
[       OK ] VulkanAPITest.transpose_4d_depth_and_width_large (2 ms)
[ RUN      ] VulkanAPITest.transpose_4d_height_and_width_large
[       OK ] VulkanAPITest.transpose_4d_height_and_width_large (1 ms)

[... other tests ...]
```

Reviewed By: SS-JIA

Differential Revision: D45878333

