### PR TITLE
Fix some move warnings by gcc13

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -2105,8 +2105,7 @@ template <
             guts::negation<std::is_constructible<IValue, Args>>...>::value,
         std::nullptr_t>>
 inline IValue::IValue(const std::tuple<Args...>& t)
-    : IValue(
-          std::move(c10::guts::apply(c10::ivalue::Tuple::create<const Args&...>, t))) {
+    : IValue(c10::guts::apply(c10::ivalue::Tuple::create<const Args&...>, t)) {
 }
 
 template <
@@ -2117,8 +2116,7 @@ template <
             guts::negation<std::is_constructible<IValue, Args>>...>::value,
         std::nullptr_t>>
 inline IValue::IValue(std::tuple<Args...>&& t)
-    : IValue(
-          std::move(c10::guts::apply(c10::ivalue::Tuple::create<Args&&...>, std::move(t)))) {
+    : IValue(c10::guts::apply(c10::ivalue::Tuple::create<Args&&...>, std::move(t))) {
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::ConstantString> v)

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -30,11 +30,11 @@ const Tensor& value){
   int64_t num_ind = 0;
   Tensor mask;
   auto self_device = self.device();
-  for (const c10::optional<Tensor> i: indices) {
+  for (const c10::optional<Tensor>& i: indices) {
     if (!i.has_value() || !(*i).defined()){
       num_ind++;
     } else {
-      Tensor index = std::move(*i);
+      const Tensor &index = *i;
       if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
           index.device() != self_device || mask.defined()){
         return std::make_tuple(false, Tensor());

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
@@ -91,7 +91,7 @@ ContextConv create(
       {stride_expanded.begin(), stride_expanded.end()},
       {dilation_expanded.begin(), dilation_expanded.end()},
       groups,
-      std::move(attr)};
+      attr};
 }
 
 void _mkldnn_convolution_out(


### PR DESCRIPTION
GCC 13 has improved warnings about std::move. This PR tries to fix some detected code issues.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10