### PR TITLE
Fix GELU-related docstring formatting

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1734,7 +1734,7 @@ where :math:`\Phi(x)` is the Cumulative Distribution Function for Gaussian Distr
 When the approximate argument is 'tanh', Gelu is estimated with
 
 .. math::
-    \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}{\sqrt(2 / \pi} * (x + 0.044715 * x^3)))
+    \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt{2 / \pi} * (x + 0.044715 * x^3)))
 
 See `Gaussian Error Linear Units (GELUs) <https://arxiv.org/abs/1606.08415>`_.
 """)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1734,7 +1734,7 @@ where :math:`\Phi(x)` is the Cumulative Distribution Function for Gaussian Distr
 When the approximate argument is 'tanh', Gelu is estimated with
 
 .. math::
-    \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
+    \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}{\sqrt(2 / \pi} * (x + 0.044715 * x^3)))
 
 See `Gaussian Error Linear Units (GELUs) <https://arxiv.org/abs/1606.08415>`_.
 """)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -657,7 +657,7 @@ class GELU(Module):
 
     When the approximate argument is 'tanh', Gelu is estimated with:
 
-    .. math:: \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}{\sqrt(2 / \pi} * (x + 0.044715 * x^3)))
+    .. math:: \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt{2 / \pi} * (x + 0.044715 * x^3)))
 
     Args:
         approximate (str, optional): the gelu approximation algorithm to use:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -657,7 +657,7 @@ class GELU(Module):
 
     When the approximate argument is 'tanh', Gelu is estimated with:
 
-    .. math:: \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
+    .. math:: \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}{\sqrt(2 / \pi} * (x + 0.044715 * x^3)))
 
     Args:
         approximate (str, optional): the gelu approximation algorithm to use:


### PR DESCRIPTION
The docstring about GELU seems formatted incorrectly. The original docstring about GELU is rendered as below:

$$ \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3))) $$

where the square root of which part is confusing. 

I double-checked the formula, which should be:

$$ \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt{2 / \pi} * (x + 0.044715 * x^3))) $$

where round brackets in resource code should be brace brackets.

> _formula in [original paper](https://arxiv.org/abs/1606.08415)_
> ![Snipaste_2023-06-03_00-43-49](https://github.com/pytorch/pytorch/assets/39690782/22511c4e-2f20-4a16-9bda-4c182a360160)