### PR TITLE
Faketensor hpu device normalization

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -939,6 +939,10 @@ class FakeTensor(torch.Tensor):
             init_cuda_context()
             if device.index is None:
                 device = torch.device(f"cuda:{torch.cuda.current_device()}")
+
+        # normalize hpu device.
+        if device.type == "hpu" and device.index is None:
+            device = torch.device(f"hpu:{torch.hpu.current_device()}")
         self.fake_device = device  # type: ignore[attr-defined]
         self.fake_mode = fake_mode  # type: ignore[attr-defined]
         self.constant = constant  # type: ignore[attr-defined]


### PR DESCRIPTION
FakeTensor doesn't normalize device_idx  and failed with below testcase.

import torch
import habana_frameworks.torch.hpu
from torch._subclasses.fake_tensor import FakeTensorMode

with FakeTensorMode.push():
    a = torch.empty(1, device="hpu")
    b = torch.empty(1, device="hpu:0")
    result = a + b
