### PR TITLE
initialize max_stream_priorities in getStreamFromPool(bool)

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -291,6 +291,7 @@ CUDAStream getStreamFromPool(const int priority, DeviceIndex device_index) {
 }
 
 CUDAStream getStreamFromPool(const bool isHighPriority, DeviceIndex device) {
+  initCUDAStreamsOnce();
   int priority = isHighPriority ? -max_stream_priorities + 1 : 0;
   return getStreamFromPool(priority, device);
 }


### PR DESCRIPTION
Summary:
`getStreamFromPool(bool, signed char)` overload doesn't initialize `max_stream_priorities`. So if we call `getStreamFromPool(true)` we would hit the following error
```
terminate called after throwing an instance of 'c10::Error'
  what():  Expected cuda stream priority to be less than or equal to 0, got 1
```

Differential Revision: D46358087

