### PR TITLE
implement __dir__ for dynamo

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1398,6 +1398,31 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         out_dtype = opt_mod(mod)
         self.assertEqual(out_dtype, torch.float32)
 
+    def test_dir(self):
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+                self.register_buffer("buf0", torch.randn(10, 10))
+                self.register_parameter(name='param0', param=torch.nn.Parameter(torch.randn(10, 10)))
+
+            def forward(self, x):
+                return self.r(torch.sin(x)) + self.buf0
+
+        mod = MockModule()
+        mod_keys = dir(mod)
+        opt_mod = torch._dynamo.optimize("eager")(mod)
+        opt_mod_keys = dir(opt_mod)
+
+        # Check user-defined attributes, parameters and buffers
+        self.assertIn('linear', opt_mod_keys)
+        self.assertIn('buf0', opt_mod_keys)
+        self.assertIn('param0', opt_mod_keys)
+
+        # Check all attributes, parameters and buffers
+        for p1, p2 in zip(mod_keys, opt_mod_keys):
+            self.assertTrue(p1 == p2)
+
     def test_recursion(self):
         mod = MockModule()
         cnt = torch._dynamo.testing.CompileCounter()

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1404,7 +1404,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
                 super().__init__()
                 self.linear = torch.nn.Linear(10, 10)
                 self.register_buffer("buf0", torch.randn(10, 10))
-                self.register_parameter(name='param0', param=torch.nn.Parameter(torch.randn(10, 10)))
+                self.register_parameter(
+                    name="param0", param=torch.nn.Parameter(torch.randn(10, 10))
+                )
 
             def forward(self, x):
                 return self.r(torch.sin(x)) + self.buf0
@@ -1415,9 +1417,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         opt_mod_keys = dir(opt_mod)
 
         # Check user-defined attributes, parameters and buffers
-        self.assertIn('linear', opt_mod_keys)
-        self.assertIn('buf0', opt_mod_keys)
-        self.assertIn('param0', opt_mod_keys)
+        self.assertIn("linear", opt_mod_keys)
+        self.assertIn("buf0", opt_mod_keys)
+        self.assertIn("param0", opt_mod_keys)
 
         # Check all attributes, parameters and buffers
         for p1, p2 in zip(mod_keys, opt_mod_keys):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -144,6 +144,8 @@ class OptimizedModule(torch.nn.Module):
             self._orig_mod._infer_parameters(self._orig_mod, args)
         return self._forward(*args, **kwargs)
 
+    def __dir__(self):
+        return self._orig_mod.__dir__()
 
 def remove_from_cache(f):
     """

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -147,6 +147,7 @@ class OptimizedModule(torch.nn.Module):
     def __dir__(self):
         return self._orig_mod.__dir__()
 
+
 def remove_from_cache(f):
     """
     Make sure f.__code__ is not cached to force a recompile


### PR DESCRIPTION
Fixes #94478 modules' attributes are not included in when `__dir__` is called on the optimized module.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx