### PR TITLE
Hint Tensor._make_subclass as a staticmethod

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -838,10 +838,10 @@ def gen_pyi(
             ],
             "as_subclass": ["def as_subclass(self, cls: Type[S]) -> S: ..."],
             "_make_subclass": [
-                "def _make_subclass({}) -> Tensor: ...".format(
+                "@staticmethod    \ndef _make_subclass({}) -> S: ...".format(
                     ", ".join(
                         [
-                            "cls",
+                            "cls: Type[S]",
                             "data: Tensor",
                             "require_grad: _bool = False",
                             "dispatch_strides: _bool = False",

--- a/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
@@ -1,11 +1,10 @@
 from contextlib import contextmanager
 
-from torch._C import _TensorBase
 import torch
 import functools
 from torch._decomp import decomposition_table
 
-from typing import Callable, Dict, cast
+from typing import Callable, Dict
 
 from torch.utils._pytree import tree_map_only
 
@@ -96,7 +95,7 @@ class ExpandedWeight(torch.Tensor):
             raise RuntimeError(f"Can only make Expanded Weights of Tensors, got {type(orig_weight).__name__}")
         if not orig_weight.requires_grad:
             raise RuntimeError("Can only build ExpandedWeights objects of tensors that require_grad")
-        ret = torch.Tensor._make_subclass(cast(_TensorBase, cls), orig_weight, True)
+        ret = torch.Tensor._make_subclass(cls, orig_weight, True)
         return ret
 
     @classmethod


### PR DESCRIPTION
Fixes #101862

No more type errors and improved return type value:
```python
import torch
from torch import nn


t = torch.tensor([1, 2, 3], dtype=torch.float32)

t2 = torch.Tensor._make_subclass(  # OK
    nn.Parameter,
    t.data,
)
reveal_type(t2)  # Type of "t2" is "Parameter"

t3 = t._make_subclass(  # OK
    nn.Parameter,
    t.data,
)
reveal_type(t3)  # Type of "t3" is "Parameter"

```

cc: @ezyang 