### PR TITLE
Fix fuse_custom_config_dict arg from being None

### DIFF
--- a/torch/ao/quantization/fuse_modules.py
+++ b/torch/ao/quantization/fuse_modules.py
@@ -161,7 +161,7 @@ def fuse_modules(model, modules_to_fuse, inplace=False, fuser_func=fuse_known_mo
         is_qat=False,
         inplace=inplace,
         fuser_func=fuser_func,
-        fuse_custom_config_dict=None)
+        fuse_custom_config_dict=fuse_custom_config_dict)
 
 def fuse_modules_qat(model, modules_to_fuse, inplace=False, fuser_func=fuse_known_modules, fuse_custom_config_dict=None):
     """ QAT version for `fuse_modules`
@@ -172,4 +172,4 @@ def fuse_modules_qat(model, modules_to_fuse, inplace=False, fuser_func=fuse_know
         is_qat=True,
         inplace=inplace,
         fuser_func=fuser_func,
-        fuse_custom_config_dict=None)
+        fuse_custom_config_dict=fuse_custom_config_dict)


### PR DESCRIPTION
`fuse_custom_config_dict` in [fuse_modules.py](https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/fuse_modules.py#L164) being passed as None even if a fuse_custom_config_dict is provided.

This patch fixes the `fuse_custom_config_dict` from being passed as None.