### PR TITLE
Add retry when cleaning up Windows workspace

### DIFF
--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -43,5 +43,10 @@ runs:
           set +e
           set -x
 
-          [ ! -z "${EXTRA_DELETE_DIR}" ]  || rm -rf "${EXTRA_DELETE_DIR}"
+          if [ -n "${EXTRA_DELETE_DIR}" ]; then
+            # It's ok to fail to clean up the extra directory on Windows as it only contains
+            # the build artifacts and doesn't take up much space, i.e. /c/5053411580/build-results
+            rm -rf "${EXTRA_DELETE_DIR}" || true
+          fi
+
           rm -rf ./*

--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -26,11 +26,22 @@ runs:
     - name: Clean up leftover processes on non-ephemeral Windows runner
       uses: pytorch/test-infra/.github/actions/cleanup-runner@main
 
+    # Cleaning up Windows workspace sometimes fails flakily with device or resource busy
+    # error, meaning one or more processes haven't stopped completely yet. So trying to
+    # retry this step several time similar to how checkout-pytorch GHA does
     - name: Cleanup workspace
       if: always()
-      shell: bash
+      uses: nick-fields/retry@v2.8.2
       env:
         EXTRA_DELETE_DIR: ${{ inputs.extra-delete-dir }}
-      run: |
-        [ ! -z "${EXTRA_DELETE_DIR}" ]  || rm -rf "${EXTRA_DELETE_DIR}"
-        rm -rf ./*
+      with:
+        shell: bash
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 90
+        command: |
+          set +e
+          set -x
+
+          [ ! -z "${EXTRA_DELETE_DIR}" ]  || rm -rf "${EXTRA_DELETE_DIR}"
+          rm -rf ./*


### PR DESCRIPTION
Windows flakiness strikes again.  There is a new flaky issue start appearing on HUD in which tearing down Windows workspace fails with `Device or resource busy` error when trying to `rm -rf ./*` the workspace, for example https://github.com/pytorch/pytorch/actions/runs/5051845102/jobs/9064107717.  It happens on both build and test jobs.  I have looked into all commits since last weekend but there is nothing standing out or Windows-related.

The error means that a process still hold the directory, but it's unclear which one as all CI processes should have been stopped by then (https://github.com/pytorch/pytorch/pull/101460) with the only exception of the runner daemon itself.  On the other hand, the issue is flaky as the next job running on the same failed runner can clean up the workspace fine when checking out PyTorch (https://github.com/pytorch/pytorch/blob/main/.github/actions/checkout-pytorch/action.yml#L21-L35).

For example, `i-0ec1767a38ec93b4e` failed at https://github.com/pytorch/pytorch/actions/runs/5051845102/jobs/9064107717 and its immediate next job succeeded https://github.com/pytorch/pytorch/actions/runs/5052147504/jobs/9064717085.  So, I think that adding retrying should help mitigate this.

Related to https://github.com/pytorch/test-infra/pull/4206 (not the same root cause, I figured out https://github.com/pytorch/test-infra/pull/4206 while working on this PR)

