### PR TITLE
No need to run C++ tests under rerun disabled tests mode

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -496,7 +496,9 @@ def run_test(
     # pytest-cpp atm. We also don't have support to disable C++ test yet, so it's ok
     # to just return successfully here
     if is_cpp_test and RERUN_DISABLED_TESTS:
-        print_to_stderr("Skipping C++ tests when running under RERUN_DISABLED_TESTS mode")
+        print_to_stderr(
+            "Skipping C++ tests when running under RERUN_DISABLED_TESTS mode"
+        )
         return 0
 
     if use_sharded_test:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -492,6 +492,13 @@ def run_test(
         use_sharded_test = True
 
     is_cpp_test = test_file.startswith(CPP_TEST_PREFIX)
+    # NB: Rerun disabled tests depends on pytest-flakefinder and it doesn't work with
+    # pytest-cpp atm. We also don't have support to disable C++ test yet, so it's ok
+    # to just return successfully here
+    if is_cpp_test and RERUN_DISABLED_TESTS:
+        print_to_stderr("Skipping C++ tests when running under RERUN_DISABLED_TESTS mode")
+        return 0
+
     if use_sharded_test:
         if is_cpp_test:
             stepcurrent_key = test_file


### PR DESCRIPTION
Per title.  I extract this part out of the draft PR that I'm working on https://github.com/pytorch/pytorch/pull/102107 because
the remaining issues with rerun disabled tests: log size and unexpected runner failures requires some further investigations while this one is clearing breaking in trunk atm.

Until we can support disable C++ tests, there is no need to run them in rerun disabled tests mode.

### Testing

Coming from https://github.com/pytorch/pytorch/pull/102107, for example https://github.com/pytorch/pytorch/actions/runs/5062224659/jobs/9087747981

```
2023-05-23T22:46:50.1953318Z Running cpp/basic 1/1 ... [2023-05-23 22:46:50.195077]
2023-05-23T22:46:50.1953847Z Skipping C++ tests when running under RERUN_DISABLED_TESTS mode
2023-05-23T22:46:50.2066032Z Running cpp/atest 1/1 ... [2023-05-23 22:46:50.206348]
2023-05-23T22:46:50.2066435Z Skipping C++ tests when running under RERUN_DISABLED_TESTS mode
2023-05-23T22:46:52.2666743Z No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
2023-05-23T22:46:52.2691817Z Ignoring disabled issues:  []
...
```
