### PR TITLE
Add functions to get and set default endianness in load() functions

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -556,6 +556,19 @@ void PyTorchStreamWriter::writeEndOfFile() {
       writeRecord("version", version.c_str(), version.size());
     }
   }
+
+  // If no "byteorder" record in the output model, rewrites byteorder info
+  if(allRecords.find("byteorder") == allRecords.end()) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    std::string byteorder = "little";
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    std::string byteorder = "big";
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
+    writeRecord("byteorder", byteorder.c_str(), byteorder.size());
+  }
+
   writeSerializationId();
 
   AT_ASSERT(!finalized_);

--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -352,3 +352,5 @@ The following utility functions are related to serialization:
 .. currentmodule:: torch.serialization
 
 .. autofunction:: register_package
+.. autofunction:: get_default_load_endianness
+.. autofunction:: set_default_load_endianness

--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -46,6 +46,7 @@ class TestMisc(PackageTestCase):
                 ├── package_a
                 │   ├── __init__.py
                 │   └── subpackage.py
+                ├── byteorder
                 └── module_a.py
             """
         )
@@ -71,6 +72,7 @@ class TestMisc(PackageTestCase):
                 ├── package_a
                 │   ├── __init__.py
                 │   └── subpackage.py
+                ├── byteorder
                 └── module_a.py
             """
         )


### PR DESCRIPTION
By default interpret tensor data as native endian, but add an option to interpret data as little endian or big endian.

Related to #101688
