### PR TITLE
Import `inf` in inductor.codegen.wrapper.WrapperCodeGen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6119,6 +6119,16 @@ class CommonTemplate:
                 opt_fn = torch._dynamo.optimize("inductor")(fn)
                 same(fn(*args, 256), opt_fn(*args, 256))
 
+    @patch.object(config, "disable_cpp_codegen", True)
+    def test_inf_import(self):
+        def fn(x):
+            return torch.full_like(x, -inf)
+
+        x = torch.rand((4, 4))
+        ref = fn(x)
+        res = torch._dynamo.optimize("inductor")(fn)(x)
+        same(res, ref)
+
     def test_slice(self):
         def fn(a, b):
             return torch.ops.aten.slice.Tensor(a, 0, 0, -b)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -303,6 +303,7 @@ class WrapperCodeGen(CodeGen):
                 from torch._inductor.hooks import run_intermediate_hooks
                 from torch._inductor.utils import maybe_profile
 
+                from math import inf
                 from torch import empty_strided, as_strided, device
                 from {codecache.__name__} import AsyncCompile
                 from torch._inductor.select_algorithm import extern_kernels


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101875

When disable_cpp_codegen is turned on, we can end up with WrapperCodeGen generating code that uses `inf`. Previously, `inf` wasn't imported so this would fail.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire

Differential Revision: [D46023537](https://our.internmc.facebook.com/intern/diff/D46023537)