### PR TITLE
[c10d] add init_barrier as a ProcessGroupOption

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -26,6 +26,18 @@ class TestFakePG(TestCase):
         super().tearDown()
         dist.destroy_process_group()
 
+    def test_fake_pg_init(self):
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake", rank=1, world_size=4, store=store
+        )
+        self.assertEqual(dist.get_rank(), 1)
+        self.assertEqual(dist.get_world_size(), 4)
+
+        new_pg = dist.new_group(ranks=[1, 3])
+        self.assertEqual(dist.get_rank(new_pg), 0)
+        self.assertEqual(dist.get_world_size(new_pg), 2)
+
     def test_all_reduce(self):
         store = FakeStore()
         dist.init_process_group(

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -55,14 +55,18 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   struct TORCH_API Options : torch::CustomClassHolder {
     explicit Options(
         std::string backend,
-        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout)
-        : timeout(timeout), backend(std::move(backend)) {}
+        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout,
+        bool init_barrier = true)
+        : timeout(timeout), backend(std::move(backend)), init_barrier(init_barrier) {}
     ~Options() override = default;
 
     std::chrono::milliseconds timeout;
 
     // backend name
     const std::string backend;
+
+    // Whether to barrier during process group initialization.
+    bool init_barrier;
   };
 
   enum BackendType {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1676,14 +1676,18 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
 )")
           .def(
               py::init([](const std::string& backend,
-                          const std::chrono::milliseconds& timeout) {
+                          const std::chrono::milliseconds& timeout,
+                          bool init_barrier) {
                 return c10::make_intrusive<::c10d::ProcessGroup::Options>(
-                    backend, timeout);
+                    backend, timeout, init_barrier);
               }),
               py::arg("backend"),
               py::arg("timeout") = kProcessGroupDefaultTimeout,
+              py::arg("init_barrier") = true,
               py::call_guard<py::gil_scoped_release>())
           .def_readonly("backend", &::c10d::ProcessGroup::Options::backend)
+          .def_readwrite(
+              "_init_barrier", &::c10d::ProcessGroup::Options::init_barrier)
           .def_readwrite("_timeout", &::c10d::ProcessGroup::Options::timeout);
 
 #ifndef _WIN32


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102343

This PR add init_barrier as a field of ProcessGroupOption, this allows
each process group instance, and custom backend (i.e. FakePG) to control
whether they need to barrier after initialization