### PR TITLE
[WIP] Let torch.load load memory-mapped tensors (binary file attempt)

### DIFF
--- a/simple_mmap_serialize.py
+++ b/simple_mmap_serialize.py
@@ -1,0 +1,32 @@
+import torch
+from memory_profiler import profile
+import time
+
+state_dict_name = "state_dict_mmap.pt"
+tensor_size = 1_000_000_000
+
+@profile
+def f():
+    # should be 1_000_000_000 * 8 bytes = 8 GB
+    print("generating weight")
+    state_dict = {'weight1': torch.randn(tensor_size, dtype=torch.float64),
+                  'weight2': torch.randn((2, 3), dtype=torch.float32)}
+    print("generation of weight done")
+    # print(state_dict['weight2'])
+    saving_start = time.time()
+    torch.save(state_dict, state_dict_name, _mmap=True)
+    saving_end = time.time()
+    print(f"saving done, time={saving_end - saving_start}")
+    loading_start = time.time()
+    state_dict_loaded = torch.load(state_dict_name, _mmap=True)
+    loading_end = time.time()
+    print(f"loading done, time={loading_end - loading_start}")
+    x = state_dict_loaded['weight1']
+    y = state_dict_loaded['weight2']
+    # print(y)
+    assert torch.equal(state_dict['weight1'], x)
+    assert torch.equal(state_dict['weight2'], y)
+    print("loading done")
+
+if __name__ == "__main__":
+    f()


### PR DESCRIPTION
Separate approach to #101446 

To my knowledge, `tarfile.extract` will create a copy on disk (and if we want to read in place (which doesn't seem super well documented(?), we still have to handled the padding to page size part).

Maybe managing our own binary file where we're super clear about how to read in place might be better. 

This PR implements the binary file format as such 

```
Format of our binary file is
    #  -------------- -------------- -------------------------- ----- ------------ ----- ------------ --------------
    # | [p] magic_no | [p] protocol | [p] total_storage_nbytes | *** | [r] s_0 ***| ... | [r] s_n ***| [p] data.pkl |
    #  -------------- -------------- -------------------------- ----- ------------ ----- ------------ --------------
    # where [p] indicates pickled and [r] indicates raw bytes and *** indicates padding up to page alignment (4096)
    # s_0 to s_n are storages
    # data.pkl indicates what is normally saved in the separate data.pkl file
    # in the zipfile using the default torch.load serialization logic
```

Something not so good about this is: **the offset passed to mmap must be page-aligned**. I'm padding all tensor starts to the nearest multiple of 4096 bytes right now. This could be problematic if 

1) save on system with one page size and load on a system with a different page size 
2) padding is a bit wasteful but I would like to argue that 4kB is not bad when mmap is mostly useful for HUGE tensors!

Not yet handled:

- [ ] endianness -- how can you byteswap + mmap
- [ ] this case: save on system with one page size and load on a system with a different page size --> warn and fallback?
- [ ] better API where `torch.save(_mmap=True)` --> no need to pass _mmap to `torch.load`


Things I am worried about/would like to do
- [ ] There is only 1 real fd open, I'm dup-ing all the rest right now. I'm setting the flag to close the fd immediately after mmap is called, which should be ok but I wonder whether there will be any weird interactions with too many fds being open?
- [ ] Try to serialize some sort of huge model + way more extensive testing
- [ ] Will there be a future world where we `torch.save` with multiple processes? How will this interact with the above?


Other thoughts
- [ ] Should the MapAllocator take the shared flag?

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #101854
* #101853

