### PR TITLE
[quant][pt2e] Fix propagate_annotation after recent refactors

### DIFF
--- a/torch/ao/quantization/_pt2e/_propagate_annotation.py
+++ b/torch/ao/quantization/_pt2e/_propagate_annotation.py
@@ -3,6 +3,10 @@ from torch.fx import Node
 from typing import (
     Callable,
 )
+from torch.ao.quantization._pt2e.quantizer import (
+    QuantizationAnnotation,
+    SharedQuantizationSpec,
+)
 
 def _is_share_obs_or_fq_op(op: Callable) -> bool:
     return op in [
@@ -23,22 +27,24 @@ def propagate_annotation(model: torch.fx.GraphModule) -> None:
         if not isinstance(prev_node, Node):
             continue
 
-        target_dtype_info = prev_node.meta.get("target_dtype_info", None)
-        if not target_dtype_info:
+        quantization_annotation = prev_node.meta.get("quantization_annotation", None)
+        if not quantization_annotation:
             continue
 
-        output_act_obs_or_fq_ctr = target_dtype_info.get("output_act_obs_or_fq_ctr", None)
-        if not output_act_obs_or_fq_ctr:
+        output_qspec = quantization_annotation.output_qspec
+        if not output_qspec:
             continue
 
         # make sure current node is not annotated
-        if "target_dtype_info" in n.meta and n.meta["target_dtype_info"].get("_annotated", False):
+        if "quantization_annotation" in n.meta and n.meta["quantization_annotation"]._annotated:
             continue
 
-        # propagate the previous output_act_obs_or_fq to the current node
-        n.meta["target_dtype_info"] = {
-            "input_act_obs_or_fq_ctr": output_act_obs_or_fq_ctr,
-            "output_act_obs_or_fq_ctr": output_act_obs_or_fq_ctr,
-            "input_output_share_observers": True,
-            "_annotated": True,
-        }
+        shared_qspec = SharedQuantizationSpec(prev_node)
+        # propagate the previous output_qspec to the current node
+        n.meta["quantization_annotation"] = QuantizationAnnotation(
+            input_qspec_map = {
+                "input_act_obs_or_fq_ctr": shared_qspec,
+            },
+            output_qspec=shared_qspec,
+            _annotated=True,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Recently we changed the annotation from "target_dtype_info" to "quantization_annotation" and introduced QuantizationAnnotation API
and SharedQuantizationSpec API for users to convey sharing between input/outputs, this PR updates the _propagate_annotation
pass to accommadate the recent changes

Differential Revision: [D46153084](https://our.internmc.facebook.com/intern/diff/D46153084/)