### PR TITLE
Improve repeat_interleave with scalar repeat value

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -119,7 +119,7 @@ Tensor repeat_interleave_symint(
                 calculated_size, " but got ", *output_size);
   }
 
-  return input.clone().flatten(dim, dim + 1);
+  return input.clone(at::MemoryFormat::Contiguous).flatten(dim, dim + 1);
 }
 
 } // namespace native

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -97,31 +97,30 @@ Tensor repeat_interleave(
   return ret;
 }
 
-Tensor repeat_interleave(
-    const Tensor& self,
-    int64_t repeats,
-    c10::optional<int64_t> dim,
-    c10::optional<int64_t> output_size) {
-  Tensor input = self;
-  at::Tensor repeats_ = at::empty(1, self.options().dtype(at::kLong)).fill_(repeats);
-  if (!output_size) {
-    if (!dim) {
-      input = input.flatten();
-      dim = 0;
-    }
-    auto input_size = input.sym_size(dim.value()).guard_int(__FILE__, __LINE__);
-    output_size = input_size * repeats;
-  }
-  return at::native::repeat_interleave(input, repeats_, dim, output_size);
-}
-
 Tensor repeat_interleave_symint(
     const Tensor& self,
     c10::SymInt repeats,
-    c10::optional<int64_t> dim,
+    c10::optional<int64_t> dim_opt,
     c10::optional<int64_t> output_size) {
-    return at::native::repeat_interleave(self, repeats.guard_int(__FILE__, __LINE__), dim, output_size);
+  Tensor input = dim_opt ? self : self.flatten();
+  int64_t dim = c10::maybe_wrap_dim(dim_opt.value_or(0), self.dim());
+  TORCH_CHECK(repeats >= 0, "Repeats must be non-negative");
+
+  input = input.unsqueeze(dim + 1);
+  auto expand_shape = input.sym_sizes().vec();
+  expand_shape[dim + 1] = repeats;
+  input = input.expand_symint(expand_shape);
+
+  // This argument doesn't really make sense for the scalar overload, but exists
+  // for consistency with the tensor overload
+  if (output_size) {
+    auto calculated_size = (repeats * expand_shape[dim]).guard_int(__FILE__, __LINE__);
+    TORCH_CHECK(calculated_size == *output_size, "repeat_interleave: Invalid output_size, expected ",
+                calculated_size, " but got ", *output_size);
   }
+
+  return input.clone().flatten(dim, dim + 1);
+}
 
 } // namespace native
 } // namespace at

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2633,6 +2633,19 @@ class CommonTemplate:
             (torch.randn([1, 2, 4, 8]),),
         )
 
+    def test_repeat_interleave(self):
+        def fn(x):
+            return (
+                x.repeat_interleave(2),
+                x.repeat_interleave(3, dim=0),
+                x.repeat_interleave(x.size(1), dim=1),
+            )
+
+        self.common(
+            fn,
+            (torch.randn([1, 2, 4, 8]),),
+        )
+
     def test_embedding(self):
         m = torch.nn.Sequential(
             torch.nn.Embedding(10, 4, padding_idx=0),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102570

`repeat_interleave_symint` is currently implemented by guarding on the `SymInt`
and converting it to a tensor to pass to the Tensor overload. This instead
implements it as a copy of an expanded tensor, which can be done without guards
and is also much more efficient in eager mode to boot.

For example, these are timings for `x.repeat_interleave(100, dim=-1)` with `x.shape == (1000, 100)`

| Device | Time (Master) | Time (This PR)  | Speedup |
|--------|---------------|-----------------|---------|
| cpu    | 18.8 ms       | 3.5 ms          | 5.4     |
| cuda   | 271 us        | 134 us          | 2.0     |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx