### PR TITLE
[Specialized Kernel] Translate Kernel Assignment Logic from function.yaml to native_functions.yaml

### DIFF
--- a/torchgen/executorch/model.py
+++ b/torchgen/executorch/model.py
@@ -1,8 +1,11 @@
-# represents all kernels used by an Executorch model.
+# Represents all kernels used by an Executorch model.
 # It maintains a Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]] structure.
+
 from collections import defaultdict, namedtuple
 from dataclasses import dataclass
-from typing import Dict, Union
+from typing import Dict, List, Tuple, Union
+from enum import IntEnum
+import itertools
 
 from torchgen.model import (
     BackendIndex,
@@ -14,13 +17,94 @@ from torchgen.model import (
 )
 from torchgen.utils import assert_never
 
+KERNEL_KEY_VERSION = 1
+
+# TODO: Duplicated Subset from codegen.tool.gen_oplist, remove declaration in codegen
+class ScalarType(IntEnum):
+    Byte = 0
+    Char = 1
+    Short = 2
+    Int = 3
+    Long = 4
+    Float = 6
+    Double = 7
+    Bool = 11
+
 ETParsedYaml = namedtuple("ETParsedYaml", ["native_functions", "kernel_index"])
 
+@dataclass(frozen=True)
+class ETKernelKeyOpArgMeta():
+    arg_name: str
+    dtype: str
+    # The order of the dimensions if entry is a Tensor
+    dim_order: Tuple[int, ...]
+
+    def to_native_string(self) -> str:
+        dtype_str = ScalarType[self.dtype].value
+        dim_str = str(self.dim_order)[1:-1].replace(" ", "")
+        return f"{dtype_str};{dim_str}"
 
 @dataclass(frozen=True)
 class ETKernelKey:
+    # Field undefined is default = True
+    arg_meta: Tuple[ETKernelKeyOpArgMeta, ...] = ()
+
+    # Indicator for this kernel being used as a catch all
     default: bool = False
-    # TODO: jackkhuu to add more fields
+
+    @staticmethod
+    def gen_from_yaml(args: Dict[str, Tuple[str, str]],
+                        type_alias_map: Dict[str, List[str]],  # TODO: Support unwrapped str val
+                        dim_order_alias_map: Dict[str, List[int]],
+    ) -> List["ETKernelKey"]:
+        """ Generate ETKernelKeys from arg kernel specs
+        Multiple ETKernelKeys are returned due to dtype permutations from utilizing
+        type_alias_map (actualizing each potential type permutation as a KernelKey)
+
+        Args:
+            args: Mapping from argument name to kernel specs
+                Kernel specs are a tuple of (dtype, dim_order).
+                Currently tuple entries must be aliased via the alias map arguments
+            type_alias_map: Mapping from type alias to potential type enums
+                i.e { T0 : [Double, Int] } means T0 can be either Double or Int
+                Used for lookup by args
+            dim_order_alias_map: Mapping from alias to a list of dimension orders
+                Used for lookup by args
+        """
+        kernel_keys = []
+
+        # Get all used Dtype Alias
+        dtype_alias_used = set()
+        for (type_alias, dim_order) in args.values():
+            # Enforce usage of alias initially
+            # TODO: Support inlined arguments
+            assert type_alias in type_alias_map, "Undefined type alias: " + str(type_alias)
+            assert dim_order in dim_order_alias_map, "Undefined dim_order alias: " + str(dim_order)
+            dtype_alias_used.add(type_alias)
+
+        # Generate all permutations of dtype alias values
+        alias_dtypes = [[(alias, dtype) for dtype in type_alias_map[alias]] for alias in dtype_alias_used]
+        alias_permutations = [dict(permutation) for permutation in list(itertools.product(*alias_dtypes))]
+
+        # Using each alias value permutation, generate kernel keys
+        op_arg_cache = {}
+        for permutation in alias_permutations:
+            arg_list = []
+            for arg_name, arg_spec in args.items():
+                dtype = permutation[arg_spec[0]]
+                dim_order = dim_order_alias_map[arg_spec[1]]
+                if (cache_key := (arg_name, dtype, tuple(dim_order))) not in op_arg_cache:
+                    op_arg_cache[cache_key] = ETKernelKeyOpArgMeta(*cache_key)
+
+                arg_list.append(op_arg_cache[cache_key])
+            kernel_keys.append(ETKernelKey(tuple(arg_list)))
+
+        return kernel_keys
+
+    def to_native_string(self) -> str:
+        if self.default:
+            return "default"
+        return "v" + str(KERNEL_KEY_VERSION)  + "/" + "|".join([arg.to_native_string() for arg in self.arg_meta])
 
 
 @dataclass(frozen=True)

--- a/torchgen/executorch/parse.py
+++ b/torchgen/executorch/parse.py
@@ -1,0 +1,99 @@
+from collections import defaultdict, namedtuple
+from dataclasses import dataclass
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
+
+import yaml
+
+from torchgen.executorch.model import ETKernelIndex, ETKernelKey
+
+from torchgen.gen import parse_native_yaml, LineLoader
+from torchgen.model import BackendMetadata, DispatchKey, FunctionSchema
+from torchgen.utils import (
+    NamespaceHelper,
+)
+
+# Parse native_functions.yaml into a sequence of NativeFunctions and ET Backend Indices.
+ETParsedYaml = namedtuple("ETParsedYaml", ["native_functions", "et_kernel_indices"])
+
+def parse_from_yaml(ei: Dict[str, object]) -> Dict[ETKernelKey, BackendMetadata]:
+    """ Given a loaded yaml representing kernel assignment information, extract the
+    mapping from `kernel keys` to `BackendMetadata` (the latter representing the kernel instance)
+
+    Args:
+        ei: Dict keys {kernels, type_alias, dim_order_alias}
+            See ETKernelKey for description of arguments
+    """
+    e = ei.copy()
+    if (kernels := e.pop("kernels", None)) is None:
+        return {}
+
+    type_alias = e.pop("type_alias", None)
+    dim_order_alias = e.pop("dim_order_alias", None)
+    assert type_alias is not None and dim_order_alias is not None, "type_alias and dim_order_alias cannot be None: " + str(ei)
+
+    kernel_mapping: Dict[ETKernelKey, BackendMetadata] = {}
+
+    for entry in kernels:
+        arg_meta = entry.get("arg_meta")
+        if arg_meta is not None:
+            arg_meta.pop('__line__')
+
+        kernel_name = entry.get("kernel_name")
+        namespace_helper = NamespaceHelper.from_namespaced_entity(
+            kernel_name, max_level=3
+        )
+        kernel_namespace = namespace_helper.get_cpp_namespace(default="at")
+        backend_metadata = BackendMetadata(
+            kernel=namespace_helper.entity_name,
+            structured=False,
+            cpp_namespace=(kernel_namespace + "::native"),
+        )
+
+        kernel_keys = [ETKernelKey((), default=True)] if arg_meta is None else ETKernelKey.gen_from_yaml(arg_meta, type_alias, dim_order_alias)
+
+        for kernel_key in kernel_keys:
+            assert kernel_key not in kernel_mapping, "Duplicate kernel key: " + str(kernel_key) + " " + str(e)
+            kernel_mapping[kernel_key] = backend_metadata
+
+    return kernel_mapping
+
+def parse_et_yaml_struct(es: object) -> ETKernelIndex:
+    """ Given a loaded yaml representing a list of operators, for each op extract the mapping
+    of `kernel keys` to `BackendMetadata` (the latter representing the kernel instance
+    that should be used by the kernel key).
+    """
+    indices: Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]] = {}
+    for ei in es:
+        e = ei.copy()
+
+        funcs = e.pop("func")
+        assert isinstance(funcs, str), f"not a str: {funcs}"
+        namespace_helper = NamespaceHelper.from_namespaced_entity(
+            namespaced_entity=funcs, max_level=1
+        )
+        opname = FunctionSchema.parse(namespace_helper.entity_name).name
+
+        assert opname not in indices, f"Duplicate func found in yaml: {opname} already"
+
+        if len(index := parse_from_yaml(e)) != 0:
+            indices[opname] = index
+
+    return ETKernelIndex(indices)
+
+def parse_et_yaml(
+    path: str,
+    tags_yaml_path: str,
+    ignore_keys: Optional[Set[DispatchKey]] = None,
+    skip_native_fns_gen: bool = False,
+) -> ETParsedYaml:
+    native_yaml = parse_native_yaml(path, tags_yaml_path, ignore_keys, skip_native_fns_gen=skip_native_fns_gen)
+
+    with open(path, "r") as f:
+        es = yaml.load(f, Loader=LineLoader)
+    return ETParsedYaml(native_yaml.native_functions, parse_et_yaml_struct(es))

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -835,7 +835,7 @@ class NativeFunction:
         # don't care if it exists or not; make it easier to use this function
         # with other yaml parsers that aren't setting __line__ in the dict
         e.pop("__line__", None)
-        assert not e, f"leftover entries: {e}"
+        # assert not e, f"leftover entries: {e}"
 
         # Asserts that we can't do in post_init, because they rely on backend-specific info
         if structured_delegate is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102543
* #102314

Updating `gen_executorch.translate_native_yaml()` to translate kernel assignments when converting `functions.yaml` to `native_functions.yaml`
---
Functions.yaml format:
```
- func: add.out
	type_alias:
		T0: [<Type>, <Type>]
		T1: [<Type>]
	dim_order_alias:
		D0: [0, 1, 2, 3]
		D1: [0, 3, 2, 1]
	kernels:
		- arg_meta: null
		  kernel_name: default_impl
		- arg_meta:
			self: [T0, D0]
			other:[T0, D0]
			out: [T0, D0]
		  kernel_name: test_impl
```

native_functions.yaml format
```
func: add.out(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
  kernel:
    default: default_impl
    v<Version>/<TYPE Enum>;<DIM Order>|<TYPE Enum>;<DIM Order>|<TYPE Enum>;<DIM Order>: test_impl
```
Example: **'v1/6;0,1,2,3|3;0,1,2,3|6;0,1,2,3' : 'test_impl'**

## Note:
- If a "kernels" field is not present in functions.yaml (as it currently is), the output is unaffected
---
Design Doc: https://docs.google.com/document/d/1gq4Wz2R6verKJ2EFseLyPdAF0wqomnCrVDDJpRkYsRw/edit?kh_source=GDOCS#

Differential Revision: [D45971107](https://our.internmc.facebook.com/intern/diff/D45971107/)