### PR TITLE
Fix merge rules for XLA pin updates

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -88,7 +88,7 @@
   - EasyCLA
   - Lint
   - pull / linux-bionic-py3_8-clang8-xla / build
-  - pull / linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.4xlarge)
+  - pull / linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.12xlarge)
 
 - name: Documentation
   patterns:

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -204,6 +204,23 @@ def xla_is_flaky_rules() -> List[FlakyRule]:
     ]
 
 
+def xla_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule]:
+    return [
+        MergeRule(
+            name=" OSS CI / pytorchbot / XLA",
+            patterns=[".github/ci_commit_pins/xla.txt"],
+            approved_by=["pytorchbot"],
+            mandatory_checks_name=[
+                "Lint",
+                "EasyCLA",
+                "pull / linux-bionic-py3_8-clang8-xla / build",
+                "pull / linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.4xlarge)",
+            ],
+            ignore_flaky_failures=False,
+        ),
+    ]
+
+
 def empty_rockset_results(head_sha: str, merge_base: str) -> List[Dict[str, Any]]:
     return []
 
@@ -559,6 +576,7 @@ class TestBypassFailures(TestCase):
         self.assertTrue(len(failed) == 0)
 
     @mock.patch("trymerge.read_flaky_rules", side_effect=xla_is_flaky_rules)
+    @mock.patch("trymerge.read_merge_rules", side_effect=xla_merge_rules)
     def test_dont_ignore_flaky_failures(self, *args: Any) -> None:
         """Regression test for https://github.com/pytorch/test-infra/issues/4126"""
         pr = GitHubPR("pytorch", "pytorch", 100369)


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/102446 moved the job to 12xlarge runner, but merge rule still refer to it as 4xlarge, which results in merge timeouts, for example see https://github.com/pytorch/pytorch/actions/runs/5150076112/jobs/9273821855
