### PR TITLE
inductor: fix bfloat16 store complier issue

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1574,6 +1574,13 @@ class CPUReproTests(TestCase):
         x = torch.rand(16)
         self.common(f, (x,))
 
+    def test_to_channels_last_bfloat16(self):
+        def f(a):
+            return a.to(memory_format=torch.channels_last)
+
+        x = torch.rand(2, 3, 14, 14).bfloat16()
+        self.common(f, (x,))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1266,19 +1266,19 @@ class CppVecKernel(CppKernel):
         if is_broadcast:
             if is_mask:
                 loadbuf = f"flag_to_float_scalar({loadbuf})"
-            line = f"at::vec::Vectorized<float>(static_cast<float>({loadbuf}));"
+            line = f"at::vec::Vectorized<float>(static_cast<float>({loadbuf}))"
         elif dtype in [torch.uint8] and opt_ctx.is_load_uint8_as_float:
-            line = f"at::vec::load_uint8_as_float({var_expr});"
+            line = f"at::vec::load_uint8_as_float({var_expr})"
         elif is_mask:
-            line = f"flag_to_float_vec({loadbuf});"
+            line = f"flag_to_float_vec({loadbuf})"
         elif dtype in [torch.bfloat16]:
             if opt_ctx.is_load_bf16_as_fp32:
-                line = f"load_bf16_as_float({loadbuf});"
+                line = f"load_bf16_as_float({loadbuf})"
             else:
                 assert opt_ctx.is_bf16_mem_copy
-                line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor});"
+                line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor})"
         else:
-            line = f"at::vec::Vectorized<float>::loadu({loadbuf});"
+            line = f"at::vec::Vectorized<float>::loadu({loadbuf})"
         if non_contiguous:
             tmpbuftype = "float" if is_mask else f"{DTYPE_TO_CPP[dtype]}"
             tmpbufsize = f"{self.tiling_factor}"
@@ -1521,12 +1521,12 @@ class CppTile2DKernel(CppVecKernel):
             loadbuf = f"{tile_var} + {cexpr_index(inner * self.tiling_factor)}"
             if V.graph.get_dtype(name) in [torch.bfloat16]:
                 if opt_ctx.is_load_bf16_as_fp32:
-                    line = f"load_bf16_as_float({loadbuf});"
+                    line = f"load_bf16_as_float({loadbuf})"
                 else:
                     assert opt_ctx.is_bf16_mem_copy
-                    line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor});"
+                    line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor})"
             else:
-                line = f"at::vec::Vectorized<float>::loadu({loadbuf});"
+                line = f"at::vec::Vectorized<float>::loadu({loadbuf})"
             return self.cse.generate(self.loads, line)
         else:
             new_index = self.scale_index_with_offset(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1266,19 +1266,19 @@ class CppVecKernel(CppKernel):
         if is_broadcast:
             if is_mask:
                 loadbuf = f"flag_to_float_scalar({loadbuf})"
-            line = f"at::vec::Vectorized<float>(static_cast<float>({loadbuf}))"
+            line = f"at::vec::Vectorized<float>(static_cast<float>({loadbuf}));"
         elif dtype in [torch.uint8] and opt_ctx.is_load_uint8_as_float:
-            line = f"at::vec::load_uint8_as_float({var_expr})"
+            line = f"at::vec::load_uint8_as_float({var_expr});"
         elif is_mask:
-            line = f"flag_to_float_vec({loadbuf})"
+            line = f"flag_to_float_vec({loadbuf});"
         elif dtype in [torch.bfloat16]:
             if opt_ctx.is_load_bf16_as_fp32:
-                line = f"load_bf16_as_float({loadbuf})"
+                line = f"load_bf16_as_float({loadbuf});"
             else:
                 assert opt_ctx.is_bf16_mem_copy
-                line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor})"
+                line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor});"
         else:
-            line = f"at::vec::Vectorized<float>::loadu({loadbuf})"
+            line = f"at::vec::Vectorized<float>::loadu({loadbuf});"
         if non_contiguous:
             tmpbuftype = "float" if is_mask else f"{DTYPE_TO_CPP[dtype]}"
             tmpbufsize = f"{self.tiling_factor}"
@@ -1521,12 +1521,12 @@ class CppTile2DKernel(CppVecKernel):
             loadbuf = f"{tile_var} + {cexpr_index(inner * self.tiling_factor)}"
             if V.graph.get_dtype(name) in [torch.bfloat16]:
                 if opt_ctx.is_load_bf16_as_fp32:
-                    line = f"load_bf16_as_float({loadbuf})"
+                    line = f"load_bf16_as_float({loadbuf});"
                 else:
                     assert opt_ctx.is_bf16_mem_copy
-                    line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor})"
+                    line = f"at::vec::Vectorized<bfloat16>::loadu({loadbuf}, {self.tiling_factor});"
             else:
-                line = f"at::vec::Vectorized<float>::loadu({loadbuf})"
+                line = f"at::vec::Vectorized<float>::loadu({loadbuf});"
             return self.cse.generate(self.loads, line)
         else:
             new_index = self.scale_index_with_offset(
@@ -1552,10 +1552,10 @@ class CppTile2DKernel(CppVecKernel):
             storebuf = f"{tile_var} + {cexpr_index(inner * self.tiling_factor)}"
             if V.graph.get_dtype(name) in [torch.bfloat16]:
                 if opt_ctx.is_store_fp32_as_bf16:
-                    line = f"store_float_as_bf16({storebuf}, {value})"
+                    line = f"store_float_as_bf16({storebuf}, {value});"
                 else:
                     assert opt_ctx.is_bf16_mem_copy
-                    line = f"{value}.store({storebuf}, {self.tiling_factor})"
+                    line = f"{value}.store({storebuf}, {self.tiling_factor});"
             else:
                 line = f"{value}.store({storebuf});"
             self.stores.writeline(DeferredLine(name, line))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #101865
* __->__ #101856
* #101793

Fix the bfloat16 compiler error:
```
/tmp/torchinductor_xiaobing/ez/cezrraw7rtu5vkxcfd544i53crqaobycprf5twyvf7b62jrgi75p.cpp: In function ‘void kernel(const bfloat16*, bfloat16*)’:
/tmp/torchinductor_xiaobing/ez/cezrraw7rtu5vkxcfd544i53crqaobycprf5twyvf7b62jrgi75p.cpp:20:79: error: expected ‘;’ before ‘}’ token
   20 |                         tmp0.store(tmp1 + static_cast<long>(16L*i1_inner), 16)
      |                                                                               ^
      |                                                                               ;
   21 |                     }

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire