### PR TITLE
equality assertions

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -703,6 +703,13 @@ class Constraint(ConstraintTarget):
             "dim": self.dim,
             "min": self.constraint_range.vr.lower,
             "max": self.constraint_range.vr.upper,
+            "shared": (
+                None if self.shared is None
+                else {
+                    "t_id": self.shared.t_id,
+                    "dim": self.shared.dim,
+                }
+            )
         }
 
     def __eq__(self, other):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -704,12 +704,13 @@ class Constraint(ConstraintTarget):
             "min": self.constraint_range.vr.lower,
             "max": self.constraint_range.vr.upper,
             "shared": (
-                None if self.shared is None
+                None
+                if self.shared is None
                 else {
                     "t_id": self.shared.t_id,
                     "dim": self.shared.dim,
                 }
-            )
+            ),
         }
 
     def __eq__(self, other):

--- a/torch/_export/graph_module.py
+++ b/torch/_export/graph_module.py
@@ -284,7 +284,11 @@ def make_export_graph_module(
         out_spec=out_spec,
         update_spec=0,
         mutation=mutation if mutation else [],
-        input_shape_constraints=input_shape_constraints_by_src_name,
+        input_shape_constraints={
+            # copy because pickle cannot handle defaultdict with lambda factory
+            name: constraints
+            for name, constraints in input_shape_constraints_by_src_name.items()
+        },
         inline_constraints=inline_constraints,
         input_name_to_example_inputs=input_name_to_example_inputs,
     )

--- a/torch/_export/graph_module.py
+++ b/torch/_export/graph_module.py
@@ -284,11 +284,8 @@ def make_export_graph_module(
         out_spec=out_spec,
         update_spec=0,
         mutation=mutation if mutation else [],
-        input_shape_constraints={
-            # copy because pickle cannot handle defaultdict with lambda factory
-            name: constraints
-            for name, constraints in input_shape_constraints_by_src_name.items()
-        },
+        # copy because pickle cannot handle defaultdict with lambda factory
+        input_shape_constraints=dict(input_shape_constraints_by_src_name.items()),
         inline_constraints=inline_constraints,
         input_name_to_example_inputs=input_name_to_example_inputs,
     )

--- a/torch/_export/graph_module.py
+++ b/torch/_export/graph_module.py
@@ -38,6 +38,12 @@ ConstraintExpr = Union[sympy.Expr, SympyBoolean]
 
 
 @dataclasses.dataclass
+class ConstraintsContainer:
+    ranges: Any
+    equalities: Any
+
+
+@dataclasses.dataclass
 class ExportMetadata:
     """The fields in this class are what used to be extra data from ExportGraphModule."""
 
@@ -247,28 +253,29 @@ def make_export_graph_module(
 
     gm = fx.GraphModule(root, graph, class_name)
 
-    tensor_id_to_input_names = defaultdict(list)
+    tensor_id_to_input_names: Dict[int, List[str]] = defaultdict(list)
     input_name_to_example_inputs: Dict[str, Any] = {}
     if example_inputs is not None:
         input_tracker = 0
         for node in gm.graph.nodes:
             if node.op == "placeholder":
                 example_input = example_inputs[input_tracker]
-                example_input_id = id(example_input)
-                tensor_id_to_input_names[example_input_id].append(node.name)
+                tensor_id_to_input_names[id(example_input)].append(node.name)
                 input_name_to_example_inputs[node.name] = example_input
                 input_tracker += 1
 
-    input_shape_constraints_by_src_name = defaultdict(lambda: {"range": [], "equality": []})
+    input_shape_constraints_by_src_name: Dict[str, ConstraintsContainer] = defaultdict(
+        lambda: ConstraintsContainer([], [])
+    )
     for constraint in input_shape_constraints:
         for name in tensor_id_to_input_names[constraint["t_id"]]:
-            input_shape_constraints_by_src_name[name]["range"].append(
+            input_shape_constraints_by_src_name[name].ranges.append(
                 (constraint["dim"], constraint["min"], constraint["max"])
             )
         if constraint["shared"] is not None:
             for name in tensor_id_to_input_names[constraint["shared"]["t_id"]]:
                 for other_name in tensor_id_to_input_names[constraint["t_id"]]:
-                    input_shape_constraints_by_src_name[name]["equality"].append(
+                    input_shape_constraints_by_src_name[name].equalities.append(
                         (constraint["shared"]["dim"], other_name, constraint["dim"])
                     )
 

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -1,9 +1,9 @@
 import math
 import operator
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import sympy
 

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -153,7 +153,7 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
             # If no dynamism is specified, we assume all dimensions are specialized
             if name not in self.constraints:
                 self._insert_specialized_shapes_assert(arg, all_dims, name, current_inp)
-                return arg
+                continue
 
             constraints = self.constraints[name]
 

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -10,7 +10,7 @@ import sympy
 import torch
 import torch.fx
 
-from torch._export.graph_module import get_export_meta
+from torch._export.graph_module import ConstraintsContainer, get_export_meta
 from torch._export.pass_base import ExportPassBase, ProxyValue
 from torch._export.pass_infra.node_metadata import NodeMetadata
 from torch.fx.passes.infra.pass_base import PassResult
@@ -21,15 +21,20 @@ __all__ = ["AddRuntimeAssertionsForConstraintsPass"]
 
 @dataclass
 class ConstraintSpec:
-    constraint_dim: int
+    """
+    Base class for constraint specs.
+    """
+    dim: int
 
 @dataclass
 class RangeConstraintSpec(ConstraintSpec):
+    # encodes min_val <= _.size()[dim] <= max_val
     min_val: int
     max_val: int
 
 @dataclass
 class EqualityConstraintSpec(ConstraintSpec):
+    # encodes _.size()[dim] = other_name.size()[other_dim]
     other_name: str
     other_dim: int
 
@@ -50,43 +55,35 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         self.current_gm: Optional[torch.fx.GraphModule] = None
 
     def _process_shape_constraints(self, constraints) -> Dict[str, List[ConstraintSpec]]:
-        input_name_to_dim_constraints = defaultdict(
-            lambda: {"range": defaultdict(list), "equality": defaultdict(list)}
+        input_name_to_dim_constraints: Dict[str, ConstraintsContainer] = defaultdict(
+            lambda: ConstraintsContainer(defaultdict(list), defaultdict(list))
         )
         for name, shape_constraints in constraints.items():
-            for dim, min_val, max_val in shape_constraints["range"]:
-                input_name_to_dim_constraints[name]["range"][dim].append(
+            for dim, min_val, max_val in shape_constraints.ranges:
+                input_name_to_dim_constraints[name].ranges[dim].append(
                     (_convert_to_int(min_val), _convert_to_int(max_val))
                 )
-            for dim, other_name, other_dim in shape_constraints["equality"]:
-                input_name_to_dim_constraints[name]["equality"][dim].append(
+            for dim, other_name, other_dim in shape_constraints.equalities:
+                input_name_to_dim_constraints[name].equalities[dim].append(
                     (other_name, other_dim)
                 )
 
         # Merge the constraints into a single list of constraints
-        input_name_to_constraints = defaultdict(list)
+        input_name_to_constraints: Dict[str, List[ConstraintSpec]] = defaultdict(list)
         for name, dim_constraints in input_name_to_dim_constraints.items():
-            for dim, range_constraints in dim_constraints["range"].items():
+            for dim, range_constraints in dim_constraints.ranges.items():
                 if range_constraints:
                     min_vals, max_vals = zip(*range_constraints)
-                    min_val = sorted(min_vals, reverse=True)[0]
-                    max_val = sorted(max_vals, reverse=False)[0]
+                    min_val = max(min_vals)
+                    max_val = min(max_vals)
                     assert min_val <= max_val
                     input_name_to_constraints[name].append(
-                        RangeConstraintSpec(
-                            constraint_dim=dim,
-                            min_val=min_val,
-                            max_val=max_val,
-                        )
+                        RangeConstraintSpec(dim=dim, min_val=min_val, max_val=max_val)
                     )
-            for dim, eq_constraints in dim_constraints["equality"].items():
+            for dim, eq_constraints in dim_constraints.equalities.items():
                 for other_name, other_dim in eq_constraints:
                     input_name_to_constraints[name].append(
-                        EqualityConstraintSpec(
-                            constraint_dim=dim,
-                            other_name=other_name,
-                            other_dim=other_dim,
-                        )
+                        EqualityConstraintSpec(dim=dim, other_name=other_name, other_dim=other_dim)
                     )
 
         return input_name_to_constraints
@@ -97,7 +94,8 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         self.constraints = self._process_shape_constraints(get_export_meta(self.current_gm).input_shape_constraints)
         self.input_name_to_example_inputs = get_export_meta(self.current_gm).input_name_to_example_inputs
         self.inline_constraints = get_export_meta(self.current_gm).inline_constraints
-        self.input_name_to_args = {}
+
+        self.input_name_to_args: Dict[str, ProxyValue] = {}
         return super().call(graph_module)
 
     def _insert_specialized_shapes_assert(self, arg, dims, name, current_inp):
@@ -137,10 +135,15 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         arg = super().placeholder(name, arg, meta)
         if name not in self.input_name_to_example_inputs:
             return arg
+        # Record the arg mapped to name.
+        # This will be used when postprocessing placeholders.
         self.input_name_to_args[name] = arg
         return arg
 
     def postprocess_placeholders(self):
+        # Add runtime asserts for input shape constraints. We do this here
+        # because we can handle both (unary) predicates and (binary) relations.
+
         assert self.current_gm is not None
         equality_constraints = []
         for name, arg in self.input_name_to_args.items():
@@ -155,20 +158,19 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
             constraints = self.constraints[name]
 
             constrained_dims = set()
-            # Add runtime asserts for user-specified range constraints for each
-            # individual dimension. Equality constraints like x[1] == x[0] are
-            # handled later.
             for constraint in constraints:
-                constrained_dims.add(constraint.constraint_dim)
+                constrained_dims.add(constraint.dim)
                 dim = super().call_operator(
                     torch.ops.aten.sym_size,
-                    (arg, constraint.constraint_dim),
+                    (arg, constraint.dim),
                     {},
                     NodeMetadata({}),
                 )
                 if isinstance(constraint, RangeConstraintSpec):
+                    # Add runtime asserts for user-specified range constraints for each
+                    # individual dimension.
                     assert_msg = (
-                        f"Input {name}'s dimension #{constraint.constraint_dim} size is "
+                        f"Input {name}'s dimension #{constraint.dim} size is "
                         f"outside of specified dynamic range [{constraint.min_val}, {constraint.max_val}]"
                     )
                     # TODO (tmanlaibaatar) we are making an assumption that graph generated for
@@ -179,26 +181,24 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
                     self._assert_range_constraint(dim, constraint.min_val, constraint.max_val, assert_msg, low_threshold=2)
                 else:
                     assert isinstance(constraint, EqualityConstraintSpec)
-                    equality_constraints.append((constraint, name, dim))
+                    # Add runtime asserts for user-specified equality constraints.
+                    other_arg = self.input_name_to_args[constraint.other_name]
+                    other_dim = super().call_operator(
+                        torch.ops.aten.sym_size,
+                        (other_arg, constraint.other_dim),
+                        {},
+                        NodeMetadata({}),
+                    )
+                    assert_msg = (
+                        f"Input {name}'s dimension #{constraint.dim} size is "
+                        f"not equal to input {constraint.other_name}'s dimension #{constraint.other_dim}"
+                    )
+                    self._assert_equality_constraint(dim, other_dim, assert_msg)
 
             specialized_dims = all_dims - constrained_dims
             # Make all non-constrained dims to be static
             self._insert_specialized_shapes_assert(arg, specialized_dims, name, current_inp)
 
-        for constraint, name, dim in equality_constraints:
-            # Add runtime asserts for user-specified equality constraints.
-            other_arg = self.input_name_to_args[constraint.other_name]
-            other_dim = super().call_operator(
-                torch.ops.aten.sym_size,
-                (other_arg, constraint.other_dim),
-                {},
-                NodeMetadata({}),
-            )
-            assert_msg = (
-                f"Input {name}'s dimension #{constraint.constraint_dim} size is "
-                f"not equal to input {constraint.other_name}'s dimension #{constraint.other_dim}"
-            )
-            self._assert_equality_constraint(dim, other_dim, assert_msg)
 
     def _assert_range_constraint(self, proxy, lower, upper, assert_msg, low_threshold=2):
         if lower > low_threshold:
@@ -244,7 +244,7 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
                         lower = _convert_to_int(constraint.lower)
                         upper = _convert_to_int(constraint.upper)
                         assert_msg = f" is outside of inline constraint [{lower}, {upper}]."
-                        call_backs.append(partial(self._assert_constraint, lower=lower, upper=upper, low_threshold=-1))
+                        call_backs.append(partial(self._assert_range_constraint, lower=lower, upper=upper, low_threshold=-1))
                         messages.append(assert_msg)
                 elif isinstance(val, torch.Tensor):
                     for i, sym in enumerate(val.shape):

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -143,9 +143,8 @@ class AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
     def postprocess_placeholders(self):
         # Add runtime asserts for input shape constraints. We do this here
         # because we can handle both (unary) predicates and (binary) relations.
-
         assert self.current_gm is not None
-        equality_constraints = []
+
         for name, arg in self.input_name_to_args.items():
             current_inp = self.input_name_to_example_inputs[name]
             all_dims = set(range(current_inp.dim()))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102256

Previously we had runtime asserts for range constraints. This diff adds runtime asserts for equality constraints.

This requires a bit of refactoring that is worth calling out.
1. [Minor] Some of the data structures produced by export and consumed by the runtime assertion pass need to be broadened. This is a WIP. There are some associated code improvements that are included in this diff, but by and large the structures are similar to what exists now. Meanwhile @angelayi and I are chatting about how to make it qualitatively better: briefly, we want to index everything by symbols, which are 1-1 with (name, dim) pairs.
2. [Major] The order in which runtime asserts are emitted is changed. Previously we used to do the work in `placeholder`, now this diff adds a hook for "post-processing" after processing of all placeholders is done. This is needed because equality constraints can mention different placeholders. This change also opens the way to optimizing codegen: e.g., each (name, dim) pair should correspond to a single intermediate variable that is reused across runtime asserts. This is future work. 

Differential Revision: [D46177642](https://our.internmc.facebook.com/intern/diff/D46177642/)

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx