### PR TITLE
Quick fix for keep-going + reruns

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -597,7 +597,7 @@ def run_test(
     should_file_rerun = (
         "--subprocess" not in command
         and not RERUN_DISABLED_TESTS
-        and not options.continue_on_error
+        and not options.continue_through_error
     )
     timeout = (
         THRESHOLD * 3

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -594,7 +594,7 @@ def run_test(
     os.close(log_fd)
 
     command = (launcher_cmd or []) + executable + argv
-    should_file_rerun = "--subprocess" not in command and not RERUN_DISABLED_TESTS
+    should_file_rerun = "--subprocess" not in command and not RERUN_DISABLED_TESTS and not options.continue_on_error
     timeout = (
         THRESHOLD * 3
         if should_file_rerun
@@ -972,8 +972,10 @@ def get_pytest_args(
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
         pytest_args.extend(
-            ["-p", "no:xdist", "--use-pytest", f"--sc={stepcurrent_key}"]
+            ["-p", "no:xdist", "--use-pytest"]
         )
+        if not options.continue_through_error:
+            pytest_args.append(f"--sc={stepcurrent_key}")
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -594,7 +594,11 @@ def run_test(
     os.close(log_fd)
 
     command = (launcher_cmd or []) + executable + argv
-    should_file_rerun = "--subprocess" not in command and not RERUN_DISABLED_TESTS and not options.continue_on_error
+    should_file_rerun = (
+        "--subprocess" not in command
+        and not RERUN_DISABLED_TESTS
+        and not options.continue_on_error
+    )
     timeout = (
         THRESHOLD * 3
         if should_file_rerun
@@ -971,9 +975,7 @@ def get_pytest_args(
     ]
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
-        pytest_args.extend(
-            ["-p", "no:xdist", "--use-pytest"]
-        )
+        pytest_args.extend(["-p", "no:xdist", "--use-pytest"])
         if not options.continue_through_error:
             pytest_args.append(f"--sc={stepcurrent_key}")
     else:


### PR DESCRIPTION
Currently file level reruns + stepcurrent are incompatible and it's making PRs green when they are actually red, so turn off stepcurrent + file level reruns when keep-going is used until I figure out a better way to do this.