### PR TITLE
[quant][pt2e][be] Remove _input_output_share_observers and _reuse_input_obs_or_fq from QuantizationAnnotation

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -985,10 +985,8 @@ class TestQuantizePT2E(QuantizationTestCase):
         original_conv_bn_getitem_meta = original_conv_bn_getitem_node.meta[
             "quantization_annotation"
         ]
-        maxpool_getitem_meta = maxpool_getitem_node.meta["quantization_annotation"]
         conv_bn_getitem_meta = conv_bn_getitem_node.meta["quantization_annotation"]
         self.assertEqual(conv_bn_getitem_meta, original_conv_bn_getitem_meta)
-        self.assertNotEqual(conv_bn_getitem_meta, maxpool_getitem_meta)
 
     def _verify_symmetric_qnnpack_qat_graph(
         self,

--- a/torch/ao/quantization/_pt2e/graph_utils.py
+++ b/torch/ao/quantization/_pt2e/graph_utils.py
@@ -16,7 +16,7 @@ _EQUIVALENT_TYPES: List[Set] = [
     {torch.nn.ReLU, torch.nn.functional.relu, torch.nn.functional.relu_},
     {torch.nn.BatchNorm2d, torch.nn.functional.batch_norm},
     {torch.nn.Hardtanh, torch.nn.functional.hardtanh, torch.nn.functional.hardtanh_},
-    {torch.add, operator.add},
+    {torch.add, operator.add, operator.iadd},
 ]
 
 

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -157,12 +157,6 @@ class QuantizationAnnotation:
     # whether the node is annotated or not
     _annotated: bool = False
 
-    # TODO: will be updated soon to use sharing group and be more general
-    _input_output_share_observers: bool = False
-
-    # TODO: remove after sharing API refactor
-    _reuse_input_obs_or_fq: bool = False
-
 class Quantizer(ABC):
 
     # annotate nodes in the graph with observer or fake quant constructors


### PR DESCRIPTION
Summary:
att, after we support SharedQuantizationSpec we don't need these things anymore, this PR refactors the
uses of _input_output_share_observers to SharedQuantizationSpec

Test Plan:
```
buck2 test mode/opt caffe2/test:quantization_pt2e -- 'caffe2/test:quantization_pt2e'
```

Reviewed By: andrewor14

Differential Revision: D46301342

