### PR TITLE
change error_message for XPU Autocast data type check

### DIFF
--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -236,7 +236,7 @@ class autocast:
             supported_dtype = [torch.bfloat16, torch.float16]
             if self.fast_dtype not in supported_dtype:
                 error_message = 'In XPU autocast, but the target dtype is not supported. Disabling autocast.\n'
-                error_message += 'XPU Autocast only supports dtype of torch.bfloat16 currently.'
+                error_message += 'XPU Autocast only supports dtypes of torch.bfloat16 and torch.float16 currently.'
                 warnings.warn(error_message)
                 enabled = False
         elif self.device == 'hpu':


### PR DESCRIPTION
XPU autocast supports bf16 and fp16 data types, we are going to change the error_message for that.


cc @mcarilli @ptrblck @leslie-fang-intel @jgong5