### PR TITLE
NCCL process group: avoid workEnqueue when capturing cuda graph

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -410,6 +410,28 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
             work.wait()
         torch.cuda.synchronize(local_device)
 
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")
+    def test_allreduce_in_cudagraph(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        pg = self._create_process_group_nccl(store, self.opts())
+        local_device_idx = self.rank_to_GPU[self.rank][0]
+
+        xs = [torch.FloatTensor([1]).cuda(local_device_idx)]
+        ys = [torch.FloatTensor([8]).cuda(local_device_idx)]
+
+        # single warmup
+        pg.allreduce(xs).wait()
+        self.assertEqual(2, xs[0].item())
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            pg.allreduce(xs).wait()
+        self.assertEqual(2, xs[0].item())
+
+        graph.replay()
+        graph.replay()
+        self.assertEqual(xs, ys)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")


### PR DESCRIPTION
Summary:
In torch.distributed, we make ProcessGroupNCCL not call workEnqueue when the cuda stream is capturing. I.e., when capturing a CUDA graph, we do not enqueue anything for the watchdog thread to consider. This allows capturing NCCL operations in a CUDA Graph. 

This is followup to an internal discussion [1] where the watchdog thread was observed to crash when using cuda graphs containing an all_reduce. The watchdog thread wants to query events pertaining to enqueued work items, but this can't be done for "events" created during cuda graph capture.

[1] https://fb.workplace.com/groups/1405155842844877/posts/6975201909173548/

Test Plan: Test added. Also, the repro mentioned in https://fb.workplace.com/groups/1405155842844877/posts/7003002339726838/ runs successfully after this change.

Differential Revision: D46274814

