### PR TITLE
Improve time savings calculation math for test reordering

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -43,6 +43,7 @@ try:
         calculate_shards,
         get_reordered_tests,
         get_test_case_configs,
+        log_time_savings,
         NUM_PROCS,
         ShardedTest,
         THRESHOLD,
@@ -1579,6 +1580,8 @@ def main():
     remaining_tests = selected_tests
     if IS_CI:
         (prioritized_tests, remaining_tests) = get_reordered_tests(selected_tests)
+        log_time_savings(selected_tests, prioritized_tests)
+
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1580,7 +1580,7 @@ def main():
     remaining_tests = selected_tests
     if IS_CI:
         (prioritized_tests, remaining_tests) = get_reordered_tests(selected_tests)
-        log_time_savings(selected_tests, prioritized_tests)
+        log_time_savings(selected_tests, prioritized_tests, is_serial_test_fn=must_serial, num_procs=NUM_PROCS)
 
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1580,7 +1580,12 @@ def main():
     remaining_tests = selected_tests
     if IS_CI:
         (prioritized_tests, remaining_tests) = get_reordered_tests(selected_tests)
-        log_time_savings(selected_tests, prioritized_tests, is_serial_test_fn=must_serial, num_procs=NUM_PROCS)
+        log_time_savings(
+            selected_tests,
+            prioritized_tests,
+            is_serial_test_fn=must_serial,
+            num_procs=NUM_PROCS,
+        )
 
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -421,9 +421,6 @@ class TestParsePrevTests(unittest.TestCase):
             ShardedTest(name="test4", shard=1, num_shards=2, time=3.0),
             ShardedTest(name="test5", shard=1, num_shards=2, time=2.0),
             ShardedTest(name="test6", shard=1, num_shards=2, time=1.0),
-            # ShardedTest(name="test7", shard=1, num_shards=2, time=3.0),
-            # ShardedTest(name="test8", shard=1, num_shards=2, time=5.0),
-            # ShardedTest(name="test9", shard=1, num_shards=2, time=3.0),
         ]
 
         prioritized_tests = ("test4", "test5", "test8")
@@ -451,7 +448,7 @@ class TestParsePrevTests(unittest.TestCase):
         ]
         prioritized_tests = ("test3", "test4", "test7")
 
-        # Drawing out the math here since this is the most complicated example
+        # Drawing out the math here since this is a complicated example
 
         # Logic for original execution assuming 2 procs
         # Test  | Proc 1 | Proc 2

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -438,7 +438,6 @@ class TestParsePrevTests(unittest.TestCase):
         self.assertEqual(
             time_savings, expected_time_savings, "Received an unexpected time savings"
         )
-        pass
 
     def test_compute_prioritization_time_savings_with_multiple_threads_and_many_prioritized_tests(
         self,

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -417,7 +417,7 @@ class TestParsePrevTests(unittest.TestCase):
         self.assertSetEqual(expected_prioritized_tests, prioritized_tests_name)
         self.assertSetEqual(expected_remaining_tests, remaining_tests_name)
 
-    def test_compute_prioritization_time_savings_with_multiple_threads(self):
+    def test_compute_prioritization_time_savings_with_multiple_threads(self) -> None:
         tests = [
             ShardedTest(name="test1", shard=1, num_shards=2, time=7.0),
             ShardedTest(name="test2", shard=1, num_shards=2, time=5.0),
@@ -442,7 +442,7 @@ class TestParsePrevTests(unittest.TestCase):
 
     def test_compute_prioritization_time_savings_with_multiple_threads_and_many_prioritized_tests(
         self,
-    ):
+    ) -> None:
         tests = [
             ShardedTest(name="test1", shard=1, num_shards=2, time=4.0),
             ShardedTest(name="test2", shard=1, num_shards=2, time=3.0),
@@ -486,7 +486,7 @@ class TestParsePrevTests(unittest.TestCase):
         )
         pass
 
-    def test_compute_prioritization_time_savings_with_serialized_test(self):
+    def test_compute_prioritization_time_savings_with_serialized_test(self) -> None:
         tests = [
             ShardedTest(name="test1", shard=1, num_shards=2, time=7.0),
             ShardedTest(name="test2", shard=1, num_shards=2, time=5.0),

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -199,55 +199,60 @@ def _python_test_file_to_test_name(tests: Set[str]) -> Set[str]:
 class PoolTimes:
     def __init__(self, num_procs):
         self.pool_times = [0.0 for _ in range(num_procs)]
+        self.serial_times = 0.0
 
-    def next_test_start_time(self):
+    def next_test_start_time(self, serial: bool):
+        if serial:
+            # Serial tests are run after all parallel tests complete
+            return max(self.pool_times) + self.serial_times
+
         return self.pool_times[0]
 
-    def schedule_test(self, test):
-        # pool_times[0] is always the thread with the least amount of time scheduled
-        heapq.heappushpop(self.pool_times, self.pool_times[0] + test.get_time())
+    def schedule_test(self, test, serial: bool):
+        if serial:
+            self.serial_times += test.get_time()
+        else:
+            # pool_times[0] is always the thread with the least amount of time scheduled
+            heapq.heappushpop(self.pool_times, self.pool_times[0] + test.get_time())
 
 
-def _get_scheduled_prioritized_tests(
-    tests: List[ShardedTest],
-    prioritized_tests: Set[str],
+def log_time_savings(
+    selected_tests: List[ShardedTest],
+    prioritized_tests: List[ShardedTest],
+    is_serial_test_fn: Callable[[str], bool],
     num_procs: int = NUM_PROCS,  # make this customizable for testing
-) -> Tuple[List[ShardedTest], List[ShardedTest]]:
-    bring_to_front = []
-    the_rest = []
+):
+    # The tests will be run in [num_procs] parallel threads, so we assume each test
+    # is allocated to the thread that'll free up first.
+    # This isn't an exact match (since other factors could change which thread
+    # pool a test gets scheduled on) but it's a good approximation.
 
-    # As we iterate through the tests, we keep track of the total time for the
-    # regular tests. The tests will be run in num_procs parallel pools, so we
-    # do the math assuming the each test is allocated to the least busy pool.
-    # This isn't an exact match (since other factors could affect what test gets
-    # scheduled on which thread pool) but it's a good approximation.
+    # Simulates the scheduled tests on each thread pool
+    default_pool = PoolTimes(num_procs)  # originally scheduled run
+    prioritized_pool = PoolTimes(num_procs)  # run for prioritized tests
+    max_time_savings_sec = 0.0
 
-    # Track how long the tests scheduled so far are expected to take. Used to calculate time savings
-    prioritized_pool = PoolTimes(num_procs)
-    default_pool = PoolTimes(num_procs)
+    # It's easier to look up prioritized tests by name
+    prioritized_test_names = {test.name for test in prioritized_tests}
 
-    # How much sooner did we run prioritized tests compared to a naive ordering
-    time_savings_sec = 0.0
-
-    for test in tests:
-        if test.name in prioritized_tests:
-            bring_to_front.append(test)
-            # Calculate approx time saved by reordering
-            # Time savings = When this would have been scheduled - When it'll actually be scheduled
-            time_savings_sec = (
-                default_pool.next_test_start_time()
-                - prioritized_pool.next_test_start_time()
-            )
+    for test in selected_tests:
+        serial = is_serial_test_fn(test.name)
+        if test.name in prioritized_test_names:
+            # Successive tests will always have a greater time savings
+            max_time_savings_sec = default_pool.next_test_start_time(
+                serial
+            ) - prioritized_pool.next_test_start_time(serial)
 
             # "schedule" this test on the prioritized pool to get time savings for future prioritized tests
-            prioritized_pool.schedule_test(test)
-        else:
-            the_rest.append(test)
+            prioritized_pool.schedule_test(test, serial)
 
-        # always schedule on the default pool to get know what the unprioritized timeline would've looked like
-        default_pool.schedule_test(test)
+        # always schedule on the default pool to know what the unprioritized timeline would've looked like
+        default_pool.schedule_test(test, serial)
 
-    return (bring_to_front, the_rest, time_savings_sec)
+    print(
+        f"Prioritized tests will run about {duration_to_str(max_time_savings_sec)} sooner than they would've otherwise"
+    )
+    return max_time_savings_sec
 
 
 def get_reordered_tests(
@@ -280,9 +285,14 @@ def get_reordered_tests(
     )
     prioritized_tests |= pri_test
 
-    bring_to_front, the_rest, time_savings_sec = _get_scheduled_prioritized_tests(
-        tests, prioritized_tests, NUM_PROCS
-    )
+    bring_to_front = []
+    the_rest = []
+
+    for test in tests:
+        if test.name in prioritized_tests:
+            bring_to_front.append(test)
+        else:
+            the_rest.append(test)
 
     if len(tests) != len(bring_to_front) + len(the_rest):
         print(
@@ -295,9 +305,6 @@ def get_reordered_tests(
     if bring_to_front:
         test_cnt_str = pluralize(len(tests), "test")
         print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
-        print(
-            f"Prioritized tests estimated to run up to {duration_to_str(time_savings_sec)} sooner than they would've otherwise"
-        )
 
         prioritized_test_names = [t.name for t in bring_to_front]
         print(f"Prioritized: {prioritized_test_names}")

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -197,18 +197,18 @@ def _python_test_file_to_test_name(tests: Set[str]) -> Set[str]:
 
 
 class PoolTimes:
-    def __init__(self, num_procs):
+    def __init__(self, num_procs: int) -> None:
         self.pool_times = [0.0 for _ in range(num_procs)]
         self.serial_times = 0.0
 
-    def next_test_start_time(self, serial: bool):
+    def next_test_start_time(self, serial: bool) -> float:
         if serial:
             # Serial tests are run after all parallel tests complete
             return max(self.pool_times) + self.serial_times
 
         return self.pool_times[0]
 
-    def schedule_test(self, test, serial: bool):
+    def schedule_test(self, test: ShardedTest, serial: bool) -> None:
         if serial:
             self.serial_times += test.get_time()
         else:
@@ -221,7 +221,7 @@ def log_time_savings(
     prioritized_tests: List[ShardedTest],
     is_serial_test_fn: Callable[[str], bool],
     num_procs: int = NUM_PROCS,  # make this customizable for testing
-):
+) -> float:
     # The tests will be run in [num_procs] parallel threads, so we assume each test
     # is allocated to the thread that'll free up first.
     # This isn't an exact match (since other factors could change which thread
@@ -252,6 +252,8 @@ def log_time_savings(
     print(
         f"Prioritized tests will run about {duration_to_str(max_time_savings_sec)} sooner than they would've otherwise"
     )
+
+    # Return value used by tests
     return max_time_savings_sec
 
 


### PR DESCRIPTION
Use a more accurate method that accounts for tests being run in parallel

Right now we still log results to the console, but later it'll get logged to Rockset for better tracking