### PR TITLE
Extend torch->onnx export for quantized convolutional ops

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -931,7 +931,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
     output_shape = MakeDeConvOutputShape<kSpatialDim>(
         N,
         M,
-        {H, W},
+        kSpatialDim == 2 ? std::vector<int64_t>{H, W} : std::vector<int64_t>{D, H, W},
         kernel_,
         stride(),
         padding(),

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -50,6 +50,7 @@ skipIfNoBFloat16Cuda = _skipper(
     lambda: not torch.cuda.is_bf16_supported(), "BFloat16 CUDA is not available"
 )
 
+skipIfQuantizationBackendQNNPack = _skipper(lambda: torch.backends.quantized.engine == "qnnpack", "Not compatible with QNNPack quantization backend")
 
 # skips tests for all versions below min_opset_version.
 # if exporting the op is only supported after a specific version,

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -50,7 +50,11 @@ skipIfNoBFloat16Cuda = _skipper(
     lambda: not torch.cuda.is_bf16_supported(), "BFloat16 CUDA is not available"
 )
 
-skipIfQuantizationBackendQNNPack = _skipper(lambda: torch.backends.quantized.engine == "qnnpack", "Not compatible with QNNPack quantization backend")
+skipIfQuantizationBackendQNNPack = _skipper(
+    lambda: torch.backends.quantized.engine == "qnnpack",
+    "Not compatible with QNNPack quantization backend",
+)
+
 
 # skips tests for all versions below min_opset_version.
 # if exporting the op is only supported after a specific version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -27,10 +27,10 @@ from pytorch_test_common import (
     RNN_INPUT_SIZE,
     RNN_SEQUENCE_LENGTH,
     skipDtypeChecking,
+    skipIfQuantizationBackendQNNPack,
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
     skipIfUnsupportedOpsetVersion,
-    skipIfQuantizationBackendQNNPack,
     skipScriptTest,
     skipShapeChecking,
     skipTraceTest,
@@ -12475,7 +12475,9 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfUnsupportedMinOpsetVersion(10)
     @skipIfQuantizationBackendQNNPack
     def test_quantized_conv3d_relu(self):
-        model = torch.ao.nn.intrinsic.quantized.ConvReLU3d(16, 33, [2, 3, 4], stride=[3, 1, 2])
+        model = torch.ao.nn.intrinsic.quantized.ConvReLU3d(
+            16, 33, [2, 3, 4], stride=[3, 1, 2]
+        )
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
         q_weight = torch.quantize_per_tensor(
@@ -12518,7 +12520,9 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfUnsupportedMinOpsetVersion(10)
     @skipIfQuantizationBackendQNNPack
     def test_quantized_conv_transpose3d(self):
-        model = torch.ao.nn.quantized.ConvTranspose3d(16, 33, [2, 3, 4], stride=[3, 1, 2])
+        model = torch.ao.nn.quantized.ConvTranspose3d(
+            16, 33, [2, 3, 4], stride=[3, 1, 2]
+        )
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
         q_weight = torch.quantize_per_tensor(

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -30,6 +30,7 @@ from pytorch_test_common import (
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
     skipIfUnsupportedOpsetVersion,
+    skipIfQuantizationBackendQNNPack,
     skipScriptTest,
     skipShapeChecking,
     skipTraceTest,
@@ -12394,6 +12395,20 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(model, input_tensor)
 
     @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv1d(self):
+        model = torch.ao.nn.quantized.Conv1d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(33, 16, 3), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 32)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_conv2d(self):
         model = torch.ao.nn.quantized.Conv2d(16, 33, 3, stride=2)
         # Manually initialize model weight and bias to random numbers.
@@ -12408,10 +12423,39 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(model, q_input)
 
     @skipIfUnsupportedMinOpsetVersion(10)
+    @skipIfQuantizationBackendQNNPack
+    def test_quantized_conv3d(self):
+        model = torch.ao.nn.quantized.Conv3d(16, 33, [2, 3, 4], stride=[3, 1, 2])
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(33, 16, 2, 3, 4), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 8, 8, 8)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_adaptive_avg_pool2d(self):
         model = torch.nn.AdaptiveAvgPool2d((5, 7))
         input = torch.randn(4, 3, 10, 14)
         q_input = torch.quantize_per_tensor(input, 0.2, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv1d_relu(self):
+        model = torch.ao.nn.intrinsic.quantized.ConvReLU1d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(33, 16, 3), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 32)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
         self.run_test(model, q_input)
 
     @skipIfUnsupportedMinOpsetVersion(10)
@@ -12429,16 +12473,60 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(model, q_input)
 
     @skipIfUnsupportedMinOpsetVersion(10)
-    def test_quantized_conv1d_relu(self):
-        model = torch.ao.nn.intrinsic.quantized.ConvReLU1d(16, 33, 3, stride=2)
+    @skipIfQuantizationBackendQNNPack
+    def test_quantized_conv3d_relu(self):
+        model = torch.ao.nn.intrinsic.quantized.ConvReLU3d(16, 33, [2, 3, 4], stride=[3, 1, 2])
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
         q_weight = torch.quantize_per_tensor(
-            torch.randn(33, 16, 3), 0.5, 0, torch.qint8
+            torch.randn(33, 16, 2, 3, 4), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 8, 8, 8)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv_transpose1d(self):
+        model = torch.ao.nn.quantized.ConvTranspose1d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(16, 33, 3), 0.5, 0, torch.qint8
         )
         bias = torch.arange(33).to(torch.float) - 16
         model.set_weight_bias(q_weight, bias)
         input = torch.randn(3, 16, 32)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv_transpose2d(self):
+        model = torch.ao.nn.quantized.ConvTranspose2d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(16, 33, 3, 3), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 32, 32)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
+        self.run_test(model, q_input)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    @skipIfQuantizationBackendQNNPack
+    def test_quantized_conv_transpose3d(self):
+        model = torch.ao.nn.quantized.ConvTranspose3d(16, 33, [2, 3, 4], stride=[3, 1, 2])
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(
+            torch.randn(16, 33, 2, 3, 4), 0.5, 0, torch.qint8
+        )
+        bias = torch.arange(33).to(torch.float) - 16
+        model.set_weight_bias(q_weight, bias)
+        input = torch.randn(3, 16, 8, 8, 8)
         q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
         self.run_test(model, q_input)
 

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -650,6 +650,10 @@ void UnpackQuantizedWeights(
   graph(%input, %packed_weight, %w_scale, %w_zero_point):
         %r = quantized::linear(%input, %packed_weight, %w_scale, %w_zero_point)
         return (%r) )";
+  std::string qconv1d = R"(
+  graph(%input, %packed_params, %scale, %zero_point):
+        %r = quantized::conv1d(%input, %packed_params, %scale, %zero_point)
+        return (%r) )";
   std::string qconv1d_relu = R"(
   graph(%input, %packed_params, %scale, %zero_point):
         %r = quantized::conv1d_relu(%input, %packed_params, %scale, %zero_point)
@@ -670,12 +674,31 @@ void UnpackQuantizedWeights(
   graph(%input, %packed_params, %scale, %zero_point):
         %r = quantized::conv3d_relu(%input, %packed_params, %scale, %zero_point)
         return (%r) )";
+  std::string qconv_transpose1d = R"(
+  graph(%input, %packed_params, %scale, %zero_point):
+        %r = quantized::conv_transpose1d(%input, %packed_params, %scale, %zero_point)
+        return (%r) )";
+  std::string qconv_transpose2d = R"(
+  graph(%input, %packed_params, %scale, %zero_point):
+        %r = quantized::conv_transpose2d(%input, %packed_params, %scale, %zero_point)
+        return (%r) )";
+  std::string qconv_transpose3d = R"(
+  graph(%input, %packed_params, %scale, %zero_point):
+        %r = quantized::conv_transpose3d(%input, %packed_params, %scale, %zero_point)
+        return (%r) )";
   unpackQuantizedWeightsHelper(
       graph,
       paramsDict,
       qlinear,
       "quantized::linear_unpack",
       QuantizedParamsType::LINEAR,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv1d,
+      "quantized::conv1d_unpack",
+      QuantizedParamsType::CONV1D,
       caffe2);
   unpackQuantizedWeightsHelper(
       graph,
@@ -710,6 +733,27 @@ void UnpackQuantizedWeights(
       paramsDict,
       qconv3d_relu,
       "quantized::conv3d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv_transpose1d,
+      "quantized::conv_transpose1d_unpack",
+      QuantizedParamsType::CONV1D,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv_transpose2d,
+      "quantized::conv_transpose2d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv_transpose3d,
+      "quantized::conv_transpose3d_unpack",
       QuantizedParamsType::CONV,
       caffe2);
   if (!caffe2) {

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -927,7 +927,7 @@ def quantized_conv2d(
 
 @_onnx_symbolic("quantized::conv3d")
 @_beartype.beartype
-def quantized_conv2d(
+def quantized_conv3d(
     g: jit_utils.GraphContext,
     q_input,
     q_weight,

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -969,7 +969,9 @@ def quantized_conv_transpose1d(
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
     output_padding = [0]
-    output = opset9.conv_transpose2d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
+    output = opset9.conv_transpose2d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
@@ -994,7 +996,9 @@ def quantized_conv_transpose2d(
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
     output_padding = [0, 0]
-    output = opset9.conv_transpose2d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
+    output = opset9.conv_transpose2d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
@@ -1019,7 +1023,9 @@ def quantized_conv_transpose3d(
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
     output_padding = [0, 0, 0]
-    output = opset9.conv_transpose3d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
+    output = opset9.conv_transpose3d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -43,7 +43,13 @@ __all__ = [
     "quantized_cat",
     "quantized_conv1d_relu",
     "quantized_conv2d_relu",
+    "quantized_conv3d_relu",
+    "quantized_conv1d",
     "quantized_conv2d",
+    "quantized_conv3d",
+    "quantized_conv_transpose1d",
+    "quantized_conv_transpose2d",
+    "quantized_conv_transpose3d",
     "quantized_group_norm",
     "quantized_hardswish",
     "quantized_instance_norm",
@@ -846,6 +852,55 @@ def quantized_conv2d_relu(
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
 
+@_onnx_symbolic("quantized::conv3d_relu")
+@_beartype.beartype
+def quantized_conv3d_relu(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv3d(g, input, weight, bias, stride, padding, dilation, groups)
+    output = opset9.relu(g, output)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv1d")
+@_beartype.beartype
+def quantized_conv1d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv1d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
 @_onnx_symbolic("quantized::conv2d")
 @_beartype.beartype
 def quantized_conv2d(
@@ -866,6 +921,105 @@ def quantized_conv2d(
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
     output = opset9.conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv3d")
+@_beartype.beartype
+def quantized_conv2d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv3d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose1d")
+@_beartype.beartype
+def quantized_conv_transpose1d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output_padding = [0]
+    output = opset9.conv_transpose2d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose2d")
+@_beartype.beartype
+def quantized_conv_transpose2d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output_padding = [0, 0]
+    output = opset9.conv_transpose2d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose3d")
+@_beartype.beartype
+def quantized_conv_transpose3d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, _ = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output_padding = [0, 0, 0]
+    output = opset9.conv_transpose3d(g, input, weight, bias, stride, padding, output_padding, groups, dilation)
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 


### PR DESCRIPTION
- Extend support:
  - quantized::conv1d
  - quantized::conv3d
  - quantized::conv3d_relu
  - quantized::conv_transpose1d
  - quantized::conv_transpose2d
  - quantized::conv_transpose3d
  - Note: quantized::{conv1d_relu,conv2d,conv2d_relu} already supported.
- To support this, quantization unpacking added for:
  - conv1d
  - conv_transpose1d
  - conv_transpose2d
  - conv_transpose3d
  - Note: conv3d/conv3d_relu already had weights unpacking set up, even though it didn't have torch.onnx support.
- Add tests.
- The 3D tests will fail if run with the qnnpack backend (e.g., on Apple silicon Mac), so added decorator skipIfQuantizationBackendQNNPack.
- Minor fix in `aten/src/ATen/native/quantized/cpu/qconv.cpp` for 3D convolutions (triggered by added tests).

Fixes #102747


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10