### PR TITLE
Fix ignored_states when they are passed as generators

### DIFF
--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -354,9 +354,9 @@ class TestFSDPIgnoredModules(FSDPTest):
             {"ignored_modules": layer1_ignored_modules}
             if ignore_modules
             else {
-                "ignored_states": {
+                "ignored_states": (
                     p for m in layer1_ignored_modules for p in m.parameters()
-                }
+                )
             }
         )
         model.layer1 = wrap_cls(model.layer1, **ignore_kwargs)

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -253,12 +253,12 @@ def _init_ignored_module_states(
     ), "Can not pass `ignored_modules` and `ignored_states` at the same time. \
         Please either pass `ignored_modules` or `ignored_states`."
     ignored_parameters = None
-    if ignored_states:
-        ignored_states_set = set(ignored_states)
-        if isinstance(next(iter(ignored_states), None), torch.nn.Parameter):
-            ignored_parameters = ignored_states_set
+    ignored_states_list = list(ignored_states) if ignored_states is not None else []
+    if ignored_states_list and len(ignored_states_list) > 0:
+        if isinstance(ignored_states_list[0], torch.nn.Parameter):
+            ignored_parameters = ignored_states_list
         else:
-            ignored_modules = ignored_states_set
+            ignored_modules = ignored_states_list
     state._ignored_modules = _get_ignored_modules(module, ignored_modules)
     state._ignored_params = _get_ignored_params(
         module,


### PR DESCRIPTION
This PR fixed the case where ignored_states are passed as generators, not List/Set

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102575

