### PR TITLE
Fixed an indentation error in the test_div_and_floordiv_vs_python function

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1847,10 +1847,10 @@ class TestBinaryUfuncs(TestCase):
                         self.assertEqual(actual_first_tensor, actual_tensor)
                         self.assertEqual(actual_second_tensor, actual_tensor)
 
-            _scalar_helper(operator.truediv, operator.truediv)
-            _scalar_helper(operator.truediv, torch.true_divide)
-            _scalar_helper(lambda a, b: math.floor(a / b), operator.floordiv)
-            _scalar_helper(lambda a, b: math.floor(a / b), torch.floor_divide)
+        _scalar_helper(operator.truediv, operator.truediv)
+        _scalar_helper(operator.truediv, torch.true_divide)
+        _scalar_helper(lambda a, b: math.floor(a / b), operator.floordiv)
+        _scalar_helper(lambda a, b: math.floor(a / b), torch.floor_divide)
 
     @onlyNativeDeviceTypes
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1846,7 +1846,7 @@ class TestBinaryUfuncs(TestCase):
                         self.assertEqual(actual_tensor.item(), expected)
                         self.assertEqual(actual_first_tensor, actual_tensor)
                         self.assertEqual(actual_second_tensor, actual_tensor)
-
+        
         _scalar_helper(operator.truediv, operator.truediv)
         _scalar_helper(operator.truediv, torch.true_divide)
         _scalar_helper(lambda a, b: math.floor(a / b), operator.floordiv)


### PR DESCRIPTION
Fixes #102147
Hello, 

Calls to _scalar_helper are moved out of the function's definition. 
They were previously indented under _scalar_helper's definition, indicating they were part of _scalar_helper, which was incorrect.  They are part of test_div_and_floordiv_vs_python, not _scalar_helper. 


