### PR TITLE
upload external pr kpi for 10 days in the past

### DIFF
--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -1,7 +1,6 @@
 name: Nightly Upload to rockset
 
 on:
-  pull_request:
   schedule:
     # Choose a random time near midnight PST because it may be delayed if there are high loads
     - cron:  37 7 * * *

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -37,6 +37,6 @@ jobs:
           retry_wait_seconds: 90
           command: |
             echo "Uploading testing aggregate data" "$(date -d yesterday '+%Y-%m-%d')"
-            python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')" --length 10
+            python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')"
             echo "Uploading external contribution stats for 10 days starting on $(date -v-10d '+%Y-%m-%d')"
-            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -v-10d '+%Y-%m-%d')"
+            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -v-10d '+%Y-%m-%d')" --length 10

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -1,6 +1,7 @@
 name: Nightly Upload to rockset
 
 on:
+  pull_request:
   schedule:
     # Choose a random time near midnight PST because it may be delayed if there are high loads
     - cron:  37 7 * * *
@@ -36,6 +37,6 @@ jobs:
           retry_wait_seconds: 90
           command: |
             echo "Uploading testing aggregate data" "$(date -d yesterday '+%Y-%m-%d')"
-            python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')"
-            echo "Uploading external contribution stats for" "$(date -d yesterday '+%Y-%m-%d')"
-            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -d yesterday '+%Y-%m-%d')"
+            python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')" --length 10
+            echo "Uploading external contribution stats for 10 days starting on $(date -v-10d '+%Y-%m-%d')"
+            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -v-10d '+%Y-%m-%d')"

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -36,7 +36,7 @@ jobs:
           max_attempts: 10
           retry_wait_seconds: 90
           command: |
-            echo "Uploading external contribution stats for 10 days starting on "$(date -d '10 days ago' '+%Y-%m-%d')"
+            echo "Uploading external contribution stats for 10 days starting on" "$(date -d '10 days ago' '+%Y-%m-%d')"
             python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -d '10 days ago' '+%Y-%m-%d')" --length 10
             echo "Uploading testing aggregate data" "$(date -d yesterday '+%Y-%m-%d')"
             python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')"

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -36,7 +36,7 @@ jobs:
           max_attempts: 10
           retry_wait_seconds: 90
           command: |
+            echo "Uploading external contribution stats for 10 days starting on "$(date -d '10 days ago' '+%Y-%m-%d')"
+            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -d '10 days ago' '+%Y-%m-%d')" --length 10
             echo "Uploading testing aggregate data" "$(date -d yesterday '+%Y-%m-%d')"
             python3 -m tools.stats.upload_test_stat_aggregates --date "$(date -d yesterday '+%Y-%m-%d')"
-            echo "Uploading external contribution stats for 10 days starting on $(date -v-10d '+%Y-%m-%d')"
-            python3 -m tools.stats.upload_external_contrib_stats --startDate "$(date -v-10d '+%Y-%m-%d')" --length 10

--- a/tools/stats/upload_external_contrib_stats.py
+++ b/tools/stats/upload_external_contrib_stats.py
@@ -2,12 +2,13 @@ import argparse
 import datetime
 import json
 import os
+
+import time
 import urllib.parse
 from typing import Any, Callable, cast, Dict, List, Optional, Set
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-import time
 from tools.stats.upload_stats_lib import upload_to_s3
 
 FILTER_OUT_USERS = {"pytorchmergebot", "facebook-github-bot", "pytorch-bot[bot]"}

--- a/tools/stats/upload_external_contrib_stats.py
+++ b/tools/stats/upload_external_contrib_stats.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, cast, Dict, List, Optional, Set
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-# import time
+import time
 from tools.stats.upload_stats_lib import upload_to_s3
 
 FILTER_OUT_USERS = {"pytorchmergebot", "facebook-github-bot", "pytorch-bot[bot]"}
@@ -143,8 +143,5 @@ if __name__ == "__main__":
             key=f"external_contribution_counts/{str(startdate)}",
             docs=data,
         )
-
-        # uncomment when running large queries locally to avoid github's rate limiting
-        #
-        # import time
-        # time.sleep(20)
+        # get around rate limiting
+        time.sleep(10)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102780

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 963044b</samp>

The pull request improves the reliability and completeness of the external contribution stats collection and upload. It adds a `time` delay to avoid API rate limit errors in `upload_external_contrib_stats.py`, and changes the order and date range of the commands in `nightly-rockset-uploads.yml`.
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 963044b</samp>

> _Oh we are the coders of the open source sea_
> _And we pull and we push with the `git` command_
> _We upload the stats of the external PRs_
> _With a ten-day range and a `time` delay_
