### PR TITLE
check users are actually recieved in upload to s3

### DIFF
--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           timeout_minutes: 10
-          max_attempts: 5
+          max_attempts: 10
           retry_wait_seconds: 90
           command: |
             echo "Uploading testing aggregate data" "$(date -d yesterday '+%Y-%m-%d')"

--- a/tools/stats/upload_external_contrib_stats.py
+++ b/tools/stats/upload_external_contrib_stats.py
@@ -11,7 +11,6 @@ from urllib.request import Request, urlopen
 from tools.stats.upload_stats_lib import upload_to_s3
 
 FILTER_OUT_USERS = {"pytorchmergebot", "facebook-github-bot", "pytorch-bot[bot]"}
-MAXIMUM_RETRIES = 5
 
 
 def _fetch_url(

--- a/tools/stats/upload_external_contrib_stats.py
+++ b/tools/stats/upload_external_contrib_stats.py
@@ -8,7 +8,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 # import time
-from tools.stats.upload_stats_lib import read_from_s3, upload_to_s3
+from tools.stats.upload_stats_lib import upload_to_s3
 
 FILTER_OUT_USERS = {"pytorchmergebot", "facebook-github-bot", "pytorch-bot[bot]"}
 MAXIMUM_RETRIES = 5
@@ -134,27 +134,16 @@ if __name__ == "__main__":
             startdate + datetime.timedelta(days=args.period_length),
             period_length=args.period_length,
         )
-        while tries < MAXIMUM_RETRIES:
-            success = True
-            upload_to_s3(
-                bucket_name="torchci-contribution-data",
-                key=f"external_contribution_counts/{str(startdate)}",
-                docs=data,
-            )
-            uploaded_data = read_from_s3(
-                "torchci-contribution-data",
-                f"external_contribution_counts/{str(startdate)}",
-            )
-            for doc in data:
-                if doc not in uploaded_data:
-                    tries += 1
-                    print(
-                        f"Failed to upload data retrying upload up to {MAXIMUM_RETRIES - tries} more times"
-                    )
-                    success = False
-                    break
-            if success:
-                break
+        for pr_info in data:
+            # sometimes users does not get added, so we check it got uploaded
+            assert "users" in pr_info
+            assert isinstance(pr_info["users"], list)
+        print(f"uploading the following data: \n {data}")
+        upload_to_s3(
+            bucket_name="torchci-contribution-data",
+            key=f"external_contribution_counts/{str(startdate)}",
+            docs=data,
+        )
 
         # uncomment when running large queries locally to avoid github's rate limiting
         #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102760

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5927156</samp>

### Summary
🔁🧹📊

<!--
1.  🔁 - This emoji represents the retry logic that is added to the script, which loops until the command succeeds or reaches the maximum number of attempts.
2.  🧹 - This emoji represents the cleanup and simplification of the code, which removes clutter and makes it easier to understand and maintain.
3.  📊 - This emoji represents the data analysis and visualization that is enabled by uploading the external contribution stats to Rockset, which allows for exploring and sharing insights on the open source community.
-->
This pull request improves the `upload_external_contrib_stats.py` script and the `nightly-rockset-uploads.yml` workflow. It makes the script more efficient and robust, and increases the retry logic for the Rockset upload command.

> _Oh we are the coders of the open source sea_
> _And we upload stats to Rockset with glee_
> _But sometimes the network is slow or breaks down_
> _So we retry the command and we don't let it drown_

### Walkthrough
* Increase the number of retries for uploading external contribution stats to Rockset to avoid failures ([link](https://github.com/pytorch/pytorch/pull/102760/files?diff=unified&w=0#diff-a0d80a44a0694ddbddd6d8cf9484f5b850268a34117c8caf1fc071ad59895f9fL35-R35))
* Simplify the logic of uploading external contribution stats to Rockset by removing the loop and adding assertions and print statements ([link](https://github.com/pytorch/pytorch/pull/102760/files?diff=unified&w=0#diff-ac022823c08d71df6cc85aae7f2ca50a1ec71e5f9eb9371ac563c12cf52b750cL137-R146))
* Remove unused import of `read_from_s3` from `upload_external_contrib_stats.py` to clean up the code ([link](https://github.com/pytorch/pytorch/pull/102760/files?diff=unified&w=0#diff-ac022823c08d71df6cc85aae7f2ca50a1ec71e5f9eb9371ac563c12cf52b750cL11-R11))

