### PR TITLE
[FSDP] Start to generalize modules to ignore for mixed precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -702,12 +702,16 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 self.fc1 = nn.Linear(2, 40, bias=False)
                 self.bn = nn.BatchNorm1d(4, affine=affine)
                 self.fc2 = nn.Linear(40, 4, bias=False)
+                self.ln = nn.LayerNorm(4)
+                self.fc3 = nn.Linear(4, 4, bias=False)
 
             def forward(self, x):
                 x = torch.reshape(self.fc1(x), (-1, 4, 10))
                 x = self.bn(x)
                 x = torch.reshape(x, (-1, 40))
                 x = self.fc2(x)
+                x = self.ln(x)
+                x = self.fc3(x)
                 return F.softmax(x, dim=1)
 
         def never_wrap_policy(*args, **kwargs):
@@ -723,6 +727,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             param_dtype=torch.float16,
             reduce_dtype=torch.float16,
             buffer_dtype=torch.float16,
+            _mixed_precision_module_classes_to_ignore=[_BatchNorm, nn.LayerNorm],
         )
         with self.assertWarnsRegex(
             expected_warning=UserWarning,
@@ -734,14 +739,16 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 auto_wrap_policy=never_wrap_policy,
             )
 
-        bn = model.bn
-        self.assertTrue(isinstance(bn, FSDP))
-        # policy should not have wrapped any other submodules
-        self.assertFalse(isinstance(model.fc1, FSDP))
-        self.assertFalse(isinstance(model.fc2, FSDP))
         no_mixed_precision = MixedPrecision()
-        self.assertEqual(no_mixed_precision, bn.mixed_precision)
-        self.assertNotEqual(no_mixed_precision, model.mixed_precision)
+        for mod in [model.ln, model.bn]:
+            self.assertTrue(isinstance(mod, FSDP))
+            self.assertEqual(no_mixed_precision, mod.mixed_precision)
+        # policy should not have wrapped any other submodules
+        for mod in [model.fc1, model.fc2, model.fc3]:
+            self.assertFalse(isinstance(mod, FSDP))
+
+        # Overall mixed precision is still enabled
+        self.assertEqual(mp_config, model.mixed_precision)
 
         inp = torch.randn((1, 2), device="cuda")
         # Without FSDP BN mixed precision fix, this would result in

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -727,7 +727,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             param_dtype=torch.float16,
             reduce_dtype=torch.float16,
             buffer_dtype=torch.float16,
-            _mixed_precision_module_classes_to_ignore=[_BatchNorm, nn.LayerNorm],
+            _module_classes_to_ignore=[_BatchNorm, nn.LayerNorm],
         )
         with self.assertWarnsRegex(
             expected_warning=UserWarning,

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -739,10 +739,10 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 auto_wrap_policy=never_wrap_policy,
             )
 
-        no_mixed_precision = MixedPrecision()
+        no_mp = MixedPrecision()
         for mod in [model.ln, model.bn]:
             self.assertTrue(isinstance(mod, FSDP))
-            self.assertEqual(no_mixed_precision, mod.mixed_precision)
+            self.assertEqual(no_mp, mod.mixed_precision)
         # policy should not have wrapped any other submodules
         for mod in [model.fc1, model.fc2, model.fc3]:
             self.assertFalse(isinstance(mod, FSDP))

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -10,7 +10,6 @@ from typing import Callable, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.modules.batchnorm import _BatchNorm
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
     BackwardPrefetch,
     CPUOffload,
@@ -28,6 +27,7 @@ from torch.distributed.fsdp.wrap import (
     wrap,
 )
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
+from torch.nn.modules.batchnorm import _BatchNorm
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _maybe_cuda,
@@ -160,7 +160,12 @@ class TestFSDPWrap(FSDPTest):
         def never_wrap_policy(*args, **kwargs):
             return False
 
-        wrap_batchnorm_individually = functools.partial(_wrap_module_cls_individually, module_classes=[_BatchNorm,])
+        wrap_batchnorm_individually = functools.partial(
+            _wrap_module_cls_individually,
+            module_classes=[
+                _BatchNorm,
+            ],
+        )
         policy = (
             functools.partial(
                 _or_policy, policies=[never_wrap_policy, wrap_batchnorm_individually]
@@ -194,8 +199,15 @@ class TestFSDPWrap(FSDPTest):
                 return True
             return isinstance(module, BatchNormNet)
 
+        wrap_batchnorm_individually = functools.partial(
+            _wrap_module_cls_individually,
+            module_classes=[
+                _BatchNorm,
+            ],
+        )
+
         my_policy = functools.partial(
-            _or_policy, policies=[wrap_bn_container, _wrap_module_cls_individually]
+            _or_policy, policies=[wrap_bn_container, wrap_batchnorm_individually]
         )
         mod = MyModule()
         fsdp = FSDP(mod, auto_wrap_policy=my_policy)

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -2,12 +2,46 @@ from typing import cast
 
 import torch
 from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.normalization import LayerNorm
 from torch.utils._mode_utils import no_dispatch
+
+from torch.distributed.utils import _apply_to_tensors
+from functools import partial
 
 
 def _contains_batchnorm(module):
     return any(isinstance(mod, _BatchNorm) for mod in module.modules())
 
+
+def _contains_module(root, module_to_check):
+    return any(isinstance(mod, module_to_check) for mod in root.modules())
+
+def _override_module_mixed_precision(root, module_to_override, wrap_override_dict={"mixed_precision": None}):
+    for mod in root.modules():
+        if isinstance(mod, module_to_override):
+            mod._wrap_overrides = wrap_override_dict  # type: ignore[assignment]
+
+        if isinstance(mod, LayerNorm): # TODO: generalize this logic if additional types need to be supported
+
+            old_dtype = None
+
+            def cast_fn(dtype, x: torch.Tensor) -> torch.Tensor:
+                if not torch.is_floating_point(x) or x.dtype == dtype:
+                    return x
+                nonlocal old_dtype
+                old_dtype = x.dtype
+                return x.to(dtype)
+
+            def ln_forward_pre_hook(module, args):
+                return _apply_to_tensors(partial(cast_fn, torch.float32), args)
+
+            def ln_forward_post_hook(module, args, output):
+                nonlocal old_dtype
+                if old_dtype is not None:
+                    return _apply_to_tensors(partial(cast_fn, old_dtype), output)
+
+            mod.register_forward_pre_hook(ln_forward_pre_hook)
+            mod.register_forward_hook(ln_forward_post_hook)
 
 def _override_batchnorm_mixed_precision(module):
     for mod in module.modules():

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -1,18 +1,16 @@
 from functools import partial
-from typing import Any, cast, Type, Dict
+from typing import Any, cast, Dict, Type
 
 import torch
 
 from torch.distributed.utils import _apply_to_tensors
-from torch.nn.modules.batchnorm import _BatchNorm
-from torch.nn.modules.normalization import LayerNorm
 from torch.utils._mode_utils import no_dispatch
 
 
 def _override_module_mixed_precision(
     root: torch.nn.Module,
     module_cls_to_override: Type[torch.nn.Module],
-    wrap_override_dict: Dict[str, Any] = {"mixed_precision": None},
+    wrap_override_dict: Dict[str, Any] = {"mixed_precision": None},  # noqa: B006
 ):
     for mod in root.modules():
         if isinstance(mod, module_cls_to_override):

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -17,7 +17,12 @@ def _override_module_mixed_precision(
     for mod in root.modules():
         if isinstance(mod, module_cls_to_override):
             mod._wrap_overrides = wrap_override_dict  # type: ignore[assignment]
-            # if isinstance(mod, LayerNorm): # TODO: generalize this logic if additional types need to be supported
+            # TODO: We need to run this mixed precision ignored module in fp32,
+            # but ensure subsequent modules, that may possibly be running with
+            # mixed precision, still receive the appropriate precision inputs
+            # without user having to adjust mixed precision config too much.
+            # As a result, we attach pre and post forward hooks to up / down
+            # cast. We should revisit this design.
             old_dtype = None
 
             def cast_fn(dtype, x: torch.Tensor) -> torch.Tensor:

--- a/torch/distributed/fsdp/_wrap_utils.py
+++ b/torch/distributed/fsdp/_wrap_utils.py
@@ -1,21 +1,26 @@
 import collections
 import functools
 import warnings
+from functools import partial
 from typing import Any, Deque, Dict, List, NamedTuple, Set, Tuple
 
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp._common_utils import _is_fsdp_flattened
 from torch.distributed.fsdp._utils import (
-    _contains_batchnorm,
-    _override_batchnorm_mixed_precision,
+    _contains_module,
+    _override_module_mixed_precision,
 )
+
 from torch.distributed.fsdp.wrap import (
     _FSDPPolicy,
     _or_policy,
     _recursive_wrap,
-    _wrap_batchnorm_individually,
+    _wrap_module_cls_individually,
 )
+
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.normalization import LayerNorm
 
 
 class FullyShardedModuleState(NamedTuple):
@@ -57,10 +62,21 @@ def _auto_wrap(
                 "if using an `auto_wrap_policy`"
             )
     mixed_precision = fsdp_kwargs["mixed_precision"]
-    if mixed_precision is not None and _contains_batchnorm(root_module):
-        _override_batchnorm_mixed_precision(root_module)
+    if mixed_precision is not None and any(
+        _contains_module(root_module, module_to_override)
+        for module_to_override in mixed_precision._mixed_precision_module_classes_to_ignore
+    ):
+        for mp_module_to_override in mixed_precision._mixed_precision_module_classes_to_ignore:
+            _override_module_mixed_precision(root_module, mp_module_to_override)
+
         auto_wrap_policy = functools.partial(
-            _or_policy, policies=[_wrap_batchnorm_individually, auto_wrap_policy]
+            _or_policy,
+            policies=[
+                auto_wrap_policy,
+                partial(
+                    _wrap_module_cls_individually, module_classes=mixed_precision._mixed_precision_module_classes_to_ignore
+                ),
+            ],
         )
         warnings.warn(
             "Both mixed precision and an `auto_wrap_policy` were specified "

--- a/torch/distributed/fsdp/_wrap_utils.py
+++ b/torch/distributed/fsdp/_wrap_utils.py
@@ -7,9 +7,7 @@ from typing import Any, Deque, Dict, List, NamedTuple, Set, Tuple
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp._common_utils import _is_fsdp_flattened
-from torch.distributed.fsdp._utils import (
-    _override_module_mixed_precision,
-)
+from torch.distributed.fsdp._utils import _override_module_mixed_precision
 
 from torch.distributed.fsdp.wrap import (
     _FSDPPolicy,
@@ -69,7 +67,8 @@ def _auto_wrap(
             policies=[
                 auto_wrap_policy,
                 partial(
-                    _wrap_module_cls_individually, module_classes=mixed_precision._module_classes_to_ignore
+                    _wrap_module_cls_individually,
+                    module_classes=mixed_precision._module_classes_to_ignore,
                 ),
             ],
         )

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -5,8 +5,9 @@ constructor arguments.
 
 from dataclasses import dataclass
 from enum import auto, Enum
+from torch.nn.modules.batchnorm import _BatchNorm
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 
@@ -133,6 +134,11 @@ class MixedPrecision:
             arguments and keyword arguments to ``param_dtype`` for the root FSDP instance.
             It takes precedence over ``cast_forward_inputs`` for the root FSDP instance.
             (Default: ``True``)
+        _mixed_precision_module_classes_to_ignore: (Sequence[type]): Module classes to ignore
+            for mixed precision. This will make the specified nn.Module types ignore mixed precision,
+            by wrapping them in their own FSDP unit and setting mixed_precision=None. Note that this
+            implies the ultimate wrapping of your FSDP module will be different than what the policy
+            specifies. Note that this API is experimental and subject to change.
 
     .. note:: This API is experimental and subject to change.
 
@@ -207,6 +213,8 @@ class MixedPrecision:
     keep_low_precision_grads: bool = False
     cast_forward_inputs: bool = False
     cast_root_forward_inputs: bool = True
+    _mixed_precision_module_classes_to_ignore: Optional[Sequence[type]] = (_BatchNorm,)
+
 
 
 @dataclass

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -136,7 +136,7 @@ class MixedPrecision:
             (Default: ``True``)
         _module_classes_to_ignore: (Sequence[type]): Module classes to ignore
             for mixed precision. This will make the specified ``nn.Module`` types ignore mixed precision,
-            by wrapping them in their own FSDP unit and setting mixed_precision=None. Note that
+            by wrapping them in their own FSDP unit and setting ``mixed_precision=None``. Note that
             this setting is only relevant for auto wrapping with ``auto_wrap_policy``, and that this
             implies the ultimate wrapping of your FSDP module will be different than what the policy
             specifies. Note that this API is experimental and subject to change.

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -5,11 +5,11 @@ constructor arguments.
 
 from dataclasses import dataclass
 from enum import auto, Enum
-from torch.nn.modules.batchnorm import _BatchNorm
 
 from typing import Optional, Sequence
 
 import torch
+from torch.nn.modules.batchnorm import _BatchNorm
 
 __all__ = [
     "ShardingStrategy",
@@ -215,7 +215,6 @@ class MixedPrecision:
     cast_forward_inputs: bool = False
     cast_root_forward_inputs: bool = True
     _module_classes_to_ignore: Optional[Sequence[type]] = (_BatchNorm,)
-
 
 
 @dataclass

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -134,9 +134,10 @@ class MixedPrecision:
             arguments and keyword arguments to ``param_dtype`` for the root FSDP instance.
             It takes precedence over ``cast_forward_inputs`` for the root FSDP instance.
             (Default: ``True``)
-        _mixed_precision_module_classes_to_ignore: (Sequence[type]): Module classes to ignore
-            for mixed precision. This will make the specified nn.Module types ignore mixed precision,
-            by wrapping them in their own FSDP unit and setting mixed_precision=None. Note that this
+        _module_classes_to_ignore: (Sequence[type]): Module classes to ignore
+            for mixed precision. This will make the specified ``nn.Module`` types ignore mixed precision,
+            by wrapping them in their own FSDP unit and setting mixed_precision=None. Note that
+            this setting is only relevant for auto wrapping with ``auto_wrap_policy``, and that this
             implies the ultimate wrapping of your FSDP module will be different than what the policy
             specifies. Note that this API is experimental and subject to change.
 
@@ -213,7 +214,7 @@ class MixedPrecision:
     keep_low_precision_grads: bool = False
     cast_forward_inputs: bool = False
     cast_root_forward_inputs: bool = True
-    _mixed_precision_module_classes_to_ignore: Optional[Sequence[type]] = (_BatchNorm,)
+    _module_classes_to_ignore: Optional[Sequence[type]] = (_BatchNorm,)
 
 
 

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -6,10 +6,9 @@
 import contextlib
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type
+from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type, Sequence
 
 import torch.nn as nn
-from torch.nn.modules.batchnorm import _BatchNorm
 
 __all__ = [
     "always_wrap_policy",
@@ -139,22 +138,16 @@ def transformer_auto_wrap_policy(
     return _module_wrap_policy(module, recurse, nonwrapped_numel, transformer_layer_cls)
 
 
-def _wrap_batchnorm_individually(
-    module: nn.Module,
-    recurse: bool,
-    *args,
-    **kwargs,
-) -> bool:
-    """
-    A policy that wraps ``BatchNorm`` instances in their own FSDP instance.
-    """
+def _wrap_module_cls_individually(
+    module: nn.Module, module_classes: Sequence[type], recurse: bool, *args, **kwargs
+):
     if recurse:
         # always recurse
         return True
     else:
-        # if not recursing, decide whether we should wrap based on whether it is a
-        # BN layer or not.
-        return isinstance(module, _BatchNorm)
+        # if not recursing, decide whether we should wrap based on whether the type of module
+        # is in `module_classes`.
+        return isinstance(module, tuple(module_classes))
 
 
 def _or_policy(
@@ -167,7 +160,12 @@ def _or_policy(
     A policy that wraps ``module`` if any policy in the passed in iterable of
     ``policies`` returns ``True``.
     """
-    return any(policy(module, recurse, nonwrapped_numel) for policy in policies)
+    return any(
+        policy(
+            module=module, recurse=recurse, nonwrapped_numel=nonwrapped_numel
+        )
+        for policy in policies
+    )
 
 
 def size_based_auto_wrap_policy(

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -6,7 +6,18 @@
 import contextlib
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type, Sequence
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Generator,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+)
 
 import torch.nn as nn
 
@@ -161,9 +172,7 @@ def _or_policy(
     ``policies`` returns ``True``.
     """
     return any(
-        policy(
-            module=module, recurse=recurse, nonwrapped_numel=nonwrapped_numel
-        )
+        policy(module=module, recurse=recurse, nonwrapped_numel=nonwrapped_numel)
         for policy in policies
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102231
* #102043
* #102040
* __->__ #102010

The main use case here is that folks would like to ignore layer norm for mixed precision. This can now be enabled with:

```
mp_config = MixedPrecision(
            param_dtype=torch.float16,
            reduce_dtype=torch.float16,
            buffer_dtype=torch.float16,
            _mixed_precision_module_classes_to_ignore=[_BatchNorm, nn.LayerNorm],
        )
```

This is done by classes of types in `_mixed_precision_module_classes_to_ignore` being wrapped in their own FSDP unit with mixed preicsion disabled. This is only enabled for auto wrapping.

We also add module pre and post hooks to cast / downcast inputs to the appropriate full precision.

Differential Revision: [D46079957](https://our.internmc.facebook.com/intern/diff/D46079957/)