### PR TITLE
Add quantization lowering for nn.PixelShuffle and nn.PixelUnshuffle

### DIFF
--- a/torch/ao/ns/fx/mappings.py
+++ b/torch/ao/ns/fx/mappings.py
@@ -336,9 +336,15 @@ def get_base_name_to_sets_of_related_ops() -> Dict[str, Set[NSNodeTargetType]]:
         },
         # pixel shuffle
         {
+            nn.PixelShuffle,
+        },
+        {
             F.pixel_shuffle,
         },
         # pixel unshuffle
+        {
+            nn.PixelUnshuffle,
+        },
         {
             F.pixel_unshuffle,
         },
@@ -684,6 +690,8 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
         nn.MaxPool1d,
         nn.MaxPool2d,
         nn.MaxPool3d,
+        nn.PixelShuffle,
+        nn.PixelUnshuffle,
         nn.ReLU6,
     }
 

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -498,6 +498,8 @@ def _get_share_qparams_op_configs(dtype_configs):
         torch.nn.MaxPool1d,
         torch.nn.MaxPool2d,
         torch.nn.MaxPool3d,
+        torch.nn.PixelShuffle,
+        torch.nn.PixelUnshuffle,
         torch.nn.ReLU,
         torch.nn.ReLU6,
         torch.adaptive_avg_pool1d,

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -170,6 +170,8 @@ def is_general_tensor_shape_node(node, modules):
     ]
     module_type_list = [
         torch.nn.Identity,
+        torch.nn.PixelShuffle,
+        torch.nn.PixelUnshuffle,
     ]
     return _is_node_in_list(node, modules, func_list, method_list, module_type_list)
 


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/96160 but for the modules
nn.PixelShuffle and nn.PixelUnshuffle.

torch.nn.PixelUnshuffle accepts both float and quantized inputs.
However, previously we would unnecessarily dequantize quantized inputs into floats
before passing them to the function. This commit fixes this by lowering the pattern
[dequant - PixelShuffle - quant].
[dequant - PixelUnshuffle - quant].

Test Plan:

python test/test_quantization.py TestQuantizeFxOps.test_pixel_shuffle_module
python test/test_quantization.py TestQuantizeFxOps.test_pixel_unshuffle_module
