### PR TITLE
[functorch] Get test_functionalize to run on FB infra

### DIFF
--- a/test/functorch/test_functionalize.py
+++ b/test/functorch/test_functionalize.py
@@ -1,8 +1,9 @@
 # Owner(s): ["module: functorch"]
 
 import functools
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+
 import test_aotdispatch
+from torch.testing._internal.common_utils import run_tests, skipIfRocm
 
 
 def make_functionalize_fn(fn):
@@ -14,29 +15,40 @@ def make_functionalize_fn(fn):
 
 
 def make_functionalize_test(cls):
-    class FunctionalizeTest(cls):
-        pass
+    def wrapper(wrapped_cls):
+        @functools.wraps(wrapped_cls, updated=[])
+        class FunctionalizeTest(cls):
+            pass
 
-    FunctionalizeTest.__name__ = f"Functionalize{cls.__name__}"
+        for name in dir(cls):
+            if name.startswith("test_"):
+                fn = getattr(cls, name)
+                if not callable(fn):
+                    continue
 
-    for name in dir(cls):
-        if name.startswith("test_"):
-            fn = getattr(cls, name)
-            if not callable(fn):
-                continue
+                fn = make_functionalize_fn(fn)
+                # https://github.com/pytorch/pytorch/issues/96560
+                fn = skipIfRocm(fn)
 
-            new_name = f"{name}_functionalize"
-            fn = make_functionalize_fn(fn)
-            fn.__name__ = new_name
-            setattr(FunctionalizeTest, name, None)
-            setattr(FunctionalizeTest, new_name, fn)
+                new_name = f"{name}_functionalize"
+                fn.__name__ = new_name
+                setattr(FunctionalizeTest, name, None)
+                setattr(FunctionalizeTest, new_name, fn)
 
-    # https://github.com/pytorch/pytorch/issues/96560
-    return skipIfRocm(FunctionalizeTest)
+        return FunctionalizeTest
+
+    return wrapper
 
 
-FunctionalizeTestPythonKeyAOT = make_functionalize_test(test_aotdispatch.TestAOTAutograd)
-FunctionalizeTestPythonKeyPartitioning = make_functionalize_test(test_aotdispatch.TestPartitioning)
+@make_functionalize_test(test_aotdispatch.TestAOTAutograd)
+class FunctionalizeTestPythonKeyAOT:
+    pass
+
+
+@make_functionalize_test(test_aotdispatch.TestPartitioning)
+class FunctionalizeTestPythonKeyPartitioning:
+    pass
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102695

A few bits of weirdness needed to happen here:

- skipIfRocm doesn't work as a unittest class decorator; it returns a function,
  and the test discovery logic looks for things that inherit from TestCase.  So
  I wrapped the individual test methods instead.
- Inside fbcode, our test runner (buck + tpx) discovers and runs tests using
  two separate processes, so it's important to use @wraps on the generated
  class to make it "look like" a regular test.

Differential Revision: [D46344980](https://our.internmc.facebook.com/intern/diff/D46344980/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D46344980/)!