### PR TITLE
compile_check V0

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.control_flow_opinfo_db import control_flow_opinfo_db
-from torch.testing._internal.optests.aot_autograd import _test_aot_autograd_forwards_backwards_helper, aot_autograd_check
+from torch.testing._internal.optests import _test_aot_autograd_forwards_backwards_helper, aot_autograd_check
 from functorch import (
     grad, vjp, vmap, jacrev,
     make_fx

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -25,9 +25,10 @@ import itertools
 from functools import partial
 from torch.nn.utils.rnn import PackedSequence
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, toleranceOverride, tol
-from torch.testing._internal.common_methods_invocations import op_db, wrapper_set_seed
+from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.control_flow_opinfo_db import control_flow_opinfo_db
+from torch.testing._internal.optests.aot_autograd import _test_aot_autograd_forwards_backwards_helper, aot_autograd_check
 from functorch import (
     grad, vjp, vmap, jacrev,
     make_fx
@@ -2855,65 +2856,6 @@ symbolic_aot_autograd_failures = {
     xfail('_upsample_bilinear2d_aa'),  # RuntimeError: isIntList() INTERNAL ASSERT FAILED  Expected IntList but got GenericList
 }
 
-def _test_aot_autograd_forwards_backwards_helper(self, f, compiled_f, args):
-    # Verify grads are equal between compiled and non-compiled versions of f.
-
-    def call_forwards_backwards(f):
-        out = wrapper_set_seed(f, args)
-        if not isinstance(out, torch.Tensor):
-            flat_out, _ = pytree.tree_flatten(out)
-            sm = 0
-            for i in flat_out:
-                sm += i.sum().abs()
-            sm.backward()
-        else:
-            out.sum().abs().backward()
-
-    def reset_grads():
-        def f(x):
-            x.grad = None
-        pytree.tree_map(f, args)
-
-    def get_grads(args):
-        return pytree.tree_map(lambda x: x.grad, args)
-
-    try:
-        reset_grads()
-        call_forwards_backwards(f)
-        orig_grad = get_grads(args)
-
-        reset_grads()
-        # See https://github.com/pytorch/pytorch/pull/98960#issuecomment-1505962215
-        if all(x is None for x in orig_grad):
-            with self.assertRaisesRegex(RuntimeError, 'does not require grad and does not have a grad_fn'):
-                call_forwards_backwards(compiled_f)
-        else:
-            call_forwards_backwards(compiled_f)
-            compiled_grad = get_grads(args)
-            self.assertEqual(orig_grad, compiled_grad)
-
-        def create_new_arg(x):
-            if isinstance(x, torch.Tensor) and x.dtype == torch.float32:
-                return x.detach().uniform_(0, 1).requires_grad_(x.requires_grad)
-            return x
-
-        args = pytree.tree_map(create_new_arg, args)
-
-        reset_grads()
-        call_forwards_backwards(f)
-        orig_grad = get_grads(args)
-
-        reset_grads()
-        # See https://github.com/pytorch/pytorch/pull/98960#issuecomment-1505962215
-        if all(x is None for x in orig_grad):
-            with self.assertRaisesRegex(RuntimeError, 'does not require grad and does not have a grad_fn'):
-                call_forwards_backwards(compiled_f)
-        else:
-            call_forwards_backwards(compiled_f)
-            compiled_grad = get_grads(args)
-            self.assertEqual(orig_grad, compiled_grad)
-    except DynamicOutputShapeException:
-        self.skipTest("Dynamic output shape operation in trace")
 
 def _test_aot_autograd_helper(self, device, dtype, op, dynamic=False):
     if not op.supports_autograd:
@@ -2923,23 +2865,12 @@ def _test_aot_autograd_helper(self, device, dtype, op, dynamic=False):
     for sample_input in sample_inputs_itr:
         t_args = [sample_input.input] + list(sample_input.args)
         t_kwargs = sample_input.kwargs
-        flat_args, args_spec = pytree.tree_flatten((t_args, t_kwargs))
-        sentinel_val = -42
-        is_tensor_spec = [sentinel_val if isinstance(arg, torch.Tensor) else arg for arg in flat_args]
-        args = [arg for arg in flat_args if isinstance(arg, torch.Tensor)]
-
-        def f(args):
-            cur_flat_args = list(is_tensor_spec)
-            args = iter(args)
-            for idx, v in enumerate(cur_flat_args):
-                if v == sentinel_val:
-                    cur_flat_args[idx] = next(args)
-            c_args, c_kwargs = pytree.tree_unflatten(cur_flat_args, args_spec)
-            return op.op(*c_args, **c_kwargs)
-
-        compiled_f = compiled_function(f, nop, nop, dynamic=dynamic, partition_fn=min_cut_rematerialization_partition)
         try:
-            _test_aot_autograd_forwards_backwards_helper(self, f, compiled_f, args)
+            aot_autograd_check(
+                op.op, t_args, t_kwargs, dynamic,
+                self.assertRaisesRegex, self.assertEqual)
+        except DynamicOutputShapeException:
+            self.skipTest("Dynamic output shape operation in trace")
         except GuardOnDataDependentSymNode:
             # Carveout for getitem; I don't want to xfail the entire test
             # because that will reject known to be good tests see
@@ -2996,7 +2927,11 @@ def _test_aot_autograd_module_helper(self, device, dtype, training, module_info,
         num_params_buffers = len(named_params) + len(named_buffers)
         compiled_f = aot_function(f, nop, num_params_buffers=num_params_buffers, dynamic=dynamic)
         params_buffers_args = [named_params, named_buffers, args]
-        _test_aot_autograd_forwards_backwards_helper(self, f, compiled_f, params_buffers_args)
+        try:
+            _test_aot_autograd_forwards_backwards_helper(
+                f, compiled_f, params_buffers_args, self.assertRaisesRegex, self.assertEqual)
+        except DynamicOutputShapeException:
+            self.skipTest("Dynamic output shape operation in trace")
 
 
 class TestEagerFusionOpInfo(AOTTestCase):

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -10,7 +10,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_methods_invocations import op_db, skip, xfail, skipOps
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, DataDependentOutputException, FakeTensorMode
 from torch._decomp import decomposition_table
-import torch.testing._internal.opcheck as opcheck
+import torch.testing._internal.optests as optests
 from torch.fx.experimental.symbolic_shapes import (
     sym_float, eval_guards, bind_symbols, fx_placeholder_vals, fx_placeholder_targets,
     constrain_range, guard_int, GuardOnDataDependentSymNode
@@ -1576,10 +1576,10 @@ def _test_make_fx_helper(self, device, dtype, op, tracing_mode, inplace=False):
         kwargs = sample_input.kwargs
 
         try:
-            opcheck.make_fx_check(fn, args, kwargs, tracing_mode, self.assertEqual)
+            optests.make_fx_check(fn, args, kwargs, tracing_mode, self.assertEqual)
         except DynamicOutputShapeException:
             self.skipTest("Dynamic output shape operation in trace")
-        except opcheck.TestFrameworkError:
+        except optests.TestFrameworkError:
             return
 
 

--- a/torch/testing/_internal/optests/__init__.py
+++ b/torch/testing/_internal/optests/__init__.py
@@ -1,0 +1,4 @@
+from .make_fx import make_fx_check
+from .aot_autograd import aot_autograd_check, _test_aot_autograd_forwards_backwards_helper
+from .compile_check import compile_check
+from .common import TestFrameworkError

--- a/torch/testing/_internal/optests/aot_autograd.py
+++ b/torch/testing/_internal/optests/aot_autograd.py
@@ -1,0 +1,107 @@
+import torch
+import torch.utils._pytree as pytree
+from torch.testing._internal.common_methods_invocations import wrapper_set_seed
+from functorch.compile import compiled_function, min_cut_rematerialization_partition, nop
+import re
+import contextlib
+
+@contextlib.contextmanager
+def assert_raises_regex(exception_cls, regex):
+    try:
+        yield
+    except exception_cls as e:
+        msg = str(e)
+        if not re.search(regex, msg):
+            raise AssertionError(
+                f"Expected exception to match regex. regex: {regex}, exception: {msg}")
+    except Exception as e:
+        raise AssertionError(
+            f"Expected {exception_cls} to be raised, instead got exception {type(e)}")
+    finally:
+        pass
+    raise AssertionError("Expected exception to be raised but none was")
+
+def aot_autograd_check(
+        func, args, kwargs, dynamic,
+        assert_raises_regex_fn=assert_raises_regex,
+        assert_equals_fn=torch.testing._comparison.assert_close):
+    flat_args, args_spec = pytree.tree_flatten((args, kwargs))
+    for arg in flat_args:
+        if isinstance(arg, int) and arg == -42:
+            raise TestFrameworkError("We've reserved -42 as an arg")
+
+    sentinel_val = -42
+    is_tensor_spec = [sentinel_val if isinstance(arg, torch.Tensor) else arg for arg in flat_args]
+    args = [arg for arg in flat_args if isinstance(arg, torch.Tensor)]
+
+    def f(args):
+        cur_flat_args = list(is_tensor_spec)
+        args = iter(args)
+        for idx, v in enumerate(cur_flat_args):
+            if v == sentinel_val:
+                cur_flat_args[idx] = next(args)
+        c_args, c_kwargs = pytree.tree_unflatten(cur_flat_args, args_spec)
+        return func(*c_args, **c_kwargs)
+
+    compiled_f = compiled_function(f, nop, nop, dynamic=dynamic, partition_fn=min_cut_rematerialization_partition)
+    _test_aot_autograd_forwards_backwards_helper(
+        f, compiled_f, args, assert_raises_regex_fn, assert_equals_fn)
+
+
+def _test_aot_autograd_forwards_backwards_helper(
+        f, compiled_f, args, assert_raises_regex_fn, assert_equals_fn):
+    # Verify grads are equal between compiled and non-compiled versions of f.
+
+    def call_forwards_backwards(f):
+        out = wrapper_set_seed(f, args)
+        if not isinstance(out, torch.Tensor):
+            flat_out, _ = pytree.tree_flatten(out)
+            sm = 0
+            for i in flat_out:
+                sm += i.sum().abs()
+            sm.backward()
+        else:
+            out.sum().abs().backward()
+
+    def reset_grads():
+        def f(x):
+            x.grad = None
+        pytree.tree_map(f, args)
+
+    def get_grads(args):
+        return pytree.tree_map(lambda x: x.grad, args)
+
+    reset_grads()
+    call_forwards_backwards(f)
+    orig_grad = get_grads(args)
+
+    reset_grads()
+    # See https://github.com/pytorch/pytorch/pull/98960#issuecomment-1505962215
+    if all(x is None for x in orig_grad):
+        with assert_raises_regex_fn(RuntimeError, 'does not require grad and does not have a grad_fn'):
+            call_forwards_backwards(compiled_f)
+    else:
+        call_forwards_backwards(compiled_f)
+        compiled_grad = get_grads(args)
+        assert_equals_fn(orig_grad, compiled_grad)
+
+    def create_new_arg(x):
+        if isinstance(x, torch.Tensor) and x.dtype == torch.float32:
+            return x.detach().uniform_(0, 1).requires_grad_(x.requires_grad)
+        return x
+
+    args = pytree.tree_map(create_new_arg, args)
+
+    reset_grads()
+    call_forwards_backwards(f)
+    orig_grad = get_grads(args)
+
+    reset_grads()
+    # See https://github.com/pytorch/pytorch/pull/98960#issuecomment-1505962215
+    if all(x is None for x in orig_grad):
+        with assert_raises_regex_fn(RuntimeError, 'does not require grad and does not have a grad_fn'):
+            call_forwards_backwards(compiled_f)
+    else:
+        call_forwards_backwards(compiled_f)
+        compiled_grad = get_grads(args)
+        assert_equals_fn(orig_grad, compiled_grad)

--- a/torch/testing/_internal/optests/aot_autograd.py
+++ b/torch/testing/_internal/optests/aot_autograd.py
@@ -3,23 +3,28 @@ import torch.utils._pytree as pytree
 from torch.testing._internal.common_methods_invocations import wrapper_set_seed
 from functorch.compile import compiled_function, min_cut_rematerialization_partition, nop
 import re
-import contextlib
 
-@contextlib.contextmanager
-def assert_raises_regex(exception_cls, regex):
-    try:
-        yield
-    except exception_cls as e:
-        msg = str(e)
-        if not re.search(regex, msg):
-            raise AssertionError(
-                f"Expected exception to match regex. regex: {regex}, exception: {msg}")
-    except Exception as e:
-        raise AssertionError(
-            f"Expected {exception_cls} to be raised, instead got exception {type(e)}")
-    finally:
+
+class assert_raises_regex:
+    def __init__(self, exception_cls, regex):
+        self.exception_cls = exception_cls
+        self.regex = regex
+
+    def __enter__(self):
         pass
-    raise AssertionError("Expected exception to be raised but none was")
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        if exc_type == self.exception_cls:
+            msg = str(exc_val)
+            if not re.search(self.regex, msg):
+                raise AssertionError(
+                    f"Expected exception to match regex. regex: {self.regex}, exception: {msg}")
+            return True  # Squashes the exception
+        if exc_type is not None:
+            raise AssertionError(
+                f"Expected {self.exception_cls} to be raised, instead got exception {exc_type}")
+        raise AssertionError("Expected exception to be raised but none was")
+
 
 def aot_autograd_check(
         func, args, kwargs, dynamic,

--- a/torch/testing/_internal/optests/common.py
+++ b/torch/testing/_internal/optests/common.py
@@ -1,0 +1,4 @@
+# Exception class for if a test fails because of a problem with the test
+# (and not a problem with the function it is testing).
+class TestFrameworkError(Exception):
+    pass

--- a/torch/testing/_internal/optests/compile_check.py
+++ b/torch/testing/_internal/optests/compile_check.py
@@ -1,0 +1,77 @@
+import torch
+from .make_fx import make_fx_check
+from .aot_autograd import aot_autograd_check
+from .common import TestFrameworkError
+from torch._subclasses.schema_check_mode import SchemaCheckMode
+import contextlib
+
+
+def compile_check(
+        func,
+        args,
+        kwargs,
+        *,
+        dynamic_only=False,
+        inference_only=False,
+        fullgraph=True,
+        raise_error=True):
+    """Check if torch.compile supports a function.
+
+    Args:
+        func (function): a Python function that takes at least one Tensor
+            as input and returns a Tensor or a Tuple of Tensors.
+        args (Tuple): args to the function
+        kwargs (dict): kwargs to the function
+        dynamic_only (bool, optional): If the function only works with dynamic
+            shapes. This can happen if it returns Tensors whose shape are
+            dependent on the data on the input Tensors. If True, we skip
+            tests related to torch.compile with static shapes.
+        inference_only (bool, optional): If the function only works with
+            inputs that do not require grad. If True, we will skip
+            autograd-related tests.
+        fullgraph (bool, optional): If we expect the entire function
+            to be captured with torch.compile without any graph breaks.
+        raise_error (bool, optional): If True, this API raises errors
+            when they are encountered.
+
+    """
+    def run_static_or_dynamic_tests(dynamic):
+        tracing_mode = 'symbolic' if dynamic else 'fake'
+        with ignore_test_framework_error():
+            make_fx_check(func, args, kwargs, tracing_mode=tracing_mode)
+        if not inference_only:
+            with ignore_test_framework_error():
+                aot_autograd_check(func, args, kwargs, dynamic=dynamic)
+        with ignore_test_framework_error():
+            check_compile(func, args, kwargs, fullgraph, dynamic=dynamic)
+
+    if not raise_error:
+        # In this case, we should return a nice report walking through
+        # all of the tests and what failed. This is not yet implemented.
+        raise NotImplementedError("NYI: raise_error=False")
+
+    with ignore_test_framework_error():
+        schema_check(func, args, kwargs)
+
+    if not dynamic_only:
+        run_static_or_dynamic_tests(dynamic=False)
+    run_static_or_dynamic_tests(dynamic=True)
+
+
+def schema_check(func, args, kwargs):
+    with SchemaCheckMode():
+        func(*args, **kwargs)
+
+
+def check_compile(func, args, kwargs, fullgraph, dynamic):
+    expected = func(*args, **kwargs)
+    result = torch.compile(func, backend='aot_eager', fullgraph=fullgraph, dynamic=dynamic)(*args, **kwargs)
+    torch.testing._comparison.assert_close(expected, result)
+
+
+@contextlib.contextmanager
+def ignore_test_framework_error():
+    try:
+        yield
+    except TestFrameworkError:
+        return

--- a/torch/testing/_internal/optests/make_fx.py
+++ b/torch/testing/_internal/optests/make_fx.py
@@ -1,0 +1,45 @@
+import torch
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_methods_invocations import wrapper_set_seed
+from .common import TestFrameworkError
+
+
+def make_fx_check(func, args, kwargs, tracing_mode, assertion_fn=torch.testing._comparison.assert_close):
+    def f(args, kwargs, extra_args, extra_kwargs):
+        if extra_args:
+            for i, t in extra_args:
+                args[i] = t.size()
+        if extra_kwargs:
+            for k, t in extra_kwargs.items():
+                kwargs[k] = t.size()
+
+        return func(*args, **kwargs)
+
+    # If any argument is a torch.Size(), maybe get dynamic shapes for it by:
+    # - Create a temporary Tensor whose size is the torch.Size() we want. Note that
+    #   we use an expanded Tensor as we cannot pass "meta" Tensors to make_fx.
+    # - Pass it to make_fx such that it is is converted to a proxy Tensor
+    # - Unpack the size in the wrapper to get a torch.Size with dynamic shapes (in
+    #   symbolic mode, a no-op otherwise)
+    extra_args = []
+    extra_kwargs = {}
+    for i, arg in enumerate(args):
+        if isinstance(arg, torch.Size):
+            extra_args.append((i, torch.empty(arg, device="cpu")))
+    for key, value in kwargs.items():
+        if isinstance(value, torch.Size):
+            extra_kwargs[key] = torch.empty(value, device="cpu")
+
+    new_f = make_fx(f, tracing_mode=tracing_mode)(args, kwargs, extra_args, extra_kwargs)
+    for arg in args:
+        if isinstance(arg, torch.Tensor) and arg.dtype == torch.float:
+            with torch.no_grad():
+                arg.uniform_(0, 1)
+    try:
+        old_out = f(args, kwargs, extra_args, extra_kwargs)
+    except Exception:
+        raise TestFrameworkError("Attempted to generate new args and invoke func ",
+                                 "but that led to an exception")
+
+    new_out = wrapper_set_seed(new_f, args, kwargs, extra_args, extra_kwargs)
+    assertion_fn(new_out, old_out)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #102170

This PR introduces
torch.testing._internal.optests.compile_check.compile_check.

compile_check is an API (like gradcheck) where a user can test if their
custom operator (or really, any function) is supported by torch.compile.

To implement compile_check, I refactored the AOTAutograd and make_fx
OpInfo tests so that we could reuse their logic.

This is a V0 because I want to dogfood this for some time and see how well
it sticks. If it works out well, then:
- we can promote it to public API
- we can add more fine-grained tests. For example, we should add a test
that functionalization exists for all present ATen ops, so the user
doesn't find out in the AOTAutograd tests.
- we can work on providing more actionable error messages.
SchemaCheckMode has really good error messages, but the
make_fx/AOTAutograd errors are more opaque.
- we can add an option for `compile_check` to just print a report of all
the problems it encountered. It would be useful for it to tell users
that "hey, you missed adding a FakeTensor rule and you're missing
functionalization", among others.

Test Plan:
- Added OpInfo test for the custom_op_db
- The rest of the tests are tested by their respective OpInfo tests
(schema_check, make_fx, aot_autograd).