### PR TITLE
[quant][pt2e] Add support for FixedQParamsQuantizationSpec

### DIFF
--- a/torch/ao/quantization/_pt2e/prepare.py
+++ b/torch/ao/quantization/_pt2e/prepare.py
@@ -36,6 +36,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     model: torch.nn.Module,
     named_modules: Dict[str, torch.nn.Module],
     obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
+    is_qat: bool,
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -47,7 +48,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
         new_arg_to_return = []
         for inner_arg in arg:
             new_inner_arg = _maybe_insert_input_observer_for_arg_or_kwarg(
-                node, inner_arg, qconfig, model, named_modules, obs_or_fq_map
+                node, inner_arg, qconfig, model, named_modules, obs_or_fq_map, is_qat,
             )
             new_arg_to_return.append(new_inner_arg)
         return type(arg)(new_arg_to_return)
@@ -60,10 +61,10 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
 
     quantization_annotation = node.meta.get("quantization_annotation", QuantizationAnnotation())
     reuse_input_obs_or_fq = quantization_annotation._reuse_input_obs_or_fq
-    arg_as_input_act_obs_or_fq = _get_arg_as_input_act_obs_or_fq(arg, node, named_modules, obs_or_fq_map)
+    arg_as_input_act_obs_or_fq = _get_arg_as_input_act_obs_or_fq(arg, node, named_modules, obs_or_fq_map, is_qat)
     arg_as_input_target_dtype, arg_as_input_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_input_act_obs_or_fq)
 
-    arg_as_output_act_obs_or_fq = _get_output_act_obs_or_fq(arg, named_modules, obs_or_fq_map)
+    arg_as_output_act_obs_or_fq = _get_output_act_obs_or_fq(arg, named_modules, obs_or_fq_map, is_qat)
     arg_as_output_target_dtype, arg_as_output_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_output_act_obs_or_fq)
 
     if arg_as_input_target_is_dynamic or arg_as_input_target_dtype not in [torch.float, None]:
@@ -93,6 +94,7 @@ def _maybe_insert_input_observers_for_node(
     model: torch.nn.Module,
     named_modules: Dict[str, torch.nn.Module],
     obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
+    is_qat: bool,
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -112,7 +114,7 @@ def _maybe_insert_input_observers_for_node(
     new_args = []
     for arg in node.args:
         new_arg = _maybe_insert_input_observer_for_arg_or_kwarg(
-            node, arg, qconfig, model, named_modules, obs_or_fq_map
+            node, arg, qconfig, model, named_modules, obs_or_fq_map, is_qat,
         )
         new_args.append(new_arg)
 
@@ -129,6 +131,7 @@ def _maybe_insert_input_and_output_observers_for_node(
     node: Node,
     model: torch.fx.GraphModule,
     obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
+    is_qat: bool,
 ):
     this_node_dtype_info = node.meta["quantization_annotation"] if "quantization_annotation" in node.meta else None
     if "val" in node.meta:
@@ -154,6 +157,7 @@ def _maybe_insert_input_and_output_observers_for_node(
         model,
         named_modules,
         obs_or_fq_map,
+        is_qat,
     )
 
     skip_inserting_output_observers = (
@@ -164,7 +168,7 @@ def _maybe_insert_input_and_output_observers_for_node(
         return
 
     # this returns the new observer node if it was needed
-    maybe_output_obs_node = _maybe_insert_output_observer_for_node(node, model, named_modules, model.graph, obs_or_fq_map)
+    maybe_output_obs_node = _maybe_insert_output_observer_for_node(node, model, named_modules, model.graph, obs_or_fq_map, is_qat)
 
     if maybe_output_obs_node is None:
         return
@@ -188,7 +192,7 @@ def _maybe_insert_input_and_output_observers_for_node(
         if user_node is maybe_output_obs_node:
             continue
         user_node.replace_input_with(node, maybe_output_obs_node)
-    _is_observer_in_same_graph_ = _is_observer_in_same_graph(node, named_modules, obs_or_fq_map)
+    _is_observer_in_same_graph_ = _is_observer_in_same_graph(node, named_modules, obs_or_fq_map, is_qat)
 
     input_output_share_observers = node.meta["quantization_annotation"]._input_output_share_observers
     reuse_input_obs_or_fq = node.meta["quantization_annotation"]._reuse_input_obs_or_fq
@@ -216,10 +220,10 @@ def prepare(
             "call_function",
             "get_attr",
         ):
-            _maybe_insert_input_and_output_observers_for_node(node, model, obs_or_fq_map)
+            _maybe_insert_input_and_output_observers_for_node(node, model, obs_or_fq_map, is_qat)
         elif node.op == "output":
             named_modules = dict(model.named_modules(remove_duplicate=False))
-            _maybe_insert_observers_before_graph_output(node, model, named_modules, model.graph, obs_or_fq_map)
+            _maybe_insert_observers_before_graph_output(node, model, named_modules, model.graph, obs_or_fq_map, is_qat)
 
     model = GraphModule(model, model.graph)
 

--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -5,6 +5,7 @@ from .quantizer import (
     Quantizer,
     QuantizationSpec,
     QuantizationAnnotation,
+    FixedQParamsQuantizationSpec,
     SharedQuantizationSpec,
     DerivedQuantizationSpec,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "QuantizationSpec",
     "QNNPackQuantizer",
     "QuantizationAnnotation",
+    "FixedQParamsQuantizationSpec",
     "SharedQuantizationSpec",
     "DerivedQuantizationSpec",
 ]

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -26,6 +26,9 @@ SUPPORTED_QSCHEMES = [
 
 @dataclass(eq=True, frozen=True)
 class QuantizationSpec:
+    """ Quantization spec for common operators that allows user to specify how to
+    quantize a Tensor, this includes dtype, quant_min, quant_max etc.
+    """
     dtype: torch.dtype
     # observer or fake_quantize constructor such as
     # MinMaxObserver, PerChannelHistogramObserver etc.
@@ -62,6 +65,15 @@ class QuantizationSpec:
         if self.ch_axis is not None and self.ch_axis < 0:
             raise ValueError("Ch_axis is < 0.")
 
+@dataclass(eq=True, frozen=True)
+class FixedQParamsQuantizationSpec:
+    dtype: torch.dtype
+    scale: float
+    zero_point: int
+    quant_min: Optional[int] = None
+    quant_max: Optional[int] = None
+    qscheme: Optional[torch.qscheme] = None
+
 EdgeOrNode = Union[Tuple[Node, Node], Node]
 
 @dataclass(eq=True, frozen=True)
@@ -75,7 +87,6 @@ class SharedQuantizationSpec:
     output value is an fx Node
     """
     edge_or_node: EdgeOrNode
-
 
 @dataclass(eq=True, frozen=True)
 class DerivedQuantizationSpec:

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -264,6 +264,7 @@ class FixedQParamsFakeQuantize(FakeQuantize):
     is supported.
     """
 
+    # TODO: rename observer to observer_ctr
     def __init__(self, observer):
         super().__init__(observer=observer)
         assert type(self.activation_post_process) == FixedQParamsObserver,\


### PR DESCRIPTION
Summary:
This PR adds support for FixedQParamsQuantizationSpec:

```
dataclass(eq=True, frozen=True)
class FixedQParamsQuantizationSpec(QuantizationSpecBase):
    dtype: torch.dtype
    scale: float
    zero_point: int
    quant_min: Optional[int] = None
    quant_max: Optional[int] = None
    qscheme: Optional[torch.qscheme] = None
```

This is useful to define quantization spec for operators like sigmoid which has predefined and fixed scale/zero_point

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- 'caffe2/test:quantization_pt2e'
buck2 test mode/opt caffe2/test:quantization_pt2e -- --exact 'caffe2/test:quantization_pt2e - test_fixed_qparams_qspec (quantization.pt2e.test_quantize_pt2e.TestQuantizePT2E)'
```

Reviewed By: kimishpatel

Differential Revision: D46153082

