### PR TITLE
Fix redudant kernel generations

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5154,7 +5154,7 @@ class CommonTemplate:
             lambda: run(torch.randn([8, 32], device=self.device))
         )
         if self.device == "cuda":
-            self.assertEqual(fw_code.count("tl.rand"), 2)
+            self.assertEqual(fw_code.count("tl.rand"), 1)
             self.assertEqual(bw_code.count("tl.rand"), 0)
             expected_kernel = 4
         else:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -414,7 +414,16 @@ class KernelArgs:
 
     def seed_offset(self, name, value):
         if "load_seed_offset" in self.sizevars.values():
-            name = "%s%d" % (name, len([x for x in self.sizevars.values() if x.startswith("load_seed_offset")]))
+            name = "%s%d" % (
+                name,
+                len(
+                    [
+                        x
+                        for x in self.sizevars.values()
+                        if x.startswith("load_seed_offset")
+                    ]
+                ),
+            )
         self.sizevars[value] = name
         return name
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -413,15 +413,8 @@ class KernelArgs:
             self.inplace_buffers[output_name] = buf
 
     def seed_offset(self, name, value):
-        if "load_seed_offset" in self.sizevars.values():
-            name = "%s%d" % (
-                name,
-                sum(
-                    1
-                    for value in self.sizevars.values()
-                    if value.startswith("load_seed_offset")
-                ),
-            )
+        if name in self.sizevars.values():
+            name = f"{name}{sum(1 for value in self.sizevars.values() if value.startswith('load_seed_offset'))}"
         self.sizevars[value] = name
         return name
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -414,7 +414,7 @@ class KernelArgs:
 
     def seed_offset(self, name, value):
         if name in self.sizevars.values():
-            name = f"{name}{sum(1 for value in self.sizevars.values() if value.startswith('load_seed_offset'))}"
+            name = f"{name}{sum(1 for value in self.sizevars.values() if value.startswith(name))}"
         self.sizevars[value] = name
         return name
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -416,12 +416,10 @@ class KernelArgs:
         if "load_seed_offset" in self.sizevars.values():
             name = "%s%d" % (
                 name,
-                len(
-                    [
-                        x
-                        for x in self.sizevars.values()
-                        if x.startswith("load_seed_offset")
-                    ]
+                sum(
+                    1
+                    for value in self.sizevars.values()
+                    if value.startswith("load_seed_offset")
                 ),
             )
         self.sizevars[value] = name

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -412,6 +412,12 @@ class KernelArgs:
             self.inplace_buffers[input_name] = buf
             self.inplace_buffers[output_name] = buf
 
+    def seed_offset(self, name, value):
+        if "load_seed_offset" in self.sizevars.values():
+            name = "%s%d" % (name, len([x for x in self.sizevars.values() if x.startswith("load_seed_offset")]))
+        self.sizevars[value] = name
+        return name
+
     def size(self, name):
         if str(name) == "seed":
             self.sizevars["seed"] = "seed"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -82,7 +82,9 @@ def config_of(args):
                 if x.name.startswith("load_seed_offset"):
                     return False
                 else:
-                    return V.graph.sizevars.statically_known_multiple_of(x.expr, ALIGNMENT)
+                    return V.graph.sizevars.statically_known_multiple_of(
+                        x.expr, ALIGNMENT
+                    )
             else:
                 return False
         raise NotImplementedError(f"unhandled {type(x)}: {x}")
@@ -350,7 +352,9 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     def load_seed(name, offset):
         var = V.kernel.args.input(name)
-        return f"tl.load({var} + {V.kernel.args.seed_offset('load_seed_offset', offset)})"
+        return (
+            f"tl.load({var} + {V.kernel.args.seed_offset('load_seed_offset', offset)})"
+        )
 
     @staticmethod
     def rsqrt(x):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -79,7 +79,10 @@ def config_of(args):
             if isinstance(x.expr, (int, sympy.Integer)):
                 # TODO(voz): These are kinda redundant, if we can solve out statically_known_multiple_of with
                 # _maybe_evaluate_static...
-                return V.graph.sizevars.statically_known_multiple_of(x.expr, ALIGNMENT)
+                if x.name.startswith("load_seed_offset"):
+                    return False
+                else:
+                    return V.graph.sizevars.statically_known_multiple_of(x.expr, ALIGNMENT)
             else:
                 return False
         raise NotImplementedError(f"unhandled {type(x)}: {x}")
@@ -347,7 +350,7 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     def load_seed(name, offset):
         var = V.kernel.args.input(name)
-        return f"tl.load({var} + {offset})"
+        return f"tl.load({var} + {V.kernel.args.seed_offset('load_seed_offset', offset)})"
 
     @staticmethod
     def rsqrt(x):


### PR DESCRIPTION
## Issue description

The PR https://github.com/pytorch/pytorch/pull/100064 introduces a new RNG operation process. However, it causes every `randint` to load a separate random seed by default. TorchInductor generates a buffer to store all necessary random seeds and places the offsets as constant values in the subsequent compute buffers. In ir_pre_fusion generated by TorchInductor, some buffers only differ by one line, which is the load random seed with the corresponding offset. Subsequently, the codegen generates Triton kernels following the same rule. Finally, in the output_code.py, some Triton kernels only differ by one line, meaning that redundant kernels are being generated.


## Solution


This PR captures the seed offset and adds it to the existing `self.sizevars` structure. It generates variable names as placeholders, allowing the code wrapper to pass the offset as an argument to the kernels. I've also modified the divisible_by_16 check to exclude this argument.

This PR reduces the number of generated kernels from 50 to 17 for BertForMaskedLM forward.

According to tests on my own environment, the compilation time of attention_is_all_you_need_pytorch has been reduced from 94s to 66s. The speedup remains largely unchanged, at 1.37X.

The following is a comparison for a simple example.
Before:
```
triton_poi_fused_0 = async_compile.triton('triton_', '''
...
def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    ...
    tmp0 = tl.load(in_ptr0 + 0)
    tmp1 = x0
    tmp2 = triton_helpers.randint64(tmp0, (tmp1).to(tl.uint32), 0, 10)

triton_poi_fused_1 = async_compile.triton('triton_', '''
...
def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    ...
    tmp0 = tl.load(in_ptr0 + 1)
    tmp1 = x0
    tmp2 = triton_helpers.randint64(tmp0, (tmp1).to(tl.uint32), 0, 10)
...''')

def call(args):
        triton_poi_fused_0.run(buf0, buf1, 1024, grid=grid(1024), stream=stream0)
        triton_poi_fused_1.run(buf0, buf2, 1024, grid=grid(1024), stream=stream0)

```
After:
```
triton_poi_fused_0 = async_compile.triton('triton_', '''
...
def triton_(in_ptr0, out_ptr0, load_seed_offset, xnumel, XBLOCK : tl.constexpr):
    ...
    tmp0 = tl.load(in_ptr0 + load_seed_offset)
    tmp1 = x0
    tmp2 = triton_helpers.randint64(tmp0, (tmp1).to(tl.uint32), 0, 10)
    ....

def call(args):
        triton_poi_fused_0.run(buf0, buf1, 0, 1024, grid=grid(1024), stream=stream0)
        triton_poi_fused_0.run(buf0, buf2, 1, 1024, grid=grid(1024), stream=stream0)

```





cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10