### PR TITLE
[inductor] Fix a cpp_wrapper issue when fx_passes modified fx graph

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -21,6 +21,7 @@ try:
             test_cpu_repro,
             test_foreach,
             test_mkldnn_pattern_matcher,
+            test_pattern_matcher,
             test_torchinductor,
             test_torchinductor_dynamic_shapes,
         )
@@ -28,6 +29,7 @@ try:
         import test_cpu_repro
         import test_foreach
         import test_mkldnn_pattern_matcher
+        import test_pattern_matcher
         import test_torchinductor
         import test_torchinductor_dynamic_shapes
 except unittest.SkipTest:
@@ -233,6 +235,11 @@ if RUN_CUDA:
             device=None,
             tests=test_foreach.ForeachTests(),
         ),  # test foreach
+        BaseTest(
+            "test_cat_slice_cat",
+            device=None,
+            tests=test_pattern_matcher.TestPaternMatcher(),
+        ),
     ]:
         make_test_case(item.name, item.device, item.tests)
 

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -3,6 +3,7 @@ import copy
 import unittest
 
 import torch
+import torch._dynamo.config as dynamo_config
 import torch._inductor.config as inductor_config
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import count_calls, counters
@@ -128,6 +129,13 @@ class TestPaternMatcher(TestCase):
         self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
 
     def test_cat_slice_cat(self):
+        def check_counter(counter, expected):
+            if not inductor_config.cpp_wrapper:
+                self.assertEqual(counter, expected)
+            elif not dynamo_config.dynamic_shapes:
+                # cpp_wrapper for the CUDA backend runs two passes
+                self.assertEqual(counter, 2 * expected)
+
         def fn(a, b):
             cat_1 = torch.ops.aten.cat.default([a, b], 1)
             slice_1 = torch.ops.aten.slice.Tensor(cat_1, 0, 0, 9223372036854775807)
@@ -141,9 +149,8 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        if not inductor_config.cpp_wrapper:
-            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        check_counter(counters["inductor"]["pattern_matcher_count"], 1)
+        check_counter(counters["inductor"]["pattern_matcher_nodes"], 4)
 
         counters.clear()
         args = [
@@ -153,9 +160,8 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        if not inductor_config.cpp_wrapper:
-            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        check_counter(counters["inductor"]["pattern_matcher_count"], 1)
+        check_counter(counters["inductor"]["pattern_matcher_nodes"], 4)
 
         # Verify we fallback to non-optimal path for negative `end`.
         def fn(a, b):
@@ -172,9 +178,8 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        if not inductor_config.cpp_wrapper:
-            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        check_counter(counters["inductor"]["pattern_matcher_count"], 1)
+        check_counter(counters["inductor"]["pattern_matcher_nodes"], 4)
 
     def test_pointless_convert(self):
         def fn1(x):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -3,6 +3,7 @@ import copy
 import unittest
 
 import torch
+import torch._inductor.config as inductor_config
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import count_calls, counters
 from torch._inductor.fx_passes import joint_graph
@@ -140,8 +141,9 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        if not inductor_config.cpp_wrapper:
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
 
         counters.clear()
         args = [
@@ -151,8 +153,9 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        if not inductor_config.cpp_wrapper:
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
 
         # Verify we fallback to non-optimal path for negative `end`.
         def fn(a, b):
@@ -169,8 +172,9 @@ class TestPaternMatcher(TestCase):
         expected = fn(*args)
         actual = torch.compile(fn)(*args)
         torch.testing.assert_close(actual, expected)
-        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
-        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+        if not inductor_config.cpp_wrapper:
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
 
     def test_pointless_convert(self):
         def fn1(x):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -193,7 +193,10 @@ def inner_compile_with_cpp_wrapper(inner_compile):
                     "cpp_wrapper": False,
                     "cudagraphs": False,
                 }
-                compiled = inner_compile(gm, example_inputs, **kwargs_patched)
+                # deepcopy(gm) makes sure no graph modification from the first pass will
+                # leak to the second pass. It does increase memory pressure, but the problem
+                # can be alleviated once we have FakeModule.
+                compiled = inner_compile(deepcopy(gm), example_inputs, **kwargs_patched)
                 if detect_fake_mode(example_inputs):
 
                     def materialize(x):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -32,6 +32,7 @@ from .fx_passes.joint_graph import joint_graph_passes
 from .fx_passes.post_grad import post_grad_passes
 from .fx_passes.pre_grad import pre_grad_passes
 from .graph import GraphLowering
+from .pattern_matcher import clone_graph
 from .utils import get_dtype_size, has_incompatible_cudagraph_ops
 from .virtualized import V
 
@@ -193,10 +194,12 @@ def inner_compile_with_cpp_wrapper(inner_compile):
                     "cpp_wrapper": False,
                     "cudagraphs": False,
                 }
-                # deepcopy(gm) makes sure no graph modification from the first pass will
+                # clone_graph(gm) makes sure no graph modification from the first pass will
                 # leak to the second pass. It does increase memory pressure, but the problem
-                # can be alleviated once we have FakeModule.
-                compiled = inner_compile(deepcopy(gm), example_inputs, **kwargs_patched)
+                # can be alleviated once we have parameters as FakeTensor.
+                compiled = inner_compile(
+                    clone_graph(gm), example_inputs, **kwargs_patched
+                )
                 if detect_fake_mode(example_inputs):
 
                     def materialize(x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #102738
* __->__ #102851

Summary: Currently cpp_wrapper for CUDA does it in two passe, which
means we need to deepcopy the input module to isolate any fx
transformations between the two passes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225