### PR TITLE
[Reland2] fix missing-prototypes warnings in torch_cpu (Part 4)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1598,6 +1598,7 @@ TORCH_COPTS = COMMON_COPTS + [
     "-fvisibility-inlines-hidden",
     "-fno-math-errno ",
     "-fno-trapping-math",
+    "-Wno-error=unused-function",
 ]
 
 torch_sources = {

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -763,6 +763,11 @@ IValueComparator getGreaterThanComparator(const IValue& v) {
   };
 }
 
+std::ostream& operator<<(std::ostream& out, const ivalue::EnumHolder& v) {
+  out << v.qualifiedClassName() << "." << v.name();
+  return out;
+}
+
 std::ostream& operator<<(std::ostream & out, const IValue & v) {
   auto formatter = [&](std::ostream& out, const IValue& v) {
     out << v;

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -763,11 +763,6 @@ IValueComparator getGreaterThanComparator(const IValue& v) {
   };
 }
 
-static std::ostream& operator<<(std::ostream& out, const ivalue::EnumHolder& v) {
-  out << v.qualifiedClassName() << "." << v.name();
-  return out;
-}
-
 std::ostream& operator<<(std::ostream & out, const IValue & v) {
   auto formatter = [&](std::ostream& out, const IValue& v) {
     out << v;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1622,7 +1622,7 @@ struct ivalue::EnumHolder : c10::intrusive_ptr_target {
 
   TORCH_API friend std::ostream& operator<<(
       std::ostream& out,
-      const EnumHolder& v);
+      const ivalue::EnumHolder& v);
 
   TORCH_API const std::string qualifiedClassName() const;
 

--- a/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
@@ -405,7 +405,7 @@ static std::tuple<Tensor,optional<int64_t>> searchsorted_batch_rule(
   TORCH_INTERNAL_ASSERT(false);
 }
 
-Tensor bucketize_decomp_Tensor(
+static Tensor bucketize_decomp_Tensor(
     const Tensor& self,
     const Tensor& boundaries,
     bool out_int32,
@@ -415,7 +415,7 @@ Tensor bucketize_decomp_Tensor(
   return at::searchsorted(boundaries, self, out_int32, right, nullopt, nullopt);
 }
 
-Tensor bucketize_decomp_Scalar(
+static Tensor bucketize_decomp_Scalar(
     const Scalar& self,
     const Tensor& boundaries,
     bool out_int32,

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -374,8 +374,8 @@ TORCH_IMPL_FUNC(softshrink_backward_out) (
   shrink_backward_stub(device_type(), *this, lambd);
 }
 
-static bool use_mkldnn(const Tensor& input) {
 #if AT_MKLDNN_ENABLED()
+static bool use_mkldnn(const Tensor& input) {
   if (!at::globalContext().userEnabledMkldnn()) {
     return false;
   }
@@ -386,9 +386,8 @@ static bool use_mkldnn(const Tensor& input) {
     (input.device().is_cpu() &&
     (((input.scalar_type() == kBFloat16) && mkldnn_bf16_device_check()) ||
     (input.scalar_type() == kFloat))); // input is dense layout and bfloat16/float32
-#endif
-  return false;
 }
+#endif
 
 TORCH_IMPL_FUNC(gelu_out_cpu) (
   const Tensor& self, c10::string_view approximate, const Tensor& result

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -809,7 +809,7 @@ Tensor& arctan2_out(const Tensor& self, const Tensor& other, Tensor& result) {
   return at::atan2_out(result, self, other);
 }
 
-Tensor& add_relu_impl(
+static Tensor& add_relu_impl(
     Tensor& result, const Tensor& self, const Tensor& other, const Scalar& alpha) {
   auto iter = TensorIterator::binary_op(result, self, other);
   Scalar min_val;
@@ -1003,7 +1003,7 @@ Tensor& mul__scalar_sparse_csr(Tensor& self, const Scalar& other) {
   return self;
 }
 
-Device correct_out_device(const Tensor& self, const Tensor& other) {
+static Device correct_out_device(const Tensor& self, const Tensor& other) {
   if (self.device() == at::kCPU){
       return other.device();
   } else {
@@ -1049,7 +1049,7 @@ Tensor div_zerotensor(const Tensor& self, const Tensor& other) {
   }
 }
 
-Tensor maybe_add_maybe_sub(const Tensor& self, const Tensor& other, const Scalar& alpha) {
+static Tensor maybe_add_maybe_sub(const Tensor& self, const Tensor& other, const Scalar& alpha) {
   auto out_device = correct_out_device(self, other);
   // hack to use the TensorIterator to get the correct broadcasting and type promotion logic
   auto device_ = Device(DeviceType::Meta);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -771,6 +771,7 @@ static void check_input_same_type_as_parameters(
   check_input_same_type_as_parameters(input, weight, /*bias=*/ Tensor());
 }
 
+#if AT_MKLDNN_ENABLED()
 static void check_input_same_type_as_parameters(
     const Tensor& input,
     const Tensor& weight,
@@ -789,6 +790,7 @@ static void check_input_same_type_as_parameters(
     check_input_same_type_as_parameters(input, weight, bias);
   }
 }
+#endif
 
 static auto view4d(const at::Tensor& tensor) -> at::Tensor {
   TORCH_CHECK(tensor.ndimension() == 3,

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -21,6 +21,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_copy_from.h>
+#include <ATen/ops/_propagate_xla_data.h>
 #include <ATen/ops/copy_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/expand_copy.h>

--- a/aten/src/ATen/native/LegacyBatching.cpp
+++ b/aten/src/ATen/native/LegacyBatching.cpp
@@ -1,4 +1,6 @@
 #include <ATen/core/Tensor.h>
+#include <ATen/ops/_add_batch_dim_native.h>
+#include <ATen/ops/_remove_batch_dim_native.h>
 #include <ATen/LegacyBatchedTensorImpl.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/LegacyVmapTransforms.h>

--- a/aten/src/ATen/native/LegacyBatching.cpp
+++ b/aten/src/ATen/native/LegacyBatching.cpp
@@ -1,9 +1,12 @@
 #include <ATen/core/Tensor.h>
-#include <ATen/ops/_add_batch_dim_native.h>
-#include <ATen/ops/_remove_batch_dim_native.h>
 #include <ATen/LegacyBatchedTensorImpl.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/LegacyVmapTransforms.h>
+
+#ifdef AT_PER_OPERATOR_HEADERS
+#include <ATen/ops/_add_batch_dim_native.h>
+#include <ATen/ops/_remove_batch_dim_native.h>
+#endif
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1893,7 +1893,7 @@ The behavior depends on the dimensionality of the Tensors as follows:
 - Otherwise, we return bmm, after broadcasting and folding the batched dimensions if
   there's more than one
 */
-Tensor _matmul_impl(
+static Tensor _matmul_impl(
     Tensor& out,
     const Tensor& tensor1,
     const Tensor& tensor2) {

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -20,7 +20,7 @@
 
 namespace at { namespace native {
 
-void checkLongTensor(const Tensor& tensor) {
+static void checkLongTensor(const Tensor& tensor) {
   TORCH_CHECK(tensor.dim() == 1 && tensor.device().type() == at::kCPU && tensor.scalar_type() == at::kLong,
            "'lengths' argument should be a 1D CPU int64 tensor, but got ",
             tensor.dim(), "D ", tensor.device().str(), " ", tensor.scalar_type(), " tensor");

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1809,7 +1809,7 @@ std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data(
                          std::move(std::get<2>(results)));
 }
 
-std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data_legacy(
+static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data_legacy(
     const Tensor& data,
     const Tensor& batch_sizes,
     c10::List<at::Tensor> hx_,

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -79,7 +79,7 @@ bool resize_output_symint(const Tensor& output, SymIntArrayRef shape) {
   return _resize_output(output, shape);
 }
 
-const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
+static const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
   TORCH_CHECK(self.device() == device, "out Tensor doesn't have the correct device set");
   at::native::resize_output(self, shape);
   return self;

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ops/resize_as_native.h>
 #include <ATen/ops/resize_native.h>
 #include <ATen/ops/resize.h>
+#include <ATen/ops/_resize_output.h>
 #endif
 
 namespace at { namespace native {
@@ -79,7 +80,7 @@ bool resize_output_symint(const Tensor& output, SymIntArrayRef shape) {
   return _resize_output(output, shape);
 }
 
-static const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
+const Tensor& _resize_output_(const Tensor& self, IntArrayRef shape, c10::Device device) {
   TORCH_CHECK(self.device() == device, "out Tensor doesn't have the correct device set");
   at::native::resize_output(self, shape);
   return self;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -400,7 +400,7 @@ static void build_index_op(
   iter.build(config);
 }
 
-void check_indices_on_cpu_or_selfdevice(
+static void check_indices_on_cpu_or_selfdevice(
     const Tensor& self,
     const at::MaterializedIOptTensorListRef& indices) {
   auto dev = self.device();
@@ -965,7 +965,7 @@ TORCH_IMPL_FUNC(index_add_cpu_out)
   }
 }
 
-void index_reduce_func_impl(
+static void index_reduce_func_impl(
   const Tensor& self,
   int64_t dim,
   const Tensor& index,
@@ -1149,7 +1149,7 @@ static void check_indexarray_range(
   }
 }
 
-Tensor & index_select_out_cpu_dim1_(
+static Tensor & index_select_out_cpu_dim1_(
     Tensor & result_contig, const Tensor & self, const Tensor & index_contig) {
 
   auto self_contig = self.contiguous();
@@ -1379,7 +1379,7 @@ Tensor index_select_quantized_cpu_(const Tensor & self, int64_t dim, const Tenso
   return at::native::index_select_out_cpu_(self, dim, index, result);
 }
 
-Tensor index_select_backward(const Tensor& grad, at::IntArrayRef self_sizes, int64_t dim, const Tensor& index) {
+static Tensor index_select_backward(const Tensor& grad, at::IntArrayRef self_sizes, int64_t dim, const Tensor& index) {
     return at::native::index_select_backward_symint(grad, c10::fromIntArrayRefSlow(self_sizes), dim, index);
 }
 
@@ -1537,7 +1537,7 @@ static void scatter_reduce_exclude_self_helper(
   });
 }
 
-void _scatter_via_index_put(
+static void _scatter_via_index_put(
   const Tensor& self,
   int64_t dim,
   const Tensor& index,

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1379,10 +1379,6 @@ Tensor index_select_quantized_cpu_(const Tensor & self, int64_t dim, const Tenso
   return at::native::index_select_out_cpu_(self, dim, index, result);
 }
 
-static Tensor index_select_backward(const Tensor& grad, at::IntArrayRef self_sizes, int64_t dim, const Tensor& index) {
-    return at::native::index_select_backward_symint(grad, c10::fromIntArrayRefSlow(self_sizes), dim, index);
-}
-
 Tensor index_select_backward_symint(const Tensor& grad, c10::SymIntArrayRef self_sizes, int64_t dim, const Tensor& index) {
   // for composite compliance, use out-of-place variant of
   // `index_add` if index tensor is a Tensor Subclass.

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1009,7 +1009,7 @@ Tensor dense_to_sparse_bsc(const Tensor& self, IntArrayRef blocksize, c10::optio
   return dense_to_sparse_compressed<Layout::SparseBsc>(self, blocksize, dense_dim_opt);
 }
 
-void _check_blocksize_matches(
+static void _check_blocksize_matches(
     const Tensor& self,
     c10::optional<IntArrayRef> blocksize_opt,
     const std::string& name) {
@@ -1023,7 +1023,7 @@ void _check_blocksize_matches(
   }
 }
 
-Tensor sparse_compressed_clone(
+static Tensor sparse_compressed_clone(
     const Tensor& self,
     c10::optional<IntArrayRef> blocksize,
     const std::string& name) {
@@ -1046,7 +1046,7 @@ Tensor sparse_compressed_clone(
       values.device());
 }
 
-Tensor sparse_compressed_to_flipped(
+static Tensor sparse_compressed_to_flipped(
     const Tensor& self,
     c10::optional<IntArrayRef> blocksize,
     const std::string& name) {

--- a/aten/src/ATen/native/Unfold3d.cpp
+++ b/aten/src/ATen/native/Unfold3d.cpp
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <ATen/native/Unfold3d.h>
 #include <ATen/Config.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -10,6 +10,8 @@
 #else
 #include <ATen/ops/_weight_norm_differentiable_backward_native.h>
 #include <ATen/ops/_weight_norm_interface.h>
+#include <ATen/ops/_weight_norm_interface_backward_native.h>
+#include <ATen/ops/_weight_norm_interface_native.h>
 #include <ATen/ops/_weight_norm_native.h>
 #include <ATen/ops/empty_strided.h>
 #include <ATen/ops/norm_except_dim.h>

--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -13,7 +13,7 @@ namespace at::native {
 
 inline namespace CPU_CAPABILITY {
 
-void pow_tensor_tensor_kernel(TensorIteratorBase& iter) {
+static void pow_tensor_tensor_kernel(TensorIteratorBase& iter) {
   const auto dtype = iter.common_dtype();
   if (isFloatingType(dtype) || isComplexType(dtype)) {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, dtype, "pow", [&]() {
@@ -90,7 +90,7 @@ void reciprocal_kernel(TensorIteratorBase& iter);
 void rsqrt_kernel(TensorIteratorBase& iter);
 void sqrt_kernel(TensorIteratorBase& iter);
 
-void pow_tensor_scalar_kernel(
+static void pow_tensor_scalar_kernel(
     TensorIteratorBase& iter,
     const Scalar& exp_scalar) {
   // prevent multiple calls to iter.common_dtype()

--- a/aten/src/ATen/native/mkl/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/mkl/SparseBlasImpl.cpp
@@ -32,6 +32,7 @@ namespace mkl {
 
 namespace {
 
+#if AT_USE_MKL_SPARSE()
 c10::MaybeOwned<Tensor> prepare_dense_matrix_for_mkl(
     const Tensor& tensor) {
   if (tensor.is_non_overlapping_and_dense() ||
@@ -110,7 +111,6 @@ void inline col_indices_and_values_resize_(const Tensor& input, int64_t nnz) {
 /*
   Resizes `input` tensor and fills it with the data from MKL.
 */
-#if AT_USE_MKL_SPARSE()
 template <typename scalar_t>
 void mkl_result_copy_(const Tensor& input, sparse_matrix_t mkl_desc) {
   sparse_index_base_t indexing = SPARSE_INDEX_BASE_ZERO;

--- a/aten/src/ATen/native/nested/NestedTensorFactories.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.cpp
@@ -6,7 +6,7 @@
 namespace at {
 namespace native {
 
-TensorOptions verify_empty_parameters(
+static TensorOptions verify_empty_parameters(
     const at::Tensor& self,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,

--- a/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
@@ -79,64 +79,6 @@ Tensor bmm_nested(const Tensor& self, const Tensor& mat2) {
   return output;
 }
 
-// utilities support `matmul_nested`
-namespace {
-// Args:
-//     self_sizes: the sizes of `self` in `matmul_nested`
-//     mat2_sizes: the sizes of `mat2` in `matmul_nested`
-//     buffer_op: the options for new buffer
-//     sizemat_op: the options for new size matrix
-// Returns:
-//     the batch size of each input underlying tensor, i.e. the product of batch-dimension sizes
-//     the empty output nested tensor
-inline std::tuple<std::vector<int64_t>, Tensor>
-matmul_nested_helper(
-    const std::vector<IntArrayRef>& self_sizes,
-    const std::vector<IntArrayRef>& mat2_sizes,
-    const c10::TensorOptions& buffer_op,
-    const c10::TensorOptions& sizemat_op) {
-  int64_t ntensors = self_sizes.size(),
-      ndims = self_sizes[0].size();
-  std::vector<int64_t> batch_sizes(ntensors, 1);
-  Tensor sizemat = at::empty({ntensors, ndims}, sizemat_op);
-  int64_t* sizemat_ptr = sizemat.mutable_data_ptr<int64_t>();
-  int64_t numel = 0;
-  for (int64_t i = 0; i < ntensors; i++) {
-    const IntArrayRef& self_size = self_sizes[i],
-        & mat2_size = mat2_sizes[i];
-    int64_t& batch_size = batch_sizes[i];
-    // batch dimensions
-    for (int64_t j = 0; j < ndims - 2; j++) {
-      const int64_t& self_sizej = self_size[j],
-          & mat2_sizej = mat2_size[j];
-      TORCH_CHECK(
-          self_sizej == mat2_sizej,
-          "matmul: For nested tensors, no broadcasting is currently performed: ",
-          i, "-th nested matrices in batch at dimension ", j + 1,
-          " have mismatching sizes ", self_sizej, " and ", mat2_sizej);
-      sizemat_ptr[j] = self_sizej;
-      batch_size *= sizemat_ptr[j];
-    }
-    // matrix multiplication dimensions
-    const int64_t& self_size0 = self_size[ndims - 2], & self_size1 = self_size[ndims - 1],
-        & mat2_size0 = mat2_size[ndims - 2], & mat2_size1 = mat2_size[ndims - 1];
-    TORCH_CHECK(
-        self_size1 == mat2_size0,
-        "matmul: ",
-        i, "-th nested matrices in batch cannot be multiplied (",
-        self_size0, "x", self_size1, " and ",
-        mat2_size0, "x", mat2_size1, ")");
-    sizemat_ptr[ndims - 2] = self_size0;
-    sizemat_ptr[ndims - 1] = mat2_size1;
-    sizemat_ptr += ndims;
-    numel += batch_size * self_size0 * mat2_size1;
-  }
-  Tensor buffer = at::empty(numel, buffer_op);
-  Tensor output = wrap_buffer(buffer, sizemat);
-  return std::make_tuple(batch_sizes, output);
-}
-}
-
 Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
   // Tensor self = self_.contiguous();
   // Tensor mat2 = mat2_.contiguous();

--- a/aten/src/ATen/native/quantized/FakeQuantPerChannelAffine.cpp
+++ b/aten/src/ATen/native/quantized/FakeQuantPerChannelAffine.cpp
@@ -128,7 +128,7 @@ Tensor fake_quantize_per_channel_affine_cachemask_backward(
   return dY * mask;
 }
 
-Tensor _get_rounded_zero_point(
+static Tensor _get_rounded_zero_point(
     const Tensor& zero_point,
     int64_t quant_min,
     int64_t quant_max) {

--- a/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
+++ b/aten/src/ATen/native/quantized/FakeQuantPerTensorAffine.cpp
@@ -133,7 +133,7 @@ Tensor fake_quantize_per_tensor_affine_cachemask_backward(
   return dY * mask;
 }
 
-int64_t _get_zero_point_from_tensor(
+static int64_t _get_zero_point_from_tensor(
     const Tensor& zero_point,
     int64_t quant_min,
     int64_t quant_max,

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -285,7 +285,7 @@ std::tuple<double, int64_t> _choose_qparams_per_tensor(
   return std::make_tuple(q_params.scale, q_params.zero_point);
 }
 
-float calculate_quant_loss(
+static float calculate_quant_loss(
     const float* input,
     int numel,
     float xmin,

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -171,7 +171,7 @@ Tensor mean_quantized_cpu(
   return result;
 }
 
-Tensor mean_quantized_cpu(
+static Tensor mean_quantized_cpu(
     const Tensor& self,
     DimnameList dim,
     bool keepdim,

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -171,15 +171,6 @@ Tensor mean_quantized_cpu(
   return result;
 }
 
-static Tensor mean_quantized_cpu(
-    const Tensor& self,
-    DimnameList dim,
-    bool keepdim,
-    optional<ScalarType> dtype) {
-  return mean_quantized_cpu(
-      self, dimnames_to_positions(self, dim), keepdim, dtype);
-}
-
 Tensor& mean_out_quantized_cpu(
     Tensor& result,
     const Tensor& self,

--- a/aten/src/ATen/native/quantized/cpu/qdropout.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qdropout.cpp
@@ -9,7 +9,7 @@ namespace native {
 
 DEFINE_DISPATCH(qdropout_stub);
 
-Tensor quantized_dropout(
+static Tensor quantized_dropout(
     const Tensor& qx, double output_scale, int64_t output_zero_point, const Scalar& p, bool training) {
   return qx;
 }

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -35,7 +35,7 @@ DEFINE_DISPATCH(qrelu_leaky_stub);
 DEFINE_DISPATCH(qprelu_stub);
 
 #ifdef USE_PYTORCH_QNNPACK
-Tensor qnnpack_relu(Tensor input) {
+static Tensor qnnpack_relu(Tensor input) {
   Tensor qy;
   TORCH_CHECK(
       input.ndimension() > 0, "qnnpack_relu(): Got empty input tensor");

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -716,12 +716,6 @@ int64_t dense_dim_sparse_csr(const SparseCsrTensor& self) {
   return get_sparse_csr_impl(self)->dense_dim();
 }
 
-static bool _is_same_size_as_sparse_compressed(
-    const SparseCsrTensor& self,
-    const SparseCsrTensor& src) {
-  return self.sizes().equals(src.sizes());
-}
-
 const SparseCsrTensor& resize_as_sparse_compressed_(
     const SparseCsrTensor& self,
     const SparseCsrTensor& src) {

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -122,7 +122,7 @@ bool solve_arange(const Tensor& input, int64_t& start, int64_t& end, int64_t& st
   formats with support to batched and dense dimensions.
 */
 
-void _validate_sparse_compressed_tensor_args_worker(const Tensor& compressed_indices, const Tensor& plain_indices, const Tensor& values, const IntArrayRef size, const Layout& layout) {
+static void _validate_sparse_compressed_tensor_args_worker(const Tensor& compressed_indices, const Tensor& plain_indices, const Tensor& values, const IntArrayRef size, const Layout& layout) {
   // Layout must be Sparse Compressed, 2.4
   AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(layout, "validate_sparse_compressed_tensor_args", [&]{});
 
@@ -321,7 +321,7 @@ void _validate_sparse_bsc_tensor_args(const Tensor& ccol_indices, const Tensor& 
 // of historical reasons (that ought to be removed in future) and does
 // not mean that the corresponding functionality would be CSR layout
 // only specific.
-SparseCsrTensor new_compressed_tensor(const TensorOptions& options) {
+static SparseCsrTensor new_compressed_tensor(const TensorOptions& options) {
   // TODO: remove this comment after enabling autograd support for CSR tensor
   // constructor.
   // TORCH_INTERNAL_ASSERT(impl::variable_excluded_from_dispatch());
@@ -401,7 +401,7 @@ SPARSE_COMPRESSED_TENSOR_UNSAFE(csc, kSparseCsc);
 SPARSE_COMPRESSED_TENSOR_UNSAFE(bsr, kSparseBsr);
 SPARSE_COMPRESSED_TENSOR_UNSAFE(bsc, kSparseBsc);
 
-DimVector _estimate_sparse_compressed_tensor_size(
+static DimVector _estimate_sparse_compressed_tensor_size(
     const Tensor& compressed_indices,
     const Tensor& plain_indices,
     const Tensor& values,
@@ -716,7 +716,7 @@ int64_t dense_dim_sparse_csr(const SparseCsrTensor& self) {
   return get_sparse_csr_impl(self)->dense_dim();
 }
 
-bool _is_same_size_as_sparse_compressed(
+static bool _is_same_size_as_sparse_compressed(
     const SparseCsrTensor& self,
     const SparseCsrTensor& src) {
   return self.sizes().equals(src.sizes());

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -342,16 +342,6 @@ inline Tensor get_result_tensor_for_unary_op(F op, const Tensor& input) {
 }
 } // namespace
 
-static constexpr bool is_mkl_supported() {
-#ifdef _MSC_VER
-  return false;
-#elif __APPLE__ || __MACH__
-  return false;
-#else
-  return true;
-#endif
-}
-
 // Only accept squares sparse matrices or dense input as a vector
 // TODO: Check what happens with MKL, the output error reported with non square
 // matrices tends to be high See:

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -79,20 +79,6 @@ namespace at::native {
 
 using namespace at::sparse;
 // --------------------------------------------------------------------
-// Utility functions
-// --------------------------------------------------------------------
-
-namespace {
-
-  inline SparseTensor get_result_tensor_for_unary_op(const SparseTensor& input) {
-    if (c10::isIntegralType(input.scalar_type(), /*includeBool=*/true)) {
-      return at::empty_like(input, input.options().dtype(c10::get_default_dtype()));
-    }
-    return at::empty_like(input);
-  }
-}
-
-// --------------------------------------------------------------------
 // zero_(SparseTensor)
 // --------------------------------------------------------------------
 

--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -16,7 +16,7 @@ nnapi_wrapper* nnapi;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 nnapi_wrapper* check_nnapi;
 
-void load_platform_library() {
+static void load_platform_library() {
   static int run_once = [](){
     nnapi_wrapper_load(&nnapi, &check_nnapi);
     CAFFE_ENFORCE(nnapi);

--- a/aten/src/ATen/nnapi/nnapi_wrapper.cpp
+++ b/aten/src/ATen/nnapi/nnapi_wrapper.cpp
@@ -23,7 +23,7 @@
 static int loaded = 0;
 static struct nnapi_wrapper nnapi_;
 static struct nnapi_wrapper check_nnapi_;
-int check__getDeviceCount(uint32_t* numDevices) {
+static int check__getDeviceCount(uint32_t* numDevices) {
   CAFFE_ENFORCE(nnapi_._getDeviceCount);
   int ret = nnapi_._getDeviceCount(numDevices);
   // TODO: Maybe add better logging here.
@@ -33,7 +33,7 @@ int check__getDeviceCount(uint32_t* numDevices) {
   );
   return ret;
 }
-int check__getDevice(uint32_t devIndex, ANeuralNetworksDevice** device) {
+static int check__getDevice(uint32_t devIndex, ANeuralNetworksDevice** device) {
   CAFFE_ENFORCE(nnapi_._getDevice);
   int ret = nnapi_._getDevice(devIndex,device);
   // TODO: Maybe add better logging here.
@@ -43,7 +43,7 @@ int check__getDevice(uint32_t devIndex, ANeuralNetworksDevice** device) {
   );
   return ret;
 }
-int check_Device_getName(const ANeuralNetworksDevice* device, const char** name) {
+static int check_Device_getName(const ANeuralNetworksDevice* device, const char** name) {
   CAFFE_ENFORCE(nnapi_.Device_getName);
   int ret = nnapi_.Device_getName(device,name);
   // TODO: Maybe add better logging here.
@@ -53,7 +53,7 @@ int check_Device_getName(const ANeuralNetworksDevice* device, const char** name)
   );
   return ret;
 }
-int check_Device_getVersion(const ANeuralNetworksDevice* device, const char** version) {
+static int check_Device_getVersion(const ANeuralNetworksDevice* device, const char** version) {
   CAFFE_ENFORCE(nnapi_.Device_getVersion);
   int ret = nnapi_.Device_getVersion(device,version);
   // TODO: Maybe add better logging here.
@@ -63,7 +63,7 @@ int check_Device_getVersion(const ANeuralNetworksDevice* device, const char** ve
   );
   return ret;
 }
-int check_Device_getFeatureLevel(const ANeuralNetworksDevice* device, int64_t* featureLevel) {
+static int check_Device_getFeatureLevel(const ANeuralNetworksDevice* device, int64_t* featureLevel) {
   CAFFE_ENFORCE(nnapi_.Device_getFeatureLevel);
   int ret = nnapi_.Device_getFeatureLevel(device,featureLevel);
   // TODO: Maybe add better logging here.
@@ -73,7 +73,7 @@ int check_Device_getFeatureLevel(const ANeuralNetworksDevice* device, int64_t* f
   );
   return ret;
 }
-int check_Model_getSupportedOperationsForDevices( const ANeuralNetworksModel* model, const ANeuralNetworksDevice* const* devices, uint32_t numDevices, bool* supportedOps) {
+static int check_Model_getSupportedOperationsForDevices( const ANeuralNetworksModel* model, const ANeuralNetworksDevice* const* devices, uint32_t numDevices, bool* supportedOps) {
   CAFFE_ENFORCE(nnapi_.Model_getSupportedOperationsForDevices);
   int ret = nnapi_.Model_getSupportedOperationsForDevices(model,devices,numDevices,supportedOps);
   // TODO: Maybe add better logging here.
@@ -83,7 +83,7 @@ int check_Model_getSupportedOperationsForDevices( const ANeuralNetworksModel* mo
   );
   return ret;
 }
-int check_Compilation_createForDevices(ANeuralNetworksModel* model, const ANeuralNetworksDevice* const* devices, uint32_t numDevices, ANeuralNetworksCompilation** compilation) {
+static int check_Compilation_createForDevices(ANeuralNetworksModel* model, const ANeuralNetworksDevice* const* devices, uint32_t numDevices, ANeuralNetworksCompilation** compilation) {
   CAFFE_ENFORCE(nnapi_.Compilation_createForDevices);
   int ret = nnapi_.Compilation_createForDevices(model,devices,numDevices,compilation);
   // TODO: Maybe add better logging here.
@@ -93,7 +93,7 @@ int check_Compilation_createForDevices(ANeuralNetworksModel* model, const ANeura
   );
   return ret;
 }
-int check_Execution_compute(ANeuralNetworksExecution* execution) {
+static int check_Execution_compute(ANeuralNetworksExecution* execution) {
   CAFFE_ENFORCE(nnapi_.Execution_compute);
   int ret = nnapi_.Execution_compute(execution);
   // TODO: Maybe add better logging here.
@@ -103,7 +103,7 @@ int check_Execution_compute(ANeuralNetworksExecution* execution) {
   );
   return ret;
 }
-int check_Memory_createFromFd(size_t size, int protect, int fd, size_t offset, ANeuralNetworksMemory** memory) {
+static int check_Memory_createFromFd(size_t size, int protect, int fd, size_t offset, ANeuralNetworksMemory** memory) {
   CAFFE_ENFORCE(nnapi_.Memory_createFromFd);
   int ret = nnapi_.Memory_createFromFd(size,protect,fd,offset,memory);
   // TODO: Maybe add better logging here.
@@ -113,11 +113,11 @@ int check_Memory_createFromFd(size_t size, int protect, int fd, size_t offset, A
   );
   return ret;
 }
-void check_Memory_free(ANeuralNetworksMemory* memory) {
+static void check_Memory_free(ANeuralNetworksMemory* memory) {
   CAFFE_ENFORCE(nnapi_.Memory_free);
   nnapi_.Memory_free(memory);
 }
-int check_Model_create(ANeuralNetworksModel** model) {
+static int check_Model_create(ANeuralNetworksModel** model) {
   CAFFE_ENFORCE(nnapi_.Model_create);
   int ret = nnapi_.Model_create(model);
   // TODO: Maybe add better logging here.
@@ -127,11 +127,11 @@ int check_Model_create(ANeuralNetworksModel** model) {
   );
   return ret;
 }
-void check_Model_free(ANeuralNetworksModel* model) {
+static void check_Model_free(ANeuralNetworksModel* model) {
   CAFFE_ENFORCE(nnapi_.Model_free);
   nnapi_.Model_free(model);
 }
-int check_Model_finish(ANeuralNetworksModel* model) {
+static int check_Model_finish(ANeuralNetworksModel* model) {
   CAFFE_ENFORCE(nnapi_.Model_finish);
   int ret = nnapi_.Model_finish(model);
   // TODO: Maybe add better logging here.
@@ -141,7 +141,7 @@ int check_Model_finish(ANeuralNetworksModel* model) {
   );
   return ret;
 }
-int check_Model_addOperand(ANeuralNetworksModel* model, const ANeuralNetworksOperandType* type) {
+static int check_Model_addOperand(ANeuralNetworksModel* model, const ANeuralNetworksOperandType* type) {
   CAFFE_ENFORCE(nnapi_.Model_addOperand);
   int ret = nnapi_.Model_addOperand(model,type);
   // TODO: Maybe add better logging here.
@@ -151,7 +151,7 @@ int check_Model_addOperand(ANeuralNetworksModel* model, const ANeuralNetworksOpe
   );
   return ret;
 }
-int check_Model_setOperandValue(ANeuralNetworksModel* model, int32_t index, const void* buffer, size_t length) {
+static int check_Model_setOperandValue(ANeuralNetworksModel* model, int32_t index, const void* buffer, size_t length) {
   CAFFE_ENFORCE(nnapi_.Model_setOperandValue);
   int ret = nnapi_.Model_setOperandValue(model,index,buffer,length);
   // TODO: Maybe add better logging here.
@@ -161,7 +161,7 @@ int check_Model_setOperandValue(ANeuralNetworksModel* model, int32_t index, cons
   );
   return ret;
 }
-int check_Model_setOperandValueFromMemory(ANeuralNetworksModel* model, int32_t index, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
+static int check_Model_setOperandValueFromMemory(ANeuralNetworksModel* model, int32_t index, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
   CAFFE_ENFORCE(nnapi_.Model_setOperandValueFromMemory);
   int ret = nnapi_.Model_setOperandValueFromMemory(model,index,memory,offset,length);
   // TODO: Maybe add better logging here.
@@ -171,7 +171,7 @@ int check_Model_setOperandValueFromMemory(ANeuralNetworksModel* model, int32_t i
   );
   return ret;
 }
-int check_Model_addOperation(ANeuralNetworksModel* model, ANeuralNetworksOperationType type, uint32_t inputCount, const uint32_t* inputs, uint32_t outputCount, const uint32_t* outputs) {
+static int check_Model_addOperation(ANeuralNetworksModel* model, ANeuralNetworksOperationType type, uint32_t inputCount, const uint32_t* inputs, uint32_t outputCount, const uint32_t* outputs) {
   CAFFE_ENFORCE(nnapi_.Model_addOperation);
   int ret = nnapi_.Model_addOperation(model,type,inputCount,inputs,outputCount,outputs);
   // TODO: Maybe add better logging here.
@@ -181,7 +181,7 @@ int check_Model_addOperation(ANeuralNetworksModel* model, ANeuralNetworksOperati
   );
   return ret;
 }
-int check_Model_identifyInputsAndOutputs(ANeuralNetworksModel* model, uint32_t inputCount, const uint32_t* inputs, uint32_t outputCount, const uint32_t* outputs) {
+static int check_Model_identifyInputsAndOutputs(ANeuralNetworksModel* model, uint32_t inputCount, const uint32_t* inputs, uint32_t outputCount, const uint32_t* outputs) {
   CAFFE_ENFORCE(nnapi_.Model_identifyInputsAndOutputs);
   int ret = nnapi_.Model_identifyInputsAndOutputs(model,inputCount,inputs,outputCount,outputs);
   // TODO: Maybe add better logging here.
@@ -191,7 +191,7 @@ int check_Model_identifyInputsAndOutputs(ANeuralNetworksModel* model, uint32_t i
   );
   return ret;
 }
-int check_Model_relaxComputationFloat32toFloat16(ANeuralNetworksModel* model, bool allow) {
+static int check_Model_relaxComputationFloat32toFloat16(ANeuralNetworksModel* model, bool allow) {
   CAFFE_ENFORCE(nnapi_.Model_relaxComputationFloat32toFloat16);
   int ret = nnapi_.Model_relaxComputationFloat32toFloat16(model,allow);
   // TODO: Maybe add better logging here.
@@ -201,7 +201,7 @@ int check_Model_relaxComputationFloat32toFloat16(ANeuralNetworksModel* model, bo
   );
   return ret;
 }
-int check_Compilation_create(ANeuralNetworksModel* model, ANeuralNetworksCompilation** compilation) {
+static int check_Compilation_create(ANeuralNetworksModel* model, ANeuralNetworksCompilation** compilation) {
   CAFFE_ENFORCE(nnapi_.Compilation_create);
   int ret = nnapi_.Compilation_create(model,compilation);
   // TODO: Maybe add better logging here.
@@ -211,11 +211,11 @@ int check_Compilation_create(ANeuralNetworksModel* model, ANeuralNetworksCompila
   );
   return ret;
 }
-void check_Compilation_free(ANeuralNetworksCompilation* compilation) {
+static void check_Compilation_free(ANeuralNetworksCompilation* compilation) {
   CAFFE_ENFORCE(nnapi_.Compilation_free);
   nnapi_.Compilation_free(compilation);
 }
-int check_Compilation_setPreference(ANeuralNetworksCompilation* compilation, int32_t preference) {
+static int check_Compilation_setPreference(ANeuralNetworksCompilation* compilation, int32_t preference) {
   CAFFE_ENFORCE(nnapi_.Compilation_setPreference);
   int ret = nnapi_.Compilation_setPreference(compilation,preference);
   // TODO: Maybe add better logging here.
@@ -225,7 +225,7 @@ int check_Compilation_setPreference(ANeuralNetworksCompilation* compilation, int
   );
   return ret;
 }
-int check_Compilation_finish(ANeuralNetworksCompilation* compilation) {
+static int check_Compilation_finish(ANeuralNetworksCompilation* compilation) {
   CAFFE_ENFORCE(nnapi_.Compilation_finish);
   int ret = nnapi_.Compilation_finish(compilation);
   // TODO: Maybe add better logging here.
@@ -235,7 +235,7 @@ int check_Compilation_finish(ANeuralNetworksCompilation* compilation) {
   );
   return ret;
 }
-int check_Execution_create(ANeuralNetworksCompilation* compilation, ANeuralNetworksExecution** execution) {
+static int check_Execution_create(ANeuralNetworksCompilation* compilation, ANeuralNetworksExecution** execution) {
   CAFFE_ENFORCE(nnapi_.Execution_create);
   int ret = nnapi_.Execution_create(compilation,execution);
   // TODO: Maybe add better logging here.
@@ -245,11 +245,11 @@ int check_Execution_create(ANeuralNetworksCompilation* compilation, ANeuralNetwo
   );
   return ret;
 }
-void check_Execution_free(ANeuralNetworksExecution* execution) {
+static void check_Execution_free(ANeuralNetworksExecution* execution) {
   CAFFE_ENFORCE(nnapi_.Execution_free);
   nnapi_.Execution_free(execution);
 }
-int check_Execution_setInput(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const void* buffer, size_t length) {
+static int check_Execution_setInput(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const void* buffer, size_t length) {
   CAFFE_ENFORCE(nnapi_.Execution_setInput);
   int ret = nnapi_.Execution_setInput(execution,index,type,buffer,length);
   // TODO: Maybe add better logging here.
@@ -259,7 +259,7 @@ int check_Execution_setInput(ANeuralNetworksExecution* execution, int32_t index,
   );
   return ret;
 }
-int check_Execution_setInputFromMemory(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
+static int check_Execution_setInputFromMemory(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
   CAFFE_ENFORCE(nnapi_.Execution_setInputFromMemory);
   int ret = nnapi_.Execution_setInputFromMemory(execution,index,type,memory,offset,length);
   // TODO: Maybe add better logging here.
@@ -269,7 +269,7 @@ int check_Execution_setInputFromMemory(ANeuralNetworksExecution* execution, int3
   );
   return ret;
 }
-int check_Execution_setOutput(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, void* buffer, size_t length) {
+static int check_Execution_setOutput(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, void* buffer, size_t length) {
   CAFFE_ENFORCE(nnapi_.Execution_setOutput);
   int ret = nnapi_.Execution_setOutput(execution,index,type,buffer,length);
   // TODO: Maybe add better logging here.
@@ -279,7 +279,7 @@ int check_Execution_setOutput(ANeuralNetworksExecution* execution, int32_t index
   );
   return ret;
 }
-int check_Execution_setOutputFromMemory(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
+static int check_Execution_setOutputFromMemory(ANeuralNetworksExecution* execution, int32_t index, const ANeuralNetworksOperandType* type, const ANeuralNetworksMemory* memory, size_t offset, size_t length) {
   CAFFE_ENFORCE(nnapi_.Execution_setOutputFromMemory);
   int ret = nnapi_.Execution_setOutputFromMemory(execution,index,type,memory,offset,length);
   // TODO: Maybe add better logging here.
@@ -289,7 +289,7 @@ int check_Execution_setOutputFromMemory(ANeuralNetworksExecution* execution, int
   );
   return ret;
 }
-int check_Execution_startCompute(ANeuralNetworksExecution* execution, ANeuralNetworksEvent** event) {
+static int check_Execution_startCompute(ANeuralNetworksExecution* execution, ANeuralNetworksEvent** event) {
   CAFFE_ENFORCE(nnapi_.Execution_startCompute);
   int ret = nnapi_.Execution_startCompute(execution,event);
   // TODO: Maybe add better logging here.
@@ -299,7 +299,7 @@ int check_Execution_startCompute(ANeuralNetworksExecution* execution, ANeuralNet
   );
   return ret;
 }
-int check_Event_wait(ANeuralNetworksEvent* event) {
+static int check_Event_wait(ANeuralNetworksEvent* event) {
   CAFFE_ENFORCE(nnapi_.Event_wait);
   int ret = nnapi_.Event_wait(event);
   // TODO: Maybe add better logging here.
@@ -309,11 +309,11 @@ int check_Event_wait(ANeuralNetworksEvent* event) {
   );
   return ret;
 }
-void check_Event_free(ANeuralNetworksEvent* event) {
+static void check_Event_free(ANeuralNetworksEvent* event) {
   CAFFE_ENFORCE(nnapi_.Event_free);
   nnapi_.Event_free(event);
 }
-int check_Execution_getOutputOperandRank(ANeuralNetworksExecution* execution, int32_t index, uint32_t* rank) {
+static int check_Execution_getOutputOperandRank(ANeuralNetworksExecution* execution, int32_t index, uint32_t* rank) {
   CAFFE_ENFORCE(nnapi_.Execution_getOutputOperandRank);
   int ret = nnapi_.Execution_getOutputOperandRank(execution,index,rank);
   // TODO: Maybe add better logging here.
@@ -323,7 +323,7 @@ int check_Execution_getOutputOperandRank(ANeuralNetworksExecution* execution, in
   );
   return ret;
 }
-int check_Execution_getOutputOperandDimensions(ANeuralNetworksExecution* execution, int32_t index, uint32_t* dimensions) {
+static int check_Execution_getOutputOperandDimensions(ANeuralNetworksExecution* execution, int32_t index, uint32_t* dimensions) {
   CAFFE_ENFORCE(nnapi_.Execution_getOutputOperandDimensions);
   int ret = nnapi_.Execution_getOutputOperandDimensions(execution,index,dimensions);
   // TODO: Maybe add better logging here.

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -83,7 +83,7 @@ QTensorImpl* get_qtensorimpl(const TensorBase& self) {
   return static_cast<QTensorImpl*>(self.unsafeGetTensorImpl());
 }
 
-int64_t get_sub_byte_tensor_size(IntArrayRef sizes, size_t dtype_itemsize, at::ScalarType t) {
+static int64_t get_sub_byte_tensor_size(IntArrayRef sizes, size_t dtype_itemsize, at::ScalarType t) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int64_t element_per_byte;
   switch(t) {
@@ -178,7 +178,7 @@ Tensor PerTensorAffineQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
-void per_tensor_affine_dequantize_impl(
+static void per_tensor_affine_dequantize_impl(
     Tensor& rtensor,
     const Tensor& qtensor,
     const double scale,
@@ -228,7 +228,7 @@ Tensor PerChannelAffineQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
-void per_channel_affine_dequantize_impl(
+static void per_channel_affine_dequantize_impl(
     Tensor& rtensor,
     const Tensor& qtensor,
     const Tensor& scale,
@@ -278,7 +278,7 @@ Tensor PerChannelAffineFloatQParamsQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
-void per_channel_affine_float_q_params_dequantize_impl(
+static void per_channel_affine_float_q_params_dequantize_impl(
     Tensor& rtensor,
     const Tensor& qtensor,
     const Tensor& scale,

--- a/aten/src/ATen/vulkan/Context.h
+++ b/aten/src/ATen/vulkan/Context.h
@@ -22,6 +22,9 @@ class VulkanImplRegistrar {
 };
 
 at::Tensor& vulkan_copy_(at::Tensor& self, const at::Tensor& src);
+namespace native {
+  bool is_vulkan_available();
+}// namespace native
 
 } // namespace vulkan
 } // namespace at

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -17,7 +17,7 @@
 
 namespace F = torch::nn::functional;
 
-F::PadFuncOptions::mode_t _get_pad_mode_from_conv_padding_mode(
+static F::PadFuncOptions::mode_t _get_pad_mode_from_conv_padding_mode(
     torch::nn::detail::conv_padding_mode_t conv_padding_mode) {
   F::PadFuncOptions::mode_t pad_mode;
   if (c10::get_if<torch::enumtype::kReflect>(&conv_padding_mode)) {

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -28,7 +28,7 @@ namespace nn {
 /// https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnRNNMode_t
 enum class CuDNNMode { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
-CuDNNMode get_cudnn_mode_for_rnn(
+static CuDNNMode get_cudnn_mode_for_rnn(
     detail::RNNOptionsBase::rnn_options_base_mode_t mode) {
   if (c10::get_if<enumtype::kRNN_RELU>(&mode)) {
     return CuDNNMode::RNN_RELU;
@@ -43,7 +43,7 @@ CuDNNMode get_cudnn_mode_for_rnn(
   }
 }
 
-Tensor apply_permutation(
+static Tensor apply_permutation(
     const Tensor& tensor,
     const Tensor& permutation,
     int64_t dim = 1) {
@@ -397,7 +397,7 @@ template class RNNImplBase<RNNImpl>;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-detail::RNNOptionsBase::rnn_options_base_mode_t compute_rnn_options_base_mode(
+static detail::RNNOptionsBase::rnn_options_base_mode_t compute_rnn_options_base_mode(
     RNNOptions::nonlinearity_t nonlinearity) {
   if (c10::get_if<enumtype::kTanh>(&nonlinearity)) {
     return torch::kRNN_TANH;

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -397,8 +397,8 @@ template class RNNImplBase<RNNImpl>;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-static detail::RNNOptionsBase::rnn_options_base_mode_t compute_rnn_options_base_mode(
-    RNNOptions::nonlinearity_t nonlinearity) {
+static detail::RNNOptionsBase::rnn_options_base_mode_t
+compute_rnn_options_base_mode(RNNOptions::nonlinearity_t nonlinearity) {
   if (c10::get_if<enumtype::kTanh>(&nonlinearity)) {
     return torch::kRNN_TANH;
   } else if (c10::get_if<enumtype::kReLU>(&nonlinearity)) {

--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -187,7 +187,7 @@ std::tuple<double, Tensor> LBFGS::_directional_evaluate(
   return std::make_tuple(loss, flat_grad);
 }
 
-double _cubic_interpolate(
+static double _cubic_interpolate(
     double x1,
     double f1,
     double g1,
@@ -236,7 +236,7 @@ using Function = std::function<std::tuple<double, Tensor>(
     const std::vector<Tensor>& x,
     double t,
     const Tensor& d)>;
-std::tuple<double, Tensor, double, int64_t> _strong_wolfe(
+static std::tuple<double, Tensor, double, int64_t> _strong_wolfe(
     const Function& obj_func,
     const std::vector<Tensor>& x,
     double t,

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -13,7 +13,7 @@
 
 namespace c10d {
 
-ProcessGroup::BackendType strToBackendType(std::string backend) {
+static ProcessGroup::BackendType strToBackendType(std::string backend) {
   if (backend == "undefined") {
     return ProcessGroup::BackendType::UNDEFINED;
   } else if (backend == "gloo") {
@@ -29,7 +29,7 @@ ProcessGroup::BackendType strToBackendType(std::string backend) {
   }
 }
 
-std::string backendTypeToStr(ProcessGroup::BackendType backendType) {
+static std::string backendTypeToStr(ProcessGroup::BackendType backendType) {
   switch (backendType) {
     case ProcessGroup::BackendType::UNDEFINED:
       return "undefined";

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -29,6 +29,25 @@ static ProcessGroup::BackendType strToBackendType(std::string backend) {
   }
 }
 
+static std::string backendTypeToStr(ProcessGroup::BackendType backendType) {
+  switch (backendType) {
+    case ProcessGroup::BackendType::UNDEFINED:
+      return "undefined";
+    case ProcessGroup::BackendType::GLOO:
+      return "gloo";
+    case ProcessGroup::BackendType::NCCL:
+      return "nccl";
+    case ProcessGroup::BackendType::UCC:
+      return "ucc";
+    case ProcessGroup::BackendType::MPI:
+      return "mpi";
+    case ProcessGroup::BackendType::CUSTOM:
+      return "custom";
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unknown backend type");
+  }
+}
+
 std::string opTypeToString(OpType opType) {
   switch (opType) {
     case OpType::BROADCAST:

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -29,25 +29,6 @@ static ProcessGroup::BackendType strToBackendType(std::string backend) {
   }
 }
 
-static std::string backendTypeToStr(ProcessGroup::BackendType backendType) {
-  switch (backendType) {
-    case ProcessGroup::BackendType::UNDEFINED:
-      return "undefined";
-    case ProcessGroup::BackendType::GLOO:
-      return "gloo";
-    case ProcessGroup::BackendType::NCCL:
-      return "nccl";
-    case ProcessGroup::BackendType::UCC:
-      return "ucc";
-    case ProcessGroup::BackendType::MPI:
-      return "mpi";
-    case ProcessGroup::BackendType::CUSTOM:
-      return "custom";
-    default:
-      TORCH_INTERNAL_ASSERT(false, "Unknown backend type");
-  }
-}
-
 std::string opTypeToString(OpType opType) {
   switch (opType) {
     case OpType::BROADCAST:

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -2596,7 +2596,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::alltoall_base(
   return work;
 }
 
-at::Tensor& checkSingleTensor(std::vector<at::Tensor>& tensors) {
+static at::Tensor& checkSingleTensor(std::vector<at::Tensor>& tensors) {
   if (tensors.size() != 1) {
     TORCH_CHECK(false, "ProcessGroupGloo::send takes a single tensor");
   }
@@ -2610,7 +2610,7 @@ at::Tensor& checkSingleTensor(std::vector<at::Tensor>& tensors) {
   return tensor;
 }
 
-uint32_t checkTag(int32_t tag) {
+static uint32_t checkTag(int32_t tag) {
   TORCH_CHECK(tag >= 0, "Tag must be nonnegative");
   return (uint32_t)tag;
 }

--- a/torch/csrc/distributed/c10d/quantization/quantization.cpp
+++ b/torch/csrc/distributed/c10d/quantization/quantization.cpp
@@ -9,7 +9,7 @@ namespace quantization {
 
 // TODO: The kernels are copied from fbgemm_gpu, we should dedup them later
 
-void FloatToBFloat16Quantized_ref(
+static void FloatToBFloat16Quantized_ref(
     const float* const input,
     const size_t nrows,
     const size_t ncols,
@@ -26,7 +26,7 @@ void FloatToBFloat16Quantized_ref(
   }
 }
 
-void BFloat16QuantizedToFloat_ref(
+static void BFloat16QuantizedToFloat_ref(
     const at::BFloat16* const input,
     const size_t nrows,
     const size_t ncols,

--- a/torch/csrc/distributed/rpc/agent_utils.cpp
+++ b/torch/csrc/distributed/rpc/agent_utils.cpp
@@ -41,7 +41,7 @@ std::unordered_map<std::string, worker_id_t> collectNames(
   return nameToId;
 }
 
-std::vector<std::string> splitString(
+static std::vector<std::string> splitString(
     const std::string& s,
     const std::string& delim) {
   std::vector<std::string> tokens;
@@ -154,7 +154,7 @@ const string storeKeyActiveCallCount = "ACTIVE_CALLS";
 const string storeKeyReady = "READY";
 static std::atomic<int> barrierId(0);
 
-std::tuple<std::string, std::string, std::string> getNextKeyIds() {
+static std::tuple<std::string, std::string, std::string> getNextKeyIds() {
   barrierId++;
   std::string processCountKey =
       fmt::format("{}{}{}", storeKeyProcessCount, storeKeyBarrierId, barrierId);

--- a/torch/csrc/distributed/rpc/testing/faulty_tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/testing/faulty_tensorpipe_agent.cpp
@@ -7,7 +7,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-std::string fromVecToString(const std::vector<char>& vec) {
+static std::string fromVecToString(const std::vector<char>& vec) {
   return std::string(vec.begin(), vec.end());
 }
 

--- a/torch/csrc/itt_wrapper.cpp
+++ b/torch/csrc/itt_wrapper.cpp
@@ -1,25 +1,25 @@
-#include <c10/macros/Export.h>
 #include <ittnotify.h>
 #include <torch/csrc/profiler/stubs/base.h>
+#include <torch/csrc/itt_wrapper.h>
 
 namespace torch {
 namespace profiler {
 __itt_domain* _itt_domain = __itt_domain_create("PyTorch");
 
-TORCH_API bool itt_is_available() {
+bool itt_is_available() {
   return torch::profiler::impl::ittStubs()->enabled();
 }
 
-TORCH_API void itt_range_push(const char* msg) {
+void itt_range_push(const char* msg) {
   __itt_string_handle* hsMsg = __itt_string_handle_create(msg);
   __itt_task_begin(_itt_domain, __itt_null, __itt_null, hsMsg);
 }
 
-TORCH_API void itt_range_pop() {
+void itt_range_pop() {
   __itt_task_end(_itt_domain);
 }
 
-TORCH_API void itt_mark(const char* msg) {
+void itt_mark(const char* msg) {
   __itt_string_handle* hsMsg = __itt_string_handle_create(msg);
   __itt_task_begin(_itt_domain, __itt_null, __itt_null, hsMsg);
   __itt_task_end(_itt_domain);

--- a/torch/csrc/itt_wrapper.cpp
+++ b/torch/csrc/itt_wrapper.cpp
@@ -1,6 +1,6 @@
 #include <ittnotify.h>
-#include <torch/csrc/profiler/stubs/base.h>
 #include <torch/csrc/itt_wrapper.h>
+#include <torch/csrc/profiler/stubs/base.h>
 
 namespace torch {
 namespace profiler {

--- a/torch/csrc/itt_wrapper.h
+++ b/torch/csrc/itt_wrapper.h
@@ -1,12 +1,13 @@
 #ifndef PROFILER_ITT_H
 #define PROFILER_ITT_H
+#include <c10/macros/Export.h>
 
 namespace torch {
 namespace profiler {
-bool itt_is_available();
-void itt_range_push(const char* msg);
-void itt_range_pop();
-void itt_mark(const char* msg);
+TORCH_API bool itt_is_available();
+TORCH_API void itt_range_push(const char* msg);
+TORCH_API void itt_range_pop();
+TORCH_API void itt_mark(const char* msg);
 } // namespace profiler
 } // namespace torch
 

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -55,7 +55,7 @@ T& toGraphFunctionImpl(F& function) {
 
 } // namespace
 
-void placeholderCreator(GraphFunction&) {
+static void placeholderCreator(GraphFunction&) {
   throw RecursiveMethodCallError();
 }
 

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -163,7 +163,7 @@ void Module::to(at::Device device, bool non_blocking) {
   to_impl(device, /*dtype=*/c10::nullopt, non_blocking);
 }
 
-void module_state_to(
+static void module_state_to(
     const autograd::Variable& variable,
     const c10::optional<at::Device>& device,
     const c10::optional<at::ScalarType>& dtype,

--- a/torch/csrc/jit/codegen/fuser/compiler.cpp
+++ b/torch/csrc/jit/codegen/fuser/compiler.cpp
@@ -53,7 +53,8 @@ bool hasFusionBackend(at::Device::Type backend_type) {
   return getFusionBackends().count(backend_type);
 }
 
-static const FusedKernelConstructor& getConstructor(at::Device::Type backend_type) {
+static const FusedKernelConstructor& getConstructor(
+    at::Device::Type backend_type) {
   std::lock_guard<std::mutex> guard(fusionBackendLock());
   return getFusionBackends().at(backend_type);
 }

--- a/torch/csrc/jit/codegen/fuser/compiler.cpp
+++ b/torch/csrc/jit/codegen/fuser/compiler.cpp
@@ -53,7 +53,7 @@ bool hasFusionBackend(at::Device::Type backend_type) {
   return getFusionBackends().count(backend_type);
 }
 
-const FusedKernelConstructor& getConstructor(at::Device::Type backend_type) {
+static const FusedKernelConstructor& getConstructor(at::Device::Type backend_type) {
   std::lock_guard<std::mutex> guard(fusionBackendLock());
   return getFusionBackends().at(backend_type);
 }

--- a/torch/csrc/jit/codegen/fuser/executor.cpp
+++ b/torch/csrc/jit/codegen/fuser/executor.cpp
@@ -190,7 +190,7 @@ static void compressContiguous(
 
 // Launches the requested fusion on the given device with the given inputs.
 // Output pointers are stored in outputs (to be put on the stack later).
-void launchFusion(
+static void launchFusion(
     const FusedKernel& fusion,
     const at::Device device,
     const at::ArrayRef<at::Tensor>& inputs,

--- a/torch/csrc/jit/frontend/canonicalize_modified_loop.cpp
+++ b/torch/csrc/jit/frontend/canonicalize_modified_loop.cpp
@@ -12,7 +12,7 @@ namespace torch::jit {
 // Transforms a Loop that has both a trip count specified and a loop
 // body condition so that the iter count is no longer specified
 // and it is recognizable as a python while loop.
-void canonicalizeModifiedLoop(Node* n) {
+static void canonicalizeModifiedLoop(Node* n) {
   LoopView loop(n);
   if (loop.loopType() != LoopView::ModifiedLoop) {
     return;
@@ -48,7 +48,7 @@ void canonicalizeModifiedLoop(Node* n) {
   loop.bodyBlock()->insertOutput(0, new_condition);
 }
 
-void canonicalizeModifiedLoops(Block* block) {
+static void canonicalizeModifiedLoops(Block* block) {
   for (Node* n : block->nodes()) {
     for (Block* b : n->blocks()) {
       canonicalizeModifiedLoops(b);

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -522,7 +522,7 @@ struct ExitTransformer {
   std::shared_ptr<Graph> graph_;
 };
 
-bool inlineConsecutiveIfs(Node* node) {
+static bool inlineConsecutiveIfs(Node* node) {
   if (node->kind() != prim::If || node->next()->kind() != prim::If) {
     return false;
   }
@@ -605,7 +605,7 @@ bool inlineConsecutiveIfs(Node* node) {
 //   return 1
 // else:
 //   return 2
-void inlineConsecutiveIfs(Block* block) {
+static void inlineConsecutiveIfs(Block* block) {
   for (auto it = block->nodes().begin(), end = block->nodes().end();
        it != end;) {
     for (Block* b : it->blocks()) {

--- a/torch/csrc/jit/frontend/inline_loop_condition.cpp
+++ b/torch/csrc/jit/frontend/inline_loop_condition.cpp
@@ -30,7 +30,7 @@ void InlineBlockBeforeNode(Node* before_node, Block* block) {
 //      <body>
 //       BlockExit(continue_condition, loop_carried_block*)
 //    }
-void inlineLoopCondition(Node* n) {
+static void inlineLoopCondition(Node* n) {
   Block* body_block = n->blocks().at(0);
 
   auto pre_header = n->blocks().at(1);
@@ -45,7 +45,7 @@ void inlineLoopCondition(Node* n) {
   n->eraseBlock(1);
 }
 
-void inlineLoopCondition(Block* block) {
+static void inlineLoopCondition(Block* block) {
   for (Node* n : block->nodes()) {
     for (Block* b : n->blocks()) {
       inlineLoopCondition(b);

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -187,7 +187,7 @@ struct CondValue {
 };
 
 enum NoneStatus { ALWAYS, MAYBE, NEVER };
-NoneStatus canBeNone(Value* v) {
+static NoneStatus canBeNone(Value* v) {
   if (v->node()->mustBeNone()) {
     return ALWAYS;
   }
@@ -5605,7 +5605,7 @@ std::vector<Function*> CompilationUnit::define(
       self);
 }
 
-void eraseListLiterals(std::shared_ptr<Graph>& graph) {
+static void eraseListLiterals(std::shared_ptr<Graph>& graph) {
   DepthFirstGraphNodeIterator it(graph);
 
   for (auto next_node = it.next(); next_node != nullptr;) {

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -548,7 +548,7 @@ MatchedSchema matchSchema(
   throw ErrorReport(loc) << failure_messages.str();
 }
 
-MatchedSchema matchSchema(
+static MatchedSchema matchSchema(
     const ::c10::FunctionSchema& schema,
     const SourceRange& loc,
     Graph& graph,

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -548,17 +548,6 @@ MatchedSchema matchSchema(
   throw ErrorReport(loc) << failure_messages.str();
 }
 
-static MatchedSchema matchSchema(
-    const ::c10::FunctionSchema& schema,
-    const SourceRange& loc,
-    Graph& graph,
-    at::ArrayRef<Value*> args,
-    at::ArrayRef<NamedValue> kwargs) {
-  std::vector<NamedValue> named_args =
-      fmap(args, [](Value* v) { return NamedValue(v); });
-  return matchSchema(schema, loc, graph, named_args, kwargs);
-}
-
 static std::string prefixLine(
     const std::string& str,
     const std::string& prefix) {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -783,7 +783,7 @@ void addInputs(
   n->addInput(list_node->output());
 }
 
-static void addInputs(
+void addInputs(
     Node* n,
     const char* name,
     c10::optional<caffe2::TypeMeta> opt_dtype) {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -783,19 +783,6 @@ void addInputs(
   n->addInput(list_node->output());
 }
 
-void addInputs(
-    Node* n,
-    const char* name,
-    c10::optional<caffe2::TypeMeta> opt_dtype) {
-  if (opt_dtype.has_value()) {
-    return addInputs(n, name, at::typeMetaToScalarType(*opt_dtype));
-  } else {
-    Graph* g = n->owningGraph();
-    Value* none = g->insertNode(g->createNone())->output();
-    n->addInput(none);
-  }
-}
-
 void addInputs(Node* n, const char* name, at::IntArrayRef value) {
   using ArgumentStash = jit::tracer::ArgumentStash;
   std::vector<Value*> info = ArgumentStash::hasIntArrayRef(name)

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -110,7 +110,7 @@ void TracingState::delValue(const IValue& var) {
 Value* getValueTrace(const IValue& var) {
   return getTracingState()->getValue(var);
 }
-Value* getOptTensorValueTrace(const c10::optional<at::Tensor>& var) {
+static Value* getOptTensorValueTrace(const c10::optional<at::Tensor>& var) {
   return getValueTrace(IValue(var));
 }
 Value* TracingState::getValue(const IValue& var) {
@@ -783,7 +783,7 @@ void addInputs(
   n->addInput(list_node->output());
 }
 
-void addInputs(
+static void addInputs(
     Node* n,
     const char* name,
     c10::optional<caffe2::TypeMeta> opt_dtype) {
@@ -1062,7 +1062,7 @@ void ArgumentStash::stashValue(
 // Stack trace recording
 ////////////////////////////////////////////////////////////////////////////////
 // no python present so we just do not record source information
-void defaultRecordSourceLocation(Node* n) {}
+static void defaultRecordSourceLocation(Node* n) {}
 std::atomic<decltype(&defaultRecordSourceLocation)> record_source_location(
     defaultRecordSourceLocation);
 void recordSourceLocation(Node* n) {
@@ -1072,7 +1072,7 @@ void setRecordSourceLocation(void (*v)(Node*)) {
   record_source_location.store(v);
 }
 
-std::vector<StackEntry> defaultPythonCallstack() {
+static std::vector<StackEntry> defaultPythonCallstack() {
   return std::vector<StackEntry>();
 }
 std::atomic<decltype(&defaultPythonCallstack)> python_callstack_fn(
@@ -1084,7 +1084,7 @@ void setPythonCallstack(std::vector<StackEntry> (*v)()) {
   python_callstack_fn.store(v);
 }
 
-void defaultWarn(const std::string& str) {
+static void defaultWarn(const std::string& str) {
   TORCH_WARN(str);
 }
 std::atomic<warn_fn_type> warn_callback{defaultWarn};

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -301,10 +301,6 @@ TORCH_API void addInputs(
     const char* name,
     ArrayRef<c10::intrusive_ptr<c10::ivalue::Object>> value,
     const c10::ClassTypePtr& class_type);
-TORCH_API void addInputs(
-    Node* n,
-    const char* name,
-    c10::optional<caffe2::TypeMeta> opt_dtype);
 TORCH_API void addInputs(Node* n, const char* name, ArrayRef<double> value);
 TORCH_API void addInputs(
     Node* n,

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -301,6 +301,10 @@ TORCH_API void addInputs(
     const char* name,
     ArrayRef<c10::intrusive_ptr<c10::ivalue::Object>> value,
     const c10::ClassTypePtr& class_type);
+TORCH_API void addInputs(
+    Node* n,
+    const char* name,
+    c10::optional<caffe2::TypeMeta> opt_dtype);
 TORCH_API void addInputs(Node* n, const char* name, ArrayRef<double> value);
 TORCH_API void addInputs(
     Node* n,

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -8,13 +8,13 @@
 
 namespace torch::jit {
 
-bool insertableTensor(const at::Tensor& ten) {
+static bool insertableTensor(const at::Tensor& ten) {
   // bail if tensor has no storage i.e. opaque tensor used in MKLdnn.
   // or gradients because we have no way of serializing them & are mutable
   return !ten.requires_grad() && ten.has_storage() && !ten.is_nested();
 }
 
-bool insertableIValue(const IValue& ivalue) {
+static bool insertableIValue(const IValue& ivalue) {
   if (ivalue.isInt() || ivalue.isNone() || ivalue.isBool() ||
       ivalue.isDouble() || ivalue.isComplexDouble() || ivalue.isString() ||
       ivalue.isDevice() || ivalue.isEnum()) {

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -128,12 +128,6 @@ static std::ostream& operator<<(
   return printValueRefs(out, nodes);
 }
 
-static std::ostream& operator<<(
-    std::ostream& out,
-    const at::ArrayRef<Value*> nodes) {
-  return printValueRefs(out, nodes);
-}
-
 struct const_value_list_with_types {
   const ArrayRef<const Value*> values;
   std::string delim;

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -128,7 +128,9 @@ static std::ostream& operator<<(
   return printValueRefs(out, nodes);
 }
 
-static std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*> nodes) {
+static std::ostream& operator<<(
+    std::ostream& out,
+    const at::ArrayRef<Value*> nodes) {
   return printValueRefs(out, nodes);
 }
 

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -128,6 +128,12 @@ static std::ostream& operator<<(
   return printValueRefs(out, nodes);
 }
 
+static std::ostream& operator<<(
+    std::ostream& out,
+    const at::ArrayRef<Value*> nodes) {
+  return printValueRefs(out, nodes);
+}
+
 struct const_value_list_with_types {
   const ArrayRef<const Value*> values;
   std::string delim;

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -122,13 +122,13 @@ static std::ostream& printValueRefs(
 // Can't make these two overloads directly a template, it'll be ambiguous with
 // the global printer for operator<<.
 
-std::ostream& operator<<(
+static std::ostream& operator<<(
     std::ostream& out,
     const at::ArrayRef<const Value*> nodes) {
   return printValueRefs(out, nodes);
 }
 
-std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*> nodes) {
+static std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*> nodes) {
   return printValueRefs(out, nodes);
 }
 
@@ -141,7 +141,7 @@ struct const_value_list_with_types {
       : values(values), delim(std::move(delim_)) {}
 };
 
-std::ostream& operator<<(
+static std::ostream& operator<<(
     std::ostream& out,
     const const_value_list_with_types& l) {
   size_t i = 0;
@@ -967,7 +967,7 @@ void Value::replaceAllUsesDominatedByNodeWith(
       uses_.end());
 }
 
-size_t findArgument(
+static size_t findArgument(
     const FunctionSchema& the_schema,
     const std::string& unqualName) {
   for (const auto i : c10::irange(the_schema.arguments().size())) {
@@ -980,7 +980,7 @@ size_t findArgument(
       std::string("Couldn't find an argument called ") + unqualName);
 }
 
-size_t findArgument(const FunctionSchema& the_schema, Symbol name) {
+static size_t findArgument(const FunctionSchema& the_schema, Symbol name) {
   const auto unqualName = name.toUnqualString();
   return findArgument(the_schema, unqualName);
 }
@@ -2054,7 +2054,7 @@ void inlineCallStackOfNode(
     Node* to_replace,
     c10::optional<ModuleInstanceInfo> m_info);
 
-void inlineCallStackOfBlock(
+static void inlineCallStackOfBlock(
     Block* b,
     std::unordered_map<InlinedCallStack*, InlinedCallStackPtr>& new_cs_entries,
     Function* callee,

--- a/torch/csrc/jit/jit_opt_limit.cpp
+++ b/torch/csrc/jit/jit_opt_limit.cpp
@@ -14,7 +14,7 @@
 namespace torch {
 namespace jit {
 
-std::unordered_map<std::string, int64_t>& passes_to_current_counter() {
+static std::unordered_map<std::string, int64_t>& passes_to_current_counter() {
   static std::unordered_map<std::string, int64_t> passes_to_current_counter;
   return passes_to_current_counter;
 }

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -95,7 +95,7 @@ uint64_t _get_model_bytecode_version(
   return _get_model_bytecode_version_from_bytes(data.get(), size);
 }
 
-uint64_t _get_model_bytecode_version_zip(
+static uint64_t _get_model_bytecode_version_zip(
     std::shared_ptr<ReadAdapterInterface> rai) {
   if (!check_zip_file(rai)) {
     TORCH_CHECK(

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -238,7 +238,7 @@ std::map<std::string, at::Tensor> mobile_module_to_parameter_map(
       "' in deserialized mobile::Module");
 }
 
-std::map<std::string, at::Tensor> _load_parameters_bytes(
+static std::map<std::string, at::Tensor> _load_parameters_bytes(
     std::shared_ptr<char> data,
     size_t size,
     c10::optional<at::Device> device) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -316,7 +316,7 @@ c10::IValue Method::operator()(std::vector<c10::IValue> stack) const {
   return stack.front();
 }
 
-c10::optional<std::string> print_type(const c10::Type& t) {
+static c10::optional<std::string> print_type(const c10::Type& t) {
   auto namedType = t.cast<c10::NamedType>();
   if (namedType && namedType->name()) {
     return namedType->name().value().qualifiedName();

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
@@ -30,7 +30,7 @@ namespace jit {
 namespace mobile {
 namespace nnc {
 
-static std::vector<int64_t> getConstSizes(const BufPtr b) {
+std::vector<int64_t> getConstSizes(const BufPtr b) {
   std::vector<int64_t> r;
   for (const auto& dim : b->dims()) {
     LongImmPtr imm_dim = to<LongImm>(dim);
@@ -42,7 +42,7 @@ static std::vector<int64_t> getConstSizes(const BufPtr b) {
 }
 
 // Construct input-specs vector from the inputs of the original graph
-static std::vector<mobile::nnc::InputSpec> toInputSpecs(
+std::vector<mobile::nnc::InputSpec> toInputSpecs(
     const std::shared_ptr<tensorexpr::TensorExprKernel>& kernel) {
   const std::shared_ptr<Graph>& g = kernel->graph();
   std::vector<mobile::nnc::InputSpec> specs;
@@ -89,7 +89,7 @@ static std::vector<mobile::nnc::InputSpec> toInputSpecs(
 // If a symbolic shape can be found in several different positions, we
 // return the first one we find (TODO: maybe we should return all and
 // verify that they all match at runtime).
-static std::vector<SymbolicShapePosition> findSymbolicShapePositions(
+std::vector<SymbolicShapePosition> findSymbolicShapePositions(
     std::shared_ptr<tensorexpr::TensorExprKernel> kernel) {
   std::vector<SymbolicShapePosition> res;
   for (int64_t sym_idx : kernel->getSymbolicShapeInputs()) {
@@ -122,7 +122,7 @@ static std::vector<SymbolicShapePosition> findSymbolicShapePositions(
   return res;
 }
 
-static std::unique_ptr<Function> compileMethod(
+std::unique_ptr<Function> compileMethod(
     std::shared_ptr<tensorexpr::TensorExprKernel> kernel,
     const std::string& method_name,
     const std::vector<std::vector<int64_t>>& sizes,
@@ -181,9 +181,7 @@ static std::unique_ptr<Function> compileMethod(
   return func;
 }
 
-// TODO(mvz): temporarily disable NNC backend in mobile builds.
-#if 0
-static std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
+std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
     const std::string& method_name,
     std::shared_ptr<Graph>& g,
     const std::vector<std::vector<int64_t>>& sizes,
@@ -219,7 +217,7 @@ static std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
   return std::make_pair(std::move(func), compiled_assembly);
 }
 
-static void writeOutputLlvmAssembly(
+void writeOutputLlvmAssembly(
     const std::string& asm_code,
     const std::string& output_llvm_file_name) {
   std::ofstream output(output_llvm_file_name);
@@ -228,7 +226,7 @@ static void writeOutputLlvmAssembly(
       "The compiled llvm assembly code was saved to ", output_llvm_file_name);
 }
 
-static std::vector<std::string> split(
+std::vector<std::string> split(
     char separator,
     const std::string& string,
     bool ignore_empty = true) {
@@ -243,7 +241,7 @@ static std::vector<std::string> split(
   return pieces;
 }
 
-static std::vector<std::vector<int64_t>> parseInputShapes(
+std::vector<std::vector<int64_t>> parseInputShapes(
     const std::string& input_dims_s) {
   std::vector<std::string> input_dims_list = split(';', input_dims_s);
   std::vector<std::vector<int64_t>> inputs;
@@ -259,7 +257,7 @@ static std::vector<std::vector<int64_t>> parseInputShapes(
   return inputs;
 }
 
-static std::vector<at::ScalarType> parseInputTypes(
+std::vector<at::ScalarType> parseInputTypes(
     const std::string& input_types_str) {
   std::vector<std::string> inputTypes = split(';', input_types_str);
   std::vector<at::ScalarType> scalarTypes;
@@ -279,7 +277,7 @@ static std::vector<at::ScalarType> parseInputTypes(
   return scalarTypes;
 }
 
-static std::vector<at::MemoryFormat> parseInputMemoryFormats(
+std::vector<at::MemoryFormat> parseInputMemoryFormats(
     const std::string& input_memory_format_str) {
   std::vector<std::string> memFormatsStr = split(';', input_memory_format_str);
   std::vector<at::MemoryFormat> memFormats;
@@ -297,7 +295,7 @@ static std::vector<at::MemoryFormat> parseInputMemoryFormats(
   return memFormats;
 }
 
-static std::vector<int64_t> parseInputDynamicShapes(
+std::vector<int64_t> parseInputDynamicShapes(
     const std::string& dynamic_dims_s) {
   std::vector<std::string> dynamic_dims_list = split(',', dynamic_dims_s);
   std::vector<int64_t> dynamic_dims;
@@ -308,7 +306,7 @@ static std::vector<int64_t> parseInputDynamicShapes(
   return dynamic_dims;
 }
 
-static std::string getNncKernelId(
+std::string getNncKernelId(
     const std::string& model_name,
     const std::string& model_version,
     const std::string& method_name) {
@@ -318,7 +316,7 @@ static std::string getNncKernelId(
       version_token;
 }
 
-static std::string getNncKernelFuncName(
+std::string getNncKernelFuncName(
     const std::string& model_name,
     const std::string& model_version,
     const std::string& method_name) {
@@ -327,8 +325,7 @@ static std::string getNncKernelFuncName(
 
 // Preprocess the graph and returns the processed graph and
 // symbolic values if dynamic input shapes are specified
-static std::pair<std::shared_ptr<Graph>, std::vector<int64_t>>
-preprocessGraphPasses(
+std::pair<std::shared_ptr<Graph>, std::vector<int64_t>> preprocessGraphPasses(
     std::shared_ptr<Graph>& graph,
     const std::vector<c10::optional<at::Tensor>>& example_inputs,
     const std::vector<int64_t>& dynamic_sizes) {
@@ -370,7 +367,7 @@ preprocessGraphPasses(
   return std::make_pair(graph, sym_val);
 }
 
-static std::vector<c10::optional<at::Tensor>> generateExampleInputs(
+std::vector<c10::optional<at::Tensor>> generateExampleInputs(
     const std::vector<std::vector<int64_t>>& inputShapes,
     const std::vector<at::ScalarType>& inputTypes,
     const std::vector<at::MemoryFormat>& inputMemoryFormats) {
@@ -385,7 +382,7 @@ static std::vector<c10::optional<at::Tensor>> generateExampleInputs(
   return example_inputs;
 }
 
-static c10::IValue preprocess(
+c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& compile_spec,
     const torch::jit::BackendDebugHandleGenerator& generate_debug_handles) {
@@ -442,8 +439,8 @@ static c10::IValue preprocess(
   }
   return cu.serialize();
 }
-#endif
 
+// TODO(mvz): temporarily disable NNC backend in mobile builds.
 // static auto reg = torch::jit::backend_preprocess_register("nnc", preprocess);
 
 } // namespace nnc

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
@@ -30,7 +30,7 @@ namespace jit {
 namespace mobile {
 namespace nnc {
 
-std::vector<int64_t> getConstSizes(const BufPtr b) {
+static std::vector<int64_t> getConstSizes(const BufPtr b) {
   std::vector<int64_t> r;
   for (const auto& dim : b->dims()) {
     LongImmPtr imm_dim = to<LongImm>(dim);
@@ -42,7 +42,7 @@ std::vector<int64_t> getConstSizes(const BufPtr b) {
 }
 
 // Construct input-specs vector from the inputs of the original graph
-std::vector<mobile::nnc::InputSpec> toInputSpecs(
+static std::vector<mobile::nnc::InputSpec> toInputSpecs(
     const std::shared_ptr<tensorexpr::TensorExprKernel>& kernel) {
   const std::shared_ptr<Graph>& g = kernel->graph();
   std::vector<mobile::nnc::InputSpec> specs;
@@ -89,7 +89,7 @@ std::vector<mobile::nnc::InputSpec> toInputSpecs(
 // If a symbolic shape can be found in several different positions, we
 // return the first one we find (TODO: maybe we should return all and
 // verify that they all match at runtime).
-std::vector<SymbolicShapePosition> findSymbolicShapePositions(
+static std::vector<SymbolicShapePosition> findSymbolicShapePositions(
     std::shared_ptr<tensorexpr::TensorExprKernel> kernel) {
   std::vector<SymbolicShapePosition> res;
   for (int64_t sym_idx : kernel->getSymbolicShapeInputs()) {
@@ -122,7 +122,7 @@ std::vector<SymbolicShapePosition> findSymbolicShapePositions(
   return res;
 }
 
-std::unique_ptr<Function> compileMethod(
+static std::unique_ptr<Function> compileMethod(
     std::shared_ptr<tensorexpr::TensorExprKernel> kernel,
     const std::string& method_name,
     const std::vector<std::vector<int64_t>>& sizes,
@@ -181,7 +181,7 @@ std::unique_ptr<Function> compileMethod(
   return func;
 }
 
-std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
+static std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
     const std::string& method_name,
     std::shared_ptr<Graph>& g,
     const std::vector<std::vector<int64_t>>& sizes,
@@ -217,7 +217,7 @@ std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
   return std::make_pair(std::move(func), compiled_assembly);
 }
 
-void writeOutputLlvmAssembly(
+static void writeOutputLlvmAssembly(
     const std::string& asm_code,
     const std::string& output_llvm_file_name) {
   std::ofstream output(output_llvm_file_name);
@@ -226,7 +226,7 @@ void writeOutputLlvmAssembly(
       "The compiled llvm assembly code was saved to ", output_llvm_file_name);
 }
 
-std::vector<std::string> split(
+static std::vector<std::string> split(
     char separator,
     const std::string& string,
     bool ignore_empty = true) {
@@ -241,7 +241,7 @@ std::vector<std::string> split(
   return pieces;
 }
 
-std::vector<std::vector<int64_t>> parseInputShapes(
+static std::vector<std::vector<int64_t>> parseInputShapes(
     const std::string& input_dims_s) {
   std::vector<std::string> input_dims_list = split(';', input_dims_s);
   std::vector<std::vector<int64_t>> inputs;
@@ -257,7 +257,7 @@ std::vector<std::vector<int64_t>> parseInputShapes(
   return inputs;
 }
 
-std::vector<at::ScalarType> parseInputTypes(
+static std::vector<at::ScalarType> parseInputTypes(
     const std::string& input_types_str) {
   std::vector<std::string> inputTypes = split(';', input_types_str);
   std::vector<at::ScalarType> scalarTypes;
@@ -277,7 +277,7 @@ std::vector<at::ScalarType> parseInputTypes(
   return scalarTypes;
 }
 
-std::vector<at::MemoryFormat> parseInputMemoryFormats(
+static std::vector<at::MemoryFormat> parseInputMemoryFormats(
     const std::string& input_memory_format_str) {
   std::vector<std::string> memFormatsStr = split(';', input_memory_format_str);
   std::vector<at::MemoryFormat> memFormats;
@@ -295,7 +295,7 @@ std::vector<at::MemoryFormat> parseInputMemoryFormats(
   return memFormats;
 }
 
-std::vector<int64_t> parseInputDynamicShapes(
+static std::vector<int64_t> parseInputDynamicShapes(
     const std::string& dynamic_dims_s) {
   std::vector<std::string> dynamic_dims_list = split(',', dynamic_dims_s);
   std::vector<int64_t> dynamic_dims;
@@ -306,7 +306,7 @@ std::vector<int64_t> parseInputDynamicShapes(
   return dynamic_dims;
 }
 
-std::string getNncKernelId(
+static std::string getNncKernelId(
     const std::string& model_name,
     const std::string& model_version,
     const std::string& method_name) {
@@ -316,7 +316,7 @@ std::string getNncKernelId(
       version_token;
 }
 
-std::string getNncKernelFuncName(
+static std::string getNncKernelFuncName(
     const std::string& model_name,
     const std::string& model_version,
     const std::string& method_name) {
@@ -325,7 +325,7 @@ std::string getNncKernelFuncName(
 
 // Preprocess the graph and returns the processed graph and
 // symbolic values if dynamic input shapes are specified
-std::pair<std::shared_ptr<Graph>, std::vector<int64_t>> preprocessGraphPasses(
+static std::pair<std::shared_ptr<Graph>, std::vector<int64_t>> preprocessGraphPasses(
     std::shared_ptr<Graph>& graph,
     const std::vector<c10::optional<at::Tensor>>& example_inputs,
     const std::vector<int64_t>& dynamic_sizes) {
@@ -367,7 +367,7 @@ std::pair<std::shared_ptr<Graph>, std::vector<int64_t>> preprocessGraphPasses(
   return std::make_pair(graph, sym_val);
 }
 
-std::vector<c10::optional<at::Tensor>> generateExampleInputs(
+static std::vector<c10::optional<at::Tensor>> generateExampleInputs(
     const std::vector<std::vector<int64_t>>& inputShapes,
     const std::vector<at::ScalarType>& inputTypes,
     const std::vector<at::MemoryFormat>& inputMemoryFormats) {
@@ -382,7 +382,7 @@ std::vector<c10::optional<at::Tensor>> generateExampleInputs(
   return example_inputs;
 }
 
-c10::IValue preprocess(
+static c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& compile_spec,
     const torch::jit::BackendDebugHandleGenerator& generate_debug_handles) {

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
@@ -325,7 +325,8 @@ static std::string getNncKernelFuncName(
 
 // Preprocess the graph and returns the processed graph and
 // symbolic values if dynamic input shapes are specified
-static std::pair<std::shared_ptr<Graph>, std::vector<int64_t>> preprocessGraphPasses(
+static std::pair<std::shared_ptr<Graph>, std::vector<int64_t>>
+preprocessGraphPasses(
     std::shared_ptr<Graph>& graph,
     const std::vector<c10::optional<at::Tensor>>& example_inputs,
     const std::vector<int64_t>& dynamic_sizes) {

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
@@ -383,6 +383,8 @@ static std::vector<c10::optional<at::Tensor>> generateExampleInputs(
   return example_inputs;
 }
 
+// TODO(mvz): temporarily disable NNC backend in mobile builds.
+/*
 static c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& compile_spec,
@@ -440,8 +442,8 @@ static c10::IValue preprocess(
   }
   return cu.serialize();
 }
+*/
 
-// TODO(mvz): temporarily disable NNC backend in mobile builds.
 // static auto reg = torch::jit::backend_preprocess_register("nnc", preprocess);
 
 } // namespace nnc

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.cpp
@@ -181,6 +181,8 @@ static std::unique_ptr<Function> compileMethod(
   return func;
 }
 
+// TODO(mvz): temporarily disable NNC backend in mobile builds.
+#if 0
 static std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
     const std::string& method_name,
     std::shared_ptr<Graph>& g,
@@ -383,8 +385,6 @@ static std::vector<c10::optional<at::Tensor>> generateExampleInputs(
   return example_inputs;
 }
 
-// TODO(mvz): temporarily disable NNC backend in mobile builds.
-/*
 static c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& compile_spec,
@@ -442,7 +442,7 @@ static c10::IValue preprocess(
   }
   return cu.serialize();
 }
-*/
+#endif
 
 // static auto reg = torch::jit::backend_preprocess_register("nnc", preprocess);
 

--- a/torch/csrc/jit/mobile/prim_ops_registery.cpp
+++ b/torch/csrc/jit/mobile/prim_ops_registery.cpp
@@ -4,7 +4,7 @@ namespace torch {
 namespace jit {
 namespace mobile {
 
-std::unordered_map<std::string, std::function<void(Stack&)>>& primOpsFnTable() {
+static std::unordered_map<std::string, std::function<void(Stack&)>>& primOpsFnTable() {
   static std::unordered_map<std::string, std::function<void(Stack&)>>
       prim_ops_fn;
   return prim_ops_fn;

--- a/torch/csrc/jit/mobile/prim_ops_registery.cpp
+++ b/torch/csrc/jit/mobile/prim_ops_registery.cpp
@@ -4,7 +4,8 @@ namespace torch {
 namespace jit {
 namespace mobile {
 
-static std::unordered_map<std::string, std::function<void(Stack&)>>& primOpsFnTable() {
+static std::unordered_map<std::string, std::function<void(Stack&)>>&
+primOpsFnTable() {
   static std::unordered_map<std::string, std::function<void(Stack&)>>
       prim_ops_fn;
   return prim_ops_fn;

--- a/torch/csrc/jit/mobile/train/optim/sgd.cpp
+++ b/torch/csrc/jit/mobile/train/optim/sgd.cpp
@@ -46,7 +46,7 @@ bool operator==(const SGDOptions& lhs, const SGDOptions& rhs) {
       (lhs.nesterov() == rhs.nesterov());
 }
 
-bool operator==(const SGDParamState& lhs, const SGDParamState& rhs) {
+static bool operator==(const SGDParamState& lhs, const SGDParamState& rhs) {
   return torch::equal(lhs.momentum_buffer(), rhs.momentum_buffer());
 }
 

--- a/torch/csrc/jit/mobile/train/optim/sgd.cpp
+++ b/torch/csrc/jit/mobile/train/optim/sgd.cpp
@@ -46,7 +46,7 @@ bool operator==(const SGDOptions& lhs, const SGDOptions& rhs) {
       (lhs.nesterov() == rhs.nesterov());
 }
 
-static bool operator==(const SGDParamState& lhs, const SGDParamState& rhs) {
+bool operator==(const SGDParamState& lhs, const SGDParamState& rhs) {
   return torch::equal(lhs.momentum_buffer(), rhs.momentum_buffer());
 }
 

--- a/torch/csrc/jit/mobile/train/optim/sgd.h
+++ b/torch/csrc/jit/mobile/train/optim/sgd.h
@@ -21,9 +21,7 @@ class SGDParamState {
     return std::make_unique<SGDParamState>(
         static_cast<const SGDParamState&>(*this));
   }
-  friend bool operator==(
-      const SGDParamState& lhs,
-      const SGDParamState& rhs);
+  friend bool operator==(const SGDParamState& lhs, const SGDParamState& rhs);
   ~SGDParamState() = default;
 };
 

--- a/torch/csrc/jit/mobile/train/optim/sgd.h
+++ b/torch/csrc/jit/mobile/train/optim/sgd.h
@@ -21,6 +21,9 @@ class SGDParamState {
     return std::make_unique<SGDParamState>(
         static_cast<const SGDParamState&>(*this));
   }
+  friend bool operator==(
+      const SGDParamState& lhs,
+      const SGDParamState& rhs);
   ~SGDParamState() = default;
 };
 

--- a/torch/csrc/jit/passes/annotate_warns.cpp
+++ b/torch/csrc/jit/passes/annotate_warns.cpp
@@ -5,7 +5,7 @@
 namespace torch {
 namespace jit {
 
-void AnnotateWarns(Block* b) {
+static void AnnotateWarns(Block* b) {
   static std::atomic<int64_t> idx(0);
   for (Node* n : b->nodes()) {
     for (Block* child_b : n->blocks()) {

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -83,7 +83,7 @@ c10::AliasAnalysisKind aliasAnalysisIsSpecialCase() {
 // Tunable parameter. Set to something larger if it turns out to be better.
 static constexpr size_t min_fusion_size = 4;
 
-bool have_same_shape(at::TensorList inputs) {
+static bool have_same_shape(at::TensorList inputs) {
   auto expected_sizes = inputs[0].sizes();
   return (std::all_of(
       inputs.begin(), inputs.end(), [expected_sizes](const at::Tensor& t) {
@@ -91,17 +91,17 @@ bool have_same_shape(at::TensorList inputs) {
       }));
 }
 
-bool should_be_transposed(at::TensorList inputs) {
+static bool should_be_transposed(at::TensorList inputs) {
   return (std::all_of(inputs.begin(), inputs.end(), [](const at::Tensor& t) {
     return t.stride(0) == 1 && t.stride(1) == t.size(0);
   }));
 }
 
-std::vector<at::Tensor> transpose_inputs(at::TensorList inputs) {
+static std::vector<at::Tensor> transpose_inputs(at::TensorList inputs) {
   return fmap(inputs, [](const at::Tensor& i) { return i.t(); });
 }
 
-bool shape_is_fast_for_reduce(const at::Tensor& lhs, const at::Tensor& rhs) {
+static bool shape_is_fast_for_reduce(const at::Tensor& lhs, const at::Tensor& rhs) {
   size_t l = lhs.size(0);
   size_t m = lhs.size(1);
   size_t r = rhs.size(1);
@@ -251,7 +251,7 @@ struct TreeToken {
 
 enum class Side { LHS, RHS };
 
-void BatchMMTreeReduce(Block* block, AliasDb& alias_db) {
+static void BatchMMTreeReduce(Block* block, AliasDb& alias_db) {
   auto graph = block->owningGraph();
 
   // Look for trees in the block
@@ -316,7 +316,7 @@ void BatchMMTreeReduce(Block* block, AliasDb& alias_db) {
   }
 }
 
-bool shape_is_fast_for_side(const at::Tensor& other_side_input) {
+static bool shape_is_fast_for_side(const at::Tensor& other_side_input) {
   // Cutoff chosed by benchmarking on a TITAN V
   return other_side_input.numel() <= 1024 * 2048;
 }
@@ -368,7 +368,7 @@ RegisterOperators mm_batch_side_reg({Operator(
     },
     aliasAnalysisIsSpecialCase())});
 
-std::pair<std::vector<Node*>, std::vector<Node*>> gatherIndependentMMUses(
+static std::pair<std::vector<Node*>, std::vector<Node*>> gatherIndependentMMUses(
     Value* value,
     AliasDb& alias_db) {
   const auto postprocess = [&](std::vector<Node*> mms) {
@@ -413,7 +413,7 @@ std::pair<std::vector<Node*>, std::vector<Node*>> gatherIndependentMMUses(
       postprocess(std::move(lhses)), postprocess(std::move(rhses)));
 }
 
-void BatchMMSide(Block* block, AliasDb& alias_db) {
+static void BatchMMSide(Block* block, AliasDb& alias_db) {
   // NB: 8 is the current loop unrolling factor
   static constexpr size_t how_many_is_many = 8;
   const auto batch_side = [&](std::vector<Node*>& mms, Side side) {
@@ -462,7 +462,7 @@ void BatchMMSide(Block* block, AliasDb& alias_db) {
   }
 }
 
-bool hasMutableOperators(Block* block) {
+static bool hasMutableOperators(Block* block) {
   for (auto n : block->nodes()) {
     if (n->kind().is_aten() && n->schema().is_mutable())
       return true;
@@ -474,7 +474,7 @@ bool hasMutableOperators(Block* block) {
   return false;
 }
 
-bool hasMMOperators(std::shared_ptr<Graph>& graph) {
+static bool hasMMOperators(std::shared_ptr<Graph>& graph) {
   DepthFirstGraphNodeIterator it(graph);
   Node* n = nullptr;
   while ((n = it.next()) != nullptr) {

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -101,7 +101,9 @@ static std::vector<at::Tensor> transpose_inputs(at::TensorList inputs) {
   return fmap(inputs, [](const at::Tensor& i) { return i.t(); });
 }
 
-static bool shape_is_fast_for_reduce(const at::Tensor& lhs, const at::Tensor& rhs) {
+static bool shape_is_fast_for_reduce(
+    const at::Tensor& lhs,
+    const at::Tensor& rhs) {
   size_t l = lhs.size(0);
   size_t m = lhs.size(1);
   size_t r = rhs.size(1);

--- a/torch/csrc/jit/passes/canonicalize.cpp
+++ b/torch/csrc/jit/passes/canonicalize.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<Graph> Canonicalize(
 }
 
 // Which index in b's owning Node is b
-size_t blockIndex(const Block* b) {
+static size_t blockIndex(const Block* b) {
   auto n = b->owningNode();
   AT_ASSERT(n);
   for (size_t i = 0; i < n->blocks().size(); ++i) {
@@ -73,7 +73,7 @@ size_t blockIndex(const Block* b) {
  * NB: this is not a topological index. Topologically, two nodes in
  * different blocks of an if node are not topologically < or > each other.
  */
-bool isBefore(Node* n1, Node* n2) {
+static bool isBefore(Node* n1, Node* n2) {
   // Invalid to call with the same node as both args
   AT_ASSERT(n1 != n2);
 
@@ -122,7 +122,7 @@ bool isBefore(Node* n1, Node* n2) {
   }
 }
 
-bool isBefore(const Use& a, const Use& b) {
+static bool isBefore(const Use& a, const Use& b) {
   // If two uses are the same node, we order on offset
   if (a.user == b.user) {
     return a.offset < b.offset;
@@ -131,7 +131,7 @@ bool isBefore(const Use& a, const Use& b) {
   return isBefore(a.user, b.user);
 }
 
-bool isAfter(const Use& a, const Use& b) {
+static bool isAfter(const Use& a, const Use& b) {
   if (a.user == b.user && a.offset == b.offset) {
     return false;
   }
@@ -157,14 +157,14 @@ c10::optional<const Use> firstOrLastUse(Value* v, bool find_first) {
   return extreme_use;
 }
 
-std::vector<c10::optional<const Use>> gatherFirstUses(
+static std::vector<c10::optional<const Use>> gatherFirstUses(
     at::ArrayRef<Value*> values) {
   return fmap(values, [&](Value* v) -> c10::optional<const Use> {
     return firstOrLastUse(v, true);
   });
 }
 
-std::vector<size_t> sort_indexes(at::ArrayRef<Value*> values) {
+static std::vector<size_t> sort_indexes(at::ArrayRef<Value*> values) {
   // initialize original index locations
   std::vector<size_t> idx(values.size());
   std::iota(idx.begin(), idx.end(), 0);
@@ -194,17 +194,17 @@ std::vector<size_t> sort_indexes(at::ArrayRef<Value*> values) {
   return idx;
 }
 
-void CanonicalizeLoopOutputs(Node* n) {
+static void CanonicalizeLoopOutputs(Node* n) {
   auto new_indices = sort_indexes(n->outputs());
   LoopView(n).permuteLoopCarried(new_indices);
 }
 
-void CanonicalizeIfOutputs(Node* n) {
+static void CanonicalizeIfOutputs(Node* n) {
   auto new_indices = sort_indexes(n->outputs());
   IfView(n).permuteOutputs(new_indices);
 }
 
-void CanonicalizeOutputs(Block* block) {
+static void CanonicalizeOutputs(Block* block) {
   // We iterate in reverse since ordering of a node's outputs is dependent on
   // the value use following it in the graph
   for (Node* n : block->nodes().reverse()) {

--- a/torch/csrc/jit/passes/check_strict_fusion.cpp
+++ b/torch/csrc/jit/passes/check_strict_fusion.cpp
@@ -22,12 +22,12 @@ bool isStrictFusion(Value* value) {
 
 } // namespace
 
-bool fusionGuardCheck(Symbol k) {
+static bool fusionGuardCheck(Symbol k) {
   return k == Symbol::prim("TensorExprDynamicGuard") || k == prim::TypeCheck ||
       k == prim::CudaFusionGuard || k == prim::RequiresGradCheck;
 }
 
-std::unordered_set<Node*> collectValuesUsedInGuard(
+static std::unordered_set<Node*> collectValuesUsedInGuard(
     Node* guarding_if,
     Node* enter_node) {
   // DFS to collect
@@ -58,7 +58,7 @@ std::unordered_set<Node*> collectValuesUsedInGuard(
   return visited_nodes;
 }
 
-void checkForUnfusedOps(Node* enter_node) {
+static void checkForUnfusedOps(Node* enter_node) {
   std::vector<Node*> unsupported_nodes;
   std::vector<Node*> guarding_ifs; // if multiple, we will throw
   for (Node* node = enter_node->next(); node->kind() != prim::Exit;

--- a/torch/csrc/jit/passes/clear_undefinedness.cpp
+++ b/torch/csrc/jit/passes/clear_undefinedness.cpp
@@ -5,7 +5,7 @@
 namespace torch {
 namespace jit {
 
-void clearUndefinedness(Value* o) {
+static void clearUndefinedness(Value* o) {
   if (o->type()->kind() == TensorType::Kind) {
     o->setType(TensorType::get());
   } else if (
@@ -16,7 +16,7 @@ void clearUndefinedness(Value* o) {
   }
 }
 
-void clearUndefinedness(Block* block) {
+static void clearUndefinedness(Block* block) {
   for (auto n : block->nodes()) {
     for (auto o : n->outputs()) {
       clearUndefinedness(o);

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -22,7 +22,7 @@ c10::AliasAnalysisKind aliasAnalysisFromSchema() {
 // helper to determine if an optional tensor argument/value passed in is
 // statically defined (neither a None constant nor a Optional[Tensor] type)
 // return yes, no, or no value if we can't tell
-c10::optional<bool> isDefined(Value* tensor) {
+static c10::optional<bool> isDefined(Value* tensor) {
   if (tensor->type()->isSubtypeOf(*TensorType::get())) {
     return true;
   }
@@ -32,7 +32,7 @@ c10::optional<bool> isDefined(Value* tensor) {
   return {};
 }
 
-bool isDecomposableNorm(Node* normalize_op) {
+static bool isDecomposableNorm(Node* normalize_op) {
   static const OperatorSet decomposable_normalization_ops = {
       "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
       "aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps, bool cudnn_enable) -> Tensor",
@@ -85,7 +85,7 @@ RegisterOperators reg_ops(
          },
          aliasAnalysisFromSchema())});
 
-bool DecomposeOps(Block* block, CompilationUnit& decompose_funcs) {
+static bool DecomposeOps(Block* block, CompilationUnit& decompose_funcs) {
   bool decomposed = false;
   for (auto it = block->nodes().begin(), end = block->nodes().end(); it != end;
        ++it) {

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -9,7 +9,7 @@
 namespace torch {
 namespace jit {
 
-void SetNumTypeToTensorType(Value* v) {
+static void SetNumTypeToTensorType(Value* v) {
   if (v->type()->isSubtypeOf(*NumberType::get())) {
     v->setType(TensorType::fromNumberType(*v->type()));
   } else if (v->type()->isSubtypeOf(*BoolType::get())) {

--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -34,7 +34,7 @@ c10::optional<IValue> getIValue(
   return toIValue(getValue(name, match_vmap, vmap));
 }
 
-std::unordered_map<std::string, c10::IValue> getConvParams(
+static std::unordered_map<std::string, c10::IValue> getConvParams(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap) {
   std::unordered_map<std::string, c10::IValue> calc_values;

--- a/torch/csrc/jit/passes/hoist_conv_packed_params.cpp
+++ b/torch/csrc/jit/passes/hoist_conv_packed_params.cpp
@@ -36,7 +36,7 @@ namespace jit {
 // %n =
 // prim::GetAttr[name="{prefix}.name1{...}.name(n-1)._packed_params"][%self]
 //
-void hoistConvPackedParams(
+static void hoistConvPackedParams(
     Module& rootModule,
     Node* getConvPackedParamsNode,
     const std::string& prefix,

--- a/torch/csrc/jit/passes/inline_fork_wait.cpp
+++ b/torch/csrc/jit/passes/inline_fork_wait.cpp
@@ -4,7 +4,7 @@
 namespace torch {
 namespace jit {
 
-void InlineForkWait(
+static void InlineForkWait(
     Block* b,
     std::unordered_map<Value*, Value*>& future_remap) {
   auto nodes = b->nodes();

--- a/torch/csrc/jit/passes/inline_forked_closures.cpp
+++ b/torch/csrc/jit/passes/inline_forked_closures.cpp
@@ -16,7 +16,7 @@ namespace jit {
 // subgraph, replace the context unpacking value with the new graph input.
 // fork(foo) ->
 // def foo(a, b):
-void inlineForkedClosure(Node* fork_closure, NodeKind genKind) {
+static void inlineForkedClosure(Node* fork_closure, NodeKind genKind) {
   Node* function_context_node = fork_closure->input()->node();
 
   if (function_context_node->inputs().size() != 2 ||
@@ -58,7 +58,7 @@ void inlineForkedClosure(Node* fork_closure, NodeKind genKind) {
   runCleanupPasses(fork_graph);
 }
 
-void inlineForkedClosures(Block* block) {
+static void inlineForkedClosures(Block* block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     Node* n = *it;
     it++;

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -30,7 +30,7 @@ GraphFunction* tryToGraphFunction(Node* n) {
   return nullptr;
 }
 
-void inlineCalls(Block* block) {
+static void inlineCalls(Block* block) {
   for (auto it = block->nodes().begin(), end = block->nodes().end();
        it != end;) {
     Node* cur = *it++;

--- a/torch/csrc/jit/passes/inplace_check.cpp
+++ b/torch/csrc/jit/passes/inplace_check.cpp
@@ -3,7 +3,7 @@
 namespace torch {
 namespace jit {
 
-void CheckInplace(Block* block) {
+static void CheckInplace(Block* block) {
   for (auto node : block->nodes()) {
     if (node->kind() == prim::PythonOp && node->hasAttribute(attr::inplace)) {
       if (node->i(attr::inplace)) {

--- a/torch/csrc/jit/passes/lift_closures.cpp
+++ b/torch/csrc/jit/passes/lift_closures.cpp
@@ -16,7 +16,7 @@ namespace jit {
 // closure block.
 // Within the closure subgraph, the context tuple is unpacked and the unpacked
 // values are used for closed over values.
-void liftClosure(Node* closure) {
+static void liftClosure(Node* closure) {
   auto block = closure->blocks().at(0);
   auto subgraph = std::make_shared<Graph>();
   // closures/forks can be nested, so use closure owning graph
@@ -56,7 +56,7 @@ void liftClosure(Node* closure) {
   runCleanupPasses(closure->g(attr::Subgraph));
 }
 
-void liftClosures(Block* block) {
+static void liftClosures(Block* block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     Node* n = *it;
     it++;

--- a/torch/csrc/jit/passes/lower_graph.cpp
+++ b/torch/csrc/jit/passes/lower_graph.cpp
@@ -21,7 +21,7 @@ struct Slot {
 // parameters/attributes with extra_ivalue input Slots that hold what value to
 // pass into the graph. Used for ONNX export to remove first-class modules
 // so it can deal purely with parameters and inputs
-std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
+static std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
     const ModulePtr& self,
     Graph& g_,
     size_t self_offset = 0) {

--- a/torch/csrc/jit/passes/metal_rewrite.cpp
+++ b/torch/csrc/jit/passes/metal_rewrite.cpp
@@ -240,25 +240,6 @@ void metalFusePrePackedConvWithClamp(script::Module& module) {
   fuseHardtanhWithPackedOps(graph);
 }
 
-static void metalInsertCopyOps(script::Module& module) {
-  auto graph = module.get_method("forward").graph();
-  auto&& outputs = graph->outputs();
-  for (const auto i : c10::irange(outputs.size())) {
-    Value* output = outputs[i];
-    auto namedValue = NamedValue("", output);
-    if (namedValue.type()->kind() == TypeKind::TensorType) {
-      // find the insertion point
-      WithInsertPoint ip(output->node()->next());
-      Value* replaced_output = graph->insert(
-          Symbol::fromQualString("metal::copy_to_host"), {namedValue});
-      // replaced the output
-      graph->block()->replaceOutput(i, replaced_output);
-    }
-  }
-  SubgraphRewriter rewriter;
-  rewriter.runOnGraph(graph);
-}
-
 static void metalRemoveMutation(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   RemoveTensorMutation(graph);

--- a/torch/csrc/jit/passes/metal_rewrite.cpp
+++ b/torch/csrc/jit/passes/metal_rewrite.cpp
@@ -240,7 +240,7 @@ void metalFusePrePackedConvWithClamp(script::Module& module) {
   fuseHardtanhWithPackedOps(graph);
 }
 
-void metalInsertCopyOps(script::Module& module) {
+static void metalInsertCopyOps(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   auto&& outputs = graph->outputs();
   for (const auto i : c10::irange(outputs.size())) {
@@ -259,12 +259,12 @@ void metalInsertCopyOps(script::Module& module) {
   rewriter.runOnGraph(graph);
 }
 
-void metalRemoveMutation(script::Module& module) {
+static void metalRemoveMutation(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   RemoveTensorMutation(graph);
 }
 
-void metalRunCanonicalOptimizations(script::Module& module) {
+static void metalRunCanonicalOptimizations(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   runOptimization(graph, false /* no loop unrolling */);
 }

--- a/torch/csrc/jit/passes/pass_manager.cpp
+++ b/torch/csrc/jit/passes/pass_manager.cpp
@@ -21,7 +21,7 @@ GraphPassNameType registerPostPass(GraphPass p) {
   return graphPassID++;
 }
 
-GraphPassNameType registerPass(GraphPass p) {
+static GraphPassNameType registerPass(GraphPass p) {
   return registerPostPass(std::move(p));
 }
 

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -332,7 +332,7 @@ struct PeepholeOptimizeImpl {
   bool shape_peepholes_;
 };
 
-bool FuseAddMM(Block* block) {
+static bool FuseAddMM(Block* block) {
   bool changed = false;
   for (Node* node : block->nodes()) {
     // XXX: remember that if you want to simplify an expression by combining

--- a/torch/csrc/jit/passes/peephole_list_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_list_idioms.cpp
@@ -15,7 +15,7 @@
 namespace torch {
 namespace jit {
 
-c10::optional<size_t> normalizeIndex(int64_t index, size_t len) {
+static c10::optional<size_t> normalizeIndex(int64_t index, size_t len) {
   if (index < 0) {
     index = index + len;
   }

--- a/torch/csrc/jit/passes/peephole_non_tensor.cpp
+++ b/torch/csrc/jit/passes/peephole_non_tensor.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/passes/peephole.h>
+#include <torch/csrc/jit/passes/peephole_non_tensor.h>
 
 #include <ATen/core/jit_type.h>
 #include <c10/util/irange.h>

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -168,7 +168,7 @@ void FoldQuantizedPrepackingOps(Module& module) {
   PrePackingOpsFolder(module, filter_fn, "quantized");
 }
 
-std::unordered_set<std::string> RegisterPrePackingParams(
+static std::unordered_set<std::string> RegisterPrePackingParams(
     Module& module,
     const std::string& method_name) {
   auto filter_fn = [](const Node* n) -> bool {

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -395,7 +395,8 @@ std::vector<Value*> getPassThroughInputs(Value* v) {
   return {};
 }
 
-static std::vector<NodeKind> toAtenSymbol(const std::vector<std::string>& func_names) {
+static std::vector<NodeKind> toAtenSymbol(
+    const std::vector<std::string>& func_names) {
   std::vector<NodeKind> symbols;
   std::transform(
       func_names.begin(),

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -253,7 +253,7 @@ bool matchCallFuncToUse(
 
 // Check any use of `v` matches the aten function call
 // or CallFunction patterns
-bool matchArgPattern(
+static bool matchArgPattern(
     Value* v,
     const AtenFuncArgs& aten_func_args,
     const CallFuncArgs& call_func_args) {
@@ -395,7 +395,7 @@ std::vector<Value*> getPassThroughInputs(Value* v) {
   return {};
 }
 
-std::vector<NodeKind> toAtenSymbol(const std::vector<std::string>& func_names) {
+static std::vector<NodeKind> toAtenSymbol(const std::vector<std::string>& func_names) {
   std::vector<NodeKind> symbols;
   std::transform(
       func_names.begin(),
@@ -405,18 +405,18 @@ std::vector<NodeKind> toAtenSymbol(const std::vector<std::string>& func_names) {
   return symbols;
 }
 
-bool isAtenFunc(Node* n, const std::vector<NodeKind>& aten_funcs) {
+static bool isAtenFunc(Node* n, const std::vector<NodeKind>& aten_funcs) {
   return std::find(aten_funcs.begin(), aten_funcs.end(), n->kind()) !=
       aten_funcs.end();
 }
 
-bool isAtenFunc(Node* n, const std::vector<std::string>& aten_funcs) {
+static bool isAtenFunc(Node* n, const std::vector<std::string>& aten_funcs) {
   const auto& symbols = toAtenSymbol(aten_funcs);
   return isAtenFunc(n, symbols);
 }
 
 // TODO: factor out isCallFunc
-bool isFunctionNode(
+static bool isFunctionNode(
     Node* n,
     const std::vector<std::string>& call_funcs,
     const std::vector<std::string>& aten_funcs) {
@@ -669,7 +669,7 @@ bool is_int_constant(
   return v && v->isInt() && v->toInt() == value;
 }
 
-bool is_functional(
+static bool is_functional(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap,
     const std::string& vname,
@@ -693,7 +693,7 @@ c10::optional<std::string> getModuleName(Value* value) {
   return c10::nullopt;
 }
 
-bool is_module(
+static bool is_module(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap,
     const std::string& vname,

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -1105,7 +1105,8 @@ graph(%packed_params, %a):
   };
 }
 
-static std::vector<QuantFusionInfo> dynamic_quant_fusion_pattern_and_replacements() {
+static std::vector<QuantFusionInfo>
+dynamic_quant_fusion_pattern_and_replacements() {
   std::string linear_dynamic = R"(
 graph(%packed_params, %a, %reduce_range, %a_dtype):
         %a_scale : float, %a_zero_point : int = aten::_choose_qparams_per_tensor(%a, %reduce_range)

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -282,7 +282,7 @@ QuantFusionInfo getObservedQParamOpFusionInfo(
 
 } // namespace
 
-std::vector<QuantFusionInfo> quant_fusion_pattern_and_replacements() {
+static std::vector<QuantFusionInfo> quant_fusion_pattern_and_replacements() {
   // aten::conv1d
   std::string conv1d = R"(
 graph(%a_quant, %packed_params, %r_scale, %r_zero_point, %r_dtype, %stride, %padding, %dilation, %groups):
@@ -1105,7 +1105,7 @@ graph(%packed_params, %a):
   };
 }
 
-std::vector<QuantFusionInfo> dynamic_quant_fusion_pattern_and_replacements() {
+static std::vector<QuantFusionInfo> dynamic_quant_fusion_pattern_and_replacements() {
   std::string linear_dynamic = R"(
 graph(%packed_params, %a, %reduce_range, %a_dtype):
         %a_scale : float, %a_zero_point : int = aten::_choose_qparams_per_tensor(%a, %reduce_range)
@@ -1142,7 +1142,7 @@ graph(%packed_params, %a):
   };
 }
 
-std::vector<QuantFusionInfo> linear_prepack_unpack_patterns() {
+static std::vector<QuantFusionInfo> linear_prepack_unpack_patterns() {
   std::string linear_with_quant = R"(
 graph(%a_dequant, %w_quant, %b):
         %w_dequant = aten::dequantize(%w_quant)
@@ -1178,7 +1178,7 @@ graph(%w, %a_dq, %b):
   };
 }
 
-std::vector<QuantFusionInfo> conv_prepack_unpack_patterns() {
+static std::vector<QuantFusionInfo> conv_prepack_unpack_patterns() {
   std::string conv1d_with_quant = R"(
 graph(%a_dequant, %w_quant, %b, %stride, %padding, %dilation, %groups):
         %w_dequant = aten::dequantize(%w_quant)

--- a/torch/csrc/jit/passes/remove_exceptions.cpp
+++ b/torch/csrc/jit/passes/remove_exceptions.cpp
@@ -7,7 +7,7 @@
 namespace torch {
 namespace jit {
 
-bool certainlyThrows(Block* block) {
+static bool certainlyThrows(Block* block) {
   for (Node* n : block->nodes()) {
     if (n->kind() == prim::RaiseException) {
       return true;
@@ -16,7 +16,7 @@ bool certainlyThrows(Block* block) {
   return false;
 }
 
-void EliminateExceptions(Block* block) {
+static void EliminateExceptions(Block* block) {
   auto graph = block->owningGraph();
   Value* false_const = graph->insertConstant(IValue(false));
   Value* true_const = graph->insertConstant(IValue(true));

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -75,7 +75,7 @@ Node* MutationRemover::createSpecialMappedOp(Node* n) {
   return new_node;
 }
 
-bool removableSetItem(Node* n) {
+static bool removableSetItem(Node* n) {
   if (n->kind() != aten::_set_item ||
       n->input(1)->node()->kind() != prim::Constant) {
     return false;

--- a/torch/csrc/jit/passes/remove_redundant_profiles.cpp
+++ b/torch/csrc/jit/passes/remove_redundant_profiles.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/remove_redundant_profiles.h>
 
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir_views.h>

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -50,7 +50,7 @@ bool mergeTypes(
   return changed;
 }
 
-void applyTypes(ArrayRef<Value*> src, ArrayRef<Value*> dst) {
+static void applyTypes(ArrayRef<Value*> src, ArrayRef<Value*> dst) {
   AT_ASSERT(src.size() == dst.size());
   for (const auto i : c10::irange(src.size())) {
     dst[i]->setType(src[i]->type());

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -103,7 +103,7 @@ struct ShapeArg
   }
 };
 
-std::ostream& operator<<(std::ostream& out, const ShapeArg& sa) {
+static std::ostream& operator<<(std::ostream& out, const ShapeArg& sa) {
   if (auto val = sa.asConstantInt()) {
     out << *val;
   } else if (auto ss = sa.asShapeSymbol()) {
@@ -149,7 +149,7 @@ struct ShapeArguments {
   std::vector<ShapeArg> maybe_shape_symbols_;
 };
 
-std::ostream& operator<<(std::ostream& os, const ShapeArguments& sa) {
+static std::ostream& operator<<(std::ostream& os, const ShapeArguments& sa) {
   if (!sa.has_dim()) {
     os << "(UNKNOWN DIM)";
     return os;
@@ -176,7 +176,7 @@ bool symbolicShapeAnalysisTestModeEnabled() {
 
 using SSArgument = c10::variant<ShapeArguments, IValue>;
 
-std::ostream& operator<<(std::ostream& out, const SSArgument& sa) {
+static std::ostream& operator<<(std::ostream& out, const SSArgument& sa) {
   if (const IValue* iv = c10::get_if<IValue>(&sa)) {
     out << *iv;
   } else {

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -20,7 +20,7 @@ namespace jit {
 
 // Inserts the Compute for Each Symbolic Shape in the TensorExpr Graph
 // and returns back a map from Symbolic Shape Value to its runtime Value *
-std::map<int64_t, Value*> InsertSymbolicShapesCompute(
+static std::map<int64_t, Value*> InsertSymbolicShapesCompute(
     const ShapeComputeGraphMapping& shape_mapping,
     Node* tensorexpr_graph) {
   WithInsertPoint guard(tensorexpr_graph);
@@ -140,7 +140,7 @@ inline StrideInput summarizeStrideDim(
   }
 }
 
-std::vector<StrideInput> summarizeInputStrides(const TensorType& tt) {
+static std::vector<StrideInput> summarizeInputStrides(const TensorType& tt) {
   auto strides = *tt.strides().concrete_sizes();
   auto sizes = *tt.sizes().concrete_sizes();
   if (c10::is_contiguous_strides(sizes, strides)) {
@@ -158,7 +158,7 @@ std::vector<StrideInput> summarizeInputStrides(const TensorType& tt) {
 };
 
 // Todo: incorporate in codegen
-StrideInput summarizeOutputStrides(const TensorType& tt) {
+static StrideInput summarizeOutputStrides(const TensorType& tt) {
   auto strides = *tt.strides().concrete_sizes();
   auto sizes = *tt.sizes().concrete_sizes();
   // We only try to maintain output striding for channels last tensors,
@@ -178,7 +178,7 @@ StrideInput summarizeOutputStrides(const TensorType& tt) {
 // Also summarize input striding behavior. The Size information is stored on the
 // type, The striding is returned. See StrideInput for description of stride
 // specializations
-c10::optional<std::vector<std::vector<StrideInput>>>
+static c10::optional<std::vector<std::vector<StrideInput>>>
 TryGeneralizeInputDimensionsToSymbolicShapes(
     std::shared_ptr<Graph> tensorexpr_graph) {
   std::map<size_t, int64_t> shape_to_sym_shape;
@@ -212,7 +212,7 @@ TryGeneralizeInputDimensionsToSymbolicShapes(
   return input_striding;
 }
 
-void moveConstantTensorsOutOfSubgraph(
+static void moveConstantTensorsOutOfSubgraph(
     Node* tensorexpr_graph_node,
     std::shared_ptr<Graph> tensorexpr_graph) {
   auto parent = tensorexpr_graph_node->owningGraph();
@@ -304,7 +304,7 @@ bool GenerateGuard(Node* tensorexpr_graph_node, bool add_composed_op) {
   return true;
 }
 
-void inlineFallbackGraphAndAddSRCopyOutOp(std::shared_ptr<Graph> graph) {
+static void inlineFallbackGraphAndAddSRCopyOutOp(std::shared_ptr<Graph> graph) {
   DepthFirstGraphNodeIterator it(graph);
 
   Node* n = nullptr;
@@ -495,7 +495,7 @@ void insertDynamicShapesGuard(
 // tensors
 // Note: this logic is meant to reflect the invocation of the TE Kernel
 // and `runWithAllocatedOutputs` in tensorexpr_fuser.cpp
-Operation StaticRuntimeCopyOuts(const Node* node) {
+static Operation StaticRuntimeCopyOuts(const Node* node) {
   auto num_ten_inputs = node->inputs().size();
   return [num_ten_inputs](Stack& stack) {
     std::vector<IValue> inputs = pop(stack, num_ten_inputs);
@@ -721,7 +721,7 @@ void runTensorExprDynamicGroup(const Code& code, Stack& stack) {
   interpreter.run(stack);
 }
 
-Operation createTensorExprDynamicGroup(const Node* node) {
+static Operation createTensorExprDynamicGroup(const Node* node) {
   const auto& graph = node->g(attr::Subgraph);
   Code code(graph, "");
   // This implementation creates a Code object and InterpreterState on every

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -43,7 +43,7 @@ namespace jit {
 
 static bool texpr_reductions_enabled = false;
 
-bool isSupportedForBlock(Node* node) {
+static bool isSupportedForBlock(Node* node) {
   switch (node->kind()) {
     case aten::add:
     case aten::mul:
@@ -187,7 +187,7 @@ bool texprReductionsEnabled() {
   return texpr_reductions_enabled;
 }
 
-void removeProfileNodesAndSpecializeTypes(Block* b) {
+static void removeProfileNodesAndSpecializeTypes(Block* b) {
   for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
     if (it->kind() == prim::profile) {
       GRAPH_DEBUG("Removing prim::profile: %", it->output()->debugName());
@@ -275,7 +275,7 @@ bool hasTensorTypeSpecialization(Value* v) {
   return true;
 }
 
-void removeTensorTypeSpecialization(Value* v) {
+static void removeTensorTypeSpecialization(Value* v) {
   if (hasTensorTypeSpecialization(v)) {
     v->setType(TensorType::get());
   }
@@ -1364,7 +1364,7 @@ void FuseTensorExprs(
   GRAPH_DUMP("After TExprFuser: ", graph);
 }
 
-Operation createTensorExprOp(const Node* node) {
+static Operation createTensorExprOp(const Node* node) {
   bool dynamic_shape_fusion_node =
       node->hasAttribute(attr::striding_inputs_desc);
   if (!dynamic_shape_fusion_node) {

--- a/torch/csrc/jit/passes/update_differentiable_graph_requires_grad.cpp
+++ b/torch/csrc/jit/passes/update_differentiable_graph_requires_grad.cpp
@@ -6,7 +6,7 @@
 namespace torch {
 namespace jit {
 
-void UpdateDifferentiableGraphRequiresGrad(
+static void UpdateDifferentiableGraphRequiresGrad(
     Block* block,
     c10::optional<bool> new_requires_grad) {
   for (Node* n : block->nodes()) {

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -227,7 +227,7 @@ void unmergeSubgraph(Node* subgraphNode) {
   subgraphNode->destroy();
 }
 
-void collectNestedUses(
+static void collectNestedUses(
     std::unordered_set<Value*>& closed_over_values,
     std::unordered_set<Value*>& new_values,
     std::unordered_map<Value*, Value*>& externalValuesMap,
@@ -271,7 +271,7 @@ void collectNestedUses(
   }
 }
 
-std::unordered_set<Value*> closedOverValues(
+static std::unordered_set<Value*> closedOverValues(
     Node* toMerge,
     std::unordered_map<Value*, Value*>& externalValuesMap) {
   std::unordered_set<Value*> closed_over_values;
@@ -602,7 +602,7 @@ void unmergeNode(Node* n, Node* subgraphNode) {
   n->destroy();
 }
 
-std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
+static std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
   if (s.size() <= maxlen) {
     return s;
   }

--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -399,12 +399,12 @@ void vulkanFoldPrePackingOps(script::Module& m) {
   PrePackingOpsFolder(m, filter_fn, "prepack_folding");
 }
 
-void vulkanRemoveMutation(script::Module& module) {
+static void vulkanRemoveMutation(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   RemoveTensorMutation(graph);
 }
 
-void vulkanRunCanonicalOptimizations(script::Module& module) {
+static void vulkanRunCanonicalOptimizations(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   for (const auto& method : module.get_methods()) {
     auto method_graph = method.graph();

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -22,7 +22,7 @@ namespace jit {
 using value_map = std::unordered_map<Value*, Value*>;
 using value_set = std::unordered_set<Value*>;
 
-void wrapDim(int64_t& dim, const std::vector<int64_t>& sizes) {
+static void wrapDim(int64_t& dim, const std::vector<int64_t>& sizes) {
   if (dim < 0) {
     dim += sizes.size();
   }
@@ -34,7 +34,7 @@ void wrapDim(int64_t& dim, const std::vector<int64_t>& sizes) {
 // kthvalue returns (kthvalue, index of kthvalue), currently autodiff only
 // supports at most one output that requires grad. Thus we need to remove
 // the grad for index that doesn't require grad.
-bool needTrimGrad(Node* n) {
+static bool needTrimGrad(Node* n) {
   static OperatorSet need_trim_grad_ops = {
       "aten::kthvalue(Tensor self, int k, int dim, bool keepdim) -> (Tensor, Tensor)",
       "aten::topk(Tensor self, int k, int dim, bool largest, bool sorted) -> (Tensor, Tensor)",
@@ -835,7 +835,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
   reverse_block->owningNode()->destroy();
 }
 
-void packReturnValuesIntoTuple(const std::shared_ptr<Graph>& graph) {
+static void packReturnValuesIntoTuple(const std::shared_ptr<Graph>& graph) {
   auto returnNode = graph->block()->return_node();
   WithInsertPoint wip(returnNode);
   auto tuple = graph->insertNode(graph->createTuple(returnNode->inputs()));

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -22,12 +22,6 @@ namespace jit {
 using value_map = std::unordered_map<Value*, Value*>;
 using value_set = std::unordered_set<Value*>;
 
-static void wrapDim(int64_t& dim, const std::vector<int64_t>& sizes) {
-  if (dim < 0) {
-    dim += sizes.size();
-  }
-}
-
 // need_trim_grad_ops contains functions that return multiple outputs in
 // forward, but only the first one requires grad.
 // Example:

--- a/torch/csrc/jit/runtime/decomposition_registry.cpp
+++ b/torch/csrc/jit/runtime/decomposition_registry.cpp
@@ -70,7 +70,7 @@ void loadDecompositionFunctions() {
 
 } // anonymous namespace
 
-void DecomposeOp(Node* n) {
+static void DecomposeOp(Node* n) {
   auto schema = n->maybeSchema();
   if (!schema) {
     return;
@@ -89,7 +89,7 @@ void DecomposeOp(Node* n) {
   n->destroy();
 }
 
-void RunDecompositions(Block* block) {
+static void RunDecompositions(Block* block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     Node* n = *it;
     it++; // advance iterator bc the current node may be destroyed

--- a/torch/csrc/jit/runtime/instruction.cpp
+++ b/torch/csrc/jit/runtime/instruction.cpp
@@ -5,7 +5,7 @@
 
 namespace torch {
 namespace jit {
-std::ostream& operator<<(std::ostream& out, OpCode op) {
+static std::ostream& operator<<(std::ostream& out, OpCode op) {
   switch (op) {
 #define OP_STRING(x, _) \
   case x:               \
@@ -27,7 +27,7 @@ char const* toString(OpCode op) {
   return nullptr;
 }
 
-const char* OpInfo(OpCode op) {
+static const char* OpInfo(OpCode op) {
   switch (op) {
 #define OP_INFO(x, info) \
   case x:                \

--- a/torch/csrc/jit/runtime/instruction.h
+++ b/torch/csrc/jit/runtime/instruction.h
@@ -95,6 +95,7 @@ std::ostream& operator<<(std::ostream& out, Instruction inst);
 
 bool isOpSupportedInMobile(OpCode op);
 char const* toString(OpCode op);
+OpCode parseOpCode(const char* str);
 std::ostream& operator<<(std::ostream& out, Instruction inst);
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -83,7 +83,7 @@ static std::atomic<bool> profiling_mode{true};
 
 static std::mutex fusion_strategy_lock;
 
-FusionStrategy getInitialStrategy() {
+static FusionStrategy getInitialStrategy() {
   if (FLAGS_torch_jit_always_dynamic) {
     return {{FusionBehavior::DYNAMIC, 12}};
   }
@@ -245,7 +245,7 @@ static C10_UNUSED void setRequiresGradOnDiffGraph(Node* dnode) {
   }
 }
 
-bool guardDifferentiableGraph(Node* dnode) {
+static bool guardDifferentiableGraph(Node* dnode) {
   auto gi = dnode->g(attr::Subgraph)->inputs();
   bool all_inputs_seen = true;
   for (const auto i : c10::irange(gi.size())) {
@@ -323,7 +323,7 @@ void runNooptPassPipeline(std::shared_ptr<Graph>& graph) {
       "After EliminateDeadCode (end of runNooptPassPipeline)\n", *graph);
 }
 
-void runPreAutodiffPassPipeline(std::shared_ptr<Graph>& graph) {
+static void runPreAutodiffPassPipeline(std::shared_ptr<Graph>& graph) {
   GRAPH_DEBUG(
       "Before InsertGuards (beginning of runPreAutodiffPassPipeline)\n",
       *graph);
@@ -700,7 +700,7 @@ GraphExecutorState ProfilingGraphExecutorImpl::getDebugState() {
   return state;
 }
 
-Node* insertFallbackFunctionCall(
+static Node* insertFallbackFunctionCall(
     Graph* graph,
     GraphFunction* func,
     ArrayRef<Value*> inputs) {
@@ -721,7 +721,7 @@ Node* insertFallbackFunctionCall(
   return fun_unpack_tuple;
 }
 
-GraphFunction* createFallbackPathFunction(
+static GraphFunction* createFallbackPathFunction(
     Block* b,
     const std::string& function_name) {
   auto value_map = [](Value* v) { return v; };

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -39,7 +39,7 @@ void fuseStaticSubgraphs(std::shared_ptr<Graph> graph, size_t min_size) {
   torch::jit::EliminateDeadCode(graph);
 }
 
-Operation createStaticSubgraphRuntime(const Node* node) {
+static Operation createStaticSubgraphRuntime(const Node* node) {
   auto g = node->g(attr::Subgraph);
   auto module = std::make_shared<torch::jit::StaticModule>(g);
   auto num_inputs = module->num_inputs();
@@ -72,7 +72,7 @@ RegisterOperators StaticSubgraphOps({torch::jit::Operator(
     return false;                           \
   }
 
-bool canHandle(Node* node) {
+static bool canHandle(Node* node) {
   for (Value* input : node->inputs()) {
     bool is_tensor = !!input->type()->cast<TensorType>();
     auto list_type = input->type()->cast<ListType>();
@@ -114,7 +114,7 @@ bool canHandle(Node* node) {
   return getOutOfPlaceOperation(node) != nullptr;
 }
 
-bool canMerge(Node* consumer, Node* producer, AliasDb* aliasDb) {
+static bool canMerge(Node* consumer, Node* producer, AliasDb* aliasDb) {
   // Only fuse within a block
   REQ(consumer->owningBlock() == producer->owningBlock());
 
@@ -137,7 +137,7 @@ bool canMerge(Node* consumer, Node* producer, AliasDb* aliasDb) {
   return true;
 }
 
-Node* getOrCreateStaticSubgraph(Node* n, AliasDb* aliasDb) {
+static Node* getOrCreateStaticSubgraph(Node* n, AliasDb* aliasDb) {
   if (n->hasAttribute(attr::Subgraph) && n->kind() == prim::StaticSubgraph) {
     return n;
   }
@@ -146,7 +146,7 @@ Node* getOrCreateStaticSubgraph(Node* n, AliasDb* aliasDb) {
       n, prim::StaticSubgraph, *aliasDb);
 }
 
-value_list sortReverseTopological(ArrayRef<Value*> inputs, Block* b) {
+static value_list sortReverseTopological(ArrayRef<Value*> inputs, Block* b) {
   value_list result;
   for (auto i : inputs) {
     if (i->node()->owningBlock() == b) {
@@ -169,7 +169,7 @@ static void debugDumpFusionGroup(const std::string& msg, Node* n) {
   }
 }
 
-c10::optional<Node*> tryMerge(
+static c10::optional<Node*> tryMerge(
     Node* fusion_group,
     Node* to_merge,
     AliasDb* aliasDb) {
@@ -208,7 +208,7 @@ c10::optional<Node*> tryMerge(
   return fusion_group;
 }
 
-std::pair<graph_node_list::iterator, bool> createFusionGroup(
+static std::pair<graph_node_list::iterator, bool> createFusionGroup(
     Node* fusion_node,
     AliasDb* aliasDb) {
   fusion_node = getOrCreateStaticSubgraph(fusion_node, aliasDb);
@@ -231,7 +231,7 @@ std::pair<graph_node_list::iterator, bool> createFusionGroup(
   return std::make_pair(++fusion_node->reverseIterator(), false);
 }
 
-std::pair<graph_node_list::iterator, bool> scanNode(Node* n, AliasDb* aliasDb) {
+static std::pair<graph_node_list::iterator, bool> scanNode(Node* n, AliasDb* aliasDb) {
   GRAPH_DEBUG("Considering node:", *n);
 
   if (!canHandle(n)) {
@@ -241,7 +241,7 @@ std::pair<graph_node_list::iterator, bool> scanNode(Node* n, AliasDb* aliasDb) {
   return createFusionGroup(n, aliasDb);
 }
 
-bool inlineIfTooSmall(Node* n, size_t min_size) {
+static bool inlineIfTooSmall(Node* n, size_t min_size) {
   if (n->kind() != prim::StaticSubgraph) {
     return false;
   }
@@ -258,7 +258,7 @@ bool inlineIfTooSmall(Node* n, size_t min_size) {
   return false;
 }
 
-void inlineSmallFusionGroups(Block* block, size_t min_size) {
+static void inlineSmallFusionGroups(Block* block, size_t min_size) {
   for (Node* n : block->nodes()) {
     for (Block* b : n->blocks()) {
       inlineSmallFusionGroups(b, min_size);
@@ -323,7 +323,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size) {
   inlineSmallFusionGroups(block, min_size);
 }
 
-void inlineFallbackGraphs(std::shared_ptr<Graph> graph) {
+static void inlineFallbackGraphs(std::shared_ptr<Graph> graph) {
   DepthFirstGraphNodeIterator it(graph);
 
   Node* n = nullptr;

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -231,7 +231,9 @@ static std::pair<graph_node_list::iterator, bool> createFusionGroup(
   return std::make_pair(++fusion_node->reverseIterator(), false);
 }
 
-static std::pair<graph_node_list::iterator, bool> scanNode(Node* n, AliasDb* aliasDb) {
+static std::pair<graph_node_list::iterator, bool> scanNode(
+    Node* n,
+    AliasDb* aliasDb) {
   GRAPH_DEBUG("Considering node:", *n);
 
   if (!canHandle(n)) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -76,7 +76,7 @@ bool allArgsAreTensors(const Node* node) {
 // These are rarely-used ops. Disallowing them typically eliminates
 // corner cases in graph optimizations, allowing for more aggressive
 // optimizations and better performance.
-bool isUnsupportedOp(const Node* node) {
+static bool isUnsupportedOp(const Node* node) {
   auto kind = node->kind();
   if (kind != aten::__is__ && kind != aten::__isnot__) {
     return false;
@@ -1587,7 +1587,7 @@ float BlockRunner::benchmark_model(
       (static_cast<float>(main_runs) * static_cast<float>(args_list.size()));
 }
 
-bool display_ivalue(const IValue& iv) {
+static bool display_ivalue(const IValue& iv) {
   if (iv.isTensor()) {
     std::cout << "Tensor " << iv.toTensor().toString() << " {";
     const auto dims = iv.toTensor().sizes();
@@ -1622,7 +1622,7 @@ bool display_ivalue(const IValue& iv) {
   return false;
 }
 
-void display_pnode_info(const ProcessedNode& pnode) {
+static void display_pnode_info(const ProcessedNode& pnode) {
   pnode.node()->print(std::cout, 0, nullptr, false);
   const auto num_inputs = static_cast<uint32_t>(pnode.num_inputs());
   for (const auto i : c10::irange(num_inputs)) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -51,7 +51,7 @@ C10_DEFINE_bool(
 namespace at {
 namespace native {
 
-void repeat_out(at::Tensor& result, const Tensor& self, IntArrayRef repeats) {
+static void repeat_out(at::Tensor& result, const Tensor& self, IntArrayRef repeats) {
   TORCH_CHECK(
       repeats.size() >= static_cast<size_t>(self.dim()),
       "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor");
@@ -115,7 +115,7 @@ at::Tensor& reshape_copy_out(
   return out;
 }
 
-at::Tensor& flatten_copy_out(
+static at::Tensor& flatten_copy_out(
     at::Tensor& out,
     const at::Tensor& self,
     int64_t start_dim,
@@ -253,7 +253,7 @@ at::Tensor& to_copy_out(
   return out;
 }
 
-Tensor& linear_out(
+static Tensor& linear_out(
     Tensor& output,
     const Tensor& input,
     const Tensor& weight,
@@ -275,7 +275,7 @@ Tensor& linear_out(
   return output;
 }
 
-Tensor& c2_argmin_out(
+static Tensor& c2_argmin_out(
     Tensor& output,
     const Tensor& input,
     const int64_t dim,
@@ -364,7 +364,7 @@ Tensor& c2_argmin_out(
   return output;
 }
 
-at::Tensor& dequantize_copy_out(Tensor& out, const Tensor& self) {
+static at::Tensor& dequantize_copy_out(Tensor& out, const Tensor& self) {
   if (C10_UNLIKELY(!self.is_quantized())) {
     // fallback to dequantize_cpu equivalent case: make sure out is at::kFloat
     DCHECK(out.scalar_type() == kFloat);
@@ -385,7 +385,7 @@ bool opIsRegistered(const c10::Symbol& op_name) {
   return SROperatorRegistry()->Has(name);
 }
 
-bool disableUnsafeMathOp(const char* op_name) {
+static bool disableUnsafeMathOp(const char* op_name) {
   if (FLAGS_static_runtime_enable_fast_math) {
     return false;
   }
@@ -428,7 +428,7 @@ bool canReuseInputsOutputs(
 // returns true if the producers of the inputs
 // to this operations are out of place.
 // This means the IValues will not change run to run
-bool inputsCanRunOutOfPlace(
+static bool inputsCanRunOutOfPlace(
     Node* n,
     const c10::FastMap<Node*, bool>& node_has_out_variant) {
   for (auto* input : n->inputs()) {
@@ -877,7 +877,7 @@ void varStackOut(ProcessedNode& pnode, int64_t dim) {
 } // namespace
 
 // Split out into a function to appease MSVC's pre-processor
-SROperator aten_stack(Node* n) {
+static SROperator aten_stack(Node* n) {
   if (!n->matches(torch::schema(
           "aten::stack(Tensor[] tensors, int dim=0) -> Tensor"))) {
     LogAndDumpSchema(n);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -51,7 +51,10 @@ C10_DEFINE_bool(
 namespace at {
 namespace native {
 
-static void repeat_out(at::Tensor& result, const Tensor& self, IntArrayRef repeats) {
+static void repeat_out(
+    at::Tensor& result,
+    const Tensor& self,
+    IntArrayRef repeats) {
   TORCH_CHECK(
       repeats.size() >= static_cast<size_t>(self.dim()),
       "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor");

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -666,7 +666,7 @@ void ReplaceWithMaybeCopy(
 #endif
 }
 
-void ReplaceWithCopyImpl(
+static void ReplaceWithCopyImpl(
     std::shared_ptr<Graph>& graph,
     const c10::FastMap<c10::Symbol, c10::Symbol>& supported,
     const std::vector<std::pair<c10::FunctionSchema, c10::Symbol>>&

--- a/torch/csrc/jit/runtime/static/te_wrapper.cpp
+++ b/torch/csrc/jit/runtime/static/te_wrapper.cpp
@@ -69,7 +69,7 @@ void TEWrapper::call(const std::vector<void*>& args) {
   DCHECK(0 && "Invalid call");
 }
 
-std::shared_ptr<TEWrapper> wrapTECompute(
+static std::shared_ptr<TEWrapper> wrapTECompute(
     std::shared_ptr<TEWrapper> wrap,
     Tensor out,
     std::vector<CodeGen::BufferArg> args,
@@ -77,7 +77,7 @@ std::shared_ptr<TEWrapper> wrapTECompute(
   return wrap;
 }
 
-std::shared_ptr<TEWrapper> wrapTECompute(
+static std::shared_ptr<TEWrapper> wrapTECompute(
     std::shared_ptr<TEWrapper> wrap,
     LoopNest* ln,
     std::vector<CodeGen::BufferArg> args) {

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1497,7 +1497,8 @@ std::unordered_map<const FunctionSchema*, GradientPair> cached_gradient_pairs;
 CompilationUnit compilation_unit;
 } // anonymous namespace
 
-static std::pair<std::shared_ptr<Graph>, Value*> extractClosure(Value* closure) {
+static std::pair<std::shared_ptr<Graph>, Value*> extractClosure(
+    Value* closure) {
   TORCH_CHECK(
       closure->node()->kind() == prim::TupleConstruct,
       "closure must be a literal tuple construct");

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1497,7 +1497,7 @@ std::unordered_map<const FunctionSchema*, GradientPair> cached_gradient_pairs;
 CompilationUnit compilation_unit;
 } // anonymous namespace
 
-std::pair<std::shared_ptr<Graph>, Value*> extractClosure(Value* closure) {
+static std::pair<std::shared_ptr<Graph>, Value*> extractClosure(Value* closure) {
   TORCH_CHECK(
       closure->node()->kind() == prim::TupleConstruct,
       "closure must be a literal tuple construct");
@@ -1510,7 +1510,7 @@ std::pair<std::shared_ptr<Graph>, Value*> extractClosure(Value* closure) {
   return std::make_pair(fn->node()->g(attr::Subgraph), context);
 }
 
-Argument originalReturnType(const TupleTypePtr& tup) {
+static Argument originalReturnType(const TupleTypePtr& tup) {
   TORCH_CHECK(tup->elements().size() > 1);
   if (tup->elements().size() == 2)
     return Argument("", tup->elements().at(0));
@@ -1523,7 +1523,7 @@ Argument originalReturnType(const TupleTypePtr& tup) {
 // overloaded functions of `func`.
 // Remove the suffix before adding the schema string to map
 // schema_to_graphs.
-std::string overloadedSchemaString(const FunctionSchema& schema) {
+static std::string overloadedSchemaString(const FunctionSchema& schema) {
   const auto& schema_name = schema.name();
   auto pos = schema_name.find_last_of('_');
   auto schema_name_suffix = schema_name.substr(pos + 1);
@@ -1539,12 +1539,12 @@ std::string overloadedSchemaString(const FunctionSchema& schema) {
   return schema_string;
 }
 
-bool isHelperFunction(const std::string& method_name) {
+static bool isHelperFunction(const std::string& method_name) {
   std::string helper_prefix = "AD_";
   return method_name.compare(0, helper_prefix.length(), helper_prefix) == 0;
 }
 
-void loadModule(const CompilationUnit& module) {
+static void loadModule(const CompilationUnit& module) {
   for (const auto& method : module.get_functions()) {
     if (isHelperFunction(method->name()))
       continue;
@@ -1607,7 +1607,7 @@ void loadModule(const CompilationUnit& module) {
   }
 }
 
-void loadFunctions() {
+static void loadFunctions() {
   for (const std::string& str : functions) {
     compilation_unit.define(c10::nullopt, str, nativeResolver(), nullptr);
   }

--- a/torch/csrc/jit/serialization/export_bytecode.cpp
+++ b/torch/csrc/jit/serialization/export_bytecode.cpp
@@ -32,7 +32,7 @@
 
 namespace torch::jit {
 
-std::vector<Method> gatherGetSetStates(ObjectPtr obj) {
+static std::vector<Method> gatherGetSetStates(ObjectPtr obj) {
   std::vector<Method> methods;
   // Use DFS on IValue's to traverse dependencies of module._ivalue and
   // add all setstate/getstates to initial stack.
@@ -63,7 +63,7 @@ std::vector<Method> gatherGetSetStates(ObjectPtr obj) {
   return methods;
 }
 
-std::vector<Method> findAllDependentFunctions(
+static std::vector<Method> findAllDependentFunctions(
     const Module& module,
     Graph& graph) {
   std::vector<Method> methods;
@@ -92,7 +92,7 @@ std::vector<Method> findAllDependentFunctions(
 // 2. All the dependent functions will come afterwards.
 // This order is meaningful because currently mobile Module looks up
 // methods with linear search.
-std::vector<std::unique_ptr<GraphFunction>> inlineFunctions(
+static std::vector<std::unique_ptr<GraphFunction>> inlineFunctions(
     const std::vector<Method>& initial_methods,
     bool incl_dependent_functions) {
   std::set<std::pair<std::string, Function*>> visited;
@@ -297,7 +297,7 @@ IValue convertMobileFunctionToCodeTable(
   return codeTable;
 }
 
-void checkSchema(const c10::FunctionSchema& schema) {
+static void checkSchema(const c10::FunctionSchema& schema) {
   TORCH_CHECK(
       schema.overload_name().empty(), // @TODO: is this check correct?
       "Overloads are not supported in mobile modules.");
@@ -308,7 +308,7 @@ void checkSchema(const c10::FunctionSchema& schema) {
       "A variable number of return values is not supported in mobile modules.");
 }
 
-bool isLoweredModule(const Module& m) {
+static bool isLoweredModule(const Module& m) {
   c10::QualifiedName type_name;
   if (m.type()->name()) {
     type_name = m.type()->name().value();
@@ -326,7 +326,7 @@ bool isLoweredModule(const Module& m) {
 // Check if the global static map of backend debug info
 // contains debug info for this module and any of its children.
 // If so combine all the maps together and return one.
-void getBackendDebugInfoMap(
+static void getBackendDebugInfoMap(
     const Module& m,
     BackendDebugInfoMapType& debug_map) {
   if (isLoweredModule(m)) {
@@ -342,7 +342,7 @@ void getBackendDebugInfoMap(
   }
 }
 
-uint64_t get_min_operator_version_from_version_map(
+static uint64_t get_min_operator_version_from_version_map(
     const mobile::Module& module) {
   uint64_t min_version = caffe2::serialize::kMinSupportedFileFormatVersion;
   for (const auto& func : module.compilation_unit().methods()) {

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -54,7 +54,7 @@ CompilationOptions getOptionsFromGlobal() {
   return compilation_options;
 }
 
-IValue to_tuple(std::initializer_list<IValue> ivalues) {
+static IValue to_tuple(std::initializer_list<IValue> ivalues) {
   return c10::ivalue::Tuple::create(ivalues);
 }
 

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -51,7 +51,7 @@ using caffe2::serialize::MemoryReadAdapter;
 using caffe2::serialize::PyTorchStreamReader;
 using caffe2::serialize::ReadAdapterInterface;
 
-void postSetStateValidate(const IValue& v) {
+static void postSetStateValidate(const IValue& v) {
   auto obj = v.toObject();
   const auto& objType = obj->type();
   for (const auto i : c10::irange(objType->numAttributes())) {

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1679,7 +1679,7 @@ uint64_t PythonPrint::minVersion() const {
 
 PythonPrint::~PythonPrint() = default;
 
-std::vector<IValue> traverseIValueAndGetObjects(IValue ivalue) {
+static std::vector<IValue> traverseIValueAndGetObjects(IValue ivalue) {
   std::vector<IValue> result;
   std::vector<IValue> stack;
   stack.emplace_back(ivalue);
@@ -1716,7 +1716,7 @@ std::vector<IValue> traverseIValueAndGetObjects(IValue ivalue) {
   return result;
 }
 
-c10::optional<std::string> printType(
+static c10::optional<std::string> printType(
     const c10::Type& type,
     torch::jit::TypeNameUniquer& type_name_uniquer) {
   if (auto dyn = type.castRaw<c10::DynamicType>()) {

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -188,7 +188,9 @@ bool is(const Type& type) {
 }
 } // namespace
 
-static void restoreContainerTypeTags(const IValue& ivalue, const TypePtr& type) {
+static void restoreContainerTypeTags(
+    const IValue& ivalue,
+    const TypePtr& type) {
   if (is<DictType>(*type)) {
     auto dict = ivalue.toGenericDict();
     dict.unsafeSetKeyType(type->containedType(0));

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -188,7 +188,7 @@ bool is(const Type& type) {
 }
 } // namespace
 
-void restoreContainerTypeTags(const IValue& ivalue, const TypePtr& type) {
+static void restoreContainerTypeTags(const IValue& ivalue, const TypePtr& type) {
   if (is<DictType>(*type)) {
     auto dict = ivalue.toGenericDict();
     dict.unsafeSetKeyType(type->containedType(0));

--- a/torch/csrc/jit/tensorexpr/block_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/block_codegen.cpp
@@ -8,7 +8,7 @@
 
 namespace torch::jit::tensorexpr {
 
-std::string blockDtypeCppString(const Dtype& dtype) {
+static std::string blockDtypeCppString(const Dtype& dtype) {
   switch (dtype.scalar_type()) {
     case ScalarType::Bool:
       return "1";

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -70,7 +70,7 @@ BoundsInfo mergeTensorAccesses(
   return ret;
 }
 
-std::unordered_map<VarPtr, BufPtr> getAllBufs(StmtPtr s) {
+static std::unordered_map<VarPtr, BufPtr> getAllBufs(StmtPtr s) {
   std::unordered_map<VarPtr, BufPtr> varToBuf;
 
   auto bufs = NodeFinder<Buf>::find(s);
@@ -80,7 +80,7 @@ std::unordered_map<VarPtr, BufPtr> getAllBufs(StmtPtr s) {
   return varToBuf;
 }
 
-std::unordered_map<VarPtr, BufPtr> getAllBufs(ExprPtr e) {
+static std::unordered_map<VarPtr, BufPtr> getAllBufs(ExprPtr e) {
   std::unordered_map<VarPtr, BufPtr> varToBuf;
 
   auto bufs = NodeFinder<Buf>::find(e);
@@ -195,7 +195,7 @@ std::vector<ExprPtr> getBoundExtents(
 
 using BoundSet = std::unordered_set<Bound, BoundHash>;
 
-BoundSet convertBounds(
+static BoundSet convertBounds(
     const std::vector<TensorAccessBoundsInfo>& bounds,
     TensorAccessKind filter = kMutate) {
   BoundSet ret;
@@ -209,7 +209,7 @@ BoundSet convertBounds(
   return ret;
 }
 
-BoundSet convertBounds(
+static BoundSet convertBounds(
     BoundsInfo& bounds,
     BufPtr buf,
     TensorAccessKind filter = kMutate) {
@@ -271,7 +271,7 @@ HazardKind getPotentialHazards(
   return HazardKind::NoDependency;
 }
 
-IndexBounds getIndexBounds(const TensorAccessBoundsInfo& tabi) {
+static IndexBounds getIndexBounds(const TensorAccessBoundsInfo& tabi) {
   TORCH_INTERNAL_ASSERT(
       tabi.start.size() == tabi.stop.size(), buildErrorMessage());
   IndexBounds ret(tabi.start.size());
@@ -284,7 +284,7 @@ IndexBounds getIndexBounds(const TensorAccessBoundsInfo& tabi) {
   return ret;
 }
 
-std::vector<IndexBounds> getIndexBounds(
+static std::vector<IndexBounds> getIndexBounds(
     const std::vector<TensorAccessBoundsInfo>& vTABI,
     TensorAccessKind filter = kMutate) {
   std::vector<IndexBounds> bounds;
@@ -296,7 +296,7 @@ std::vector<IndexBounds> getIndexBounds(
   return bounds;
 }
 
-bool hasConflictingOverlap(
+static bool hasConflictingOverlap(
     const BoundsInfo& aBounds,
     const BoundsInfo& bBounds,
     TensorAccessKind aFilter = kMutate,

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -6,7 +6,7 @@
 namespace torch::jit::tensorexpr::analysis {
 
 // Returns true if the given expression is guaranteed to be positive.
-bool mustBePositive(ExprPtr e) {
+static bool mustBePositive(ExprPtr e) {
   if (e->isConstant()) {
     int e_val = immediateAs<int>(e);
     return e_val > 0;
@@ -15,7 +15,7 @@ bool mustBePositive(ExprPtr e) {
 }
 
 // Returns true if the given expression is guaranteed to be negative.
-bool mustBeNegative(ExprPtr e) {
+static bool mustBeNegative(ExprPtr e) {
   if (e->isConstant()) {
     int e_val = immediateAs<int>(e);
     return e_val < 0;
@@ -24,7 +24,7 @@ bool mustBeNegative(ExprPtr e) {
 }
 
 // Returns true if the given expression is guaranteed to be zero.
-bool mustBeZero(ExprPtr e) {
+static bool mustBeZero(ExprPtr e) {
   if (e->isConstant()) {
     int e_val = immediateAs<int>(e);
     return e_val == 0;

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -95,7 +95,7 @@ void CodeGen::call_with_numel(void** args, int64_t numel) {
       false, "This codegen backend does not implement call_with_numel");
 }
 
-c10::optional<size_t> bufSize(BufPtr buf) {
+static c10::optional<size_t> bufSize(BufPtr buf) {
   size_t size = elementSize(buf->dtype().scalar_type()) * buf->dtype().lanes();
   for (auto& d : buf->dims()) {
     if (!d->isConstant()) {
@@ -115,7 +115,7 @@ c10::optional<size_t> bufSize(BufPtr buf) {
 // allocations available, we'll create memory for it. Once we are beyond the
 // liveness range of this buffer, we'll mark its corresponding memory allocation
 // as "up for grabs" for future reuse.
-std::vector<std::pair<BufPtr, BufPtr>> AllocBufsWithMemReuse(
+static std::vector<std::pair<BufPtr, BufPtr>> AllocBufsWithMemReuse(
     const std::unordered_set<BufPtr>& bufs,
     const std::unordered_map<BufPtr, std::tuple<int32_t, int32_t>>& buf_ranges,
     const std::unordered_set<BufPtr>& bufs_external_allocs) {
@@ -198,7 +198,7 @@ std::vector<std::pair<BufPtr, BufPtr>> AllocBufsWithMemReuse(
   return buf_allocs;
 }
 
-StmtPtr insertAllocFree(
+static StmtPtr insertAllocFree(
     std::vector<std::pair<BufPtr, BufPtr>>& buf_allocs,
     const std::unordered_set<BufPtr>& bufs_external_allocs,
     StmtPtr stmt) {

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -358,7 +358,6 @@ static at::Tensor quantized_cat(
       zero);
 }
 
-}
 #endif // _WIN32
 
 #ifdef C10_MOBILE

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -358,11 +358,6 @@ static at::Tensor quantized_cat(
       zero);
 }
 
-static at::Tensor quantized_relu(const at::Tensor& qx) {
-  const auto op = c10::Dispatcher::singleton()
-                      .findSchemaOrThrow("quantized::relu", "")
-                      .typed<at::Tensor(at::Tensor)>();
-  return op.call(qx);
 }
 #endif // _WIN32
 

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -1471,7 +1471,7 @@ static void nnc_prepacked_conv2d_clamp_run(
 
 #endif // USE_XNNPACK
 
-static void nnc_aten_embedding(
+void nnc_aten_embedding(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -328,7 +328,10 @@ static at::Tensor quantized_mul_scalar(const at::Tensor& x, double scalar) {
   return op.call(x, s);
 }
 
-static at::Tensor quantized_sigmoid(const at::Tensor& x, double scale, int64_t zero) {
+static at::Tensor quantized_sigmoid(
+    const at::Tensor& x,
+    double scale,
+    int64_t zero) {
   const auto op = c10::Dispatcher::singleton()
                       .findSchemaOrThrow("quantized::sigmoid", "")
                       .typed<at::Tensor(at::Tensor, double, int64_t)>();

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -328,16 +328,6 @@ static at::Tensor quantized_mul_scalar(const at::Tensor& x, double scalar) {
   return op.call(x, s);
 }
 
-static at::Tensor quantized_sigmoid(
-    const at::Tensor& x,
-    double scale,
-    int64_t zero) {
-  const auto op = c10::Dispatcher::singleton()
-                      .findSchemaOrThrow("quantized::sigmoid", "")
-                      .typed<at::Tensor(at::Tensor, double, int64_t)>();
-  return op.call(x, scale, zero);
-}
-
 static at::Tensor quantized_cat(
     const c10::List<at::Tensor>& qxs,
     int64_t dim,

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -25,7 +25,7 @@
 
 namespace torch::jit::tensorexpr {
 
-c10::MemoryFormat deduce_memory_format(
+static c10::MemoryFormat deduce_memory_format(
     c10::IntArrayRef strides,
     c10::IntArrayRef dims) {
   if (strides.size() == 4 && strides[3] == dims[1] && strides[1] == 1l) {
@@ -34,14 +34,14 @@ c10::MemoryFormat deduce_memory_format(
   return c10::MemoryFormat::Contiguous;
 }
 
-c10::MemoryFormat deduce_memory_format(
+static c10::MemoryFormat deduce_memory_format(
     const std::vector<int64_t>& strides,
     const std::vector<int64_t>& dims) {
   return deduce_memory_format(
       c10::IntArrayRef(strides), c10::IntArrayRef(dims));
 }
 
-at::Tensor from_blob_quantized(
+static at::Tensor from_blob_quantized(
     void* data,
     at::IntArrayRef sizes,
     at::IntArrayRef strides,
@@ -164,7 +164,7 @@ std::vector<at::Tensor> constructTensors(
   return tensors;
 }
 
-std::vector<at::Tensor> constructTensors(
+static std::vector<at::Tensor> constructTensors(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -274,7 +274,7 @@ std::vector<at::Tensor> constructTensors2(
   return tensors;
 }
 
-std::vector<at::Tensor> constructTensors2(
+static std::vector<at::Tensor> constructTensors2(
     int64_t bufs_in_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -296,7 +296,7 @@ std::vector<at::Tensor> constructTensors2(
 }
 
 #ifndef _WIN32
-at::Tensor quantized_add(
+static at::Tensor quantized_add(
     const at::Tensor& x1,
     const at::Tensor& x2,
     double scale,
@@ -308,7 +308,7 @@ at::Tensor quantized_add(
   return qadd_op.call(x1, x2, scale, zero);
 }
 
-at::Tensor quantized_mul(
+static at::Tensor quantized_mul(
     const at::Tensor& x1,
     const at::Tensor& x2,
     double scale,
@@ -320,7 +320,7 @@ at::Tensor quantized_mul(
   return op.call(x1, x2, scale, zero);
 }
 
-at::Tensor quantized_mul_scalar(const at::Tensor& x, double scalar) {
+static at::Tensor quantized_mul_scalar(const at::Tensor& x, double scalar) {
   const auto op = c10::Dispatcher::singleton()
                       .findSchemaOrThrow("quantized::mul", "Scalar")
                       .typed<at::Tensor(at::Tensor, c10::Scalar const&)>();
@@ -328,14 +328,14 @@ at::Tensor quantized_mul_scalar(const at::Tensor& x, double scalar) {
   return op.call(x, s);
 }
 
-at::Tensor quantized_sigmoid(const at::Tensor& x, double scale, int64_t zero) {
+static at::Tensor quantized_sigmoid(const at::Tensor& x, double scale, int64_t zero) {
   const auto op = c10::Dispatcher::singleton()
                       .findSchemaOrThrow("quantized::sigmoid", "")
                       .typed<at::Tensor(at::Tensor, double, int64_t)>();
   return op.call(x, scale, zero);
 }
 
-at::Tensor quantized_cat(
+static at::Tensor quantized_cat(
     const c10::List<at::Tensor>& qxs,
     int64_t dim,
     c10::optional<double> scale,
@@ -355,7 +355,7 @@ at::Tensor quantized_cat(
       zero);
 }
 
-at::Tensor quantized_relu(const at::Tensor& qx) {
+static at::Tensor quantized_relu(const at::Tensor& qx) {
   const auto op = c10::Dispatcher::singleton()
                       .findSchemaOrThrow("quantized::relu", "")
                       .typed<at::Tensor(at::Tensor)>();
@@ -907,7 +907,7 @@ void nnc_aten_quantized_sigmoid(
   memcpy(buf_data[0], r.const_data_ptr(), r.element_size() * r.numel());
 }
 
-void nnc_aten_quantized_sigmoid_out(
+static void nnc_aten_quantized_sigmoid_out(
     int64_t bufs_in_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1388,7 +1388,7 @@ void nnc_aten_addmm(
 
 // Only provides first output, the second output is just a copy of one of the
 // inputs
-void nnc_aten_triangular_solve(
+static void nnc_aten_triangular_solve(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1436,7 +1436,7 @@ void nnc_mkldnn_prepacked_conv_run(
 
 #ifdef USE_XNNPACK
 
-void nnc_prepacked_linear_clamp_run(
+static void nnc_prepacked_linear_clamp_run(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1459,7 +1459,7 @@ void nnc_prepacked_linear_clamp_run(
       output.element_size() * output.numel());
 }
 
-void nnc_prepacked_conv2d_clamp_run(
+static void nnc_prepacked_conv2d_clamp_run(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1484,7 +1484,7 @@ void nnc_prepacked_conv2d_clamp_run(
 
 #endif // USE_XNNPACK
 
-void nnc_aten_embedding(
+static void nnc_aten_embedding(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -894,7 +894,7 @@ void nnc_aten_quantized_sigmoid(
   memcpy(buf_data[0], r.const_data_ptr(), r.element_size() * r.numel());
 }
 
-static void nnc_aten_quantized_sigmoid_out(
+void nnc_aten_quantized_sigmoid_out(
     int64_t bufs_in_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1375,7 +1375,7 @@ void nnc_aten_addmm(
 
 // Only provides first output, the second output is just a copy of one of the
 // inputs
-static void nnc_aten_triangular_solve(
+void nnc_aten_triangular_solve(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1423,7 +1423,7 @@ void nnc_mkldnn_prepacked_conv_run(
 
 #ifdef USE_XNNPACK
 
-static void nnc_prepacked_linear_clamp_run(
+void nnc_prepacked_linear_clamp_run(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1446,7 +1446,7 @@ static void nnc_prepacked_linear_clamp_run(
       output.element_size() * output.numel());
 }
 
-static void nnc_prepacked_conv2d_clamp_run(
+void nnc_prepacked_conv2d_clamp_run(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,

--- a/torch/csrc/jit/tensorexpr/external_functions.h
+++ b/torch/csrc/jit/tensorexpr/external_functions.h
@@ -10,6 +10,7 @@
   _(nnc_aten_conv2d)                    \
   _(nnc_aten_conv1d)                    \
   _(nnc_aten_conv1d_out)                \
+  _(nnc_aten_embedding)                 \
   _(nnc_aten_matmul)                    \
   _(nnc_aten_mv)                        \
   _(nnc_aten_mm)                        \

--- a/torch/csrc/jit/tensorexpr/external_functions.h
+++ b/torch/csrc/jit/tensorexpr/external_functions.h
@@ -7,16 +7,18 @@
 #include <vector>
 
 #define FOR_ALL_EXTERNAL_FUNCTIONS(_)   \
+  _(nnc_aten_adaptive_avg_pool2d)       \
+  _(nnc_aten_addmm)                     \
   _(nnc_aten_conv2d)                    \
   _(nnc_aten_conv1d)                    \
   _(nnc_aten_conv1d_out)                \
+  _(nnc_aten_dequantize)                \
+  _(nnc_aten_dequantize_out)            \
   _(nnc_aten_embedding)                 \
   _(nnc_aten_matmul)                    \
   _(nnc_aten_mv)                        \
   _(nnc_aten_mm)                        \
-  _(nnc_aten_adaptive_avg_pool2d)       \
   _(nnc_aten_mean)                      \
-  _(nnc_aten_addmm)                     \
   _(nnc_aten_max_red)                   \
   _(nnc_aten_max_red_out)               \
   _(nnc_aten_quantized_conv1d)          \
@@ -36,12 +38,14 @@
   _(nnc_aten_quantized_mul_scalar_out)  \
   _(nnc_aten_quantized_relu)            \
   _(nnc_aten_quantized_sigmoid)         \
+  _(nnc_aten_quantized_sigmoid_out)     \
   _(nnc_aten_quantize_per_tensor)       \
   _(nnc_aten_quantize_per_tensor_out)   \
-  _(nnc_aten_dequantize)                \
-  _(nnc_aten_dequantize_out)            \
+  _(nnc_aten_triangular_solve)          \
   _(nnc_aten_upsample_nearest2d)        \
-  _(nnc_aten_upsample_nearest2d_out)
+  _(nnc_aten_upsample_nearest2d_out)    \
+  _(nnc_prepacked_conv2d_clamp_run)     \
+  _(nnc_prepacked_linear_clamp_run)
 
 #define DECLARE_EXTERNAL_FUNCTION(NAME) \
   TORCH_API void NAME(                  \

--- a/torch/csrc/jit/tensorexpr/external_functions_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions_codegen.cpp
@@ -13,7 +13,7 @@ namespace torch::jit::tensorexpr {
 extern "C" {
 #endif
 
-void nnc_aten_abs(
+static void nnc_aten_abs(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -31,7 +31,7 @@ void nnc_aten_abs(
   } catch (...) {
   }
 }
-void nnc_aten_absolute(
+static void nnc_aten_absolute(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -49,7 +49,7 @@ void nnc_aten_absolute(
   } catch (...) {
   }
 }
-void nnc_aten_angle(
+static void nnc_aten_angle(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -67,7 +67,7 @@ void nnc_aten_angle(
   } catch (...) {
   }
 }
-void nnc_aten_sgn(
+static void nnc_aten_sgn(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -85,7 +85,7 @@ void nnc_aten_sgn(
   } catch (...) {
   }
 }
-void nnc_aten_acos(
+static void nnc_aten_acos(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -103,7 +103,7 @@ void nnc_aten_acos(
   } catch (...) {
   }
 }
-void nnc_aten_arccos(
+static void nnc_aten_arccos(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -121,7 +121,7 @@ void nnc_aten_arccos(
   } catch (...) {
   }
 }
-void nnc_aten_acosh(
+static void nnc_aten_acosh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -139,7 +139,7 @@ void nnc_aten_acosh(
   } catch (...) {
   }
 }
-void nnc_aten_arccosh(
+static void nnc_aten_arccosh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -157,7 +157,7 @@ void nnc_aten_arccosh(
   } catch (...) {
   }
 }
-void nnc_aten_asinh(
+static void nnc_aten_asinh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -175,7 +175,7 @@ void nnc_aten_asinh(
   } catch (...) {
   }
 }
-void nnc_aten_arcsinh(
+static void nnc_aten_arcsinh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -193,7 +193,7 @@ void nnc_aten_arcsinh(
   } catch (...) {
   }
 }
-void nnc_aten_atanh(
+static void nnc_aten_atanh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -211,7 +211,7 @@ void nnc_aten_atanh(
   } catch (...) {
   }
 }
-void nnc_aten_arctanh(
+static void nnc_aten_arctanh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -229,7 +229,7 @@ void nnc_aten_arctanh(
   } catch (...) {
   }
 }
-void nnc_aten_asin(
+static void nnc_aten_asin(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -247,7 +247,7 @@ void nnc_aten_asin(
   } catch (...) {
   }
 }
-void nnc_aten_arcsin(
+static void nnc_aten_arcsin(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -265,7 +265,7 @@ void nnc_aten_arcsin(
   } catch (...) {
   }
 }
-void nnc_aten_atan(
+static void nnc_aten_atan(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -283,7 +283,7 @@ void nnc_aten_atan(
   } catch (...) {
   }
 }
-void nnc_aten_arctan(
+static void nnc_aten_arctan(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -301,7 +301,7 @@ void nnc_aten_arctan(
   } catch (...) {
   }
 }
-void nnc_aten_bitwise_not(
+static void nnc_aten_bitwise_not(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -319,7 +319,7 @@ void nnc_aten_bitwise_not(
   } catch (...) {
   }
 }
-void nnc_aten_copysign(
+static void nnc_aten_copysign(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -338,7 +338,7 @@ void nnc_aten_copysign(
   } catch (...) {
   }
 }
-void nnc_aten_logical_not(
+static void nnc_aten_logical_not(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -356,7 +356,7 @@ void nnc_aten_logical_not(
   } catch (...) {
   }
 }
-void nnc_aten_logical_xor(
+static void nnc_aten_logical_xor(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -375,7 +375,7 @@ void nnc_aten_logical_xor(
   } catch (...) {
   }
 }
-void nnc_aten_logical_and(
+static void nnc_aten_logical_and(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -394,7 +394,7 @@ void nnc_aten_logical_and(
   } catch (...) {
   }
 }
-void nnc_aten_logical_or(
+static void nnc_aten_logical_or(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -413,7 +413,7 @@ void nnc_aten_logical_or(
   } catch (...) {
   }
 }
-void nnc_aten_bmm(
+static void nnc_aten_bmm(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -432,7 +432,7 @@ void nnc_aten_bmm(
   } catch (...) {
   }
 }
-void nnc_aten_ceil(
+static void nnc_aten_ceil(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -450,7 +450,7 @@ void nnc_aten_ceil(
   } catch (...) {
   }
 }
-void nnc_aten_clamp_max(
+static void nnc_aten_clamp_max(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -469,7 +469,7 @@ void nnc_aten_clamp_max(
   } catch (...) {
   }
 }
-void nnc_aten_clamp_min(
+static void nnc_aten_clamp_min(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -488,7 +488,7 @@ void nnc_aten_clamp_min(
   } catch (...) {
   }
 }
-void nnc_aten_complex(
+static void nnc_aten_complex(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -507,7 +507,7 @@ void nnc_aten_complex(
   } catch (...) {
   }
 }
-void nnc_aten_polar(
+static void nnc_aten_polar(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -526,7 +526,7 @@ void nnc_aten_polar(
   } catch (...) {
   }
 }
-void nnc_aten_cos(
+static void nnc_aten_cos(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -544,7 +544,7 @@ void nnc_aten_cos(
   } catch (...) {
   }
 }
-void nnc_aten_cosh(
+static void nnc_aten_cosh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -562,7 +562,7 @@ void nnc_aten_cosh(
   } catch (...) {
   }
 }
-void nnc_aten_div(
+static void nnc_aten_div(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -581,7 +581,7 @@ void nnc_aten_div(
   } catch (...) {
   }
 }
-void nnc_aten_divide(
+static void nnc_aten_divide(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -600,7 +600,7 @@ void nnc_aten_divide(
   } catch (...) {
   }
 }
-void nnc_aten_true_divide(
+static void nnc_aten_true_divide(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -619,7 +619,7 @@ void nnc_aten_true_divide(
   } catch (...) {
   }
 }
-void nnc_aten_dot(
+static void nnc_aten_dot(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -638,7 +638,7 @@ void nnc_aten_dot(
   } catch (...) {
   }
 }
-void nnc_aten_vdot(
+static void nnc_aten_vdot(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -657,7 +657,7 @@ void nnc_aten_vdot(
   } catch (...) {
   }
 }
-void nnc_aten_erf(
+static void nnc_aten_erf(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -675,7 +675,7 @@ void nnc_aten_erf(
   } catch (...) {
   }
 }
-void nnc_aten_erfc(
+static void nnc_aten_erfc(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -693,7 +693,7 @@ void nnc_aten_erfc(
   } catch (...) {
   }
 }
-void nnc_aten_exp(
+static void nnc_aten_exp(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -711,7 +711,7 @@ void nnc_aten_exp(
   } catch (...) {
   }
 }
-void nnc_aten_exp2(
+static void nnc_aten_exp2(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -729,7 +729,7 @@ void nnc_aten_exp2(
   } catch (...) {
   }
 }
-void nnc_aten_expm1(
+static void nnc_aten_expm1(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -747,7 +747,7 @@ void nnc_aten_expm1(
   } catch (...) {
   }
 }
-void nnc_aten_floor(
+static void nnc_aten_floor(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -765,7 +765,7 @@ void nnc_aten_floor(
   } catch (...) {
   }
 }
-void nnc_aten_floor_divide(
+static void nnc_aten_floor_divide(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -784,7 +784,7 @@ void nnc_aten_floor_divide(
   } catch (...) {
   }
 }
-void nnc_aten_frac(
+static void nnc_aten_frac(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -802,7 +802,7 @@ void nnc_aten_frac(
   } catch (...) {
   }
 }
-void nnc_aten_gcd(
+static void nnc_aten_gcd(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -821,7 +821,7 @@ void nnc_aten_gcd(
   } catch (...) {
   }
 }
-void nnc_aten_lcm(
+static void nnc_aten_lcm(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -840,7 +840,7 @@ void nnc_aten_lcm(
   } catch (...) {
   }
 }
-void nnc_aten_inverse(
+static void nnc_aten_inverse(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -858,7 +858,7 @@ void nnc_aten_inverse(
   } catch (...) {
   }
 }
-void nnc_aten_kron(
+static void nnc_aten_kron(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -877,7 +877,7 @@ void nnc_aten_kron(
   } catch (...) {
   }
 }
-void nnc_aten_ldexp(
+static void nnc_aten_ldexp(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -896,7 +896,7 @@ void nnc_aten_ldexp(
   } catch (...) {
   }
 }
-void nnc_aten_log(
+static void nnc_aten_log(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -914,7 +914,7 @@ void nnc_aten_log(
   } catch (...) {
   }
 }
-void nnc_aten_log10(
+static void nnc_aten_log10(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -932,7 +932,7 @@ void nnc_aten_log10(
   } catch (...) {
   }
 }
-void nnc_aten_log1p(
+static void nnc_aten_log1p(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -950,7 +950,7 @@ void nnc_aten_log1p(
   } catch (...) {
   }
 }
-void nnc_aten_log2(
+static void nnc_aten_log2(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -968,7 +968,7 @@ void nnc_aten_log2(
   } catch (...) {
   }
 }
-void nnc_aten_logaddexp(
+static void nnc_aten_logaddexp(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -987,7 +987,7 @@ void nnc_aten_logaddexp(
   } catch (...) {
   }
 }
-void nnc_aten_logaddexp2(
+static void nnc_aten_logaddexp2(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1006,7 +1006,7 @@ void nnc_aten_logaddexp2(
   } catch (...) {
   }
 }
-void nnc_aten_xlogy(
+static void nnc_aten_xlogy(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1044,7 +1044,7 @@ void nnc_aten_matmul(
   } catch (...) {
   }
 }
-void nnc_aten__compute_linear_combination(
+static void nnc_aten__compute_linear_combination(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1082,7 +1082,7 @@ void nnc_aten_mm(
   } catch (...) {
   }
 }
-void nnc_aten_mul(
+static void nnc_aten_mul(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1101,7 +1101,7 @@ void nnc_aten_mul(
   } catch (...) {
   }
 }
-void nnc_aten_multiply(
+static void nnc_aten_multiply(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1139,7 +1139,7 @@ void nnc_aten_mv(
   } catch (...) {
   }
 }
-void nnc_aten_rad2deg(
+static void nnc_aten_rad2deg(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1157,7 +1157,7 @@ void nnc_aten_rad2deg(
   } catch (...) {
   }
 }
-void nnc_aten_deg2rad(
+static void nnc_aten_deg2rad(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1175,7 +1175,7 @@ void nnc_aten_deg2rad(
   } catch (...) {
   }
 }
-void nnc_aten_reciprocal(
+static void nnc_aten_reciprocal(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1193,7 +1193,7 @@ void nnc_aten_reciprocal(
   } catch (...) {
   }
 }
-void nnc_aten_neg(
+static void nnc_aten_neg(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1211,7 +1211,7 @@ void nnc_aten_neg(
   } catch (...) {
   }
 }
-void nnc_aten_negative(
+static void nnc_aten_negative(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1229,7 +1229,7 @@ void nnc_aten_negative(
   } catch (...) {
   }
 }
-void nnc_aten_round(
+static void nnc_aten_round(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1247,7 +1247,7 @@ void nnc_aten_round(
   } catch (...) {
   }
 }
-void nnc_aten_rsqrt(
+static void nnc_aten_rsqrt(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1265,7 +1265,7 @@ void nnc_aten_rsqrt(
   } catch (...) {
   }
 }
-void nnc_aten_silu(
+static void nnc_aten_silu(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1283,7 +1283,7 @@ void nnc_aten_silu(
   } catch (...) {
   }
 }
-void nnc_aten_mish(
+static void nnc_aten_mish(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1301,7 +1301,7 @@ void nnc_aten_mish(
   } catch (...) {
   }
 }
-void nnc_aten_sigmoid(
+static void nnc_aten_sigmoid(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1319,7 +1319,7 @@ void nnc_aten_sigmoid(
   } catch (...) {
   }
 }
-void nnc_aten_sin(
+static void nnc_aten_sin(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1337,7 +1337,7 @@ void nnc_aten_sin(
   } catch (...) {
   }
 }
-void nnc_aten_sinc(
+static void nnc_aten_sinc(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1355,7 +1355,7 @@ void nnc_aten_sinc(
   } catch (...) {
   }
 }
-void nnc_aten_sinh(
+static void nnc_aten_sinh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1373,7 +1373,7 @@ void nnc_aten_sinh(
   } catch (...) {
   }
 }
-void nnc_aten_sqrt(
+static void nnc_aten_sqrt(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1391,7 +1391,7 @@ void nnc_aten_sqrt(
   } catch (...) {
   }
 }
-void nnc_aten_square(
+static void nnc_aten_square(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1409,7 +1409,7 @@ void nnc_aten_square(
   } catch (...) {
   }
 }
-void nnc_aten_tan(
+static void nnc_aten_tan(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1427,7 +1427,7 @@ void nnc_aten_tan(
   } catch (...) {
   }
 }
-void nnc_aten_tanh(
+static void nnc_aten_tanh(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1445,7 +1445,7 @@ void nnc_aten_tanh(
   } catch (...) {
   }
 }
-void nnc_aten_trunc(
+static void nnc_aten_trunc(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1463,7 +1463,7 @@ void nnc_aten_trunc(
   } catch (...) {
   }
 }
-void nnc_aten_fix(
+static void nnc_aten_fix(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1481,7 +1481,7 @@ void nnc_aten_fix(
   } catch (...) {
   }
 }
-void nnc_aten_heaviside(
+static void nnc_aten_heaviside(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1500,7 +1500,7 @@ void nnc_aten_heaviside(
   } catch (...) {
   }
 }
-void nnc_aten_hspmm(
+static void nnc_aten_hspmm(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1519,7 +1519,7 @@ void nnc_aten_hspmm(
   } catch (...) {
   }
 }
-void nnc_aten_bitwise_and(
+static void nnc_aten_bitwise_and(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1538,7 +1538,7 @@ void nnc_aten_bitwise_and(
   } catch (...) {
   }
 }
-void nnc_aten_bitwise_or(
+static void nnc_aten_bitwise_or(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1557,7 +1557,7 @@ void nnc_aten_bitwise_or(
   } catch (...) {
   }
 }
-void nnc_aten_bitwise_xor(
+static void nnc_aten_bitwise_xor(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1576,7 +1576,7 @@ void nnc_aten_bitwise_xor(
   } catch (...) {
   }
 }
-void nnc_aten_ne(
+static void nnc_aten_ne(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1595,7 +1595,7 @@ void nnc_aten_ne(
   } catch (...) {
   }
 }
-void nnc_aten_not_equal(
+static void nnc_aten_not_equal(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1614,7 +1614,7 @@ void nnc_aten_not_equal(
   } catch (...) {
   }
 }
-void nnc_aten_eq(
+static void nnc_aten_eq(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1633,7 +1633,7 @@ void nnc_aten_eq(
   } catch (...) {
   }
 }
-void nnc_aten_ge(
+static void nnc_aten_ge(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1652,7 +1652,7 @@ void nnc_aten_ge(
   } catch (...) {
   }
 }
-void nnc_aten_greater_equal(
+static void nnc_aten_greater_equal(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1671,7 +1671,7 @@ void nnc_aten_greater_equal(
   } catch (...) {
   }
 }
-void nnc_aten_le(
+static void nnc_aten_le(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1690,7 +1690,7 @@ void nnc_aten_le(
   } catch (...) {
   }
 }
-void nnc_aten_less_equal(
+static void nnc_aten_less_equal(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1709,7 +1709,7 @@ void nnc_aten_less_equal(
   } catch (...) {
   }
 }
-void nnc_aten_gt(
+static void nnc_aten_gt(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1728,7 +1728,7 @@ void nnc_aten_gt(
   } catch (...) {
   }
 }
-void nnc_aten_greater(
+static void nnc_aten_greater(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1747,7 +1747,7 @@ void nnc_aten_greater(
   } catch (...) {
   }
 }
-void nnc_aten_lt(
+static void nnc_aten_lt(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1766,7 +1766,7 @@ void nnc_aten_lt(
   } catch (...) {
   }
 }
-void nnc_aten_less(
+static void nnc_aten_less(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1785,7 +1785,7 @@ void nnc_aten_less(
   } catch (...) {
   }
 }
-void nnc_aten_take(
+static void nnc_aten_take(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1804,7 +1804,7 @@ void nnc_aten_take(
   } catch (...) {
   }
 }
-void nnc_aten_masked_select(
+static void nnc_aten_masked_select(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1823,7 +1823,7 @@ void nnc_aten_masked_select(
   } catch (...) {
   }
 }
-void nnc_aten_nonzero(
+static void nnc_aten_nonzero(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1841,7 +1841,7 @@ void nnc_aten_nonzero(
   } catch (...) {
   }
 }
-void nnc_aten_orgqr(
+static void nnc_aten_orgqr(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1860,7 +1860,7 @@ void nnc_aten_orgqr(
   } catch (...) {
   }
 }
-void nnc_aten_lu_solve(
+static void nnc_aten_lu_solve(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1880,7 +1880,7 @@ void nnc_aten_lu_solve(
   } catch (...) {
   }
 }
-void nnc_aten_lgamma(
+static void nnc_aten_lgamma(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1898,7 +1898,7 @@ void nnc_aten_lgamma(
   } catch (...) {
   }
 }
-void nnc_aten_digamma(
+static void nnc_aten_digamma(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1916,7 +1916,7 @@ void nnc_aten_digamma(
   } catch (...) {
   }
 }
-void nnc_aten_erfinv(
+static void nnc_aten_erfinv(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1934,7 +1934,7 @@ void nnc_aten_erfinv(
   } catch (...) {
   }
 }
-void nnc_aten_i0(
+static void nnc_aten_i0(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1952,7 +1952,7 @@ void nnc_aten_i0(
   } catch (...) {
   }
 }
-void nnc_aten_sign(
+static void nnc_aten_sign(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1970,7 +1970,7 @@ void nnc_aten_sign(
   } catch (...) {
   }
 }
-void nnc_aten_signbit(
+static void nnc_aten_signbit(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -1988,7 +1988,7 @@ void nnc_aten_signbit(
   } catch (...) {
   }
 }
-void nnc_aten_atan2(
+static void nnc_aten_atan2(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2007,7 +2007,7 @@ void nnc_aten_atan2(
   } catch (...) {
   }
 }
-void nnc_aten_lerp(
+static void nnc_aten_lerp(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2027,7 +2027,7 @@ void nnc_aten_lerp(
   } catch (...) {
   }
 }
-void nnc_aten_fmod(
+static void nnc_aten_fmod(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2046,7 +2046,7 @@ void nnc_aten_fmod(
   } catch (...) {
   }
 }
-void nnc_aten_hypot(
+static void nnc_aten_hypot(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2065,7 +2065,7 @@ void nnc_aten_hypot(
   } catch (...) {
   }
 }
-void nnc_aten_igamma(
+static void nnc_aten_igamma(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2084,7 +2084,7 @@ void nnc_aten_igamma(
   } catch (...) {
   }
 }
-void nnc_aten_igammac(
+static void nnc_aten_igammac(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2103,7 +2103,7 @@ void nnc_aten_igammac(
   } catch (...) {
   }
 }
-void nnc_aten_nextafter(
+static void nnc_aten_nextafter(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2122,7 +2122,7 @@ void nnc_aten_nextafter(
   } catch (...) {
   }
 }
-void nnc_aten_remainder(
+static void nnc_aten_remainder(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2141,7 +2141,7 @@ void nnc_aten_remainder(
   } catch (...) {
   }
 }
-void nnc_aten_fmin(
+static void nnc_aten_fmin(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2160,7 +2160,7 @@ void nnc_aten_fmin(
   } catch (...) {
   }
 }
-void nnc_aten_fmax(
+static void nnc_aten_fmax(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2179,7 +2179,7 @@ void nnc_aten_fmax(
   } catch (...) {
   }
 }
-void nnc_aten_maximum(
+static void nnc_aten_maximum(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2198,7 +2198,7 @@ void nnc_aten_maximum(
   } catch (...) {
   }
 }
-void nnc_aten_max(
+static void nnc_aten_max(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2217,7 +2217,7 @@ void nnc_aten_max(
   } catch (...) {
   }
 }
-void nnc_aten_minimum(
+static void nnc_aten_minimum(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2236,7 +2236,7 @@ void nnc_aten_minimum(
   } catch (...) {
   }
 }
-void nnc_aten_min(
+static void nnc_aten_min(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2255,7 +2255,7 @@ void nnc_aten_min(
   } catch (...) {
   }
 }
-void nnc_aten_msort(
+static void nnc_aten_msort(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2273,7 +2273,7 @@ void nnc_aten_msort(
   } catch (...) {
   }
 }
-void nnc_aten_pow(
+static void nnc_aten_pow(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2292,7 +2292,7 @@ void nnc_aten_pow(
   } catch (...) {
   }
 }
-void nnc_aten_float_power(
+static void nnc_aten_float_power(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2311,7 +2311,7 @@ void nnc_aten_float_power(
   } catch (...) {
   }
 }
-void nnc_aten_hardsigmoid(
+static void nnc_aten_hardsigmoid(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2329,7 +2329,7 @@ void nnc_aten_hardsigmoid(
   } catch (...) {
   }
 }
-void nnc_aten_hardswish(
+static void nnc_aten_hardswish(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2347,7 +2347,7 @@ void nnc_aten_hardswish(
   } catch (...) {
   }
 }
-void nnc_aten_log_sigmoid(
+static void nnc_aten_log_sigmoid(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2365,7 +2365,7 @@ void nnc_aten_log_sigmoid(
   } catch (...) {
   }
 }
-void nnc_aten_log_sigmoid_backward(
+static void nnc_aten_log_sigmoid_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2385,7 +2385,7 @@ void nnc_aten_log_sigmoid_backward(
   } catch (...) {
   }
 }
-void nnc_aten_adaptive_avg_pool3d_backward(
+static void nnc_aten_adaptive_avg_pool3d_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2404,7 +2404,7 @@ void nnc_aten_adaptive_avg_pool3d_backward(
   } catch (...) {
   }
 }
-void nnc_aten_adaptive_max_pool2d_backward(
+static void nnc_aten_adaptive_max_pool2d_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2424,7 +2424,7 @@ void nnc_aten_adaptive_max_pool2d_backward(
   } catch (...) {
   }
 }
-void nnc_aten_adaptive_max_pool3d_backward(
+static void nnc_aten_adaptive_max_pool3d_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2444,7 +2444,7 @@ void nnc_aten_adaptive_max_pool3d_backward(
   } catch (...) {
   }
 }
-void nnc_aten_sigmoid_backward(
+static void nnc_aten_sigmoid_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2463,7 +2463,7 @@ void nnc_aten_sigmoid_backward(
   } catch (...) {
   }
 }
-void nnc_aten_tanh_backward(
+static void nnc_aten_tanh_backward(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2482,7 +2482,7 @@ void nnc_aten_tanh_backward(
   } catch (...) {
   }
 }
-void nnc_aten_isposinf(
+static void nnc_aten_isposinf(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2500,7 +2500,7 @@ void nnc_aten_isposinf(
   } catch (...) {
   }
 }
-void nnc_aten_isneginf(
+static void nnc_aten_isneginf(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2518,7 +2518,7 @@ void nnc_aten_isneginf(
   } catch (...) {
   }
 }
-void nnc_aten_special_entr(
+static void nnc_aten_special_entr(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2536,7 +2536,7 @@ void nnc_aten_special_entr(
   } catch (...) {
   }
 }
-void nnc_aten_special_expm1(
+static void nnc_aten_special_expm1(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2554,7 +2554,7 @@ void nnc_aten_special_expm1(
   } catch (...) {
   }
 }
-void nnc_aten_special_exp2(
+static void nnc_aten_special_exp2(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2572,7 +2572,7 @@ void nnc_aten_special_exp2(
   } catch (...) {
   }
 }
-void nnc_aten_special_gammaln(
+static void nnc_aten_special_gammaln(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2590,7 +2590,7 @@ void nnc_aten_special_gammaln(
   } catch (...) {
   }
 }
-void nnc_aten_special_erf(
+static void nnc_aten_special_erf(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2608,7 +2608,7 @@ void nnc_aten_special_erf(
   } catch (...) {
   }
 }
-void nnc_aten_special_erfc(
+static void nnc_aten_special_erfc(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2626,7 +2626,7 @@ void nnc_aten_special_erfc(
   } catch (...) {
   }
 }
-void nnc_aten_special_erfinv(
+static void nnc_aten_special_erfinv(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2644,7 +2644,7 @@ void nnc_aten_special_erfinv(
   } catch (...) {
   }
 }
-void nnc_aten_special_xlog1py(
+static void nnc_aten_special_xlog1py(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2663,7 +2663,7 @@ void nnc_aten_special_xlog1py(
   } catch (...) {
   }
 }
-void nnc_aten_special_i0e(
+static void nnc_aten_special_i0e(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2681,7 +2681,7 @@ void nnc_aten_special_i0e(
   } catch (...) {
   }
 }
-void nnc_aten_special_expit(
+static void nnc_aten_special_expit(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2699,7 +2699,7 @@ void nnc_aten_special_expit(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_cholesky(
+static void nnc_aten_linalg_cholesky(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2717,7 +2717,7 @@ void nnc_aten_linalg_cholesky(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_det(
+static void nnc_aten_linalg_det(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2735,7 +2735,7 @@ void nnc_aten_linalg_det(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_eigvals(
+static void nnc_aten_linalg_eigvals(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2753,7 +2753,7 @@ void nnc_aten_linalg_eigvals(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_householder_product(
+static void nnc_aten_linalg_householder_product(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2772,7 +2772,7 @@ void nnc_aten_linalg_householder_product(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_inv(
+static void nnc_aten_linalg_inv(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2790,7 +2790,7 @@ void nnc_aten_linalg_inv(
   } catch (...) {
   }
 }
-void nnc_aten_inner(
+static void nnc_aten_inner(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2809,7 +2809,7 @@ void nnc_aten_inner(
   } catch (...) {
   }
 }
-void nnc_aten_outer(
+static void nnc_aten_outer(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2828,7 +2828,7 @@ void nnc_aten_outer(
   } catch (...) {
   }
 }
-void nnc_aten_ger(
+static void nnc_aten_ger(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2847,7 +2847,7 @@ void nnc_aten_ger(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_svdvals(
+static void nnc_aten_linalg_svdvals(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,
@@ -2865,7 +2865,7 @@ void nnc_aten_linalg_svdvals(
   } catch (...) {
   }
 }
-void nnc_aten_linalg_solve(
+static void nnc_aten_linalg_solve(
     int64_t bufs_num,
     void** buf_data,
     int64_t* buf_ranks,

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -9,7 +9,7 @@
 namespace torch::jit::tensorexpr {
 
 // Move the given user of `aten::cat` op to its inputs.
-Node* moveCatAfterUse(Node* cat, Node* user, std::shared_ptr<Graph> subgraph) {
+static Node* moveCatAfterUse(Node* cat, Node* user, std::shared_ptr<Graph> subgraph) {
   // Example IR:
   //   %1 = ...
   //   %2 = ...
@@ -81,7 +81,7 @@ Node* moveCatAfterUse(Node* cat, Node* user, std::shared_ptr<Graph> subgraph) {
   return new_cat;
 }
 
-int numTensorInputs(Node* node) {
+static int numTensorInputs(Node* node) {
   int count = 0;
   for (auto v : node->inputs()) {
     if (v->type()->cast<c10::TensorType>()) {
@@ -94,7 +94,7 @@ int numTensorInputs(Node* node) {
 // Returns true if the given `cat` node promotes types.
 // If the inputs to `cat` are of different types, then the implementation
 // of `cat` is expected to promote type.
-bool doesCatPromoteTypes(Node* node) {
+static bool doesCatPromoteTypes(Node* node) {
   TORCH_INTERNAL_ASSERT(
       node->kind() == aten::cat,
       buildErrorMessage("Graph node is not aten::cat."));
@@ -137,7 +137,7 @@ bool doesCatPromoteTypes(Node* node) {
 //      - When the cat op promote types, the type of inputs to cat after moving
 //        it user needs to reflect the original type. This is currently not
 //        handled. TODO
-void moveCatOpToEnd(Node* cat, std::shared_ptr<Graph> subgraph) {
+static void moveCatOpToEnd(Node* cat, std::shared_ptr<Graph> subgraph) {
   TORCH_INTERNAL_ASSERT(
       cat->kind() == aten::cat,
       buildErrorMessage("Graph node is not aten::cat."));
@@ -159,7 +159,7 @@ void moveCatOpToEnd(Node* cat, std::shared_ptr<Graph> subgraph) {
 
 // Moves the users of `aten::cat` ops to its inputs whenever possible
 // in the given subgraph.
-void moveCatOpsToEnd(std::shared_ptr<Graph> subgraph) {
+static void moveCatOpsToEnd(std::shared_ptr<Graph> subgraph) {
   std::vector<Node*> cat_nodes;
   for (Node* n : subgraph->nodes()) {
     if (n->kind() == aten::cat) {
@@ -299,7 +299,7 @@ bool isGraphCompilable(const std::shared_ptr<Graph>& graph) {
   return true;
 }
 
-void fixupTypeInfoForValue(
+static void fixupTypeInfoForValue(
     Value* v,
     c10::optional<at::ScalarType> scalar_type,
     c10::optional<at::Device> device) {
@@ -336,7 +336,7 @@ void fixupTypeInfoForValue(
   v->setType(new_tt);
 }
 
-c10::optional<at::ScalarType> inferScalarType(Node* n) {
+static c10::optional<at::ScalarType> inferScalarType(Node* n) {
   c10::optional<at::ScalarType> scalar_type;
   for (auto v : n->inputs()) {
     auto const& t = v->type();
@@ -355,7 +355,7 @@ c10::optional<at::ScalarType> inferScalarType(Node* n) {
   return scalar_type;
 }
 
-c10::optional<at::Device> inferDevice(Node* n) {
+static c10::optional<at::Device> inferDevice(Node* n) {
   c10::optional<at::Device> device;
   for (auto v : n->inputs()) {
     auto const& t = v->type();
@@ -420,7 +420,7 @@ std::shared_ptr<Graph> replaceListOutputWithTuple(
   return graph;
 }
 
-bool trimGraphOnce(const std::shared_ptr<Graph>& graph) {
+static bool trimGraphOnce(const std::shared_ptr<Graph>& graph) {
   Node* ret = graph->return_node();
   std::unordered_set<Value*> graph_inputs(
       graph->inputs().begin(), graph->inputs().end());
@@ -451,7 +451,7 @@ bool trimGraphOnce(const std::shared_ptr<Graph>& graph) {
   return changed;
 }
 
-std::shared_ptr<Graph> dequantizeResults(const std::shared_ptr<Graph>& graph) {
+static std::shared_ptr<Graph> dequantizeResults(const std::shared_ptr<Graph>& graph) {
   for (auto v : graph->outputs()) {
     auto& t = v->type();
     if (t->kind() == TypeKind::TensorType) {

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -9,7 +9,10 @@
 namespace torch::jit::tensorexpr {
 
 // Move the given user of `aten::cat` op to its inputs.
-static Node* moveCatAfterUse(Node* cat, Node* user, std::shared_ptr<Graph> subgraph) {
+static Node* moveCatAfterUse(
+    Node* cat,
+    Node* user,
+    std::shared_ptr<Graph> subgraph) {
   // Example IR:
   //   %1 = ...
   //   %2 = ...
@@ -451,7 +454,8 @@ static bool trimGraphOnce(const std::shared_ptr<Graph>& graph) {
   return changed;
 }
 
-static std::shared_ptr<Graph> dequantizeResults(const std::shared_ptr<Graph>& graph) {
+static std::shared_ptr<Graph> dequantizeResults(
+    const std::shared_ptr<Graph>& graph) {
   for (auto v : graph->outputs()) {
     auto& t = v->type();
     if (t->kind() == TypeKind::TensorType) {

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -20,7 +20,7 @@ static Dtype dtypeOfIndices(const std::vector<ExprPtr>& indices) {
   return indices.at(0)->dtype();
 }
 
-void castIndicesToInts(std::vector<ExprPtr>& indices) {
+static void castIndicesToInts(std::vector<ExprPtr>& indices) {
   // Cast all indices to either Int or Long
   auto index_dtype = ScalarType::Int;
   for (auto& index : indices) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -2658,7 +2658,10 @@ StmtPtr SimplifierUnderContext::mutate(ForPtr v) {
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, x has to be not negative. d) j is not negative
-static ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
+static ExprPtr distributeDiv(
+    ExprPtr lhs,
+    ExprPtr rhs,
+    VarBoundInfo var_bound_info) {
   if (!lhs || !rhs) {
     return nullptr;
   }
@@ -2776,7 +2779,10 @@ static ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_in
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, j has to be not negative. d) j is not negative
-static ExprPtr distributeMod(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
+static ExprPtr distributeMod(
+    ExprPtr lhs,
+    ExprPtr rhs,
+    VarBoundInfo var_bound_info) {
   if (!lhs || !rhs) {
     return nullptr;
   }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -82,7 +82,7 @@ T gcd(T a, T b) {
 
 // Helper for determining if an Expr is a multi-lane primitive (e.g. Broadcast
 // or Ramp).
-bool isMultilanePrimitive(ExprPtr e) {
+static bool isMultilanePrimitive(ExprPtr e) {
   return to<Broadcast>(e) || to<Ramp>(e);
 }
 
@@ -232,7 +232,7 @@ ExprPtr combineMultilane(ExprPtr lhs, ExprPtr rhs) {
 }
 
 // Handles optimization cases for Broadcast/Ramp * Broadcast/Ramp
-ExprPtr mulMultilane(ExprPtr lhs, ExprPtr rhs) {
+static ExprPtr mulMultilane(ExprPtr lhs, ExprPtr rhs) {
   if (BroadcastPtr bc = to<Broadcast>(lhs)) {
     if (BroadcastPtr bcother = to<Broadcast>(rhs)) {
       if (bc->lanes() != bcother->lanes()) {
@@ -1004,7 +1004,7 @@ ExprPtr PolynomialTransformer::mutate(MulPtr v) {
   return alloc<Term>(hasher_, immLike(v, 1), lhs_new, rhs_new);
 }
 
-ExprPtr factorizeDivision(ExprPtr lhs_new, ExprPtr rhs_new) {
+static ExprPtr factorizeDivision(ExprPtr lhs_new, ExprPtr rhs_new) {
   if (!lhs_new || !rhs_new) {
     return nullptr;
   }
@@ -1610,7 +1610,7 @@ StmtPtr PolynomialBase::mutate(CondPtr v) {
   return v;
 }
 
-StmtPtr handleForCondReordering(ForPtr loop, CondPtr cond) {
+static StmtPtr handleForCondReordering(ForPtr loop, CondPtr cond) {
   if (cond->false_stmt()) {
     return nullptr;
   }
@@ -1809,7 +1809,7 @@ ExprPtr TermExpander::mutate(TermPtr v) {
 // Returns an immediate containing the greatest common divisor of all terms
 // (inc. the scalar term) in the polynomial. If the GCD is uninteresting
 // (e.g. 1) then returns nullptr.
-ExprPtr polyGCD(PolynomialPtr poly) {
+static ExprPtr polyGCD(PolynomialPtr poly) {
   ExprPtr scalar = poly->scalar();
   const std::vector<TermPtr>& variables = poly->variables();
 
@@ -1867,7 +1867,7 @@ class ModRound {
   ExprPtr mod_divisor;
 };
 
-c10::optional<class ModRound> isModRound(TermPtr e) {
+static c10::optional<class ModRound> isModRound(TermPtr e) {
   DivPtr div{nullptr};
   ModPtr mod{nullptr};
   ExprPtr denom{nullptr};
@@ -1976,7 +1976,7 @@ c10::optional<class ModRound> isModRound(TermPtr e) {
 // (1) Round + Mod pattern: (x/y) * y + x % y => RoundOff(x,y) + Mod(x, y) => x
 // (2) Mod round + Mod pattern: (x/y % z)*y + x%y => ModRound(x, y, z) + Mod(x,
 // y) => x % (y*z)
-ExprPtr simplifyRoundModPattern(PolynomialPtr poly) {
+static ExprPtr simplifyRoundModPattern(PolynomialPtr poly) {
   std::vector<TermPtr> rounds;
   std::vector<TermPtr> mods;
   std::vector<TermPtr> mod_rounds;
@@ -2658,7 +2658,7 @@ StmtPtr SimplifierUnderContext::mutate(ForPtr v) {
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, x has to be not negative. d) j is not negative
-ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
+static ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
   if (!lhs || !rhs) {
     return nullptr;
   }
@@ -2776,7 +2776,7 @@ ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, j has to be not negative. d) j is not negative
-ExprPtr distributeMod(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
+static ExprPtr distributeMod(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
   if (!lhs || !rhs) {
     return nullptr;
   }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -87,6 +87,7 @@ static int64_t randomTransformsRequested() {
   return std::stoi(std::string(enable_c_str));
 }
 
+#ifdef TORCH_ENABLE_LLVM
 static bool dontUseLLVMFlag() {
   static const char* enable_c_str =
       std::getenv("PYTORCH_TENSOREXPR_DONT_USE_LLVM");
@@ -95,6 +96,7 @@ static bool dontUseLLVMFlag() {
   }
   return std::string(enable_c_str) == "1";
 }
+#endif
 
 int& getTECudaPointwiseLoopLevels() {
   return te_cuda_pointwise_loop_levels;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -142,7 +142,8 @@ c10::optional<at::Device> pickDeviceType(
   return device;
 }
 
-static c10::optional<at::Device> pickDeviceType(const std::shared_ptr<Graph>& graph) {
+static c10::optional<at::Device> pickDeviceType(
+    const std::shared_ptr<Graph>& graph) {
   c10::optional<at::Device> device = c10::nullopt;
   for (auto const& node : graph->nodes()) {
     for (auto const& input : node->inputs()) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -64,7 +64,7 @@ bool fallbackAllowed() {
   return true;
 }
 
-bool fallbackEnforced() {
+static bool fallbackEnforced() {
   static const char* enable_c_str = std::getenv("PYTORCH_TENSOREXPR_FALLBACK");
   if (tensorexpr::getTEGenerateBlockCode()) {
     return false;
@@ -78,7 +78,7 @@ bool fallbackEnforced() {
   return false;
 }
 
-int64_t randomTransformsRequested() {
+static int64_t randomTransformsRequested() {
   const char* enable_c_str =
       std::getenv("PYTORCH_TENSOREXPR_RANDOM_TRANSFORM_SEED");
   if (!enable_c_str) {
@@ -87,7 +87,7 @@ int64_t randomTransformsRequested() {
   return std::stoi(std::string(enable_c_str));
 }
 
-bool dontUseLLVMFlag() {
+static bool dontUseLLVMFlag() {
   static const char* enable_c_str =
       std::getenv("PYTORCH_TENSOREXPR_DONT_USE_LLVM");
   if (!enable_c_str) {
@@ -142,7 +142,7 @@ c10::optional<at::Device> pickDeviceType(
   return device;
 }
 
-c10::optional<at::Device> pickDeviceType(const std::shared_ptr<Graph>& graph) {
+static c10::optional<at::Device> pickDeviceType(const std::shared_ptr<Graph>& graph) {
   c10::optional<at::Device> device = c10::nullopt;
   for (auto const& node : graph->nodes()) {
     for (auto const& input : node->inputs()) {
@@ -177,7 +177,7 @@ c10::optional<at::Device> pickDeviceType(const std::shared_ptr<Graph>& graph) {
 
 // If v is a Tensor with concretely-known sizes and dtype, return them, else
 // nullopt.
-c10::optional<TensorInfo> getTensorInfoJit(torch::jit::Value* v) {
+static c10::optional<TensorInfo> getTensorInfoJit(torch::jit::Value* v) {
   auto const& it = v->type()->cast<TensorType>();
 
   c10::ScalarType dtype = c10::ScalarType::Float;
@@ -200,7 +200,7 @@ c10::optional<TensorInfo> getTensorInfoJit(torch::jit::Value* v) {
   }
   return TensorInfo{*concrete_sizes, dtype};
 }
-std::vector<int64_t> _pair_int(IValue v) {
+static std::vector<int64_t> _pair_int(IValue v) {
   if (v.isIntList()) {
     return v.toIntVector();
   } else {
@@ -232,7 +232,7 @@ bool isContiguous(const torch::jit::Value* v, at::MemoryFormat memory_format) {
   return *strides == TensorType::contiguousStridesOf(*sizes, memory_format);
 }
 
-size_t get_conv_groups_index(const torch::jit::Node* node) {
+static size_t get_conv_groups_index(const torch::jit::Node* node) {
   switch (node->kind()) {
     case aten::conv2d:
       return 6;
@@ -525,7 +525,7 @@ std::vector<ExprHandle> TensorExprKernel::sizesForValue(
   throw malformed_input(msg);
 }
 
-c10::optional<ScalarType> findDtypeForValue(const torch::jit::Value* v) {
+static c10::optional<ScalarType> findDtypeForValue(const torch::jit::Value* v) {
   if (v->type()->kind() == TypeKind::TensorType) {
     auto tt = v->type()->cast<TensorType>();
     if (tt->scalarType()) {
@@ -535,7 +535,7 @@ c10::optional<ScalarType> findDtypeForValue(const torch::jit::Value* v) {
   return tryScalarTypeFromJitType(*v->type());
 }
 
-bool constZeroDimTensorAsScalarArg(
+static bool constZeroDimTensorAsScalarArg(
     const Value* v,
     std::vector<ArgValue>& args) {
   if (v->node()->kind() != prim::Constant || !v->type()->cast<TensorType>()) {
@@ -644,7 +644,7 @@ Tensor TensorExprKernel::computeValue(const torch::jit::Value* v) {
 }
 
 // True if all the loops in this vector have equal bounds.
-bool loopBoundsAllEqual(const std::vector<ForPtr>& loops) {
+static bool loopBoundsAllEqual(const std::vector<ForPtr>& loops) {
   if (loops.size() <= 1) {
     return true;
   }
@@ -665,7 +665,7 @@ bool loopBoundsAllEqual(const std::vector<ForPtr>& loops) {
 // on matching bounds exists to avoid inserting conditionals on the loop
 // indices where none would be needed, which would significantly complicate
 // vectorization.
-void fuseAllLoops(StmtPtr st) {
+static void fuseAllLoops(StmtPtr st) {
   auto block = to<tensorexpr::Block>(st);
   if (block == nullptr) {
     return;
@@ -705,7 +705,7 @@ void fuseAllLoops(StmtPtr st) {
 }
 
 // Compute the trip count of a loop if it is a constant.
-c10::optional<int64_t> tripCount(ForPtr loop) {
+static c10::optional<int64_t> tripCount(ForPtr loop) {
   auto tc = IRSimplifier::simplify(
       cast<int64_t>(ExprHandle(loop->stop()) - ExprHandle(loop->start())));
   if (auto val = to<LongImm>(tc.node())) {
@@ -1246,7 +1246,7 @@ std::vector<size_t> reverse_sort_indices(const std::vector<T>& v) {
   return idx;
 }
 
-bool denseAndNonOverlapping(
+static bool denseAndNonOverlapping(
     at::ArrayRef<int64_t> sizes,
     at::ArrayRef<int64_t> strides) {
   return (strides == at::infer_dense_strides(sizes, strides));

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1117,22 +1117,6 @@ class ContainedStmtsFinder : public IRVisitor {
   std::unordered_set<StmtPtr> contained_;
 };
 
-static bool containsAll(
-    const std::vector<BufLoadOrStoreUse>& uses,
-    BlockPtr b) {
-  std::unordered_set<StmtPtr> not_found;
-  for (const auto& use : uses) {
-    not_found.insert(use.s);
-  }
-
-  ContainedStmtsFinder csf;
-  const std::unordered_set<StmtPtr>& contained = csf.findContainedStmts(b);
-  for (const auto& s : contained) {
-    not_found.erase(s);
-  }
-  return not_found.empty();
-}
-
 class StmtDeleter : public IRMutator {
  public:
   StmtDeleter(const std::unordered_set<StmtPtr>& targets) : targets_(targets) {}

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1117,7 +1117,9 @@ class ContainedStmtsFinder : public IRVisitor {
   std::unordered_set<StmtPtr> contained_;
 };
 
-static bool containsAll(const std::vector<BufLoadOrStoreUse>& uses, BlockPtr b) {
+static bool containsAll(
+    const std::vector<BufLoadOrStoreUse>& uses,
+    BlockPtr b) {
   std::unordered_set<StmtPtr> not_found;
   for (const auto& use : uses) {
     not_found.insert(use.s);
@@ -1141,7 +1143,8 @@ static BlockPtr findParentBlock(StmtPtr s) {
   return nullptr;
 }
 
-static BlockPtr findLowestContainingBlock(const std::vector<BufLoadOrStoreUse>& uses) {
+static BlockPtr findLowestContainingBlock(
+    const std::vector<BufLoadOrStoreUse>& uses) {
   // TODO: we're not using the most efficient algorithm here for simplicity.
   // Replace with something more performant in case it becomes a bottleneck.
   BlockPtr b = findParentBlock(uses[0].s);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1133,27 +1133,6 @@ static bool containsAll(
   return not_found.empty();
 }
 
-static BlockPtr findParentBlock(StmtPtr s) {
-  while (s) {
-    if (auto b = to<Block>(s)) {
-      return b;
-    }
-    s = s->get_parent();
-  }
-  return nullptr;
-}
-
-static BlockPtr findLowestContainingBlock(
-    const std::vector<BufLoadOrStoreUse>& uses) {
-  // TODO: we're not using the most efficient algorithm here for simplicity.
-  // Replace with something more performant in case it becomes a bottleneck.
-  BlockPtr b = findParentBlock(uses[0].s);
-  while (b && !containsAll(uses, b)) {
-    b = findParentBlock(b->get_parent());
-  }
-  return b;
-}
-
 class StmtDeleter : public IRMutator {
  public:
   StmtDeleter(const std::unordered_set<StmtPtr>& targets) : targets_(targets) {}

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -878,7 +878,7 @@ class FunctionInliner : public IRMutator {
   bool success_ = true;
 };
 
-StmtPtr computeInlineImpl(
+static StmtPtr computeInlineImpl(
     BufPtr b,
     StmtPtr stmt,
     const std::unordered_set<BufPtr>& output_bufs) {
@@ -1117,7 +1117,7 @@ class ContainedStmtsFinder : public IRVisitor {
   std::unordered_set<StmtPtr> contained_;
 };
 
-bool containsAll(const std::vector<BufLoadOrStoreUse>& uses, BlockPtr b) {
+static bool containsAll(const std::vector<BufLoadOrStoreUse>& uses, BlockPtr b) {
   std::unordered_set<StmtPtr> not_found;
   for (const auto& use : uses) {
     not_found.insert(use.s);
@@ -1131,7 +1131,7 @@ bool containsAll(const std::vector<BufLoadOrStoreUse>& uses, BlockPtr b) {
   return not_found.empty();
 }
 
-BlockPtr findParentBlock(StmtPtr s) {
+static BlockPtr findParentBlock(StmtPtr s) {
   while (s) {
     if (auto b = to<Block>(s)) {
       return b;
@@ -1141,7 +1141,7 @@ BlockPtr findParentBlock(StmtPtr s) {
   return nullptr;
 }
 
-BlockPtr findLowestContainingBlock(const std::vector<BufLoadOrStoreUse>& uses) {
+static BlockPtr findLowestContainingBlock(const std::vector<BufLoadOrStoreUse>& uses) {
   // TODO: we're not using the most efficient algorithm here for simplicity.
   // Replace with something more performant in case it becomes a bottleneck.
   BlockPtr b = findParentBlock(uses[0].s);
@@ -1794,12 +1794,12 @@ std::vector<ForPtr> LoopNest::distributeLoopAndParentsOverInnerLoops(
   return result;
 }
 
-bool areEqual(ExprPtr expr1, ExprPtr expr2) {
+static bool areEqual(ExprPtr expr1, ExprPtr expr2) {
   auto diff = IRSimplifier::simplify(alloc<Sub>(expr1, expr2));
   return diff->isConstant() && (immediateAs<int>(diff) == 0);
 };
 
-bool doesExprContainAnyVar(
+static bool doesExprContainAnyVar(
     ExprPtr expr,
     const std::unordered_set<VarPtr>& vars) {
   for (const auto& v : VarFinder::find(expr)) {
@@ -1813,7 +1813,7 @@ bool doesExprContainAnyVar(
 // Returns true if the given list of indices refer to two accesses
 // that are loop-independent w.r.t. the given list of outer loop
 // variables.
-bool areIndicesLoopIndependent(
+static bool areIndicesLoopIndependent(
     const std::vector<ExprPtr>& expr_list1,
     const std::vector<ExprPtr>& expr_list2,
     const std::unordered_set<VarPtr>& outer_loop_vars) {
@@ -2190,7 +2190,7 @@ void LoopNest::reorderAxis(ForPtr a, ForPtr b) {
   }
 }
 
-bool isTrivialPermutation(const std::vector<size_t>& permutation) {
+static bool isTrivialPermutation(const std::vector<size_t>& permutation) {
   for (size_t i = 0; i < permutation.size(); ++i) {
     if (permutation[i] != i) {
       return false;
@@ -2199,7 +2199,7 @@ bool isTrivialPermutation(const std::vector<size_t>& permutation) {
   return true;
 }
 
-bool isValidPermutation(std::vector<size_t> permutation) {
+static bool isValidPermutation(std::vector<size_t> permutation) {
   std::sort(permutation.begin(), permutation.end());
   return isTrivialPermutation(permutation);
 }

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -16,7 +16,7 @@ namespace torch::jit::tensorexpr {
 
 namespace randomization_helper {
 
-int64_t max_transformations(int n_max_transforms) {
+static int64_t max_transformations(int n_max_transforms) {
   // Reuse the env variable PYTORCH_JIT_OPT_LIMIT to control the max number of
   // transformations.  Example - set the env variable
   // PYTORCH_JIT_OPT_LIMIT="loopnest_randomization=10" to set max
@@ -32,7 +32,7 @@ int64_t max_transformations(int n_max_transforms) {
   return max_transforms;
 }
 
-std::vector<std::vector<ForPtr>> GetAllPerfectlyNestedLoopNests(
+static std::vector<std::vector<ForPtr>> GetAllPerfectlyNestedLoopNests(
     std::vector<ForPtr> loops) {
   // Find the first set of loops that can be reordered
   std::vector<std::vector<ForPtr>> all_nested_loops;
@@ -80,7 +80,7 @@ std::tuple<std::vector<T>, std::vector<int>> select_n_randomly(
   return std::make_tuple(selected_objects, selected_indices);
 }
 
-int find_factor(ForPtr loop) {
+static int find_factor(ForPtr loop) {
   // Find valid factors
   ExprPtr loop_stop = loop->stop();
   auto loop_imm = intValue(loop_stop);
@@ -92,7 +92,7 @@ int find_factor(ForPtr loop) {
   return -1;
 }
 
-void printHistory(int index, std::string message) {
+static void printHistory(int index, std::string message) {
   message = "Random Transform Sequence - Transformations[" +
       std::to_string(index) + "] = " + message;
   GRAPH_DEBUG(message);
@@ -107,7 +107,7 @@ std::string join(std::vector<T> indices, char sep = ',') {
   return s;
 }
 
-std::string join(std::vector<std::string> indices, char sep = ',') {
+static std::string join(std::vector<std::string> indices, char sep = ',') {
   std::string s = "";
   for (const auto& index : indices) {
     s += index + sep;

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/jit_opt_limit.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/loopnest_randomization.h>
 
 namespace torch::jit::tensorexpr {
 

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -30,7 +30,7 @@ const char* AccessToString(AccessType a) {
   return "Unknown";
 }
 
-void getDependencyChain(
+static void getDependencyChain(
     const std::shared_ptr<AccessInfo>& info,
     DependencySet& dependencies) {
   if (!dependencies.insert(info).second) {
@@ -42,7 +42,7 @@ void getDependencyChain(
   }
 }
 
-void getDependentsChain(
+static void getDependentsChain(
     const std::shared_ptr<AccessInfo>& info,
     DependencySet& dependents) {
   if (!dependents.insert(info).second) {
@@ -582,7 +582,7 @@ void MemDependencyChecker::visit(LoadPtr v) {
 // dependence. This function does not consider overlap in bound range, but
 // rather the stride of the bound relative to the loop variable. This is the
 // section of the code which considers iteration order, if allowed.
-bool executionSafetyCheck(
+static bool executionSafetyCheck(
     const std::shared_ptr<AccessInfo>& info,
     const std::shared_ptr<AccessInfo>& other,
     const std::vector<ExprPtr>& aStrides,

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -245,7 +245,7 @@ Tensor conv2d_depthwise(
       groups);
 }
 
-std::vector<int64_t> _pair_int(ArgValue v) {
+static std::vector<int64_t> _pair_int(ArgValue v) {
   if (auto t = c10::get_if<IntList>(&v)) {
     return {(*t)[0], (*t)[1]};
   }
@@ -253,7 +253,7 @@ std::vector<int64_t> _pair_int(ArgValue v) {
   return {i, i};
 }
 
-std::vector<int64_t> _single_int_list(ArgValue v) {
+static std::vector<int64_t> _single_int_list(ArgValue v) {
   if (auto t = c10::get_if<IntList>(&v)) {
     return {(*t)[0]};
   }

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -70,7 +70,7 @@ static bool checkTypes(const ScalarType highType, const int typeConstraints) {
   return false;
 }
 
-bool isScalar(ExprHandle e) {
+static bool isScalar(ExprHandle e) {
   auto n = e.node();
   return n->isConstant() || to<Var>(n);
 }
@@ -188,7 +188,7 @@ static bool isOne(ExprHandle e) {
   return *n == 1;
 }
 
-std::pair<std::vector<ExprHandle>, bool> broadcastShapesImpl(
+static std::pair<std::vector<ExprHandle>, bool> broadcastShapesImpl(
     const std::vector<ExprHandle>& a,
     const std::vector<ExprHandle>& b) {
   auto at = a.rbegin();
@@ -224,7 +224,7 @@ std::pair<std::vector<ExprHandle>, bool> broadcastShapesImpl(
   return {ret, hasBroadcast};
 }
 
-std::pair<std::vector<ExprHandle>, bool> broadcastShapesImpl(
+static std::pair<std::vector<ExprHandle>, bool> broadcastShapesImpl(
     std::vector<std::vector<ExprHandle>> shapes) {
   size_t n = shapes.size();
   if (n == 1) {
@@ -508,7 +508,7 @@ static std::pair<ScalarType, std::vector<BufHandle>> processCatList(
   return {highType, nonEmptyInputs};
 }
 
-Tensor computeCatWoConditionals(
+static Tensor computeCatWoConditionals(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
     const std::vector<ExprHandle>& outputStrides) {

--- a/torch/csrc/jit/tensorexpr/operators/quantization.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/quantization.cpp
@@ -39,7 +39,7 @@ bool isQuantized(const BufHandle& qx) {
   return qx.node()->qscale() && qx.node()->qzero();
 }
 
-BufHandle makeQBufHandleChannelsLast(
+static BufHandle makeQBufHandleChannelsLast(
     const std::string& name,
     const std::vector<ExprHandle>& dims,
     Dtype dtype,
@@ -52,7 +52,7 @@ BufHandle makeQBufHandleChannelsLast(
   return ResultBuf;
 }
 
-BufHandle makeQBufHandleChannelsLast(
+static BufHandle makeQBufHandleChannelsLast(
     const std::string& name,
     const std::vector<ExprHandle>& dims,
     Dtype dtype,
@@ -66,7 +66,7 @@ BufHandle makeQBufHandleChannelsLast(
       LongImm::make(qzero).node());
 }
 
-BufHandle makeQBufHandleContiguous(
+static BufHandle makeQBufHandleContiguous(
     const std::string& name,
     const std::vector<ExprHandle>& dims,
     Dtype dtype,
@@ -79,7 +79,7 @@ BufHandle makeQBufHandleContiguous(
   return ResultBuf;
 }
 
-BufHandle makeQBufHandleContiguous(
+static BufHandle makeQBufHandleContiguous(
     const std::string& name,
     const std::vector<ExprHandle>& dims,
     Dtype dtype,
@@ -93,7 +93,7 @@ BufHandle makeQBufHandleContiguous(
       LongImm::make(qzero).node());
 }
 
-bool isChannelsLast(const BufHandle& buf) {
+static bool isChannelsLast(const BufHandle& buf) {
   const auto& strides = buf.node()->strides();
   const auto& dims = buf.node()->dims();
   const auto rank = dims.size();
@@ -108,7 +108,7 @@ bool isChannelsLast(const BufHandle& buf) {
   return ((stridesLast == dimsC) && (stridesC == 1));
 }
 
-ExprHandle quant(
+static ExprHandle quant(
     ExprHandle x,
     Dtype out_dtype,
     ExprHandle qscale,
@@ -120,7 +120,7 @@ ExprHandle quant(
       out_dtype.scalar_type());
 }
 
-ExprHandle dequant(
+static ExprHandle dequant(
     ExprHandle qx,
     Dtype out_dtype,
     ExprHandle qscale,

--- a/torch/csrc/lazy/backend/backend_interface.cpp
+++ b/torch/csrc/lazy/backend/backend_interface.cpp
@@ -29,7 +29,7 @@ const IrBuilder* getIrBuilder() {
   return builder;
 }
 
-at::Tensor MakeTensorFromComputationData(
+static at::Tensor MakeTensorFromComputationData(
     const BackendDataPtr data,
     c10::optional<at::ScalarType> logical_scalar_type) {
   return getBackend()->MakeTensorFromComputationData(data, logical_scalar_type);

--- a/torch/csrc/lazy/backend/backend_interface.cpp
+++ b/torch/csrc/lazy/backend/backend_interface.cpp
@@ -29,12 +29,6 @@ const IrBuilder* getIrBuilder() {
   return builder;
 }
 
-static at::Tensor MakeTensorFromComputationData(
-    const BackendDataPtr data,
-    c10::optional<at::ScalarType> logical_scalar_type) {
-  return getBackend()->MakeTensorFromComputationData(data, logical_scalar_type);
-}
-
 std::unique_ptr<LoweringContext> LoweringContext::Create(
     const std::string& name,
     BackendDevice device,

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -49,7 +49,7 @@ std::unordered_set<std::string>* LoadExperiments() {
 
 } // namespace
 
-std::vector<SourceLocation> NoPythonFrames() {
+static std::vector<SourceLocation> NoPythonFrames() {
   SourceLocation dummy_loc;
   dummy_loc.file = "No Python Frames";
   return {dummy_loc};

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -60,7 +60,7 @@ bool symbolicShapeEnabled() {
   return enabled || FLAGS_ltc_enable_symbolic_shapes;
 }
 
-c10::SymbolicShape get_symbolic_shape(at::Tensor& tensor) {
+static c10::SymbolicShape get_symbolic_shape(at::Tensor& tensor) {
   auto ltc_tensor = TryGetLtcTensor(tensor);
   if (!ltc_tensor) {
     // Set Concrete sizes for Concrete tensors

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -357,7 +357,9 @@ std::vector<Shape> compute_shape_min(const at::Tensor& self) {
   return {Shape(self.scalar_type(), {})};
 }
 
-static std::vector<Shape> compute_shape_nonzero(const at::Tensor& t, bool as_tuple) {
+static std::vector<Shape> compute_shape_nonzero(
+    const at::Tensor& t,
+    bool as_tuple) {
   if (as_tuple) {
     auto res = std::vector<Shape>();
     for (auto dim_size : t.sizes()) {

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -716,12 +716,6 @@ std::vector<Shape> compute_shape_relu(const at::Tensor& self) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
-static std::vector<Shape> compute_shape_bitwise_and(
-    const at::Tensor& self,
-    const at::Scalar& other) {
-  return {Shape(self.scalar_type(), self.sizes().vec())};
-}
-
 std::vector<Shape> compute_shape_sum(
     const at::Tensor& self,
     c10::optional<at::ScalarType> dtype) {
@@ -758,21 +752,6 @@ std::vector<Shape> compute_shape_sort(
   return {
       Shape(self.scalar_type(), self.sizes().vec()),
       Shape(c10::ScalarType::Long, self.sizes().vec())};
-}
-
-static std::vector<Shape> compute_shape_smooth_l1_loss(
-    const at::Tensor& self,
-    const at::Tensor& target,
-    int64_t reduction,
-    double beta) {
-  // Taken from definition of 'Output' shape here:
-  // https://pytorch.org/docs/stable/generated/torch.nn.SmoothL1Loss.html
-  switch (reduction) {
-    case at::Reduction::None:
-      return {Shape(self.scalar_type(), self.sizes().vec())};
-    default:
-      return {Shape(self.scalar_type(), {})};
-  }
 }
 
 std::vector<Shape> compute_shape_slogdet(const at::Tensor& self) {

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -75,7 +75,7 @@ namespace lazy {
 
 // Copied from ATen/native/utils/ParamUtils.h, which aparently I can't include
 // from here?
-std::vector<int64_t> expand_param_if_needed(
+static std::vector<int64_t> expand_param_if_needed(
     at::IntArrayRef list_param,
     const char* param_name,
     int64_t expected_dim) {
@@ -357,7 +357,7 @@ std::vector<Shape> compute_shape_min(const at::Tensor& self) {
   return {Shape(self.scalar_type(), {})};
 }
 
-std::vector<Shape> compute_shape_nonzero(const at::Tensor& t, bool as_tuple) {
+static std::vector<Shape> compute_shape_nonzero(const at::Tensor& t, bool as_tuple) {
   if (as_tuple) {
     auto res = std::vector<Shape>();
     for (auto dim_size : t.sizes()) {
@@ -714,7 +714,7 @@ std::vector<Shape> compute_shape_relu(const at::Tensor& self) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
-std::vector<Shape> compute_shape_bitwise_and(
+static std::vector<Shape> compute_shape_bitwise_and(
     const at::Tensor& self,
     const at::Scalar& other) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
@@ -758,7 +758,7 @@ std::vector<Shape> compute_shape_sort(
       Shape(c10::ScalarType::Long, self.sizes().vec())};
 }
 
-std::vector<Shape> compute_shape_smooth_l1_loss(
+static std::vector<Shape> compute_shape_smooth_l1_loss(
     const at::Tensor& self,
     const at::Tensor& target,
     int64_t reduction,

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -567,7 +567,7 @@ std::tuple<Tensor, Tensor, Tensor> LazyNativeFunctions::native_group_norm(
       input, weight, bias, N, C, HxW, group, eps);
 }
 
-void InitializeAtenBindings() {}
+static void InitializeAtenBindings() {}
 
 } // namespace lazy
 } // namespace torch

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -567,7 +567,5 @@ std::tuple<Tensor, Tensor, Tensor> LazyNativeFunctions::native_group_norm(
       input, weight, bias, N, C, HxW, group, eps);
 }
 
-static void InitializeAtenBindings() {}
-
 } // namespace lazy
 } // namespace torch

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -16,7 +16,7 @@ std::string GetFirstUserFrameInPythonIfEnabled() {
 namespace torch {
 namespace lazy {
 
-hash_t OperandHashes(
+static hash_t OperandHashes(
     const OpList& operands,
     const c10::ArrayRef<Shape>& shapes,
     const hash_t& seed,

--- a/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
@@ -64,34 +64,6 @@ static torch::jit::Value* GenerateClone(
   return cloned.front();
 }
 
-static void GenerateCopy(
-    torch::jit::Value* destination,
-    torch::jit::Value* source,
-    std::shared_ptr<torch::jit::GraphFunction> function) {
-  std::vector<torch::jit::NamedValue> arguments;
-  arguments.emplace_back(destination);
-  arguments.emplace_back(source);
-  LowerBuiltin(at::aten::copy_, function, arguments);
-}
-
-static torch::jit::Value* GenerateSlice(
-    torch::jit::Value* base,
-    int64_t dim,
-    int64_t start,
-    int64_t end,
-    int64_t step,
-    std::shared_ptr<torch::jit::GraphFunction> function) {
-  std::vector<torch::jit::NamedValue> arguments;
-  arguments.emplace_back(base);
-  arguments.emplace_back(dim);
-  arguments.emplace_back(start);
-  arguments.emplace_back(end);
-  arguments.emplace_back(step);
-  TSOpVector selected = LowerBuiltin(at::aten::slice, function, arguments);
-  TORCH_CHECK_EQ(selected.size(), 1);
-  return selected.front();
-}
-
 // Node Lowerings
 
 // Default node lowering

--- a/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
@@ -16,14 +16,14 @@
 namespace torch {
 namespace lazy {
 
-TSOpVector LowerBuiltin(
+static TSOpVector LowerBuiltin(
     const torch::lazy::Node* node,
     std::shared_ptr<torch::jit::GraphFunction> function,
     const std::vector<torch::jit::NamedValue>& arguments,
     const std::vector<torch::jit::NamedValue>& kwarguments = {}) {
   return LowerTSBuiltin(function, node->op().op, arguments, kwarguments);
 }
-TSOpVector LowerBuiltin(
+static TSOpVector LowerBuiltin(
     c10::Symbol sym,
     std::shared_ptr<torch::jit::GraphFunction> function,
     const std::vector<torch::jit::NamedValue>& arguments,
@@ -54,7 +54,7 @@ TSOpVector LowerTSBuiltin(
   return {sv.getValue()};
 }
 
-torch::jit::Value* GenerateClone(
+static torch::jit::Value* GenerateClone(
     torch::jit::Value* val,
     std::shared_ptr<torch::jit::GraphFunction> function) {
   std::vector<torch::jit::NamedValue> clone_arguments;
@@ -64,7 +64,7 @@ torch::jit::Value* GenerateClone(
   return cloned.front();
 }
 
-void GenerateCopy(
+static void GenerateCopy(
     torch::jit::Value* destination,
     torch::jit::Value* source,
     std::shared_ptr<torch::jit::GraphFunction> function) {
@@ -74,7 +74,7 @@ void GenerateCopy(
   LowerBuiltin(at::aten::copy_, function, arguments);
 }
 
-torch::jit::Value* GenerateSlice(
+static torch::jit::Value* GenerateSlice(
     torch::jit::Value* base,
     int64_t dim,
     int64_t start,

--- a/torch/csrc/profiler/standalone/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_graph_observer.cpp
@@ -503,7 +503,8 @@ static void recordOperatorStart(
   }
 }
 
-static std::unique_ptr<ObserverContext> onFunctionEnter(const RecordFunction& fn) {
+static std::unique_ptr<ObserverContext> onFunctionEnter(
+    const RecordFunction& fn) {
   using RunState = ExecutionGraphObserver::RunState;
   auto ob = ObserverManager::get();
   if (ob != nullptr && ob->getState() == RunState::enabled) {

--- a/torch/csrc/profiler/standalone/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_graph_observer.cpp
@@ -242,7 +242,7 @@ struct FunctionCallContext : public ObserverContext {
 };
 
 // Opens the json file to write the execution graph.
-std::ofstream openOutputFile(const std::string& name) {
+static std::ofstream openOutputFile(const std::string& name) {
   std::ofstream stream;
   stream.open(name, std::ofstream::out | std::ofstream::trunc);
   if (!stream) {
@@ -253,7 +253,7 @@ std::ofstream openOutputFile(const std::string& name) {
   return stream;
 }
 
-void writeJsonNode(
+static void writeJsonNode(
     std::ofstream& out,
     const std::string& name,
     const uint64_t id,
@@ -302,7 +302,7 @@ inline std::string timeString(const std::time_t timepoint) {
   return oss.str();
 }
 
-bool initExecutionGraphStart(ExecutionGraphObserver& ob) {
+static bool initExecutionGraphStart(ExecutionGraphObserver& ob) {
   ob.out = openOutputFile(ob.file_name);
   // If somehow the output stream failed to open, finish observer here.
   if (!ob.out) {
@@ -331,7 +331,7 @@ bool initExecutionGraphStart(ExecutionGraphObserver& ob) {
 }
 
 // Write out Execution Graph to file
-void finalizeExecutionGraphOutput(ExecutionGraphObserver& ob) {
+static void finalizeExecutionGraphOutput(ExecutionGraphObserver& ob) {
   writeJsonNode(
       ob.out,
       "[pytorch|profiler|execution_graph|process]",
@@ -437,7 +437,7 @@ inline void appendValueInfo(
   shapes.push_back(getValueShape(val));
 }
 
-void recordOperatorStart(
+static void recordOperatorStart(
     ExecutionGraphObserver& ob,
     FunctionCallContext& fc,
     const RecordFunction& fn) {
@@ -503,7 +503,7 @@ void recordOperatorStart(
   }
 }
 
-std::unique_ptr<ObserverContext> onFunctionEnter(const RecordFunction& fn) {
+static std::unique_ptr<ObserverContext> onFunctionEnter(const RecordFunction& fn) {
   using RunState = ExecutionGraphObserver::RunState;
   auto ob = ObserverManager::get();
   if (ob != nullptr && ob->getState() == RunState::enabled) {
@@ -542,7 +542,7 @@ inline std::string json_str_escape(const std::string& str) {
   return ostream.str();
 }
 
-void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
+static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
   using RunState = ExecutionGraphObserver::RunState;
   auto ob = ObserverManager::get();
   if (ob == nullptr || ctx_ptr == nullptr) {

--- a/torch/csrc/profiler/standalone/nvtx_observer.cpp
+++ b/torch/csrc/profiler/standalone/nvtx_observer.cpp
@@ -65,7 +65,7 @@ std::pair<at::RecordFunctionHandle, int> NVTXThreadLocalState::getOpIdFromInput(
   return producer_op_pair;
 }
 
-std::list<std::pair<at::RecordFunctionHandle, int>> flattenOpIdList(
+static std::list<std::pair<at::RecordFunctionHandle, int>> flattenOpIdList(
     c10::List<c10::IValue> list,
     std::string fn_name) {
   std::list<std::pair<at::RecordFunctionHandle, int>> input_op_id_list;
@@ -81,7 +81,7 @@ std::list<std::pair<at::RecordFunctionHandle, int>> flattenOpIdList(
   return input_op_id_list;
 }
 
-std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
+static std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
     const at::RecordFunction& fn) {
   std::pair<at::RecordFunctionHandle, int> undefined_op_pair(0, -1);
   std::list<std::pair<at::RecordFunctionHandle, int>> input_producer_ops_;
@@ -110,7 +110,7 @@ std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
   return input_producer_ops_;
 }
 
-void updateOutputTensorTracker(const at::RecordFunction& fn) {
+static void updateOutputTensorTracker(const at::RecordFunction& fn) {
   int output_nr = 0;
   auto state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -228,7 +228,7 @@ std::string stacksToStr(
   return "\"" + rc + "\"";
 }
 
-std::vector<std::vector<int64_t>> flattenList(
+static std::vector<std::vector<int64_t>> flattenList(
     c10::List<c10::IValue> list,
     std::string fn_name) {
   std::vector<std::vector<int64_t>> tensor_dims;


### PR DESCRIPTION
This PR relands the changes introduced in PR https://github.com/pytorch/pytorch/pull/100849. The old PR turnd nnc_* functions into  static. We now add declarations for them and hope that inter builds will pass.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang @izaitsevfb @albanD 