### PR TITLE
[fx][2/n] Add metadata to placeholders

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -37,7 +37,7 @@ from collections import namedtuple
 
 from torch.fx.proxy import TraceError
 from torch.fx._compatibility import _BACK_COMPAT_OBJECTS, _MARKED_WITH_COMPATIBILITY
-from torch.fx._symbolic_trace import PHBase
+from torch.fx._symbolic_trace import PHBase, PHWithMeta
 from fx.test_subgraph_rewriter import TestSubgraphRewriter  # noqa: F401
 from fx.test_dce_pass import TestDCE  # noqa: F401
 from fx.test_fx_const_fold import TestConstFold  # noqa: F401
@@ -3572,6 +3572,61 @@ class TestFX(JitTestCase):
 
         nf = symbolic_trace(nf)
         self.assertEqual(nf(**val), f(**val))
+
+    def test_metadata_on_ph(self):
+        def f_sum(a: int, b: int) -> int:
+            return a + b
+
+        # Due to unflattening of dict, the batch argument
+        # will be split into two separate nodes with the names
+        # "batch_1" and "batch_2", referring to the keys
+        # "f1" and "f2" respectively in the dict.
+        def f_dict(a: Dict[str, str]) -> bool:
+            return a["f1"] == a["f2"]
+
+        def verify_metadata(gm: GraphModule, arg_names: List[str], metadata: List[str]):
+            for node in gm.graph.nodes:
+                if node.op == "placeholder":
+                    self.assertTrue(node.name in arg_names)
+                    self.assertTrue(node.ph_key in metadata)
+
+        verify_metadata(
+            gm=symbolic_trace(
+                f_sum,
+                concrete_args={"a": PHWithMeta(ph_key="a"), "b": PHWithMeta(ph_key="b")}
+            ),
+            arg_names=["a_1", "b_1"],
+            metadata=["a", "b"]
+        )
+        verify_metadata(
+            gm=symbolic_trace(
+                f_dict,
+                concrete_args={"a": {"f1": PHWithMeta(ph_key="f1"), "f2": PHWithMeta(ph_key="f2")}}
+            ),
+            arg_names=["a_1", "a_2"],
+            metadata=["f1", "f2"]
+        )
+
+        # Ensures that tags on nodes are NOT overwritten by PH attributes with same attr name (tag)
+        class TaggingTracer(Tracer):
+            def create_node(self, kind : str, target : Union[str, Callable],
+                            args : Tuple[Argument, ...], kwargs : Dict[str, Any], name : Optional[str] = None,
+                            type_expr : Optional[Any] = None) -> Node:
+                n = super().create_node(kind, target, args, kwargs, name)
+                n.tag = "foo"
+                return n
+
+        class PHWithTag(PHBase):
+            def __init__(self, tag: str):
+                super().__init__()
+
+                self.tag = tag
+
+        g = TaggingTracer().trace(f_sum, concrete_args={"a": PHWithTag(tag="bar"), "b": PHWithTag(tag="bar")})
+        for n in g.nodes:
+            self.assertTrue(hasattr(n, "tag"))
+            # Ensure that tag is still "foo" and not "bar" (from PHWithTag)
+            self.assertEqual(n.tag, "foo")
 
     def test_custom_codegen(self):
         class ListCodeGen(CodeGen):


### PR DESCRIPTION
Summary:
# Context
In TorchRec's train pipeline, we need to fx trace a module to analyze the arguments on the forward call. In order to do this, we need to preserve some sort of meaning with each argument (a key or name of sorts that lets us identify the argument).

The issue is, when you use concrete args, internally, fx will unflatten the arg into it's constituents (to locate PHs).

Given a function that looks like this:
```
def process(batch: Dict[str, torch.Tensor]):
   ....

symbolic_trace(process, concrete_args: {"batch": {"f1": PH, "f2": PH}})

# function will be rewritten to look like:
def process(batch_1, batch_2):  # batch_1 -> "f1", batch_2->"f2"
  ...
```

When you traverse through the nodes of the graph, the names of the argument nodes to the function are batch_1 and batch_2. **This doesn't mean anything to the user who is fx tracing.** There isn't anything indicating that batch_1 corresponds to key "f1" in the batch input.

# Solution

When fx sees a "PH", it creates a proxy node.

The user does not have direct access to proxy creation, but only through the PH structure.

Attach a piece of metadata, `ph_key`, to the PH when you set it in the concrete args, it will get passed into proxy + node creation. So when you traverse the graph, this metadata sticks onto the node as an attribute. This way you have a way of tagging that  "batch_1" as "f1".

Test Plan: added a unit test

Reviewed By: dstaay-fb

Differential Revision: D44947653

