### PR TITLE
Enable CuDNN v8 frontend in RL

### DIFF
--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -103,7 +103,7 @@ __host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::comple
 
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
 // Compile time for CUDA-11.4 is 3x slower than with CUDA-11.6+, specifically for complex numbers
-#if defined(FBCODE_CAFFE2)
+#if defined(FBCODE_CAFFE2) || defined(OVRSOURCE)
 #define _LCME_DISPATCH AT_DISPATCH_FLOATING_TYPES_AND2
 #else
 #define _LCME_DISPATCH AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2

--- a/aten/src/ATen/native/cudnn/Macros.h
+++ b/aten/src/ATen/native/cudnn/Macros.h
@@ -5,7 +5,7 @@
 // Note: The version below should not actually be 8000. Instead, it should
 // be whatever version of cuDNN that v8 API work with PyTorch correctly.
 // The version is set to 8000 today for convenience of debugging.
-#if defined(USE_EXPERIMENTAL_CUDNN_V8_API) && defined(CUDNN_VERSION) && CUDNN_VERSION >= 8300
+#if defined(USE_EXPERIMENTAL_CUDNN_V8_API) && defined(CUDNN_VERSION) && CUDNN_VERSION >= 8200
 #define HAS_CUDNN_V8() true
 #else
 #define HAS_CUDNN_V8() false

--- a/aten/src/ATen/native/quantized/ConvUtils.h
+++ b/aten/src/ATen/native/quantized/ConvUtils.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <ATen/core/List.h>
+#include <ATen/native/ConvUtils.h>
+
+namespace at::native::quantized {
+namespace {
+// MakeConvOutputShape used from both CPU and CUDA libraries
+// and exporting symbol from torch_cpu would probaby take more storage
+// than duplicating implementation which likely be inlined away
+template <int kSpatialDim>
+at::SmallVector<int64_t, kSpatialDim + 2> MakeConvOutputShape(
+    int N, // mini-batch
+    int M, // output channels
+    const std::array<int64_t, kSpatialDim>& input_image_shape,
+    const std::vector<int64_t>& kernel,
+    const torch::List<int64_t>& stride,
+    const torch::List<int64_t>& padding,
+    const torch::List<int64_t>& dilation);
+
+#if defined(USE_CUDA) || defined(USE_PYTORCH_QNNPACK)
+template <>
+at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
+    int N, // mini-batch
+    int M, // output channels
+    const std::array<int64_t, 2>& input_image_shape,
+    const std::vector<int64_t>& kernel,
+    const at::List<int64_t>& stride,
+    const at::List<int64_t>& padding,
+    const at::List<int64_t>& dilation) {
+  const int H = input_image_shape[0];
+  const int W = input_image_shape[1];
+  const int64_t Y_H =
+      (H + 2 * padding[0] - dilation[0] * (kernel[0] - 1) - 1) / stride[0] + 1;
+  const int64_t Y_W =
+      (W + 2 * padding[1] - dilation[1] * (kernel[1] - 1) - 1) / stride[1] + 1;
+  return {N, M, Y_H, Y_W};
+}
+
+template <>
+at::SmallVector<int64_t, 5> MakeConvOutputShape<3>(
+    int N, // mini-batch
+    int M, // output channels
+    const std::array<int64_t, 3>& input_image_shape,
+    const std::vector<int64_t>& kernel,
+    const at::List<int64_t>& stride,
+    const at::List<int64_t>& padding,
+    const torch::List<int64_t>& dilation) {
+  const int D = input_image_shape[0];
+  const int H = input_image_shape[1];
+  const int W = input_image_shape[2];
+  const int64_t Y_D =
+      (D + 2 * padding[0] - dilation[0] * (kernel[0] - 1) - 1) / stride[0] + 1;
+  const int64_t Y_H =
+      (H + 2 * padding[1] - dilation[1] * (kernel[1] - 1) - 1) / stride[1] + 1;
+  const int64_t Y_W =
+      (W + 2 * padding[2] - dilation[2] * (kernel[2] - 1) - 1) / stride[2] + 1;
+  return {N, M, Y_D, Y_H, Y_W};
+}
+
+#endif
+} // anonymous namespace
+} // namespace at::native::quantized

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -14,7 +14,7 @@
 #include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/XnnpackUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
-#include <ATen/native/ConvUtils.h>
+#include <ATen/native/quantized/ConvUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
@@ -187,55 +187,6 @@ std::array<int64_t, 2> MakeInputShape(int64_t /*D*/, int64_t H, int64_t W) {
 template <>
 std::array<int64_t, 3> MakeInputShape(int64_t D, int64_t H, int64_t W) {
   return {D, H, W};
-}
-
-template <int kSpatialDim>
-at::SmallVector<int64_t, kSpatialDim + 2> MakeConvOutputShape(
-    int N, // mini-batch
-    int M, // output channels
-    const std::array<int64_t, kSpatialDim>& input_image_shape,
-    const std::vector<int64_t>& kernel,
-    const torch::List<int64_t>& stride,
-    const torch::List<int64_t>& padding,
-    const torch::List<int64_t>& dilation);
-
-template <>
-at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
-    int N, // mini-batch
-    int M, // output channels
-    const std::array<int64_t, 2>& input_image_shape,
-    const std::vector<int64_t>& kernel,
-    const torch::List<int64_t>& stride,
-    const torch::List<int64_t>& padding,
-    const torch::List<int64_t>& dilation) {
-  const int H = input_image_shape[0];
-  const int W = input_image_shape[1];
-  const int64_t Y_H =
-      (H + 2 * padding[0] - dilation[0] * (kernel[0] - 1) - 1) / stride[0] + 1;
-  const int64_t Y_W =
-      (W + 2 * padding[1] - dilation[1] * (kernel[1] - 1) - 1) / stride[1] + 1;
-  return {N, M, Y_H, Y_W};
-}
-
-template <>
-at::SmallVector<int64_t, 5> MakeConvOutputShape<3>(
-    int N, // mini-batch
-    int M, // output channels
-    const std::array<int64_t, 3>& input_image_shape,
-    const std::vector<int64_t>& kernel,
-    const torch::List<int64_t>& stride,
-    const torch::List<int64_t>& padding,
-    const torch::List<int64_t>& dilation) {
-  const int D = input_image_shape[0];
-  const int H = input_image_shape[1];
-  const int W = input_image_shape[2];
-  const int64_t Y_D =
-      (D + 2 * padding[0] - dilation[0] * (kernel[0] - 1) - 1) / stride[0] + 1;
-  const int64_t Y_H =
-      (H + 2 * padding[1] - dilation[1] * (kernel[1] - 1) - 1) / stride[1] + 1;
-  const int64_t Y_W =
-      (W + 2 * padding[2] - dilation[2] * (kernel[2] - 1) - 1) / stride[2] + 1;
-  return {N, M, Y_D, Y_H, Y_W};
 }
 
 #endif // USE_PYTORCH_QNNPACK
@@ -793,7 +744,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl_xnnp(
     output_shape = MakeDeConvOutputShape<kSpatialDim>(
         N, M, {H, W}, kernel_, stride(), padding(), output_padding(), dilation());
   } else {
-    output_shape = MakeConvOutputShape<kSpatialDim>(
+    output_shape = at::native::quantized::MakeConvOutputShape<kSpatialDim>(
         N, M, input_shape, kernel_, stride(), padding(), dilation());
   }
 
@@ -987,7 +938,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         output_padding(),
         dilation());
   } else {
-    output_shape = MakeConvOutputShape<kSpatialDim>(
+    output_shape = at::native::quantized::MakeConvOutputShape<kSpatialDim>(
         N, M, input_shape, kernel_, stride(), padding(), dilation());
   }
 
@@ -1425,8 +1376,7 @@ template at::Tensor PackedConvWeightsOnednn<3>::apply_relu(
 
 #endif // #if AT_MKLDNN_ENABLED()
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 /*
@@ -1585,5 +1535,4 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 }
 
 } // namespace
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -11,9 +11,9 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cudnn/Handle.h>
-#include <ATen/native/ConvUtils.h>
 #include <ATen/native/cudnn/ConvShared.h>
 #include <ATen/native/quantized/cudnn/utils.h>
+#include <ATen/native/quantized/ConvUtils.h>
 #include <ATen/native/quantized/PackedParams.h>
 #include <ATen/native/utils/ParamsHash.h>
 #include <ATen/TensorUtils.h>
@@ -52,40 +52,11 @@ struct CacheKey {
   bool kReluFused;
 };
 std::unordered_map<CacheKey, cudnn_frontend::ExecutionPlan, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
-}
+} // anonymous namespace
 // TODO: we can use cudnn_frontend::ExecutionPlanCache when it supports caching
 // multiple operators
 // reference: https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/conv_sample.cpp#L293
 //static cudnn_frontend::ExecutionPlanCache plan_cache("sample_cache");
-
-template <int kSpatialDim>
-at::SmallVector<int64_t, kSpatialDim + 2> MakeConvOutputShape(
-    int N, // mini-batch
-    int M, // output channels
-    const std::array<int64_t, kSpatialDim>& input_image_shape,
-    const std::vector<int64_t>& kernel,
-    const torch::List<int64_t>& stride,
-    const torch::List<int64_t>& padding,
-    const torch::List<int64_t>& dilation);
-
-template <>
-at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
-    int N, // mini-batch
-    int M, // output channels
-    const std::array<int64_t, 2>& input_image_shape,
-    const std::vector<int64_t>& kernel,
-    const torch::List<int64_t>& stride,
-    const torch::List<int64_t>& padding,
-    const torch::List<int64_t>& dilation) {
-  const int H = input_image_shape[0];
-  const int W = input_image_shape[1];
-  const int64_t Y_H =
-      (H + 2 * padding[0] - dilation[0] * (kernel[0] - 1) - 1) / stride[0] + 1;
-  const int64_t Y_W =
-      (W + 2 * padding[1] - dilation[1] * (kernel[1] - 1) - 1) / stride[1] + 1;
-  return {N, M, Y_H, Y_W};
-}
-
 
 // the parameter quantized_output is a quantized tensor
 template <int kSpatialDim>
@@ -314,7 +285,7 @@ at::Tensor PackedConvWeightCudnn<kSpatialDim>::apply_impl(
   const auto W = act.size(kSpatialDim + 1);
   const auto num_output_channels = maybe_padded_weight_.size(0); // output channels
   std::vector<int64_t> kernel_size = {maybe_padded_weight_.size(2), maybe_padded_weight_.size(3)};
-  at::SmallVector<int64_t, kSpatialDim + 2> output_shape = MakeConvOutputShape<kSpatialDim>(batch_size, num_output_channels, {H, W},
+  auto output_shape = at::native::quantized::MakeConvOutputShape<kSpatialDim>(batch_size, num_output_channels, {H, W},
   kernel_size, stride_, padding_, dilation_);
   at::Tensor quantized_output = at::_empty_affine_quantized(
       output_shape,
@@ -369,8 +340,7 @@ template at::Tensor PackedConvWeightCudnn<2>::apply_relu(
     double output_scale,
     int64_t output_zero_point);
 
-namespace at {
-namespace native {
+namespace at:: native {
 namespace {
 
 template <bool kReluFused>
@@ -427,9 +397,8 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv2d_relu.new"), QConvInt8<2, true>::run);
 }
 
-} // namespace
-} // namespace native
-} // namespace at
+} // anonyous namespace
+} // namespace at::native
 
 
 #endif  // HAS_CUDNN_V8


### PR DESCRIPTION
Summary:
This enables use of CUDNN v8 in all Meta internal workflows. Also, fixes two minor issues:
- Skip LogCumSumExp compilation for complex dtypes for fbcode and RL
- Move `MakeConvOutputShape` template definition/specialization to anonymous namespace inside `at::native::quantized` as it is referenced from both `torch_cpu` and `torch_cuda`. This is necessary to avoid `duplicate symbol` linker error if say `libtorch_cpu` and `libtorch_cuda` are statically linked together.
- Lower CuDNN v8 version guard from 8.3 to 8.2 (as there are no good reason why it should be 8.3, first version of the library that properly supports all the features is actually 8.5)

Test Plan: CI

Differential Revision: D46161651



cc @seemethere @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10