### PR TITLE
Remove inplace buffers when original and mutation are both removed

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -480,6 +480,8 @@ class KernelArgs:
         call_args = []
         precompile_args = []
         for inplaced in unique(self.inplace_buffers.values()):
+            if inplaced == "REMOVED":
+                continue
             arg_defs.append(inplaced.inner_name)
             call_args.append(inplaced.other_names[-1])
             precompile_args.append(
@@ -506,6 +508,8 @@ class KernelArgs:
 
     def aliases(self):
         for inplaced in unique(self.inplace_buffers.values()):
+            if inplaced == "REMOVED":
+                continue
             for other in inplaced.other_names:
                 if other in V.graph.inplaced_to_remove:
                     continue

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -446,6 +446,8 @@ class KernelArgs:
         arg_defs = []
         arg_types = []
         for inplaced in unique(self.inplace_buffers.values()):
+            if inplaced == "REMOVED":
+                continue
             outer = inplaced.other_names[-1]
             inner = inplaced.inner_name
             dtype = buffer_types[outer]

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -534,6 +534,8 @@ class KernelArgs:
     def live_output_buffers(self):
         live_outs = set()
         for inplaced in unique(self.inplace_buffers.values()):
+            if inplaced == "REMOVED":
+                continue
             live_outs.add(inplaced.other_names[-1])
         for outer, inner in self.output_buffers.items():
             if outer in self.inplace_buffers or inner == "REMOVED":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1553,7 +1553,10 @@ class TritonKernel(Kernel):
         for mutation in self.mutations:
             if mutation in self.args.input_buffers:
                 mutated_args.add(self.args.input_buffers[mutation])
-            if mutation in self.args.inplace_buffers and self.args.inplace_buffers[mutation] != "REMOVED":
+            if (
+                mutation in self.args.inplace_buffers
+                and mutation not in V.graph.removed_buffers
+            ):
                 mutated_args.add(self.args.inplace_buffers[mutation].inner_name)
             if mutation in self.args.output_buffers:
                 mutated_args.add(self.args.output_buffers[mutation])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1553,7 +1553,7 @@ class TritonKernel(Kernel):
         for mutation in self.mutations:
             if mutation in self.args.input_buffers:
                 mutated_args.add(self.args.input_buffers[mutation])
-            if mutation in self.args.inplace_buffers:
+            if mutation in self.args.inplace_buffers and self.args.inplace_buffers[mutation] != "REMOVED":
                 mutated_args.add(self.args.inplace_buffers[mutation].inner_name)
             if mutation in self.args.output_buffers:
                 mutated_args.add(self.args.output_buffers[mutation])

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -450,7 +450,6 @@ class WrapperCodeGen(CodeGen):
             # codegen allocations in two passes
             planning_state = MemoryPlanningState()
             for i in range(len(self.lines)):
-                print("line", self.lines[i])
                 if isinstance(self.lines[i], MemoryPlanningLine):
                     self.lines[i] = self.lines[i].plan(planning_state)
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -169,6 +169,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.buffers: List[ir.ComputedBuffer] = []
         self.constants: Dict[str, torch.Tensor] = {}
         self.removed_buffers: Set[str] = set()
+        self.removed_inplace_buffers: Set[str] = set()
         self.inplaced_to_remove: Set[str] = set()
         self.wrapper_code: Optional[WrapperCodeGen] = None
         self.num_static_inputs = num_static_inputs

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1119,41 +1119,30 @@ class Scheduler:
         Any buffers that are both created and have a last use in the
         same kernel can be removed.
         """
-        print(V.kernel.args.inplace_buffers)
-        names_to_remove = V.kernel.store_buffer_names & self.buffer_names_no_longer_needed
+
+        names_to_remove = (
+            V.kernel.store_buffer_names & self.buffer_names_no_longer_needed
+        )
+
         def remove_filter(n):
-                return n not in V.kernel.must_keep_buffers \
-                and n not in V.kernel.args.input_buffers \
-                and n not in self.mutation_renames \
+            return (
+                n not in V.kernel.must_keep_buffers
+                and n not in V.kernel.args.input_buffers
+                and n not in self.mutation_renames
                 and n not in self.mutation_real_name
+            )
 
         names_to_remove = list(filter(remove_filter, names_to_remove))
 
         for name in names_to_remove:
-            # if (
-            #     name not in V.kernel.must_keep_buffers
-            #     and name not in V.kernel.args.input_buffers
-            #     and name not in self.mutation_renames
-            #     and name not in self.mutation_real_name
-            # ):
-                print("name", name)
-                # For inplace buffers subject to remove, we don't actually
-                # remove them but put them in a dedicated set. This simplifies
-                # the life cycle management of inplace buffers.
-                # This set is used to
-                # 1) avoid unnecessary store in DeferredLine.
-                # 2) avoid alias var definitions in kernel.
-                if name in V.kernel.args.inplace_buffers:
-                    buf = V.kernel.args.inplace_buffers[name]
-                    remove = True
-                    for on in buf.other_names:
-                        if on not in names_to_remove:
-                            remove = False
-                    if remove:
-                        self.remove_inplace_buffer(name)
-                    V.graph.inplaced_to_remove.add(name)
-                else:
-                    self.remove_buffer(name)
+            if name in V.kernel.args.inplace_buffers:
+                buf = V.kernel.args.inplace_buffers[name]
+                remove = all(n in names_to_remove for n in buf.other_names)
+                if remove:
+                    self.remove_inplace_buffer(name)
+                V.graph.inplaced_to_remove.add(name)
+            else:
+                self.remove_buffer(name)
 
     def remove_buffer(self, name):
         # Assign a special value instead of deleting the entry
@@ -1166,7 +1155,7 @@ class Scheduler:
     def remove_inplace_buffer(self, name):
         log.debug("removing_inplace_buffer(%r)", name)
         V.kernel.args.inplace_buffers[name] = "REMOVED"
-        V.graph.removed_inplace_buffers.add(name)
+        V.graph.removed_buffers.add(name)
 
     def flush(self):
         for backend in self.backends.values():


### PR DESCRIPTION
Currently if we have an inplaced buffer that's completely internal to a fused kernel and thus doesn't need to be allocated, we are still allocating it and sending unused argument to a kernel, because our analysis for removing buffers treats it separately (assuming that either original or mutated value are still needed). 
This PR extends buffer removal to inplaced buffers that can be removed. 

Generated kernel for e.g. ln changes from 
```
def triton_(in_out_ptr0, in_out_ptr1, in_ptr0, in_ptr1, in_ptr2, out_ptr0, out_ptr1, xnumel, rnumel, XBLOCK : tl.constexpr):
```
where in_out_ptr0 is unused in the kernel to 
```
def triton_(in_out_ptr1, in_ptr0, in_ptr1, in_ptr2, out_ptr0, out_ptr1, xnumel, rnumel, XBLOCK : tl.constexpr):
```
and corresponding allocation/reuse lines in the wrapper are removed. 
The `in_out_ptr1` is also mislabeled - it's not `in_out`, it's only written to, but this PR doesn't fix it. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10