### PR TITLE
[BE] Enable uploading metrics and upload Test Reordering metrics to dynamodb

### DIFF
--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -23,3 +23,4 @@ xdoctest==1.1.0
 filelock==3.6.0
 sympy==1.11.1
 pytest-cpp==2.3.0
+rockset==1.0.3

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -151,6 +151,11 @@ jobs:
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           PYTORCH_RETRY_TEST_CASES: 1
@@ -185,6 +190,11 @@ jobs:
             ${GPU_FLAG:-} \
             -e BUILD_ENVIRONMENT \
             -e GITHUB_ACTIONS \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_WORKFLOW \
+            -e GITHUB_JOB \
+            -e GITHUB_RUN_NUMBER \
+            -e GITHUB_RUN_ATTEMPT \
             -e GIT_DEFAULT_BRANCH="$GIT_DEFAULT_BRANCH" \
             -e SHARD_NUMBER \
             -e NUM_TEST_SHARDS \

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -154,6 +154,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -140,7 +140,8 @@ jobs:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -197,7 +198,8 @@ jobs:
             -e PR_NUMBER \
             -e GITHUB_ACTIONS \
             -e GITHUB_REPOSITORY \
-            -e GITHUB_RUN_ID \
+            -e GITHUB_WORKFLOW \
+            -e GITHUB_JOB \
             -e GITHUB_RUN_NUMBER \
             -e GITHUB_RUN_ATTEMPT \
             -e BASE_SHA \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -139,6 +139,10 @@ jobs:
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -192,6 +196,10 @@ jobs:
             -e BUILD_ENVIRONMENT \
             -e PR_NUMBER \
             -e GITHUB_ACTIONS \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_RUN_ID \
+            -e GITHUB_RUN_NUMBER \
+            -e GITHUB_RUN_ATTEMPT \
             -e BASE_SHA \
             -e BRANCH \
             -e SHA1 \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -142,6 +142,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -200,6 +201,7 @@ jobs:
             -e GITHUB_REPOSITORY \
             -e GITHUB_WORKFLOW \
             -e GITHUB_JOB \
+            -e GITHUB_RUN_ID \
             -e GITHUB_RUN_NUMBER \
             -e GITHUB_RUN_ATTEMPT \
             -e BASE_SHA \

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -134,6 +134,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -131,6 +131,11 @@ jobs:
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           # shellcheck disable=SC1090
           set -ex

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -116,6 +116,11 @@ jobs:
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           PYTORCH_RETRY_TEST_CASES: 1
@@ -165,6 +170,11 @@ jobs:
             -e BUILD_ENVIRONMENT \
             -e PR_NUMBER \
             -e GITHUB_ACTIONS \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_WORKFLOW \
+            -e GITHUB_JOB \
+            -e GITHUB_RUN_NUMBER \
+            -e GITHUB_RUN_ATTEMPT \
             -e BRANCH \
             -e SHA1 \
             -e AWS_DEFAULT_REGION \

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -119,6 +119,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -173,6 +174,7 @@ jobs:
             -e GITHUB_REPOSITORY \
             -e GITHUB_WORKFLOW \
             -e GITHUB_JOB \
+            -e GITHUB_RUN_ID \
             -e GITHUB_RUN_NUMBER \
             -e GITHUB_RUN_ATTEMPT \
             -e BRANCH \

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -126,6 +126,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -70,6 +70,18 @@ jobs:
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
+      # TODO: Move to a requirements.txt file for windows
+      - name: Install pip dependencies
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 30
+          command: |
+            set -eu
+            python3 -m pip install rockset==1.0.3
+
       - name: Start monitoring script
         id: monitor-script
         shell: bash

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -123,6 +123,11 @@ jobs:
           VC_YEAR: "2019"
           AWS_DEFAULT_REGION: us-east-1
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CUDA_VERSION: ${{ inputs.cuda-version }}
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -51,10 +51,10 @@ try:
     )
 
     HAVE_TEST_SELECTION_TOOLS = True
-except ImportError:
+except ImportError as e:
     HAVE_TEST_SELECTION_TOOLS = False
     print(
-        "Unable to import test_selections from tools/testing. Running without test selection stats..."
+        f"Unable to import test_selections from tools/testing. Running without test selection stats.... Reason: {e}"
     )
 
 

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -125,147 +125,6 @@ def upload_to_rockset(
     print("Done!")
 
 
-def _convert_float_values_to_decimals(data: Dict[str, Any]) -> Dict[str, Any]:
-    for key, value in data.items():
-        if isinstance(value, float):
-            data[key] = decimal.Decimal(str(value))  # str() preserves the precision
-    return data
-
-
-class EnvVarMetric:
-    name: str
-    env_var: str
-    required: bool = True
-    # Used to cast the value of the env_var to the correct type (defaults to str)
-    type_conversion_fn: Any = None
-
-    def __init__(
-        self,
-        name: str,
-        env_var: str,
-        required: bool = True,
-        type_conversion_fn: Any = None,
-    ) -> None:
-        self.name = name
-        self.env_var = env_var
-        self.required = required
-        self.type_conversion_fn = type_conversion_fn
-
-    def value(self) -> Any:
-        value = os.environ.get(self.env_var)
-        if value is None:
-            if self.required:
-                raise ValueError(
-                    (
-                        f"Not emitting metrics, missing {self.name}. Please set the {self.env_var}"
-                        "environment variable to pass in this value."
-                    )
-                )
-            else:
-                return None
-        if self.type_conversion_fn:
-            return self.type_conversion_fn(value)
-        return value
-
-
-def emit_metric(
-    metric_name: str,
-    metrics: Dict[str, Any],
-) -> None:
-    """
-    Upload a metric to DynamoDB (and from there, Rockset).
-
-    Parameters:
-        metric_name:
-            Name of the metric. Every unique metric should have a different name
-            and be emitted just once per run attempt.
-            Metrics are namespaced by their module and the function that emitted them.
-        metrics: The actual data to record.
-
-    Some default values are populated from environment variables, which must be set
-    for metrics to be emitted. (If they're not set, this function becomes a noop):
-
-    Env vars which should be set:
-        GITHUB_REPOSITORY: The repo name, e.g. "pytorch/pytorch"
-        GITHUB_WORKFLOW: The workflow name
-        GITHUB_JOB: The job name
-        GITHUB_RUN_ID: The workflow run number (aka job id)
-        GITHUB_RUN_NUMBER: The workflow run number
-        GITHUB_RUN_ATTEMPT: The workflow run attempt
-    """
-
-    if metrics is None:
-        raise ValueError("You didn't ask to upload any metrics!")
-
-    # Env vars that we use to determine basic info about the workflow run.
-    # This also helps ensure that we only emit metrics during CI.
-    env_var_metrics = [
-        EnvVarMetric("repo", "GITHUB_REPOSITORY"),
-        EnvVarMetric("workflow", "GITHUB_WORKFLOW"),
-        EnvVarMetric("build_environment", "BUILD_ENVIRONMENT"),
-        EnvVarMetric("job", "GITHUB_JOB"),
-        EnvVarMetric("test_config", "TEST_CONFIG", required=False),
-        EnvVarMetric("run_id", "GITHUB_RUN_ID", type_conversion_fn=int),
-        EnvVarMetric("run_number", "GITHUB_RUN_NUMBER", type_conversion_fn=int),
-        EnvVarMetric("run_attempt", "GITHUB_RUN_ATTEMPT", type_conversion_fn=int),
-    ]
-
-    # Ensure the metrics dict doesn't contain any reserved keys
-    reserved_metric_keys = [
-        *[metric.name for metric in env_var_metrics],
-        "dynamo_key",
-        "metric_name",
-        "calling_file",
-        "calling_module",
-        "calling_function",
-    ]
-
-    for key in reserved_metric_keys:
-        used_reserved_keys = [k for k in metrics.keys() if k == key]
-        if used_reserved_keys:
-            raise ValueError(f"Metrics dict contains reserved keys [{', '.join(key)}]")
-
-    dynamo_key = "/".join(
-        [
-            metric_name,
-            *[
-                str(metric.value())
-                for metric in env_var_metrics
-                if metric.value() is not None
-            ],
-        ]
-    )
-
-    # Use info about the function that invoked this one as a namespace and a way to filter metrics.
-    calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]
-    calling_frame_info = inspect.getframeinfo(calling_frame)  # type: ignore[arg-type]
-    calling_file = os.path.basename(calling_frame_info.filename)
-    calling_module = inspect.getmodule(calling_frame).__name__  # type: ignore[union-attr]
-    calling_function = calling_frame_info.function
-
-    # boto3 doesn't support uplaoding float values to DynamoDB, so convert them all to decimals.
-    metrics = _convert_float_values_to_decimals(metrics)
-
-    try:
-        session = boto3.Session(region_name="us-east-1")
-        session.resource("dynamodb").Table("torchci-metrics").put_item(
-            Item={
-                "dynamo_key": dynamo_key,
-                "metric_name": metric_name,
-                "calling_file": calling_file,
-                "calling_module": calling_module,
-                "calling_function": calling_function,
-                **{m.name: m.value() for m in env_var_metrics},
-                **metrics,
-            }
-        )
-    except Exception as e:
-        # We don't want to fail the job if we can't upload the metric.
-        # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
-        warn(f"Error uploading metric to DynamoDB: {e}")
-        return
-
-
 def upload_to_s3(
     bucket_name: str,
     key: str,
@@ -358,3 +217,132 @@ def is_rerun_disabled_tests(root: ET.ElementTree) -> bool:
 
     message = skipped.attrib.get("message", "")
     return TARGET_WORKFLOW in message or "num_red" in message
+
+
+def _convert_float_values_to_decimals(data: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in data.items():
+        if isinstance(value, float):
+            data[key] = decimal.Decimal(str(value))  # str() preserves the precision
+    return data
+
+
+class EnvVarMetric:
+    name: str
+    env_var: str
+    required: bool = True
+    # Used to cast the value of the env_var to the correct type (defaults to str)
+    type_conversion_fn: Any = None
+
+    def __init__(
+        self,
+        name: str,
+        env_var: str,
+        required: bool = True,
+        type_conversion_fn: Any = None,
+    ) -> None:
+        self.name = name
+        self.env_var = env_var
+        self.required = required
+        self.type_conversion_fn = type_conversion_fn
+
+    def value(self) -> Any:
+        value = os.environ.get(self.env_var)
+        if value is None:
+            if self.required:
+                raise ValueError(
+                    (
+                        f"Not emitting metrics, missing {self.name}. Please set the {self.env_var}"
+                        "environment variable to pass in this value."
+                    )
+                )
+            else:
+                return None
+        if self.type_conversion_fn:
+            return self.type_conversion_fn(value)
+        return value
+
+
+def emit_metric(
+    metric_name: str,
+    metrics: Dict[str, Any],
+) -> None:
+    """
+    Upload a metric to DynamoDB (and from there, Rockset).
+
+    Parameters:
+        metric_name:
+            Name of the metric. Every unique metric should have a different name
+            and be emitted just once per run attempt.
+            Metrics are namespaced by their module and the function that emitted them.
+        metrics: The actual data to record.
+
+    Some default values are populated from environment variables, which must be set
+    for metrics to be emitted. (If they're not set, this function becomes a noop):
+    """
+
+    if metrics is None:
+        raise ValueError("You didn't ask to upload any metrics!")
+
+    # We use these env vars that to determine basic info about the workflow run.
+    # By using env vars, we don't have to pass this info around to every function.
+    # It also helps ensure that we only emit metrics during CI
+    env_var_metrics = [
+        EnvVarMetric("repo", "GITHUB_REPOSITORY"),
+        EnvVarMetric("workflow", "GITHUB_WORKFLOW"),
+        EnvVarMetric("build_environment", "BUILD_ENVIRONMENT"),
+        EnvVarMetric("job", "GITHUB_JOB"),
+        EnvVarMetric("test_config", "TEST_CONFIG", required=False),
+        EnvVarMetric("run_id", "GITHUB_RUN_ID", type_conversion_fn=int),
+        EnvVarMetric("run_number", "GITHUB_RUN_NUMBER", type_conversion_fn=int),
+        EnvVarMetric("run_attempt", "GITHUB_RUN_ATTEMPT", type_conversion_fn=int),
+    ]
+
+    dynamo_key = "/".join(
+        [
+            metric_name,
+            *[
+                str(metric.value())
+                for metric in env_var_metrics
+                if metric.value() is not None
+            ],
+        ]
+    )
+
+    # Use info about the function that invoked this one as a namespace and a way to filter metrics.
+    calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]
+    calling_frame_info = inspect.getframeinfo(calling_frame)  # type: ignore[arg-type]
+    calling_file = os.path.basename(calling_frame_info.filename)
+    calling_module = inspect.getmodule(calling_frame).__name__  # type: ignore[union-attr]
+    calling_function = calling_frame_info.function
+
+    reserved_metrics = {
+        "dynamo_key": dynamo_key,
+        "metric_name": metric_name,
+        "calling_file": calling_file,
+        "calling_module": calling_module,
+        "calling_function": calling_function,
+        **{m.name: m.value() for m in env_var_metrics},
+    }
+
+    # Ensure the metrics dict doesn't contain any reserved keys
+    for key in reserved_metrics.keys():
+        used_reserved_keys = [k for k in metrics.keys() if k == key]
+        if used_reserved_keys:
+            raise ValueError(f"Metrics dict contains reserved keys: [{', '.join(key)}]")
+
+    # boto3 doesn't support uplaoding float values to DynamoDB, so convert them all to decimals.
+    metrics = _convert_float_values_to_decimals(metrics)
+
+    try:
+        session = boto3.Session(region_name="us-east-1")
+        session.resource("dynamodb").Table("torchci-metrics").put_item(
+            Item={
+                **reserved_metrics,
+                **metrics,
+            }
+        )
+    except Exception as e:
+        # We don't want to fail the job if we can't upload the metric.
+        # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
+        warn(f"Error uploading metric to DynamoDB: {e}")
+        return

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -305,7 +305,6 @@ def emit_metric(
     calling_module = inspect.getmodule(calling_frame).__name__  # type: ignore[union-attr]
     calling_function = calling_frame_info.function
 
-
     try:
         reserved_metrics = {
             "metric_name": metric_name,

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -321,7 +321,9 @@ def emit_metric(
         return
 
     # Prefix key with metric name and timestamp to derisk chance of a uuid1 name collision
-    reserved_metrics["dynamo_key"] = f"{metric_name}_{int(time.time())}_{uuid.uuid1().hex}"
+    reserved_metrics[
+        "dynamo_key"
+    ] = f"{metric_name}_{int(time.time())}_{uuid.uuid1().hex}"
 
     # Ensure the metrics dict doesn't contain any reserved keys
     for key in reserved_metrics.keys():

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -131,6 +131,32 @@ def _convert_float_values_to_decimals(data: Dict[str, Any]) -> Dict[str, Any]:
             data[key] = decimal.Decimal(str(value))  # str() preserves the precision
     return data
 
+class EnvVarMetric:
+    name: str
+    env_var: str
+    required: bool = True
+    # Used to cast the value of the env_var to the correct type (defaults to str)
+    type_conversion_fn: Any = None
+
+
+    def __init__(self, name: str, env_var: str, required: bool = True, type_conversion_fn: Any = None) -> None:
+        self.name = name
+        self.env_var = env_var
+        self.required = required
+        self.type_conversion_fn = type_conversion_fn
+
+    def value(self) -> Any:
+        value = os.environ.get(self.env_var)
+        if value is None:
+            if self.required:
+                raise ValueError(
+                    f"Not emitting metrics, missing {self.name}. Please set the {self.env_var} environment variable to pass in this value."
+                )
+            else:
+                return None
+        if self.type_conversion_fn:
+            return self.type_conversion_fn(value)
+        return value
 
 def emit_metric(
     metric_name: str,
@@ -163,56 +189,37 @@ def emit_metric(
 
     # Env vars that we use to determine basic info about the workflow run.
     # This also helps ensure that we only emit metrics during CI.
-    input_via_env_vars = {
-        "repo": "GITHUB_REPOSITORY",
-        "workflow": "GITHUB_WORKFLOW",
-        "job": "GITHUB_JOB",
-        "run_id": "GITHUB_RUN_ID",
-        "run_number": "GITHUB_RUN_NUMBER",
-        "run_attempt": "GITHUB_RUN_ATTEMPT",
-    }
+    env_var_metrics = [
+        EnvVarMetric("repo", "GITHUB_REPOSITORY"),
+        EnvVarMetric("workflow", "GITHUB_WORKFLOW"),
+        EnvVarMetric("build_environment", "BUILD_ENVIRONMENT"),
+        EnvVarMetric("job", "GITHUB_JOB"),
+        EnvVarMetric("test_config", "TEST_CONFIG", required=False), # This isn't always set
+        EnvVarMetric("run_id", "GITHUB_RUN_ID", type_conversion_fn=int),
+        EnvVarMetric("run_number", "GITHUB_RUN_NUMBER", type_conversion_fn=int),
+        EnvVarMetric("run_attempt", "GITHUB_RUN_ATTEMPT", type_conversion_fn=int),
+    ]
 
+    # Ensure the metrics dict doesn't contain any reserved keys
     reserved_metric_keys = [
+        *[metric.name for metric in env_var_metrics],
         "dynamo_key",
         "metric_name",
         "calling_file",
         "calling_module",
         "calling_function",
-        *input_via_env_vars.keys(),
     ]
 
-    # Ensure the metrics dict doesn't contain these reserved keys
     for key in reserved_metric_keys:
         used_reserved_keys = [k for k in metrics.keys() if k == key]
         if used_reserved_keys:
             raise ValueError(f"Metrics dict contains reserved keys [{', '.join(key)}]")
 
-    reserved_env_metrics: Dict[str, Any] = {}
-    # Ensure we have a value for all the required env var based metrics
-    for var, env_var in input_via_env_vars.items():
-        reserved_env_metrics[var] = os.environ[env_var]
-        if not reserved_env_metrics[var]:
-            warn(
-                f"Not emitting metrics, missing {var}. Please set the {env_var} environment variable to pass in this value."
-            )
-            return
 
-    dynamo_key = "/".join(
-        [
-            reserved_env_metrics["repo"],
+    dynamo_key = "/".join([
             metric_name,
-            reserved_env_metrics["workflow"],
-            reserved_env_metrics["job"],
-            reserved_env_metrics["run_id"],
-            reserved_env_metrics["run_number"],
-            reserved_env_metrics["run_attempt"],
-        ]
-    )
-
-    # These are ints, even though the env vars were read as strings. Lets emit them that way
-    reserved_env_metrics["run_id"] = int(reserved_env_metrics["run_id"])
-    reserved_env_metrics["run_number"] = int(reserved_env_metrics["run_number"])
-    reserved_env_metrics["run_attempt"] = int(reserved_env_metrics["run_attempt"])
+            *[str(metric.value()) for metric in env_var_metrics if metric.value() is not None],
+        ])
 
     # Use info about the function that invoked this one as a namespace and a way to filter metrics.
     calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]
@@ -233,7 +240,7 @@ def emit_metric(
                 "calling_file": calling_file,
                 "calling_module": calling_module,
                 "calling_function": calling_function,
-                **reserved_env_metrics,
+                **{ m.name : m.value() for m in env_var_metrics },
                 **metrics,
             }
         )

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -153,7 +153,7 @@ def emit_metric(
         raise ValueError("You didn't ask to upload any metrics!")
 
     # Env vars that we use to determine basic info about the workflow run.
-    # This also helps ensure that we only emit metrics during CI
+    # This also helps ensure that we only emit metrics during CI.
     input_via_env_vars = {
         "repo": "GITHUB_REPOSITORY",
         "workflow": "GITHUB_WORKFLOW",

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -1,3 +1,4 @@
+import decimal
 import gzip
 import inspect
 import io
@@ -5,7 +6,6 @@ import json
 import os
 import xml.etree.ElementTree as ET
 import zipfile
-import decimal
 
 from pathlib import Path
 from typing import Any, Dict, List
@@ -124,11 +124,13 @@ def upload_to_rockset(
     )
     print("Done!")
 
+
 def _convert_float_values_to_decimals(data: Dict[str, Any]) -> Dict[str, Any]:
     for key, value in data.items():
         if isinstance(value, float):
-            data[key] = decimal.Decimal(str(value)) # str() preserves the precision
+            data[key] = decimal.Decimal(str(value))  # str() preserves the precision
     return data
+
 
 def emit_metric(
     metric_name: str,

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -14,8 +14,6 @@ import boto3  # type: ignore[import]
 import requests
 import rockset  # type: ignore[import]
 
-from torch.testing._internal.common_utils import IS_CI
-
 PYTORCH_REPO = "https://api.github.com/repos/pytorch/pytorch"
 S3_RESOURCE = boto3.resource("s3")
 TARGET_WORKFLOW = "--rerun-disabled-tests"
@@ -151,13 +149,11 @@ def emit_metric(
         GITHUB_RUN_ATTEMPT: The workflow run attempt
     """
 
-    if not IS_CI:
-        return  # Don't emit metrics if we're not running in CI
-
     if metrics is None:
         raise ValueError("You didn't ask to upload any metrics!")
 
-    # Env vars that we use to determine basic info about the workflow run
+    # Env vars that we use to determine basic info about the workflow run.
+    # This also helps ensure that we only emit metrics during CI
     input_via_env_vars = {
         "repo": "GITHUB_REPOSITORY",
         "workflow": "GITHUB_WORKFLOW",

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -205,7 +205,7 @@ def emit_metric(
     calling_function = calling_frame_info.function
 
     try:
-        session = boto3.Session(region_name='us-east-1')
+        session = boto3.Session(region_name="us-east-1")
         session.resource("dynamodb").Table("torchci-metrics").put_item(
             Item={
                 "dynamo_key": dynamo_key,

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -206,6 +206,10 @@ def emit_metric(
         ]
     )
 
+    # These are ints, even though the env vars were read as strings. Lets emit them that way
+    reserved_env_metrics["workflow_run_number"] = int(reserved_env_metrics["workflow_run_number"])
+    reserved_env_metrics["workflow_run_attempt"] = int(reserved_env_metrics["workflow_run_attempt"])
+
     # Use info about the function that invoked this one as a namespace and a way to filter metrics.
     calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]
     calling_frame_info = inspect.getframeinfo(calling_frame)  # type: ignore[arg-type]

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -176,7 +176,7 @@ def emit_metric(
         if used_reserved_keys:
             raise ValueError(f"Metrics dict contains reserved keys [{', '.join(key)}]")
 
-    reserved_env_metrics = {}
+    reserved_env_metrics: Dict[str, Any] = {}
     # Ensure we have a value for all the required env var based metrics
     for var, env_var in input_via_env_vars.items():
         reserved_env_metrics[var] = os.environ[env_var]
@@ -198,10 +198,10 @@ def emit_metric(
     )
 
     # Use info about the function that invoked this one as a namespace and a way to filter metrics.
-    calling_frame = inspect.currentframe().f_back
-    calling_frame_info = inspect.getframeinfo(calling_frame)
+    calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]
+    calling_frame_info = inspect.getframeinfo(calling_frame)  # type: ignore[arg-type]
     calling_file = os.path.basename(calling_frame_info.filename)
-    calling_module = inspect.getmodule(calling_frame).__name__
+    calling_module = inspect.getmodule(calling_frame).__name__  # type: ignore[union-attr]
     calling_function = calling_frame_info.function
 
     try:

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from typing import Any, Dict, List
 from warnings import warn
 
-from torch.testing._internal.common_utils import IS_CI
-
 import boto3  # type: ignore[import]
 import requests
 import rockset  # type: ignore[import]
+
+from torch.testing._internal.common_utils import IS_CI
 
 PYTORCH_REPO = "https://api.github.com/repos/pytorch/pytorch"
 S3_RESOURCE = boto3.resource("s3")
@@ -123,27 +123,36 @@ def upload_to_rockset(
     )
     print("Done!")
 
+
 def emit_metric(
-        metric_name: str,
-        metrics: Dict[str, Any],
-        # Below params are for testing. Normally they're read from env vars.
-        repo: str = "",
-        workflow_run_number: int = 0,
-        workflow_run_attempt: int = 0,
+    metric_name: str,
+    metrics: Dict[str, Any],
+    # Below params are for testing. Normally they're read from env vars.
+    repo: str = "",
+    workflow_run_number: int = 0,
+    workflow_run_attempt: int = 0,
 ) -> None:
     """
     Upload a metric to DynamoDB (and from there, Rockset).
 
     Parameters:
-        metric_name: Name of the metric. Every unique metric must have a different name and must be emitted just once per run attempt.
+        metric_name:
+            Name of the metric. Every unique metric must have a different name
+            and must be emitted just once per run attempt.
         metrics: The actual data to record.
-        repo: Name of the repo. If left blank, will be read from the GITHUB_REPOSITORY environment variable.
-        workflow_run_number: Workflow run number. If left blank, will be read from the GITHUB_RUN_NUMBER environment variable.
-        workflow_run_attempt: Workflow run attempt. If left blank, will be read from the GITHUB_RUN_ATTEMPT environment variable.
+        repo:
+            Name of the repo. If left blank, will be read from the GITHUB_REPOSITORY
+            environment variable.
+        workflow_run_number:
+            Workflow run number. If left blank, will be read from the GITHUB_RUN_NUMBER
+            environment variable.
+        workflow_run_attempt:
+            Workflow run attempt. If left blank, will be read from the GITHUB_RUN_ATTEMPT
+            environment variable.
     """
 
     if not IS_CI:
-        return # Don't emit metrics if we're not running in CI
+        return  # Don't emit metrics if we're not running in CI
 
     if metrics is None:
         raise ValueError("You didn't ask to upload any metrics!")
@@ -165,7 +174,9 @@ def emit_metric(
         if not locals()[var]:
             locals()[var] = os.environ[env_var]
             if not locals()[var]:
-                raise ValueError(f"Missing required {var} parameter. Please either pass it in or set the {env_var} environment variable.")
+                raise ValueError(
+                    f"Missing required {var} parameter. Please either pass it in or set the {env_var} environment variable."
+                )
 
     # Ensure the metrics dict doesn't contain these reserved keys
     for key in reserved_metric_keys:
@@ -182,7 +193,7 @@ def emit_metric(
                 "repo": repo,
                 "workflow_run_number": workflow_run_number,
                 "workflow_run_attempt": workflow_run_attempt,
-                **metrics, # Expand the metrics dict into the top-level of the item
+                **metrics,  # Expand the metrics dict into the top-level of the item
             }
         )
     except Exception as e:

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -3,7 +3,6 @@ import inspect
 import io
 import json
 import os
-import sys
 import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
@@ -199,7 +198,7 @@ def emit_metric(
     )
 
     # Use info about the function that invoked this one as a namespace and a way to filter metrics.
-    calling_frame = sys._getframe(1)
+    calling_frame = inspect.currentframe().f_back
     calling_frame_info = inspect.getframeinfo(calling_frame)
     calling_file = os.path.basename(calling_frame_info.filename)
     calling_module = inspect.getmodule(calling_frame).__name__

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -152,7 +152,8 @@ def emit_metric(
     Env vars which should be set:
         GITHUB_REPOSITORY: The repo name, e.g. "pytorch/pytorch"
         GITHUB_WORKFLOW: The workflow name
-        GITHUB_JOB: The job id
+        GITHUB_JOB: The job name
+        GITHUB_RUN_ID: The workflow run number (aka job id)
         GITHUB_RUN_NUMBER: The workflow run number
         GITHUB_RUN_ATTEMPT: The workflow run attempt
     """
@@ -166,8 +167,9 @@ def emit_metric(
         "repo": "GITHUB_REPOSITORY",
         "workflow": "GITHUB_WORKFLOW",
         "job": "GITHUB_JOB",
-        "workflow_run_number": "GITHUB_RUN_NUMBER",
-        "workflow_run_attempt": "GITHUB_RUN_ATTEMPT",
+        "run_id": "GITHUB_RUN_ID",
+        "run_number": "GITHUB_RUN_NUMBER",
+        "run_attempt": "GITHUB_RUN_ATTEMPT",
     }
 
     reserved_metric_keys = [
@@ -201,14 +203,16 @@ def emit_metric(
             metric_name,
             reserved_env_metrics["workflow"],
             reserved_env_metrics["job"],
-            reserved_env_metrics["workflow_run_number"],
-            reserved_env_metrics["workflow_run_attempt"],
+            reserved_env_metrics["run_id"],
+            reserved_env_metrics["run_number"],
+            reserved_env_metrics["run_attempt"],
         ]
     )
 
     # These are ints, even though the env vars were read as strings. Lets emit them that way
-    reserved_env_metrics["workflow_run_number"] = int(reserved_env_metrics["workflow_run_number"])
-    reserved_env_metrics["workflow_run_attempt"] = int(reserved_env_metrics["workflow_run_attempt"])
+    reserved_env_metrics["run_id"] = int(reserved_env_metrics["run_id"])
+    reserved_env_metrics["run_number"] = int(reserved_env_metrics["run_number"])
+    reserved_env_metrics["run_attempt"] = int(reserved_env_metrics["run_attempt"])
 
     # Use info about the function that invoked this one as a namespace and a way to filter metrics.
     calling_frame = inspect.currentframe().f_back  # type: ignore[union-attr]

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -205,7 +205,8 @@ def emit_metric(
     calling_function = calling_frame_info.function
 
     try:
-        boto3.resource("dynamodb").Table("torchci-metrics").put_item(
+        session = boto3.Session(region_name='us-east-1')
+        session.resource("dynamodb").Table("torchci-metrics").put_item(
             Item={
                 "dynamo_key": dynamo_key,
                 "metric_name": metric_name,

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -65,7 +65,7 @@ class TestUploadStats(unittest.TestCase):
         }
 
         # Preserve the metric emitted
-        emitted_metric: Dict[str:Any] = {}
+        emitted_metric: Dict[str, Any] = {}
 
         def mock_put_item(Item: Dict[str, Any]) -> None:
             nonlocal emitted_metric

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -75,7 +75,7 @@ class TestUploadStats(unittest.TestCase):
 
         emit_metric("metric_name", metric)
 
-        self.assertDictEqual(emitted_metric | emit_should_include, emitted_metric)
+        self.assertDictContainsSubset(emit_should_include, emitted_metric)
 
     @mock.patch("boto3.resource")
     def test_blocks_emission_if_reserved_keyword_used(self, mock_resource: Any) -> None:

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -67,7 +67,7 @@ class TestUploadStats(unittest.TestCase):
         # Preserve the metric emitted
         emitted_metric: Dict[str:Any] = {}
 
-        def mock_put_item(Item: Dict[str:Any]) -> None:
+        def mock_put_item(Item: Dict[str, Any]) -> None:
             nonlocal emitted_metric
             emitted_metric = Item
 

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -8,11 +8,13 @@ from tools.stats.upload_stats_lib import emit_metric
 
 # default values
 REPO = "some/repo"
+BUILD_ENV = "cuda-10.2"
+TEST_CONFIG = "test-config"
 WORKFLOW = "some-workflow"
 JOB = "some-job"
-WORKFLOW_RUN_ID = 56
-WORKFLOW_RUN_NUMBER = 123
-WORKFLOW_RUN_ATTEMPT = 3
+RUN_ID = 56
+RUN_NUMBER = 123
+RUN_ATTEMPT = 3
 
 
 class TestUploadStats(unittest.TestCase):
@@ -22,12 +24,14 @@ class TestUploadStats(unittest.TestCase):
             "os.environ",
             {
                 "CI": "true",
+                "BUILD_ENVIRONMENT": BUILD_ENV,
+                "TEST_CONFIG": TEST_CONFIG,
                 "GITHUB_REPOSITORY": REPO,
                 "GITHUB_WORKFLOW": WORKFLOW,
                 "GITHUB_JOB": JOB,
-                "GITHUB_RUN_ID": str(WORKFLOW_RUN_ID),
-                "GITHUB_RUN_NUMBER": str(WORKFLOW_RUN_NUMBER),
-                "GITHUB_RUN_ATTEMPT": str(WORKFLOW_RUN_ATTEMPT),
+                "GITHUB_RUN_ID": str(RUN_ID),
+                "GITHUB_RUN_NUMBER": str(RUN_NUMBER),
+                "GITHUB_RUN_ATTEMPT": str(RUN_ATTEMPT),
             },
         ).start()
 
@@ -44,17 +48,19 @@ class TestUploadStats(unittest.TestCase):
         current_module = inspect.getmodule(inspect.currentframe()).__name__  # type: ignore[union-attr]
 
         expected_emit = {
-            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_ID}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
+            "dynamo_key": f"metric_name/{REPO}/{WORKFLOW}/{BUILD_ENV}/{JOB}/{TEST_CONFIG}/{RUN_ID}/{RUN_NUMBER}/{RUN_ATTEMPT}",
             "metric_name": "metric_name",
             "calling_file": "test_upload_stats_lib.py",
             "calling_module": current_module,
             "calling_function": "test_emit_metric",
             "repo": REPO,
             "workflow": WORKFLOW,
+            "build_environment": BUILD_ENV,
             "job": JOB,
-            "run_id": WORKFLOW_RUN_ID,
-            "run_number": WORKFLOW_RUN_NUMBER,
-            "run_attempt": WORKFLOW_RUN_ATTEMPT,
+            "test_config": TEST_CONFIG,
+            "run_id": RUN_ID,
+            "run_number": RUN_NUMBER,
+            "run_attempt": RUN_ATTEMPT,
             "some_number": 123,
             "float_number": decimal.Decimal(str(32.34)),
         }

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,7 +1,7 @@
 import decimal
 import inspect
 import unittest
-from typing import Any
+from typing import Any, Dict
 from unittest import mock
 
 from tools.stats.upload_stats_lib import emit_metric
@@ -65,9 +65,9 @@ class TestUploadStats(unittest.TestCase):
         }
 
         # Preserve the metric emitted
-        emitted_metric = None
+        emitted_metric: Dict[str:Any] = {}
 
-        def mock_put_item(Item: Any) -> None:
+        def mock_put_item(Item: Dict[str:Any]) -> None:
             nonlocal emitted_metric
             emitted_metric = Item
 

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,7 +1,6 @@
-from typing import Any
 import unittest
+from typing import Any
 from unittest import mock
-import boto3
 
 from tools.stats.upload_stats_lib import emit_metric
 
@@ -10,31 +9,36 @@ REPO = "some/repo"
 WORKFLOW_RUN_NUMBER = 123
 WORKFLOW_RUN_ATTEMPT = 3
 
+
 class TestUploadStats(unittest.TestCase):
-    @mock.patch('boto3.resource')
-    def test_emit_metric(self, mock_resource) -> None:
-        metric = {"some_number" : 123}
+    @mock.patch("boto3.resource")
+    def test_emit_metric(self, mock_resource: Any) -> None:
+        metric = {"some_number": 123}
 
         expected_emit = {
-            'dynamo_key': f"{REPO}/metric_name/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
-            'metric_name': 'metric_name',
-            'repo': REPO,
-            'workflow_run_number': WORKFLOW_RUN_NUMBER,
-            'workflow_run_attempt': WORKFLOW_RUN_ATTEMPT,
-            **metric
+            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
+            "metric_name": "metric_name",
+            "repo": REPO,
+            "workflow_run_number": WORKFLOW_RUN_NUMBER,
+            "workflow_run_attempt": WORKFLOW_RUN_ATTEMPT,
+            **metric,
         }
 
-        emit_metric("metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT)
+        emit_metric(
+            "metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT
+        )
 
         mock_table = mock_resource.return_value.Table.return_value
         mock_table.put_item.assert_called_once_with(Item=expected_emit)
 
-    @mock.patch('boto3.resource')
-    def test_blocks_emission_if_reserved_keyword_used(self, mock_resource) -> None:
+    @mock.patch("boto3.resource")
+    def test_blocks_emission_if_reserved_keyword_used(self, mock_resource: Any) -> None:
         metric = {"repo": "awesome/repo"}
 
         with self.assertRaises(ValueError):
-            emit_metric("metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT)
+            emit_metric(
+                "metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT
+            )
 
 
 if __name__ == "__main__":

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -10,8 +10,8 @@ from tools.stats.upload_stats_lib import emit_metric
 REPO = "some/repo"
 WORKFLOW = "some-workflow"
 JOB = "some-job"
-WORKFLOW_RUN_NUMBER = "123"
-WORKFLOW_RUN_ATTEMPT = "3"
+WORKFLOW_RUN_NUMBER = 123
+WORKFLOW_RUN_ATTEMPT = 3
 
 
 class TestUploadStats(unittest.TestCase):

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 from typing import Any
 from unittest import mock
@@ -31,11 +32,16 @@ class TestUploadStats(unittest.TestCase):
     def test_emit_metric(self, mock_resource: Any) -> None:
         metric = {"some_number": 123}
 
+        # Querying for this instead of hard coding it b/c this will change
+        # based on whether we run this test directly from python or from
+        # pytest
+        current_module = inspect.getmodule(inspect.currentframe()).__name__  # type: ignore[union-attr]
+
         expected_emit = {
             "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
             "metric_name": "metric_name",
             "calling_file": "test_upload_stats_lib.py",
-            "calling_module": "__main__",
+            "calling_module": current_module,
             "calling_function": "test_emit_metric",
             "repo": REPO,
             "workflow": WORKFLOW,

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -10,6 +10,7 @@ from tools.stats.upload_stats_lib import emit_metric
 REPO = "some/repo"
 WORKFLOW = "some-workflow"
 JOB = "some-job"
+WORKFLOW_RUN_ID = 56
 WORKFLOW_RUN_NUMBER = 123
 WORKFLOW_RUN_ATTEMPT = 3
 
@@ -24,6 +25,7 @@ class TestUploadStats(unittest.TestCase):
                 "GITHUB_REPOSITORY": REPO,
                 "GITHUB_WORKFLOW": WORKFLOW,
                 "GITHUB_JOB": JOB,
+                "GITHUB_RUN_ID": str(WORKFLOW_RUN_ID),
                 "GITHUB_RUN_NUMBER": str(WORKFLOW_RUN_NUMBER),
                 "GITHUB_RUN_ATTEMPT": str(WORKFLOW_RUN_ATTEMPT),
             },
@@ -42,7 +44,7 @@ class TestUploadStats(unittest.TestCase):
         current_module = inspect.getmodule(inspect.currentframe()).__name__  # type: ignore[union-attr]
 
         expected_emit = {
-            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
+            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_ID}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
             "metric_name": "metric_name",
             "calling_file": "test_upload_stats_lib.py",
             "calling_module": current_module,
@@ -50,8 +52,9 @@ class TestUploadStats(unittest.TestCase):
             "repo": REPO,
             "workflow": WORKFLOW,
             "job": JOB,
-            "workflow_run_number": WORKFLOW_RUN_NUMBER,
-            "workflow_run_attempt": WORKFLOW_RUN_ATTEMPT,
+            "run_id": WORKFLOW_RUN_ID,
+            "run_number": WORKFLOW_RUN_NUMBER,
+            "run_attempt": WORKFLOW_RUN_ATTEMPT,
             "some_number": 123,
             "float_number": decimal.Decimal(str(32.34)),
         }

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -6,27 +6,42 @@ from tools.stats.upload_stats_lib import emit_metric
 
 # default values
 REPO = "some/repo"
+WORKFLOW = "some-workflow"
+JOB = "some-job"
 WORKFLOW_RUN_NUMBER = 123
 WORKFLOW_RUN_ATTEMPT = 3
 
 
 class TestUploadStats(unittest.TestCase):
+    # Before each test, set the env vars to their default values
+    def setUp(self) -> None:
+        mock.patch.dict(
+            "os.environ",
+            {
+                "GITHUB_REPOSITORY": REPO,
+                "GITHUB_WORKFLOW": WORKFLOW,
+                "GITHUB_JOB": JOB,
+                "GITHUB_RUN_NUMBER": str(WORKFLOW_RUN_NUMBER),
+                "GITHUB_RUN_ATTEMPT": str(WORKFLOW_RUN_ATTEMPT),
+            },
+        ).start()
+
     @mock.patch("boto3.resource")
     def test_emit_metric(self, mock_resource: Any) -> None:
         metric = {"some_number": 123}
 
         expected_emit = {
-            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
+            "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
             "metric_name": "metric_name",
             "repo": REPO,
+            "workflow": WORKFLOW,
+            "job": JOB,
             "workflow_run_number": WORKFLOW_RUN_NUMBER,
             "workflow_run_attempt": WORKFLOW_RUN_ATTEMPT,
             **metric,
         }
 
-        emit_metric(
-            "metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT
-        )
+        emit_metric("metric_name", metric)
 
         mock_table = mock_resource.return_value.Table.return_value
         mock_table.put_item.assert_called_once_with(Item=expected_emit)
@@ -36,9 +51,7 @@ class TestUploadStats(unittest.TestCase):
         metric = {"repo": "awesome/repo"}
 
         with self.assertRaises(ValueError):
-            emit_metric(
-                "metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT
-            )
+            emit_metric("metric_name", metric)
 
 
 if __name__ == "__main__":

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,3 +1,4 @@
+import decimal
 import inspect
 import unittest
 from typing import Any
@@ -30,7 +31,10 @@ class TestUploadStats(unittest.TestCase):
 
     @mock.patch("boto3.Session.resource")
     def test_emit_metric(self, mock_resource: Any) -> None:
-        metric = {"some_number": 123}
+        metric = {
+            "some_number": 123,
+            "float_number": 32.34,
+        }
 
         # Querying for this instead of hard coding it b/c this will change
         # based on whether we run this test directly from python or from
@@ -48,7 +52,8 @@ class TestUploadStats(unittest.TestCase):
             "job": JOB,
             "workflow_run_number": WORKFLOW_RUN_NUMBER,
             "workflow_run_attempt": WORKFLOW_RUN_ATTEMPT,
-            **metric,
+            "some_number": 123,
+            "float_number": decimal.Decimal(str(32.34)),
         }
 
         emit_metric("metric_name", metric)

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -28,7 +28,7 @@ class TestUploadStats(unittest.TestCase):
             },
         ).start()
 
-    @mock.patch("boto3.resource")
+    @mock.patch("boto3.Session.resource")
     def test_emit_metric(self, mock_resource: Any) -> None:
         metric = {"some_number": 123}
 

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -64,7 +64,7 @@ class TestUploadStats(unittest.TestCase):
         mock.patch.dict(
             "os.environ",
             {
-                "GITHUB_REPOSITORY": "", # unset this env var
+                "GITHUB_REPOSITORY": "",  # unset this env var
             },
         ).start()
 
@@ -72,6 +72,7 @@ class TestUploadStats(unittest.TestCase):
 
         mock_table = mock_resource.return_value.Table.return_value
         mock_table.put_item.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -91,14 +91,23 @@ class TestUploadStats(unittest.TestCase):
         mock.patch.dict(
             "os.environ",
             {
-                "GITHUB_REPOSITORY": "",  # unset this env var
+                "CI": "true",
+                "BUILD_ENVIRONMENT": BUILD_ENV,
             },
+            clear=True,
         ).start()
+
+        put_item_invoked = False
+
+        def mock_put_item(Item: Dict[str, Any]) -> None:
+            nonlocal put_item_invoked
+            put_item_invoked = True
+
+        mock_resource.return_value.Table.return_value.put_item = mock_put_item
 
         emit_metric("metric_name", metric)
 
-        mock_table = mock_resource.return_value.Table.return_value
-        mock_table.put_item.assert_not_called()
+        self.assertFalse(put_item_invoked)
 
 
 if __name__ == "__main__":

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -8,8 +8,8 @@ from tools.stats.upload_stats_lib import emit_metric
 REPO = "some/repo"
 WORKFLOW = "some-workflow"
 JOB = "some-job"
-WORKFLOW_RUN_NUMBER = 123
-WORKFLOW_RUN_ATTEMPT = 3
+WORKFLOW_RUN_NUMBER = "123"
+WORKFLOW_RUN_ATTEMPT = "3"
 
 
 class TestUploadStats(unittest.TestCase):
@@ -33,6 +33,9 @@ class TestUploadStats(unittest.TestCase):
         expected_emit = {
             "dynamo_key": f"{REPO}/metric_name/{WORKFLOW}/{JOB}/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
             "metric_name": "metric_name",
+            "calling_file": "test_upload_stats_lib.py",
+            "calling_module": "__main__",
+            "calling_function": "test_emit_metric",
             "repo": REPO,
             "workflow": WORKFLOW,
             "job": JOB,

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,0 +1,41 @@
+from typing import Any
+import unittest
+from unittest import mock
+import boto3
+
+from tools.stats.upload_stats_lib import emit_metric
+
+# default values
+REPO = "some/repo"
+WORKFLOW_RUN_NUMBER = 123
+WORKFLOW_RUN_ATTEMPT = 3
+
+class TestUploadStats(unittest.TestCase):
+    @mock.patch('boto3.resource')
+    def test_emit_metric(self, mock_resource) -> None:
+        metric = {"some_number" : 123}
+
+        expected_emit = {
+            'dynamo_key': f"{REPO}/metric_name/{WORKFLOW_RUN_NUMBER}/{WORKFLOW_RUN_ATTEMPT}",
+            'metric_name': 'metric_name',
+            'repo': REPO,
+            'workflow_run_number': WORKFLOW_RUN_NUMBER,
+            'workflow_run_attempt': WORKFLOW_RUN_ATTEMPT,
+            **metric
+        }
+
+        emit_metric("metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT)
+
+        mock_table = mock_resource.return_value.Table.return_value
+        mock_table.put_item.assert_called_once_with(Item=expected_emit)
+
+    @mock.patch('boto3.resource')
+    def test_blocks_emission_if_reserved_keyword_used(self, mock_resource) -> None:
+        metric = {"repo": "awesome/repo"}
+
+        with self.assertRaises(ValueError):
+            emit_metric("metric_name", metric, REPO, WORKFLOW_RUN_NUMBER, WORKFLOW_RUN_ATTEMPT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -260,9 +260,12 @@ def log_time_savings(
         f"Prioritized tests will run about {duration_to_str(max_time_savings_sec)} sooner than they would've otherwise"
     )
 
-    emit_metric("test_reordering_time_savings", {
-        "time_savings_sec": max_time_savings_sec,
-    })
+    emit_metric(
+        "test_reordering_time_savings",
+        {
+            "time_savings_sec": max_time_savings_sec,
+        },
+    )
 
     # Return value used by tests
     return max_time_savings_sec
@@ -327,12 +330,15 @@ def get_reordered_tests(
     else:
         print("Didn't find any tests to prioritize")
 
-    emit_metric("test_reordering_prioritized_tests", {
-        "prioritized_test_cnt": len(bring_to_front),
-        "total_test_cnt": len(tests),
-        "prioritized_tests": prioritized_test_names,
-        "remaining_tests": remaining_test_names,
-    })
+    emit_metric(
+        "test_reordering_prioritized_tests",
+        {
+            "prioritized_test_cnt": len(bring_to_front),
+            "total_test_cnt": len(tests),
+            "prioritized_tests": prioritized_test_names,
+            "remaining_tests": remaining_test_names,
+        },
+    )
 
     return (bring_to_front, the_rest)
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -11,6 +11,7 @@ from warnings import warn
 from tools.shared.logging_utils import duration_to_str, pluralize
 
 from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
+from tools.stats.upload_stats_lib import emit_metric
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 
@@ -259,6 +260,10 @@ def log_time_savings(
         f"Prioritized tests will run about {duration_to_str(max_time_savings_sec)} sooner than they would've otherwise"
     )
 
+    emit_metric("test_reordering_time_savings", {
+        "time_savings_sec": max_time_savings_sec,
+    })
+
     # Return value used by tests
     return max_time_savings_sec
 
@@ -309,7 +314,8 @@ def get_reordered_tests(
         )
         return ([], tests)
 
-    # TODO: Would be great to upload these stats to RDS/Rockset!
+    prioritized_test_names = []
+    remaining_test_names = []
     if bring_to_front:
         test_cnt_str = pluralize(len(tests), "test")
         print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
@@ -320,6 +326,13 @@ def get_reordered_tests(
         print(f"The Rest: {remaining_test_names}")
     else:
         print("Didn't find any tests to prioritize")
+
+    emit_metric("test_reordering_prioritized_tests", {
+        "prioritized_test_cnt": len(bring_to_front),
+        "total_test_cnt": len(tests),
+        "prioritized_tests": prioritized_test_names,
+        "remaining_tests": remaining_test_names,
+    })
 
     return (bring_to_front, the_rest)
 


### PR DESCRIPTION
Added a feature to upload test statistics to DynamoDB and Rockset using a new function `emit_metric` in `tools/stats/upload_stats_lib.py`. 

Added metrics to measure test reordering effectiveness in `tools/testing/test_selections.py`. 