### PR TITLE
[Reland] fix missing-prototypes warnings in torch_cpu (Part 5) 

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -140,16 +140,6 @@ namespace {
     }
   }
 
-  Tensor& adaptive_avg_pool2d_backward_out_cpu(
-    Tensor& grad_input,
-    const Tensor& grad_output,
-    const Tensor& input)
-  {
-    adaptive_avg_pool2d_backward_out_cpu_template(
-      grad_input, grad_output, input);
-    return grad_input;
-  }
-
   Tensor adaptive_avg_pool2d_backward_cpu(
     const Tensor& grad_output,
     const Tensor& input)

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1482,23 +1482,23 @@ Tensor& not_equal_(Tensor& self, const Scalar& other) { return self.ne_(other); 
 Tensor& logical_and_out(const Tensor& self, const Tensor& other, Tensor& result) { return comparison_op_out(result, self, other, logical_and_stub); }
 Tensor logical_and(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_and_out)); }
 Tensor& logical_and_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_and_out)); }
-Tensor& logical_and_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_and_out)); }
-Tensor logical_and(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_and_out)); }
-Tensor& logical_and_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_and_out)); }
+static Tensor& logical_and_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_and_out)); }
+static Tensor logical_and(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_and_out)); }
+static Tensor& logical_and_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_and_out)); }
 
 Tensor& logical_or_out(const Tensor& self, const Tensor& other, Tensor& result) { return comparison_op_out(result, self, other, logical_or_stub); }
 Tensor logical_or(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_or_out)); }
 Tensor& logical_or_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_or_out)); }
-Tensor& logical_or_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_or_out)); }
-Tensor logical_or(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_or_out)); }
-Tensor& logical_or_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_or_out)); }
+static Tensor& logical_or_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_or_out)); }
+static Tensor logical_or(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_or_out)); }
+static Tensor& logical_or_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_or_out)); }
 
 Tensor& logical_xor_out(const Tensor& self, const Tensor& other, Tensor& result) { return comparison_op_out(result, self, other, logical_xor_stub); }
 Tensor logical_xor(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
 Tensor& logical_xor_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
-Tensor& logical_xor_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_xor_out)); }
-Tensor logical_xor(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
-Tensor& logical_xor_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+static Tensor& logical_xor_out(Tensor& result, const Tensor& self, const Scalar& other) { return comparison_op_out(result, self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+static Tensor logical_xor(const Tensor& self, const Scalar& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
+static Tensor& logical_xor_(Tensor& self, const Scalar& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_xor_out)); }
 
 // binary max, alias for maximum
 Tensor& max_out(const Tensor& self, const Tensor& other, Tensor& result) {

--- a/aten/src/ATen/native/ComparisonUtils.cpp
+++ b/aten/src/ATen/native/ComparisonUtils.cpp
@@ -22,7 +22,7 @@ void _assert_match(const O& original, const C& compared, const std::string& name
   }
 }
 
-void _assert_tensor_metadata(at::Tensor const& tensor, at::OptionalIntArrayRef sizes, at::OptionalIntArrayRef strides, c10::optional<c10::ScalarType> dtype) {
+static void _assert_tensor_metadata(at::Tensor const& tensor, at::OptionalIntArrayRef sizes, at::OptionalIntArrayRef strides, c10::optional<c10::ScalarType> dtype) {
   _assert_match(tensor.sizes(), sizes, "sizes");
   _assert_match(tensor.strides(), strides, "strides");
   _assert_match(tensor.dtype(), dtype, "dtype");

--- a/aten/src/ATen/native/ComparisonUtils.cpp
+++ b/aten/src/ATen/native/ComparisonUtils.cpp
@@ -4,6 +4,10 @@
 #include <ATen/core/TensorBody.h>
 #include <c10/util/OptionalArrayRef.h>
 
+#ifdef AT_PER_OPERATOR_HEADERS
+#include <ATen/ops/_assert_tensor_metadata_native.h>
+#endif
+
 namespace at {
 
 class Tensor;
@@ -22,7 +26,7 @@ void _assert_match(const O& original, const C& compared, const std::string& name
   }
 }
 
-static void _assert_tensor_metadata(at::Tensor const& tensor, at::OptionalIntArrayRef sizes, at::OptionalIntArrayRef strides, c10::optional<c10::ScalarType> dtype) {
+void _assert_tensor_metadata(at::Tensor const& tensor, at::OptionalIntArrayRef sizes, at::OptionalIntArrayRef strides, c10::optional<c10::ScalarType> dtype) {
   _assert_match(tensor.sizes(), sizes, "sizes");
   _assert_match(tensor.strides(), strides, "strides");
   _assert_match(tensor.dtype(), dtype, "dtype");

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -22,6 +22,7 @@
 #else
 #include <ATen/ops/_copy_from.h>
 #include <ATen/ops/_propagate_xla_data.h>
+#include <ATen/ops/_propagate_xla_data_native.h>
 #include <ATen/ops/copy_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/expand_copy.h>
@@ -321,7 +322,7 @@ void copy_ignoring_overlaps(const TensorBase &dst, const TensorBase &src) {
   copy_stub(iter.device_type(), iter, /*non_blocking=*/false);
 }
 
-static void _propagate_xla_data(const Tensor& input, const Tensor& output) {
+void _propagate_xla_data(const Tensor& input, const Tensor& output) {
   TORCH_INTERNAL_ASSERT(input.device().type() == kXLA, "This op should only be called by XLA")
 }
 

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -321,7 +321,7 @@ void copy_ignoring_overlaps(const TensorBase &dst, const TensorBase &src) {
   copy_stub(iter.device_type(), iter, /*non_blocking=*/false);
 }
 
-void _propagate_xla_data(const Tensor& input, const Tensor& output) {
+static void _propagate_xla_data(const Tensor& input, const Tensor& output) {
   TORCH_INTERNAL_ASSERT(input.device().type() == kXLA, "This op should only be called by XLA")
 }
 

--- a/aten/src/ATen/native/Histogram.cpp
+++ b/aten/src/ATen/native/Histogram.cpp
@@ -269,7 +269,7 @@ std::pair<double, double> histc_select_outer_bin_edges(const Tensor& input,
 
 } // namespace
 
-std::vector<Tensor> allocate_bin_edges_tensors(const Tensor& self) {
+static std::vector<Tensor> allocate_bin_edges_tensors(const Tensor& self) {
     TORCH_CHECK(self.dim() >= 2, "torch.histogramdd: input tensor should have at least 2 dimensions");
     const int64_t N = self.size(-1);
     std::vector<Tensor> bin_edges_out(N);
@@ -281,7 +281,7 @@ std::vector<Tensor> allocate_bin_edges_tensors(const Tensor& self) {
 
 /* Versions of histogramdd in which bins is a Tensor[] defining the sequences of bin edges.
  */
-Tensor& histogramdd_out(const Tensor& self, TensorList bins,
+static Tensor& histogramdd_out(const Tensor& self, TensorList bins,
         const c10::optional<Tensor>& weight, bool density,
         Tensor& hist, TensorList& bin_edges) {
     histogramdd_check_inputs(self, bins, weight);
@@ -308,7 +308,7 @@ Tensor _histogramdd(const Tensor& self, TensorList bins,
 /* Versions of histogramdd in which bins is an int[]
  * defining the number of bins in each dimension.
  */
-std::vector<Tensor>& histogramdd_bin_edges_out(const Tensor& self, IntArrayRef bin_ct,
+static std::vector<Tensor>& histogramdd_bin_edges_out(const Tensor& self, IntArrayRef bin_ct,
         c10::optional<c10::ArrayRef<double>> range,
         const c10::optional<Tensor>& weight, bool density,
         std::vector<Tensor>& bin_edges_out) {
@@ -340,7 +340,7 @@ std::vector<Tensor> histogramdd_bin_edges(const Tensor& self, IntArrayRef bin_ct
     return histogramdd_bin_edges_out(self, bin_ct, range, weight, density, bin_edges_out);
 }
 
-Tensor& histogramdd_out(const Tensor& self, IntArrayRef bin_ct,
+static Tensor& histogramdd_out(const Tensor& self, IntArrayRef bin_ct,
         c10::optional<c10::ArrayRef<double>> range,
         const c10::optional<Tensor>& weight, bool density,
         Tensor& hist, TensorList& bin_edges) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -326,7 +326,7 @@ DEFINE_DISPATCH(addr_stub);
 
 // As P is a permutation matrix
 // det(P) = 1 if it's an even permutation and det(P) = -1 if it's an odd permutation
-Tensor lu_det_P(const Tensor& pivots) {
+static Tensor lu_det_P(const Tensor& pivots) {
   return (at::arange(1, pivots.size(-1) + 1, pivots.options()) != pivots)
     .sum(-1, /*keepdim=*/false, /*dtype=*/at::kLong)
     .fmod_(2)
@@ -1594,7 +1594,7 @@ inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, const T
     });
 }
 
-void baddbmm_with_gemm_(const Tensor &result, const Tensor &mat1, const Tensor &mat2, const Scalar &beta_, const Scalar &alpha_) {
+static void baddbmm_with_gemm_(const Tensor &result, const Tensor &mat1, const Tensor &mat2, const Scalar &beta_, const Scalar &alpha_) {
   TORCH_INTERNAL_ASSERT(result.is_contiguous());
 
   const auto result_sizes = result.sizes();
@@ -1766,7 +1766,7 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
   return;
 }
 
-void conjugate_mutable_input_if_needed(const Tensor& self, bool conjugate) {
+static void conjugate_mutable_input_if_needed(const Tensor& self, bool conjugate) {
   if (conjugate) {
     self.conj_physical_();
   }
@@ -1823,7 +1823,7 @@ Tensor& vdot_out(const Tensor& self, const Tensor& other, Tensor& result) {
   return result.fill_(self.vdot(other));
 }
 
-bool should_fold(const Tensor& tensor1, const Tensor& tensor2) {
+static bool should_fold(const Tensor& tensor1, const Tensor& tensor2) {
   // We check that we can fold the larger tensor into a matrix and dispatch to mm or mv rather than
   // to bmm. We want to make sure we can do so without incurring in any extra copy
   const auto tensor1_larger = tensor1.dim() >= tensor2.dim();
@@ -2678,7 +2678,7 @@ TORCH_IMPL_FUNC(linalg_vector_norm_out)(const Tensor& self, const Scalar& scalar
   norm_stub(iter.device_type(), iter, ord);
 }
 
-void _linalg_matrix_norm_checks(const Tensor& A, std::vector<int64_t>& dim, optional<ScalarType> opt_dtype, bool low_precision) {
+static void _linalg_matrix_norm_checks(const Tensor& A, std::vector<int64_t>& dim, optional<ScalarType> opt_dtype, bool low_precision) {
   // A
   at::native::checkIsMatrix(A, "linalg.matrix_norm");
   at::native::checkFloatingOrComplex(A, "linalg.matrix_norm", /*low_precision*/low_precision);
@@ -2950,7 +2950,7 @@ Tensor& nuclear_norm_out(const Tensor& self, IntArrayRef dim, bool keepdim, Tens
 
 
 // This function helps to dispatch norm computations depending on 'ord' of variant type
-Tensor _linalg_cond_helper(const Tensor& self, c10::variant<Scalar, c10::string_view> ord_variant) {
+static Tensor _linalg_cond_helper(const Tensor& self, c10::variant<Scalar, c10::string_view> ord_variant) {
   Tensor inverse, info;
   std::tie(inverse, info) = at::linalg_inv_ex(self);
   info.unsqueeze_(-1).unsqueeze_(-1);
@@ -2967,13 +2967,13 @@ Tensor _linalg_cond_helper(const Tensor& self, c10::variant<Scalar, c10::string_
 }
 
 // Return zero for each matrix in the batch
-Tensor _linalg_cond_empty_matrix(const Tensor& self, c10::ScalarType dtype) {
+static Tensor _linalg_cond_empty_matrix(const Tensor& self, c10::ScalarType dtype) {
   auto result_shape = IntArrayRef(self.sizes().cbegin(), self.sizes().cend()-2);
   TensorOptions options = self.options().dtype(toRealValueType(self.scalar_type()));
   return at::zeros(result_shape, options);
 }
 
-void _linalg_cond_check_ord(c10::variant<Scalar, c10::string_view> ord_variant) {
+static void _linalg_cond_check_ord(c10::variant<Scalar, c10::string_view> ord_variant) {
   if (ord_variant.index() == 0) {
     Scalar* ord = c10::get_if<Scalar>(&ord_variant);
     double abs_ord = std::abs(ord->toDouble());

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -668,7 +668,7 @@ Tensor nll_loss_symint(const Tensor & self, const Tensor & target, const c10::op
 }
 
 // Duplicate of above code for non-symbolic ints. Kept for BC purposes and to minimize breakages.
-Tensor nll_loss(const Tensor & self, const Tensor & target, const c10::optional<Tensor>& weight_opt, int64_t reduction, int64_t ignore_index) {
+static Tensor nll_loss(const Tensor & self, const Tensor & target, const c10::optional<Tensor>& weight_opt, int64_t reduction, int64_t ignore_index) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;

--- a/aten/src/ATen/native/LossNLL2d.cpp
+++ b/aten/src/ATen/native/LossNLL2d.cpp
@@ -495,7 +495,7 @@ Tensor nll_loss2d_symint(const Tensor & self, const Tensor & target, const c10::
 }
 
 // Duplicate of above code for non-symbolic ints. Kept for BC purposes and to minimize breakages.
-Tensor nll_loss2d(const Tensor & self, const Tensor & target, const c10::optional<Tensor>& weight_opt, int64_t reduction, int64_t ignore_index) {
+static Tensor nll_loss2d(const Tensor & self, const Tensor & target, const c10::optional<Tensor>& weight_opt, int64_t reduction, int64_t ignore_index) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;

--- a/aten/src/ATen/native/MetaTensor.cpp
+++ b/aten/src/ATen/native/MetaTensor.cpp
@@ -30,7 +30,7 @@ Tensor empty_meta_symint(
 }
 
 // Kept only for BC with XLA
-Tensor empty_strided_meta(
+static Tensor empty_strided_meta(
   IntArrayRef size,
   IntArrayRef stride,
   c10::optional<ScalarType> dtype_opt,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -799,7 +799,7 @@ TORCH_IMPL_FUNC(slow_conv_transpose2d_structured_cpu)
       dilation);
  }
 
-std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose2d_backward_out_cpu(const Tensor& grad_output,
+static std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose2d_backward_out_cpu(const Tensor& grad_output,
     const Tensor& input,
     const Tensor& weight,
     IntArrayRef kernel_size,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -872,7 +872,7 @@ Tensor slow_conv_transpose3d_cpu(
   return output;
 }
 
-std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose3d_backward_out_cpu(const Tensor& grad_output,
+static std::tuple<Tensor&, Tensor&, Tensor&> slow_conv_transpose3d_backward_out_cpu(const Tensor& grad_output,
     const Tensor& input,
     const Tensor& weight,
     IntArrayRef kernel_size,

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -339,10 +339,10 @@ Tensor& gather_out(const Tensor& self, Dimname dim, const Tensor& index, bool sp
 Tensor index_add(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source, const Scalar &alpha) {
   reportNYIDimnameOverload("index_add");
 }
-Tensor& index_add_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source, const Scalar &alpha) {
+static Tensor& index_add_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source, const Scalar &alpha) {
   reportNYIDimnameOverload("index_add");
 }
-Tensor& index_add_out(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source, const Scalar& alpha, Tensor& result) {
+static Tensor& index_add_out(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source, const Scalar& alpha, Tensor& result) {
   reportNYIDimnameOverload("index_add");
 }
 Tensor index_fill(const Tensor& self, Dimname dim, const Tensor& index, const Scalar& source) {
@@ -372,19 +372,19 @@ Tensor index_select(const Tensor& self, Dimname dim, const Tensor& index) {
 Tensor scatter(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   reportNYIDimnameOverload("scatter");
 }
-Tensor& scatter_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
+static Tensor& scatter_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   reportNYIDimnameOverload("scatter");
 }
 Tensor scatter(const Tensor& self, Dimname dim, const Tensor& index, const Scalar& source) {
   reportNYIDimnameOverload("scatter");
 }
-Tensor& scatter_(Tensor& self, Dimname dim, const Tensor& index, const Scalar& source) {
+static Tensor& scatter_(Tensor& self, Dimname dim, const Tensor& index, const Scalar& source) {
   reportNYIDimnameOverload("scatter");
 }
 Tensor scatter_add(const Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   reportNYIDimnameOverload("scatter_add");
 }
-Tensor& scatter_add_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
+static Tensor& scatter_add_(Tensor& self, Dimname dim, const Tensor& index, const Tensor& source) {
   reportNYIDimnameOverload("scatter_add");
 }
 std::tuple<Tensor&, Tensor&> sort_out(const Tensor& self, c10::optional<bool> stable, Dimname dim, bool keepdim, Tensor& values, Tensor& indices) {

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -792,30 +792,30 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const c10:
 }
 
 
-std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_cpu(
+static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_cpu(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps) {
   return batch_norm_cpu(self, weight_opt, bias_opt, running_mean, running_var, train, momentum, eps);
 }
 
-std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_stats_cpu(
+static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_stats_cpu(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     bool train, double momentum, double eps) {
   return batch_norm_cpu(self, weight_opt, bias_opt, Tensor(), Tensor(), train, momentum, eps);
 }
-std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_training(
+static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_training(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     const Tensor& running_mean, const Tensor& running_var, double momentum, double eps) {
   return at::_native_batch_norm_legit(self, weight_opt, bias_opt, const_cast<Tensor&>(running_mean), const_cast<Tensor&>(running_var), /*train=*/false, momentum, eps);
 }
 
 
-std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
+static std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
   return batch_norm_cpu_out(self, weight_opt, bias_opt, running_mean, running_var, train, momentum, eps, out, save_mean, save_var);
 }
 
 
-std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_no_stats_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
+static std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_no_stats_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
   return batch_norm_cpu_out(self, weight_opt, bias_opt, Tensor(), Tensor(), train, momentum, eps, out, save_mean, save_var);
 }
 

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -25,6 +25,8 @@
 #include <ATen/ops/_batch_norm_impl_index.h>
 #include <ATen/ops/_batch_norm_impl_index_backward_native.h>
 #include <ATen/ops/_batch_norm_impl_index_native.h>
+#include <ATen/ops/_native_batch_norm_legit_native.h>
+#include <ATen/ops/_native_batch_norm_legit_no_training.h>
 #include <ATen/ops/alias.h>
 #include <ATen/ops/batch_norm.h>
 #include <ATen/ops/batch_norm_native.h>
@@ -792,30 +794,30 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const c10:
 }
 
 
-static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_cpu(
+std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_cpu(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps) {
   return batch_norm_cpu(self, weight_opt, bias_opt, running_mean, running_var, train, momentum, eps);
 }
 
-static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_stats_cpu(
+std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_stats_cpu(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     bool train, double momentum, double eps) {
   return batch_norm_cpu(self, weight_opt, bias_opt, Tensor(), Tensor(), train, momentum, eps);
 }
-static std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_training(
+std::tuple<Tensor, Tensor, Tensor> _batch_norm_legit_no_training(
     const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
     const Tensor& running_mean, const Tensor& running_var, double momentum, double eps) {
   return at::_native_batch_norm_legit(self, weight_opt, bias_opt, const_cast<Tensor&>(running_mean), const_cast<Tensor&>(running_var), /*train=*/false, momentum, eps);
 }
 
 
-static std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
+std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, Tensor& running_mean, Tensor& running_var, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
   return batch_norm_cpu_out(self, weight_opt, bias_opt, running_mean, running_var, train, momentum, eps, out, save_mean, save_var);
 }
 
 
-static std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_no_stats_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
+std::tuple<Tensor&, Tensor&, Tensor&> _batch_norm_legit_no_stats_cpu_out(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, bool train, double momentum, double eps, Tensor& out, Tensor& save_mean, Tensor& save_var) {
   return batch_norm_cpu_out(self, weight_opt, bias_opt, Tensor(), Tensor(), train, momentum, eps, out, save_mean, save_var);
 }
 

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -27,6 +27,7 @@
 #include <ATen/ops/_batch_norm_impl_index_native.h>
 #include <ATen/ops/_native_batch_norm_legit_native.h>
 #include <ATen/ops/_native_batch_norm_legit_no_training.h>
+#include <ATen/ops/_native_batch_norm_legit_no_training_native.h>
 #include <ATen/ops/alias.h>
 #include <ATen/ops/batch_norm.h>
 #include <ATen/ops/batch_norm_native.h>

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -27,6 +27,7 @@
 #include <ATen/ops/_thnn_fused_lstm_cell.h>
 #include <ATen/ops/_thnn_fused_lstm_cell_backward.h>
 #include <ATen/ops/_thnn_fused_lstm_cell_backward_impl.h>
+#include <ATen/ops/_thnn_fused_lstm_cell_backward_native.h>
 #include <ATen/ops/_use_cudnn_rnn_flatten_weight_native.h>
 #include <ATen/ops/cat.h>
 #include <ATen/ops/cudnn_is_acceptable.h>
@@ -1169,7 +1170,7 @@ bool _use_cudnn_rnn_flatten_weight() {
 // NB: This a (composite) wrapper for _thnn_fused_lstm_cell_backward_impl.
 //     It duplicates the outputs of this function so the non-composite verison doesn't have to.
 //     The point is so that we avoid triggering TensorImpl use count asserts in debug mode
-static std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backward( const c10::optional<Tensor>& grad_hy_opt, const c10::optional<Tensor>& grad_cy_opt,
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backward( const c10::optional<Tensor>& grad_hy_opt, const c10::optional<Tensor>& grad_cy_opt,
       const Tensor& cx, const Tensor& cy,
       const Tensor& workspace, bool has_bias) {
   TORCH_INTERNAL_ASSERT(!GradMode::is_enabled());

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1169,7 +1169,7 @@ bool _use_cudnn_rnn_flatten_weight() {
 // NB: This a (composite) wrapper for _thnn_fused_lstm_cell_backward_impl.
 //     It duplicates the outputs of this function so the non-composite verison doesn't have to.
 //     The point is so that we avoid triggering TensorImpl use count asserts in debug mode
-std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backward( const c10::optional<Tensor>& grad_hy_opt, const c10::optional<Tensor>& grad_cy_opt,
+static std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backward( const c10::optional<Tensor>& grad_hy_opt, const c10::optional<Tensor>& grad_cy_opt,
       const Tensor& cx, const Tensor& cy,
       const Tensor& workspace, bool has_bias) {
   TORCH_INTERNAL_ASSERT(!GradMode::is_enabled());
@@ -1378,7 +1378,7 @@ ONE_HIDDEN_QRNN(quantized_gru, GRUCell<QRNNCellParamsWrapper>)
 
 // BC wrappers for quantized_gru
 
-std::tuple<Tensor, Tensor> quantized_gru_input_legacy(
+static std::tuple<Tensor, Tensor> quantized_gru_input_legacy(
     const Tensor& _input,
     const Tensor& hx,
     c10::List<at::Tensor> _params,
@@ -1395,7 +1395,7 @@ std::tuple<Tensor, Tensor> quantized_gru_input_legacy(
       "using the newer definitions in torch.jit.quantized");
 }
 
-std::tuple<Tensor, Tensor> quantized_gru_data_legacy(
+static std::tuple<Tensor, Tensor> quantized_gru_data_legacy(
     const Tensor& data,
     const Tensor& batch_sizes,
     const Tensor& hx,
@@ -1743,7 +1743,7 @@ std::tuple<Tensor, Tensor, Tensor> quantized_lstm_input(
 
 // BC wrappers for quantized_lstm
 
-std::tuple<Tensor, Tensor, Tensor> quantized_lstm_input_legacy(
+static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_input_legacy(
     const Tensor& _input,
     c10::List<at::Tensor> hx_,
     c10::List<at::Tensor> _params_,
@@ -1884,7 +1884,7 @@ return_type name( \
 // Quantized LSTM cell
 using quantized_lstm_cell_type = LSTMCell<QuantizedCellParams>;
 using quantized_lstm_return_type = std::tuple<Tensor, Tensor>;
-std::tuple<Tensor, Tensor> prepare_quantized_lstm_hx(TensorList hx) {
+static std::tuple<Tensor, Tensor> prepare_quantized_lstm_hx(TensorList hx) {
   return std::make_tuple(hx[0], hx[1]);
 }
 
@@ -1893,11 +1893,11 @@ using quantized_lstm_cell_dynamic_type = LSTMCell<QuantizedCellParamsDynamic>;
 
 DEFINE_QUANTIZED_RNN_CELL(quantized_lstm_cell, TensorList, quantized_lstm_cell_type, quantized_lstm_return_type, prepare_quantized_lstm_hx);
 
-DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_lstm_cell_dynamic, TensorList, quantized_lstm_cell_dynamic_type, quantized_lstm_return_type, prepare_quantized_lstm_hx);
+static DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_lstm_cell_dynamic, TensorList, quantized_lstm_cell_dynamic_type, quantized_lstm_return_type, prepare_quantized_lstm_hx);
 
 // Helpers for simpler cells
 using simple_hx_type = const Tensor&;
-simple_hx_type prepare_quantized_hx(simple_hx_type hx) {
+static simple_hx_type prepare_quantized_hx(simple_hx_type hx) {
   return hx;
 }
 
@@ -1907,19 +1907,19 @@ using quantized_gru_cell_dynamic_type = GRUCell<QuantizedCellParamsDynamic>;
 
 DEFINE_QUANTIZED_RNN_CELL(quantized_gru_cell, simple_hx_type, quantized_gru_cell_type, Tensor, prepare_quantized_hx);
 
-DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_gru_cell_dynamic, simple_hx_type, quantized_gru_cell_dynamic_type, Tensor, prepare_quantized_hx);
+static DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_gru_cell_dynamic, simple_hx_type, quantized_gru_cell_dynamic_type, Tensor, prepare_quantized_hx);
 
 // Quantized RNN w/ ReLU cell
 using quantized_rnn_relu_cell_type = SimpleCell<relu_f, QuantizedCellParams>;
 DEFINE_QUANTIZED_RNN_CELL(quantized_rnn_relu_cell, simple_hx_type, quantized_rnn_relu_cell_type, Tensor, prepare_quantized_hx);
 using quantized_rnn_relu_cell_dynamic_type = SimpleCell<relu_f, QuantizedCellParamsDynamic>;
-DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_rnn_relu_cell_dynamic, simple_hx_type, quantized_rnn_relu_cell_dynamic_type, Tensor, prepare_quantized_hx);
+static DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_rnn_relu_cell_dynamic, simple_hx_type, quantized_rnn_relu_cell_dynamic_type, Tensor, prepare_quantized_hx);
 
 // Quantized RNN w/ tanh cell
 using quantized_rnn_tanh_cell_type = SimpleCell<tanh_f, QuantizedCellParams>;
 DEFINE_QUANTIZED_RNN_CELL(quantized_rnn_tanh_cell, simple_hx_type, quantized_rnn_tanh_cell_type, Tensor, prepare_quantized_hx);
 using quantized_rnn_tanh_cell_dynamic_type = SimpleCell<tanh_f, QuantizedCellParamsDynamic>;
-DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_rnn_tanh_cell_dynamic, simple_hx_type, quantized_rnn_tanh_cell_dynamic_type, Tensor, prepare_quantized_hx);
+static DEFINE_QUANTIZED_RNN_CELL_DYNAMIC(quantized_rnn_tanh_cell_dynamic, simple_hx_type, quantized_rnn_tanh_cell_dynamic_type, Tensor, prepare_quantized_hx);
 
 namespace {
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -24,6 +24,8 @@
 #include <ATen/ops/_cummax_helper_native.h>
 #include <ATen/ops/_cummin_helper.h>
 #include <ATen/ops/_cummin_helper_native.h>
+#include <ATen/ops/_is_all_true.h>
+#include <ATen/ops/_is_any_true.h>
 #include <ATen/ops/_logcumsumexp.h>
 #include <ATen/ops/_logcumsumexp_native.h>
 #include <ATen/ops/_sparse_sum.h>
@@ -2000,11 +2002,11 @@ Tensor all(const Tensor& self, Dimname dim, bool keepdim) {
 Tensor& all_out(const Tensor &self, Dimname dim, bool keepdim, Tensor& result) {
   reportNYIDimnameOverload("all");
 }
-static Tensor _is_all_true(const Tensor& self) {
+Tensor _is_all_true(const Tensor& self) {
   TORCH_INTERNAL_ASSERT(self.scalar_type() == at::kBool);
   return self.all();
 }
-static Tensor _is_any_true(const Tensor& self) {
+Tensor _is_any_true(const Tensor& self) {
   TORCH_INTERNAL_ASSERT(self.scalar_type() == at::kBool);
   return self.any();
 }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -160,7 +160,7 @@ static ScalarType get_result_or_bytebool_dtype(const Tensor& self, const Tensor&
   }
 }
 
-void check_result_is_bytebool(const char* name, const Tensor& self, const Tensor& result) {
+static void check_result_is_bytebool(const char* name, const Tensor& self, const Tensor& result) {
   if (result.defined()) {
     // Refer [all, any : uint8 compatibility]
     TORCH_CHECK(
@@ -207,7 +207,7 @@ TORCH_META_FUNC(any)(const Tensor& self) {
   allany_meta(*this, "any", self, {}, false);
 }
 
-void check_argmax_argmin(
+static void check_argmax_argmin(
     const char* name,
     const Tensor& self,
     const c10::optional<int64_t>& dim) {
@@ -233,7 +233,7 @@ TORCH_META_FUNC(argmin)
   resize_reduction(*this, self, optional_to_arrayref(dim), keepdim, kLong);
 }
 
-void meta_func_cum_ops(
+static void meta_func_cum_ops(
     impl::MetaBase& meta,
     const char* name,
     const Tensor& self,
@@ -305,7 +305,7 @@ TORCH_META_FUNC2(mean, dim)
   resize_reduction(*this, self, opt_dim, keepdim, out_dtype);
 }
 
-ScalarType get_result_or_self_value_dtype(
+static ScalarType get_result_or_self_value_dtype(
     const Tensor& self,
     const Tensor& result,
     const c10::optional<ScalarType>& dtype) {
@@ -501,7 +501,7 @@ TORCH_IMPL_FUNC(cumprod_out)
   impl_func_cum_ops(self, dim, result, cumprod_stub);
 }
 
-Tensor reversed_cumsum(const Tensor& w, int64_t dim) {
+static Tensor reversed_cumsum(const Tensor& w, int64_t dim) {
   return w.flip(dim).cumsum(dim).flip(dim);
 }
 
@@ -984,7 +984,7 @@ Tensor& diff_out(const Tensor& self, int64_t n, int64_t dim, const c10::optional
   }
 }
 
-void pre_check_gradient(const Tensor& self, c10::optional<int64_t> spacing_size, at::OptionalIntArrayRef dim,  int64_t edge_order) {
+static void pre_check_gradient(const Tensor& self, c10::optional<int64_t> spacing_size, at::OptionalIntArrayRef dim,  int64_t edge_order) {
   // Helper for gradient function to make sure input data satisfies prerequisites
   TORCH_CHECK(self.scalar_type() != ScalarType::Byte, "torch.gradient does not support uint8 input.");
   if (spacing_size.has_value() && !dim.has_value()) {
@@ -1009,7 +1009,7 @@ void pre_check_gradient(const Tensor& self, c10::optional<int64_t> spacing_size,
   }
 }
 
-std::vector<Tensor> gradient_helper(const Tensor& self, TensorList coordinates, IntArrayRef dim, int64_t edge_order) {
+static std::vector<Tensor> gradient_helper(const Tensor& self, TensorList coordinates, IntArrayRef dim, int64_t edge_order) {
   for (const auto i : c10::irange(coordinates.size())) {
     TORCH_CHECK(self.device() == coordinates[i].device(), "torch.gradient expected each tensor to be on the same device, but got devices ", self.device(), " and ", coordinates[i].device(), "!");
   }
@@ -1050,7 +1050,7 @@ std::vector<Tensor> gradient_helper(const Tensor& self, TensorList coordinates, 
   return result;
 }
 
-std::vector<Tensor> gradient_helper_float(const Tensor& self, ArrayRef<Scalar> spacing, IntArrayRef dim, int64_t edge_order) {
+static std::vector<Tensor> gradient_helper_float(const Tensor& self, ArrayRef<Scalar> spacing, IntArrayRef dim, int64_t edge_order) {
   std::vector<Tensor> result;
   for (const auto i : c10::irange(dim.size())) {
       int64_t direction = maybe_wrap_dim(dim[i], self.dim());
@@ -1070,7 +1070,7 @@ std::vector<Tensor> gradient_helper_float(const Tensor& self, ArrayRef<Scalar> s
   return result;
 }
 
-std::vector<int64_t> gradient_dim_preprocess(const Tensor& self, c10::optional<int64_t> dim) {
+static std::vector<int64_t> gradient_dim_preprocess(const Tensor& self, c10::optional<int64_t> dim) {
   // if gradient dim is provided as an integer, then we need to compute gradient only on this direction.
   // Moreover, if it's not provided at all, then we are interested in gradient for all directions.
   // Finally, if dim is provided as vector of ints, then it is not expected to be called by this function.
@@ -1253,7 +1253,7 @@ Tensor trace_cpu(const Tensor& self) {
   return result;
 }
 
-void impl_func_prod(
+static void impl_func_prod(
     const Tensor& self,
     IntArrayRef dims,
     bool keepdim,
@@ -1434,7 +1434,7 @@ Tensor& special_logsumexp_out(const Tensor& self, IntArrayRef dims, bool keepdim
   return at::logsumexp_out(result, self, dims, keepdim);
 }
 
-void impl_func_norm(
+static void impl_func_norm(
     const Tensor& self,
     const OptionalScalarRef& opt_p,
     IntArrayRef dim,
@@ -2000,11 +2000,11 @@ Tensor all(const Tensor& self, Dimname dim, bool keepdim) {
 Tensor& all_out(const Tensor &self, Dimname dim, bool keepdim, Tensor& result) {
   reportNYIDimnameOverload("all");
 }
-Tensor _is_all_true(const Tensor& self) {
+static Tensor _is_all_true(const Tensor& self) {
   TORCH_INTERNAL_ASSERT(self.scalar_type() == at::kBool);
   return self.all();
 }
-Tensor _is_any_true(const Tensor& self) {
+static Tensor _is_any_true(const Tensor& self) {
   TORCH_INTERNAL_ASSERT(self.scalar_type() == at::kBool);
   return self.any();
 }
@@ -2104,7 +2104,7 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
   return result.load();
 }
 
-Tensor value_selecting_reduction_backward(const Tensor& grad, int64_t dim, const Tensor& indices, at::IntArrayRef sizes, bool keepdim) {
+static Tensor value_selecting_reduction_backward(const Tensor& grad, int64_t dim, const Tensor& indices, at::IntArrayRef sizes, bool keepdim) {
     return at::native::value_selecting_reduction_backward_symint(grad, dim, indices, c10::fromIntArrayRefSlow(sizes), keepdim);
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -24,8 +24,8 @@
 #include <ATen/ops/_cummax_helper_native.h>
 #include <ATen/ops/_cummin_helper.h>
 #include <ATen/ops/_cummin_helper_native.h>
-#include <ATen/ops/_is_all_true.h>
-#include <ATen/ops/_is_any_true.h>
+#include <ATen/ops/_is_all_true_native.h>
+#include <ATen/ops/_is_any_true_native.h>
 #include <ATen/ops/_logcumsumexp.h>
 #include <ATen/ops/_logcumsumexp_native.h>
 #include <ATen/ops/_sparse_sum.h>

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -839,7 +839,7 @@ static void reflection_pad3d_backward_out_loop(
 
 // TODO: I tihnk this function should be removed since we implement it with
 // TORCH_IMPL_FUNC below
-Tensor& reflection_pad1d_out_cpu(const Tensor& input, IntArrayRef padding,
+static Tensor& reflection_pad1d_out_cpu(const Tensor& input, IntArrayRef padding,
     Tensor& output) {
   reflection_pad1d_out_template(output, input, padding);
   return output;

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -97,7 +97,7 @@ Tensor repeat_interleave(
   return ret;
 }
 
-Tensor repeat_interleave(
+static Tensor repeat_interleave(
     const Tensor& self,
     int64_t repeats,
     c10::optional<int64_t> dim,

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -80,7 +80,7 @@ bool resize_output_symint(const Tensor& output, SymIntArrayRef shape) {
   return _resize_output(output, shape);
 }
 
-static const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
+const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
   TORCH_CHECK(self.device() == device, "out Tensor doesn't have the correct device set");
   at::native::resize_output(self, shape);
   return self;

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -44,11 +44,11 @@ bool resize_output_check_symint(const Tensor& output, SymIntArrayRef shape) {
   return _resize_output_check(output, shape);
 }
 
-void native_resize_(const Tensor& output, IntArrayRef shape) {
+static void native_resize_(const Tensor& output, IntArrayRef shape) {
   native::resize_(output, shape);
 }
 
-void native_resize_(const Tensor& output, SymIntArrayRef shape) {
+static void native_resize_(const Tensor& output, SymIntArrayRef shape) {
   native::resize__symint(output, shape);
 }
 
@@ -80,7 +80,7 @@ bool resize_output_symint(const Tensor& output, SymIntArrayRef shape) {
   return _resize_output(output, shape);
 }
 
-const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
+static const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
   TORCH_CHECK(self.device() == device, "out Tensor doesn't have the correct device set");
   at::native::resize_output(self, shape);
   return self;
@@ -155,7 +155,7 @@ const Tensor& resize_as_(
 }
 
 
-void resize_bytes_meta(StorageImpl* storage, c10::SymInt size_bytes) {
+static void resize_bytes_meta(StorageImpl* storage, c10::SymInt size_bytes) {
   TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
   storage->set_nbytes(std::move(size_bytes));
 }
@@ -224,7 +224,7 @@ TensorImpl* resize_impl_cpu_(
   return _resize_impl_(self, size, stride, resize_storage);
 }
 
-TensorImpl* resize_impl_meta_(
+static TensorImpl* resize_impl_meta_(
     TensorImpl* self,
     c10::SymIntArrayRef size,
     at::OptionalSymIntArrayRef stride,

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -12,6 +12,7 @@
 #include <ATen/ops/resize_native.h>
 #include <ATen/ops/resize.h>
 #include <ATen/ops/_resize_output.h>
+#include <ATen/ops/_resize_output_native.h>
 #endif
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -17,6 +17,7 @@
 #include <ATen/ops/_log_softmax.h>
 #include <ATen/ops/_log_softmax_backward_data_native.h>
 #include <ATen/ops/_log_softmax_native.h>
+#include <ATen/ops/_masked_softmax_backward_native.h>
 #include <ATen/ops/_masked_softmax_native.h>
 #include <ATen/ops/_softmax.h>
 #include <ATen/ops/_softmax_backward_data_native.h>
@@ -648,7 +649,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
   return output;
 }
 
-static Tensor masked_softmax_backward_cpu(
+Tensor masked_softmax_backward_cpu(
     const Tensor& grad_,
     const Tensor& output_,
     const Tensor& mask_,

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -440,7 +440,7 @@ TORCH_IMPL_FUNC(log_softmax_backward_cpu_out) (
   }
 }
 
-Tensor softmax(const Tensor& input_, const int64_t dim_) {
+static Tensor softmax(const Tensor& input_, const int64_t dim_) {
   auto result = [&]() {
     NoNamesGuard guard;
     return at::_softmax(input_, dim_, false);
@@ -505,7 +505,7 @@ Tensor special_softmax(const Tensor& input_, const int64_t dim_, c10::optional<S
   return at::softmax(input_, dim_, dtype);
 }
 
-Tensor log_softmax(const Tensor& input_, const int64_t dim_) {
+static Tensor log_softmax(const Tensor& input_, const int64_t dim_) {
   auto result = [&]() {
     NoNamesGuard guard;
     return at::_log_softmax(input_, dim_, false);
@@ -648,7 +648,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
   return output;
 }
 
-Tensor masked_softmax_backward_cpu(
+static Tensor masked_softmax_backward_cpu(
     const Tensor& grad_,
     const Tensor& output_,
     const Tensor& mask_,

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -751,7 +751,7 @@ Tensor fft_rfftfreq(int64_t n, double d,
 
 // If an array dim is specified, wraps them according to self.dim().
 // Otherwise returns a vector of all dims.
-DimVector default_alldims(const Tensor& self, at::OptionalIntArrayRef dim_opt) {
+static DimVector default_alldims(const Tensor& self, at::OptionalIntArrayRef dim_opt) {
   DimVector dim;
   if (dim_opt) {
     IntArrayRef dim_unwrapped = *dim_opt;
@@ -1175,7 +1175,7 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
 #undef REPR
 }
 
-Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop_lengthOpt,
+static Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop_lengthOpt,
              const optional<int64_t> win_lengthOpt, const Tensor& window,
              const bool center, const bool normalized, const optional<bool> onesidedOpt,
              const optional<int64_t> lengthOpt) {

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -760,10 +760,10 @@ std::tuple<Tensor, Tensor> max(const Tensor& self, Dimname dim, bool keepdim) {
 std::tuple<Tensor&, Tensor&> max_out(const Tensor& self, Dimname dim, bool keepdim, Tensor& max, Tensor& max_indices) {
   return at::max_out(max, max_indices, self, dimname_to_position(self, dim), keepdim);
 }
-Tensor argmax(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
+static Tensor argmax(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argmax");
 }
-Tensor argmin(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
+static Tensor argmin(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argmin");
 }
 Tensor argsort(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -812,7 +812,7 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   return new_tensor;
 }
 
-Tensor _tile_tensor(const Tensor& self, IntArrayRef blocksize) {
+static Tensor _tile_tensor(const Tensor& self, IntArrayRef blocksize) {
   // This code turns a matrix into a sequence of blocks
   //
   // Given matrix
@@ -841,7 +841,7 @@ Tensor _tile_tensor(const Tensor& self, IntArrayRef blocksize) {
       .contiguous();
 }
 
-Tensor _batch_tile_tensor(const Tensor& self, IntArrayRef blocksize, const int64_t dense_dim) {
+static Tensor _batch_tile_tensor(const Tensor& self, IntArrayRef blocksize, const int64_t dense_dim) {
   if (self.dim() == 2 + dense_dim) {
     return _tile_tensor(self, blocksize);
   }
@@ -860,7 +860,7 @@ Tensor _batch_tile_tensor(const Tensor& self, IntArrayRef blocksize, const int64
   return self.reshape(tiled_sizes).transpose(n_batch_dim + 1, n_batch_dim + 2).contiguous();
 }
 
-Tensor _mask_to_indices(const Tensor& mask) {
+static Tensor _mask_to_indices(const Tensor& mask) {
   // This function returns a vector of the indices at which given
   // boolean mask is True. at::nonzero can achieve the same, but
   // we yet have to compare the performance difference.
@@ -871,7 +871,7 @@ Tensor _mask_to_indices(const Tensor& mask) {
       .masked_select(mask);
 }
 
-std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
+static std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
     Tensor not_zero_mask,
     ScalarType index_dtype,
     Device index_device) {

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -86,7 +86,7 @@ Tensor & detach_(Tensor & self) {
   return self;
 }
 
-Tensor contiguous(const Tensor & self) {
+static Tensor contiguous(const Tensor & self) {
   return contiguous(self, MemoryFormat::Contiguous);
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -48,6 +48,7 @@
 #include <ATen/ops/_neg_view_copy_native.h>
 #include <ATen/ops/_reshape_alias_copy_native.h>
 #include <ATen/ops/_reshape_alias_native.h>
+#include <ATen/ops/_reshape_copy_native.h>
 #include <ATen/ops/_reshape_from_tensor_native.h>
 #include <ATen/ops/_shape_as_tensor_native.h>
 #include <ATen/ops/_sparse_broadcast_to.h>
@@ -1609,7 +1610,7 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   return at::_unsafe_view_symint(self.clone(at::MemoryFormat::Contiguous), shape);
 }
 
-static Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
+Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     TORCH_CHECK(0, "_reshape_copy is not implemented for sparse tensors");
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1129,7 +1129,7 @@ Tensor sum_to_size_symint(const Tensor& self, SymIntArrayRef size) {
 
 // We currently do not support per-channel quant for unfold, diagonal, expand, permute.
 // TODO: Make this an aten function and replace as_strided_qtensorimpl once that is done.
-Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef stride, QuantizerPtr quantizer) {
+static Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef stride, QuantizerPtr quantizer) {
   auto result = at::detail::make_tensor<QTensorImpl>(
       c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
   setStrided(result, size, stride, self.storage_offset());
@@ -1145,7 +1145,7 @@ Tensor as_strided_tensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef s
   return result;
 }
 
-Tensor as_strided_tensorimpl_meta(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_) {
+static Tensor as_strided_tensorimpl_meta(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   auto result = at::detail::make_tensor<TensorImpl>(
       c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
@@ -1194,7 +1194,7 @@ Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef 
 // and is currently not available through the dispatcher. The additional
 // input, quantizer, is called by the select & slice methods.
 // TODO: Make this function compatible with the dispatcher
-Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_,
+static Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_,
   QuantizerPtr quantizer) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   TORCH_CHECK(
@@ -1213,7 +1213,7 @@ const Tensor &as_strided__symint(const Tensor& self, SymIntArrayRef size, SymInt
   return self;
 }
 
-Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
+static Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
   return self.narrow(dim, start, length).clone(at::MemoryFormat::Contiguous);
 }
 
@@ -1378,7 +1378,7 @@ Tensor narrow_tensor_symint(const Tensor& self, int64_t dim, const Tensor& start
 }
 
 std::tuple<DimVector, DimVector, std::vector<int64_t>>
-_permute_size_stride_estimation(const Tensor& self, IntArrayRef dims) {
+static _permute_size_stride_estimation(const Tensor& self, IntArrayRef dims) {
   const auto ndim = self.dim();
   TORCH_CHECK(ndim == static_cast<int64_t>(dims.size()),
       "permute(sparse_coo): number of dimensions in the tensor input ",
@@ -1609,7 +1609,7 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   return at::_unsafe_view_symint(self.clone(at::MemoryFormat::Contiguous), shape);
 }
 
-Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
+static Tensor _reshape_copy_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     TORCH_CHECK(0, "_reshape_copy is not implemented for sparse tensors");
   }
@@ -1724,7 +1724,7 @@ static Tensor select_sparse(const Tensor& self, int64_t dim, int64_t index) {
 // this is an auxiliary function, called by the select&slice methods, that
 // creates a new quantizer from the given input
 // is_select is true if calling function is select()
-QuantizerPtr create_subtensor_quantizer(const Tensor& self, bool is_select, int64_t start,
+static QuantizerPtr create_subtensor_quantizer(const Tensor& self, bool is_select, int64_t start,
   int64_t end, int64_t dim, int64_t step) {
   auto quantizer_prev = get_qtensorimpl(self)->quantizer();
   if (quantizer_prev->qscheme() == QScheme::PER_TENSOR_AFFINE) {
@@ -2651,7 +2651,7 @@ Tensor _stack_cpu(TensorList tensors, int64_t dim) {
   return at::native::_stack_out_cpu(tensors, dim, result);
 }
 
-void check_stack_inputs(TensorList tensors, int64_t dim) {
+static void check_stack_inputs(TensorList tensors, int64_t dim) {
   at::IntArrayRef entry_shape = tensors[0].sizes();
   for (const auto i : c10::irange(1, tensors.size())) {
     TORCH_CHECK(tensors[i].sizes() == entry_shape,
@@ -3075,7 +3075,7 @@ Tensor & t_(Tensor & self) {
 }
 
 std::tuple<SymDimVector, SymDimVector>
-inferSqueezeGeometry(const Tensor &tensor) {
+static inferSqueezeGeometry(const Tensor &tensor) {
   SymDimVector sizes;
   SymDimVector strides;
 
@@ -3090,7 +3090,7 @@ inferSqueezeGeometry(const Tensor &tensor) {
 }
 
 std::tuple<SymDimVector, SymDimVector>
-inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
+static inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
   SymDimVector sizes;
   SymDimVector strides;
 
@@ -3104,7 +3104,7 @@ inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
 }
 
 std::tuple<SymDimVector, SymDimVector>
-inferSqueezeGeometry(const Tensor &tensor, std::bitset<dim_bitset_size> dim_mask) {
+static inferSqueezeGeometry(const Tensor &tensor, std::bitset<dim_bitset_size> dim_mask) {
   const auto ndim = tensor.dim();
   const auto sym_sizes = tensor.sym_sizes();
   const auto sym_strides = tensor.sym_strides();
@@ -3141,7 +3141,7 @@ inferUnsqueezeGeometry(const Tensor& tensor, int64_t dim) {
 }
 
 // dim is present if squeezing a single dimension and absent if squeezing all dimensions
-Tensor squeeze_qtensor(const Tensor& self, c10::OptionalIntArrayRef dims) {
+static Tensor squeeze_qtensor(const Tensor& self, c10::OptionalIntArrayRef dims) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   SymDimVector sizes;
   SymDimVector strides;
@@ -3417,7 +3417,7 @@ static inline void handle_unflatten_exception(const std::runtime_error &e,
   }
 }
 
-Tensor unflatten_impl(const Tensor& self, int64_t dim, SymIntArrayRef sizes, c10::optional<DimnameList> names) {
+static Tensor unflatten_impl(const Tensor& self, int64_t dim, SymIntArrayRef sizes, c10::optional<DimnameList> names) {
   dim = maybe_wrap_dim(dim, self.dim());
 
   TORCH_CHECK(!sizes.empty(), "unflatten: sizes must be non-empty");
@@ -3468,7 +3468,7 @@ Tensor view_as(const Tensor& self, const Tensor& other) {
   return self.view_symint(other.sym_sizes());
 }
 
-int64_t numel(const Tensor& self) {
+static int64_t numel(const Tensor& self) {
   return self.unsafeGetTensorImpl()->numel();
 }
 

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -17,6 +17,7 @@
 #include <ATen/ops/atleast_2d_native.h>
 #include <ATen/ops/atleast_3d_native.h>
 #include <ATen/ops/cat.h>
+#include <ATen/ops/chalf_native.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/flip_native.h>
 #include <ATen/ops/fliplr_native.h>
@@ -230,7 +231,7 @@ std::vector<Tensor> atleast_3d(TensorList tensors) {
   return result;
 }
 
-static Tensor chalf(const Tensor& self, c10::optional<MemoryFormat> memory_format) {
+Tensor chalf(const Tensor& self, c10::optional<MemoryFormat> memory_format) {
   return self.to(kComplexHalf, false, false, memory_format);
 }
 

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -230,7 +230,7 @@ std::vector<Tensor> atleast_3d(TensorList tensors) {
   return result;
 }
 
-Tensor chalf(const Tensor& self, c10::optional<MemoryFormat> memory_format) {
+static Tensor chalf(const Tensor& self, c10::optional<MemoryFormat> memory_format) {
   return self.to(kComplexHalf, false, false, memory_format);
 }
 

--- a/aten/src/ATen/native/TestOps.cpp
+++ b/aten/src/ATen/native/TestOps.cpp
@@ -106,7 +106,7 @@ Tensor _test_autograd_multiple_dispatch_view(const Tensor &self) {
   return self.view(-1);
 }
 
-Tensor _test_check_tensor(const Tensor& self) {
+static Tensor _test_check_tensor(const Tensor& self) {
   TORCH_CHECK_TENSOR_ALL(self, "Test message for TORCH_CHECK_TENSOR_ALL");
   return self.clone();
 }

--- a/aten/src/ATen/native/TestOps.cpp
+++ b/aten/src/ATen/native/TestOps.cpp
@@ -12,6 +12,7 @@
 #include <ATen/ops/_test_ambiguous_defaults_native.h>
 #include <ATen/ops/_test_autograd_multiple_dispatch_native.h>
 #include <ATen/ops/_test_autograd_multiple_dispatch_view_native.h>
+#include <ATen/ops/_test_check_tensor_native.h>
 #include <ATen/ops/_test_optional_filled_intlist_native.h>
 #include <ATen/ops/_test_optional_floatlist_native.h>
 #include <ATen/ops/_test_optional_intlist_native.h>
@@ -106,7 +107,7 @@ Tensor _test_autograd_multiple_dispatch_view(const Tensor &self) {
   return self.view(-1);
 }
 
-static Tensor _test_check_tensor(const Tensor& self) {
+Tensor _test_check_tensor(const Tensor& self) {
   TORCH_CHECK_TENSOR_ALL(self, "Test message for TORCH_CHECK_TENSOR_ALL");
   return self.clone();
 }

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -181,7 +181,7 @@ TORCH_IMPL_FUNC(triu_cpu)(const Tensor& self, int64_t k, const Tensor &result) {
   compute_triu_tril<UpperTriangle>(self, k, result);
 }
 
-Tensor trace_backward(const Tensor& grad, at::IntArrayRef sizes) {
+static Tensor trace_backward(const Tensor& grad, at::IntArrayRef sizes) {
     return at::native::trace_backward_symint(grad, c10::fromIntArrayRefSlow(sizes));
 }
 

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -24,7 +24,7 @@
 
 namespace at { namespace native {
 
-bool is_cuda(const Tensor& self) {
+static bool is_cuda(const Tensor& self) {
   return self.is_cuda();
 }
 
@@ -60,15 +60,15 @@ bool is_neg(const Tensor& self) {
   return self.is_neg();
 }
 
-bool is_sparse(const Tensor& self) {
+static bool is_sparse(const Tensor& self) {
   return self.is_sparse();
 }
 
-bool is_sparse_csr(const Tensor& self) {
+static bool is_sparse_csr(const Tensor& self) {
   return self.is_sparse_csr();
 }
 
-bool is_quantized(const Tensor& self) {
+static bool is_quantized(const Tensor& self) {
   return self.is_quantized();
 }
 

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -16,6 +16,14 @@ namespace at { namespace native {
 using unary_fn = void(*)(TensorIteratorBase&);
 using unary_fn_with_scalar = void(*)(TensorIteratorBase&, const Scalar& a);
 
+inline namespace CPU_CAPABILITY {
+void conj_kernel(TensorIteratorBase &iter);
+void neg_kernel(TensorIteratorBase &iter);
+void reciprocal_kernel(TensorIteratorBase &iter);
+void rsqrt_kernel(TensorIteratorBase& iter);
+void sqrt_kernel(TensorIteratorBase& iter);
+} // namespace CPU_CAPABILITY
+
 DECLARE_DISPATCH(unary_fn, abs_stub);
 DECLARE_DISPATCH(unary_fn, angle_stub);
 DECLARE_DISPATCH(unary_fn, conj_physical_stub);

--- a/aten/src/ATen/native/ao_sparse/library.cpp
+++ b/aten/src/ATen/native/ao_sparse/library.cpp
@@ -3,11 +3,7 @@
 
 #include <torch/custom_class.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
-
-namespace ao {
-namespace sparse {
-int register_linear_params();
-}}
+#include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
 
 // Register operators
 TORCH_LIBRARY(sparse, m) {

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
@@ -10,7 +10,7 @@
 
 namespace ao {
 namespace sparse {
-static int register_linear_params() {
+int register_linear_params() {
   static auto register_linear_params =
       torch::selective_class_<LinearPackedParamsBase>(
           "sparse", TORCH_SELECTIVE_CLASS("LinearPackedParamsBase"))

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
@@ -10,7 +10,7 @@
 
 namespace ao {
 namespace sparse {
-int register_linear_params() {
+static int register_linear_params() {
   static auto register_linear_params =
       torch::selective_class_<LinearPackedParamsBase>(
           "sparse", TORCH_SELECTIVE_CLASS("LinearPackedParamsBase"))

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
@@ -89,3 +89,8 @@ struct TORCH_API PackedLinearWeight
 }}  // namespace ao::sparse
 
 #endif // USE_FBGEMM
+
+namespace ao {
+namespace sparse {
+int register_linear_params();
+}}  // namespace ao::sparse

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/Copy.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/CopyKernel.h>
 #include <ATen/native/cpu/Loops.h>
 #include <c10/util/TypeCast.h>
 #include <ATen/native/cpu/zmath.h>
@@ -164,7 +165,7 @@ static void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_n
   }
 }
 
-static void direct_copy_kernel(TensorIteratorBase &iter) {
+void direct_copy_kernel(TensorIteratorBase &iter) {
   // TODO: we don't actually need separate instantiations per dtype;
   // we only need a separate instantiation per dtype size. This would
   // probably save us a little bit of code size here

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -13,7 +13,7 @@ inline namespace CPU_CAPABILITY {
 void neg_kernel(TensorIteratorBase &iter);
 void conj_kernel(TensorIteratorBase &iter);
 
-void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
+static void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
   auto strides_out = iter.strides(0);
   auto strides_in = iter.strides(1);
   auto shape = iter.shape();
@@ -164,7 +164,7 @@ void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
   }
 }
 
-void direct_copy_kernel(TensorIteratorBase &iter) {
+static void direct_copy_kernel(TensorIteratorBase &iter) {
   // TODO: we don't actually need separate instantiations per dtype;
   // we only need a separate instantiation per dtype size. This would
   // probably save us a little bit of code size here
@@ -193,7 +193,7 @@ void direct_copy_kernel(TensorIteratorBase &iter) {
   }
 }
 
-void neg_conj_kernel(TensorIteratorBase &iter) {
+static void neg_conj_kernel(TensorIteratorBase &iter) {
   // fused a = b.neg().conj_physical()
   AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "neg_conj_cpu", [&] {
     cpu_kernel_vec(
@@ -203,7 +203,7 @@ void neg_conj_kernel(TensorIteratorBase &iter) {
   });
 }
 
-void copy_same_dtype(TensorIteratorBase &iter, bool requires_conj, bool requires_neg) {
+static void copy_same_dtype(TensorIteratorBase &iter, bool requires_conj, bool requires_neg) {
   if (requires_neg) {
     // This case should never actually happen since currently there's no way to get a complex tensor
     // with negative bit.
@@ -221,7 +221,7 @@ void copy_same_dtype(TensorIteratorBase &iter, bool requires_conj, bool requires
   }
 }
 
-void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
+static void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
   ScalarType dtype = iter.dtype(0);
   const bool requires_conj = (
       isComplexType(dtype) && (iter.tensor_base(0).is_conj() != iter.tensor_base(1).is_conj()));

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/native/Copy.h>
+#include <ATen/native/UnaryOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/CopyKernel.h>
 #include <ATen/native/cpu/Loops.h>
@@ -11,8 +12,6 @@
 
 namespace at::native {
 inline namespace CPU_CAPABILITY {
-void neg_kernel(TensorIteratorBase &iter);
-void conj_kernel(TensorIteratorBase &iter);
 
 static void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
   auto strides_out = iter.strides(0);
@@ -222,7 +221,7 @@ static void copy_same_dtype(TensorIteratorBase &iter, bool requires_conj, bool r
   }
 }
 
-static void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
+void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
   ScalarType dtype = iter.dtype(0);
   const bool requires_conj = (
       isComplexType(dtype) && (iter.tensor_base(0).is_conj() != iter.tensor_base(1).is_conj()));

--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/Pow.h>
+#include <ATen/native/UnaryOps.h>
 #include <ATen/native/cpu/Loops.h>
 
 #include <c10/core/Scalar.h>
@@ -84,11 +85,6 @@ void pow_tensor_scalar_optimized_kernel(TensorIteratorBase& iter, const exp_scal
     );
   }
 }
-
-// Forward declare some unary ops
-void reciprocal_kernel(TensorIteratorBase& iter);
-void rsqrt_kernel(TensorIteratorBase& iter);
-void sqrt_kernel(TensorIteratorBase& iter);
 
 static void pow_tensor_scalar_kernel(
     TensorIteratorBase& iter,

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -139,7 +139,7 @@ void LogitMKLKernel(T eps, TensorIteratorBase* it) {
 
 #endif // AT_MKL_ENABLED
 
-void logit_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
+static void logit_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
   AT_DISPATCH_FLOATING_TYPES_AND(
       kBFloat16, iter.common_dtype(), "logit_cpu", [&]() {
         const scalar_t eps = eps_scalar.to<scalar_t>();
@@ -205,7 +205,7 @@ static void angle_kernel(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-void conj_kernel(TensorIteratorBase& iter) {
+static void conj_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_SWITCH(iter.common_dtype(), "conj_cpu",
     AT_DISPATCH_CASE_ALL_TYPES_AND3(kBool, kBFloat16, kHalf, [&] {
       // conj is a no-op for non-complex types
@@ -243,7 +243,7 @@ static void bitwise_not_kernel(TensorIteratorBase& iter) {
   }
 }
 
-void frac_kernel(TensorIteratorBase& iter) {
+static void frac_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "frac_cpu", [&]() {
     cpu_kernel_vec(
         iter,
@@ -252,7 +252,7 @@ void frac_kernel(TensorIteratorBase& iter) {
   });
 }
 
-void logical_not_kernel(TensorIteratorBase& iter) {
+static void logical_not_kernel(TensorIteratorBase& iter) {
   // NOTE: this implementation differs from the CUDA implementation which only does single dispatch
   // (to avoid expensive compilation) because CPU kernels don't handle dynamic_casting
   // (see needs_dynamic_casting).
@@ -264,7 +264,7 @@ void logical_not_kernel(TensorIteratorBase& iter) {
   });
 }
 
-void reciprocal_kernel(TensorIteratorBase& iter) {
+static void reciprocal_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "reciprocal_cpu", [&]() {
     cpu_kernel_vec(
         iter,
@@ -274,7 +274,7 @@ void reciprocal_kernel(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-void neg_kernel(TensorIteratorBase& iter) {
+static void neg_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kComplexHalf, kBFloat16, kHalf, iter.dtype(), "neg_cpu", [&]() {
     cpu_kernel_vec(
         iter,
@@ -283,7 +283,7 @@ void neg_kernel(TensorIteratorBase& iter) {
   });
 }
 
-void sign_kernel(TensorIteratorBase& iter){
+static void sign_kernel(TensorIteratorBase& iter){
   if(iter.dtype() == ScalarType::Bool){
       cpu_kernel(iter, [=](bool x) -> bool { return x; });
   } else {
@@ -468,7 +468,7 @@ static void kaiser_window_kernel(TensorIteratorBase& iter, int64_t window_length
   });
 }
 
-void rsqrt_kernel(TensorIteratorBase& iter) {
+static void rsqrt_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "rsqrt_cpu", [&] {
     cpu_kernel_vec(
         iter,
@@ -559,7 +559,7 @@ static void erfcx_kernel(TensorIteratorBase& iter){
   });
 }
 
-void round_decimals_kernel(TensorIteratorBase& iter, int64_t decimals) {
+static void round_decimals_kernel(TensorIteratorBase& iter, int64_t decimals) {
   AT_DISPATCH_FLOATING_TYPES_AND(
       ScalarType::BFloat16, iter.dtype(), "round_cpu", [&]() {
         bool neg_flag = false;

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -205,7 +205,7 @@ static void angle_kernel(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-static void conj_kernel(TensorIteratorBase& iter) {
+void conj_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_SWITCH(iter.common_dtype(), "conj_cpu",
     AT_DISPATCH_CASE_ALL_TYPES_AND3(kBool, kBFloat16, kHalf, [&] {
       // conj is a no-op for non-complex types
@@ -264,7 +264,7 @@ static void logical_not_kernel(TensorIteratorBase& iter) {
   });
 }
 
-static void reciprocal_kernel(TensorIteratorBase& iter) {
+void reciprocal_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "reciprocal_cpu", [&]() {
     cpu_kernel_vec(
         iter,
@@ -274,7 +274,7 @@ static void reciprocal_kernel(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-static void neg_kernel(TensorIteratorBase& iter) {
+void neg_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kComplexHalf, kBFloat16, kHalf, iter.dtype(), "neg_cpu", [&]() {
     cpu_kernel_vec(
         iter,
@@ -468,7 +468,7 @@ static void kaiser_window_kernel(TensorIteratorBase& iter, int64_t window_length
   });
 }
 
-static void rsqrt_kernel(TensorIteratorBase& iter) {
+void rsqrt_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "rsqrt_cpu", [&] {
     cpu_kernel_vec(
         iter,

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -28,7 +28,7 @@
 namespace at {
 namespace native {
 
-void layer_norm_with_mean_rstd_out(
+static void layer_norm_with_mean_rstd_out(
     at::Tensor& out,
     at::Tensor& mean,
     at::Tensor& rstd,

--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -23,7 +23,7 @@ DEFINE_DISPATCH(nested_dense_elementwise_stub);
 REGISTER_NO_CPU_DISPATCH(nested_dense_elementwise_stub);
 
 std::pair<NestedTensorImpl*, NestedTensorImpl*>
-get_elementwise_nested_tensor_impl(
+static get_elementwise_nested_tensor_impl(
     const Tensor& self,
     const Tensor& other,
     const std::string& op_name) {

--- a/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
@@ -79,7 +79,7 @@ Tensor bmm_nested(const Tensor& self, const Tensor& mat2) {
   return output;
 }
 
-Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
+static Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
   // Tensor self = self_.contiguous();
   // Tensor mat2 = mat2_.contiguous();
   // self [N, n_heads, *, head_dim]

--- a/aten/src/ATen/native/prim_native_functions.cpp
+++ b/aten/src/ATen/native/prim_native_functions.cpp
@@ -33,12 +33,12 @@ bool is_nonzero(const Tensor& self) {
 
 // Aux function used in the test TestPythonDispatch.test_kwarg_only_and_positional_default
 // within test/test_python_dispatch.py
-Tensor foobar(const Tensor& self, bool arg1, bool arg2, bool arg3) {
+static Tensor foobar(const Tensor& self, bool arg1, bool arg2, bool arg3) {
   return self;
 }
 
 // Aux function used to test functorch fallback warning
-Tensor _test_functorch_fallback(const Tensor& self, const Tensor& other) {
+static Tensor _test_functorch_fallback(const Tensor& self, const Tensor& other) {
   return self.clone();
 }
 

--- a/aten/src/ATen/native/prim_native_functions.cpp
+++ b/aten/src/ATen/native/prim_native_functions.cpp
@@ -5,6 +5,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/is_nonzero_native.h>
+#include <ATen/ops/_test_functorch_fallback_native.h>
 #endif
 
 namespace at {
@@ -33,12 +34,12 @@ bool is_nonzero(const Tensor& self) {
 
 // Aux function used in the test TestPythonDispatch.test_kwarg_only_and_positional_default
 // within test/test_python_dispatch.py
-static Tensor foobar(const Tensor& self, bool arg1, bool arg2, bool arg3) {
+Tensor foobar(const Tensor& self, bool arg1, bool arg2, bool arg3) {
   return self;
 }
 
 // Aux function used to test functorch fallback warning
-static Tensor _test_functorch_fallback(const Tensor& self, const Tensor& other) {
+Tensor _test_functorch_fallback(const Tensor& self, const Tensor& other) {
   return self.clone();
 }
 

--- a/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
@@ -76,7 +76,7 @@ Tensor & masked_fill__quantized_cpu(Tensor& self, const Tensor & mask, const Ten
   return self;
 }
 
-Tensor & masked_fill_impl_quantized_cuda(Tensor& self, const Tensor & mask, const Scalar& value) {
+static Tensor & masked_fill_impl_quantized_cuda(Tensor& self, const Tensor & mask, const Scalar& value) {
   TORCH_CHECK(self.device() == mask.device(), "expected self and mask to be on the same device, but got mask on ",
     mask.device(), " and self on ", self.device());
   TORCH_CHECK(mask.scalar_type() == kBool, "masked_fill only supports boolean masks, "

--- a/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/BinaryOps.cpp
@@ -483,7 +483,7 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 
 }  // namespace
 
-Tensor quantized_add(Tensor qa, Tensor qb, double scale, int64_t zero_point){
+static Tensor quantized_add(Tensor qa, Tensor qb, double scale, int64_t zero_point){
   return qadd<false>(std::move(qa), std::move(qb), scale, zero_point);
 }
 

--- a/aten/src/ATen/native/quantized/cpu/MakePerTensorQuantizedTensor.cpp
+++ b/aten/src/ATen/native/quantized/cpu/MakePerTensorQuantizedTensor.cpp
@@ -8,6 +8,7 @@
 #include <ATen/Functions.h>
 #else
 #include <ATen/ops/_empty_affine_quantized.h>
+#include <ATen/ops/_make_per_tensor_quantized_tensor_native.h>
 #endif
 
 namespace at {

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -16,6 +16,7 @@
 #include <ATen/ops/mean_native.h>                     // for mean_out_quanti...
 #include <ATen/ops/quantize_per_tensor.h>             // for quantize_per_te...
 #include <ATen/ops/std.h>
+#include <ATen/ops/std_native.h>
 #include <ATen/ops/zeros_like_ops.h>
 #endif
 
@@ -54,7 +55,7 @@ inline bool is_mean_inner_dim_fast_path(
 }
 
 #ifdef USE_PYTORCH_QNNPACK
-Tensor qnnpack_mean(const Tensor& input, IntArrayRef dim, bool keepdim) {
+static Tensor qnnpack_mean(const Tensor& input, IntArrayRef dim, bool keepdim) {
   Tensor output;
   TORCH_CHECK(
       input.ndimension() == 4,
@@ -171,7 +172,7 @@ Tensor mean_quantized_cpu(
   return result;
 }
 
-Tensor& mean_out_quantized_cpu(
+static Tensor& mean_out_quantized_cpu(
     Tensor& result,
     const Tensor& self,
     DimnameList dim,
@@ -236,7 +237,7 @@ Tensor std_quantized_cpu(
   return result;
 }
 
-Tensor std_quantized_cpu(
+static Tensor std_quantized_cpu(
     const Tensor& self,
     DimnameList dim,
     const c10::optional<Scalar>& correction,
@@ -245,7 +246,7 @@ Tensor std_quantized_cpu(
       self, dimnames_to_positions(self, dim), correction, keepdim);
 }
 
-Tensor& std_out_quantized_cpu(
+static Tensor& std_out_quantized_cpu(
     Tensor& result,
     const Tensor& self,
     DimnameList dim,

--- a/aten/src/ATen/native/quantized/cpu/Sorting.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Sorting.cpp
@@ -23,7 +23,7 @@ namespace native {
 //
 // If we want to support this publicly, we need to add
 // a requantization step to the kernel.
-std::tuple<Tensor&, Tensor&> quantized_topk_out_cpu(
+static std::tuple<Tensor&, Tensor&> quantized_topk_out_cpu(
     Tensor& values,
     Tensor& indices,
     const Tensor& self,

--- a/aten/src/ATen/native/quantized/cpu/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/UpSampleBilinear2d.cpp
@@ -219,7 +219,7 @@ Tensor upsample_bilinear2d_quantized_cpu(
 using at::native::upsample::compute_output_size;
 using at::native::upsample::get_scale_value;
 
-Tensor upsample_bilinear2d_quantized_cpu(
+static Tensor upsample_bilinear2d_quantized_cpu(
     const Tensor& input,
     at::OptionalIntArrayRef output_size,
       bool align_corners,

--- a/aten/src/ATen/native/quantized/cpu/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/UpSampleNearest2d.cpp
@@ -218,7 +218,7 @@ Tensor _upsample_nearest_exact2d_quantized_cpu(
   return _upsample_nearest2d_quantized_cpu<nearest_neighbor_exact_compute_source_index>(input, osize, scale_h, scale_w);
 }
 
-Tensor upsample_nearest2d_quantized_cpu(
+static Tensor upsample_nearest2d_quantized_cpu(
     const Tensor& input,
     at::OptionalIntArrayRef output_size,
     c10::optional<ArrayRef<double>> scale_factors) {
@@ -228,7 +228,7 @@ Tensor upsample_nearest2d_quantized_cpu(
   return upsample_nearest2d_quantized_cpu(input, osize, scale_h, scale_w);
 }
 
-Tensor _upsample_nearest_exact2d_quantized_cpu(
+static Tensor _upsample_nearest_exact2d_quantized_cpu(
     const Tensor& input,
     at::OptionalIntArrayRef output_size,
     c10::optional<ArrayRef<double>> scale_factors) {

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1059,7 +1059,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
 }
 
 #ifdef USE_XNNPACK
-bool can_use_xnnp(
+static bool can_use_xnnp(
     c10::ScalarType dtype,
     int kSpatialDim,
     bool per_channel,

--- a/aten/src/ATen/native/quantized/cpu/qelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qelu.cpp
@@ -15,14 +15,14 @@ namespace native {
 
 DEFINE_DISPATCH(qelu_stub);
 
-Tensor quantized_elu(
+static Tensor quantized_elu(
     const Tensor& qx, double output_scale, int64_t output_zero_point, const Scalar& alpha, const Scalar& scale, const Scalar& input_scale) {
   Tensor qy = at::_empty_affine_quantized(qx.sizes(), qx.options(), output_scale, output_zero_point);
   qelu_stub(qx.device().type(), qx, alpha, scale, input_scale, qy);
   return qy;
 }
 
-Tensor quantized_celu(const Tensor& qx, double output_scale, int64_t output_zero_point, const Scalar& alpha) {
+static Tensor quantized_celu(const Tensor& qx, double output_scale, int64_t output_zero_point, const Scalar& alpha) {
   TORCH_CHECK(alpha.to<double>() != 0,
       "ZeroDivisionError: alpha cannot be 0 for CELU");
   double inv_alpha = 1. / alpha.to<double>();

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -837,7 +837,7 @@ Tensor& embedding_bag_4bit_rowwise_offsets_out(
       false);
 }
 
-Tensor& embedding_bag_2bit_rowwise_offsets_out(
+static Tensor& embedding_bag_2bit_rowwise_offsets_out(
     Tensor& output,
     const Tensor& weight,
     const Tensor& indices,

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/quantized/cpu/EmbeddingPackedParams.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qembeddingbag.h>
 #include <c10/util/irange.h>
 #include <torch/library.h>
 

--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -80,7 +80,7 @@ Tensor qnnpack_hardswish(const Tensor& qx, Tensor& qy) {
 
 } // namespace
 
-Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output_zero_point) {
+static Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output_zero_point) {
   Tensor qy = at::_empty_affine_quantized(
       qx.sizes(),
       at::device(kCPU).dtype(qx.scalar_type()),

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -730,7 +730,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
 }
 
 #ifdef USE_XNNPACK
-bool can_use_xnnp(c10::ScalarType dtype, bool per_channel) {
+static bool can_use_xnnp(c10::ScalarType dtype, bool per_channel) {
   if(!at::native::xnnpack::available()) {
     return false;
   }

--- a/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
@@ -20,7 +20,7 @@ namespace native {
 DEFINE_DISPATCH(quantized_normalize_stub);
 DEFINE_DISPATCH(quantized_groupnorm_nhwc_stub);
 
-Tensor quantized_layer_norm_impl(
+static Tensor quantized_layer_norm_impl(
     const Tensor& input,
     IntArrayRef normalized_shape,
     const Tensor& weight /* optional */,
@@ -53,7 +53,7 @@ Tensor quantized_layer_norm_impl(
   return Y;
 }
 
-Tensor quantized_group_norm_impl(
+static Tensor quantized_group_norm_impl(
     const Tensor& qx,
     int64_t num_groups,
     const Tensor& weight, // optional
@@ -107,7 +107,7 @@ Tensor quantized_group_norm_impl(
   return Y;
 }
 
-Tensor quantized_instance_norm_impl(
+static Tensor quantized_instance_norm_impl(
     const Tensor& qx,
     const Tensor& weight, // optional
     const Tensor& bias, // optional

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -17,6 +17,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_empty_affine_quantized.h>
+#include <ATen/ops/_prelu_kernel_native.h>
 #include <ATen/ops/hardtanh_native.h>
 #include <ATen/ops/leaky_relu_native.h>
 #include <ATen/ops/prelu.h>
@@ -150,7 +151,7 @@ Tensor& leaky_relu_quantized_cpu_(Tensor& self, const Scalar& negval) {
   return self;
 }
 
-Tensor _prelu_kernel_quantized_cpu_impl(const Tensor& self, const Tensor& weight,
+static Tensor _prelu_kernel_quantized_cpu_impl(const Tensor& self, const Tensor& weight,
                                 double output_scale, int64_t output_zero_point) {
   auto ndim = self.dim();
   // for ndim < 1 or > 5, go to reference path

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -26,7 +26,7 @@ namespace native {
 DEFINE_DISPATCH(qsigmoid_stub);
 
 #ifdef USE_PYTORCH_QNNPACK
-Tensor qnnpack_sigmoid(
+static Tensor qnnpack_sigmoid(
     Tensor input, double output_scale, int64_t output_zero_point) {
   TORCH_CHECK(input.ndimension() > 0, "qnnpack_sigmoid(): Got empty input tensor");
   TORCH_CHECK(input.scalar_type() == c10::kQUInt8,

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -22,7 +22,7 @@ DEFINE_DISPATCH(qtanh_stub);
 
 #ifdef USE_PYTORCH_QNNPACK
 // This ALWAYS outputs scale=2.0/256, zp=128, dtype=quint8
-Tensor qnnpack_tanh(Tensor input) {
+static Tensor qnnpack_tanh(Tensor input) {
   TORCH_CHECK(input.ndimension() > 0, "qnnpack_tanh(): Got empty input tensor");
   TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
                "qnnpack_tanh(): Expected input data type ",

--- a/aten/src/ATen/native/quantized/cpu/qthreshold.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qthreshold.cpp
@@ -19,7 +19,7 @@ namespace native {
 DEFINE_DISPATCH(qthreshold_stub);
 
 // the underlying implementation for quantized threshold kernel
-Tensor quantized_threshold_impl(
+static Tensor quantized_threshold_impl(
     const Tensor& qx,
     const Scalar& threshold,
     const Scalar& value) {

--- a/aten/src/ATen/native/sparse/SoftMax.cpp
+++ b/aten/src/ATen/native/sparse/SoftMax.cpp
@@ -602,7 +602,7 @@ Tensor log_softmax_backward_sparse_cpu(
   return grad_input;
 }
 
-Tensor _sparse_softmax(const Tensor& input_, const int64_t dim_) {
+static Tensor _sparse_softmax(const Tensor& input_, const int64_t dim_) {
   auto result = [&]() {
     NoNamesGuard guard;
     return at::_sparse_softmax(input_, dim_, false);
@@ -629,7 +629,7 @@ Tensor _sparse_softmax(const Tensor& self, Dimname dim, optional<ScalarType> dty
   return at::_sparse_softmax(self, dimname_to_position(self, dim), dtype);
 }
 
-Tensor _sparse_log_softmax(const Tensor& input_, const int64_t dim_) {
+static Tensor _sparse_log_softmax(const Tensor& input_, const int64_t dim_) {
   auto result = [&]() {
     NoNamesGuard guard;
     return at::_sparse_log_softmax(input_, dim_, false);

--- a/aten/src/ATen/native/sparse/SparseBlas.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlas.cpp
@@ -19,6 +19,7 @@
 #include <ATen/ops/addmm.h>
 #include <ATen/ops/resize_as_sparse_native.h>
 #include <ATen/ops/sparse_sampled_addmm_native.h>
+#include <ATen/ops/triangular_solve_native.h>
 #endif
 
 #include <c10/util/MaybeOwned.h>
@@ -92,7 +93,7 @@ Tensor& addmv_out_sparse_compressed(
   * `X` - dense Tensor of size m × nrhs.
   * `clone_A` - cloned matrix A, required only for compatibility with strided layout interface.
 */
-static std::tuple<Tensor&, Tensor&> triangular_solve_out_sparse_csr_cpu(
+std::tuple<Tensor&, Tensor&> triangular_solve_out_sparse_csr_cpu(
     const Tensor& B,
     const Tensor& A,
     bool upper,

--- a/aten/src/ATen/native/sparse/SparseBlas.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlas.cpp
@@ -92,7 +92,7 @@ Tensor& addmv_out_sparse_compressed(
   * `X` - dense Tensor of size m × nrhs.
   * `clone_A` - cloned matrix A, required only for compatibility with strided layout interface.
 */
-std::tuple<Tensor&, Tensor&> triangular_solve_out_sparse_csr_cpu(
+static std::tuple<Tensor&, Tensor&> triangular_solve_out_sparse_csr_cpu(
     const Tensor& B,
     const Tensor& A,
     bool upper,

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -346,7 +346,7 @@ inline Tensor get_result_tensor_for_unary_op(F op, const Tensor& input) {
 // TODO: Check what happens with MKL, the output error reported with non square
 // matrices tends to be high See:
 // https://github.com/pytorch/pytorch/issues/58770
-bool is_square_or_vec(int64_t dim_i, int64_t dim_j, int64_t dim_k) {
+static bool is_square_or_vec(int64_t dim_i, int64_t dim_j, int64_t dim_k) {
   return (dim_i == dim_k && dim_k == dim_j) || (dim_i == dim_j && dim_k == 1);
 }
 
@@ -460,7 +460,7 @@ CREATE_UNARY_UFUNC(tan);
 CREATE_UNARY_UFUNC(tanh);
 CREATE_UNARY_UFUNC(trunc);
 CREATE_UNARY_UFUNC(conj_physical);
-CREATE_UNARY_UFUNC(relu);
+static CREATE_UNARY_UFUNC(relu);
 
 // With addition of `round.decimals` overload, using CREATE_UNARY_UFUNC leads
 // to unresolved overload.
@@ -772,7 +772,7 @@ Tensor _sparse_csr_mm(const Tensor& mat1, const Tensor& mat2) {
       1.0);
 }
 
-Tensor _sparse_csr_addmm(
+static Tensor _sparse_csr_addmm(
     const Tensor& t,
     const SparseCsrTensor& sparse,
     const Tensor& dense,
@@ -802,7 +802,7 @@ Tensor& add_sparse_csr_(
   return at::add_out(self, self, other, alpha); // redispatch!
 }
 
-void add_out_dense_sparse_csr_cpu(
+static void add_out_dense_sparse_csr_cpu(
     const Tensor& out,
     const Tensor& dense,
     const SparseCsrTensor& src,
@@ -1266,7 +1266,7 @@ struct ReductionMulOp {
 
 }  // namespace
 
-Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, bool keepdim, c10::optional<ScalarType> dtype) {
+static Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, bool keepdim, c10::optional<ScalarType> dtype) {
   ScalarType dtype_ = dtype.value_or(input.scalar_type());
   Tensor input_ = input.to(dtype_);
   Tensor result;
@@ -1278,7 +1278,7 @@ Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, bool ke
   return result;
 }
 
-Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_reduce, bool keepdim, c10::optional<ScalarType> dtype) {
+static Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_reduce, bool keepdim, c10::optional<ScalarType> dtype) {
   ScalarType dtype_ = dtype.value_or(input.scalar_type());
   Tensor input_ = input.to(dtype_);
   Tensor result;
@@ -1290,7 +1290,7 @@ Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_reduce, boo
   return result;
 }
 
-std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
+static std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
     const Tensor& self,
     const Tensor& other,
     const c10::string_view reduce) {
@@ -1341,7 +1341,7 @@ std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
   return std::make_tuple(std::move(out), std::move(arg_out));
 }
 
-std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_backward_sparse_csr_cpu(
+static std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_backward_sparse_csr_cpu(
     const Tensor& self,
     const Tensor& grad_out,
     const Tensor& other,

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -27,7 +27,11 @@
 #include <ATen/ops/_convert_indices_from_csr_to_coo_native.h>
 #include <ATen/ops/_sparse_bsr_tensor_unsafe_native.h>
 #include <ATen/ops/_sparse_compressed_tensor_unsafe_native.h>
+#include <ATen/ops/_sparse_csr_prod_native.h>
+#include <ATen/ops/_sparse_csr_sum_native.h>
 #include <ATen/ops/_sparse_csr_tensor_unsafe_native.h>
+#include <ATen/ops/_sparse_mm_reduce_impl_backward_native.h>
+#include <ATen/ops/_sparse_mm_reduce_impl_backward_native.h>
 #include <ATen/ops/_unique.h>
 #include <ATen/ops/abs.h>
 #include <ATen/ops/abs_native.h>
@@ -460,7 +464,7 @@ CREATE_UNARY_UFUNC(tan);
 CREATE_UNARY_UFUNC(tanh);
 CREATE_UNARY_UFUNC(trunc);
 CREATE_UNARY_UFUNC(conj_physical);
-static CREATE_UNARY_UFUNC(relu);
+CREATE_UNARY_UFUNC(relu);
 
 // With addition of `round.decimals` overload, using CREATE_UNARY_UFUNC leads
 // to unresolved overload.
@@ -772,7 +776,7 @@ Tensor _sparse_csr_mm(const Tensor& mat1, const Tensor& mat2) {
       1.0);
 }
 
-static Tensor _sparse_csr_addmm(
+Tensor _sparse_csr_addmm(
     const Tensor& t,
     const SparseCsrTensor& sparse,
     const Tensor& dense,
@@ -1266,7 +1270,7 @@ struct ReductionMulOp {
 
 }  // namespace
 
-static Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, bool keepdim, c10::optional<ScalarType> dtype) {
+Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, bool keepdim, c10::optional<ScalarType> dtype) {
   ScalarType dtype_ = dtype.value_or(input.scalar_type());
   Tensor input_ = input.to(dtype_);
   Tensor result;
@@ -1278,7 +1282,7 @@ static Tensor _sparse_csr_sum_cpu(const Tensor& input, IntArrayRef dims_to_sum, 
   return result;
 }
 
-static Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_reduce, bool keepdim, c10::optional<ScalarType> dtype) {
+Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_reduce, bool keepdim, c10::optional<ScalarType> dtype) {
   ScalarType dtype_ = dtype.value_or(input.scalar_type());
   Tensor input_ = input.to(dtype_);
   Tensor result;
@@ -1290,7 +1294,7 @@ static Tensor _sparse_csr_prod_cpu(const Tensor& input, IntArrayRef dims_to_redu
   return result;
 }
 
-static std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
+std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
     const Tensor& self,
     const Tensor& other,
     const c10::string_view reduce) {
@@ -1341,7 +1345,7 @@ static std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_sparse_csr_cpu(
   return std::make_tuple(std::move(out), std::move(arg_out));
 }
 
-static std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_backward_sparse_csr_cpu(
+std::tuple<Tensor, Tensor> _sparse_mm_reduce_impl_backward_sparse_csr_cpu(
     const Tensor& self,
     const Tensor& grad_out,
     const Tensor& other,

--- a/aten/src/ATen/native/sparse/SparseFactories.cpp
+++ b/aten/src/ATen/native/sparse/SparseFactories.cpp
@@ -17,7 +17,7 @@ namespace at::native {
 
 DEFINE_DISPATCH(spdiags_kernel_stub);
 
-Tensor spdiags(
+static Tensor spdiags(
     const Tensor& diagonals,
     const Tensor& offsets,
     IntArrayRef shape,

--- a/aten/src/ATen/native/sparse/SparseFactories.cpp
+++ b/aten/src/ATen/native/sparse/SparseFactories.cpp
@@ -6,6 +6,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_spdiags_native.h>
 #include <ATen/ops/_unique.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
@@ -17,7 +18,7 @@ namespace at::native {
 
 DEFINE_DISPATCH(spdiags_kernel_stub);
 
-static Tensor spdiags(
+Tensor spdiags(
     const Tensor& diagonals,
     const Tensor& offsets,
     IntArrayRef shape,

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -140,7 +140,7 @@ Tensor values_default(const Tensor& self) {
 
 /*** Helper methods ***/
 
-SparseTensor new_sparse(
+static SparseTensor new_sparse(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -267,7 +267,7 @@ Tensor& div_sparse_(Tensor& self, const Tensor& value) {
   return div_out_sparse_zerodim(self, value, self);
 }
 
-SparseTensor& div_out_sparse_scalar(const SparseTensor& t, Scalar value, SparseTensor& r) {
+static SparseTensor& div_out_sparse_scalar(const SparseTensor& t, Scalar value, SparseTensor& r) {
   return div_out_sparse_zerodim(t, wrapped_scalar_tensor(value), r);
 }
 
@@ -284,7 +284,7 @@ Tensor& div_sparse_(Tensor& self, const Tensor& value, c10::optional<c10::string
   return div_out_sparse_zerodim(self, value, std::move(rounding_mode), self);
 }
 
-SparseTensor& div_out_sparse_scalar(const SparseTensor& t, Scalar value, c10::optional<c10::string_view> rounding_mode, SparseTensor& r) {
+static SparseTensor& div_out_sparse_scalar(const SparseTensor& t, Scalar value, c10::optional<c10::string_view> rounding_mode, SparseTensor& r) {
   return div_out_sparse_zerodim(t, wrapped_scalar_tensor(value), std::move(rounding_mode), r);
 }
 
@@ -347,7 +347,7 @@ Tensor& floor_divide_sparse_(Tensor& self, const Tensor& value) {
   return floor_divide_out_sparse_zerodim(self, value, self);
 }
 
-SparseTensor& floor_divide_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, const Scalar& value) {
+static SparseTensor& floor_divide_out_sparse_scalar(SparseTensor& r, const SparseTensor& t, const Scalar& value) {
   return floor_divide_out_sparse_zerodim(t, wrapped_scalar_tensor(value), r);
 }
 
@@ -445,7 +445,7 @@ Tensor& sub_out_sparse(const Tensor& self, const Tensor& other, const Scalar& al
 }
 
 
-SparseTensor& add_out_sparse_contiguous(SparseTensor& r, const SparseTensor& t, const SparseTensor& src, const Scalar& value, ScalarType commonDtype) {
+static SparseTensor& add_out_sparse_contiguous(SparseTensor& r, const SparseTensor& t, const SparseTensor& src, const Scalar& value, ScalarType commonDtype) {
     // saving those because they can be overwritten when doing in-place operations
     int64_t t_nnz = t._nnz(), s_nnz = src._nnz(), max_nnz = t_nnz + s_nnz;
     bool coalesced = t.is_coalesced() && src.is_coalesced();
@@ -533,7 +533,7 @@ SparseTensor& add_out_sparse_contiguous(SparseTensor& r, const SparseTensor& t, 
     return r._coalesced_(coalesced);
 }
 
-SparseTensor& add_out_sparse_non_contiguous(SparseTensor& r, const SparseTensor& t, const SparseTensor& src, const Scalar& value, ScalarType commonDtype) {
+static SparseTensor& add_out_sparse_non_contiguous(SparseTensor& r, const SparseTensor& t, const SparseTensor& src, const Scalar& value, ScalarType commonDtype) {
     Tensor t_values = t._values().to(commonDtype);
     Tensor s_values = src._values().to(commonDtype);
 
@@ -1235,7 +1235,7 @@ void s_addmm_out_sparse_dense_worker(int64_t nnz, int64_t dim_i, int64_t dim_j, 
   }
 };
 
-Tensor& s_addmm_out_sparse_dense_cpu(
+static Tensor& s_addmm_out_sparse_dense_cpu(
     Tensor& r,
     const Tensor& t,
     const SparseTensor& sparse_,
@@ -1323,7 +1323,7 @@ Tensor& addmm_out_sparse_dense_cpu(
   return s_addmm_out_sparse_dense_cpu(result, *b_self, mat1, mat2, beta, alpha);
 }
 
-Tensor s_addmm_sparse_dense_cpu(
+static Tensor s_addmm_sparse_dense_cpu(
     const Tensor& t,
     const SparseTensor& sparse,
     const Tensor& dense,

--- a/aten/src/ATen/native/sparse/SparseUnaryOps.cpp
+++ b/aten/src/ATen/native/sparse/SparseUnaryOps.cpp
@@ -7,6 +7,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
+#include <ATen/ops/_sparse_mm_reduce_impl_native.h>
 #include <ATen/ops/abs.h>
 #include <ATen/ops/abs_native.h>
 #include <ATen/ops/asin.h>

--- a/aten/src/ATen/native/sparse/ValidateCompressedIndicesKernel.cpp
+++ b/aten/src/ATen/native/sparse/ValidateCompressedIndicesKernel.cpp
@@ -1,6 +1,10 @@
 #include <ATen/native/sparse/ValidateCompressedIndicesCommon.h>
 #include <ATen/native/cpu/Loops.h>
 
+#ifdef AT_PER_OPERATOR_HEADERS
+#include <ATen/ops/_validate_compressed_sparse_indices_native.h>
+#endif
+
 namespace at::native {
 
 namespace {
@@ -27,7 +31,7 @@ struct CPUVecKernel {
 
 }
 
-static void _validate_compressed_sparse_indices_cpu(
+void _validate_compressed_sparse_indices_cpu(
     const bool is_crow,
     const Tensor& cidx,
     const Tensor& idx,

--- a/aten/src/ATen/native/sparse/ValidateCompressedIndicesKernel.cpp
+++ b/aten/src/ATen/native/sparse/ValidateCompressedIndicesKernel.cpp
@@ -27,7 +27,7 @@ struct CPUVecKernel {
 
 }
 
-void _validate_compressed_sparse_indices_cpu(
+static void _validate_compressed_sparse_indices_cpu(
     const bool is_crow,
     const Tensor& cidx,
     const Tensor& idx,


### PR DESCRIPTION
PR #101788 depended on https://github.com/pytorch/pytorch/pull/100849 which was  reverted. Now that https://github.com/pytorch/pytorch/pull/100849 has been relanded,  we can reland #101788 too.
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @izaitsevfb @Skylion007  