### PR TITLE
[inductor] Update qualname and module for wrapped testcases

### DIFF
--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -187,6 +187,9 @@ class ContextDecorator(contextlib.ContextDecorator):
                         self.__exit__(None, None, None)
 
             _TestCase.__name__ = func.__name__
+            _TestCase.__qualname__ = func.__qualname__
+            _TestCase.__module__ = func.__module__
+
             return _TestCase
 
         return super().__call__(func)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101975

D45936056 was hitting bizarre failures running unit tests under FB's
test runner, where we'd see things like:
```
9 TESTS FAILED
  ✗ caffe2/test/inductor:fused_attention - <locals> (unittest.loader._FailedTest)
```

The reason for this is, it turns out the test runner uses a two-step process
where it first lists the tests, in one process, and then runs them using the
names from the listing step in separate processes

But, since we're decorating the class, it ends getting listed with a weird name
like `torch._dynamo.config_utils.ContextDecorator.__call__.<locals>._TestCase`,
and when the runner tries to load that module, it fails.

So one solution (other than, you know, using pytest) is to update the
__qualname__ and __module__ of the _TestCase wrapper so that the runner will
actually load the right module.

@build[pytorch_dynamo_inductor]

Differential Revision: [D46044467](https://our.internmc.facebook.com/intern/diff/D46044467/)

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx