### PR TITLE
[pt2] Turn off lazy reinit when cuda graph is on

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1496,6 +1496,10 @@ class _TorchCompileInductorWrapper:
                 options or ()
             ), "triton.cudagraphs does not support dynamic shapes. Please set dynamic=False or triton.cudagraphs=False"
 
+        # FIXME: CUPTI Lazy Re-init and CUDA Graph crashes with CUDA 11.
+        if self.config.get("triton.cudagraphs", False):
+            os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
+
     def __eq__(self, other):
         return (isinstance(other, _TorchCompileInductorWrapper) and
                 self.config == other.config and


### PR DESCRIPTION
Summary: cuda graph doesn't work with cuda 11's cupti lazy reinit. So we'll turn it off if any modules turn on cudagraph

Test Plan: test with cuda graph on

Reviewed By: aaronenyeshi

Differential Revision: D45967197

