### PR TITLE
Use 32bit for indexing in `multi_tensor_apply` as possible

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -39,7 +39,7 @@ struct LpNormFunctor {
       opmath_t* output_per_tensor,
       const int max_chunks_per_tensor) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    const index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
     index_t n = tl.numel_for_tensor[tensor_loc];
 
     T* x = (T*)tl.addresses[0][tensor_loc];

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -57,7 +57,7 @@ struct LpNormFunctor {
            i_start * kILP < n && i_start * kILP < chunk_size;
            i_start += blockDim.x) {
         // load
-        load_store(r_x, x, 0, i_start);
+        load_store(r_x, x, static_cast<decltype(i_start)>(0), i_start);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
           opmath_t next = static_cast<opmath_t>(r_x[ii]);
@@ -69,7 +69,7 @@ struct LpNormFunctor {
            i_start += blockDim.x * kILP) {
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          const auto i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             opmath_t next = static_cast<opmath_t>(x[i]);
             vals[ii] += NormType == 1 ? ::abs(next) : next * next;

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -349,7 +349,7 @@ void multi_tensor_apply_for_fused_optimizer(
     if (static_cast<decltype(num_tensors)>(num_zero_tensors) == num_tensors) {
       continue;
     }
-    const int64_t chunks =
+    const auto chunks =
         (tensor_lists[0]
                      [tensor_index -
                       static_cast<decltype(tensor_index)>(

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -10,9 +10,9 @@ namespace at::native {
 
 namespace {
 
-static constexpr int64_t kILP = 4;
-static constexpr int64_t kChunkSize = 65536;
-static constexpr int64_t kBlockSize = 512;
+static constexpr int kILP = 4;
+static constexpr int kChunkSize = 65536;
+static constexpr int kBlockSize = 512;
 
 // TODO(crcrpar): Add `n>5` for `low prec params & their higher prec copy`
 // TensorListMetadata has to be < 4KB - the limit for kernel launch argument
@@ -28,12 +28,12 @@ __device__ __forceinline__ bool is_aligned(T* p) {
   return ((uint64_t)p) % (kILP * sizeof(T)) == 0;
 }
 
-template <typename T>
+template <typename T, typename index_t>
 __device__ __forceinline__ void load_store(
     T* dst,
     T* src,
-    int64_t dst_offset,
-    int64_t src_offset) {
+    const index_t dst_offset,
+    const index_t src_offset) {
   using LT = at::native::memory::aligned_vector<T, kILP>;
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -122,9 +122,9 @@ struct FusedAdamMathFunctor {
             const float* found_inf_ptr,
             const ADAM_MODE adam_mode
   ) {
-        int tensor_loc = tl.block_to_tensor[blockIdx.x];
-        int chunk_idx = tl.block_to_chunk[blockIdx.x];
-        int n = tl.numel_for_tensor[tensor_loc];
+        const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+        const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+        auto n = tl.numel_for_tensor[tensor_loc];
 
         if (found_inf_ptr && *found_inf_ptr == 1) {
             return;
@@ -140,14 +140,14 @@ struct FusedAdamMathFunctor {
             for (int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
 #pragma unroll
                 for (int i = 0; i < depth; i++) {
-                    load_store(r_args[i], args[i], 0, i_start);
+                    load_store(r_args[i], args[i], static_cast<decltype(i_start)>(0), i_start);
                 }
                 adam_math<scalar_type, opmath_t, depth>(
                     r_args, step_count, lr, beta1, beta2, weight_decay, eps, maximize, amsgrad, grad_scale_ptr, found_inf_ptr, adam_mode);
 #pragma unroll
                 for (int i = 0; i < depth; i++) {
                   if (i != kGradIdx || grad_scale_ptr) {
-                    load_store(args[i], r_args[i], i_start, 0);
+                    load_store(args[i], r_args[i], i_start, static_cast<decltype(i_start)>(0));
                   }
                 }
             }

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -125,7 +125,7 @@ struct FusedAdamMathFunctor {
             const ADAM_MODE adam_mode
   ) {
         const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-        const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+        const index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
         index_t n = tl.numel_for_tensor[tensor_loc];
 
         if (found_inf_ptr && *found_inf_ptr == 1) {
@@ -142,14 +142,14 @@ struct FusedAdamMathFunctor {
             for (index_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
 #pragma unroll
                 for (int i = 0; i < depth; i++) {
-                    load_store(r_args[i], args[i], static_cast<decltype(i_start)>(0), i_start);
+                    load_store(r_args[i], args[i], static_cast<index_t>(0), i_start);
                 }
                 adam_math<scalar_type, opmath_t, depth>(
                     r_args, step_count, lr, beta1, beta2, weight_decay, eps, maximize, amsgrad, grad_scale_ptr, found_inf_ptr, adam_mode);
 #pragma unroll
                 for (int i = 0; i < depth; i++) {
                   if (i != kGradIdx || grad_scale_ptr) {
-                    load_store(args[i], r_args[i], i_start, static_cast<decltype(i_start)>(0));
+                    load_store(args[i], r_args[i], i_start, static_cast<index_t>(0));
                   }
                 }
             }


### PR DESCRIPTION
I do think there's a better way to propagate what type to use for indexing, but I found an anonymous argument convenient to some extent as I was writing. Also, I can imagine the availability check of 32bit is a bit too optimistic.

Rel:
- https://github.com/pytorch/pytorch/pull/101760

---

Used optimizer with huggingface/transformers gpt2 setting as it doesn't need int64_t for indexing.
The second row is to update `state_step` tensors of 1 element.


**This PR**

```
 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     99.2        341260837       1000  341260.8  529094.0      7071    542342     240433.6  void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorLi…
      0.2           665096        200    3325.5    3328.0      3072      3616        107.8  void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::TensorListMetadata<(in…
```

**Main (`2.1.0a0+git07104ca`)**
```
 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     99.2        341346490       1000  341346.5  530021.0      7104    541893     240468.5  void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorLi…
      0.2           664935        200    3324.7    3343.5      3072      3585        110.9  void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::TensorListMetadata<(in…
```

script

```python
import torch
from accelerate import Accelerator, DistributedType
from accelerate.logging import get_logger
from accelerate.utils import set_seed
from datasets import load_dataset
from huggingface_hub import Repository, create_repo
from torch.utils.data import DataLoader
from tqdm.auto import tqdm

import transformers
from transformers import (
    CONFIG_MAPPING,
    AutoModelForCausalLM,
)


config = CONFIG_MAPPING["gpt2"]()
model = AutoModelForCausalLM.from_config(config).cuda()

no_decay = ["bias", "layer_norm.weight"]
optimizer_grouped_parameters = [
	{
		"params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
		"weight_decay": 0.1,
	},
	{
		"params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
		"weight_decay": 0.0,
	},
]
optimizer = torch.optim.AdamW(optimizer_grouped_parameters, fused=True)


with torch.no_grad():
	for p in model.parameters():
		if p.requires_grad:
			p.grad = torch.rand_like(p)


for _ in range(100):
	optimizer.step()

print("DONE")
```

command
```console
nsys nvprof python script.py
```

cc @mcarilli