### PR TITLE
[data_loader] Enable overriding signal handler in DataLoader.cpp

### DIFF
--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -103,14 +103,18 @@ static void handler_SIGTERM(int sig, siginfo_t* info, void* ctx) {
   }
 }
 
-static PyObject* THPModule_setWorkerSignalHandlers(
-    PyObject* module,
-    PyObject* arg) {
-  HANDLE_TH_ERRORS
+__attribute__((weak)) void setDataLoaderSignalHandlers() {
   setSignalHandler(SIGBUS, &handler_SIGBUS, nullptr);
   setSignalHandler(SIGSEGV, &handler_SIGSEGV, nullptr);
   setSignalHandler(SIGTERM, &handler_SIGTERM, nullptr);
   setSignalHandler(SIGFPE, &handler_SIGFPE, nullptr);
+}
+
+static PyObject* THPModule_setWorkerSignalHandlers(
+    PyObject* module,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  setDataLoaderSignalHandlers();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
Summary: Custom signal handlers (e.g. with more logging) can help in debugging crashes.

Test Plan: builds

Reviewed By: drej82

Differential Revision: D45934625

