### PR TITLE
[quant][pt2] Add test for inplace add

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1019,6 +1019,28 @@ class TestQuantizePT2E(QuantizationTestCase):
             m1, example_inputs, is_per_channel=True, has_relu=True
         )
 
+    def test_qat_inplace_add_relu(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(1, 1, 1)
+                self.relu = torch.nn.ReLU(inplace=True)
+
+            def forward(self, x):
+                x0 = x
+                x = self.conv(x)
+                x += x0
+                x = self.relu(x)
+                return x
+
+        example_inputs = (torch.randn(1, 1, 3, 3),)
+        self._verify_symmetric_qnnpack_qat_numerics(
+            M(), example_inputs, is_per_channel=False, verify_convert=True,
+        )
+        self._verify_symmetric_qnnpack_qat_numerics(
+            M(), example_inputs, is_per_channel=True, verify_convert=True,
+        )
+
     def test_prepare_qat_conv_bn_fusion_getitem_placeholder(self):
         """
         Test this special case seen in resnet18:


### PR DESCRIPTION
Summary: This was broken after the recent partitioner refactors.

Test Plan: python test/test_quantization.py TestQuantizePT2E.test_qat_inplace_add_relu

Differential Revision: D46402378

