### PR TITLE
RelaxUnspecConstraint some more

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -247,6 +247,18 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         torch._dynamo.mark_dynamic(y, 0)
         opt_fn(y)
 
+    def test_mark_01_dynamic(self):
+        def fn(x):
+            return x * 2
+
+        x = torch.randn(1)
+        torch._dynamo.mark_dynamic(x, 0)
+        opt_fn = torch._dynamo.optimize("eager")(fn)
+        # This will fail to compile a generic kernel, but we should not
+        # complain about it (mark dynamic will try its best but 0/1
+        # specialization is allowed)
+        opt_fn(x)
+
     def test_conv1d_symint_padding(self):
         kernel = torch.randn(1, 1, 4)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -519,14 +519,14 @@ class RelaxedUnspecConstraint(Constraint):
     unspecialized."  However, this constraint doesn't say very much about what
     specialization is permitted; for example, if we guard on a size being
     even, this would still be acceptable under an unspec constraint.  This
-    makes UnspecConstraint useful for eager mode, where your backend compiler
+    makes RelaxedUnspecConstraint useful for eager mode, where your backend compiler
     may add constraints to otherwise dynamic dimensions; we can't assert that
     there are NO guards as this is brittle because compilers should be able to
     add extra constraints.  If you want to assert that there are no guards,
     use StrictMinMaxConstraint with an unbounded ValueRanges.
     """
     def render(self, source: Source):
-        return f"UnspecConstraint({source.name()})"
+        return f"RelaxedUnspecConstraint({source.name()})"
 
 # NB: None here indicates the client constraint is whatever is implicitly
 # inferred by guards from tracing, and that a backend can add whatever guards
@@ -2282,9 +2282,21 @@ class ShapeEnv:
                 elif isinstance(-s, sympy.Symbol):
                     symbol_to_source[-s].append(NegateSource(source))
                 else:
-                    if constraint is not None:
-                        # TODO: Maybe non-strict constraint shouldn't error
-                        # here?  Check what happens in practice
+                    constraint_violated = False
+                    if isinstance(constraint, StrictMinMaxConstraint):
+                        constraint_violated = True
+                    elif isinstance(constraint, RelaxedUnspecConstraint):
+                        if s.free_symbols:
+                            # TODO: Maybe non-strict constraint shouldn't error
+                            # here?  Check what happens in practice
+                            constraint_violated = True
+                        else:
+                            i = int(s)
+                            # Don't complain about 0/1 specialization, we
+                            # expect to have to compile in this case anyway
+                            if i not in (0, 1):
+                                constraint_violated = True
+                    if constraint_violated:
                         def hint(s):
                             if s.free_symbols:
                                 return (
@@ -2312,12 +2324,19 @@ class ShapeEnv:
             else:
                 s = sympy.Integer(val)
                 input_guards.append((source, s))
-                if constraint is not None:
+                constraint_violated = False
+                if isinstance(constraint, StrictMinMaxConstraint):
+                    constraint_violated = True
+                elif isinstance(constraint, RelaxedUnspecConstraint):
+                    # Don't complain about 0/1 specialization, we
+                    # expect to have to compile in this case anyway
+                    if val not in (0, 1):
+                        constraint_violated = True
+                if constraint_violated:
                     msg = (
                         f"Could not validate constraint {constraint.render(source)} as "
-                        f"{source.name()} was inferred to be constant.  For more information "
-                        # TODO: fold this into TORCH_LOGS
-                        "about why it is constant, set torch._dynamo.config.print_specializations = True"
+                        f"{source.name()} was inferred to be constant ({val}).  For more information "
+                        "about why it is constant, run with TORCH_LOGS=dynamic"
                     )
                     record_constraint_violation(constraint.warn_only, msg)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102729

One annoyance with mark_dynamic is if you use it on a user specified
tensor input (the idea being that you want to compile a function and
have it be polymorphic in size), you will get an error if the user
ever sends you a 0/1 size input, because of course we are probably
going to specialize it.  So I relax the constraint even more: even if we
find it's constant, if the value is 0/1, that's no big deal.

There's some irritating code duplication that I don't entirely know how
to resolve.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy