### PR TITLE
[quant][pt2] Fix convert in Conv + BN QAT fusion

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1127,24 +1127,25 @@ class TestQuantizePT2E(QuantizationTestCase):
         self.assertEqual(eps, 1e-5)
 
     # TODO: merge these numerics tests with the graph tests above
-    def test_prepare_qat_conv_bn_numerics(self):
+    def test_qat_conv_bn_numerics(self):
         m = TestHelperModules.ConvWithBNRelu(relu=False)
         example_inputs = (torch.randn(1, 3, 5, 5),)
         self._verify_symmetric_qnnpack_qat_numerics(
-            m, example_inputs, is_per_channel=False
+            m, example_inputs, is_per_channel=False, verify_convert=True,
         )
         self._verify_symmetric_qnnpack_qat_numerics(
-            m, example_inputs, is_per_channel=True
+            m, example_inputs, is_per_channel=True, verify_convert=True,
         )
 
-    def test_prepare_qat_conv_bn_relu_numerics(self):
+    def test_qat_conv_bn_relu_numerics(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)
         example_inputs = (torch.randn(1, 3, 5, 5),)
+        # TODO: verify convert numerics in a future PR
         self._verify_symmetric_qnnpack_qat_numerics(
-            m, example_inputs, is_per_channel=False
+            m, example_inputs, is_per_channel=False, verify_convert=False,
         )
         self._verify_symmetric_qnnpack_qat_numerics(
-            m, example_inputs, is_per_channel=True
+            m, example_inputs, is_per_channel=True, verify_convert=False,
         )
 
     def _verify_symmetric_qnnpack_qat_numerics(
@@ -1198,24 +1199,15 @@ class TestQuantizePT2E(QuantizationTestCase):
         self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
 
         if verify_convert:
+            model_pt2e.eval()
             model_pt2e = convert_pt2e(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)
-
+            model_fx.eval()
             model_fx = _convert_to_reference_decomposed_fx(
-                model_fx, backend_config=backend_config
+                model_fx, backend_config=backend_config,
             )
             quant_result_fx = model_fx(*example_inputs)
-            self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
-
-    def test_convert_qat_conv_bn_numerics(self):
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        self._verify_symmetric_qnnpack_qat_numerics(
-            TestHelperModules.ConvWithBNRelu(relu=False),
-            example_inputs,
-            is_per_channel=False,
-        )
-        # TODO: enable in a separate PR
-        # self._verify_symmetric_qnnpack_qat_numerics(M(), example_inputs, is_per_channel=True)
+            self.assertEqual(quant_result_pt2e, quant_result_fx)
 
 
 class TestQuantizePT2EModels(QuantizationTestCase):

--- a/torch/ao/quantization/_pt2e/utils.py
+++ b/torch/ao/quantization/_pt2e/utils.py
@@ -36,24 +36,26 @@ def _fold_bn_weights_into_conv_node(
     bn_node: Node,
     m: GraphModule
 ) -> None:
-    # conv weight
+    # conv args: input, weight, bias, stride, padding, dilation, transposed, ...
     conv_w = _get_tensor_constant_from_node(conv_weight_node, m)
-    # conv bias
     conv_b = _get_tensor_constant_from_node(conv_bias_node, m)
     transpose = conv_node.args[6]
 
+    # eval bn args: input, weight, bias, running mean, running var, momentum, eps
+    # train bn args: input, weight, bias, running mean, running var, training, momentum, eps
     bn_args_schema = bn_node.target._schema.arguments  # type: ignore[union-attr]
     bn_args = _get_all_arguments(bn_node.args, bn_node.kwargs, bn_args_schema)
-
-    # bn weight
     bn_w = _get_tensor_constant_from_node(bn_args[1], m)
-    # bn bias
     bn_b = _get_tensor_constant_from_node(bn_args[2], m)
-    # bn running mean
     bn_rm = _get_tensor_constant_from_node(bn_args[3], m)
-    # bn running variance
     bn_rv = _get_tensor_constant_from_node(bn_args[4], m)
-    bn_eps = bn_args[6]
+    if bn_node.target == torch.ops.aten._native_batch_norm_legit_no_training.default:
+        eps_arg_index = 6
+    elif bn_node.target == torch.ops.aten._native_batch_norm_legit.default:
+        eps_arg_index = 7
+    else:
+        raise ValueError("BN node target is unexpected ", bn_node.target)
+    bn_eps = bn_args[eps_arg_index]
 
     fused_weight, fused_bias = fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=transpose)
 


### PR DESCRIPTION
Summary:
Previously, the test for the convert flow in Conv + BN
QAT fusion was not enabled by mistake. However, reenabling this
test uncovered several bugs:

(1) The replaced nodes returned by subgraph rewriter were not
handled correctly. This is because a recent change in the subgraph
rewriter (#100556) fixed only the prepare case but not the convert
case. This commit brings this fix to the convert case as well and
deduplicates some code between the two cases.

(2) When folding BN into conv, we used the wrong arg index to get
the BN eps value. This resulted in an incorrect conv weight.

(3) In FX, we currently do a hack for weighted modules where we
observe the weights once in convert in order to ensure we get the
right shapes for these weight observers. This caused the numerics
to diverge between PT2 and FX. This commit fixes this by skipping
this unnecessary hack for `_convert_to_reference_decomposed_fx`.

(4) Per channel support was simply missing. This commit adds
support for this by matching the quantize_per_channel and
dequantize_per_channel ops in addition to the existing ones.

Test Plan:
python test/test_quantization.py TestQuantizePT2E.test_qat_conv_bn_numerics

Reviewed By: jerryzh168

Differential Revision: D46097783

