### PR TITLE
Avoid grad_fn getting garbage collected in multihooks

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -399,6 +399,7 @@ def register_multi_grad_hook(tensors: Sequence[torch.Tensor], fn: Callable[[Sequ
         def remove(self):
             for handle in self.handles:
                 handle.remove()
+            self.grad_fns = None
 
         def __getstate__(self):
             return self.handles


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102175

Workaround for https://github.com/pytorch/pytorch/issues/102174