### PR TITLE
Remove GCC version guards for ancient GCCs

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/common.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/common.h
@@ -9,17 +9,10 @@
 #pragma once
 
 #if defined(__GNUC__)
-#if defined(__clang__) || (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define PYTORCH_QNNP_UNREACHABLE \
   do {                           \
     __builtin_unreachable();     \
   } while (0)
-#else
-#define PYTORCH_QNNP_UNREACHABLE \
-  do {                           \
-    __builtin_trap();            \
-  } while (0)
-#endif
 #elif defined(_MSC_VER)
 #define PYTORCH_QNNP_UNREACHABLE __assume(0)
 #else

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/scalar-utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/scalar-utils.h
@@ -26,14 +26,11 @@
 #if __GNUC__ >= 8
 #define PYTORCH_QNNP_IGNORE_SHIFT_BASE_UB \
   __attribute__((__no_sanitize__("shift-base")))
-#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 9 || __GNUC__ > 4
-/* 4.9 <= gcc < 8 support ubsan, but doesn't support no_sanitize attribute */
+#else
 #define PYTORCH_QNNP_IGNORE_SHIFT_BASE_UB
 #ifndef PYTORCH_QNNP_USE_SHIFT_BASE_UB_WORKAROUND
 #define PYTORCH_QNNP_USE_SHIFT_BASE_UB_WORKAROUND 1
 #endif
-#else
-#define PYTORCH_QNNP_IGNORE_SHIFT_BASE_UB
 #endif
 #else
 #define PYTORCH_QNNP_IGNORE_SHIFT_BASE_UB

--- a/caffe2/core/common_gpu.h
+++ b/caffe2/core/common_gpu.h
@@ -7,9 +7,7 @@
 
 #if !defined(USE_ROCM)
 #ifdef __GNUC__
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
-#endif
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif // __GNUC__
 #endif // USE_ROCM
@@ -62,9 +60,7 @@ constexpr int kFp16CUDADevicePropMajor = 3;
 // Re-enable strict aliasing diagnostic if it was disabled.
 #if !defined(USE_ROCM)
 #ifdef __GNUC__
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
-#endif
 #endif // __GNUC__
 #endif // USE_ROCM
 


### PR DESCRIPTION
I don't think PyTorch can even be built with GCC 4 anymore.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10