### PR TITLE
[PT2][Quant] Introduce composable quantizer

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -1,17 +1,20 @@
 from .qnnpack_quantizer import QNNPackQuantizer
 from .quantizer import (
+    DerivedQuantizationSpec,
     EdgeOrNode,
     OperatorConfig,
-    Quantizer,
-    QuantizationSpecBase,
-    QuantizationSpec,
     FixedQParamsQuantizationSpec,
-    SharedQuantizationSpec,
-    DerivedQuantizationSpec,
     QuantizationAnnotation,
+    QuantizationSpec,
+    QuantizationSpecBase,
+    Quantizer,
+    SharedQuantizationSpec,
 )
 
+from .composable_quantizer import ComposableQuantizer
+
 __all__ = [
+    "ComposableQuantizer",
     "EdgeOrNode",
     "OperatorConfig",
     "Quantizer",

--- a/torch/ao/quantization/_pt2e/quantizer/composable_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/composable_quantizer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+
+from torch.fx import Node
+
+from .quantizer import OperatorConfig, QuantizationAnnotation, Quantizer
+
+__all__ = [
+    "ComposableQuantizer",
+]
+
+
+class ComposableQuantizer(Quantizer):
+    """
+    ComposableQuantizer allows users to combine more than one quantizer into a single quantizer.
+    This allows users to quantize a model with multiple quantizers. E.g., embedding quantization
+    maybe supported by one quantizer while linear layers and other ops might be supported by another
+    quantizer.
+
+    ComposableQuantizer is initialized with a list of `Quantizer` instances.
+    The order of the composition matters since that is the order in which the quantizers will be
+    applies.
+    Example:
+    ```
+    embedding_quantizer = EmbeddingQuantizer()
+    linear_quantizer = MyLinearQuantizer()
+    xnnpack_quantizer = XNNPackQuantizer() # to handle ops not quantized by previous two quantizers
+    composed_quantizer = ComposableQuantizer([embedding_quantizer, linear_quantizer, xnnpack_quantizer])
+    prepared_m = prepare_pt2e(model, composed_quantizer)
+    ```
+    """
+
+    def __init__(self, quantizers: List[Quantizer]):
+        super().__init__()
+        self.quantizers = quantizers
+        self._graph_annotations: Dict[Node, QuantizationAnnotation] = {}
+
+    def _record_and_validate_annotations(
+        self, gm: torch.fx.GraphModule, quantizer: Quantizer
+    ) -> None:
+        for n in gm.graph.nodes:
+            if "quantization_annotation" in n.meta:
+                # check if the annotation has been changed by
+                # comparing QuantizationAnnotation object id
+                if n in self._graph_annotations and (
+                    id(self._graph_annotations[n])
+                    != id(n.meta["quantization_annotation"])
+                ):
+                    raise RuntimeError(
+                        f"Quantizer {quantizer.__class__.__name__} has changed annotations on node {n}"
+                    )
+                else:
+                    self._graph_annotations[n] = n.meta["quantization_annotation"]
+            else:
+                if n in self._graph_annotations:
+                    raise RuntimeError(
+                        f"Quantizer {quantizer.__class__.__name__} has removed annotations on node {n}"
+                    )
+
+    def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+        """just handling global spec for now"""
+        for quantizer in self.quantizers:
+            quantizer.annotate(model)
+            self._record_and_validate_annotations(model, quantizer)
+        return model
+
+    def validate(self, model: torch.fx.GraphModule) -> None:
+        pass
+
+    @classmethod
+    def get_supported_operators(cls) -> List[OperatorConfig]:
+        return []


### PR DESCRIPTION
Summary:
Using composable quantizer, we can now composable two or more quantizers. In
the test here we compose quantizer configured with dynamic linear quantization,
with quantizer configured for static quantization.

Note that composable quantizer has strict order in which annotations are
applied

Test Plan: test_composable_quantizer*

Reviewed By: jerryzh168

Differential Revision: D46267690

