### PR TITLE
[partitioner] Disable CSE pass as it undo activation checkpointing

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -28,7 +28,7 @@ debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", False)
 static_weight_shapes = True
 
 # Applies CSE to the graph before partitioning
-cse = True
+cse = False
 
 # Restricts the amount of computation AOTAutograd can do.
 max_dist_from_bw = 3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102233
* #102203
* #102344
* #102123
* #102022


The understanding is that it does not really help with performance today. Those optimizations are present in Inductor anyways. For Activation checkpointing, it undoes the recomputation and raises peak memory footprint.
