### PR TITLE
[BE] Make `test_no_triton_on_import` simple

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5729,22 +5729,15 @@ class TestBlockStateAbsorption(TestCase):
 
 
     def test_no_triton_on_import(self):
-        script = """import sys; import torch; torch.rand(2, device='cuda'); exit(2 if "triton" in sys.modules else 0)
-                 """
+        """ Test that Trition is not imported on first GPU use """
+        script = "import sys; import torch; torch.rand(2, device='cuda'); exit(2 if 'triton' in sys.modules else 0)"
 
-        try:
-            subprocess.check_output(
-                [sys.executable, '-c', script],
-                stderr=subprocess.STDOUT,
-                # On Windows, opening the subprocess with the default CWD makes `import torch`
-                # fail, so just set CWD to this script's directory
-                cwd=os.path.dirname(os.path.realpath(__file__)))
-        except subprocess.CalledProcessError as e:
-            if e.returncode > 0:
-                if e.returncode == 2:
-                    self.assertTrue(False, "Triton was imported when importing torch!")
-                else:
-                    raise e
+        subprocess.check_output(
+            [sys.executable, '-c', script],
+            stderr=subprocess.STDOUT,
+            # On Windows, opening the subprocess with the default CWD makes `import torch`
+            # fail, so just set CWD to this script's directory
+            cwd=os.path.dirname(os.path.realpath(__file__)))
 
 
 instantiate_parametrized_tests(TestCuda)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5730,14 +5730,14 @@ class TestBlockStateAbsorption(TestCase):
 
     def test_no_triton_on_import(self):
         """ Test that Trition is not imported on first GPU use """
-        script = "import sys; import torch; torch.rand(2, device='cuda'); exit(2 if 'triton' in sys.modules else 0)"
+        script = "import sys; import torch; torch.rand(2, device='cuda'); print('triton' in sys.modules)"
 
-        subprocess.check_output(
+        rc = subprocess.check_output(
             [sys.executable, '-c', script],
-            stderr=subprocess.STDOUT,
             # On Windows, opening the subprocess with the default CWD makes `import torch`
             # fail, so just set CWD to this script's directory
-            cwd=os.path.dirname(os.path.realpath(__file__)))
+            cwd=os.path.dirname(os.path.realpath(__file__))).strip().decode('ascii')
+        self.assertEqual(rc, "False", "Triton was imported when importing torch!")
 
 
 instantiate_parametrized_tests(TestCuda)


### PR DESCRIPTION
Do not try to parse raised exception for no good reason
Add short description
Reduce script to a single line

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea4164e</samp>

> _`test_no_triton_on_import`_
> _Cleans up the code, adds docs_
> _No hidden errors_
