### PR TITLE
Change some py_context_manager_DEPRECATED to py_context_manager

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -38,6 +38,7 @@
 #include <utility>
 
 using torch::impl::py_context_manager_DEPRECATED;
+using torch::impl::py_context_manager;
 
 namespace {
 
@@ -384,23 +385,21 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   py_context_manager_DEPRECATED<c10::InferenceMode, bool>(
       _C_m, "_InferenceMode");
-  py_context_manager_DEPRECATED<at::impl::RestorePythonTLSSnapshot>(
+  py_context_manager<at::impl::RestorePythonTLSSnapshot>(
       _C_m, "_RestorePythonTLSSnapshot");
 
   py_context_manager_DEPRECATED<torch::DisableTorchDispatch>(
       _C_m, "_DisableTorchDispatch");
   py_context_manager_DEPRECATED<EnableTorchFunction>(
       _C_m, "_EnableTorchFunction");
-  py_context_manager_DEPRECATED<EnablePythonDispatcher>(
-      _C_m, "_EnablePythonDispatcher");
-  py_context_manager_DEPRECATED<c10::impl::DisablePythonDispatcher>(
+  py_context_manager<EnablePythonDispatcher>(_C_m, "_EnablePythonDispatcher");
+  py_context_manager<c10::impl::DisablePythonDispatcher>(
       _C_m, "_DisablePythonDispatcher");
   py_context_manager_DEPRECATED<DisableFuncTorch>(_C_m, "_DisableFuncTorch");
   py_context_manager_DEPRECATED<MultithreadingEnabled, bool>(
       _C_m, "_MultithreadingEnabled");
-  py_context_manager_DEPRECATED<DisableAutocast>(_C_m, "_DisableAutocast");
-  py_context_manager_DEPRECATED<ViewReplayEnabled, bool>(
-      _C_m, "_ViewReplayEnabled");
+  py_context_manager<DisableAutocast>(_C_m, "_DisableAutocast");
+  py_context_manager<ViewReplayEnabled, bool>(_C_m, "_ViewReplayEnabled");
   py::class_<torch::autograd::SavedVariable>(std::move(m), "SavedTensor")
       .def(py::init([]() -> torch::autograd::SavedVariable {
         TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #102643
* #102642
* #102579

I confirmed that there are no usages of these APIs on github code search
or internally. There may still be usages (hence the BC-breaking label),
but I expect none to very few.

There are some leftover py_context_manager_DEPRECATED that will likely
stay that way for a while because:
- they are used outside of the pytorch repo (`_AutoDispatchBelowAutograd`,
`_DisableTorchDispatch`, `_InferenceMode`)
- they are high risk (all of the torch_function / torch_dispatch related
stuff)
- PyTorch requires that the object behaves like a "Python RAII guard"
(`_DisableFuncTorch`, `_MultithreadingEnabled`)

This is probably the last PR in the context manager cleanup series.

Test Plan:
- existing tests

cc @ezyang @gchanan