### PR TITLE
Disable -Wambiguous-reversed-operator for specific targets (caffe2)

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -55,6 +55,7 @@ compiler_specific_flags = {
         "-Wno-absolute-value",
         "-Wno-pass-failed",
         "-Wno-braced-scalar-init",
+        "-Wno-ambiguous-reversed-operator",
     ],
     "gcc": [
         "-Wno-error=array-bounds",


### PR DESCRIPTION
Summary:
Disable -Wambiguous-reversed-operator for specific targets using LLVM15

Error seen with the warning enabled:
```
fbcode/caffe2/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h:839:17: error: ISO C++20 considers use of overloaded operator '!=' (with operand types 'const at::vec::Vectorized<c10::Half>' and 'const Vectorized<c10::Half>') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]
  return (*this != other) & Vectorized<Half>(1.0f);
          ~~~~~ ^  ~~~~~
fbcode/caffe2/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h:584:24: note: candidate function with non-reversed arguments
  Vectorized<T> inline operator!=(const Vectorized<T>& other) const {
                       ^
fbcode/caffe2/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h:581:24: note: ambiguous candidate function with reversed arguments
  Vectorized<T> inline operator==(const Vectorized<T>& other) const {
                       ^
```

The ambiguous reversed operators here have complex resolutions, so these are being exempted from the warning so that it can be enabled globally to prevent any new failures from being introduced. This is important as this will become an error in the C++23 standard.

Test Plan: sandcastle

Differential Revision: D45966850

