### PR TITLE
Add `-debug` suffix to trunk libtorch builds

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -51,8 +51,8 @@ jobs:
       docker-image: ${{ needs.linux-bionic-cuda11_8-py3_10-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_8-py3_10-gcc7-build.outputs.test-matrix }}
 
-  libtorch-linux-bionic-cuda11_8-py3_7-gcc9-build:
-    name: libtorch-linux-bionic-cuda11.8-py3.7-gcc9
+  libtorch-linux-bionic-cuda11_8-py3_7-gcc9-debug-build:
+    name: libtorch-linux-bionic-cuda11.8-py3.7-gcc9-debug
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: libtorch-linux-bionic-cuda11.8-py3.7-gcc9


### PR DESCRIPTION
Cause that's what they are according to 
https://github.com/pytorch/pytorch/blob/30558c28966a31f9147d260176837f2804ab8d66/.ci/pytorch/build.sh#L307

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 40cd88d</samp>

> _`libtorch` debug_
> _Build with symbols for Linux_
> _Winter of errors_
