### PR TITLE
[Typing] Export `torch.backends` as subpackage

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1400,14 +1400,7 @@ from torch import hub as hub
 from torch import random as random
 from torch import distributions as distributions
 from torch import testing as testing
-import torch.backends.cpu
-import torch.backends.cuda
-import torch.backends.mps
-import torch.backends.cudnn
-import torch.backends.mkl
-import torch.backends.mkldnn
-import torch.backends.openmp
-import torch.backends.quantized
+from torch import backends as backends
 import torch.utils.data
 from torch import __config__ as __config__
 from torch import __future__ as __future__
@@ -1696,6 +1689,8 @@ def _sparse_coo_tensor_unsafe(*args, **kwargs):
     kwargs['check_invariants'] = False
     return torch.sparse_coo_tensor(*args, **kwargs)
 
+# Register MPS specific decomps
+torch.backends.mps._init()
 
 from . import _logging
 _logging._init_logs()

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -45,3 +45,13 @@ class PropModule(types.ModuleType):
 
     def __getattr__(self, attr):
         return self.m.__getattribute__(attr)
+
+
+from torch.backends import cpu as cpu
+from torch.backends import cuda as cuda
+from torch.backends import mps as mps
+from torch.backends import cudnn as cudnn
+from torch.backends import mkl as mkl
+from torch.backends import mkldnn as mkldnn
+from torch.backends import openmp as openmp
+from torch.backends import quantized as quantized

--- a/torch/backends/mps/__init__.py
+++ b/torch/backends/mps/__init__.py
@@ -25,11 +25,12 @@ def is_macos13_or_newer(minor: int = 0) -> bool:
 
 
 # Register prims as implementation of var_mean and group_norm
-if is_built():
-    from ...library import Library as _Library
-    from ..._refs import var_mean as _var_mean, native_group_norm as _native_group_norm
-    from ..._decomp.decompositions import native_group_norm_backward as _native_group_norm_backward
-    _lib = _Library("aten", "IMPL")
-    _lib.impl("var_mean.correction", _var_mean, "MPS")
-    _lib.impl("native_group_norm", _native_group_norm, "MPS")
-    _lib.impl("native_group_norm_backward", _native_group_norm_backward, "MPS")
+def _init():
+    if is_built():
+        from ...library import Library as _Library
+        from ..._refs import var_mean as _var_mean, native_group_norm as _native_group_norm
+        from ..._decomp.decompositions import native_group_norm_backward as _native_group_norm_backward
+        _lib = _Library("aten", "IMPL")
+        _lib.impl("var_mean.correction", _var_mean, "MPS")
+        _lib.impl("native_group_norm", _native_group_norm, "MPS")
+        _lib.impl("native_group_norm_backward", _native_group_norm_backward, "MPS")

--- a/torch/backends/mps/__init__.py
+++ b/torch/backends/mps/__init__.py
@@ -1,5 +1,6 @@
 import torch
 from functools import lru_cache as _lru_cache
+from ...library import Library as _Library
 
 __all__ = ["is_built", "is_available", "is_macos13_or_newer"]
 
@@ -24,13 +25,15 @@ def is_macos13_or_newer(minor: int = 0) -> bool:
     return torch._C._mps_is_on_macos_13_or_newer(minor)
 
 
-# Register prims as implementation of var_mean and group_norm
+_lib = None
 def _init():
-    if is_built():
-        from ...library import Library as _Library
-        from ..._refs import var_mean as _var_mean, native_group_norm as _native_group_norm
-        from ..._decomp.decompositions import native_group_norm_backward as _native_group_norm_backward
-        _lib = _Library("aten", "IMPL")
-        _lib.impl("var_mean.correction", _var_mean, "MPS")
-        _lib.impl("native_group_norm", _native_group_norm, "MPS")
-        _lib.impl("native_group_norm_backward", _native_group_norm_backward, "MPS")
+    r"""Register prims as implementation of var_mean and group_norm"""
+    global _lib
+    if is_built() is False or _lib is not None:
+        return
+    from ..._refs import var_mean as _var_mean, native_group_norm as _native_group_norm
+    from ..._decomp.decompositions import native_group_norm_backward as _native_group_norm_backward
+    _lib = _Library("aten", "IMPL")
+    _lib.impl("var_mean.correction", _var_mean, "MPS")
+    _lib.impl("native_group_norm", _native_group_norm, "MPS")
+    _lib.impl("native_group_norm_backward", _native_group_norm_backward, "MPS")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102099
* #102004

So that `pyright` is happy.

Do a little refactor in `mps/__init__.py` to avoid cyclical dependency on `torch.fx` by calling `mps._init()` implicitly.

Fixes https://github.com/pytorch/pytorch/issues/101686