### PR TITLE
before the PR, running ```super(MyConv1d, self).forward```, dynamo will create a graph break when executing NNModuleVariable.call_method and raise unimplemented error for name=_conv_forward. see issue for full detail: https://github.com/pytorch/pytorch/issues/101155

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -729,6 +729,20 @@ class ConvTransposeCallForwardDirectly(torch.nn.Module):
         return self.layer.forward(x)
 
 
+class ConvCallSuperForwardDirectly(torch.nn.Conv1d):
+    def __init__(self, in_channels, out_channels, kernel_size, **kwargs):
+        super(ConvCallSuperForwardDirectly, self).__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            **kwargs,
+        )
+
+    def forward(self, inputs, mask=None):
+        outputs = super(ConvCallSuperForwardDirectly, self).forward(inputs)
+        return outputs
+
+
 class ModuleNameString(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -1316,6 +1330,14 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
     def test_conv_transpose_call_forward_directly(self):
         m = ConvTransposeCallForwardDirectly()
         x = torch.rand([4, 4, 4, 4])
+        ref = m(x)
+        opt_m = torch.compile(backend="eager", fullgraph=True)(m)
+        res = opt_m(x)
+        self.assertTrue(torch.allclose(ref, res))
+
+    def test_conv_call_super_forward_directly(self):
+        x = torch.randn(4, 4)
+        m = ConvCallSuperForwardDirectly(4, 4, 4)
         ref = m(x)
         opt_m = torch.compile(backend="eager", fullgraph=True)(m)
         res = opt_m(x)

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -606,6 +606,18 @@ class NNModuleVariable(VariableTracker):
                 [self] + args,
                 kwargs,
             )
+        elif name == "_conv_forward":
+            # inline the torch.nn.modules.conv._conv_forward
+            fn = getattr(module, name).__func__
+            module_attr = getattr(fn, "__module__", "")
+            if module_attr is not None and module_attr.startswith(
+                "torch.nn.modules.conv"
+            ):
+                return tx.inline_user_function_return(
+                    variables.UserMethodVariable(fn, self, **options),
+                    [self] + args,
+                    kwargs,
+                )
         # A loose heuristic, but seems to be generally good before we drop into the
         # manual handling of inputs
         elif (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102499

after the PR, for torch.nn.conv module with function name _conv_forward, we inline the function with tx.inline_user_function_return

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx