### PR TITLE
Fix warning in CUDA kernel loops

### DIFF
--- a/caffe2/core/common_gpu.h
+++ b/caffe2/core/common_gpu.h
@@ -258,14 +258,14 @@ CAFFE2_CUDA_API const char* curandGetErrorString(curandStatus_t error);
         << ::caffe2::curandGetErrorString(status); \
   } while (0)
 
-#define CUDA_1D_KERNEL_LOOP(i, n)                                 \
-  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
+#define CUDA_1D_KERNEL_LOOP(i, n)                                  \
+  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
        i += blockDim.x * gridDim.x)
 
-#define CUDA_2D_KERNEL_LOOP(i, n, j, m)                             \
-  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (n);   \
-       i += blockDim.x * gridDim.x)                                 \
-    for (size_t j = blockIdx.y * blockDim.y + threadIdx.y; j < (m); \
+#define CUDA_2D_KERNEL_LOOP(i, n, j, m)                              \
+  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < (n);   \
+       i += blockDim.x * gridDim.x)                                  \
+    for (int64_t j = blockIdx.y * blockDim.y + threadIdx.y; j < (m); \
          j += blockDim.y * gridDim.y)
 
 // The following helper functions are here so that you can write a kernel call


### PR DESCRIPTION
Summary:
Fixes:
```
[Security Sensitive] Implicitly casting an integer multiplication operation to a bigger type. This multiplication operation will overflow before being casted to the target type. To fix this issue, explicitly cast one of the operand. Please see https://fburl.com/wiki/ayqfi88r for more details
fbcode/caffe2/caffe2/core/common_gpu.h:263:13: expanded from macro 'CUDA_1D_KERNEL_LOOP'
         i += blockDim.x * gridDim.x)
```

Test Plan: Sandcastle

Reviewed By: ngimel

Differential Revision: D46320673

