### PR TITLE
Make _StorageBase.byteswap faster ( > 10000x)

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6868,7 +6868,7 @@ class TestTorch(TestCase):
         swapped_8bytes = [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8]
         swapped_4bytes = [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12]
         swapped_2bytes = [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14]
-        swapped_1byte  = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        swapped_1byte = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 
         storage = torch.storage.TypedStorage(input, dtype=torch.uint8)._untyped_storage
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6863,6 +6863,63 @@ class TestTorch(TestCase):
         self.assertEqual(complexdouble_storage.type(), 'torch.ComplexDoubleStorage')
         self.assertIs(complexdouble_storage.dtype, torch.complex128)
 
+    def test_storage_byteswap(self):
+        input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        swapped_8bytes = [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8]
+        swapped_4bytes = [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12]
+        swapped_2bytes = [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14]
+        swapped_1byte  = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+        storage = torch.storage.TypedStorage(input, dtype=torch.uint8)._untyped_storage
+
+        storage_f64 = storage.__copy__()
+        storage_f64.byteswap(torch.float64)
+        self.assertEqual(storage_f64.tolist(), swapped_8bytes)
+
+        storage_f32 = storage.__copy__()
+        storage_f32.byteswap(torch.float32)
+        self.assertEqual(storage_f32.tolist(), swapped_4bytes)
+
+        storage_f16 = storage.__copy__()
+        storage_f16.byteswap(torch.float16)
+        self.assertEqual(storage_f16.tolist(), swapped_2bytes)
+
+        storage_bf16 = storage.__copy__()
+        storage_bf16.byteswap(torch.bfloat16)
+        self.assertEqual(storage_bf16.tolist(), swapped_2bytes)
+
+        storage_i64 = storage.__copy__()
+        storage_i64.byteswap(torch.int64)
+        self.assertEqual(storage_i64.tolist(), swapped_8bytes)
+
+        storage_i32 = storage.__copy__()
+        storage_i32.byteswap(torch.int32)
+        self.assertEqual(storage_i32.tolist(), swapped_4bytes)
+
+        storage_i16 = storage.__copy__()
+        storage_i16.byteswap(torch.int16)
+        self.assertEqual(storage_i16.tolist(), swapped_2bytes)
+
+        storage_i8 = storage.__copy__()
+        storage_i8.byteswap(torch.int8)
+        self.assertEqual(storage_i8.tolist(), swapped_1byte)
+
+        storage_ui8 = storage.__copy__()
+        storage_ui8.byteswap(torch.uint8)
+        self.assertEqual(storage_ui8.tolist(), swapped_1byte)
+
+        storage_bool = storage.__copy__()
+        storage_bool.byteswap(torch.bool)
+        self.assertEqual(storage_bool.tolist(), swapped_1byte)
+
+        storage_c128 = storage.__copy__()
+        storage_c128.byteswap(torch.complex128)
+        self.assertEqual(storage_c128.tolist(), swapped_8bytes)
+
+        storage_c64 = storage.__copy__()
+        storage_c64.byteswap(torch.complex64)
+        self.assertEqual(storage_c64.tolist(), swapped_4bytes)
+
     # Test that internal versions of functions related to TypedStorage do not
     # produce a deprecation warning
     def test_typed_storage_internal_no_warning(self):

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -658,28 +658,28 @@ PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
 
   const auto& storage = THPStorage_Unpack(self);
   const auto nbytes = static_cast<uint64_t>(storage.nbytes());
+  const uint64_t count = nbytes / elem_size;
+
+  if (elem_size == 1) {
+    Py_RETURN_NONE;
+  }
+  THPUtils_assert(
+      nbytes % elem_size == 0,
+      "the length of data is not a multiple of %ld",
+      elem_size);
 
   if (elem_size == 2) {
-    THPUtils_assert(
-        nbytes % 2 == 0, "the length of data is not a multiple of 2");
     auto buffer = static_cast<uint16_t*>(storage.mutable_data());
-    const uint64_t count = nbytes / 2;
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap16(*buffer);
     }
   } else if (elem_size == 4) {
-    THPUtils_assert(
-        nbytes % 4 == 0, "the length of data is not a multiple of 4");
     auto buffer = static_cast<uint32_t*>(storage.mutable_data());
-    const uint64_t count = nbytes / 4;
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap32(*buffer);
     }
   } else if (elem_size == 8) {
-    THPUtils_assert(
-        nbytes % 8 == 0, "the length of data is not a multiple of 8");
     auto buffer = static_cast<uint64_t*>(storage.mutable_data());
-    const uint64_t count = nbytes / 8;
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap64(*buffer);
     }

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -663,7 +663,7 @@ PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
     THPUtils_assert(
         nbytes % 2 == 0, "the length of data is not a multiple of 2");
     auto buffer = static_cast<uint16_t*>(storage.mutable_data());
-    const uint64_t count = nbytes / 4;
+    const uint64_t count = nbytes / 2;
     for (uint64_t i = 0; i < count; i++, buffer++) {
       *buffer = thp_bswap16(*buffer);
     }

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -645,50 +645,6 @@ PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   }
 }
 
-PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
-  HANDLE_TH_ERRORS
-  THPUtils_assert(PyTuple_GET_SIZE(args) == 1, "tuple of 1 item expected");
-  PyObject* _elem_size = PyTuple_GET_ITEM(args, 0);
-  THPUtils_assert(
-      THPUtils_checkLong(_elem_size), "_byteswap(): arg must be an 'int'");
-  auto elem_size = THPUtils_unpackLong(_elem_size);
-  THPUtils_assert(
-      elem_size == 1 || elem_size == 2 || elem_size == 4 || elem_size == 8,
-      "elem_size must be 1, 2, 4, or 8");
-
-  const auto& storage = THPStorage_Unpack(self);
-  const auto nbytes = static_cast<uint64_t>(storage.nbytes());
-  const uint64_t count = nbytes / elem_size;
-
-  if (elem_size == 1) {
-    Py_RETURN_NONE;
-  }
-  THPUtils_assert(
-      nbytes % elem_size == 0,
-      "the length of data is not a multiple of %ld",
-      elem_size);
-
-  if (elem_size == 2) {
-    auto buffer = static_cast<uint16_t*>(storage.mutable_data());
-    for (uint64_t i = 0; i < count; i++, buffer++) {
-      *buffer = thp_bswap16(*buffer);
-    }
-  } else if (elem_size == 4) {
-    auto buffer = static_cast<uint32_t*>(storage.mutable_data());
-    for (uint64_t i = 0; i < count; i++, buffer++) {
-      *buffer = thp_bswap32(*buffer);
-    }
-  } else if (elem_size == 8) {
-    auto buffer = static_cast<uint64_t*>(storage.mutable_data());
-    for (uint64_t i = 0; i < count; i++, buffer++) {
-      *buffer = thp_bswap64(*buffer);
-    }
-  }
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)
 static PyMethodDef THPStorage_sharingMethods[] = {
     {"_new_with_weak_ptr",
@@ -729,7 +685,6 @@ static PyMethodDef THPStorage_sharingMethods[] = {
     {"_shared_incref", THPStorage_sharedIncref, METH_NOARGS, nullptr},
     {"_get_shared_fd", THPStorage_sharedFd, METH_NOARGS, nullptr},
     {"is_shared", THPStorage_isShared, METH_NOARGS, nullptr},
-    {"_byteswap", THPStorage_byteswap, METH_VARARGS, nullptr},
     {nullptr}};
 
 PyMethodDef* THPStorage_getSharingMethods() {

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -12,7 +12,6 @@
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/copy_utils.h>
-#include <torch/csrc/utils/byte_order.h>
 
 #include <c10/util/intrusive_ptr.h>
 #include <fmt/format.h>

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/copy_utils.h>
+#include <torch/csrc/utils/byte_order.h>
 
 #include <c10/util/intrusive_ptr.h>
 #include <fmt/format.h>
@@ -644,6 +645,50 @@ PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   }
 }
 
+PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
+  HANDLE_TH_ERRORS
+  THPUtils_assert(PyTuple_GET_SIZE(args) == 1, "tuple of 1 item expected");
+  PyObject* _elem_size = PyTuple_GET_ITEM(args, 0);
+  THPUtils_assert(
+      THPUtils_checkLong(_elem_size), "_byteswap(): arg must be an 'int'");
+  auto elem_size = THPUtils_unpackLong(_elem_size);
+  THPUtils_assert(
+      elem_size == 1 || elem_size == 2 || elem_size == 4 || elem_size == 8,
+      "elem_size must be 1, 2, 4, or 8");
+
+  const auto& storage = THPStorage_Unpack(self);
+  const auto nbytes = static_cast<uint64_t>(storage.nbytes());
+
+  if (elem_size == 2) {
+    THPUtils_assert(
+        nbytes % 2 == 0, "the length of data is not a multiple of 2");
+    auto buffer = static_cast<uint16_t*>(storage.mutable_data());
+    const uint64_t count = nbytes / 4;
+    for (uint64_t i = 0; i < count; i++, buffer++) {
+      *buffer = thp_bswap16(*buffer);
+    }
+  } else if (elem_size == 4) {
+    THPUtils_assert(
+        nbytes % 4 == 0, "the length of data is not a multiple of 4");
+    auto buffer = static_cast<uint32_t*>(storage.mutable_data());
+    const uint64_t count = nbytes / 4;
+    for (uint64_t i = 0; i < count; i++, buffer++) {
+      *buffer = thp_bswap32(*buffer);
+    }
+  } else if (elem_size == 8) {
+    THPUtils_assert(
+        nbytes % 8 == 0, "the length of data is not a multiple of 8");
+    auto buffer = static_cast<uint64_t*>(storage.mutable_data());
+    const uint64_t count = nbytes / 8;
+    for (uint64_t i = 0; i < count; i++, buffer++) {
+      *buffer = thp_bswap64(*buffer);
+    }
+  }
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)
 static PyMethodDef THPStorage_sharingMethods[] = {
     {"_new_with_weak_ptr",
@@ -684,6 +729,7 @@ static PyMethodDef THPStorage_sharingMethods[] = {
     {"_shared_incref", THPStorage_sharedIncref, METH_NOARGS, nullptr},
     {"_get_shared_fd", THPStorage_sharedFd, METH_NOARGS, nullptr},
     {"is_shared", THPStorage_isShared, METH_NOARGS, nullptr},
+    {"_byteswap", THPStorage_byteswap, METH_VARARGS, nullptr},
     {nullptr}};
 
 PyMethodDef* THPStorage_getSharingMethods() {

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -29,7 +29,6 @@ class _StorageBase:
     def __init__(self, *args, **kwargs): ...  # noqa: E704
     def __len__(self) -> int: ...  # noqa: E704
     def __getitem__(self, idx): ...  # noqa: E704
-    def __setitem__(self, *args, **kwargs): ...  # noqa: E704
     def copy_(self, source: T, non_blocking: bool = None) -> T: ...  # noqa: E704
     def new(self) -> T: ...  # noqa: E704
     def nbytes(self) -> int: ...  # noqa: E704
@@ -80,6 +79,7 @@ class _StorageBase:
     def from_file(cls, filename, shared, nbytes) -> T: ...  # noqa: E704
     @classmethod
     def _expired(cls, *args, **kwargs) -> T: ...  # noqa: E704
+    def _byteswap(self, *args, **kwargs): ...  # noqa: E704
 
     def __str__(self):
         info_str = (
@@ -266,10 +266,7 @@ class _StorageBase:
         # for complex types, don't swap first and second numbers
         if dtype.is_complex:
             elem_size = max(int(elem_size / 2), 1)
-        for i in range(int(len(self) / elem_size)):
-            for k in range(int(elem_size / 2)):
-                self[i * elem_size + k], self[i * elem_size + elem_size - k - 1] = \
-                    self[i * elem_size + elem_size - k - 1], self[i * elem_size + k]
+        self._byteswap(elem_size)
 
 
 def _share_memory_lock_protected(fn):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -29,6 +29,7 @@ class _StorageBase:
     def __init__(self, *args, **kwargs): ...  # noqa: E704
     def __len__(self) -> int: ...  # noqa: E704
     def __getitem__(self, idx): ...  # noqa: E704
+    def __setitem__(self, *args, **kwargs): ...  # noqa: E704
     def copy_(self, source: T, non_blocking: bool = None) -> T: ...  # noqa: E704
     def new(self) -> T: ...  # noqa: E704
     def nbytes(self) -> int: ...  # noqa: E704


### PR DESCRIPTION
This PR addresses #101690. This PR implement faster data elements swap in `_StorageBase` using C++ rather than using Python.

This PR helps such a situation that a large model saved on a little-endian machine will be loaded on a big-endian machine.

TODO:
- [x] Add test cases
- [x] Add performance comparison before and after the PR
- [ ] (Optional) Investigate further opportunities for performance improvements by [SIMDization](https://dev.to/wunk/fast-array-reversal-with-simd-j3p)

Fixes #101690
