### PR TITLE
Fix shape function for transpose convolution

### DIFF
--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -1772,7 +1772,8 @@ def transpose(self: List[int],
     _3 = torch.append(out0, elem0)
   return (out, out0, [grad_output[1]])
 
-def conv_forwards(input: List[int],
+)=====")
++ std::string(R"=====(def conv_forwards(input: List[int],
     weight: List[int],
     bias: Optional[List[int]],
     stride: List[int],
@@ -1782,6 +1783,7 @@ def conv_forwards(input: List[int],
     output_padding: List[int],
     groups: int) -> List[int]:
   has_dilation = torch.gt(torch.len(dilation), 0)
+  has_output_padding = torch.gt(torch.len(output_padding), 0)
   dim = torch.len(input)
   output_size = annotate(List[int], [])
   if transposed:
@@ -1789,27 +1791,91 @@ def conv_forwards(input: List[int],
   else:
     weight_output_channels_dim = 0
   _0 = torch.append(output_size, input[0])
-  _1 = torch.append(output_size, weight[weight_output_channels_dim])
-  for _2 in range(torch.__range_length(2, dim, 1)):
-    d = torch.__derive_index(_2, 2, 1)
+  if transposed:
+    _1 = torch.mul(weight[weight_output_channels_dim], groups)
+    _2 = torch.append(output_size, _1)
+  else:
+    _3 = torch.append(output_size, weight[weight_output_channels_dim])
+  for _4 in range(torch.__range_length(2, dim, 1)):
+    d = torch.__derive_index(_4, 2, 1)
     if has_dilation:
       dilation_ = dilation[torch.sub(d, 2)]
     else:
       dilation_ = 1
+    if has_output_padding:
+      output_padding_ = output_padding[torch.sub(d, 2)]
+    else:
+      output_padding_ = 0
     if transposed:
       kernel = torch.mul(dilation_, torch.sub(weight[d], 1))
-      _3 = torch.mul(torch.sub(input[d], 1), stride[torch.sub(d, 2)])
-      _4 = torch.mul(padding[torch.sub(d, 2)], 2)
-      _5 = torch.add(torch.sub(_3, _4), kernel)
-      _6 = torch.append(output_size, torch.add(_5, 1))
+      _5 = torch.mul(torch.sub(input[d], 1), stride[torch.sub(d, 2)])
+      _6 = torch.mul(padding[torch.sub(d, 2)], 2)
+      _7 = torch.add(torch.sub(_5, _6), kernel)
+      _8 = torch.add(torch.add(_7, output_padding_), 1)
+      _9 = torch.append(output_size, _8)
     else:
-      _7 = torch.mul(dilation_, torch.sub(weight[d], 1))
-      kernel0 = torch.add(_7, 1)
-      _8 = input[d]
-      _9 = torch.mul(padding[torch.sub(d, 2)], 2)
-      _10 = torch.sub(torch.add(_8, _9), kernel0)
-      _11 = torch.floordiv(_10, stride[torch.sub(d, 2)])
-      _12 = torch.append(output_size, torch.add(_11, 1))
+      _10 = torch.mul(dilation_, torch.sub(weight[d], 1))
+      kernel0 = torch.add(_10, 1)
+      _11 = input[d]
+      _12 = torch.mul(padding[torch.sub(d, 2)], 2)
+      _13 = torch.sub(torch.add(_11, _12), kernel0)
+      _14 = torch.floordiv(_13, stride[torch.sub(d, 2)])
+      _15 = torch.append(output_size, torch.add(_14, 1))
+  return output_size
+
+)=====")
++ std::string(R"=====(def _conv_forwards(input: List[int],
+    weight: List[int],
+    bias: Optional[List[int]],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
+    transposed: bool,
+    output_padding: List[int],
+    groups: int,
+    benchmark: bool,
+    deterministic: bool,
+    cudnn_enabled: bool,
+    allow_tf32: bool) -> List[int]:
+  has_dilation = torch.gt(torch.len(dilation), 0)
+  has_output_padding = torch.gt(torch.len(output_padding), 0)
+  dim = torch.len(input)
+  output_size = annotate(List[int], [])
+  if transposed:
+    weight_output_channels_dim = 1
+  else:
+    weight_output_channels_dim = 0
+  _0 = torch.append(output_size, input[0])
+  if transposed:
+    _1 = torch.mul(weight[weight_output_channels_dim], groups)
+    _2 = torch.append(output_size, _1)
+  else:
+    _3 = torch.append(output_size, weight[weight_output_channels_dim])
+  for _4 in range(torch.__range_length(2, dim, 1)):
+    d = torch.__derive_index(_4, 2, 1)
+    if has_dilation:
+      dilation_ = dilation[torch.sub(d, 2)]
+    else:
+      dilation_ = 1
+    if has_output_padding:
+      output_padding_ = output_padding[torch.sub(d, 2)]
+    else:
+      output_padding_ = 0
+    if transposed:
+      kernel = torch.mul(dilation_, torch.sub(weight[d], 1))
+      _5 = torch.mul(torch.sub(input[d], 1), stride[torch.sub(d, 2)])
+      _6 = torch.mul(padding[torch.sub(d, 2)], 2)
+      _7 = torch.add(torch.sub(_5, _6), kernel)
+      _8 = torch.add(torch.add(_7, output_padding_), 1)
+      _9 = torch.append(output_size, _8)
+    else:
+      _10 = torch.mul(dilation_, torch.sub(weight[d], 1))
+      kernel0 = torch.add(_10, 1)
+      _11 = input[d]
+      _12 = torch.mul(padding[torch.sub(d, 2)], 2)
+      _13 = torch.sub(torch.add(_11, _12), kernel0)
+      _14 = torch.floordiv(_13, stride[torch.sub(d, 2)])
+      _15 = torch.append(output_size, torch.add(_14, 1))
   return output_size
 
 )=====")
@@ -1829,6 +1895,11 @@ def conv_forwards(input: List[int],
     padding0 = [0, 0]
   else:
     padding0 = unchecked_cast(List[int], padding)
+  if torch.__is__(output_padding, None):
+    output_padding0 = [0, 0]
+  else:
+    output_padding1 = unchecked_cast(List[int], output_padding)
+    output_padding0 = output_padding1
   if torch.__is__(dilation, None):
     dilation0 = [1, 1]
   else:
@@ -1837,7 +1908,7 @@ def conv_forwards(input: List[int],
   dim = torch.len(input)
   output_size = annotate(List[int], [])
   _0 = torch.append(output_size, input[0])
-  _1 = torch.append(output_size, weight[1])
+  _1 = torch.append(output_size, torch.mul(weight[1], groups))
   for _2 in range(torch.__range_length(2, dim, 1)):
     d = torch.__derive_index(_2, 2, 1)
     if has_dilation:
@@ -1848,7 +1919,8 @@ def conv_forwards(input: List[int],
     _3 = torch.mul(torch.sub(input[d], 1), stride0[torch.sub(d, 2)])
     _4 = torch.mul(padding0[torch.sub(d, 2)], 2)
     _5 = torch.add(torch.sub(_3, _4), kernel)
-    _6 = torch.append(output_size, torch.add(_5, 1))
+    _6 = torch.add(_5, output_padding0[torch.sub(d, 2)])
+    _7 = torch.append(output_size, torch.add(_6, 1))
   return output_size
 
 )=====")
@@ -3211,6 +3283,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::conv3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, int groups=1) -> Tensor", "conv3d"},
     {"aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, int[]? bias_sizes, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)", "conv_backwards"},
     {"aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor", "conv_forwards"},
+    {"aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor", "_conv_forwards"},
     {"aten::conv_transpose2d.input(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int groups=1, int[2] dilation=1) -> Tensor", "conv_transpose2d_input"},
     {"aten::flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)", "flatten"},
     {"aten::cat(Tensor[] tensors, int dim=0) -> Tensor", "cat"},

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -781,32 +781,40 @@ def conv_transpose2d_input(input: List[int], weight: List[int], bias: Optional[L
     input_batch_size_dim = 0
     weight_output_channels_dim = 1
     output_size.append(input[input_batch_size_dim])
-    output_size.append(weight[weight_output_channels_dim])
+    output_size.append(weight[weight_output_channels_dim] * groups)
 
     for d in range(2, dim):
         dilation_ = dilation[d - 2] if has_dilation else 1
         kernel = dilation_ * (weight[d] - 1)
-        output_size.append((input[d] - 1) * stride[d - 2] - 2 * padding[d - 2] + kernel + 1)
+        output_size.append((input[d] - 1) * stride[d - 2] - 2 * padding[d - 2] + kernel + output_padding[d - 2] + 1)
     return output_size
 
 def conv_forwards(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], transposed: bool, output_padding: List[int], groups: int) -> List[int]:
     has_dilation = len(dilation) > 0
+    has_output_padding = len(output_padding) > 0
     dim = len(input)
     output_size: List[int] = []
     input_batch_size_dim = 0
     weight_output_channels_dim = 1 if transposed else 0
     output_size.append(input[input_batch_size_dim])
-    output_size.append(weight[weight_output_channels_dim])
+    if transposed:
+        output_size.append(weight[weight_output_channels_dim] * groups)
+    else:
+        output_size.append(weight[weight_output_channels_dim])
 
     for d in range(2, dim):
         dilation_ = dilation[d - 2] if has_dilation else 1
+        output_padding_ = output_padding[d - 2] if has_output_padding else 0
         if transposed:
             kernel = dilation_ * (weight[d] - 1)
-            output_size.append((input[d] - 1) * stride[d - 2] - 2 * padding[d - 2] + kernel + 1)
+            output_size.append((input[d] - 1) * stride[d - 2] - 2 * padding[d - 2] + kernel + output_padding_ + 1)
         else:
             kernel = dilation_ * (weight[d] - 1) + 1
             output_size.append((input[d] + (2 * padding[d - 2]) - kernel) // stride[d - 2] + 1)
     return output_size
+
+def _conv_forwards(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], transposed: bool, output_padding: List[int], groups: int, benchmark: bool, deterministic: bool, cudnn_enabled: bool, allow_tf32: bool) -> List[int]:
+    return conv_forwards(input, weight, bias, stride, padding, dilation, transposed, output_padding, groups)
 
 def batch_norm(
     input: List[int],
@@ -1124,6 +1132,7 @@ add_shape_compute_mapping("aten::batch_norm(Tensor input, Tensor? weight, Tensor
 add_shape_compute_mapping("aten::conv3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, int groups=1) -> Tensor", conv3d)
 add_shape_compute_mapping("aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, int[]? bias_sizes, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)", conv_backwards)
 add_shape_compute_mapping("aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups) -> Tensor", conv_forwards)
+add_shape_compute_mapping("aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor", _conv_forwards)
 add_shape_compute_mapping("aten::conv_transpose2d.input(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int groups=1, int[2] dilation=1) -> Tensor", conv_transpose2d_input)
 add_shape_compute_mapping("aten::flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)", flatten)
 add_shape_compute_mapping("aten::cat(Tensor[] tensors, int dim=0) -> Tensor", cat)


### PR DESCRIPTION
Fixes #98129.
Fixes the shape function for jit conv_transpose, as defined by the documentation https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html#torch.nn.ConvTranspose2d, includes output_padding.
