### PR TITLE
Improve `clip_grad_norm`  to use torch.linalg.vector_norm

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -46,7 +46,7 @@ def clip_grad_norm_(
         = _group_tensors_by_device_and_dtype([[g.detach() for g in grads]])  # type: ignore[assignment]
 
     if norm_type == inf:
-        norms = [g.detach().abs().max().to(first_device) for g in grads]
+        norms = [torch.linalg.norm(g.detach(), inf) for g in grads]
         total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         norms = []
@@ -56,9 +56,9 @@ def clip_grad_norm_(
             elif foreach:
                 raise RuntimeError(f'foreach=True was passed, but can\'t use the foreach API on {device.type} tensors')
             else:
-                norms.extend([torch.norm(g, norm_type) for g in grads])
+                norms.extend([torch.linalg.norm(g, norm_type) for g in grads])
 
-        total_norm = torch.norm(torch.stack([norm.to(first_device) for norm in norms]), norm_type)
+        total_norm = torch.linalg.norm(torch.stack([norm.to(first_device) for norm in norms]), norm_type)
 
     if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
         raise RuntimeError(

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -46,7 +46,7 @@ def clip_grad_norm_(
         = _group_tensors_by_device_and_dtype([[g.detach() for g in grads]])  # type: ignore[assignment]
 
     if norm_type == inf:
-        norms = [torch.linalg.norm(g.detach(), inf) for g in grads]
+        norms = [torch.linalg.norm(g.detach(), inf).to(first_device) for g in grads]
         total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         norms = []

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -46,7 +46,7 @@ def clip_grad_norm_(
         = _group_tensors_by_device_and_dtype([[g.detach() for g in grads]])  # type: ignore[assignment]
 
     if norm_type == inf:
-        norms = [torch.linalg.norm(g.detach(), inf).to(first_device) for g in grads]
+        norms = [torch.linalg.vector_norm(g.detach(), inf).to(first_device) for g in grads]
         total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         norms = []
@@ -56,9 +56,9 @@ def clip_grad_norm_(
             elif foreach:
                 raise RuntimeError(f'foreach=True was passed, but can\'t use the foreach API on {device.type} tensors')
             else:
-                norms.extend([torch.linalg.norm(g, norm_type) for g in grads])
+                norms.extend([torch.linalg.vector_norm(g, norm_type) for g in grads])
 
-        total_norm = torch.linalg.norm(torch.stack([norm.to(first_device) for norm in norms]), norm_type)
+        total_norm = torch.linalg.vector_norm(torch.stack([norm.to(first_device) for norm in norms]), norm_type)
 
     if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
         raise RuntimeError(


### PR DESCRIPTION
Done in this PR:
 - Use `torch.linalg.vector_norm` instead of `torch.norm`
 - Reduce bandwidth boundary of clip_grad_norm when used with `inf`, ie no need to get the returned tensor after `abs`
 
What I'm slightly unsure:
 - I don't know if `inf` support `torch._foreach` API
