### PR TITLE
[quant][pt2e] Add support for SharedQuantizationSpec

### DIFF
--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -12,6 +12,10 @@ from .quantization_mappings import *  # type: ignore[no-redef]
 from .quantize import *  # noqa: F403
 from .quantize_jit import *  # noqa: F403
 from .stubs import *  # noqa: F403
+from typing import Union
+
+ObserverOrFakeQuantizer = Union[ObserverBase, FakeQuantizeBase]
+ObserverOrFakeQuantizer.__module__ = "torch.ao.quantization"
 
 __all__ = [
     "DeQuantStub",
@@ -129,6 +133,7 @@ __all__ = [
     "script_qconfig_dict",
     "swap_module",
     "weight_observer_range_neg_127_to_127",
+    "ObserverOrFakeQuantizer",
 ]
 
 def default_eval_fn(model, calib_data):

--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -1,14 +1,18 @@
 from .qnnpack_quantizer import QNNPackQuantizer
 from .quantizer import (
+    EdgeOrNode,
     OperatorConfig,
     Quantizer,
     QuantizationSpec,
     QuantizationAnnotation,
+    SharedQuantizationSpec,
 )
 
 __all__ = [
+    "EdgeOrNode",
     "Quantizer",
     "QuantizationSpec",
     "QNNPackQuantizer",
     "QuantizationAnnotation",
+    "SharedQuantizationSpec",
 ]

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from torch.fx import Node
-from typing import Callable, List, NamedTuple, Optional, Dict, Any
+from typing import Callable, List, NamedTuple, Optional, Dict, Any, Union, Tuple
 from torch.ao.quantization.qconfig import _ObserverOrFakeQuantizeConstructor
 
 import torch
@@ -60,6 +60,19 @@ class QuantizationSpec:
         if self.ch_axis is not None and self.ch_axis < 0:
             raise ValueError("Ch_axis is < 0.")
 
+EdgeOrNode = Union[Tuple[Node, Node], Node]
+
+@dataclass(eq=True, frozen=True)
+class SharedQuantizationSpec:
+    """
+    Quantization spec for the Tensors whose quantization parameters are shared with other Tensors
+
+    The way we refer to other points of quantization in the graph will be either
+    an input edge or an output value
+    input edge is the connection between input node and the node consuming the input, so it's a Tuple[Node, Node]
+    output value is an fx Node
+    """
+    edge_or_node: EdgeOrNode
 
 # In the absence of better name, just winging it with QuantizationConfig
 @dataclass(eq=True, frozen=True)


### PR DESCRIPTION
Summary:
This PR adds support for SharedQuantizationSpec, it's used to express the sharing between
two Tensors in the prepared graph, the Tensor will either be input of some node (expressed as a Tuple of fx nodes) or
output of some node (expressed as an fx Node)

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- 'caffe2/test:quantization_pt2e'
buck2 test mode/opt caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_resnet18_with_quantizer_api (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2EModels)'
```

Differential Revision: D46043026

