### PR TITLE
Support FakeTensor with FlatParameter

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -29,6 +29,7 @@ import copy
 import torch._functorch.config
 from unittest.mock import patch
 
+from torch import distributed as dist
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten
@@ -66,6 +67,16 @@ class FakeTensorTest(TestCase):
             x = torch.rand([4])
             y = torch.nn.parameter.Parameter(x)
             self.assertTrue(isinstance(y, torch.nn.Parameter))
+
+    @unittest.skipIf(not dist.is_available(), "requires distributed")
+    def test_fsdp_flat_param(self):
+        from torch.distributed.fsdp.flat_param import FlatParameter
+        with FakeTensorMode() as m:
+            data = torch.randn(2, 2)
+            param = FlatParameter(data, requires_grad=True)
+        self.assertIsInstance(param, FlatParameter)
+        self.assertIsInstance(param, torch.nn.Parameter)
+        self.assertIsInstance(param, FakeTensor)
 
     def test_non_parameter_grad(self):
         mode = FakeTensorMode()

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -283,7 +283,7 @@ def _get_param_to_fqns(
         ):
             local_fqns = (
                 param._fqns
-                if type(param) is flat_param_file.FlatParameter
+                if isinstance(param, flat_param_file.FlatParameter)
                 else [param_name]
             )  # prefixed from `module`
             global_fqns = [
@@ -293,7 +293,7 @@ def _get_param_to_fqns(
             if not is_shared_param:
                 param_to_fqns[param] = global_fqns
             else:
-                if type(param) is flat_param_file.FlatParameter:
+                if isinstance(param, flat_param_file.FlatParameter):
                     # DMP overwrites `named_parameters` and skip (advance to
                     # the next child module) the wrapped_module (e.g.,
                     # _dmp_wrapped_module and _fsdp_wrapped_module). When a user

--- a/torch/distributed/fsdp/_debug_utils.py
+++ b/torch/distributed/fsdp/_debug_utils.py
@@ -75,7 +75,7 @@ def _get_sharded_module_tree_with_module_name_to_fqns(
 
         for handle in handles:
             param = handle.flat_param
-            assert type(param) is flat_param_file.FlatParameter
+            assert isinstance(param, flat_param_file.FlatParameter)
             global_fqns = [
                 clean_tensor_name(prefix + name) for name in param._fqns
             ]  # prefixed from the top level `model` (i.e. including `prefix`)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -985,7 +985,7 @@ def _get_flat_param_to_fqn(model: torch.nn.Module) -> Dict[nn.Parameter, str]:
         for param_name, param in _named_parameters_with_duplicates(
             module, recurse=False
         ):
-            if type(param) is not FlatParameter:
+            if not isinstance(param, FlatParameter):
                 continue
             fqn = clean_tensor_name(prefix + param_name)
             flat_param_to_fqn[param] = fqn

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -371,7 +371,7 @@ def _shard_orig_param_state(
             and value.dim() > 0
             and fsdp_state.sharding_strategy != ShardingStrategy.NO_SHARD
         ):
-            value = value.flatten()[intra_param_start_idx : intra_param_end_idx + 1]
+            value = value.flatten()[intra_param_start_idx : intra_param_end_idx + 1]  # type: ignore[operator]
         new_optim_state[state_name] = value
     return new_optim_state
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -668,7 +668,7 @@ class FlatParamHandle:
         device: Optional[torch.device] = None
         # For `use_orig_params=True`, permit non-uniform `requires_grad`
         for tensor in tensors:
-            if type(tensor) is FlatParameter:
+            if isinstance(tensor, FlatParameter):
                 raise ValueError("Cannot flatten a `FlatParameter`")
             if dtype is None and not tensor.is_floating_point():
                 raise ValueError("Cannot flatten integer dtype tensors")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #101987

In this PR we turn FlatParameter into a virtual tensor subclass
which doesn't actually ever get instantiated: __new__ will create
a Parameter instead (or a FakeTensor, if necessary).

Signed-off-by: Edward Z. Yang <ezyang@meta.com>