### PR TITLE
Fix rocm sharding

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -18,15 +18,16 @@ IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
 # used to run tests.  If they are not equal, the only consequence should be
 # unequal shards.
+IS_ROCM = os.path.exists("/opt/rocm")
 NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 2
-NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS
+NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS if not IS_ROCM or IS_MEM_LEAK_CHECK else 2
 THRESHOLD = 60 * 10  # 10 minutes
 
 # See Note [ROCm parallel CI testing]
 # Special logic for ROCm GHA runners to query number of GPUs available.
 # torch.version.hip was not available to check if this was a ROCm self-hosted runner.
 # Must check for ROCm runner in another way. We look for /opt/rocm directory.
-if os.path.exists("/opt/rocm") and not IS_MEM_LEAK_CHECK:
+if IS_ROCM and not IS_MEM_LEAK_CHECK:
     try:
         # This is the same logic used in GHA health check, see .github/templates/common.yml.j2
         lines = (
@@ -42,7 +43,6 @@ if os.path.exists("/opt/rocm") and not IS_MEM_LEAK_CHECK:
     except subprocess.CalledProcessError as e:
         # The safe default for ROCm GHA runners is to run tests serially.
         NUM_PROCS = 1
-    NUM_PROCS_FOR_SHARDING_CALC = 2
 
 
 class ShardedTest(NamedTuple):

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -17,7 +17,8 @@ IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
 # used to run tests
-NUM_PROCS, NUM_PROCS_FOR_SHARDING_CALC = 1 if IS_MEM_LEAK_CHECK else 2
+NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 2
+NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS
 THRESHOLD = 60 * 10  # 10 minutes
 
 # See Note [ROCm parallel CI testing]

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -16,7 +16,8 @@ IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
-# used to run tests
+# used to run tests.  If they are not equal, the only consequence should be
+# unequal shards.
 NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 2
 NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS
 THRESHOLD = 60 * 10  # 10 minutes

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -42,7 +42,7 @@ if os.path.exists("/opt/rocm") and not IS_MEM_LEAK_CHECK:
     except subprocess.CalledProcessError as e:
         # The safe default for ROCm GHA runners is to run tests serially.
         NUM_PROCS = 1
-    NUM_PROCS_FOR_SHARDING_CALC = 1
+    NUM_PROCS_FOR_SHARDING_CALC = 2
 
 
 class ShardedTest(NamedTuple):


### PR DESCRIPTION
Rocm queries for the number of processes it should use per machine, which might cause it be different across shards, which leads to inconsistencies when distributing tests among shards.  

My solution is to separate the vars used for shard calculations and the actual number of procs that can be used and to ensure that the var used for shard calculations is consistent across all shards for a test config + job.  I believe that the only consequence is that rocm sharding might become unbalanced.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo