### PR TITLE
[FSDP]Add device_mesh to FSDPstate

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -27,6 +27,7 @@ from torch.distributed._composable_state import _get_module_state, _State
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
 )
+from torch.distributed._tensor.device_mesh import DeviceMesh
 
 from .api import (
     FullOptimStateDictConfig,
@@ -119,6 +120,7 @@ class _FSDPState(_State):
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
+        self._device_mesh: Optional[DeviceMesh] = None
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -24,10 +24,10 @@ import torch.distributed as dist
 import torch.distributed.fsdp.flat_param as flat_param_file
 import torch.nn as nn
 from torch.distributed._composable_state import _get_module_state, _State
+from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
 )
-from torch.distributed._tensor.device_mesh import DeviceMesh
 
 from .api import (
     FullOptimStateDictConfig,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -209,7 +209,7 @@ def _init_device_mesh(
 ) -> Optional[DeviceMesh]:
     # We are testing 1D DeviceMesh where dist.get_world_size(pg) == dist.get_world_size() for now.
     # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size(). This would capture
-    #       what DeviceMesh initilization currently would not work for:
+    #       what 1D DeviceMesh currently would not work for:
     #       1) HSDP Hybrid Sharding, 2) 2D FSDP + TP, 3) dist.new_group() cannot be expressed in 1D DeviceMesh.
     if get_world_size(pg) != get_world_size():
         return None

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -275,6 +275,7 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._free_event_queue = root_state._free_event_queue
         fsdp_state._handles_prefetched = root_state._handles_prefetched
         fsdp_state._needs_pre_backward_unshard = root_state._needs_pre_backward_unshard
+        # QQ: Not sure how to add a test for this. Any suggestion?
         fsdp_state._device_mesh = root_state._device_mesh
         for handle in fsdp_state._handles:
             handle.init_flat_param_attributes()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -208,7 +208,9 @@ def _init_device_mesh(
     pg: ProcessGroup,
 ) -> Optional[DeviceMesh]:
     # We are testing 1D DeviceMesh where dist.get_world_size(pg) == dist.get_world_size() for now.
-    # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size().
+    # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size(). This would capture
+    #       what DeviceMesh initilization currently would not work for:
+    #       1) HSDP Hybrid Sharding, 2) 2D FSDP + TP, 3) dist.new_group() cannot be expressed in 1D DeviceMesh.
     if get_world_size(pg) != get_world_size():
         return None
     mesh_tensor = torch.arange(get_world_size(pg))

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -17,7 +17,7 @@ import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
-from torch.distributed import get_world_size, ProcessGroup
+from torch.distributed import ProcessGroup
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
@@ -204,11 +204,18 @@ def _check_flat_params_on_expected_device(state: _FSDPState, module: nn.Module):
             )
 
 
+import torch.distributed as dist
+
+
 def _init_device_mesh(
     pg: ProcessGroup,
-) -> DeviceMesh:
-    world_size = get_world_size(pg)
-    device_mesh = DeviceMesh("cuda", torch.arange(world_size))
+) -> Optional[DeviceMesh]:
+    # We are testing for dist.get_world_size(pg) == dist.get_world_size() for now.
+    # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size().
+    if dist.get_world_size(pg) != dist.get_world_size():
+        return None
+    mesh_tensor = torch.arange(dist.get_world_size(pg))
+    device_mesh = DeviceMesh("cuda", mesh_tensor)
     return device_mesh
 
 


### PR DESCRIPTION
This PR creates a device_mesh and share it across all FSDP state. The device_mesh will later be used to test out dtensor state_dict (1d device_mesh). 

cc @zhaojuanmao @mrshenli @rohan-varma @awgu