### PR TITLE
Revert "implement __dir__ for dynamo (#102480)"

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1398,33 +1398,6 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         out_dtype = opt_mod(mod)
         self.assertEqual(out_dtype, torch.float32)
 
-    def test_dir(self):
-        class MockModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(10, 10)
-                self.register_buffer("buf0", torch.randn(10, 10))
-                self.register_parameter(
-                    name="param0", param=torch.nn.Parameter(torch.randn(10, 10))
-                )
-
-            def forward(self, x):
-                return self.r(torch.sin(x)) + self.buf0
-
-        mod = MockModule()
-        mod_keys = dir(mod)
-        opt_mod = torch._dynamo.optimize("eager")(mod)
-        opt_mod_keys = dir(opt_mod)
-
-        # Check user-defined attributes, parameters and buffers
-        self.assertIn("linear", opt_mod_keys)
-        self.assertIn("buf0", opt_mod_keys)
-        self.assertIn("param0", opt_mod_keys)
-
-        # Check all attributes, parameters and buffers
-        for p1, p2 in zip(mod_keys, opt_mod_keys):
-            self.assertTrue(p1 == p2)
-
     def test_recursion(self):
         mod = MockModule()
         cnt = torch._dynamo.testing.CompileCounter()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -143,9 +143,6 @@ class OptimizedModule(torch.nn.Module):
             self._orig_mod._infer_parameters(self._orig_mod, args)
         return self._forward(*args, **kwargs)
 
-    def __dir__(self):
-        return self._orig_mod.__dir__()
-
 
 def remove_from_cache(f):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #102766

This reverts commit b02f48b18152ddfcf5fcbefb68f6b66a6c44b37f.

If a user does this:

```
mod = torch.compile(mod)
mod.is_compiled = True
assert "is_compiled" in dir(mod)
```

it will fail after #102480.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy

Differential Revision: [D46368712](https://our.internmc.facebook.com/intern/diff/D46368712)