### PR TITLE
Added xla friendly codepath to single_tensor_adamw

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -333,7 +333,9 @@ def _single_tensor_adam(params: List[Tensor],
 
         # If compiling, the compiler will handle cudagraph checks, see note [torch.compile x capturable]
         if not torch._utils.is_compiling() and capturable:
-            assert param.is_cuda and step_t.is_cuda, "If capturable=True, params and state_steps must be CUDA tensors."
+            assert (
+                (param.is_cuda and step_t.is_cuda) or (param.is_xla and step_t.is_xla)
+            ), "If capturable=True, params and state_steps must be CUDA or XLA tensors."
 
         # update step
         step_t += 1

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -372,8 +372,8 @@ def _single_tensor_adamw(
         # If compiling, the compiler will handle cudagraph checks, see note [torch.compile x capturable]
         if not torch._utils.is_compiling() and capturable:
             assert (
-                param.is_cuda and step_t.is_cuda
-            ), "If capturable=True, params and state_steps must be CUDA tensors."
+                (param.is_cuda and step_t.is_cuda) or (param.is_xla and step_t.is_xla)
+            ), "If capturable=True, params and state_steps must be CUDA or XLA tensors."
 
         if torch.is_complex(param):
             grad = torch.view_as_real(grad)

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -265,8 +265,9 @@ def _single_tensor_nadam(params: List[Tensor],
 
         # If compiling, the compiler will handle cudagraph checks, see note [torch.compile x capturable]
         if not torch._utils.is_compiling() and capturable:
-            assert param.is_cuda and mu_product.is_cuda and step_t.is_cuda, \
-                "If capturable=True, params, mu_products, and state_steps must be CUDA tensors."
+            assert (
+                (param.is_cuda and mu_product.is_cuda and step_t.is_cuda) or (param.is_xla and mu_product.is_xla and step_t.is_xla)
+            ), "If capturable=True, params, mu_products, and state_steps must be CUDA or XLA tensors."
 
         # update step
         step_t += 1


### PR DESCRIPTION
There are extra graph compilations on XLA when beta{1,2} ** step get too small. This PR addresses this issue by making the `capturable` interface enabled for XLA, as well as switching to `torch.float_power` which preserves the same behaviour as the non-capturable flow on XLA.