### PR TITLE
Add type hints in torch/distributed/utils.py

### DIFF
--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,9 +1,10 @@
 import dataclasses
 import traceback
-from typing import Any, Callable, Dict, List, OrderedDict, Set, Tuple, Union
+from typing import Any, Callable, Container, Dict, List, Optional, OrderedDict, Tuple, TypeVar, overload
 
 import torch
 import torch.distributed as dist
+from torch import nn
 from torch.nn.parallel._functions import _get_stream
 from torch.nn.parallel.scatter_gather import (  # type: ignore[attr-defined]
     _is_namedtuple,
@@ -53,6 +54,20 @@ def _unpack_kwargs(
     args = flat_args[: -len(kwarg_keys)]
     kwargs = dict(zip(kwarg_keys, flat_args[-len(kwarg_keys) :]))
     return args, kwargs
+
+
+T = TypeVar("T", torch.Tensor, PackedSequence)
+S = TypeVar("S", dict, list, tuple)
+
+
+@overload
+def _recursive_to(inputs: T, target_device: torch.device, use_side_stream_for_tensor_copies: bool) -> Tuple[T]:
+    ...
+
+
+@overload
+def _recursive_to(inputs: S, target_device: torch.device, use_side_stream_for_tensor_copies: bool) -> List[S]:
+    ...
 
 
 def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
@@ -160,16 +175,25 @@ def _free_storage(tensor: torch.Tensor) -> bool:
         return not already_freed
 
 
-def _apply_to_tensors(
-    fn: Callable,
-    container: Union[torch.Tensor, Dict, List, Tuple, Set, OrderedDict, PackedSequence],
-) -> Any:
+Q = TypeVar("Q")
+R = TypeVar("R", dict, list, tuple, set, OrderedDict, PackedSequence, Any)
+
+
+@overload
+def _apply_to_tensors(fn: Callable[[torch.Tensor], Q], container: torch.Tensor) -> Q:
+    ...
+
+
+@overload
+def _apply_to_tensors(fn: Callable[[torch.Tensor], Any], container: R) -> R:
+    ...
+
+
+def _apply_to_tensors(fn, container):
     """Recursively apply to all tensor in different kinds of container types."""
 
-    def apply(
-        x: Union[torch.Tensor, Dict, List, Tuple, Set, OrderedDict, PackedSequence]
-    ) -> Any:
-        if torch.is_tensor(x):
+    def apply(x):
+        if isinstance(x, torch.Tensor):
             return fn(x)
         elif hasattr(x, "__dataclass_fields__"):
             dc = dataclasses.replace(x)
@@ -198,45 +222,49 @@ def _apply_to_tensors(
     return apply(container)
 
 
-def _to_kwargs(inputs, kwargs, target_device, use_side_stream_for_tensor_copies):
-    inputs = (
+def _to_kwargs(
+    inputs: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]],
+    target_device: torch.device, use_side_stream_for_tensor_copies: bool
+) -> Tuple[Tuple[Any, ...], Tuple[Dict[str, Any], ...]]:
+    moved_inputs = (
         _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies)
         if inputs
         else []
     )
-    kwargs = (
+    moved_kwargs = (
         _recursive_to(kwargs, target_device, use_side_stream_for_tensor_copies)
         if kwargs
         else []
     )
-    if len(inputs) < len(kwargs):
-        inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
-    elif len(kwargs) < len(inputs):
-        kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
-    inputs = tuple(inputs)
-    kwargs = tuple(kwargs)
-    return inputs, kwargs
+    if len(moved_inputs) < len(moved_kwargs):
+        moved_inputs.extend([() for _ in range(len(moved_kwargs) - len(inputs))])
+    elif len(moved_kwargs) < len(moved_inputs):
+        moved_kwargs.extend([{} for _ in range(len(moved_inputs) - len(moved_kwargs))])
+    return tuple(moved_inputs), tuple(moved_kwargs)
 
 
-def _verify_param_shape_across_processes(process_group, tensors, logger=None):
+def _verify_param_shape_across_processes(
+    process_group: dist.ProcessGroup, tensors: List[torch.Tensor], logger: Optional[dist.Logger] = None
+):
     return dist._verify_params_across_processes(process_group, tensors, logger)
 
 
 def _sync_module_states(
-    module,
-    process_group,
-    broadcast_bucket_size,
-    src,
-    params_and_buffers_to_ignore,
-    broadcast_buffers=True,
-):
+    module: nn.Module,
+    process_group: dist.ProcessGroup,
+    broadcast_bucket_size: int,
+    src: int,
+    params_and_buffers_to_ignore: Container[str],
+    broadcast_buffers: bool = True,
+) -> None:
     """
     Syncs ``module``'s parameters and buffers state so that all ranks contain
     the same module state across all ranks. Note that this API assumes that all
     parameter shapes are consistent before running the synchronization. This can
     be checked with ``_verify_param_shape_across_processes``.
     """
-    module_states = []
+    module_states: List[torch.Tensor] = []
     for name, param in module.named_parameters():
         if name not in params_and_buffers_to_ignore:
             module_states.append(param.detach())
@@ -254,7 +282,7 @@ def _sync_params_and_buffers(
     module_states: List[torch.Tensor],
     broadcast_bucket_size: int,
     src: int,
-):
+) -> None:
     """
     Synchronizes ``module_states`` (list of tensors) across all processes by
     broadcasting them from rank 0.

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -42,9 +42,7 @@ def _pack_kwargs(*args: Any, **kwargs: Any) -> Tuple[Tuple[Any, ...], Tuple[str,
     return tuple(flat_args), tuple(kwarg_keys)
 
 
-def _unpack_kwargs(
-    flat_args: Tuple[Any, ...], kwarg_keys: Tuple[str, ...]
-) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+def _unpack_kwargs(flat_args: Tuple[Any, ...], kwarg_keys: Tuple[str, ...]) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
     """See _pack_kwargs."""
     assert len(kwarg_keys) <= len(
         flat_args
@@ -56,17 +54,17 @@ def _unpack_kwargs(
     return args, kwargs
 
 
-T = TypeVar("T", torch.Tensor, PackedSequence)
 S = TypeVar("S", dict, list, tuple)
-
-
-@overload
-def _recursive_to(inputs: T, target_device: torch.device, use_side_stream_for_tensor_copies: bool) -> Tuple[T]:
-    ...
+T = TypeVar("T", torch.Tensor, PackedSequence)
 
 
 @overload
 def _recursive_to(inputs: S, target_device: torch.device, use_side_stream_for_tensor_copies: bool) -> List[S]:
+    ...
+
+
+@overload
+def _recursive_to(inputs: T, target_device: torch.device, use_side_stream_for_tensor_copies: bool) -> Tuple[T]:
     ...
 
 
@@ -225,7 +223,8 @@ def _apply_to_tensors(fn, container):
 def _to_kwargs(
     inputs: Tuple[Any, ...],
     kwargs: Optional[Dict[str, Any]],
-    target_device: torch.device, use_side_stream_for_tensor_copies: bool
+    target_device: torch.device,
+    use_side_stream_for_tensor_copies: bool,
 ) -> Tuple[Tuple[Any, ...], Tuple[Dict[str, Any], ...]]:
     moved_inputs = (
         _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1430,13 +1430,13 @@ class DistributedDataParallel(Module, Joinable):
             self._check_global_requires_backward_grad_sync(is_joined_rank=False)
 
         if self.device_ids:
-            inputs, kwargs = _to_kwargs(
+            moved_inputs, moved_kwargs = _to_kwargs(
                 inputs,
                 kwargs,
                 torch.device(self.device_type, self.device_ids[0]),
                 self.use_side_stream_for_tensor_copies,
             )
-            args, kwargs = inputs[0], kwargs[0]  # type: ignore[index]
+            args, kwargs = moved_inputs[0], moved_kwargs[0]
             # Cast inputs to reduced precision if needed.
             if self.mixed_precision is not None:
                 args, kwargs = _cast_forward_inputs(


### PR DESCRIPTION
Fixes #77190

Pretty similar to the typing in `torch/nn/parallel`, which was also improved recently: #102194

cc: @rohan-varma 