### PR TITLE
No need to run non-CUDA jobs in memory leak check mode

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -51,7 +51,7 @@ def is_cuda_or_rocm_job(job_name: Optional[str]) -> bool:
 # Supported modes when running periodically. Only applying the mode when
 # its lambda condition returns true
 SUPPORTED_PERIODICAL_MODES: Dict[str, Callable[[Optional[str]], bool]] = {
-    # Memory leak check is only needed for CUDA and ROCm jobs utilizing GPU memory
+    # Memory leak check is only needed for CUDA and ROCm jobs which utilize GPU memory
     "mem_leak_check": is_cuda_or_rocm_job,
     "rerun_disabled_tests": lambda job_name: True,
 }
@@ -386,10 +386,10 @@ def main() -> None:
         # No PR number, no tag, we can just return the test matrix as it is
         filtered_test_matrix = test_matrix
 
-    #if args.event_name == "schedule" and args.schedule == "29 8 * * *":
-    # we don't want to run the mem leack check or disabled tests on normal
-    # periodically scheduled jobs, only the ones at this time
-    filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
+    if args.event_name == "schedule" and args.schedule == "29 8 * * *":
+        # we don't want to run the mem leack check or disabled tests on normal
+        # periodically scheduled jobs, only the ones at this time
+        filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
 
     if args.workflow and args.job_name and args.branch not in EXCLUDED_BRANCHES:
         # If both workflow and job name are available, we will check if the current job

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -378,10 +378,10 @@ def main() -> None:
         # No PR number, no tag, we can just return the test matrix as it is
         filtered_test_matrix = test_matrix
 
-    if args.event_name == "schedule" and args.schedule == "29 8 * * *":
-        # we don't want to run the mem leack check or disabled tests on normal
-        # periodically scheduled jobs, only the ones at this time
-        filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
+    #if args.event_name == "schedule" and args.schedule == "29 8 * * *":
+    # we don't want to run the mem leack check or disabled tests on normal
+    # periodically scheduled jobs, only the ones at this time
+    filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
 
     if args.workflow and args.job_name and args.branch not in EXCLUDED_BRANCHES:
         # If both workflow and job name are available, we will check if the current job

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Any
+from typing import Any, Dict, List
 from unittest import main, mock, TestCase
 
 import yaml
@@ -170,22 +170,39 @@ class TestConfigFilter(TestCase):
             self.assertEqual(case["expected"], json.dumps(filtered_test_matrix))
 
     def test_set_periodic_modes(self) -> None:
-        testcases = [
+        testcases: List[Dict[str, str]] = [
             {
+                "job_name": "a CI job",
                 "test_matrix": "{include: []}",
                 "description": "Empty test matrix",
             },
             {
+                "job_name": "a-ci-job",
                 "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
                 "descripion": "Replicate each periodic mode in a different config",
+            },
+            {
+                "job_name": "a-ci-cuda11.8-job",
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
+                "descripion": "Replicate each periodic mode in a different config for a CUDA job",
+            },
+            {
+                "job_name": "a-ci-rocm-job",
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
+                "descripion": "Replicate each periodic mode in a different config for a ROCm job",
             },
         ]
 
         for case in testcases:
+            job_name = case["job_name"]
             test_matrix = yaml.safe_load(case["test_matrix"])
-            scheduled_test_matrix = set_periodic_modes(test_matrix)
+            scheduled_test_matrix = set_periodic_modes(test_matrix, job_name)
+
+            expected_modes = [
+                m for m, c in SUPPORTED_PERIODICAL_MODES.items() if c(job_name)
+            ]
             self.assertEqual(
-                len(test_matrix["include"]) * len(SUPPORTED_PERIODICAL_MODES),
+                len(test_matrix["include"]) * len(expected_modes),
                 len(scheduled_test_matrix["include"]),
             )
 

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -191,10 +191,19 @@ class TestConfigFilter(TestCase):
                 "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
                 "descripion": "Replicate each periodic mode in a different config for a ROCm job",
             },
+            {
+                "job_name": "",
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
+                "descripion": "Empty job name",
+            },
+            {
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "cfg", runner: "macos"}]}',
+                "descripion": "Missing job name",
+            },
         ]
 
         for case in testcases:
-            job_name = case["job_name"]
+            job_name = case.get("job_name", None)
             test_matrix = yaml.safe_load(case["test_matrix"])
             scheduled_test_matrix = set_periodic_modes(test_matrix, job_name)
 


### PR DESCRIPTION
Memory leak check mode is only meant for runner with GPU such as CUDA and ROCm https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_utils.py#L1093.  So it's a waste of time and resource to run them for CPU-only jobs

### Testing

CUDA jobs have both `mem_leak_check` and `rerun_disabled_tests`:
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109448858#step:9:131
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109449417#step:9:123 
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109452338#step:9:111

Same goes for Bazel CUDA job:
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109451535#step:3:132

And ROCM job:
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109451353#step:9:117

Non CUDA or ROCM jobs have only `rerun_disabled_tests` mode, for example:
* https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109449894#step:9:127
* ASAN https://github.com/pytorch/pytorch/actions/runs/5072143038/jobs/9109449157#step:9:126