### PR TITLE
Add gelu vulkan function

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/gelu_tanh.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/gelu_tanh.glsl
@@ -1,0 +1,28 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 inval = texelFetch(uInput, pos, 0);
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 outval = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/gelu_tanh_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/gelu_tanh_.glsl
@@ -1,0 +1,27 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION restrict Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 inval = imageLoad(uOutput, pos);
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 outval = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1901,6 +1901,37 @@ TEST_F(VulkanAPITest, expand_as) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, gelu) {
+  const auto in_cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  auto out_cpu = at::gelu(in_cpu, "tanh");
+  auto out_vulkan = at::gelu(in_vulkan, "tanh");
+
+  auto check = almostEqual(out_cpu, out_vulkan.cpu());
+
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, gelu_) {
+  auto cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  auto vulkan = cpu.vulkan();
+
+  at::gelu_(cpu, "tanh");
+  at::gelu_(vulkan, "tanh");
+
+  auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 void test_glu(const at::IntArrayRef input_shape) {
   const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_vulkan = in_cpu.vulkan();


### PR DESCRIPTION
Summary: Add gelu function in vulkan

Test Plan:
buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64

[ RUN      ] VulkanAPITest.gelu
[       OK ] VulkanAPITest.gelu (63 ms)
[ RUN      ] VulkanAPITest.gelu_
[       OK ] VulkanAPITest.gelu_ (83 ms)

Reviewed By: SS-JIA

Differential Revision: D46297340

