### PR TITLE
Add comptime.breakpoint

### DIFF
--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -297,6 +297,10 @@ def print_guards():
     comptime(lambda ctx: ctx.print_guards())
 
 
+def breakpoint():
+    comptime(lambda ctx: breakpoint())
+
+
 def comptime(fn):
     """fn gets called at compile time in TorchDynamo, does nothing otherwise"""
     return
@@ -310,3 +314,4 @@ comptime.print_value_stack_and_return = print_value_stack_and_return
 comptime.print_locals = print_locals
 comptime.print_bt = print_bt
 comptime.print_guards = print_guards
+comptime.breakpoint = breakpoint

--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -302,6 +302,22 @@ def print_guards():
 
 
 def breakpoint():
+    """
+    Like pdb breakpoint(), but drop into pdb whenever this line
+    of code is compiled by dynamo.  Use it by putting
+    this in your model code::
+
+        from torch._dynamo.comptime import comptime
+        comptime.breakpoint()
+
+    And then, inside pdb, you can access 'ctx' to query things
+    about the compilation context::
+
+        (Pdb) !ctx.print_bt()
+        (Pdb) !ctx.print_locals()
+        (Pdb) p ctx.get_local("attention").as_fake()
+    """
+
     def inner(inner_ctx):
         ctx = inner_ctx.parent()
         builtins.breakpoint()

--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -5,6 +5,7 @@
 # The goal of the public API is to give users rope, without actually
 # leaking private implementation details of Dynamo.
 
+import builtins
 import dis
 import traceback
 from typing import Optional, Union
@@ -146,6 +147,9 @@ class ComptimeContext:
         print(
             self.__tx.output.graph.python_code("self", verbose=verbose).src, file=file
         )
+
+    def parent(self):
+        return ComptimeContext(self.__tx.parent)
 
     def __get_tx(self, stacklevel):
         tx = self.__tx
@@ -298,7 +302,11 @@ def print_guards():
 
 
 def breakpoint():
-    comptime(lambda ctx: breakpoint())
+    def inner(inner_ctx):
+        ctx = inner_ctx.parent()
+        builtins.breakpoint()
+
+    comptime(inner)
 
 
 def comptime(fn):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102758

This sets a pdb breakpoint to fire whenever we *compile* this
Python code in Dynamo.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy