### PR TITLE
Lower xdist processes from auto to NUM_PROCS

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -953,7 +953,7 @@ def get_pytest_args(options, stepcurrent_key, is_cpp_test=False):
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly
-        pytest_args.extend(["-n", "auto"])
+        pytest_args.extend(["-n", NUM_PROCS])
 
         if IS_CI:
             # Add the option to generate XML test report here as C++ tests

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -953,7 +953,7 @@ def get_pytest_args(options, stepcurrent_key, is_cpp_test=False):
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly
-        pytest_args.extend(["-n", NUM_PROCS])
+        pytest_args.extend(["-n", str(NUM_PROCS)])
 
         if IS_CI:
             # Add the option to generate XML test report here as C++ tests


### PR DESCRIPTION
This is to avoid CUDA OOM issues when running C++ tests both regularly and in memory leak check mode.