### PR TITLE
Introduce fast path for cuda_equal

### DIFF
--- a/aten/src/ATen/native/cuda/Equal.cpp
+++ b/aten/src/ATen/native/cuda/Equal.cpp
@@ -26,6 +26,22 @@ bool cuda_equal(const Tensor& self, const Tensor &src) {
   if (self.numel() == 0) {
     return true;
   }
+
+  // This is the same optimization done in the cpu_equal. Since the flags like neg/conj should be already handled outside the
+  // cuda_equal, it should be safe to have the following fast path by
+  // ensuring the storage and strides exactly the same.
+  if (self.is_alias_of(src)
+      && self.storage_offset() == src.storage_offset()
+      && self.dtype() == src.dtype()
+      && self.is_contiguous() == src.is_contiguous()
+      && self.strides().equals(src.strides())
+      // Extra checks to ensure the safety in case cuda_equal is directly called in C++.
+      && self.layout() == src.layout()
+      && self.is_neg() == src.is_neg()
+      && self.is_conj() == src.is_conj()) {
+    return true;
+  }
+
   return at::cuda::eq(self, src).all().item().to<bool>();
 }
 


### PR DESCRIPTION
We introduce the same trick for cuda_equal. Assuming in cuda_equal, the flags are already handled correctly.

Added the tests for cuda part.