### PR TITLE
`collect_env`: parse HIP version exception free

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -435,7 +435,7 @@ def get_env_info():
         else:  # HIP version
             def get_version_or_na(cfg, prefix):
                 _lst = [s.rsplit(None, 1)[-1] for s in cfg if prefix in s]
-                return _lst[0] if len(_lst) > 0 else 'N/A'
+                return _lst[0] if _lst else 'N/A'
 
             cfg = torch._C._show_config().split('\n')
             hip_runtime_version = get_version_or_na(cfg, 'HIP Runtime')

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -433,9 +433,13 @@ def get_env_info():
         if not hasattr(torch.version, 'hip') or torch.version.hip is None:  # cuda version
             hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
         else:  # HIP version
+            def get_version_or_na(cfg, prefix):
+                _lst = [s.rsplit(None, 1)[-1] for s in cfg if prefix in s]
+                return _lst[0] if len(_lst) > 0 else 'N/A'
+
             cfg = torch._C._show_config().split('\n')
-            hip_runtime_version = [s.rsplit(None, 1)[-1] for s in cfg if 'HIP Runtime' in s][0]
-            miopen_runtime_version = [s.rsplit(None, 1)[-1] for s in cfg if 'MIOpen' in s][0]
+            hip_runtime_version = get_version_or_na(cfg, 'HIP Runtime')
+            miopen_runtime_version = get_version_or_na(cfg, 'MIOpen')
             cuda_version_str = 'N/A'
             hip_compiled_version = torch.version.hip
     else:


### PR DESCRIPTION
Should prevent broken collect_env reporting as shown in https://github.com/pytorch/vision/issues/7561#issue-1698000841

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5204e0f</samp>

> _`get_version_or_na`_
> _Helper function refactors_
> _Code like autumn leaves_

