### PR TITLE
[FSDP] summon_full_params allows multiple modules

### DIFF
--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -242,7 +242,7 @@ class TestUnshardParams(TestUnshardParamsBase):
             * dist.get_world_size()
         )
         tot_numel = 0
-        with FSDP.summon_full_params(models):
+        with FSDP.summon_full_params(tuple(models)):
             for model in models:
                 numel = sum(p.numel() for p in model.parameters())
                 tot_numel += numel
@@ -457,6 +457,8 @@ class TestUnshardParams(TestUnshardParamsBase):
             self.process_group,
         )
         fsdp_model.register_buffer("buffer", torch.ones(1))
+        is_iterable = iter(fsdp_model)
+        print(f"RV: {fsdp_model} is_iterable {is_iterable}")
         with FSDP.summon_full_params(fsdp_model):
             for call in ["named_parameters", "named_buffers"]:
                 for (n1, p1), (n2, p2) in itertools.zip_longest(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102692
* #102680
* #102679
* #102672
* #102669
* #102658
* #102657
* __->__ #102655
* #102639
* #102637
* #102508

Since this is a staticmethod, slight enhancement to allow summoning
full params for multiple modules. This is a small UX improvement for things
like testing use cases when we want to run this for multiple FSDP modules and
compare things.

Note that for now, the configuration under which they are summoned is the same.

Differential Revision: [D46334991](https://our.internmc.facebook.com/intern/diff/D46334991/)