### PR TITLE
Improve debuggability of activation checkpointing

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
 )
 from weakref import ReferenceType
+from torch.testing._internal.logging_tensor import LoggingTensorMode
 
 import torch
 
@@ -290,6 +291,8 @@ def checkpoint(
     *args,
     use_reentrant: Optional[bool] = None,
     context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
+    determinism_check: str = "default",
+    debug: bool = False,
     **kwargs
 ):
     r"""Checkpoint a model or part of the model
@@ -382,6 +385,18 @@ def checkpoint(
             context managers. The function and its recomputation will be run
             under the first and second context managers respectively.
             This argument is only supported if ``use_reentrant=False``.
+        determinism_check(str, optional): A string specifying the determinism
+            check to perform. By default it is set to ``"default"`` which
+            compares the shapes, dtypes, and devices of the recomputed tensors
+            against those the saved tensors. To turn off this check, specify
+            ``"none"``. Currently these are the only two supported values.
+            Please open an issue if you would like to see more determinism
+            checks. This argument is only supported if ``use_reentrant=False``,
+            if ``use_reentrant=True``, the determinism check is always disabled.
+        debug(bool, optional): If ``True``, error messages will also include
+            a trace of the operators ran during the original forward computation
+            as well as the recomputation. This argument is only supported if
+            ``use_reentrant=False``.
         args: tuple containing inputs to the :attr:`function`
 
     Returns:
@@ -405,9 +420,10 @@ def checkpoint(
         )
 
     if use_reentrant:
-        if context_fn is not noop_context_fn:
+        if context_fn is not noop_context_fn or debug is not False:
             raise ValueError(
-                "Passing context_fn is only supported when use_reentrant=False."
+                "Passing `context_fn` or `debug` is only supported when "
+                "use_reentrant=False."
             )
         return CheckpointFunction.apply(function, preserve, *args)
     else:
@@ -415,6 +431,8 @@ def checkpoint(
             function,
             preserve,
             context_fn,
+            determinism_check,
+            debug,
             *args,
             **kwargs,
         )
@@ -717,7 +735,7 @@ class _NoopSaveInputs(torch.autograd.Function):
 
 
 class _CheckpointFrame:
-    def __init__(self, recompute_fn, early_stop):
+    def __init__(self, recompute_fn, early_stop, unpack_error_cb, metadata_fn):
         self.recompute_fn = recompute_fn
         self.input_saver = None
         self.weak_holders: List[ReferenceType] = []
@@ -735,6 +753,171 @@ class _CheckpointFrame:
         # See Rule 5
         self.early_stop = early_stop
 
+        # Debugging
+        self.metadata_fn = metadata_fn
+        self.unpack_error_cb = unpack_error_cb
+        self.x_metadatas = []
+        self.forward_completed = False
+
+    def check_recomputed_tensors_match(self, gid):
+        # NOTE [ Error handling for checkpoint ]
+        #
+        # At a high level, we need to check that the tensors saved
+        # during original forward matches tensors saved during recompute
+        # This means handling 3 cases:
+        #
+        # 1. During recompute, more tensors were saved.
+        #
+        #    Usually this is hidden due to the StopRecomputationError
+        #    but if early stop is not enabled, or we would have errored
+        #    anyway because there aren't enough weak_holders. But we
+        #    do want to have a nice error. See the _recomputation_hook
+        #    for details.
+
+        if not len(self.weak_holders) == self.recomp_counter[gid]:
+            # 2. During recompute, fewer tensors were saved
+            #
+            # We know that everytime we save something do original forward
+            # we append to weak_holder, and every time we save a tensor
+            # during recompute we increment recompute_counter.
+            raise CheckpointError(
+                "torch.utils.checkpoint: A different number of tensors was saved "
+                "during the original forward and recomputation.\n"
+                f"Number of tensors saved during forward: {len(self.weak_holders)}\n"
+                f"Number of tensors saved during recomputation: {self.recomp_counter[gid]}"
+            )
+
+        # 3. During recompute, the same tensors were saved, but they
+        #    have different metadata
+        nb_meta_different = []
+        for idx, weak_holder in enumerate(self.weak_holders):
+            holder = weak_holder()
+            if holder is None:
+                continue
+            # We've seen all holders since we iterate over them in order
+            # For every holder that is still alive now, it must've been
+            # alive when we saw it during recompute, therefore, the
+            # gid must be set.
+            _internal_assert(gid in holder.handles)
+            # We know this is the first unpack, so it couldn't have been set
+            # to None yet.
+            _internal_assert(holder.handles[gid] is not None)
+            # We always set these together in the recomputation hook
+            _internal_assert(holder.handles[gid] in self.recomputed[gid])
+            # see pack hook, x_metadata is 1:1 with weak_holders.
+            x_meta = self.x_metadatas[idx]
+            recomputed_x = self.recomputed[gid][holder.handles[gid]]
+            if x_meta != self.metadata_fn(recomputed_x):
+                nb_meta_different.append((idx, x_meta, self.metadata_fn(recomputed_x)))
+
+        if len(nb_meta_different) > 0:
+            mismatched_tensors = ""
+            for idx, x_meta, recomputed_meta in nb_meta_different:
+                mismatched_tensors += (
+                    f"tensor at position {idx}:\n"
+                    f"saved metadata: {x_meta}\n"
+                    f"recomputed metadata: {recomputed_meta}\n"
+                )
+            raise CheckpointError(
+                "torch.utils.checkpoint: Recomputed values for the following tensors "
+                "have different metadata than during the forward pass.\n"
+                f"{mismatched_tensors}"
+            )
+
+
+_checkpoint_error_template = """ \
+An error happened while unpacking tensors; dumping logs of latest computation
+because you passed `debug=True` to `torch.utils.checkpoint.checkpoint()`.
+Scroll all the way down for guidance on how to navigate these logs.
+
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+|        1. Stack traces of the operators that ran in the original forward
++------------------------------------------------------------------------------+
+
+{forward_traces}
+
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+|        2. Stack traces of the operators that ran during recomputation
++------------------------------------------------------------------------------+
+
+{recompute_traces}
+
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+|      3. Traces of the operators in the original forward and recomputation
++------------------------------------------------------------------------------+
+(Scroll up to correlate stack traces with each operation listed below. This
+ helps identify their source in the code.)
+
+IMPORTANT: Differences in "detach" calls between the original forward and the
+           recomputation are expected. They are introduced by the checkpointing
+           mechanism and can be ignored.
+
+Operations executed during the original forward:
+{forward_ops}
+
+Operations executed during recomputation:
+{recompute_ops}
+
++------------------------------------------------------------------------------+
+ ERROR: Detected non-determinism while running activation checkpointing
+
+ You are seeing this error because you passed `debug=True` to checkpoint and
+ tensors to be saved during the original forward and differ between those saved
+ during recomputation. This can happen if different operators were ran in the
+ original forward and in the recomputation.
+
+ To identify where the mismatch may be coming from, you can do the following:
+
+ 1) Compare the operators ran during original forward and recomputation to
+    see where they differ. These operators are printed above in the order they
+    were executed.
+
+ 2) Review the stack trace for each operator to locate its invocation source.
+    Each operator's stack trace is printed in their execution order.
+
+ Note that the logs can be quite long. Here's how they are structured:
+
+ 1. Original Forward Operator Stack Traces
+ 2. Recomputation Operator Stack Traces
+ 3. Operations in Original Forward and Recomputation
+ 4. Error message                                       <--- You are here
+--------------------------------------------------------------------------------
+"""
+
+def _get_debug_context_and_cb() -> Tuple[Optional[Dict[str, Any]], Optional[Callable]]:
+    logging_mode_fwd = LoggingTensorMode(collect_logs=True)
+    logging_mode_recompute = LoggingTensorMode(collect_logs=True)
+
+    def unpack_error_cb(e: CheckpointError):
+        raise CheckpointError(
+            _checkpoint_error_template.format(
+                forward_traces=logging_mode_fwd.str_traces(),
+                recompute_traces=logging_mode_fwd.str_traces(),
+                forward_ops=logging_mode_fwd.str_logs(),
+                recompute_ops=logging_mode_recompute.str_logs(),
+            )
+        ) from e
+
+    def context_fn():
+        return logging_mode_fwd, logging_mode_recompute
+
+    return context_fn, unpack_error_cb
+
+def _default_meta_extractor(x: torch.Tensor) -> Dict[str, Any]:
+    # These properties are fast to check, easy to understand
+    return {
+        "shape": x.shape,
+        "dtype": x.dtype,
+        "device": x.device
+    }
+
+_allowed_determinism_checks_to_fns: Dict[str, Callable[[torch.Tensor], Any]] = {
+    "default": _default_meta_extractor,
+    "none": lambda _: None,
+}
+
+class CheckpointError(Exception):
+    pass
 
 # See Rule 5
 class _StopRecomputationError(Exception):
@@ -750,9 +933,15 @@ class _recomputation_hook(torch.autograd.graph.saved_tensors_hooks):
             target_frame.recomp_counter[gid] += 1
 
             if recomp_idx >= len(target_frame.weak_holders):
-                # We run into this case when early stop is not enabled and do
-                # grad within checkpoint.
-                return x.detach()
+                if not target_frame.forward_completed:
+                    # We run into this case when early stop is not enabled and do
+                    # grad within checkpoint.
+                    return x.detach()
+                raise CheckpointError(
+                    "torch.utils.checkpoint: trying to save more tensors during "
+                    "recomputation than during the original forward pass."
+                )
+
             holder = target_frame.weak_holders[recomp_idx]()
 
             # This holder may have been cleared because someone may have called
@@ -779,10 +968,14 @@ class _recomputation_hook(torch.autograd.graph.saved_tensors_hooks):
 
 class _checkpoint_hook(torch.autograd.graph.saved_tensors_hooks):
     def __init__(self, frame):
-        def pack_hook(_unused_x):
+        def pack_hook(x):
             # See Rule 4 above
             holder = _Holder()
             frame.weak_holders.append(weakref.ref(holder))
+            # Save metadata to detect non-determinism
+            if frame.metadata_fn is not None:
+                with torch.no_grad():
+                    frame.x_metadatas.append(frame.metadata_fn(x))
             return holder
 
         def unpack_hook(holder):
@@ -807,20 +1000,30 @@ class _checkpoint_hook(torch.autograd.graph.saved_tensors_hooks):
                 except _StopRecomputationError:
                     pass
                 frame.is_recomputed[gid] = True
+                frame.check_recomputed_tensors_match(gid)
+
+            _internal_assert(gid in holder.handles)
 
             if holder.handles[gid] is None:
-                raise RuntimeError(
-                    "torch.utils.checkpoint: unpack is being triggered for a tensor that was either "
-                    "never recomputed, or already unpacked once. If you are calling ctx.saved_tensors "
-                    "in backward, make sure to do so only once. Otherwise please open an issue with "
-                    "details on your use case."
+                raise CheckpointError(
+                    "torch.utils.checkpoint: Unpack is being triggered for a tensor that was already "
+                    "unpacked once. If you are calling ctx.saved_tensors in backward, make sure to do "
+                    "so only once. Otherwise please open an issue with details on your use case."
                 )
             _internal_assert(holder.handles[gid] in frame.recomputed[gid])
             ret = frame.recomputed[gid][holder.handles[gid]]
             holder.handles[gid] = None
             return ret
 
-        super().__init__(pack_hook, unpack_hook)
+        if frame.unpack_error_cb is not None:
+            def unpack_hook_with_error_cb(holder):
+                try:
+                    return unpack_hook(holder)
+                except CheckpointError as e:
+                    frame.unpack_error_cb(e)
+            super().__init__(pack_hook, unpack_hook_with_error_cb)
+        else:
+            super().__init__(pack_hook, unpack_hook)
 
 
 # NB: this helper wraps fn before calling checkpoint_impl. kwargs and
@@ -829,6 +1032,8 @@ def _checkpoint_without_reentrant(
     fn,
     preserve_rng_state=True,
     context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
+    determinism_check: str = "default",
+    debug: bool = False,
     *args,
     **kwargs
 ):
@@ -845,9 +1050,36 @@ def _checkpoint_without_reentrant(
         context_fn(Callable, optional): A callable returning a tuple of two
             context managers. The function and its recomputation will be run
             under the first and second context managers respectively.
+        determinism_check(str, optional): A string specifying the determinism
+            check to perform. By default it is set to ``"default"`` which
+            compares the shapes, dtypes, and devices of the recomputed tensors
+            against those the saved tensors. To turn off this check, specify
+            ``"none"``. Currently these are the only two supported values.
+            Please open an issue if you would like to see more determinism
+            checks.
+        debug(bool, optional): If ``True``, error messages will also include
+            a trace of the operators ran during the original forward computation
+            as well as the recomputation.
         *args: Arguments to pass in to the given ``function``.
         **kwargs: Keyword arguments to pass into the given ``function``.
     """
+    unpack_error_cb = None
+
+    if debug:
+        if context_fn != noop_context_fn:
+            raise ValueError(
+                "debug=True is incompatible with non-default context_fn"
+            )
+        context_fn, unpack_error_cb = _get_debug_context_and_cb()
+
+    if determinism_check in _allowed_determinism_checks_to_fns:
+        metadata_fn = _allowed_determinism_checks_to_fns[determinism_check]
+    else:
+        raise ValueError(
+            f"determinism_check should be one of {list(_allowed_determinism_checks_to_fns.keys())}, "
+            f"but got {determinism_check}"
+        )
+
     device = _infer_device_type(*args)
     device_module = _get_device_module(device)
     forward_context, recompute_context = context_fn()
@@ -886,7 +1118,12 @@ def _checkpoint_without_reentrant(
             ), torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:
                 fn(*args, **kwargs)
 
-    new_frame = _CheckpointFrame(recompute_fn, _enable_checkpoint_early_stop)
+    new_frame = _CheckpointFrame(
+        recompute_fn,
+        _enable_checkpoint_early_stop,
+        unpack_error_cb,
+        metadata_fn
+    )
     dummy = torch.empty((0,), requires_grad=True)
     new_frame.input_saver = _NoopSaveInputs.apply(dummy, kwargs, *args)
 
@@ -896,6 +1133,7 @@ def _checkpoint_without_reentrant(
 
     with _checkpoint_hook(new_frame), forward_context:
         ret = fn(*args, **kwargs)
+    new_frame.forward_completed = True
 
     if device_module._initialized and preserve_rng_state and not had_device_in_fwd:
         # Device was not initialized before running the forward, so we didn't


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102241
* #102309
* #102860
* #102859

This PR makes some improvements for debuggability of checkpointing:
- improved error messages that are more understandable
- errors are now `CheckpointError` which subclasses `RuntimeError` (only `CheckpointError` triggers debug message, see below)
- stricter error checking by default:
   - shapes, dtypes, and device are compared 
   - we also now error when more tensors are being saved for backward during recompute
   - NOTE: checks are relaxed if it is detected that you are doing backward within forward
 - shapes, dtype, and device checking can be disabled by passing `determinism_check="none"`
 - new debug flag: more helpful error message when `debug=True`

Note:
- cpp stack trace is only included for x86 linux machines
- the error message if cpp stack trace is included can be quite long. For a function checkpointed with 8 operators, the log was around 1300 lines! (should this be hidden behind a flag?)

<details>

<summary>
click to see error message when debug='True' (python stack trace only)
</summary>

```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Recomputed values for the following tensors have different metadata than during the forward pass.
tensor at position 1:
saved metadata: {'shape': torch.Size([1]), 'dtype': torch.float32, 'device': device(type='cpu')}
recomputed metadata: {'shape': torch.Size([2]), 'dtype': torch.float32, 'device': device(type='cpu')}


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/local/pytorch1/test/test_autograd.py", line 5692, in test_checkpoint_detects_non_determinism
    out.backward()
  File "/local/pytorch1/torch/_tensor.py", line 488, in backward
    torch.autograd.backward(
  File "/local/pytorch1/torch/autograd/__init__.py", line 204, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/local/pytorch1/torch/utils/checkpoint.py", line 1065, in unpack_hook_with_error_cb
    frame.unpack_error_cb(e)
  File "/local/pytorch1/torch/utils/checkpoint.py", line 936, in unpack_error_cb
    raise CheckpointError(
torch.utils.checkpoint.CheckpointError:  An error happened while unpacking tensors; dumping logs of latest computation
because you passed `debug=True` to `torch.utils.checkpoint.checkpoint()`.
Scroll all the way down for guidance on how to navigate these logs.

+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|        1. Stack traces of the operators that ran in the original forward     |
+------------------------------------------------------------------------------+

$1: f32[1] = torch._ops.aten.sin.default($0)   (1 of 2 in original)

/local/pytorch1/test/test_autograd.py:5648:save_2_tensors
/local/pytorch1/test/test_autograd.py:5658:fn
/local/pytorch1/torch/utils/checkpoint.py:1177:_checkpoint_without_reentrant
/local/pytorch1/torch/utils/checkpoint.py:431:checkpoint
/local/pytorch1/test/test_autograd.py:5691:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$2: f32[1] = torch._ops.aten.exp.default($1)   (2 of 2 in original)

/local/pytorch1/test/test_autograd.py:5648:save_2_tensors
/local/pytorch1/test/test_autograd.py:5658:fn
/local/pytorch1/torch/utils/checkpoint.py:1177:_checkpoint_without_reentrant
/local/pytorch1/torch/utils/checkpoint.py:431:checkpoint
/local/pytorch1/test/test_autograd.py:5691:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>


+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|        2. Stack traces of the operators that ran during recomputation        |
+------------------------------------------------------------------------------+

$1: f32[1] = torch._ops.aten.detach.default($0)   (1 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:998:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$2: f32[1] = torch._ops.aten.detach.default($1)   (2 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:998:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$3: f32[1] = torch._ops.aten.detach.default($0)   (3 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:1005:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$4: f32[1] = torch._ops.aten.detach.default($3)   (4 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:1005:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$5: f32[1] = torch._ops.aten.sin.default($0)   (5 of 8 in recompute)

/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$6: f32[2] = torch._ops.aten.lift_fresh.default($6)   (6 of 8 in recompute)

/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$7: f32[2] = torch._ops.aten.detach.default($6)   (7 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:998:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>

$8: f32[2] = torch._ops.aten.detach.default($7)   (8 of 8 in recompute)

/local/pytorch1/torch/utils/checkpoint.py:998:pack_hook
/local/pytorch1/test/test_autograd.py:5651:save_2_tensors_alt
/local/pytorch1/test/test_autograd.py:5660:fn
/local/pytorch1/torch/utils/checkpoint.py:1161:recompute_fn
/local/pytorch1/torch/utils/checkpoint.py:1041:unpack_hook
/local/pytorch1/torch/utils/checkpoint.py:1063:unpack_hook_with_error_cb
/local/pytorch1/torch/autograd/__init__.py:204:backward
/local/pytorch1/torch/_tensor.py:488:backward
/local/pytorch1/test/test_autograd.py:5692:test_checkpoint_detects_non_determinism
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:550:_callTestMethod
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:592:run
/local/pytorch1/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/local/pytorch1/torch/testing/_internal/common_utils.py:2319:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/case.py:651:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:122:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/suite.py:84:__call__
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/runner.py:184:run
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:271:runTests
/opt/miniconda3/envs/pytorch1/lib/python3.9/unittest/main.py:101:__init__
/local/pytorch1/torch/testing/_internal/common_utils.py:892:run_tests
/local/pytorch1/test/test_autograd.py:11248:<module>


+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|       3. Log of operators in the original forward and recomputation          |
+------------------------------------------------------------------------------+
(Scroll up to correlate stack traces with each operation listed below. This
 helps identify their source in the code.)

IMPORTANT: Differences in "detach" calls between the original forward and the
           recomputation are expected. They are introduced by the checkpointing
           mechanism and can be ignored.

Operations executed during the original forward:

$1: f32[1] = torch._ops.aten.sin.default($0)
$2: f32[1] = torch._ops.aten.exp.default($1)

Operations executed during recomputation:

$1: f32[1] = torch._ops.aten.detach.default($0)
$2: f32[1] = torch._ops.aten.detach.default($1)
$3: f32[1] = torch._ops.aten.detach.default($0)
$4: f32[1] = torch._ops.aten.detach.default($3)
$5: f32[1] = torch._ops.aten.sin.default($0)
$6: f32[2] = torch._ops.aten.lift_fresh.default($6)
$7: f32[2] = torch._ops.aten.detach.default($6)
$8: f32[2] = torch._ops.aten.detach.default($7)

+------------------------------------------------------------------------------+
 ERROR: Detected non-determinism while running activation checkpointing

 You are seeing this error because you passed `debug=True` to checkpoint and
 tensors to be saved during the original forward and differ between those saved
 during recomputation. This can happen if different operators were ran in the
 original forward and in the recomputation.

 To identify where the mismatch may be coming from, you can do the following:

 1) Compare the operators ran during original forward and recomputation to
    see where they differ. These operators are printed above in the order they
    were executed.

 2) Review the stack trace for each operator to locate its invocation source.
    Each operator's stack trace is printed in their execution order.

 Note that the logs can be quite long. Here's how they are structured:
 (Tip: you can Ctrl-f for these headers)

 1. Stack traces of the operators that ran in the original forward
 2. Stack traces of the operators that ran during recomputation
 3. Log of operators in the original forward and recomputation
 4. Error message                                             <--- You are here
--------------------------------------------------------------------------------
```

</details>

<details>

<summary>
click to see error message when debug='True' (with python and cpp stacktrace)
</summary>

```
======================================================================
ERROR: test_checkpoint_detects_non_determinism (__main__.TestAutograd)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py", line 1071, in unpack_hook_with_error_cb
    return unpack_hook(holder)
  File "/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py", line 1053, in unpack_hook
    frame.check_recomputed_tensors_match(gid)
  File "/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py", line 826, in check_recomputed_tensors_match
    raise CheckpointError(
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Recomputed values for the following tensors have different metadata than during the forward pass.
tensor at position 1:
saved metadata: {'shape': torch.Size([1]), 'dtype': torch.float32, 'device': device(type='cpu')}
recomputed metadata: {'shape': torch.Size([2]), 'dtype': torch.float32, 'device': device(type='cpu')}


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/jw3468/local/a/pytorch/test/test_autograd.py", line 5695, in test_checkpoint_detects_non_determinism
    out.backward()
  File "/home/jw3468/local/a/pytorch/torch/_tensor.py", line 488, in backward
    torch.autograd.backward(
  File "/home/jw3468/local/a/pytorch/torch/autograd/__init__.py", line 204, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py", line 1073, in unpack_hook_with_error_cb
    frame.unpack_error_cb(e)
  File "/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py", line 944, in unpack_error_cb
    raise CheckpointError(
torch.utils.checkpoint.CheckpointError:  An error happened while unpacking tensors; dumping logs of latest computation
because you passed `debug=True` to `torch.utils.checkpoint.checkpoint()`.
Scroll all the way down for guidance on how to navigate these logs.

+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|        1. Stack traces of the operators that ran in the original forward     |
+------------------------------------------------------------------------------+

$1: f32[1] = torch._ops.aten.sin.default($0)   (1 of 2 in original)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5648:save_2_tensors
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5659:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1185:_checkpoint_without_reentrant
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:431:checkpoint
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5694:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$2: f32[1] = torch._ops.aten.exp.default($1)   (2 of 2 in original)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::exp::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableType_2.cpp:0:torch::autograd::VariableType::(anonymous namespace)::exp(c10::DispatchKeySet, at::Tensor const&)
VariableType_2.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::exp>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::exp::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_exp(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5648:save_2_tensors
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5659:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1185:_checkpoint_without_reentrant
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:431:checkpoint
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5694:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start



+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|        2. Stack traces of the operators that ran during recomputation        |
+------------------------------------------------------------------------------+

$1: f32[1] = torch._ops.aten.detach.default($0)   (1 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1006:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$2: f32[1] = torch._ops.aten.detach.default($1)   (2 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::torchDispatchFromTensorImpl(c10::TensorImpl const*, char const*, _object*, char const*, c10::SmallVector<pybind11::object, 1u>)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::detach(c10::TensorImpl const*) const
??:0:c10::intrusive_ptr<c10::TensorImpl, c10::detail::intrusive_target_default_null_type<c10::TensorImpl> > c10::TensorImpl::shallow_copy_and_detach_core<c10::VariableVersion const&>(c10::VariableVersion const&, bool) const
??:0:c10::TensorImpl::shallow_copy_and_detach(c10::VariableVersion const&, bool) const
offloadstuff.c:0:torch::autograd::make_variable_non_differentiable_view(at::Tensor, at::Tensor const&, bool)
offloadstuff.c:0:torch::autograd::as_view(at::Tensor const&, at::Tensor const&, bool, bool, std::function<at::Tensor (at::Tensor const&)>, torch::autograd::CreationMeta, bool)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1006:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$3: f32[1] = torch._ops.aten.detach.default($0)   (3 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1013:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$4: f32[1] = torch._ops.aten.detach.default($3)   (4 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::torchDispatchFromTensorImpl(c10::TensorImpl const*, char const*, _object*, char const*, c10::SmallVector<pybind11::object, 1u>)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::detach(c10::TensorImpl const*) const
??:0:c10::intrusive_ptr<c10::TensorImpl, c10::detail::intrusive_target_default_null_type<c10::TensorImpl> > c10::TensorImpl::shallow_copy_and_detach_core<c10::VariableVersion const&>(c10::VariableVersion const&, bool) const
??:0:c10::TensorImpl::shallow_copy_and_detach(c10::VariableVersion const&, bool) const
offloadstuff.c:0:torch::autograd::make_variable_non_differentiable_view(at::Tensor, at::Tensor const&, bool)
offloadstuff.c:0:torch::autograd::as_view(at::Tensor const&, at::Tensor const&, bool, bool, std::function<at::Tensor (at::Tensor const&)>, torch::autograd::CreationMeta, bool)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1013:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$5: f32[1] = torch._ops.aten.sin.default($0)   (5 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::sin(c10::DispatchKeySet, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::sin>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::sin::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_sin(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$6: f32[2] = torch._ops.aten.lift_fresh.default($6)   (6 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::lift_fresh::call(at::Tensor const&)
tensor_new.cpp:0:torch::utils::(anonymous namespace)::internal_new_from_data(c10::TensorOptions, c10::ScalarType, c10::optional<c10::Device>, _object*, bool, bool, bool, bool)
??:0:torch::utils::tensor_ctor(c10::DispatchKey, c10::ScalarType, torch::PythonArgs&)
python_torch_functions_manual.cpp:0:torch::autograd::THPVariable_tensor(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$7: f32[2] = torch._ops.aten.detach.default($6)   (7 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const
PythonFallbackKernel.cpp:0:(anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1006:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::mul_Tensor(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::mul_Tensor>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&, at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&)
??:0:at::_ops::mul_Tensor::call(at::Tensor const&, at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_mul(_object*, _object*, _object*)
python_variable_methods.cpp:0:_object* torch::autograd::TypeError_to_NotImplemented_<&torch::autograd::THPVariable_mul>(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:344:method_vectorcall_VARARGS_KEYWORDS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7284:slot_nb_multiply
/usr/local/src/conda/python-3.10.11/Objects/abstract.c:891:binary_op1
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Python/ceval.c:2003:_PyEval_EvalFrameDefault
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start


$8: f32[2] = torch._ops.aten.detach.default($7)   (8 of 8 in recompute)

/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:577:PyObject_CallMethod
??:0:torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<pybind11::handle>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName)
PyInterpreter.cpp:0:(anonymous namespace)::torchDispatchFromTensorImpl(c10::TensorImpl const*, char const*, _object*, char const*, c10::SmallVector<pybind11::object, 1u>)
PyInterpreter.cpp:0:(anonymous namespace)::ConcretePyInterpreterVTable::detach(c10::TensorImpl const*) const
??:0:c10::intrusive_ptr<c10::TensorImpl, c10::detail::intrusive_target_default_null_type<c10::TensorImpl> > c10::TensorImpl::shallow_copy_and_detach_core<c10::VariableVersion const&>(c10::VariableVersion const&, bool) const
??:0:c10::TensorImpl::shallow_copy_and_detach(c10::VariableVersion const&, bool) const
offloadstuff.c:0:torch::autograd::make_variable_non_differentiable_view(at::Tensor, at::Tensor const&, bool)
offloadstuff.c:0:torch::autograd::as_view(at::Tensor const&, at::Tensor const&, bool, bool, std::function<at::Tensor (at::Tensor const&)>, torch::autograd::CreationMeta, bool)
offloadstuff.c:0:torch::ADInplaceOrView::detach(c10::DispatchKeySet, at::Tensor const&)
offloadstuff.c:0:c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::ADInplaceOrView::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, at::Tensor (c10::DispatchKeySet, at::Tensor const&)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::redispatch(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:torch::autograd::VariableType::(anonymous namespace)::detach(c10::DispatchKeySet, at::Tensor const&)
VariableTypeManual.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::detach>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&)
??:0:at::_ops::detach::call(at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_detach(_object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:432:method_vectorcall_NOARGS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1006:pack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_pack_hook(at::Tensor const&)
??:0:torch::autograd::SavedVariable::set_hooks_and_pack_data(std::unique_ptr<torch::autograd::SavedVariableHooks, std::default_delete<torch::autograd::SavedVariableHooks> >&&, at::Tensor const&)
??:0:torch::autograd::SavedVariable::SavedVariable(at::Tensor const&, bool, bool)
VariableType_0.cpp:0:torch::autograd::VariableType::(anonymous namespace)::mul_Tensor(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&)
VariableType_0.cpp:0:c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&, at::Tensor const&), &torch::autograd::VariableType::(anonymous namespace)::mul_Tensor>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, at::Tensor const&> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
PythonFallbackKernel.cpp:0:void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
offloadstuff.c:0:c10::impl::BoxedKernelWrapper<at::Tensor (at::Tensor const&, at::Tensor const&), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, at::Tensor const&)
??:0:at::_ops::mul_Tensor::call(at::Tensor const&, at::Tensor const&)
python_variable_methods.cpp:0:torch::autograd::THPVariable_mul(_object*, _object*, _object*)
python_variable_methods.cpp:0:_object* torch::autograd::TypeError_to_NotImplemented_<&torch::autograd::THPVariable_mul>(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/descrobject.c:344:method_vectorcall_VARARGS_KEYWORDS
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7284:slot_nb_multiply
/usr/local/src/conda/python-3.10.11/Objects/abstract.c:891:binary_op1
/home/jw3468/local/a/pytorch/test/test_autograd.py:5651:save_2_tensors_alt
/usr/local/src/conda/python-3.10.11/Python/ceval.c:2003:_PyEval_EvalFrameDefault
/home/jw3468/local/a/pytorch/test/test_autograd.py:5661:fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1169:recompute_fn
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1049:unpack_hook
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch/torch/utils/checkpoint.py:1071:unpack_hook_with_error_cb
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/autograd/__init__.py:204:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:841:PyObject_CallFunctionObjArgs
??:0:torch::autograd::PySavedVariableHooks::call_unpack_hook()
??:0:torch::autograd::SavedVariable::unpack(std::shared_ptr<torch::autograd::Node>) const
??:0:torch::autograd::generated::ExpBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
offloadstuff.c:0:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)
??:0:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&)
??:0:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&)
??:0:torch::autograd::Engine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::python::PythonEngine::execute_with_graph_task(std::shared_ptr<torch::autograd::GraphTask> const&, std::shared_ptr<torch::autograd::Node>, torch::autograd::InputBuffer&&)
??:0:torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&)
??:0:THPEngine_run_backward(_object*, _object*, _object*)
/usr/local/src/conda/python-3.10.11/Objects/methodobject.c:543:cfunction_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/_tensor.py:488:backward
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:5695:test_checkpoint_detects_non_determinism
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:549:_callTestMethod
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:591:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2248:_run_with_retry
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:2319:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/case.py:650:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:122:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/suite.py:84:__call__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:5945:do_call_core
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/runner.py:184:run
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:7494:slot_tp_call
/usr/local/src/conda/python-3.10.11/Objects/call.c:215:_PyObject_MakeTpCall
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:271:runTests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch-env/lib/python3.10/unittest/main.py:101:__init__
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/torch/testing/_internal/common_utils.py:892:run_tests
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Objects/call.c:153:_PyObject_FastCallDictTstate
/usr/local/src/conda/python-3.10.11/Objects/call.c:431:_PyObject_Call_Prepend
/usr/local/src/conda/python-3.10.11/Objects/typeobject.c:1135:type_call
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:112:_PyObject_VectorcallTstate
/home/jw3468/local/a/pytorch/test/test_autograd.py:11251:<module>
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Include/cpython/abstract.h:114:_PyObject_VectorcallTstate
/usr/local/src/conda/python-3.10.11/Include/internal/pycore_ceval.h:46:_PyEval_EvalFrame
/usr/local/src/conda/python-3.10.11/Python/ceval.c:1134:PyEval_EvalCode
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1291:run_eval_code_obj
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1312:run_mod
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:1208:pyrun_file
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:456:_PyRun_SimpleFileObject
/usr/local/src/conda/python-3.10.11/Python/pythonrun.c:90:_PyRun_AnyFileObject
/usr/local/src/conda/python-3.10.11/Modules/main.c:357:pymain_run_file_obj
/usr/local/src/conda/python-3.10.11/Modules/main.c:1090:Py_BytesMain
??:0:__libc_start_call_main
:0:__libc_start_main_alias_2
??:0:_start



+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|       3. Log of operators in the original forward and recomputation          |
+------------------------------------------------------------------------------+
(Scroll up to correlate stack traces with each operation listed below. This
 helps identify their source in the code.)

IMPORTANT: Differences in "detach" calls between the original forward and the
           recomputation are expected. They are introduced by the checkpointing
           mechanism and can be ignored.

Operations executed during the original forward:

$1: f32[1] = torch._ops.aten.sin.default($0)
$2: f32[1] = torch._ops.aten.exp.default($1)

Operations executed during recomputation:

$1: f32[1] = torch._ops.aten.detach.default($0)
$2: f32[1] = torch._ops.aten.detach.default($1)
$3: f32[1] = torch._ops.aten.detach.default($0)
$4: f32[1] = torch._ops.aten.detach.default($3)
$5: f32[1] = torch._ops.aten.sin.default($0)
$6: f32[2] = torch._ops.aten.lift_fresh.default($6)
$7: f32[2] = torch._ops.aten.detach.default($6)
$8: f32[2] = torch._ops.aten.detach.default($7)

+------------------------------------------------------------------------------+
 ERROR: Detected non-determinism while running activation checkpointing

 You are seeing this error because you passed `debug=True` to checkpoint and
 tensors to be saved during the original forward and differ between those saved
 during recomputation. This can happen if different operators were ran in the
 original forward and in the recomputation.

 To identify where the mismatch may be coming from, you can do the following:

 1) Compare the operators ran during original forward and recomputation to
    see where they differ. These operators are printed above in the order they
    were executed.

 2) Review the stack trace for each operator to locate its invocation source.
    Each operator's stack trace is printed in their execution order.

 Note that the logs can be quite long. Here's how they are structured:
 (Tip: you can Ctrl-f for these headers)

 1. Stack traces of the operators that ran in the original forward
 2. Stack traces of the operators that ran during recomputation
 3. Log of operators in the original forward and recomputation
 4. Error message                                             <--- You are here
--------------------------------------------------------------------------------
```

</details>