### PR TITLE
Clean up collective rewrite

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -426,6 +426,32 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         assert counter.op_count == 3
         assert same(outputs, correct_outputs)
 
+
+    def test_dynamo_graphbreaks_unsupported_async_op(self):
+
+        def func(inp, out, *, pg):
+            work = torch.distributed.reduce_scatter_tensor(
+                out,
+                inp,
+                group=pg,
+                async_op=True
+            )
+            work.wait()
+        local_size = [4, 4]
+        # single-proc test
+        global_size = local_size
+
+        inputs = torch.ones(local_size, device=self.device)
+        outputs = torch.empty(global_size, device=self.device)
+        correct_outputs = torch.empty(global_size, device=self.device)
+        counter = CompileCounter()
+        compiled = torch.compile(func, backend=counter)
+        compiled(inputs, outputs, pg=GroupMember.WORLD)
+        func(inputs, correct_outputs, pg=GroupMember.WORLD)
+        assert counter.frame_count == 0
+        assert counter.op_count == 0
+        assert same(outputs, correct_outputs)
+
     def test_dynamo_trace_reduce_scatter_tensor(self):
 
         def func(inp, *, tag, ranks, group_size):

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import torch
 from torch._C import FileCheck
 # for some reason importing functional collectives after dynamo breaks collectives handling!
-# import torch.distributed
 import torch.distributed._functional_collectives as _functional_collectives
 import torch._dynamo
 import torch._dynamo.test_case

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -72,7 +72,11 @@ from .dicts import (
     DefaultDictVariable,
     HFPretrainedConfigVariable,
 )
-from .functions import UserFunctionVariable, UserMethodVariable
+from .functions import (
+    CollectiveFunctionRewriteVariable,
+    UserFunctionVariable,
+    UserMethodVariable,
+)
 from .lists import (
     ListVariable,
     NamedTupleVariable,
@@ -443,28 +447,10 @@ class VariableBuilder:
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         # NB: These can't be put in type_dispatch, they have to run later
-        elif inspect.isfunction(value) and value in {
-            torch.distributed.distributed_c10d.all_gather_into_tensor,
-            torch.distributed.distributed_c10d.reduce_scatter_tensor,
-        }:
-            from torch.distributed._functional_collectives import (
-                all_gather_tensor_inplace,
-                reduce_scatter_tensor_inplace,
-            )
-            from torch.distributed.distributed_c10d import (
-                all_gather_into_tensor as legacy_allgather,
-                reduce_scatter_tensor as legacy_reducescatter,
-            )
-
-            # TODO assert that async_op is false, and, possibly some other limitations
-            # current remapping is very brittle, in regards to handling args at call time
-            # and seriously.. can't import properly, and also getting line-too-long linter
-            traceable_collective_remaps = {
-                legacy_allgather: all_gather_tensor_inplace,
-                legacy_reducescatter: reduce_scatter_tensor_inplace,
-            }
-            return UserFunctionVariable(
-                traceable_collective_remaps[value],
+        elif CollectiveFunctionRewriteVariable.can_rewrite(value):
+            return CollectiveFunctionRewriteVariable(
+                CollectiveFunctionRewriteVariable.rewrite(value),
+                orig_fn=value,
                 source=self.source,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -531,3 +531,48 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
             codegen.extend_output(create_call_function(1, True))
 
         return []
+
+
+class CollectiveFunctionRewriteVariable(UserFunctionVariable):
+    """
+    Some of the torch.distributed.* collective APIs are possible to rewrite to 'traceable' collectives.
+
+    This class provides both a way to check if a function is remappable, and perform the remapping.
+
+    In the case that a function is 'remappable' but only for some combinations of call-time arguments,
+    we check the args at `call_function` time and fall back to graph-breaking if needed.  This is no worse
+    than status-quo as we currently graph-break on all distributed.* collectives.
+    """
+
+    def __init__(self, fn, *, orig_fn, **kwargs):
+        # orig_fn lets us implement any fn-specific args/kwargs restrictions inside call_function
+        self.orig_fn = orig_fn
+
+        # remapped_fn gets stuffed in self.fn and used in super().call_function
+        super().__init__(fn, **kwargs)
+
+    @staticmethod
+    def can_rewrite(variable):
+        from torch.distributed._functional_collectives import (
+            traceable_collective_remaps,
+        )
+
+        return inspect.isfunction(variable) and variable in traceable_collective_remaps
+
+    @staticmethod
+    def rewrite(fn):
+        from torch.distributed._functional_collectives import (
+            traceable_collective_remaps,
+        )
+
+        return traceable_collective_remaps[fn]
+
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        # call_function must check any unsupported arguments and graph-break.
+        # It's safe to assume args/kwargs from orig_fn map 1:1 to args/kwargs of remapped_fn,
+        # since that's the contract for putting a mapping in `traceable_collective_remaps`
+        if kwargs.get("async_op", False):
+            unimplemented(f"CollectiveFunctionRewriteVariable can't support async_op=True for {self.orig_fn}")
+        return super().call_function(tx, args, kwargs)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -545,3 +545,19 @@ def reduce_scatter_tensor_inplace(
 ):
     assert not async_op, "Can't remap async version of inplace op to functional collective"
     return output.copy_(reduce_scatter_tensor(input, op, scatter_dim, group, tag))
+
+from torch.distributed.distributed_c10d import (
+    all_gather_into_tensor as legacy_allgather,
+    reduce_scatter_tensor as legacy_reducescatter,
+)
+
+"""
+This dict should contain sets of functions that dynamo is allowed to remap.
+
+Functions in this set should accept the same args/kwargs 1:1 as their mapping.
+"""
+
+traceable_collective_remaps = {
+    legacy_allgather: all_gather_tensor_inplace,
+    legacy_reducescatter: reduce_scatter_tensor_inplace,
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102281
* #102232
* #102222
* #102274

- solve some of the import issues
- put the rewriting inside a class with staticmethods
   (was originally doing it in .__init__, but that makes .clone harder)
- add check for unsupported async_op

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx