### PR TITLE
[codemod][3.10][NamedTuple] Use typing_extensions to get NamedTuple Generics

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -18,14 +18,20 @@ from typing import (
     Generic,
     Iterator,
     List,
-    NamedTuple,
     Optional,
     Set,
     Tuple,
     Type,
     TypeVar,
     Union,
+    TYPE_CHECKING
 )
+if not TYPE_CHECKING:
+    # pyre isn't treating this the same as a typing.NamedTuple
+    from typing_extensions import NamedTuple
+else:
+    from typing import NamedTuple
+
 from unittest import skipIf
 
 import numpy as np


### PR DESCRIPTION
Summary:
3.10 doesn't have support for Generic NamedTuples, but it exists in future versions so typing_extensions supports it

(Note: this ignores all push blocking failures!)

Test Plan: sandcastle

Reviewed By: itamaro

Differential Revision: D45923201

