### PR TITLE
[quant][pt2e] Add Support for DerivedQuantizationSpec

### DIFF
--- a/torch/ao/quantization/_pt2e/prepare.py
+++ b/torch/ao/quantization/_pt2e/prepare.py
@@ -27,7 +27,7 @@ from torch.ao.quantization._pt2e.quantizer import (
     QuantizationAnnotation,
     EdgeOrNode,
 )
-from torch.ao.quantization import ObserverOrFakeQuantizer
+from torch.ao.quantization import ObserverOrFakeQuantize
 
 def _maybe_insert_input_observer_for_arg_or_kwarg(
     node: Union[Node, Any],
@@ -35,7 +35,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     qconfig: QConfigAny,
     model: torch.nn.Module,
     named_modules: Dict[str, torch.nn.Module],
-    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantizer],
+    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -92,7 +92,7 @@ def _maybe_insert_input_observers_for_node(
     qconfig: QConfigAny,
     model: torch.nn.Module,
     named_modules: Dict[str, torch.nn.Module],
-    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantizer],
+    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -124,7 +124,7 @@ def _maybe_insert_input_observers_for_node(
 def _maybe_insert_input_and_output_observers_for_node(
     node: Node,
     model: torch.fx.GraphModule,
-    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantizer],
+    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
 ):
     this_node_dtype_info = node.meta["quantization_annotation"] if "quantization_annotation" in node.meta else None
     if "val" in node.meta:
@@ -201,7 +201,7 @@ def prepare(
     # Since we are mutating the graph as we go, we iterate over the original
     # nodes before observer insertion, instead of model.graph.nodes.
     nodes_before_observation = list(model.graph.nodes)
-    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantizer] = {}
+    obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize] = {}
 
     for node in nodes_before_observation:
 

--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -6,6 +6,7 @@ from .quantizer import (
     QuantizationSpec,
     QuantizationAnnotation,
     SharedQuantizationSpec,
+    DerivedQuantizationSpec,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "QNNPackQuantizer",
     "QuantizationAnnotation",
     "SharedQuantizationSpec",
+    "DerivedQuantizationSpec",
 ]

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -2,7 +2,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from torch.fx import Node
 from typing import Callable, List, NamedTuple, Optional, Dict, Any, Union, Tuple
+from torch.ao.quantization import ObserverOrFakeQuantize
 from torch.ao.quantization.qconfig import _ObserverOrFakeQuantizeConstructor
+from torch import Tensor
 
 import torch
 
@@ -73,6 +75,18 @@ class SharedQuantizationSpec:
     output value is an fx Node
     """
     edge_or_node: EdgeOrNode
+
+
+@dataclass(eq=True, frozen=True)
+class DerivedQuantizationSpec:
+    """ quantization spec for the Tensors whose quantization parameters are derived from other Tensors
+    """
+    derived_from: List[EdgeOrNode]
+    derive_qparams_fn: Callable[[List[ObserverOrFakeQuantize]], Tuple[Tensor, Tensor]]
+    dtype: torch.dtype
+    quant_min: Optional[int] = None
+    quant_max: Optional[int] = None
+    qscheme: Optional[torch.qscheme] = None
 
 # In the absence of better name, just winging it with QuantizationConfig
 @dataclass(eq=True, frozen=True)


### PR DESCRIPTION
Summary:
```
"""
4. DerivedQuantizationSpec
this is the quantization spec for the Tensors whose quantization parameters are derived from other Tensors
"""

class DerivedQuantizationSpec(QuantizationSpecBase):
    # specifies which Tensors the quantization parameters are derived from
    # this can either be an edge from argument to node, or a node
    derived_from: List[EdgeOrNode]
    derive_qparams_fn: Callabale[List[ObserverOrFakeQuantize], Tuple[Tensor, Tensor]]
     ...
```

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- 'caffe2/test:quantization_pt2e'
buck2 test mode/opt caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_resnet18_with_quantizer_api (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2EModels)'
```

Reviewed By: kimishpatel

Differential Revision: D46097855

