### PR TITLE
Add torch._utils.render_call, improve printoptions

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -849,6 +849,17 @@ class TestExtensionUtils(TestCase):
         self.assertEqual(torch._utils._get_device_index('foo:1'), 1)
         self.assertEqual(torch._utils._get_device_index(torch.device("foo:2")), 2)
 
+class TestRenderUtils(TestCase):
+    def test_basic(self):
+        self.assertExpectedInline(
+            torch._utils.render_call(torch.sum, [torch.randn(100)], {'dim': 0}),
+            '''torch.sum(tensor([...], size=(100,)), dim=0)'''
+        )
+        self.assertExpectedInline(
+            torch._utils.render_call(torch.sum, [torch.randn(100, 100)], {'dim': 0}),
+            '''torch.sum(tensor([...], size=(100, 100)), dim=0)'''
+        )
+
 class TestDeviceUtils(TestCase):
     def test_basic(self):
         with torch.device('meta') as dev:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -23,6 +23,7 @@ from torch._prims_common import (
     is_integer_dtype,
 )
 from torch._subclasses.meta_utils import MetaConverter
+from torch._utils import render_call
 from torch.fx.experimental.symbolic_shapes import DimConstraint, DimDynamic
 from torch.fx.operator_schemas import normalize_function
 from torch.multiprocessing.reductions import StorageWeakRef
@@ -1417,12 +1418,12 @@ class FakeTensorMode(TorchDispatchMode):
             if not isinstance(x, FakeTensor):
                 if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
                     raise Exception(
-                        f"Can't call metadata mutating ops on non-Fake Tensor inputs. Found in {func}(*{args}, **{kwargs})"
+                        f"Can't call metadata mutating ops on non-Fake Tensor inputs. Found in {render_call(func, args, kwargs)}"
                     )
                 if not self.allow_non_fake_inputs:
                     raise Exception(
                         f"Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
-                        f"with 'allow_non_fake_inputs'. Found in {func}(*{args}, **{kwargs}) "
+                        f"with 'allow_non_fake_inputs'. Found in {render_call(func, args, kwargs)}"
                     )
 
                 x = converter(self, x)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -1,11 +1,14 @@
+import contextlib
+import dataclasses
 import math
 import textwrap
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import torch
 from torch import inf
 
 
+@dataclasses.dataclass
 class __PrinterOptions:
     precision: int = 4
     threshold: float = 1000
@@ -89,6 +92,25 @@ def set_printoptions(
     if linewidth is not None:
         PRINT_OPTS.linewidth = linewidth
     PRINT_OPTS.sci_mode = sci_mode
+
+
+def get_printoptions() -> Dict[str, Any]:
+    r"""Gets the current options for printing, as a dictionary that
+    can be passed as ``**kwargs`` to set_printoptions().
+    """
+    return dataclasses.asdict(PRINT_OPTS)
+
+
+@contextlib.contextmanager
+def printoptions(**kwargs):
+    r"""Context manager that temporarily changes the print options.  Accepted
+    arguments are same as :func:`set_printoptions`."""
+    old_kwargs = get_printoptions()
+    set_printoptions(**kwargs)
+    try:
+        yield
+    finally:
+        set_printoptions(**old_kwargs)
 
 
 def tensor_totype(t):
@@ -228,7 +250,10 @@ def _vector_str(self, indent, summarize, formatter1, formatter2=None):
         else:
             return formatter1.format(val)
 
-    if summarize and self.size(0) > 2 * PRINT_OPTS.edgeitems:
+    if summarize and not PRINT_OPTS.edgeitems:
+        # Deal with edge case that negative zero is zero
+        data = ["..."]
+    elif summarize and self.size(0) > 2 * PRINT_OPTS.edgeitems:
         data = (
             [_val_formatter(val) for val in self[: PRINT_OPTS.edgeitems].tolist()]
             + [" ..."]
@@ -355,7 +380,9 @@ def get_summarized_data(self):
             )
         else:
             return self
-    if self.size(0) > 2 * PRINT_OPTS.edgeitems:
+    if not PRINT_OPTS.edgeitems:
+        return self.new_empty([0] * self.dim())
+    elif self.size(0) > 2 * PRINT_OPTS.edgeitems:
         start = [self[i] for i in range(0, PRINT_OPTS.edgeitems)]
         end = [self[i] for i in range(len(self) - PRINT_OPTS.edgeitems, len(self))]
         return torch.stack([get_summarized_data(x) for x in (start + end)])
@@ -560,6 +587,9 @@ def _str_intern(inp, *, tensor_contents=None):
                 if not custom_contents_provided:
                     tensor_str = "[]"
             else:
+                if not PRINT_OPTS.edgeitems:
+                    suffixes.append("size=" + str(tuple(self.shape)))
+
                 if not has_default_dtype:
                     suffixes.append("dtype=" + str(self.dtype))
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -592,6 +592,25 @@ def annotate(ret, **kwargs):
     return dec
 
 
+def render_call(fn, args, kwargs):
+    import torch._tensor_str
+    from torch.overrides import resolve_name
+
+    str_fn = resolve_name(fn)
+    if str_fn is None:
+        str_fn = str(fn)
+
+    def render_arg(t):
+        return repr(t)
+
+    str_args = []
+    with torch._tensor_str.printoptions(threshold=0, edgeitems=0):
+        str_args.extend(render_arg(a) for a in args)
+        str_args.extend(f"{k}={render_arg(v)}" for k, v in kwargs.items())
+        r = f"{str_fn}({', '.join(str_args)})"
+    return r
+
+
 # NOTE [ Python Traceback Reference Cycle Problem ]
 #
 # When using sys.exc_info(), it is important to **not** store the exc_info[2],

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -593,20 +593,14 @@ def annotate(ret, **kwargs):
 
 
 def render_call(fn, args, kwargs):
-    import torch._tensor_str
-    from torch.overrides import resolve_name
-
-    str_fn = resolve_name(fn)
+    str_fn = torch.overrides.resolve_name(fn)
     if str_fn is None:
         str_fn = str(fn)
 
-    def render_arg(t):
-        return repr(t)
-
-    str_args = []
+    str_args: List[str] = []
     with torch._tensor_str.printoptions(threshold=0, edgeitems=0):
-        str_args.extend(render_arg(a) for a in args)
-        str_args.extend(f"{k}={render_arg(v)}" for k, v in kwargs.items())
+        str_args.extend(repr(a) for a in args)
+        str_args.extend(f"{k}={repr(v)}" for k, v in kwargs.items())
         r = f"{str_fn}({', '.join(str_args)})"
     return r
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102623

- Add get_printoptions and printoptions context manager
- Improve edgeitems handling when it is zero
- Add render_call which can be used to conveniently print command
  line arguments of a function call, while suppressing actual
  tensor data

Signed-off-by: Edward Z. Yang <ezyang@meta.com>