### PR TITLE
[PT2][Quant] Use module partition for fused patterns

### DIFF
--- a/test/quantization/pt2e/test_graph_utils.py
+++ b/test/quantization/pt2e/test_graph_utils.py
@@ -1,0 +1,90 @@
+# Owner(s): ["oncall: quantization"]
+import copy
+import operator
+import unittest
+from typing import Any, List, Optional, Tuple
+
+import torch
+import torch._dynamo as torchdynamo
+
+from torch.ao.quantization._pt2e.graph_utils import find_sequential_partitions
+from torch.fx import Node
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestGraphUtils(TestCase):
+    def test_conv_bn_relu(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 3, 3)
+                self.bn1 = torch.nn.BatchNorm2d(3)
+                self.conv2 = torch.nn.Conv2d(3, 3, 3)
+                self.relu2 = torch.nn.ReLU()
+
+            def forward(self, x):
+                bn_out = self.bn1(self.conv1(x))
+                relu_out = torch.nn.functional.relu(bn_out)
+                return self.relu2(self.conv2(relu_out))
+
+        m = M().eval()
+        example_inputs = (torch.randn(1, 3, 5, 5),)
+
+        # program capture
+        m, guards = torchdynamo.export(
+            m,
+            *copy.deepcopy(example_inputs),
+            aten_graph=True,
+        )
+        fused_partitions = find_sequential_partitions(
+            m, [torch.nn.Conv2d, torch.nn.BatchNorm2d]
+        )
+        self.assertEqual(len(fused_partitions), 1)
+        fused_partitions = find_sequential_partitions(
+            m, [torch.nn.Conv2d, torch.nn.BatchNorm2d, torch.nn.ReLU]
+        )
+        self.assertEqual(len(fused_partitions), 1)
+        x = lambda: find_sequential_partitions(
+            m,
+            [
+                torch.nn.Conv2d,
+                torch.nn.BatchNorm2d,
+                torch.nn.ReLU,
+                torch.nn.functional.conv2d,
+            ],
+        )
+        self.assertRaises(ValueError, x)
+
+    def test_conv_bn_relu(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn1 = torch.nn.BatchNorm2d(3)
+                self.conv2 = torch.nn.Conv2d(3, 3, 3)
+                self.relu2 = torch.nn.ReLU()
+
+            def forward(self, x):
+                bn_out = self.bn1(x)
+                return self.relu2(self.conv2(bn_out))
+
+        m = M().eval()
+        example_inputs = (torch.randn(1, 3, 5, 5),)
+
+        # program capture
+        m, guards = torchdynamo.export(
+            m,
+            *copy.deepcopy(example_inputs),
+            aten_graph=True,
+        )
+        fused_partitions = find_sequential_partitions(
+            m, [torch.nn.Conv2d, torch.nn.BatchNorm2d]
+        )
+        self.assertEqual(len(fused_partitions), 0)
+        fused_partitions = find_sequential_partitions(
+            m, [torch.nn.BatchNorm2d, torch.nn.Conv2d]
+        )
+        self.assertEqual(len(fused_partitions), 1)
+        fused_partitions = find_sequential_partitions(
+            m, [torch.nn.BatchNorm2d, torch.nn.ReLU]
+        )
+        self.assertEqual(len(fused_partitions), 0)

--- a/torch/ao/quantization/_pt2e/graph_utils.py
+++ b/torch/ao/quantization/_pt2e/graph_utils.py
@@ -1,0 +1,81 @@
+import itertools
+from typing import Any, Dict, List, OrderedDict, Set
+
+import torch
+
+from torch.fx.passes.utils.source_matcher_utils import (
+    check_subgraphs_connected,
+    get_source_partitions,
+    SourcePartition,
+)
+
+_EQUIVALENT_TYPES: List[Set] = [
+    {torch.nn.Conv2d, torch.nn.functional.conv2d},
+    {torch.nn.ReLU, torch.nn.functional.relu, torch.nn.functional.relu_},
+    {torch.nn.BatchNorm2d, torch.nn.functional.batch_norm},
+]
+
+
+def _create_equivalent_types_dict():
+    _DICT = {}
+    for values in _EQUIVALENT_TYPES:
+        for v in values:
+            _DICT[v] = list(values)
+    return _DICT
+
+
+_EQUIVALET_TYPES_DICT = _create_equivalent_types_dict()
+
+
+def _partitions_sequential(partitions: List[SourcePartition]):
+    prev_partition = None
+    for partition in partitions:
+        if prev_partition is not None and not check_subgraphs_connected(
+            prev_partition, partition
+        ):
+            return False
+        prev_partition = partition
+    return True
+
+
+def _get_matching_types(partition_type):
+    matching_types = [partition_type]
+    if partition_type in _EQUIVALET_TYPES_DICT:
+        matching_types.extend(_EQUIVALET_TYPES_DICT[partition_type])
+    return matching_types
+
+
+def _valid_type_sequence(partition_types: List[Any]):
+    partition_types_set = set()
+    for partition_type in partition_types:
+        matching_types = _get_matching_types(partition_type)
+        matching_types_set = set(matching_types)
+        if len(partition_types_set & matching_types_set) > 0:
+            return False
+        partition_types_set |= matching_types_set
+    return True
+
+
+def find_sequential_partitions(
+    gm: torch.fx.GraphModule,
+    partition_types: List[Any],
+    include_functional_equivalent=True,
+):
+    if not _valid_type_sequence(partition_types):
+        raise ValueError(
+            f"Invalid partition types: {partition_types}. Each type in the sequence must be unique"
+        )
+
+    typed_partitions: OrderedDict[Any, List[SourcePartition]] = OrderedDict()
+    for partition_type in partition_types:
+        types_to_match = _get_matching_types(partition_type)
+        partitions = get_source_partitions(gm.graph, types_to_match)
+        typed_partitions[partition_type] = list(itertools.chain(*partitions.values()))
+
+    typed_partitions_list = list(typed_partitions.values())
+    fusion_candidates = itertools.product(*typed_partitions_list)
+    fused_partitions = []
+    for candidate in fusion_candidates:
+        if _partitions_sequential(candidate):
+            fused_partitions.append(candidate)
+    return fused_partitions

--- a/torch/ao/quantization/_pt2e/quantizer/utils.py
+++ b/torch/ao/quantization/_pt2e/quantizer/utils.py
@@ -1,4 +1,5 @@
 import torch
+from torch.fx import Node
 from torch.ao.quantization._pt2e.quantizer.quantizer import (
     QuantizationConfig,
     QuantizationSpec,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This diff introduces utility `find_sequential_partitions`.
This utility allows one to specify sequential pattern of
nn.Module/nn.functional and returns a list. Each item in the list contains a
List[SourcePartition] that represents sequentially connected partitions that
are of the pattern requested.
For example `find_sequential_partitions(model, [nn.Conv2d, nn.ReLU])` will find
all nn.Conv2d and nn.ReLU partitions that are sequentially connected.

Furthmore, move to using `find_sequential_partitions` for conv_bn/conv_bn_relu
for QAT.

Differential Revision: [D45948057](https://our.internmc.facebook.com/intern/diff/D45948057/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D45948057/)!