### PR TITLE
[1/n]fsdp dtensor state_dict support: add the flag use_dtensor to both StateDictConfig and OptimStateDictConfig

### DIFF
--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -273,6 +273,7 @@ class StateDictConfig:
     """
 
     offload_to_cpu: bool = False
+    use_dtensor: bool = True
 
 
 @dataclass
@@ -328,6 +329,7 @@ class OptimStateDictConfig:
 
     # TODO: actually use this flag in the _optim_utils.py
     offload_to_cpu: bool = True
+    use_dtensor: bool = True
 
 
 @dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102545
* __->__ #102544

