### PR TITLE
Demonstrate effective graph-break comm overlap

### DIFF
--- a/benchmarks/dynamo/distributed.py
+++ b/benchmarks/dynamo/distributed.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
         "--toy-model", "--toy_model", action="store_true", help="use toy model instead"
     )
     args = parser.parse_args()
-
+    torch.autograd.set_detect_anomaly(True)
     model_name = args.torchbench_model
     if args.toy_model:
         model_name = "ToyModel"

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -371,7 +371,7 @@ def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = 
     :: N.B. If you pass a PG or a 1D list to perform a MPMD collective, the compiler won't be able to recover
     that information and perform collective algebraic optimization. Use other forms of input for that.
     """
-    tag, rankset, group_size = _expand_group(group, tag)
+    tag, rankset, group_size = torch.distributed._functional_collectives._expand_group(group, tag)
     tensor = torch.ops.c10d_functional.all_reduce(self, reduceOp, tag, rankset, group_size)  # type: ignore[attr-defined]
     return _maybe_wrap_tensor(tensor)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102791
* __->__ #102787
* #102782

Not necessarily for landing (or i'd have to clean up), this PR is more for POC that we are able to see overlap in reality.

`torchrun --nproc_per_node 2 benchmarks/dynamo/distributed.py --toy_model --profile --dynamo inductor`

I made the gemms and allreduce large enough that they are not 'overhead dominated' kernels and then I experimented with adding graph-breaks and confirmed the allreduce still overlaps with following gemm layers, finally blocking before doing an eltwise add kernel and continuing with  gemms.

The flow of this is essentially a skip-connection.                                 

"""
                                     -> allreduce -----------------
module -> module -> | -> module -> module -> ...   | -> wait -> add -> module -> module ...

"""
<img width="1250" alt="image" src="https://github.com/pytorch/pytorch/assets/4984825/e07987e9-0351-4168-a9e1-4d30122bf123">



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov