### PR TITLE
Make exir passes work with map_impl HigherOrderOperator.

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -62,7 +62,7 @@ class Verifier:
         return [
             operator.getitem,
             control_flow.cond,
-            control_flow.map,
+            torch.ops.map_impl,
         ]
 
     @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Summary: Forward fix t53725825. New map implementation breaks multiple internal tests. forward fix it for some of them. To unblock others, mark unfixed ones are expectedFailure first.

Test Plan: Test with CI.

Reviewed By: angelayi

Differential Revision: D46084287

