### PR TITLE
[profiler] simplify fwdThreadId getter implementation

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -909,7 +909,7 @@ FORWARD_FROM_RESULT(deviceResourceId, kineto_info_.resource)
   TYPED_ATTR_WITH_DEFAULT(event_type, method_name, expression, {})
 
 TYPED_ATTR_WITH_DEFAULT(TorchOp, sequenceNr, e.sequence_number_, -1)
-TYPED_ATTR(TorchOp, fwdThreadId, e.sequence_number_ >= 0 ? e.forward_tid_ : 0)
+TYPED_ATTR_WITH_DEFAULT(TorchOp, fwdThreadId, e.forward_tid_, 0);
 TYPED_ATTR(TorchOp, scope, static_cast<uint8_t>(e.scope_))
 TYPED_ATTR(TorchOp, hasModuleHierarchy, !e.jit_modules_.empty())
 TYPED_ATTR(TorchOp, isAsync, e.is_async_)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #102332

I spent a while trying to understand why there is this special handling.

From what I can tell, we actually don't need this special handling; maybe it's left over from when there was no default initialization for the fields in TorchOpBasicFields.