### PR TITLE
[RFC] Debug log tensor assignments and sizes to graph

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1104,6 +1104,14 @@ def wrap_fx_proxy_cls(
         # tensor, the stored example value will update too!)
         example_value = _clone_input(example_value)
         proxy.node.meta["example_value"] = example_value
+
+        maybe_user_loc = ""
+        from torch._guards import TracingContext
+        from torch.utils._traceback import format_frame
+        user_tb = TracingContext.extract_stack()
+        if user_tb:
+            maybe_user_loc = " at " + format_frame(user_tb[-1])
+        log.debug("%s: %s%s", proxy.node, tuple(example_value.size()), maybe_user_loc)
         specialized_props = target_cls.specialize(example_value)
         if isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor):
             # NB: This will be wrong for ignore_subclass; fix it up later!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102817

The logs look like this:

```
[2023-06-01 19:43:32,799] torch._dynamo.variables.builder: [DEBUG] add_24: (4, 2048, 512) at transformers/src/transformers/models/t5/modeling_t5.py:609 in forward
[2023-06-01 19:43:32,821] torch._dynamo.variables.builder: [DEBUG] to_14: (4, 2048, 512) at transformers/src/transformers/models/t5/modeling_t5.py:252 in forward
[2023-06-01 19:43:32,823] torch._dynamo.variables.builder: [DEBUG] pow_12: (4, 2048, 512) at transformers/src/transformers/models/t5/modeling_t5.py:252 in forward
[2023-06-01 19:43:32,827] torch._dynamo.variables.builder: [DEBUG] mean_11: (4, 2048, 1) at transformers/src/transformers/models/t5/modeling_t5.py:252 in forward
[2023-06-01 19:43:32,829] torch._dynamo.variables.builder: [DEBUG] add_25: (4, 2048, 1) at transformers/src/transformers/models/t5/modeling_t5.py:253 in forward
[2023-06-01 19:43:32,831] torch._dynamo.variables.builder: [DEBUG] rsqrt_11: (4, 2048, 1) at transformers/src/transformers/models/t5/modeling_t5.py:253 in forward
[2023-06-01 19:43:32,833] torch._dynamo.variables.builder: [DEBUG] mul_25: (4, 2048, 512) at transformers/src/transformers/models/t5/modeling_t5.py:253 in forward
```

Thoughts? Yay? Nay?

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy