### PR TITLE
Serialize pytree to string

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -2,7 +2,15 @@
 
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
-from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten, TreeSpec, LeafSpec
+from torch.utils._pytree import (
+    tree_flatten,
+    tree_map,
+    tree_unflatten,
+    TreeSpec,
+    LeafSpec,
+    pytree_to_str,
+    str_to_pytree,
+)
 from torch.utils._pytree import _broadcast_to_and_flatten, tree_map_only, tree_all
 from torch.utils._pytree import tree_any, tree_all_only, tree_any_only
 from collections import namedtuple, OrderedDict
@@ -250,6 +258,41 @@ class TestPytree(TestCase):
             _, to_spec = tree_flatten(to_pytree)
             result = _broadcast_to_and_flatten(pytree, to_spec)
             self.assertEqual(result, expected, msg=str([pytree, to_spec, expected]))
+
+    @parametrize("spec, str_spec", [
+        (TreeSpec(list, None, [LeafSpec()]), "L(*)"),
+        (TreeSpec(list, None, [LeafSpec(), LeafSpec()]), "L(*,*)"),
+        (TreeSpec(tuple, None, [LeafSpec(), LeafSpec(), LeafSpec()]), "T(*,*,*)"),
+        (TreeSpec(dict, ['a', 'b', 'c'], [LeafSpec(), LeafSpec(), LeafSpec()]), "D('a':*,'b':*,'c':*)"),
+        (TreeSpec(list, None, [
+            TreeSpec(tuple, None, [
+                LeafSpec(),
+                LeafSpec(),
+                TreeSpec(list, None, [
+                    LeafSpec(),
+                    LeafSpec(),
+                ]),
+            ]),
+        ]), "L(T(*,*,L(*,*)))"),
+    ], name_fn=lambda _, str_spec: str_spec)
+    def test_pytree_serialize(self, spec, str_spec):
+        self.assertEqual(pytree_to_str(spec), str_spec)
+        print(spec)
+        print(str_to_pytree(str_spec))
+        self.assertTrue(spec == str_to_pytree(str_spec))
+        self.assertTrue(spec == str_to_pytree(pytree_to_str(spec)))
+
+    def test_pytree_serialize_namedtuple(self):
+        Point = namedtuple('Point', ['x', 'y'])
+        spec = TreeSpec(namedtuple, Point, [LeafSpec(), LeafSpec()])
+        str_spec = "N(Point,*,*)"
+
+        self.assertEqual(pytree_to_str(spec), str_spec)
+
+        roundtrip_spec = str_to_pytree(pytree_to_str(spec))
+        # The context in the namedtuple is different now because we recreate the
+        # namedtuple type.
+        self.assertEqual(spec.children_specs, roundtrip_spec.children_specs)
 
 
 instantiate_parametrized_tests(TestPytree)

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -263,7 +263,10 @@ class TestPytree(TestCase):
         (TreeSpec(list, None, [LeafSpec()]), "L(*)"),
         (TreeSpec(list, None, [LeafSpec(), LeafSpec()]), "L(*,*)"),
         (TreeSpec(tuple, None, [LeafSpec(), LeafSpec(), LeafSpec()]), "T(*,*,*)"),
-        (TreeSpec(dict, ['a', 'b', 'c'], [LeafSpec(), LeafSpec(), LeafSpec()]), "D('a':*,'b':*,'c':*)"),
+        (
+            TreeSpec(dict, ['a', 'b', 'c'], [LeafSpec(), LeafSpec(), LeafSpec()]),
+            "D(a:*,b:*,c:*)"
+        ),
         (TreeSpec(list, None, [
             TreeSpec(tuple, None, [
                 LeafSpec(),
@@ -277,22 +280,20 @@ class TestPytree(TestCase):
     ], name_fn=lambda _, str_spec: str_spec)
     def test_pytree_serialize(self, spec, str_spec):
         self.assertEqual(pytree_to_str(spec), str_spec)
-        print(spec)
-        print(str_to_pytree(str_spec))
         self.assertTrue(spec == str_to_pytree(str_spec))
         self.assertTrue(spec == str_to_pytree(pytree_to_str(spec)))
 
     def test_pytree_serialize_namedtuple(self):
-        Point = namedtuple('Point', ['x', 'y'])
+        Point = namedtuple("Point", ["x", "y"])
         spec = TreeSpec(namedtuple, Point, [LeafSpec(), LeafSpec()])
-        str_spec = "N(Point,*,*)"
+        str_spec = "N(Point(x, y),*,*)"
 
         self.assertEqual(pytree_to_str(spec), str_spec)
 
         roundtrip_spec = str_to_pytree(pytree_to_str(spec))
-        # The context in the namedtuple is different now because we recreate the
-        # namedtuple type.
-        self.assertEqual(spec.children_specs, roundtrip_spec.children_specs)
+        # The context in the namedtuple is different now because we recreated
+        # the namedtuple type.
+        self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
 
 
 instantiate_parametrized_tests(TestPytree)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -52,10 +52,8 @@ def _register_pytree_node(
     typ: Any,
     flatten_fn: FlattenFunc,
     unflatten_fn: UnflattenFunc,
-    to_str: str = "",
+    to_str: str = "C",
 ) -> None:
-    if len(to_str) == 0:
-        to_str = "C"
     assert len(to_str) == 1
     node_def = NodeDef(typ, flatten_fn, unflatten_fn, to_str)
     SUPPORTED_NODES[typ] = node_def


### PR DESCRIPTION
* list --> `L(value1,value2)`
* tuple --> `T(value1,value2)`
* dict --> `D(key1:value1,key2:value2)`
* ordered dict --> `O(key1:value1,key2:value2)`
* namedtuple --> `N(type(key1, key2),value1,value2)`
* leaf --> `*`

Restrictions
* serializing custom types is not supported
* we only support serializing string keys in dictionaries