### PR TITLE
Add mps support for maxpool3d

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -13,13 +13,15 @@
 #include <ATen/ops/avg_pool2d_native.h>
 #include <ATen/ops/max_pool2d_with_indices_backward_native.h>
 #include <ATen/ops/max_pool2d_with_indices_native.h>
+#include <ATen/ops/max_pool3d_with_indices_backward_native.h>
+#include <ATen/ops/max_pool3d_with_indices_native.h>
 #endif
 
 namespace at::native {
 namespace mps {
 
-struct PoolingCachedGraph : public MPSCachedGraph {
-  PoolingCachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
+struct PoolingCachedGraph2D : public MPSCachedGraph {
+  PoolingCachedGraph2D(MPSGraph* graph) : MPSCachedGraph(graph) {}
   MPSGraphTensor* inputTensor = nil;
   MPSGraphTensor* outputTensor = nil;
   MPSGraphTensor* indicesTensor = nil;
@@ -27,8 +29,23 @@ struct PoolingCachedGraph : public MPSCachedGraph {
   MPSGraphTensor* divisorTensor = nil;
 };
 
-typedef MPSGraphTensor* (^PoolingOpBlock)(PoolingCachedGraph&, MPSGraphPooling2DOpDescriptor*);
-#define PoolingOpFn(graph, desc) MPSGraphTensor*(mps::PoolingCachedGraph & graph, MPSGraphPooling2DOpDescriptor * desc)
+struct PoolingCachedGraph3D : public MPSCachedGraph {
+  PoolingCachedGraph3D(MPSGraph* graph) : MPSCachedGraph(graph) {}
+  MPSGraphTensor* inputTensor = nil;
+  MPSGraphTensor* expandedInputTensor = nil;
+  MPSGraphTensor* pooledTensor = nil;
+  MPSGraphTensor* outputTensor = nil;
+  MPSGraphTensor* indicesTensor = nil;
+  MPSGraphTensor* gradOutputTensor = nil;
+  MPSGraphTensor* expandedGradOutputTensor = nil;
+  MPSGraphTensor* divisorTensor = nil;
+};
+
+typedef MPSGraphTensor* (^PoolingOpBlock2D)(PoolingCachedGraph2D&, MPSGraphPooling2DOpDescriptor*);
+#define PoolingOpFn2D(graph, desc) MPSGraphTensor*(mps::PoolingCachedGraph2D & graph, MPSGraphPooling2DOpDescriptor * desc)
+
+typedef MPSGraphTensor* (^PoolingOpBlock3D)(PoolingCachedGraph3D&, MPSGraphPooling4DOpDescriptor*);
+#define PoolingOpFn3D(graph, desc) MPSGraphTensor*(mps::PoolingCachedGraph3D & graph, MPSGraphPooling4DOpDescriptor * desc)
 
 // Pooling ops (1D/2D forward and backward Max and Average pooling)
 static void pool2d_template(const Tensor& input,
@@ -42,7 +59,7 @@ static void pool2d_template(const Tensor& input,
                             bool ceil_mode,
                             bool count_include_pad,
                             const c10::optional<int64_t> divisor_override,
-                            PoolingOpBlock poolingBlock,
+                            PoolingOpBlock2D poolingBlock,
                             const c10::string& op_name) {
   if (!is_macos_13_or_newer()) {
     TORCH_CHECK(input.scalar_type() != ScalarType::Long,
@@ -153,7 +170,7 @@ static void pool2d_template(const Tensor& input,
     MPSShape* inputShape = getMPSShape(input, memory_format);
     MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;
 
-    auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
+    auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph2D>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       MPSGraphPooling2DOpDescriptor* desc = [MPSGraphPooling2DOpDescriptor
           descriptorWithKernelWidth:kW
                        kernelHeight:kH
@@ -272,7 +289,7 @@ static void avg_pool2d_template(const Tensor& input,
     return;
   }
 
-  mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
+  mps::PoolingOpBlock2D pooling_op_block = ^PoolingOpFn2D(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();
     const int64_t ndims = input.ndimension();
     MPSShape* paddingShape = nil;
@@ -350,6 +367,201 @@ static void avg_pool2d_template(const Tensor& input,
                   op_name);
 }
 
+static void pool3d_template(const Tensor& input,
+                            const Tensor& output,
+                            const c10::optional<Tensor>& indices_opt,
+                            const c10::optional<Tensor>& grad_output_opt,
+                            IntArrayRef kernel_size,
+                            IntArrayRef stride,
+                            IntArrayRef padding,
+                            IntArrayRef dilation,
+                            bool ceil_mode,
+                            bool count_include_pad,
+                            const c10::optional<int64_t> divisor_override,
+                            PoolingOpBlock3D poolingBlock,
+                            const c10::string& op_name) {
+  if (input.numel() == 0) {
+    return;
+  }
+  if (!is_macos_13_or_newer()) {
+    TORCH_CHECK(input.scalar_type() != ScalarType::Long,
+                "MPS: ",
+                op_name,
+                " op with int64 input is supported natively starting from macOS 13.0.");
+  }
+  const int64_t ndims = input.ndimension();
+  const Tensor& grad_output = *(at::borrow_from_optional_tensor(grad_output_opt));
+  const Tensor& indices = *(at::borrow_from_optional_tensor(indices_opt));
+  const bool is_backward_pass = grad_output.defined();
+  const bool has_indices = indices.defined();
+  const bool has_divisor = divisor_override.has_value() && divisor_override.value() != 0;
+  const auto suggested_memory_format = input.suggest_memory_format();
+  // for max_pool2d_with_indices() we cannot pass ChannelsLast (i.e., NHWC) to 'desc.dataLayout' in MPSGraph.
+  // Because the returned indices will be selected based on NHWC memory layout which will
+  // be incompatible with the PyTorch's global NCHW layout.
+  const auto memory_format = has_indices ? MemoryFormat::Contiguous : suggested_memory_format;
+
+  TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
+              op_name,
+              ": kernel_size must either be a single int, or a tuple of three ints")
+  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+              op_name,
+              ": stride must either be omitted, a single int, or a tuple of three ints")
+  TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
+              op_name,
+              ": padding must be either be a single int, or a tuple of three ints");
+  TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
+              op_name,
+              ": dilation must be either a single int, or a tuple of three ints");
+
+  if (suggested_memory_format == at::MemoryFormat::ChannelsLast) {
+    TORCH_CHECK(ndims == 5, "non-empty 5D (batch mode) tensor expected for input with channels_last layout");
+  } else if (suggested_memory_format == at::MemoryFormat::Contiguous) {
+    TORCH_CHECK((ndims == 4 || ndims == 5), "non-empty 4D or 5D (batch mode) tensor expected for input");
+  } else {
+    AT_ERROR("Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+
+  int padT = safe_downcast<int, int64_t>(padding[0]);
+  int padH = padding.size() == 1 ? padT : safe_downcast<int, int64_t>(padding[1]);
+  int padW = padding.size() == 1 ? padT : safe_downcast<int, int64_t>(padding[2]);
+  const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
+  const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
+  const int dH = stride.empty() ? kH : stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty() ? kW : stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[2]);
+  const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
+  const int64_t nbatch = ndims == 5 ? input.size(-5) : 1;
+  const int64_t nInputPlane = input.size(-4);
+  const int64_t inputDepth = input.size(-3);
+  const int64_t inputHeight = input.size(-2);
+  const int64_t inputWidth = input.size(-1);
+  const int64_t outputDepth = pooling_output_shape<int64_t>(inputDepth, kT, padT, dT, dilationT, ceil_mode);
+  const int64_t outputHeight = pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, dilationH, ceil_mode);
+  const int64_t outputWidth = pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, dilationW, ceil_mode);
+
+  pool3d_shape_check(input,
+                     nInputPlane,
+                     kT, kH, kW,
+                     dT, dH, dW,
+                     padT, padH, padW,
+                     dilationT, dilationH, dilationW,
+                     inputDepth, inputHeight, inputWidth,
+                     outputDepth, outputHeight, outputWidth,
+                     op_name.data(),
+                     true);
+
+
+  auto output_memory_format = output.suggest_memory_format();
+  // the output and indices are 'empty', so we could avoid unnecessary gatherView on empty tensors
+  // by simply restriding them (instead of calling the costly Contiguous()).
+  if (indices.suggest_memory_format() == MemoryFormat::ChannelsLast) {
+    indices.unsafeGetTensorImpl()->empty_tensor_restride(MemoryFormat::Contiguous);
+  }
+  if (output.numel() == 0) {
+    std::vector<int64_t> outputSizes{nInputPlane, outputDepth, outputHeight, outputWidth};
+    if (ndims == 5) {
+      outputSizes.insert(outputSizes.begin(), nbatch);
+    }
+    output.resize_(outputSizes);
+  } else if (output_memory_format == MemoryFormat::ChannelsLast) {
+    output.unsafeGetTensorImpl()->empty_tensor_restride(MemoryFormat::Contiguous);
+    output_memory_format = MemoryFormat::Contiguous;
+  }
+
+  if (output.numel() == 0 || (is_backward_pass && grad_output.numel() == 0)) {
+    return;
+  }
+  // workaround for issue #103039644: mismatching MPS vs. CPU results
+  // when both ceil_mode and count_include_pad are True
+  if (count_include_pad && ceil_mode) {
+    padT = padH = padW = 0;
+  }
+  @autoreleasepool {
+    string key = op_name + getTensorsStringKey({input, indices, grad_output}) + ":K[" + getArrayRefString(kernel_size) +
+        "]:S[" + getArrayRefString(stride) + "]:P[" + getArrayRefString(padding) + "]:D[" +
+        getArrayRefString(dilation) + "]" + (ceil_mode ? ":ceil" : "") + (count_include_pad ? ":include_pad" : "") +
+        (has_divisor ? ":divisor" : "") + ":" +
+        (suggested_memory_format == MemoryFormat::ChannelsLast ? "NHWC" : "NCHW");
+
+    MPSShape* inputShape = getMPSShape(input, memory_format);
+    MPSShape* gradOutputShape = is_backward_pass ? getMPSShape(grad_output, memory_format) : nullptr;
+
+    auto cachedGraph = LookUpOrCreateCachedGraph<PoolingCachedGraph3D>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
+      MPSGraphPooling4DOpDescriptor* desc = [MPSGraphPooling4DOpDescriptor
+          descriptorWithKernelSizes:@[ @1, @(kT), @(kW), @(kH) ]
+                            strides:@[ @1, @(dT), @(dW), @(dH) ]
+                      dilationRates:@[ @1, @(dilationT), @(dilationW), @(dilationH) ]
+                      paddingValues:@[ @0, @0,
+                                       @(padT), ceil_mode ? @(padT * dT) : @(padT),
+                                       @(padW), ceil_mode ? @(padW * dW) : @(padW),
+                                       @(padH), ceil_mode ? @(padH * dH) : @(padH) ]
+                        paddingStyle:MPSGraphPaddingStyleExplicit];
+
+      desc.ceilMode = (padT == 0 && padW == 0 && padH == 0) ? ceil_mode : false;
+      if (has_indices) {
+        desc.returnIndicesMode = MPSGraphPoolingReturnIndicesGlobalFlatten3D;
+        desc.returnIndicesDataType = MPSDataTypeInt32;
+      }
+      newCachedGraph->inputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input.scalar_type()), inputShape);
+      if (is_backward_pass) {
+        newCachedGraph->gradOutputTensor =
+            mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output.scalar_type()), gradOutputShape);
+      }
+      if (has_divisor) {
+        newCachedGraph->divisorTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeFloat32, @[ @1 ]);
+      }
+      MPSGraphTensor* outputTensor = poolingBlock(*newCachedGraph, desc);
+      // with desc.dataLayout = NHWC (i.e., ChannelsLast), the results need to be converted back to NCHW
+      newCachedGraph->outputTensor =
+          memory_format == MemoryFormat::ChannelsLast ? convertNHWCtoNCHW(mpsGraph, outputTensor) : outputTensor;
+    });
+
+    MPSStream* mpsStream = getCurrentMPSStream();
+    // in case of ChannelsLast we don't perform gather() in placeholder to avoid implicit conversion to NCHW
+    Placeholder inputPlaceholder =
+        Placeholder(cachedGraph->inputTensor, input, inputShape, memory_format != MemoryFormat::ChannelsLast);
+    Placeholder gradOutputPlaceholder = !is_backward_pass
+        ? Placeholder()
+        : Placeholder(
+              cachedGraph->gradOutputTensor, grad_output, gradOutputShape, memory_format != MemoryFormat::ChannelsLast);
+    Placeholder indicesPlaceholder = has_indices ? Placeholder(cachedGraph->indicesTensor, indices) : Placeholder();
+    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, output);
+    NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
+    NSMutableDictionary* results = [[NSMutableDictionary new] autorelease];
+
+    feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
+    results[outputPlaceholder.getMPSGraphTensor()] = outputPlaceholder.getMPSGraphTensorData();
+
+    if (cachedGraph->gradOutputTensor) {
+      feeds[gradOutputPlaceholder.getMPSGraphTensor()] = gradOutputPlaceholder.getMPSGraphTensorData();
+    }
+    if (cachedGraph->indicesTensor) {
+      if (is_backward_pass) {
+        feeds[indicesPlaceholder.getMPSGraphTensor()] = indicesPlaceholder.getMPSGraphTensorData();
+      } else {
+        results[indicesPlaceholder.getMPSGraphTensor()] = indicesPlaceholder.getMPSGraphTensorData();
+      }
+    }
+    MPSScalar divisor_scalar;
+    if (cachedGraph->divisorTensor) {
+      const float divisor = float(kT * kH * kW) / (float)divisor_override.value();
+      divisor_scalar = getMPSScalar(divisor, ScalarType::Float);
+      feeds[cachedGraph->divisorTensor] = getMPSGraphTensorFromScalar(mpsStream, divisor_scalar);
+    }
+
+    runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
+
+    if (output_memory_format != suggested_memory_format) {
+      const_cast<Tensor&>(output) = output.to(suggested_memory_format);
+    }
+  }
+}
+
 } // namespace mps
 
 Tensor mps_max_pool2d(const Tensor& input,
@@ -359,7 +571,7 @@ Tensor mps_max_pool2d(const Tensor& input,
                       IntArrayRef dilation,
                       bool ceil_mode) {
   Tensor output = at::empty({0}, input.options(), MemoryFormat::Contiguous);
-  mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
+  mps::PoolingOpBlock2D pooling_op_block = ^PoolingOpFn2D(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();
     return [mpsGraph maxPooling2DWithSourceTensor:cachedGraph.inputTensor descriptor:desc name:nil];
   };
@@ -388,7 +600,7 @@ Tensor mps_max_pool2d_backward(const Tensor& grad_output,
                                IntArrayRef dilation,
                                bool ceil_mode) {
   Tensor grad_input = at::empty(input.sizes(), input.options(), MemoryFormat::Contiguous);
-  mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
+  mps::PoolingOpBlock2D pooling_op_block = ^PoolingOpFn2D(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();
     return [mpsGraph maxPooling2DGradientWithGradientTensor:cachedGraph.gradOutputTensor
                                                sourceTensor:cachedGraph.inputTensor
@@ -412,6 +624,86 @@ Tensor mps_max_pool2d_backward(const Tensor& grad_output,
   return grad_input;
 }
 
+Tensor mps_max_pool3d(const Tensor& input,
+                      IntArrayRef kernel_size,
+                      IntArrayRef stride,
+                      IntArrayRef padding,
+                      IntArrayRef dilation,
+                      bool ceil_mode) {
+  Tensor output = at::empty({0}, input.options(), MemoryFormat::Contiguous);
+  mps::PoolingOpBlock3D pooling_op_block = ^PoolingOpFn3D(cachedGraph, desc) {
+    MPSGraph* mpsGraph = cachedGraph.graph();
+    cachedGraph.expandedInputTensor = [mpsGraph expandDimsOfTensor:cachedGraph.inputTensor
+                                                        axis:2
+                                                        name:nil];
+
+    cachedGraph.pooledTensor = [mpsGraph maxPooling4DWithSourceTensor:cachedGraph.expandedInputTensor
+                                                               descriptor:desc
+                                                                     name:nil];
+    return [mpsGraph squeezeTensor:cachedGraph.pooledTensor
+                              axis:2
+                              name:nil];
+  };
+  mps::pool3d_template(input,
+                       output,
+                       c10::nullopt,
+                       c10::nullopt,
+                       kernel_size,
+                       stride,
+                       padding,
+                       dilation,
+                       ceil_mode,
+                       false,
+                       c10::nullopt,
+                       pooling_op_block,
+                       "max_pool3d");
+
+  return output;
+}
+
+Tensor mps_max_pool3d_backward(const Tensor& grad_output,
+                               const Tensor& input,
+                               IntArrayRef kernel_size,
+                               IntArrayRef stride,
+                               IntArrayRef padding,
+                               IntArrayRef dilation,
+                               bool ceil_mode) {
+  Tensor grad_input = at::empty(input.sizes(), input.options(), MemoryFormat::Contiguous);
+  mps::PoolingOpBlock3D pooling_op_block = ^PoolingOpFn3D(cachedGraph, desc) {
+    MPSGraph* mpsGraph = cachedGraph.graph();
+    cachedGraph.expandedInputTensor = [mpsGraph expandDimsOfTensor:cachedGraph.inputTensor
+                                                        axis:2
+                                                        name:nil];
+
+    cachedGraph.expandedGradOutputTensor = [mpsGraph expandDimsOfTensor:cachedGraph.gradOutputTensor
+                                                                   axis:2
+                                                                   name:nil];
+
+    cachedGraph.pooledTensor = [mpsGraph maxPooling4DGradientWithGradientTensor:cachedGraph.expandedGradOutputTensor
+                                                                               sourceTensor:cachedGraph.expandedInputTensor
+                                                                                 descriptor:desc
+                                                                                       name:nil];
+    return [mpsGraph squeezeTensor:cachedGraph.pooledTensor
+                              axis:2
+                              name:nil];
+  };
+  mps::pool3d_template(input,
+                       grad_input,
+                       c10::nullopt,
+                       grad_output,
+                       kernel_size,
+                       stride,
+                       padding,
+                       dilation,
+                       ceil_mode,
+                       false,
+                       c10::nullopt,
+                       pooling_op_block,
+                       "max_pool3d_backward");
+
+  return grad_input;
+}
+
 TORCH_IMPL_FUNC(max_pool2d_with_indices_out_mps)
 (const Tensor& input,
  IntArrayRef kernel_size,
@@ -423,7 +715,7 @@ TORCH_IMPL_FUNC(max_pool2d_with_indices_out_mps)
  const Tensor& indices) {
   auto indices_memory_format = indices.suggest_memory_format();
 
-  mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
+  mps::PoolingOpBlock2D pooling_op_block = ^PoolingOpFn2D(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();
     NSArray<MPSGraphTensor*>* poolOutputs = [mpsGraph maxPooling2DReturnIndicesWithSourceTensor:cachedGraph.inputTensor
                                                                                      descriptor:desc
@@ -460,7 +752,7 @@ TORCH_IMPL_FUNC(max_pool2d_with_indices_backward_out_mps)
  bool ceil_mode,
  const Tensor& indices,
  const Tensor& grad_input) {
-  mps::PoolingOpBlock pooling_op_block = ^PoolingOpFn(cachedGraph, desc) {
+  mps::PoolingOpBlock2D pooling_op_block = ^PoolingOpFn2D(cachedGraph, desc) {
     MPSGraph* mpsGraph = cachedGraph.graph();
     return [mpsGraph maxPooling2DGradientWithGradientTensor:cachedGraph.gradOutputTensor
                                                sourceTensor:cachedGraph.inputTensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3627,10 +3627,20 @@
     CompositeImplicitAutograd: max_pool2d
     MPS: mps_max_pool2d
 
+- func: max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: max_pool3d
+    MPS: mps_max_pool3d
+
 - func: max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   dispatch:
     MPS: mps_max_pool2d_backward
   autogen: max_pool2d_backward.out
+
+- func: max_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
+  dispatch:
+    MPS: mps_max_pool3d_backward
+  autogen: max_pool3d_backward.out
 
 - func: mkldnn_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   dispatch:
@@ -3667,8 +3677,6 @@
   dispatch:
     QuantizedCPU: quantized_max_pool3d
   autogen: quantized_max_pool3d.out
-
-- func: max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
 
 # The CPU and GPU dispatch variants are named weirdly here because otherwise there
 # are namespacing issues in C++

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2190,6 +2190,9 @@
 - name: max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   self: max_pool2d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode)
 
+- name: max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
+  self: max_pool3d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode)
+
 - name: _mps_convolution(Tensor self, Tensor weight, Tensor? bias, int[] padding, int[] stride, int[] dilation, int groups) -> Tensor
   self, weight, bias: "grad.defined() ? mps_convolution_backward(self, grad, weight, padding, stride, dilation, groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 


### PR DESCRIPTION
Fixes #100674

Added mps support for forward / backward passes of maxpool3d.

As mentioned in the referenced issue, I'm utilizing the maxpool 4d op that is available from the metal library to achieve this.

cc: @mattiaspaul
