### PR TITLE
Run libtorch in 2 shards (manual sharding)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -543,13 +543,6 @@ test_libtorch() {
 
     export CPP_TESTS_DIR="${TORCH_BIN_DIR}"
 
-    # Start background download
-    MNIST_DIR="${PWD}/test/cpp/api/mnist"
-    python tools/download_mnist.py --quiet -d "${MNIST_DIR}" &
-
-    # Wait for background download to finish
-    wait
-
     if [[ -z "${SHARD}" || "${SHARD}" == "1" ]]; then
       test_libtorch_jit
     fi
@@ -591,6 +584,10 @@ test_libtorch_jit() {
 }
 
 test_libtorch_api() {
+  # Start background download
+  MNIST_DIR="${PWD}/test/cpp/api/mnist"
+  python tools/download_mnist.py --quiet -d "${MNIST_DIR}"
+
   if [[ "$BUILD_ENVIRONMENT" == *asan* || "$BUILD_ENVIRONMENT" == *slow-gradcheck* ]]; then
     TEST_REPORTS_DIR=test/test-reports/cpp-unittest/test_libtorch
     mkdir -p $TEST_REPORTS_DIR

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -527,6 +527,8 @@ if [[ "${BUILD_ENVIRONMENT}" == *tbb* ]]; then
 fi
 
 test_libtorch() {
+  local SHARD="$1"
+
   # The slow test config corresponds to a default test config that should run
   # the libtorch tests instead.
   if [[ "$BUILD_ENVIRONMENT" != *rocm* && "$TEST_CONFIG" != "slow" ]]; then
@@ -545,57 +547,69 @@ test_libtorch() {
     MNIST_DIR="${PWD}/test/cpp/api/mnist"
     python tools/download_mnist.py --quiet -d "${MNIST_DIR}" &
 
-    # Prepare the model used by test_jit, the model needs to be in the test directory
-    # to get picked up by run_test
-    pushd test
-    python cpp/jit/tests_setup.py setup
-    popd
-
-    # Run JIT cpp tests
-    if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
-      python test/run_test.py --cpp --verbose -i cpp/test_jit cpp/nvfuser_tests
-    else
-      # CUDA tests have already been skipped when CUDA is not available
-      python test/run_test.py --cpp --verbose -i cpp/test_jit -k "not CUDA"
-    fi
-
-    # Run Lazy Tensor cpp tests
-    if [[ "$BUILD_ENVIRONMENT" == *cuda* && "$TEST_CONFIG" != *nogpu* ]]; then
-      LTC_TS_CUDA=1 python test/run_test.py --cpp --verbose -i cpp/test_lazy
-    else
-      python test/run_test.py --cpp --verbose -i cpp/test_lazy
-    fi
-
-    # Cleaning up test artifacts in the test folder
-    pushd test
-    python cpp/jit/tests_setup.py shutdown
-    popd
-
     # Wait for background download to finish
     wait
 
-    if [[ "$BUILD_ENVIRONMENT" == *asan* || "$BUILD_ENVIRONMENT" == *slow-gradcheck* ]]; then
-        TEST_REPORTS_DIR=test/test-reports/cpp-unittest/test_libtorch
-        mkdir -p $TEST_REPORTS_DIR
-
-        # TODO: Not quite sure why these tests time out on ASAN and SLOW, probably
-        # this is due to the fact that a python executable is used or some logic
-        # inside run_test. This test usually takes only minutes to run
-        OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="${MNIST_DIR}" "$TORCH_BIN_DIR"/test_api --gtest_filter='-IMethodTest.*' --gtest_output=xml:$TEST_REPORTS_DIR/test_api.xml
-        "$TORCH_BIN_DIR"/test_tensorexpr --gtest_output=xml:$TEST_REPORTS_DIR/test_tensorexpr.xml
-    else
-        # Exclude IMethodTest that relies on torch::deploy, which will instead be ran in test_deploy
-        OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="${MNIST_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_api -k "not IMethodTest"
-        python test/run_test.py --cpp --verbose -i cpp/test_tensorexpr
+    if [[ -z "${SHARD}" || "${SHARD}" == "1" ]]; then
+      test_libtorch_jit
     fi
 
-    if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* && "${BUILD_ENVIRONMENT}" != *asan* ]]; then
-      # NB: This test is not under TORCH_BIN_DIR but under BUILD_BIN_DIR
-      export CPP_TESTS_DIR="${BUILD_BIN_DIR}"
-      python test/run_test.py --cpp --verbose -i cpp/static_runtime_test
+    if [[ -z "${SHARD}" || "${SHARD}" == "2" ]]; then
+      test_libtorch_api
     fi
 
     assert_git_not_dirty
+  fi
+}
+
+test_libtorch_jit() {
+  # Prepare the model used by test_jit, the model needs to be in the test directory
+  # to get picked up by run_test
+  pushd test
+  python cpp/jit/tests_setup.py setup
+  popd
+
+  # Run JIT cpp tests
+  if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
+    python test/run_test.py --cpp --verbose -i cpp/test_jit cpp/nvfuser_tests
+  else
+    # CUDA tests have already been skipped when CUDA is not available
+    python test/run_test.py --cpp --verbose -i cpp/test_jit -k "not CUDA"
+  fi
+
+  # Run Lazy Tensor cpp tests
+  if [[ "$BUILD_ENVIRONMENT" == *cuda* && "$TEST_CONFIG" != *nogpu* ]]; then
+    LTC_TS_CUDA=1 python test/run_test.py --cpp --verbose -i cpp/test_lazy
+  else
+    python test/run_test.py --cpp --verbose -i cpp/test_lazy
+  fi
+
+  # Cleaning up test artifacts in the test folder
+  pushd test
+  python cpp/jit/tests_setup.py shutdown
+  popd
+}
+
+test_libtorch_api() {
+  if [[ "$BUILD_ENVIRONMENT" == *asan* || "$BUILD_ENVIRONMENT" == *slow-gradcheck* ]]; then
+    TEST_REPORTS_DIR=test/test-reports/cpp-unittest/test_libtorch
+    mkdir -p $TEST_REPORTS_DIR
+
+    # TODO: Not quite sure why these tests time out on ASAN and SLOW, probably
+    # this is due to the fact that a python executable is used or some logic
+    # inside run_test. This test usually takes only minutes to run
+    OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="${MNIST_DIR}" "$TORCH_BIN_DIR"/test_api --gtest_filter='-IMethodTest.*' --gtest_output=xml:$TEST_REPORTS_DIR/test_api.xml
+    "$TORCH_BIN_DIR"/test_tensorexpr --gtest_output=xml:$TEST_REPORTS_DIR/test_tensorexpr.xml
+  else
+    # Exclude IMethodTest that relies on torch::deploy, which will instead be ran in test_deploy
+    OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="${MNIST_DIR}" python test/run_test.py --cpp --verbose -i cpp/test_api -k "not IMethodTest"
+    python test/run_test.py --cpp --verbose -i cpp/test_tensorexpr
+  fi
+
+  if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* && "${BUILD_ENVIRONMENT}" != *asan* ]]; then
+    # NB: This test is not under TORCH_BIN_DIR but under BUILD_BIN_DIR
+    export CPP_TESTS_DIR="${BUILD_BIN_DIR}"
+    python test/run_test.py --cpp --verbose -i cpp/static_runtime_test
   fi
 }
 
@@ -1009,10 +1023,11 @@ elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   test_python_shard 1
   test_aten
+  test_libtorch 1
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   test_python_shard 2
-  test_libtorch
+  test_libtorch 2
   test_aot_compilation
   test_custom_script_ops
   test_custom_backend

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -386,10 +386,11 @@ def main() -> None:
         # No PR number, no tag, we can just return the test matrix as it is
         filtered_test_matrix = test_matrix
 
-    if args.event_name == "schedule" and args.schedule == "29 8 * * *":
-        # we don't want to run the mem leak check or disabled tests on normal
-        # periodically scheduled jobs, only the ones at this time
-        filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
+    # DEBUG - TO BE REVERTED BEFORE MERGING
+    # if args.event_name == "schedule" and args.schedule == "29 8 * * *":
+    # we don't want to run the mem leak check or disabled tests on normal
+    # periodically scheduled jobs, only the ones at this time
+    filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
 
     if args.workflow and args.job_name and args.branch not in EXCLUDED_BRANCHES:
         # If both workflow and job name are available, we will check if the current job

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -386,11 +386,10 @@ def main() -> None:
         # No PR number, no tag, we can just return the test matrix as it is
         filtered_test_matrix = test_matrix
 
-    # DEBUG - TO BE REVERTED BEFORE MERGING
-    # if args.event_name == "schedule" and args.schedule == "29 8 * * *":
-    # we don't want to run the mem leak check or disabled tests on normal
-    # periodically scheduled jobs, only the ones at this time
-    filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
+    if args.event_name == "schedule" and args.schedule == "29 8 * * *":
+        # we don't want to run the mem leak check or disabled tests on normal
+        # periodically scheduled jobs, only the ones at this time
+        filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
 
     if args.workflow and args.job_name and args.branch not in EXCLUDED_BRANCHES:
         # If both workflow and job name are available, we will check if the current job


### PR DESCRIPTION
This is a quick way to mitigate libtorch timing out issue on 2nd shard when running with memory leak check, for example https://github.com/pytorch/pytorch/actions/runs/5119293905/jobs/9204880456

### Testing

* Slow gradcheck https://github.com/pytorch/pytorch/actions/runs/5128253177
  * `slow / linux-bionic-cuda12.1-py3-gcc7-slow-gradcheck / test (default, 1, 4, linux.4xlarge.nvidia.gpu)`: `3h40` → `3h20`?
  * `slow / linux-bionic-cuda12.1-py3-gcc7-slow-gradcheck / test (default, 2, 4, linux.4xlarge.nvidia.gpu)`: `4h30` → `3h50`
  * `linux-bionic-cuda12.1-py3-gcc7-slow-gradcheck / test (default, 1, 4, linux.4xlarge.nvidia.gpu, mem_leak_check)`: `3h35` → `3h20`
  * `linux-bionic-cuda12.1-py3-gcc7-slow-gradcheck / test (default, 2, 4, linux.4xlarge.nvidia.gpu, mem_leak_check)`: `4h20` → `4h`
* Linux GPU https://github.com/pytorch/pytorch/actions/runs/5128252752
  * `linux-bionic-cuda11.8-py3.10-gcc7 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)`: `1h40` → `1h40` 
  * `linux-bionic-cuda11.8-py3.10-gcc7 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)`: `2h10` → `1h35`
  * `linux-bionic-cuda11.8-py3.10-gcc7 / test (default, 1, 5, linux.4xlarge.nvidia.gpu, mem_leak_check)`: `2h30` → `2h50`
  * `linux-bionic-cuda11.8-py3.10-gcc7 / test (default, 2, 5, linux.4xlarge.nvidia.gpu, mem_leak_check)`: `3h20` → `2h50` 
