### PR TITLE
Update batch size for a couple models

### DIFF
--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -117,7 +117,7 @@ BATCH_SIZE_DIVISORS = {
     "DebertaForMaskedLM": 4,
     "DebertaForQuestionAnswering": 2,
     "DebertaV2ForMaskedLM": 4,
-    "DebertaV2ForQuestionAnswering": 4,
+    "DebertaV2ForQuestionAnswering": 8,
     "DistilBertForMaskedLM": 2,
     "DistilBertForQuestionAnswering": 2,
     "DistillGPT2": 2,

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -43,7 +43,7 @@ with open(filename, "r") as fh:
 
 BATCH_SIZE_DIVISORS = {
     "beit_base_patch16_224": 2,
-    "cait_m36_384": 2,
+    "cait_m36_384": 4,
     "convit_base": 2,
     "convmixer_768_32": 2,
     "convnext_base": 2,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101837

The memory compression for these models is at parity, but because we interleave timings between torch.compile and eager run memory is duplicated between between eager and cudagraphs pool and causes OOM.  


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire