### PR TITLE
[quant][pt2e][be] Move annotate helper function to quantizer/utils.py

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py
@@ -13,6 +13,8 @@ from torch.ao.quantization._pt2e.quantizer.utils import (
     get_act_qspec,
     get_weight_qspec,
     get_bias_qspec,
+    _annotate_input_qspec_map,
+    _annotate_output_qspec,
 )
 
 from torch.fx import Node
@@ -26,8 +28,6 @@ from .quantizer import (
     QuantizationSpec,
     Quantizer,
     QuantizationAnnotation,
-    _annotate_input_qspec_map,
-    _annotate_output_qspec,
 )
 from torch.ao.quantization.fake_quantize import FusedMovingAvgObsFakeQuantize
 from torch.ao.quantization.observer import (

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -134,16 +134,3 @@ class Quantizer(ABC):
     @abstractmethod
     def get_supported_operators(cls) -> List[OperatorConfig]:
         pass
-
-def _annotate_input_qspec_map(node: Node, input_node: Node, qspec):
-    quantization_annotation = node.meta.get("quantization_annotation", QuantizationAnnotation())
-    if quantization_annotation.input_qspec_map is None:
-        quantization_annotation.input_qspec_map = {}
-    quantization_annotation.input_qspec_map[input_node] = qspec
-    node.meta["quantization_annotation"] = quantization_annotation
-
-
-def _annotate_output_qspec(node: Node, qspec):
-    quantization_annotation = node.meta.get("quantization_annotation", QuantizationAnnotation())
-    quantization_annotation.output_qspec = qspec
-    node.meta["quantization_annotation"] = quantization_annotation


### PR DESCRIPTION
Summary: att

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_resnet18_with_quantizer_api (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2EModels)'
```

Reviewed By: kimishpatel

Differential Revision: D46001285

