### PR TITLE
[1/n] instanceof instead of singleton for ph check

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -580,7 +580,7 @@ class Tracer(TracerBase):
                     out = self.create_proxy(
                         "placeholder", f"{name}_{str(cnt)}", default, {}
                     )
-                    if x == PH:
+                    if isinstance(x, PHBase):
                         return out
                     # Union[int, bool] == bool in Python <= 3.6
                     if (


### PR DESCRIPTION
Summary: Change placeholder check from singleton to instanceof PHBase so you can create your own PH class with metadata

Test Plan: added unit test

Reviewed By: joshuadeng

Differential Revision: D46085128

