### PR TITLE
[DTensor][Random Ops] separate DeviceMesh RNG state from the default RNG state

### DIFF
--- a/torch/distributed/_tensor/ops/random_ops.py
+++ b/torch/distributed/_tensor/ops/random_ops.py
@@ -8,7 +8,7 @@ from torch.distributed._tensor.ops.utils import register_prop_rule
 from torch.distributed._tensor.placement_types import _Partial, DTensorSpec
 
 aten = torch.ops.aten
-random_ops = [
+random_init_ops = [
     aten.normal_.default,
     aten.uniform_.default,
 ]
@@ -54,5 +54,5 @@ def dropout_rule(op_schema: OpSchema) -> OutputSharding:
         return OutputSharding([self_spec, self_spec])
 
 
-for op in random_ops:
+for op in random_init_ops:
     _register_non_deterministic_op(op)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102359
* __->__ #102358


# Goal
To have ATEN random ops and DTensor random ops use different RNG state (i.e. `(seed, offset)` pair):
- for ATEN random ops, use the RNG state stored in device's default `Generator` object
- for DTensor random ops, use the RNG state stored in `DeviceMesh`.

# Change
1. modify APIs under `torch.distributed._tensor.random`. Previously `set_rng_state` and `get_rng_state` access  `Generator` directly but now they access `DeviceMesh`. Calling `set_rng_state` won't change the device's RNG state until a DTensor random op is called. The same rule applies to `manual_seed`. The internal APIs that access `Generator` are renamed to `_get_device_rng_state` and `_set_device_rng_state`.
2. When we execute a DTensor random op call, now we use `fork_rng` to set/reset device's RNG state. This guarantees that `Generator`'s RNG state and `DeviceMesh`'s RNG state are isolated.
3. Seed synchronization now happens when a `DeviceMesh` is created. The seed to broadcast is a random `int` value generated on rank 0 and the offset is set to 0. The reason we use a random int rather than the random seed itself is we want to avoid `reusing` a random seed in different places.
4. Existing tests are adapted to the above changes. First, we no longer check `Generator`'s RNG state in testing because `DeviceMesh`'s RNG state only becomes effective during the op call and cannot be checked. We can still check `DeviceMesh`'s RNG state but that seems trivial. Second, we add some testing code to verify that the device's `Generator` RNG state is not modified after a DTensor random op call. This check can be refactored to a wrapper.

# Next
1. Compare to other frameworks like TensorFlow and JAX on how the distributed RNG state is used.
2. Think how this can be used in TP. Existing TP code either initializes identical weights on all ranks or generate different numbers for `Replicate`. 
