### PR TITLE
[Dynamo] Fix if condition on UnspecializedNNModuleVariable

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3808,7 +3808,7 @@ def fn():
                 self.x = x
 
             def __bool__(self):
-                self.x = 1
+                self.x = 1.2
                 return self.x
 
         def fn(a, obj):
@@ -3824,7 +3824,7 @@ def fn():
             opt_fn(x, obj)
             self.assertFalse(True)
         except TypeError as e:
-            self.assertIn("__bool__ should return bool, returned int", str(e))
+            self.assertIn("__bool__ should return bool, returned float", str(e))
 
     def test_if_cond_user_defined_object3(self):
         # obj.__bool__ is not existed, but obj.__len__ exists

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1091,9 +1091,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             self.assertTrue(same(opt_model(a, b, c, d), correct))
 
         if torch._dynamo.config.assume_static_by_default:
-            self.assertEqual(cnt.frame_count, 4)
+            self.assertEqual(cnt.frame_count, ifdyn(2, 4))
         else:
-            self.assertEqual(cnt.frame_count, 6)
+            self.assertEqual(cnt.frame_count, ifdyn(3, 6))
 
     def test_hf_model_output(self):
         ex = ModelOutput(a=torch.randn(10), b=torch.randn(10), c=torch.randn(10))

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -336,11 +336,8 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
             if isinstance(x, UserMethodVariable):
                 state = self.copy_graphstate()
                 result = x.call_function(self, [], {})
-                if isinstance(result, ConstantVariable) and (
-                    x.fn.__name__ == "__bool__"
-                    and isinstance(result.value, bool)
-                    or x.fn.__name__ == "__len__"
-                    and isinstance(result.value, int)
+                if isinstance(result, ConstantVariable) and isinstance(
+                    result.value, (bool, int)
                 ):
                     self.output.guards.update(result.guards)
                     if truth_fn(result.value):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -329,24 +329,25 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                 self.jump(inst)
         elif isinstance(value, UserDefinedObjectVariable):
             x = value.var_getattr(self, "__bool__")
-            # __bool__ is function
+            # if __bool__ is missing, trying __len__ to infer a truth value.
+            if x.is_python_constant() and not x.as_python_constant():
+                x = value.var_getattr(self, "__len__")
+            # __bool__ or __len__ is function
             if isinstance(x, UserMethodVariable):
                 state = self.copy_graphstate()
                 result = x.call_function(self, [], {})
-                if isinstance(result, ConstantVariable) and isinstance(
-                    result.value, bool
-                ):
+                if isinstance(result, ConstantVariable):
                     self.output.guards.update(result.guards)
                     if truth_fn(result.value):
                         push and self.push(value)
                         self.jump(inst)
                 else:
-                    # rollback to the state before the __bool__ inline
+                    # rollback to the state before the __bool__ or __len__ inline
                     self.restore_graphstate(state)
                     unimplemented(
                         "generic_jump on UserDefined with __bool__ returning non-constant"
                     )
-            # __bool__ is non-function or not existed in the user defined object
+            # __bool__ or __len__ is non-function or not existed in the user defined object
             else:
                 if truth_fn(True):
                     push and self.push(value)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -404,27 +404,22 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.__func__, self, source=source, **options
             )
-        elif isinstance(subobj, types.FunctionType):
+        elif isinstance(subobj, (types.FunctionType, types.MethodType)):
+            if isinstance(subobj, types.MethodType):
+                func = subobj.__func__
+            else:
+                assert isinstance(subobj, types.FunctionType)
+                func = subobj
             # Since we get subobj via self._getattr_static, which may not trigger dynamic lookup.
             # Static lookup can't tell us it's a method or function correctly,
             # so we trigger dynamic lookup here to get the correct type.
             dynamic_subobj = getattr(self.value, name)
             if inspect.ismethod(dynamic_subobj):
                 return variables.UserMethodVariable(
-                    subobj, self, source=source, **options
+                    func, self, source=source, **options
                 )
             elif inspect.isfunction(dynamic_subobj):
-                return variables.UserFunctionVariable(subobj, source=source, **options)
-        elif isinstance(subobj, types.MethodType):
-            func = subobj.__func__
-            obj = subobj.__self__
-            obj_source = AttrSource(self.source, "__self__") if self.source else None
-            return variables.UserMethodVariable(
-                func,
-                UserDefinedObjectVariable(obj, source=obj_source, **options),
-                source=source,
-                **options,
-            )
+                return variables.UserFunctionVariable(func, source=source, **options)
 
         if (
             name in getattr(value, "__dict__", {})

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -404,9 +404,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.__func__, self, source=source, **options
             )
-        elif isinstance(subobj, (types.FunctionType, types.MethodType)):
+        elif isinstance(subobj, types.FunctionType) or (
+            isinstance(subobj, types.MethodType)
+            and isinstance(self.value, torch.nn.Module)
+        ):
             if isinstance(subobj, types.MethodType):
                 func = subobj.__func__
+                source = AttrSource(source, "__func__") if source else None
             else:
                 assert isinstance(subobj, types.FunctionType)
                 func = subobj

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -415,6 +415,16 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 )
             elif inspect.isfunction(dynamic_subobj):
                 return variables.UserFunctionVariable(subobj, source=source, **options)
+        elif isinstance(subobj, types.MethodType):
+            func = subobj.__func__
+            obj = subobj.__self__
+            obj_source = AttrSource(self.source, "__self__") if self.source else None
+            return variables.UserMethodVariable(
+                func,
+                UserDefinedObjectVariable(obj, source=obj_source, **options),
+                source=source,
+                **options,
+            )
 
         if (
             name in getattr(value, "__dict__", {})


### PR DESCRIPTION
Fixes #102315

The root cause is for ```UnspecializedNNModuleVariable``` which extends from ```UserDefinedObjectVariable```, if ```__bool__``` is missing, we should use ```__len__``` to infer a truth value.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy