### PR TITLE
Don't print args/kwargs on fake tensor error.

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1417,12 +1417,12 @@ class FakeTensorMode(TorchDispatchMode):
             if not isinstance(x, FakeTensor):
                 if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
                     raise Exception(
-                        f"Can't call metadata mutating ops on non-Fake Tensor inputs. Found in {func}(*{args}, **{kwargs})"
+                        f"Can't call metadata mutating ops on non-Fake Tensor inputs."
                     )
                 if not self.allow_non_fake_inputs:
                     raise Exception(
                         f"Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
-                        f"with 'allow_non_fake_inputs'. Found in {func}(*{args}, **{kwargs}) "
+                        f"with 'allow_non_fake_inputs'."
                     )
 
                 x = converter(self, x)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1417,12 +1417,12 @@ class FakeTensorMode(TorchDispatchMode):
             if not isinstance(x, FakeTensor):
                 if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
                     raise Exception(
-                        f"Can't call metadata mutating ops on non-Fake Tensor inputs."
+                        f"Can't call metadata mutating ops on non-Fake Tensor inputs on.  Found in {func}."
                     )
                 if not self.allow_non_fake_inputs:
                     raise Exception(
-                        f"Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
-                        f"with 'allow_non_fake_inputs'."
+                        "Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
+                        f"with 'allow_non_fake_inputs' on.  Found in {func}."
                     )
 
                 x = converter(self, x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102620

Under certain obscure circumstances (notably while I was debugging
https://github.com/pytorch/pytorch/issues/101160 ) this printing
causes PyTorch to hang.  I tried a bit to root cause the issue but
couldn't work it out, sending this in to unblock for now.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>