### PR TITLE
[inductor] Replaced refs.op by torch.op in _refs/*

### DIFF
--- a/torch/_refs/special/__init__.py
+++ b/torch/_refs/special/__init__.py
@@ -121,7 +121,7 @@ def log_ndtr(a: TensorLikeType) -> TensorLikeType:
     return torch.where(
         a < 1.0,
         torch.log(torch.special.erfcx(-t) / 2) - t * t,
-        torch.log1p(-refs.erfc(t) / 2),
+        torch.log1p(-torch.erfc(t) / 2),
     )
 
 
@@ -161,7 +161,7 @@ def xlog1py(a: Union[TensorLikeType, NumberType], b: Union[TensorLikeType, Numbe
     # mypy: expected "Tensor"
     assert isinstance(a, TensorLike)
     assert isinstance(b, TensorLike)
-    rhs = torch.where(torch.eq(a, 0), 0, torch.mul(a, refs.log1p(b)))
+    rhs = torch.where(torch.eq(a, 0), 0, torch.mul(a, torch.log1p(b)))
     return torch.where(torch.isnan(b), float("nan"), rhs)
 
 


### PR DESCRIPTION
Description:
- Replaced `refs.op` by `torch.op` in `_refs/*`

cc @lezcano 