### PR TITLE
Preserve coalesce state in sparse COO tensor serialization

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -316,7 +316,7 @@ class SerializationMixin:
                 torch.save({"tensor": x}, f)
                 f.seek(0)
                 y = torch.load(f, weights_only=weights_only)
-                self.assertEqual(x, y["tensor"])
+                self.assertEqual(x, y["tensor"], exact_is_coalesced=True)
         _test_serialization(lambda x: x.to_sparse())
         _test_serialization(lambda x: x.to_sparse_csr())
         _test_serialization(lambda x: x.to_sparse_csc())

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -329,7 +329,7 @@ class Tensor(torch._C._TensorBase):
             if self.layout == torch.sparse_coo:
                 args_sparse = (
                     self.layout,
-                    (self._indices(), self._values(), self.size()),
+                    (self._indices(), self._values(), self.size(), self.is_coalesced()),
                 )
             else:
                 raise NotImplementedError(

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -237,8 +237,15 @@ def _rebuild_sparse_tensor(layout, data):
         data (tuple): The tensor's sparse storage representation.
     """
     if layout == torch.sparse_coo:
-        indices, values, size = data
+        if len(data) == 3:
+            # For BC:
+            indices, values, size = data
+            is_coalesced = None
+        else:
+            indices, values, size, is_coalesced = data
         result = torch.sparse_coo_tensor(indices, values, size, check_invariants=False)
+        if is_coalesced is not None:
+            result._coalesced_(is_coalesced)
         _sparse_tensors_to_validate.append(result)
         return result
 


### PR DESCRIPTION
Fixes #101186

Also, resolves the "serialization to preserve coalesced-ness" part in https://github.com/pytorch/pytorch/issues/73479

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102647



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @mruberry @mikaylagawarecki