### PR TITLE
get_arch_list check _is_compiled

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -683,7 +683,7 @@ def device_count() -> int:
 
 def get_arch_list() -> List[str]:
     r"""Returns list CUDA architectures this library was compiled for."""
-    if not is_available():
+    if not _is_compiled():
         return []
     arch_flags = torch._C._cuda_getArchFlags()
     if arch_flags is None:


### PR DESCRIPTION
`torch.cuda.get_arch_list()` need not require a device to report the CUDA architectures the library was compiled for.  
 Rather, the requirement is that torch has been compiled with CUDA capabilities.  Replace `is_available()` with `_is_compiled()`.  

This change is useful inside a docker build, where the docker image contains CUDA but no CUDA device is mounted at build time. Prior to the PR, `get_cuda_arch()` returns an empty list as `is_available()` returns False, despite the fact that `torch._C._cuda_getArchFlags()` would succeed.