### PR TITLE
[inductor] use native fetch_add function for trivial types

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/inductor_cpu_atomic.py
+++ b/benchmarks/dynamo/microbenchmarks/inductor_cpu_atomic.py
@@ -1,0 +1,78 @@
+import itertools
+
+import torch
+import torch._dynamo
+from benchmark_helper import time_with_torch_timer
+
+
+@torch._dynamo.optimize("inductor", nopython=True)
+def inductor_scatter_add(dst, src, index):
+    return torch.scatter_add(dst, 1, index, src)
+
+
+def torch_scatter_add(dst, src, index):
+    return torch.scatter_add(dst, 1, index, src)
+
+
+def test_total_time(shapes, types):
+    print(
+        "shape; type; torch scatter_add; inductor scatter_add; torch scatter_add (worst case); inductor scatter_add (worst case)"
+    )
+    for shape, dtype in itertools.product(shapes, types):
+        print(shape, dtype, sep="; ", end="; ")
+
+        torch.manual_seed(1)
+        if dtype.is_floating_point:
+            src = torch.randn(shape, device="cpu", dtype=dtype)
+            dst = torch.randn(shape, device="cpu", dtype=dtype)
+        else:
+            src = torch.randint(0, shape[1], shape, device="cpu", dtype=dtype)
+            dst = torch.randint(0, shape[1], shape, device="cpu", dtype=dtype)
+        index = torch.randint(0, shape[1], shape, device="cpu", dtype=torch.int64)
+        worst_index = torch.tensor([[0] * shape[1]], device="cpu", dtype=torch.int64)
+
+        torch_result = torch_scatter_add(dst, src, index)
+        inductor_result = inductor_scatter_add(dst, src, index)
+        torch.testing.assert_close(torch_result, inductor_result)
+
+        torch_ms = (
+            time_with_torch_timer(torch_scatter_add, (dst, src, index)).mean * 1000
+        )
+        inductor_ms = (
+            time_with_torch_timer(inductor_scatter_add, (dst, src, index)).mean * 1000
+        )
+        torch_worst_ms = (
+            time_with_torch_timer(torch_scatter_add, (dst, src, worst_index)).mean
+            * 1000
+        )
+        inductor_worst_ms = (
+            time_with_torch_timer(inductor_scatter_add, (dst, src, worst_index)).mean
+            * 1000
+        )
+
+        print(torch_ms, inductor_ms, torch_worst_ms, inductor_worst_ms, sep="; ")
+
+        torch._dynamo.reset()
+
+
+if __name__ == "__main__":
+    shapes = [
+        ([1, 4096]),
+        ([1, 65536]),
+    ]
+    types = [
+        torch.float32,
+        torch.int32,
+    ]
+    print("test total time")
+    test_total_time(shapes, types)
+
+# Results preview on 5800H
+"""
+test total time
+shape; type; torch scatter_add; inductor scatter_add; torch scatter_add (worst case); inductor scatter_add (worst case)
+[1, 4096]; torch.float32; 0.14733232000025964; 0.05388864999986254; 0.1451428800010035; 0.06496850000075938
+[1, 4096]; torch.int32; 0.1440268700002889; 0.05882900999949925; 0.1429359899998417; 0.07036211000013282
+[1, 65536]; torch.float32; 1.3435545300012564; 0.15207924000151252; 1.2523296799986383; 3.1408327299982375
+[1, 65536]; torch.int32; 1.3407247500003905; 0.12999147000073208; 1.2956029100018895; 0.853825209999286
+"""

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -80,7 +80,9 @@ inline bfloat16 fetch_value<bfloat16>(volatile bfloat16 *addr) {
   return bfloat16(addr->x);
 }
 
-template <typename T> void atomic_add(volatile T *addr, T offset) {
+template <typename T>
+typename std::enable_if<!std::is_integral<T>::value>::type
+atomic_add(volatile T *addr, T offset) {
   typedef typename AsIntegerType<T>::type alt_type;
 
   static_assert(sizeof(std::atomic<alt_type>) == sizeof(T),
@@ -97,6 +99,18 @@ template <typename T> void atomic_add(volatile T *addr, T offset) {
     reinterpret_cast<T *>(&desired)[0] = val + offset;
   } while (!atomic_addr->compare_exchange_weak(expected, desired,
                                                std::memory_order_relaxed));
+}
+
+// Since C++20 float is supported by fetch_add, but the performance may not
+// better than compare_exchange_weak, which can be checked by microbenchmark
+// inductor_cpu_atomic.py
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value>::type
+atomic_add(volatile T *addr, T offset) {
+  static_assert(sizeof(std::atomic<T>) == sizeof(T),
+                "std::atomic issue");
+  std::atomic<T> *atomic_addr = (std::atomic<T> *)addr;
+  atomic_addr->fetch_add(offset, std::memory_order_relaxed);
 }
 
 // This function is used to convert bool or uint8 to float mask for


### PR DESCRIPTION
floating-point is supported by std::atomic::fetch_add since C++20.
However, this code path is not activated yet because cpp_flags in codecache.py is hard-coded to "-std=c++17"

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @anijain2305