### PR TITLE
Document faster builds for C++ changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,21 @@ Follow the instructions for [installing PyTorch from source](https://github.com/
 
 * If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
-* When installing with `python setup.py develop` (in contrast to `python setup.py install`) Python runtime will use 
+* When installing with `python setup.py develop` (in contrast to `python setup.py install`) Python runtime will use
   the current local source-tree when importing `torch` package. (This is done by creating [`.egg-link`](https://wiki.python.org/moin/PythonPackagingTerminology#egg-link) file in `site-packages` folder)
   This way you do not need to repeatedly install after modifying Python files (`.py`).
   However, you would need to reinstall if you modify Python interface (`.pyi`, `.pyi.in`) or
    non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
-  One way to avoid running `python setup.py develop` every time one makes a change to C++/CUDA/ObjectiveC files on Linux/Mac, is to create a symbolic link from `build` folder to `torch/lib`, for example, by issuing following: `pushd torch/lib; rm libtorch_cpu.so; ln -sf ../../build/lib/libtorch_cpu.so .; popd`. After doing that rebuilding appropriate library (for example by running `ninja torch_cpu` from `build` folder), would be sufficient to make change visible in `torch` package.
-   
+
+
+  One way to avoid running `python setup.py develop` every time one makes a change to C++/CUDA/ObjectiveC files on Linux/Mac,
+  is to create a symbolic link from `build` folder to `torch/lib`, for example, by issuing following:
+  ```bash
+   pushd torch/lib; sh -c "ln -sf ../../build/lib/libtorch_cpu.* ."; popd
+  ```
+   Afterwards rebuilding a library (for example to rebuild `libtorch_cpu.so` issue `ninja torch_cpu` from `build` folder),
+   would be sufficient to make change visible in `torch` package.
+
 
   To reinstall, first uninstall all existing PyTorch installs. You may need to run `pip
   uninstall torch` multiple times. You'll know `torch` is fully

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,13 @@ Follow the instructions for [installing PyTorch from source](https://github.com/
 
 * If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
-* When installing with `python setup.py develop` (in contrast to `python setup.py install`) you will symlink
-   the Python files from the current local source-tree into the Python install.
+* When installing with `python setup.py develop` (in contrast to `python setup.py install`) Python runtime will use 
+  the current local source-tree when importing `torch` package. (This is done by creating [`.egg-link`](https://wiki.python.org/moin/PythonPackagingTerminology#egg-link) file in `site-packages` folder)
   This way you do not need to repeatedly install after modifying Python files (`.py`).
   However, you would need to reinstall if you modify Python interface (`.pyi`, `.pyi.in`) or
    non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
+  One way to avoid running `python setup.py develop` every time one makes a change to C++/CUDA/ObjectiveC files on Linux/Mac, is to create a symbolic link from `build` folder to `torch/lib`, for example, by issuing following: `pushd torch/lib; rm libtorch_cpu.so; ln -sf ../../build/lib/libtorch_cpu.so .; popd`. After doing that rebuilding appropriate library (for example by running `ninja torch_cpu` from `build` folder), would be sufficient to make change visible in `torch` package.
+   
 
   To reinstall, first uninstall all existing PyTorch installs. You may need to run `pip
   uninstall torch` multiple times. You'll know `torch` is fully


### PR DESCRIPTION
Update `CONTRIBUTING.md` with tip on how to avoid rebuilding/copying libs every time one makes a small change to the native code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5e8394</samp>

> _`setup.py` docs_
> _Link to source and build dirs_
> _Winter of testing_
