### PR TITLE
[quant][pt2e][be] Add QuantizationSpecBase

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -3,20 +3,23 @@ from .quantizer import (
     EdgeOrNode,
     OperatorConfig,
     Quantizer,
+    QuantizationSpecBase,
     QuantizationSpec,
-    QuantizationAnnotation,
     FixedQParamsQuantizationSpec,
     SharedQuantizationSpec,
     DerivedQuantizationSpec,
+    QuantizationAnnotation,
 )
 
 __all__ = [
     "EdgeOrNode",
+    "OperatorConfig",
     "Quantizer",
-    "QuantizationSpec",
     "QNNPackQuantizer",
-    "QuantizationAnnotation",
+    "QuantizationSpecBase",
+    "QuantizationSpec",
     "FixedQParamsQuantizationSpec",
     "SharedQuantizationSpec",
     "DerivedQuantizationSpec",
+    "QuantizationAnnotation",
 ]

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from torch.fx import Node
-from typing import Callable, List, NamedTuple, Optional, Dict, Any, Union, Tuple
+from typing import Callable, List, NamedTuple, Optional, Dict, Union, Tuple
 from torch.ao.quantization import ObserverOrFakeQuantize
 from torch.ao.quantization.qconfig import _ObserverOrFakeQuantizeConstructor
 from torch import Tensor
@@ -10,7 +10,11 @@ import torch
 
 __all__ = [
     "Quantizer",
+    "QuantizationSpecBase",
     "QuantizationSpec",
+    "FixedQParamsQuantizationSpec",
+    "SharedQuantizationSpec",
+    "DerivedQuantizationSpec",
     "QuantizationAnnotation",
 ]
 
@@ -24,8 +28,14 @@ SUPPORTED_QSCHEMES = [
     torch.per_channel_affine_float_qparams,
 ]
 
+class QuantizationSpecBase(ABC):
+    """ Base class for different types of quantization specs that allows users to
+    specify how to quantize a Tensor (input/output of a Node) in the model
+    """
+    pass
+
 @dataclass(eq=True, frozen=True)
-class QuantizationSpec:
+class QuantizationSpec(QuantizationSpecBase):
     """ Quantization spec for common operators that allows user to specify how to
     quantize a Tensor, this includes dtype, quant_min, quant_max etc.
     """
@@ -66,7 +76,7 @@ class QuantizationSpec:
             raise ValueError("Ch_axis is < 0.")
 
 @dataclass(eq=True, frozen=True)
-class FixedQParamsQuantizationSpec:
+class FixedQParamsQuantizationSpec(QuantizationSpecBase):
     dtype: torch.dtype
     scale: float
     zero_point: int
@@ -77,7 +87,7 @@ class FixedQParamsQuantizationSpec:
 EdgeOrNode = Union[Tuple[Node, Node], Node]
 
 @dataclass(eq=True, frozen=True)
-class SharedQuantizationSpec:
+class SharedQuantizationSpec(QuantizationSpecBase):
     """
     Quantization spec for the Tensors whose quantization parameters are shared with other Tensors
 
@@ -89,7 +99,7 @@ class SharedQuantizationSpec:
     edge_or_node: EdgeOrNode
 
 @dataclass(eq=True, frozen=True)
-class DerivedQuantizationSpec:
+class DerivedQuantizationSpec(QuantizationSpecBase):
     """ quantization spec for the Tensors whose quantization parameters are derived from other Tensors
     """
     derived_from: List[EdgeOrNode]
@@ -136,13 +146,12 @@ class QuantizationAnnotation:
     operator Graph is observed (PTQ) or fake quantized (QAT)
     """
 
-    # a map from torch.fx.Node to QuantizationSpec
-    # TODO: change the value to QuantizationSpec in a separate PR
-    input_qspec_map: Dict[Node, Any] = field(default_factory=dict)
+    # a map from torch.fx.Node to a type of QuantizationSpecBase
+    input_qspec_map: Dict[Node, QuantizationSpecBase] = field(default_factory=dict)
 
-    # How the output of this node is quantized, expressed as QuantizationSPec
+    # How the output of this node is quantized, expressed as QuantizationSpec
     # TODO: change the value to QuantizationSpec in a separate PR
-    output_qspec: Optional[Any] = None
+    output_qspec: Optional[QuantizationSpecBase] = None
 
     # whether the node is annotated or not
     _annotated: bool = False


### PR DESCRIPTION
Summary:
Make all quantization spec to inherit from the same base class in order to simplify the typing
for QuantizationAnnotation

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- 'caffe2/test:quantization_pt2e'
```

Reviewed By: kimishpatel

Differential Revision: D46173954

