### PR TITLE
[c10d] Add flag value for direct teardown without comm abort

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -632,11 +632,23 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       (dist_debug_level_ >= DebugLevel::Detail);
   avoidRecordStreams_ = parseEnvVarFlag(TORCH_NCCL_AVOID_RECORD_STREAMS);
 
-  if (blockingWait_ && desyncDebug_) {
-    LOG(INFO) << "[Rank " << rank_ << "] NCCL_BLOCKING_WAIT and "
-              << "NCCL_DESYNC_DEBUG should not both be enabled. "
-              << "Only NCCL_BLOCKING_WAIT is being used in this process.";
-    desyncDebug_ = false;
+  if (blockingWait_) {
+    if (asyncErrorHandling_ != NoHandling || desyncDebug_) {
+      LOG(INFO) << "[Rank " << rank_ << "] NCCL_BLOCKING_WAIT and "
+                << "NCCL_ASYNC_ERROR_HANDLING|NCCL_DESYNC_DEBUG"
+                << "should not both be enabled. "
+                << "Only NCCL_BLOCKING_WAIT is being used in this process.";
+      asyncErrorHandling_ = NoHandling;
+      desyncDebug_ = false;
+    }
+  } else {
+    if (desyncDebug_ && asyncErrorHandling_ == NoHandling) {
+      LOG(INFO) << "[Rank " << rank_
+                << "] NCCL_DESYNC_DEBUG and NCCL_ASYNC_ERROR_HANDLING "
+                << "must both be enabled. "
+                << "Enabling NCCL_ASYNC_ERROR_HANDLING.";
+      asyncErrorHandling_ = TearDown;
+    }
   }
 
   if (parseEnvVarFlag(ENABLE_NCCL_HEALTH_CHECK)) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -52,9 +52,9 @@ constexpr const char* NCCL_BACKEND_NAME = "nccl";
 // last resort in case `ncclCommAbort` itself is hanging
 enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2, SkipCleanUp = 3 };
 
-#define SHOULD_CLEAN_UP(a) a != NoHandling && a != SkipCleanUp
+#define SHOULD_CLEAN_UP(a) (a != NoHandling && a != SkipCleanUp)
 
-#define SHOULD_TEAR_DOWN(a) a != NoHandling && a != CleanUpOnly
+#define SHOULD_TEAR_DOWN(a) (a != NoHandling && a != CleanUpOnly)
 
 // If set, ProcessGroupNCCL doesn't use recordStream calls to ensure
 // caching allocator safety for tensors used on both user-facing and

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -44,9 +44,17 @@ constexpr const char* NCCL_DESYNC_DEBUG = "NCCL_DESYNC_DEBUG";
 
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
-// TearDown mode: tear down process upon error, see `WorkNCCL::handleException`
-// Soft mode: just clean up collectives and abort communicators without tearing down process
-enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2 };
+// NoHandling: do not handle asynchronous NCCL errors
+// TearDown: tear down process upon error, see `WorkNCCL::handleException`
+// CleanUpOnly: just clean up collectives and abort communicators without tearing down process
+// SkipCleanUp: (this is a temporary option and can be removed in future) tear
+// down process without cleaning up NCCL communicators. This should be used as a
+// last resort in case `ncclCommAbort` itself is hanging
+enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2, SkipCleanUp = 3 };
+
+#define SHOULD_CLEAN_UP(a) a != NoHandling && a != SkipCleanUp
+
+#define SHOULD_TEAR_DOWN(a) a != NoHandling && a != CleanUpOnly
 
 // If set, ProcessGroupNCCL doesn't use recordStream calls to ensure
 // caching allocator safety for tensors used on both user-facing and


### PR DESCRIPTION
It was recently reported that `ncclCommAbort` itself may hang in some NCCL versions. For example, https://github.com/NVIDIA/nccl/issues/829.
In that case, it may be desirable to directly tear down the program without properly aborting the NCCL communicator, so that user does not wait for hours before noticing a hang.
This PR adds new value 3 for env `NCCL_ASYNC_ERROR_HANDLING` that skips the comm abort, and directly throws error in case of exception (timeout, async error, etc)