### PR TITLE
[inductor] include global cache dir in inductor resources

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -170,7 +170,14 @@ compile_threads = decide_compile_threads()
 
 # gemm autotuning global cache dir
 if is_fbcode():
-    global_cache_dir = "fb/cache"
+    from libfb.py import parutil
+
+    try:
+        global_cache_dir = parutil.get_dir_path(
+            os.path.join(__package__.replace(".", os.sep), "fb/cache")
+        )
+    except ValueError:
+        global_cache_dir = None
 else:
     global_cache_dir = None
 


### PR DESCRIPTION
Summary: adding global cache dir glob to inductor resources

Test Plan: sandcastle + CI + tested locally

Differential Revision: D46131451



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov