### PR TITLE
[rng][needs discussion] Return seed and offset as cuda tensors to work with inductor

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1130,7 +1130,7 @@ def make_fallback(kernel, layout_constraint=None, warn=True):
     return register_lowering(kernel, type_promotion_kind=None)(fallback_handler(kernel))
 
 
-def philox_rand_offset(shape):
+def philox_rand_offset(shape, device):
     """
     TorchInductor offset calculation differs from PyTorch eager offset
     calculation for random ops (tl.rand vs torch.rand). In future, we should
@@ -1139,7 +1139,7 @@ def philox_rand_offset(shape):
     numel = 1
     for s in shape:
         numel = numel * s
-    return tensor(numel, dtype=torch.int64)
+    return tensor(numel, dtype=torch.int64, device=device)
 
 
 @register_lowering(torch.ops.rngprims.philox_rand, type_promotion_kind=None)
@@ -1177,7 +1177,7 @@ def philox_rand(size, seed, offset, stride, device, dtype):
         ranges=list(size),
     )
 
-    offset_node = philox_rand_offset(size)
+    offset_node = philox_rand_offset(size, device)
     return random_values_node, offset_node
 
 

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -120,7 +120,7 @@ def register_philox_rand():
             CUDARngStateHelper.set_torch_state_tensor(seed, offset)
             random_values = torch.rand(shape, device=device, dtype=dtype)
 
-        return random_values, philox_rand_offset(shape)
+        return random_values, philox_rand_offset(shape).to(device=device)
 
     register_rng_prim(
         name=name,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1781,8 +1781,8 @@ class CUDARngStateHelper:
             raise RuntimeError("CUDA not available")
 
         with fake_mode:
-            seed = torch.tensor(torch.cuda.initial_seed())
-            offset = torch.tensor(torch.cuda._get_rng_state_offset())
+            seed = torch.tensor(torch.cuda.initial_seed(), device="cuda")
+            offset = torch.tensor(torch.cuda._get_rng_state_offset(), device="cuda")
             return seed, offset
 
     @staticmethod
@@ -1790,7 +1790,7 @@ class CUDARngStateHelper:
         # Rng state is [64-bit seed, 64-bit offset]
         seed_portion = seed.reshape([1]).view(torch.uint8)
         offset_portion = offset.reshape([1]).view(torch.uint8)
-        new_state = torch.cat([seed_portion, offset_portion])
+        new_state = torch.cat([seed_portion, offset_portion]).to(device="cpu")
         torch.cuda.set_rng_state(new_state)
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102233
* __->__ #102203
* #102344
* #102123
* #102022

There are a few reasons to pass seed and offset as CUDA tensors

1) Cudagraphs in Inductor - Currently, seed and offset being CPU tensors, prevent us from using Cudagraphs when functionalization is turned on. This is bad for perf.
2) More cuda kernels in inductor - Having a mix of CPU and CUDA in Inductor could be avoided. All of the computation, including offset calculation becomes gpu kernels, and its better.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10