### PR TITLE
Fix lr_scheduler serialization contains bound methods issue

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1,9 +1,8 @@
 # Owner(s): ["module: optimizer", "module: LrScheduler" ]
-
+import types
 import warnings
 import math
 import pickle
-import weakref
 
 import torch
 import torch.optim as optim
@@ -1532,7 +1531,7 @@ class TestLRScheduler(TestCase):
     def test_cycle_lr_state_dict_picklable(self):
         adam_opt = optim.Adam(self.net.parameters())
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
-        self.assertIsInstance(scheduler._scale_fn_ref, weakref.WeakMethod)
+        self.assertIsInstance(scheduler._scale_fn_ref, types.FunctionType)
         state = scheduler.state_dict()
         self.assertNotIn("_scale_fn_ref", state)
         pickle.dumps(state)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1270,10 +1270,12 @@ class CyclicLR(LRScheduler):
         else:
             return self._scale_fn_ref()(x)
 
-    def _triangular_scale_fn(self, x):
+    @staticmethod
+    def _triangular_scale_fn(x):
         return 1.
 
-    def _triangular2_scale_fn(self, x):
+    @staticmethod
+    def _triangular2_scale_fn(x):
         return 1 / (2. ** (x - 1))
 
     def _exp_range_scale_fn(self, x):
@@ -1688,12 +1690,14 @@ class OneCycleLR(LRScheduler):
         else:
             return [param] * len(optimizer.param_groups)
 
-    def _annealing_cos(self, start, end, pct):
+    @staticmethod
+    def _annealing_cos(start, end, pct):
         "Cosine anneal from `start` to `end` as pct goes from 0.0 to 1.0."
         cos_out = math.cos(math.pi * pct) + 1
         return end + (start - end) / 2.0 * cos_out
 
-    def _annealing_linear(self, start, end, pct):
+    @staticmethod
+    def _annealing_linear(start, end, pct):
         "Linearly anneal from `start` to `end` as pct goes from 0.0 to 1.0."
         return (end - start) * pct + start
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1244,10 +1244,10 @@ class CyclicLR(LRScheduler):
         if self._scale_fn_custom is not None:
             return
         if self.mode == 'triangular':
-            self._scale_fn_ref = weakref.WeakMethod(self._triangular_scale_fn)
+            self._scale_fn_ref = self._triangular_scale_fn
             self.scale_mode = 'cycle'
         elif self.mode == 'triangular2':
-            self._scale_fn_ref = weakref.WeakMethod(self._triangular2_scale_fn)
+            self._scale_fn_ref = self._triangular2_scale_fn
             self.scale_mode = 'cycle'
         elif self.mode == 'exp_range':
             self._scale_fn_ref = weakref.WeakMethod(self._exp_range_scale_fn)
@@ -1266,9 +1266,10 @@ class CyclicLR(LRScheduler):
     def scale_fn(self, x):
         if self._scale_fn_custom is not None:
             return self._scale_fn_custom(x)
-
-        else:
+        elif isinstance(self._scale_fn_ref, weakref.WeakMethod):  # method is bound
             return self._scale_fn_ref()(x)
+        else:
+            return self._scale_fn_ref(x)  # static method
 
     @staticmethod
     def _triangular_scale_fn(x):


### PR DESCRIPTION
Fixes #42376
`torch.save` serializes bound methods inside LR scheduler resulting in large serialized file.

Test cases include checking file size, checking if the `anneal_func` is bounded and file is loaded correctly.