### PR TITLE
[pytorch] add Vulkan support for the `aten::cat` operator for 1d, 2d, 3d and 4d

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -17,10 +17,37 @@ inline int64_t normalize_dim(int64_t d, int64_t n) {
 } // namespace
 
 Tensor cat_batch(const MaterializedITensorListRef& tensors, vTensor& v_output) {
-  (void)tensors;
-  (void)v_output;
+  api::Context* const context = api::context();
 
-  TORCH_CHECK(false, "Vulkan cat not implemented for batch dimension!");
+  uvec3 src_offset{};
+  uvec3 dst_offset{};
+
+  for (const at::Tensor& tensor : tensors) {
+    const vTensor& v_self = convert(tensor);
+
+    api::PipelineBarrier pipeline_barrier{};
+
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
+        // pipeline barrier
+        pipeline_barrier,
+        // images
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::TRANSFER,
+            api::MemoryAccessType::WRITE),
+        // copy details
+        v_self.extents(),
+        src_offset,
+        dst_offset,
+        // fence handle
+        VK_NULL_HANDLE);
+
+    // Increment by the number of texels in the depth dimension
+    dst_offset.data[2u] += v_self.extents().data[2u];
+  }
+
+  return convert(v_output);
 }
 
 Tensor cat_feature(
@@ -168,10 +195,38 @@ Tensor cat_feature_mult4ch(
 }
 
 Tensor cat_width(const MaterializedITensorListRef& tensors, vTensor& v_output) {
-  (void)tensors;
-  (void)v_output;
+  // TORCH_CHECK(false, "Vulkan cat not implemented for width dimension!");
+  api::Context* const context = api::context();
 
-  TORCH_CHECK(false, "Vulkan cat not implemented for width dimension!");
+  uvec3 src_offset{};
+  uvec3 dst_offset{};
+
+  for (const at::Tensor& tensor : tensors) {
+    const vTensor& v_self = convert(tensor);
+
+    api::PipelineBarrier pipeline_barrier{};
+
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
+        // pipeline barrier
+        pipeline_barrier,
+        // images
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::TRANSFER,
+            api::MemoryAccessType::WRITE),
+        // copy details
+        v_self.extents(),
+        src_offset,
+        dst_offset,
+        // fence handle
+        VK_NULL_HANDLE);
+
+    // Increment by width
+    dst_offset.data[0u] += v_self.extents().data[0u];
+  }
+
+  return convert(v_output);
 }
 
 Tensor cat_height(
@@ -213,22 +268,26 @@ Tensor cat_height(
 Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
   TORCH_CHECK(!tensors.empty(), "Vulkan cat expects at least one tensor");
 
-  const int64_t dim = normalize_dim(in_dim, 4);
   auto materialized = tensors.materialize();
   TORCH_INTERNAL_ASSERT(!materialized.empty(), "Accessing empty array");
   const at::Tensor& tensor = materialized[0];
+  auto ndim = safe_downcast<uint32_t>(tensor.dim());
+  const int64_t dim = normalize_dim(in_dim, ndim);
   int64_t cat_dim_size = 0;
   bool is_mult4ch = true;
 
   for (const at::Tensor& t : materialized) {
     TORCH_INTERNAL_ASSERT(
-        t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
+        t.dim() <= 4,
+        "Vulkan cat expects inputs to have at most 4 dimensions, but got ",
+        t.dim(),
+        "d");
 
-    if (t.sizes()[1] % 4 != 0) {
+    if (ndim < 3 || t.sizes()[1 - (4u - ndim)] % 4 != 0) {
       is_mult4ch = false;
     }
 
-    for (const auto d : c10::irange(4)) {
+    for (const auto d : c10::irange(ndim)) {
       if (d == dim) {
         continue;
       }
@@ -245,12 +304,12 @@ Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
 
   vTensor v_output{api::context(), result_size, tensor.scalar_type()};
 
-  if (dim == 3) {
+  if (dim == ndim - 1) {
     return cat_width(materialized, v_output);
   }
-  if (dim == 2) {
+  if (dim == ndim - 2) {
     return cat_height(materialized, v_output);
-  } else if (dim == 1) {
+  } else if (dim == ndim - 3) {
     if (is_mult4ch) {
       return cat_feature_mult4ch(materialized, v_output);
     }

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3551,7 +3551,7 @@ TEST_F(VulkanAPITest, view_invalid_inputs) {
   }, ::std::runtime_error);
 }
 
-TEST_F(VulkanAPITest, cat_dim0_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, cat_4d_dim0_invalidinputs_exceptions) {
   // Arrange: Vulkan cat inputs must have matching sizes except concatenated dimension
   {
     const auto in_cpu1 = at::rand({3, 5, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3575,22 +3575,178 @@ TEST_F(VulkanAPITest, cat_dim0_invalidinputs_exceptions) {
       const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
     }, ::c10::Error);
   }
+}
 
-  // Arrange: Vulkan cat not implemented for batch dimension!
-  {
-    const auto in_cpu1 = at::rand({221, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu2 = at::rand({112, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu3 = at::rand({331, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+TEST_F(VulkanAPITest, cat_4d_dim0_samebatch_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({221, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({221, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
 
-    // Act
-    EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
-    }, ::c10::Error);
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0); // dim=batch
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
   }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim0_diffbatch_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({117, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({139, 3, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0); // dim=batch
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim0_singledepth_success) {
+  // Arrange: batch x channel (1x1) = single depth texture
+  const auto in_cpu1 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0); // dim=batch
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim0_singletensor_success) {
+  // Arrange: single input tensor
+  const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1}, 0);
+  const auto out_vulkan = at::cat({in_cpu1}, 0); // dim=batch
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim0_twotensors_success) {
+  // Arrange: two input tensors
+  const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan()}, 0); // dim=batch
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim0_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 9, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({113, 9, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({331, 9, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -4);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -4);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim1_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 221, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 113, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 331, 193, 3}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -3);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -3);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim2_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 221, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 113, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 331, 3}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_4d_dim3_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 3, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 3, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 3, 331}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
 }
 
 #if !defined(__APPLE__)
-TEST_F(VulkanAPITest, DISABLED_cat_dim1_samefeature_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_4d_dim1_samefeature_success) {
   // Arrange
   const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3609,7 +3765,7 @@ TEST_F(VulkanAPITest, DISABLED_cat_dim1_samefeature_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, DISABLED_cat_dim1_difffeature_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_4d_dim1_difffeature_success) {
   // Arrange
   const auto in_cpu1 = at::rand({3, 3, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 8, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3628,7 +3784,7 @@ TEST_F(VulkanAPITest, DISABLED_cat_dim1_difffeature_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_texture2d_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_texture2d_success) {
   // Arrange: 2D Texture (VK_IMAGE_VIEW_TYPE_2D)
   const auto in_cpu1 = at::rand({2, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({2, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3648,7 +3804,7 @@ TEST_F(VulkanAPITest, cat_dim1_texture2d_success) {
 }
 #endif /* !defined(__APPLE__) */
 
-TEST_F(VulkanAPITest, cat_dim1_singledepth_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_singledepth_success) {
   // Arrange: batch x channel (1x1) = single depth texture
   const auto in_cpu1 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3667,7 +3823,7 @@ TEST_F(VulkanAPITest, cat_dim1_singledepth_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_singletensor_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_singletensor_success) {
   // Arrange: single input tensor
   const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
 
@@ -3684,7 +3840,7 @@ TEST_F(VulkanAPITest, cat_dim1_singletensor_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, DISABLED_cat_dim1_twotensors_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_4d_dim1_twotensors_success) {
   // Arrange: two input tensors
   const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3702,7 +3858,7 @@ TEST_F(VulkanAPITest, DISABLED_cat_dim1_twotensors_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_bat1_mult4ch_success) {
   // Arrange: batch=1 and channel (a multiple of 4 <-> channel %4 == 0)
   const auto in_cpu1 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3721,7 +3877,7 @@ TEST_F(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_bat2_mult4ch_success) {
   // Arrange: batch=2 and channel (a multiple of 4 <-> channel %4 == 0)
   const auto in_cpu1 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3740,7 +3896,7 @@ TEST_F(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
+TEST_F(VulkanAPITest, cat_4d_dim1_mult4ch_mixed_success) {
   // Arrange: batch=1 and channel (different multiples of 4 <-> channel %4 == 0)
   const auto in_cpu1 = at::rand({3, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 8, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3759,7 +3915,7 @@ TEST_F(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, DISABLED_cat_dim1_mult4ch_nonmult4ch_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_4d_dim1_mult4ch_nonmult4ch_success) {
   // Arrange: batch=1 and channel (a mixed set of multiples and non-multiples of 4)
   const auto in_cpu1 = at::rand({3, 3, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3779,7 +3935,7 @@ TEST_F(VulkanAPITest, DISABLED_cat_dim1_mult4ch_nonmult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim2_sameheight_success) {
+TEST_F(VulkanAPITest, cat_4d_dim2_sameheight_success) {
   // Arrange
   const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3798,7 +3954,7 @@ TEST_F(VulkanAPITest, cat_dim2_sameheight_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim2_diffheight_success) {
+TEST_F(VulkanAPITest, cat_4d_dim2_diffheight_success) {
   // Arrange
   const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3817,26 +3973,7 @@ TEST_F(VulkanAPITest, cat_dim2_diffheight_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim2_negdim_success) {
-  // Arrange
-  const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu2 = at::rand({3, 9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
-
-  // Act
-  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -2);
-  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -2);
-
-  // Assert
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, cat_dim2_singledepth_success) {
+TEST_F(VulkanAPITest, cat_4d_dim2_singledepth_success) {
   // Arrange: batch x channel (1x1) = single depth texture
   const auto in_cpu1 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3855,7 +3992,7 @@ TEST_F(VulkanAPITest, cat_dim2_singledepth_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, cat_4d_dim2_invalidinputs_exceptions) {
   // Arrange: Vulkan cat inputs must have matching sizes except concatenated dimension
   {
     const auto in_cpu1 = at::rand({3, 5, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3868,7 +4005,7 @@ TEST_F(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
     }, ::c10::Error);
   }
 
-  // Arrange: Vulkan cat expects 4 dimensional inputs
+  // Arrange: Vulkan cat expects inputs of same dimensions
   {
     const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
     const auto in_cpu2 = at::rand({9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -3879,62 +4016,413 @@ TEST_F(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
       const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 2);
     }, ::c10::Error);
   }
+}
 
-  // Arrange: Vulkan cat is implemented only for height dimension
+TEST_F(VulkanAPITest, cat_4d_dim3_invalidinputs_exceptions) {
+  // Arrange: Vulkan cat inputs must have matching sizes except concatenated dimension
   {
-    const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+    const auto in_cpu1 = at::rand({3, 5, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
     const auto in_cpu2 = at::rand({3, 9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
     const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
 
     // Act
     EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
     }, ::c10::Error);
-    EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
-    }, ::c10::Error);
+  }
+
+  // Arrange: Vulkan cat expects 4 dimensional inputs
+  {
+    const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+    const auto in_cpu2 = at::rand({9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
+    const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+    // Act
     EXPECT_THROW({
       const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
     }, ::c10::Error);
   }
 }
 
-TEST_F(VulkanAPITest, cat_dim3_invalidinputs_exceptions) {
-  // Arrange: Vulkan cat inputs must have matching sizes except concatenated dimension
-  {
-    const auto in_cpu1 = at::rand({3, 5, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu2 = at::rand({3, 9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+TEST_F(VulkanAPITest, cat_4d_dim3_samewidth_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
 
-    // Act
-    EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
-    }, ::c10::Error);
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 3);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
   }
 
-  // Arrange: Vulkan cat expects 4 dimensional inputs
-  {
-    const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu2 = at::rand({9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  ASSERT_TRUE(check);
+}
 
-    // Act
-    EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
-    }, ::c10::Error);
+TEST_F(VulkanAPITest, cat_4d_dim3_diffwidth_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({3, 9, 193, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 9, 193, 331}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 3);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
   }
 
-  // Arrange: Vulkan cat not implemented for width dimension!
-  {
-    const auto in_cpu1 = at::rand({3, 9, 193, 221}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu2 = at::rand({3, 9, 193, 112}, at::device(at::kCPU).dtype(at::kFloat));
-    const auto in_cpu3 = at::rand({3, 9, 193, 331}, at::device(at::kCPU).dtype(at::kFloat));
+  ASSERT_TRUE(check);
+}
 
-    // Act
-    EXPECT_THROW({
-      const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 3);
-    }, ::c10::Error);
+
+TEST_F(VulkanAPITest, cat_3d_dim0_diff_channel_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({113, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({331, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
   }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim0_same_channel_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim1_diffheight_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 113, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim1_same_height_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim2_diffwidth_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 331}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim2_samewidth_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim0_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({113, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({331, 9, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -3);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -3);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim1_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({9, 113, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_3d_dim2_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 13, 89}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193, 13, 59}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193, 13, 67}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim0_same_height_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim0_diff_height_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({191, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({137, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim1_same_width_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim1_diff_width_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193, 131}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193, 127}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim0_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({113, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({131, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({127, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_2d_dim1_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193, 113}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193, 131}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193, 127}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_1d_dim0_same_width_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_1d_dim0_diff_width_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({137}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({131}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, cat_1d_dim0_negdim_success) {
+  // Arrange
+  const auto in_cpu1 = at::rand({193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({137}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({131}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, -1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, -1);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
 }
 
 TEST_F(VulkanAPITest, permute_2d_success) {


### PR DESCRIPTION
Summary: Implement `torch.cat(tensors, dim=0)`, which concatenates a given sequence of tensors in the given dimension, for Vulkan backend. See the behavior of the operator here: https://pytorch.org/docs/stable/generated/torch.cat.html

Test Plan:
```
(base) luwei@luwei-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*cat_*"
Downloaded 0/2 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 12.2 sec (100%) 471/471 jobs, 2/471 updated
  Total time: 12.2 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *cat_*
[==========] Running 40 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 40 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.cat_4d_dim0_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim0_invalidinputs_exceptions (73 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_samebatch_success
[       OK ] VulkanAPITest.cat_4d_dim0_samebatch_success (36 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_diffbatch_success
[       OK ] VulkanAPITest.cat_4d_dim0_diffbatch_success (20 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim0_singledepth_success (2 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_singletensor_success
[       OK ] VulkanAPITest.cat_4d_dim0_singletensor_success (4 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_twotensors_success
[       OK ] VulkanAPITest.cat_4d_dim0_twotensors_success (13 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim0_negdim_success (38 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim1_negdim_success (26 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim2_negdim_success (31 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim3_negdim_success (30 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim1_singledepth_success (2 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_singletensor_success
[       OK ] VulkanAPITest.cat_4d_dim1_singletensor_success (4 ms)
[ DISABLED ] VulkanAPITest.DISABLED_cat_4d_dim1_twotensors_success
[ RUN      ] VulkanAPITest.cat_4d_dim1_bat1_mult4ch_success
[       OK ] VulkanAPITest.cat_4d_dim1_bat1_mult4ch_success (4 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_bat2_mult4ch_success
[       OK ] VulkanAPITest.cat_4d_dim1_bat2_mult4ch_success (7 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_mult4ch_mixed_success
[       OK ] VulkanAPITest.cat_4d_dim1_mult4ch_mixed_success (19 ms)
[ DISABLED ] VulkanAPITest.DISABLED_cat_4d_dim1_mult4ch_nonmult4ch_success
[ RUN      ] VulkanAPITest.cat_4d_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_4d_dim2_sameheight_success (23 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_4d_dim2_diffheight_success (23 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim2_singledepth_success (2 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim2_invalidinputs_exceptions (23 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim3_invalidinputs_exceptions (23 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_samewidth_success
[       OK ] VulkanAPITest.cat_4d_dim3_samewidth_success (30 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_diffwidth_success
[       OK ] VulkanAPITest.cat_4d_dim3_diffwidth_success (22 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_diff_channel_success
[       OK ] VulkanAPITest.cat_3d_dim0_diff_channel_success (8 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_same_channel_success
[       OK ] VulkanAPITest.cat_3d_dim0_same_channel_success (5 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_diffheight_success
[       OK ] VulkanAPITest.cat_3d_dim1_diffheight_success (7 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_same_height_success
[       OK ] VulkanAPITest.cat_3d_dim1_same_height_success (6 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_diffwidth_success
[       OK ] VulkanAPITest.cat_3d_dim2_diffwidth_success (9 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_samewidth_success
[       OK ] VulkanAPITest.cat_3d_dim2_samewidth_success (4 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim0_negdim_success (8 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim1_negdim_success (8 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim2_negdim_success (5 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_same_height_success
[       OK ] VulkanAPITest.cat_2d_dim0_same_height_success (2 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_diff_height_success
[       OK ] VulkanAPITest.cat_2d_dim0_diff_height_success (1 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_same_width_success
[       OK ] VulkanAPITest.cat_2d_dim1_same_width_success (1 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_diff_width_success
[       OK ] VulkanAPITest.cat_2d_dim1_diff_width_success (1 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_2d_dim0_negdim_success (1 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_2d_dim1_negdim_success (2 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_same_width_success
[       OK ] VulkanAPITest.cat_1d_dim0_same_width_success (0 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_diff_width_success
[       OK ] VulkanAPITest.cat_1d_dim0_diff_width_success (0 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_1d_dim0_negdim_success (0 ms)
[----------] 40 tests from VulkanAPITest (543 ms total)

[----------] Global test environment tear-down
[==========] 40 tests from 1 test suite ran. (543 ms total)
[  PASSED  ] 40 tests.

  YOU HAVE 2 DISABLED TESTS
```

Reviewed By: SS-JIA

Differential Revision: D46059444

