### PR TITLE
[pytorch-vulkan] aten::uniform

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/uniform_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/uniform_.glsl
@@ -1,0 +1,47 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D uOutput;
+layout(set = 0, binding = 1) uniform PRECISION restrict Block {
+  ivec3 size;
+  float from;
+  float to;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+uint pcg_hash(uint v) {
+  // From: https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/
+  uint state = v * 747796405u + 2891336453u;
+  uint word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+  return (word >> 22u) ^ word;
+}
+
+float rand2(ivec4 pos) {
+  uint s =
+      pcg_hash(pos.x) + pcg_hash(pos.y) + pcg_hash(pos.z) + pcg_hash(pos.w);
+  return fract(s / 1234567.0);
+}
+
+float get_uniform(ivec4 pos) {
+  float v = rand2(pos);
+  return uBlock.from + v * (uBlock.to - uBlock.from);
+}
+
+void main() {
+  ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size))) {
+    vec4 v = vec4(
+        get_uniform(ivec4(pos, -20)),
+        get_uniform(ivec4(pos, 40)),
+        get_uniform(ivec4(pos, -30)),
+        get_uniform(ivec4(pos, 15)));
+    imageStore(uOutput, pos, v);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Random.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Random.cpp
@@ -1,0 +1,71 @@
+#include <ATen/ArrayRef.h>
+#include <ATen/CPUGeneratorImpl.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <torch/library.h>
+#include <vector>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+
+using namespace api::utils;
+
+Tensor& uniform_(
+    Tensor& self,
+    double from,
+    double to,
+    c10::optional<at::Generator> /* not implemented */) {
+  TORCH_CHECK(
+      self.is_vulkan(),
+      "Vulkan: In-place operator is only supported on Vulkan tensors.");
+
+  api::Context* const context = api::context();
+
+  vTensor& v_self = convert(self);
+
+  const struct Block final {
+    uvec3 extents;
+    float from;
+    float to;
+  } block{v_self.extents(), static_cast<float>(from), static_cast<float>(to)};
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      // shader_descriptor,
+      VK_KERNEL(uniform_),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_self.extents(),
+      // local work group size
+      adaptive_work_group_size(v_self.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_self.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      // params buffer
+      params.buffer());
+
+  return self;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::uniform_"), TORCH_FN(uniform_));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary:
aten::uniform implementation.

the randomization function didn't use Perlin, as the outcome distribution is not uniform.

choose to use PCG (https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/) instead.

Test Plan:
```
yipjustin@yipjustin-mac fbsource % buck run  -c pt.vulkan_full_precision=1  --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -- --gtest_filter="*uniform*"
Downloaded 0/47 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 40.0 sec (100%) 524/524 jobs, 10/524 updated
  Total time: 40.0 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *uniform*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VulkanAPITest
[ RUN      ] VulkanAPITest.uniform
[       OK ] VulkanAPITest.uniform (54 ms)
[----------] 1 test from VulkanAPITest (54 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (54 ms total)
[  PASSED  ] 1 test.
```

Differential Revision: D46170098

