### PR TITLE
[ONNX] Add constant folding for Softmax op

### DIFF
--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -535,6 +535,10 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       total_size *= size;
     }
     return c10::optional<at::Tensor>(IntToTensor(total_size));
+  } else if (node->kind() == onnx::Softmax) {
+    int64_t axis = node->hasAttributeS("axis") ? node->i(attr::axis) : -1;
+    updated_val = at::softmax(inputTensorValues[0], axis);
+    return c10::optional<at::Tensor>(updated_val);
   } else {
     return c10::nullopt;
   }


### PR DESCRIPTION
This commit adds a torch implementation for the ONNX Softmax op, which allows it to be folded during ONNX export if all its inputs are known.

Fixes #97927
