### PR TITLE
[CUDAGraph Trees] Fix empty storages handling

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -704,6 +704,17 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 node = self.curr_node()
                 self.assertEqual(len(list(node.path_live_weakrefs())), 1)
 
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return (x + x + x), torch.rand([4], device="cuda") + 10
+
+            inp = torch.rand([0], device="cuda")
+            for _ in range(3):
+                out = foo(inp)
+                node = self.curr_node()
+                self.assertEqual(len(list(node.path_live_weakrefs())), 1)
+
+
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_aliased_output_checkpoint(self):
             def foo(args):

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -693,6 +693,17 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             self.assertEqual(self.curr_node().cached_tensor_outputs, [None, None])
 
+        def test_empty_storage(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return (x + x + x), torch.zeros([0], device="cuda")
+
+            inp = torch.rand([4], device="cuda")
+            for _ in range(3):
+                out = foo(inp)
+                node = self.curr_node()
+                self.assertEqual(len(list(node.path_live_weakrefs())), 1)
+
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_aliased_output_checkpoint(self):
             def foo(args):

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -714,7 +714,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 node = self.curr_node()
                 self.assertEqual(len(list(node.path_live_weakrefs())), 1)
 
-
         @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
         def test_aliased_output_checkpoint(self):
             def foo(args):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -19,7 +19,7 @@ with a lot of caveats.  CUDA graph trees remove these restrictions:
 * Previously, if you executed graph A, some non-CUDA graph code, and then
   graph B, after executing graph B, it was not safe to retain any references
   to intermediates produced by A.  With CUDA graph trees, we track if any
-  outputs of graph A are still live by the time graph B is run, and make
+outputs of graph A are still live by the time graph B is run, and make
   sure graph B doesn't clobber there memory when reusing the CUDA graphs
   pool.  You'll get a separate recording of B depending on what tensors
   stay live or dead.
@@ -581,6 +581,7 @@ class CUDAWarmupNode:
                 o is not None
                 and o.is_cuda
                 and o.untyped_storage().data_ptr() not in non_cudagraph_inps
+                and o.untyped_storage().data_ptr() != 0
             )
 
         self.outputs_weakrefs.extend(
@@ -1063,7 +1064,10 @@ class CUDAGraphNode:
             ref = static_input_persistent_storage_ptrs.get(
                 o.untyped_storage().data_ptr(), None
             )
-            if ref and ref() is not None:
+            # also treat empty storages as static outputs because we do need to manage their lifetime
+            # and they should not participate in checkpointing
+            is_empty_storage = o.data_ptr() == 0
+            if ref and ref() is not None or is_empty_storage:
                 self.output_storage_alias.append(None)
                 self.static_output_tensors[i] = o
                 continue

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1009,6 +1009,7 @@ class CUDAGraphNode:
                 StorageWeakRefWrapper(elem)
                 for i, elem in enumerate(inputs)
                 if i not in self.wrapped_function.static_input_idxs
+                and elem.data_ptr() != 0
             ]
             check_memory_pool(self.device, self.cuda_graphs_pool, memory)
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1064,7 +1064,7 @@ class CUDAGraphNode:
             ref = static_input_persistent_storage_ptrs.get(
                 o.untyped_storage().data_ptr(), None
             )
-            # also treat empty storages as static outputs because we do need to manage their lifetime
+            # also treat empty storages as static outputs because we do not need to manage their lifetime
             # and they should not participate in checkpointing
             is_empty_storage = o.data_ptr() == 0
             if ref and ref() is not None or is_empty_storage:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102273

We don't need to handle managing their memory since they dont have any. Previously you would get error `RuntimeError: These storage data ptrs are not allocated in pool (0, 2) but should be {0}`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10