### PR TITLE
fix functorch/test_ops.py test_vjp flash attention unexpected success

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_utils import skipIfRocm
 import torch
 from torch import Tensor
 import functools
-from torch.testing._internal.common_cuda import with_tf32_off
+from torch.testing._internal.common_cuda import with_tf32_off, SM90OrLater
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_device_type import ops
 from torch.testing._internal.common_device_type import \
@@ -596,7 +596,7 @@ class TestOperators(TestCase):
         # RuntimeError: query: last dimension must be contiguous
         # The fused attention kernels require the last dim to be contiguous
         decorate('nn.functional.scaled_dot_product_attention', device_type="cuda",
-                 decorator=expectedFailureIf(not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0)))),
+                 decorator=expectedFailureIf(not SM90OrLater)),
         # BUG
         # AssertionError: Tensor-likes are not close!
         xfail('as_strided'),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -253,7 +253,6 @@ def _get_vjpfull_variant(fn, primals):
     return wrapped, args
 
 
-
 def get_jvp_variant(f, sample):
     # We want this higher-order variant of jvp, so that it can
     # be used to wrap vmap
@@ -541,7 +540,6 @@ class TestOperators(TestCase):
                                      clone_inputs=True,
                                      fixme_ref_jvp_local=fixme_ref_jvp_local)
 
-
     def jvp_opinfo_test(self, fn, sample, output_process_fn,
                         clone_inputs, fixme_ref_jvp_local):
         # NB: we used requires_grad=True to determine where the primals are,
@@ -597,7 +595,8 @@ class TestOperators(TestCase):
         xfail('view_as_complex'),
         # RuntimeError: query: last dimension must be contiguous
         # The fused attention kernels require the last dim to be contiguous
-        xfail('nn.functional.scaled_dot_product_attention', device_type="cuda"),
+        decorate('nn.functional.scaled_dot_product_attention', device_type="cuda",
+                 decorator=expectedFailureIf(not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0)))),
         # BUG
         # AssertionError: Tensor-likes are not close!
         xfail('as_strided'),
@@ -1597,7 +1596,6 @@ class TestOperators(TestCase):
             for loop_out, batched_out in generator:
                 self.assertEqual(loop_out, batched_out)
 
-
     def _make_extremal_inputs(self, shape, device):
         if shape is None:
             return (None,)
@@ -1669,7 +1667,6 @@ class TestOperators(TestCase):
                 result = torch.nn.functional.softmax(input)
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.softmax, (cotangents, input))
-
 
     def test_extremal_numerics_log_softmax(self, device):
         N, C, H, W = 3, 4, 5, 6

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -22,6 +22,7 @@ SM53OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_devic
 SM60OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (6, 0))
 SM70OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (7, 0))
 SM80OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0))
+SM90OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0))
 
 PLATFORM_SUPPORTS_FUSED_SDPA: bool = TEST_CUDA and not TEST_WITH_ROCM
 


### PR DESCRIPTION
add isSm90 check for expected failure in nn.functional.scaled_dot_product_attention in functorch/test_ops.py

Fixes #102029 

Uses solution https://github.com/pytorch/pytorch/issues/102029#issuecomment-1560052965 which was verified by 
https://github.com/pytorch/pytorch/issues/102029#issuecomment-1560071148

cc @drisspg, @xwang233 