### PR TITLE
[fake tensor] register copy, copy_, slice_scatter handling

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -611,7 +611,7 @@ class FakeTensorTest(TestCase):
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_multi_device_slice_assign(self):
         def fn(self, other):
-            self[:,::2] = other
+            self[:, ::2] = other
 
         x = torch.rand((4, 4))
         y = torch.rand((4, 2), device='cuda')

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -648,7 +648,7 @@ def conv(fake_mode, func, *args, **kwargs):
 
 # See [Copy ops where device can differ]
 @register_op_impl(lambda op: op in [aten.copy.default, aten.slice_scatter.default])
-def copy_default(fake_mode, func, *args, **kwargs):
+def copy_and_slice_scatter(fake_mode, func, *args, **kwargs):
     with in_kernel_invocation_manager(fake_mode):
         out = func(*args, **kwargs)
     device = args[0].device
@@ -657,7 +657,7 @@ def copy_default(fake_mode, func, *args, **kwargs):
 
 # See [Copy ops where device can differ]
 @register_op_impl(aten.copy_.default)
-def copy_default(fake_mode, func, *args, **kwargs):
+def copy_inplace(fake_mode, func, *args, **kwargs):
     with in_kernel_invocation_manager(fake_mode):
         out = func(*args, **kwargs)
     return out

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -642,6 +642,27 @@ def conv(fake_mode, func, *args, **kwargs):
             )
 
 
+# Note: [Copy ops where device can differ]
+# These ops are like self.copy_(other), which will copy other into self.
+# self and other can have different devices.
+
+# See [Copy ops where device can differ]
+@register_op_impl(lambda op: op in [aten.copy.default, aten.slice_scatter.default])
+def copy_default(fake_mode, func, *args, **kwargs):
+    with in_kernel_invocation_manager(fake_mode):
+        out = func(*args, **kwargs)
+    device = args[0].device
+    return FakeTensor(fake_mode, out, device)
+
+
+# See [Copy ops where device can differ]
+@register_op_impl(aten.copy_.default)
+def copy_default(fake_mode, func, *args, **kwargs):
+    with in_kernel_invocation_manager(fake_mode):
+        out = func(*args, **kwargs)
+    return out
+
+
 FAST_OP_IMPLEMENTATIONS = {}
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102677

Normally, fake tensor assumes that inputs to ops must all have the same devices, with a few exceptions. That's not true for these three ops, which have the format op(self, other, ...) and where `other` is copied either into `self` or into a new tensor.

This PR registers special handling for these ops, specifying the devices explicitly instead of relying on the automatic device-merging logic.

For reference, this was the previous error:

```
Traceback (most recent call last):
  File "test/test_fake_tensor.py", line 627, in test_multi_device_slice_assign
    out = fn(x_f, y_f)
  File "test/test_fake_tensor.py", line 614, in fn
    self[:,::2] = other
  File "/scratch/dberard/dynamo38/pytorch/torch/utils/_stats.py", line 20, in wrapper
    return fn(*args, **kwargs)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1174, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1409, in dispatch
    return self.wrap_meta_outputs_with_default_device_logic(r, func, args, kwargs)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1475, in wrap_meta_outputs_with_default_device_logic
    return tree_map(partial(wrap), r)
  File "/scratch/dberard/dynamo38/pytorch/torch/utils/_pytree.py", line 196, in tree_map
    return tree_unflatten([fn(i) for i in flat_args], spec)
  File "/scratch/dberard/dynamo38/pytorch/torch/utils/_pytree.py", line 196, in <listcomp>
    return tree_unflatten([fn(i) for i in flat_args], spec)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1492, in wrap
    ) = FakeTensor._find_common_device(func, args, kwargs)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1104, in _find_common_device
    tree_map(merge_devices, args)
  File "/scratch/dberard/dynamo38/pytorch/torch/utils/_pytree.py", line 196, in tree_map
    return tree_unflatten([fn(i) for i in flat_args], spec)
  File "/scratch/dberard/dynamo38/pytorch/torch/utils/_pytree.py", line 196, in <listcomp>
    return tree_unflatten([fn(i) for i in flat_args], spec)
  File "/scratch/dberard/dynamo38/pytorch/torch/_subclasses/fake_tensor.py", line 1100, in merge_devices
    raise RuntimeError(
RuntimeError: Unhandled FakeTensor Device Propagation for aten.copy_.default, found two different devices cpu, cuda:0
```