### PR TITLE
Demonstrate lack of overlap when using functional allreduce

### DIFF
--- a/benchmarks/dynamo/dist_util.py
+++ b/benchmarks/dynamo/dist_util.py
@@ -67,8 +67,7 @@ class MyGraphBreakAllReduce(torch.nn.Module):
         super().__init__()
 
     def forward(self, x):
-        tag, rankset, group_size = torch.distributed._functional_collectives._expand_group(GroupMember.WORLD, tag="")
-        ar = torch.ops.c10d_functional.all_reduce(x, "sum", tag, rankset, group_size)
+        ar = torch.distributed._functional_collectives.all_reduce(x, "sum", GroupMember.WORLD, "")
         print("Graph break")
         return x, ar
 
@@ -78,8 +77,7 @@ class MyWait(torch.nn.Module):
 
     def forward(self, x):
         x, passthrough = x
-        synced = torch.ops.c10d_functional.wait_tensor(passthrough)
-        return x + synced
+        return x + passthrough
         # return x
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102791
* #102787
* #102782

Compared to the previous PR, this shows no overlap. The reason is that dynamo tracing of functional allreduce immediately issues a wait().  The previous PR relied on usercode explicitly calling the ops.allreduce and ops.wait in separate graphs to achieve overlap.

<img width="1175" alt="image" src="https://github.com/pytorch/pytorch/assets/4984825/37c704f7-b2be-490f-aabc-6d83e9e04f6f">


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov