### PR TITLE
[Executorch][codegen] Add ETKernelIndex for aggregating all kernels for kernel

### DIFF
--- a/tools/test/test_executorch_custom_ops.py
+++ b/tools/test/test_executorch_custom_ops.py
@@ -7,6 +7,7 @@ import expecttest
 
 import torchgen
 from torchgen.executorch.api.custom_ops import ComputeNativeFunctionStub
+from torchgen.executorch.model import ETKernelIndex
 from torchgen.gen_executorch import gen_headers
 from torchgen.model import Location, NativeFunction
 from torchgen.selective_build.selector import SelectiveBuilder
@@ -93,9 +94,8 @@ class TestGenCustomOpsHeader(unittest.TestCase):
                 native_functions=[],
                 gen_custom_ops_header=True,
                 custom_ops_native_functions=[],
-                static_dispatch_idx=[],
                 selector=SelectiveBuilder.get_nop_selector(),
-                backend_indices={},
+                kernel_index=ETKernelIndex(index={}),
                 cpu_fm=fm,
                 use_aten_lib=False,
             )
@@ -114,9 +114,8 @@ class TestGenCustomOpsHeader(unittest.TestCase):
                 native_functions=[],
                 gen_custom_ops_header=False,
                 custom_ops_native_functions=[],
-                static_dispatch_idx=[],
                 selector=SelectiveBuilder.get_nop_selector(),
-                backend_indices={},
+                kernel_index=ETKernelIndex(index={}),
                 cpu_fm=fm,
                 use_aten_lib=False,
             )

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -4,6 +4,8 @@ import unittest
 from typing import Dict
 
 import yaml
+
+from torchgen.executorch.model import ETKernelIndex
 from torchgen.gen import LineLoader
 
 from torchgen.gen_executorch import gen_functions_declarations, translate_native_yaml
@@ -165,6 +167,7 @@ class TestGenFunctionsDeclarations(unittest.TestCase):
             )
             for k in backend_indices
         ]
+        self.kernel_index = ETKernelIndex.from_backend_indices(backend_indices)
 
     def test_operators_with_different_namespaces_are_grouped_correctly(self) -> None:
         declarations = gen_functions_declarations(
@@ -172,7 +175,7 @@ class TestGenFunctionsDeclarations(unittest.TestCase):
                 self.custom_1_native_function,
                 self.custom_2_native_function,
             ],
-            static_dispatch_idx=self.static_dispatch_idx,
+            kernel_index=self.kernel_index,
             selector=SelectiveBuilder.get_nop_selector(),
             use_aten_lib=False,
         )
@@ -209,7 +212,7 @@ TORCH_API inline bool op_2(torch::executor::RuntimeContext & context) {
             native_functions=[
                 self.custom_1_native_function,
             ],
-            static_dispatch_idx=self.static_dispatch_idx,
+            kernel_index=self.kernel_index,
             selector=SelectiveBuilder.get_nop_selector(),
             use_aten_lib=True,
         )

--- a/torchgen/executorch/api/custom_ops.py
+++ b/torchgen/executorch/api/custom_ops.py
@@ -8,7 +8,8 @@ from torchgen import dest
 # disable import sorting to avoid circular dependency.
 from torchgen.api.types import DispatcherSignature  # isort:skip
 from torchgen.context import method_with_native_function
-from torchgen.model import BackendIndex, DispatchKey, NativeFunction, Variant
+from torchgen.executorch.model import ETKernelIndex
+from torchgen.model import DispatchKey, NativeFunction, Variant
 from torchgen.selective_build.selector import SelectiveBuilder
 from torchgen.utils import concatMap, Target
 
@@ -65,7 +66,7 @@ def gen_custom_ops_registration(
     *,
     native_functions: Sequence[NativeFunction],
     selector: SelectiveBuilder,
-    backend_index: BackendIndex,
+    kernel_index: ETKernelIndex,
     rocm: bool,
 ) -> Tuple[str, str]:
     """
@@ -73,12 +74,16 @@ def gen_custom_ops_registration(
 
     :param native_functions: a sequence of `NativeFunction`
     :param selector: for selective build.
-    :param backend_index: kernels for all the ops.
+    :param kernel_index: kernels for all the ops.
     :param rocm: bool for dest.RegisterDispatchKey.
     :return: generated C++ code to register custom operators into PyTorch
     """
-    dispatch_key = DispatchKey.CPU
 
+    # convert kernel index to BackendIndex. This is because we can't handle ETKernelIndex yet.
+    # TODO larryliu: evaluate if this code is still needed. If yes let it handle ETKernelIndex.
+
+    dispatch_key = DispatchKey.CPU
+    backend_index = kernel_index._to_backend_index()
     static_init_dispatch_registrations = ""
     ns_grouped_native_functions: Dict[str, List[NativeFunction]] = defaultdict(list)
     for native_function in native_functions:

--- a/torchgen/executorch/model.py
+++ b/torchgen/executorch/model.py
@@ -1,0 +1,93 @@
+# represents all kernels used by an Executorch model.
+# It maintains a Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]] structure.
+from collections import defaultdict, namedtuple
+from dataclasses import dataclass
+from typing import Dict, Union
+
+from torchgen.model import (
+    BackendIndex,
+    BackendMetadata,
+    DispatchKey,
+    NativeFunction,
+    NativeFunctionsGroup,
+    OperatorName,
+)
+from torchgen.utils import assert_never
+
+ETParsedYaml = namedtuple("ETParsedYaml", ["native_functions", "kernel_index"])
+
+
+@dataclass(frozen=True)
+class ETKernelKey:
+    default: bool = False
+    # TODO: jackkhuu to add more fields
+
+
+@dataclass(frozen=True)
+class ETKernelIndex:
+    index: Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]]
+
+    def has_kernels(self, g: Union[NativeFunction, NativeFunctionsGroup]) -> bool:
+        m = self.get_kernels(g)
+        return m is not None
+
+    def get_kernels(
+        self, g: Union[NativeFunction, NativeFunctionsGroup]
+    ) -> Dict[ETKernelKey, BackendMetadata]:
+        if isinstance(g, NativeFunction):
+            f = g
+        elif isinstance(g, NativeFunctionsGroup):
+            f = g.functional
+        else:
+            assert_never(g)
+        if f.func.name not in self.index:
+            return {}
+        return self.index[f.func.name]
+
+    @staticmethod
+    def grow_from_backend_indices(
+        kernel_index: Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]],
+        backend_indices: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]],
+    ) -> None:
+        for dk in backend_indices:
+            index = backend_indices[dk]
+            for op, backend_metadata in index.items():
+                if op in kernel_index:
+                    kernel_index[op][ETKernelKey(default=True)] = backend_metadata
+                else:
+                    kernel_index[op] = {ETKernelKey(default=True): backend_metadata}
+
+    @staticmethod
+    def from_backend_indices(
+        backend_indices: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]]
+    ) -> "ETKernelIndex":
+        kernel_index: Dict[
+            OperatorName, Dict[ETKernelKey, BackendMetadata]
+        ] = defaultdict(dict)
+        ETKernelIndex.grow_from_backend_indices(kernel_index, backend_indices)
+        return ETKernelIndex(kernel_index)
+
+    def grow(
+        self, backend_indices: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]]
+    ) -> "ETKernelIndex":
+        ETKernelIndex.grow_from_backend_indices(self.index, backend_indices)
+        return self
+
+    def _to_backend_index(self) -> BackendIndex:
+        """
+        WARNING: this will be deprecated once all the codegen places know how to handle ETKernelIndex.
+        """
+        index: Dict[OperatorName, BackendMetadata] = {}
+        for op in self.index:
+            kernel_dict = self.index[op]
+            assert (
+                len(kernel_dict.values()) == 1
+            ), f"Can't convert ETKernelIndex to BackendIndex because {op} has more than one kernels. Got {kernel_dict}"
+            index[op] = kernel_dict[ETKernelKey(default=True)]
+        return BackendIndex(
+            dispatch_key=DispatchKey.CPU,
+            use_out_as_primary=False,
+            device_guard=False,
+            external=False,
+            index=index,
+        )

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -19,19 +19,20 @@ from torchgen.executorch.api.custom_ops import (
 )
 from torchgen.executorch.api.types import contextArg, ExecutorchCppSignature
 from torchgen.executorch.api.unboxing import Unboxing
+from torchgen.executorch.model import ETKernelIndex, ETParsedYaml
 from torchgen.gen import (
     get_custom_build_selector,
     get_native_function_declarations,
+    get_native_function_declarations_from_ns_grouped_kernels,
     get_native_function_schema_registrations,
     LineLoader,
     parse_native_yaml,
-    ParsedYaml,
 )
 from torchgen.model import (
     BackendIndex,
     BackendMetadata,
+    DEFAULT_KERNEL_NAMESPACE,
     DispatchKey,
-    is_cuda_dispatch_key,
     Location,
     NativeFunction,
     NativeFunctionsGroup,
@@ -237,28 +238,33 @@ def gen_unboxing(
     )
 
 
-@with_native_function_and_index
+@with_native_function_and_index  # type: ignore[arg-type]
 def compute_native_function_declaration(
-    g: Union[NativeFunctionsGroup, NativeFunction], backend_index: BackendIndex
+    g: Union[NativeFunctionsGroup, NativeFunction], kernel_index: ETKernelIndex
 ) -> List[str]:
     assert isinstance(g, NativeFunction)
     sig = ExecutorchCppSignature.from_native_function(f=g)
-    metadata = backend_index.get_kernel(g)
-    if metadata is None:
+    metadata_list = kernel_index.get_kernels(g).values()
+    if metadata_list is None:
         return []
-    prefix = "static" if backend_index.external else "TORCH_API"
+    prefix = "TORCH_API"
+
     # for kernels in lean mode, we declare two versions, one with context and one without.
     # In the end we will cleanup the unused one.
+    def gen_decl(metadata: BackendMetadata, include_context: bool) -> str:
+        return f"{prefix} {sig.decl(name=metadata.kernel, include_context=include_context)};"
+
     return [
-        f"{prefix} {sig.decl(name=metadata.kernel)};",
-        f"{prefix} {sig.decl(name=metadata.kernel, include_context=False)};",
+        gen_decl(metadata, include_context)
+        for include_context in [False, True]
+        for metadata in metadata_list
     ]
 
 
 def gen_functions_declarations(
     *,
     native_functions: Sequence[NativeFunction],
-    static_dispatch_idx: List[BackendIndex],
+    kernel_index: ETKernelIndex,
     selector: SelectiveBuilder,
     use_aten_lib: bool,
     custom_ops_native_functions: Optional[Sequence[NativeFunction]] = None,
@@ -272,6 +278,13 @@ def gen_functions_declarations(
     in `torch::executor::custom_1::foo_out`. This way we avoid symbol conflict when
     the other `custom_2::foo.out` is available.
     """
+
+    # convert kernel index to BackendIndex. This is because we can't handle ETKernelIndex yet.
+    # TODO larryliu: evaluate if this code is still needed. If yes let it handle ETKernelIndex.
+
+    dispatch_key = DispatchKey.CPU
+    backend_index = kernel_index._to_backend_index()
+
     ns_grouped_functions = defaultdict(list)
     for native_function in native_functions:
         ns_grouped_functions[native_function.namespace].append(native_function)
@@ -286,7 +299,7 @@ def gen_functions_declarations(
         declarations = list(
             mapMaybe(
                 ComputeFunction(
-                    static_dispatch_backend_indices=static_dispatch_idx,
+                    static_dispatch_backend_indices=[backend_index],
                     selector=selector,
                     use_aten_lib=use_aten_lib,
                     is_custom_op=lambda f: custom_ops_native_functions is not None
@@ -303,14 +316,44 @@ def gen_functions_declarations(
     return functions_declarations
 
 
+def get_ns_grouped_kernels(
+    *,
+    native_functions: Sequence[NativeFunction],
+    kernel_index: ETKernelIndex,
+    native_function_decl_gen: Callable[
+        [
+            Union[NativeFunctionsGroup, NativeFunction],
+            ETKernelIndex,
+        ],
+        List[str],
+    ],
+) -> Dict[str, List[str]]:
+    ns_grouped_kernels: Dict[str, List[str]] = defaultdict(list)
+    for f in native_functions:
+        native_function_namespaces = set()
+        op_kernels = kernel_index.get_kernels(f)
+        for backend_metadata in op_kernels.values():
+            if backend_metadata:
+                namespace = backend_metadata.cpp_namespace
+                native_function_namespaces.add(namespace)
+            else:
+                namespace = DEFAULT_KERNEL_NAMESPACE
+            assert (
+                len(native_function_namespaces) <= 1
+            ), f"Codegen only supports one namespace per operator, got {native_function_namespaces}"
+            ns_grouped_kernels[namespace].extend(
+                native_function_decl_gen(f, kernel_index)
+            )
+    return ns_grouped_kernels
+
+
 def gen_headers(
     *,
     native_functions: Sequence[NativeFunction],
     gen_custom_ops_header: bool,
     custom_ops_native_functions: Sequence[NativeFunction],
-    static_dispatch_idx: List[BackendIndex],
     selector: SelectiveBuilder,
-    backend_indices: Dict[DispatchKey, BackendIndex],
+    kernel_index: ETKernelIndex,
     cpu_fm: FileManager,
     use_aten_lib: bool,
 ) -> None:
@@ -320,13 +363,12 @@ def gen_headers(
         native_functions (Sequence[NativeFunction]): a collection of NativeFunction for ATen ops.
         gen_custom_ops_header (bool): whether we should generate CustomOpsNativeFunctions.h
         custom_ops_native_functions (Sequence[NativeFunction]): a collection of NativeFunction for custom ops.
-        static_dispatch_idx (List[BackendIndex]): kernel collection
-        selector (SelectiveBuilder): for selective build
-        backend_indices (Dict[DispatchKey, BackendIndex]): kernel collection TODO (larryliu): merge with static_dispatch_idx
+        kernel_index (ETKernelIndex): kernel collection
         cpu_fm (FileManager): file manager manages output stream
         use_aten_lib (bool): whether we are generating for PyTorch types or Executorch types.
     """
     aten_headers = ["#include <ATen/Functions.h>"]
+    backend_indices = {DispatchKey.CPU: kernel_index._to_backend_index()}
     if gen_custom_ops_header:
         cpu_fm.write_with_template(
             "CustomOpsNativeFunctions.h",
@@ -348,45 +390,56 @@ def gen_headers(
             else ['#include "NativeFunctions.h"'],
             "Functions_declarations": gen_functions_declarations(
                 native_functions=native_functions,
-                static_dispatch_idx=static_dispatch_idx,
+                kernel_index=kernel_index,
                 selector=selector,
                 use_aten_lib=use_aten_lib,
                 custom_ops_native_functions=custom_ops_native_functions,
             ),
         },
     )
-
-    cpu_fm.write(
-        "NativeFunctions.h",
-        lambda: {
-            "nativeFunctions_declarations": get_native_function_declarations(
-                grouped_native_functions=native_functions,
-                backend_indices=backend_indices,
-                native_function_decl_gen=dest.compute_native_function_declaration
-                if use_aten_lib
-                else compute_native_function_declaration,
-            ),
-        },
-    )
+    if use_aten_lib:
+        cpu_fm.write(
+            "NativeFunctions.h",
+            lambda: {
+                "nativeFunctions_declarations": get_native_function_declarations(
+                    grouped_native_functions=native_functions,
+                    backend_indices=backend_indices,
+                    native_function_decl_gen=dest.compute_native_function_declaration,
+                ),
+            },
+        )
+    else:
+        ns_grouped_kernels = get_ns_grouped_kernels(
+            native_functions=native_functions,
+            kernel_index=kernel_index,
+            native_function_decl_gen=compute_native_function_declaration,  # type: ignore[arg-type]
+        )
+        cpu_fm.write(
+            "NativeFunctions.h",
+            lambda: {
+                "nativeFunctions_declarations": get_native_function_declarations_from_ns_grouped_kernels(
+                    ns_grouped_kernels=ns_grouped_kernels,
+                ),
+            },
+        )
 
 
 def gen_custom_ops(
     *,
     native_functions: Sequence[NativeFunction],
     selector: SelectiveBuilder,
-    backend_indices: Dict[DispatchKey, BackendIndex],
+    kernel_index: ETKernelIndex,
     cpu_fm: FileManager,
     rocm: bool,
 ) -> None:
     dispatch_key = DispatchKey.CPU
-    backend_index = backend_indices[dispatch_key]
     (
         anonymous_definition,
         static_init_dispatch_registrations,
     ) = gen_custom_ops_registration(
         native_functions=native_functions,
         selector=selector,
-        backend_index=backend_index,
+        kernel_index=kernel_index,
         rocm=rocm,
     )
     cpu_fm.write_with_template(
@@ -515,30 +568,6 @@ def translate_native_yaml(
         yaml.dump(native_es, out_file, width=1000)
 
 
-def convert_backend_indices(
-    bs: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]]
-) -> Dict[DispatchKey, BackendIndex]:
-    indices: Dict[DispatchKey, BackendIndex] = defaultdict(
-        lambda: BackendIndex(
-            dispatch_key=DispatchKey.Undefined,
-            use_out_as_primary=True,
-            external=False,
-            device_guard=False,
-            index={},
-        )
-    )
-    for k, v in bs.items():
-        indices[k] = BackendIndex(
-            dispatch_key=k,
-            use_out_as_primary=True,
-            external=False,
-            # Only cuda-like devices in tree require device guards
-            device_guard=is_cuda_dispatch_key(k),
-            index=v,
-        )
-    return indices
-
-
 def parse_yaml(
     path: Optional[str],
     tags_yaml_path: str,
@@ -577,7 +606,7 @@ def parse_yaml_files(
     custom_ops_yaml_path: Optional[str],
     selector: SelectiveBuilder,
     use_aten_lib: bool,
-) -> Tuple[ParsedYaml, Optional[ParsedYaml]]:
+) -> Tuple[ETParsedYaml, Optional[ETParsedYaml]]:
     """Parses functions.yaml and custom_ops.yaml files.
 
     Args:
@@ -624,25 +653,15 @@ def parse_yaml_files(
         )
 
         combined_functions = translated_functions + custom_ops_functions
-        combined_backend_indices: Dict[
-            DispatchKey, Dict[OperatorName, BackendMetadata]
-        ] = defaultdict(dict)
-        combined_backend_indices.update(translated_backend_indices)
-
-        for dk in custom_ops_backend_indices:
-            if dk not in combined_backend_indices:
-                combined_backend_indices.update({dk: custom_ops_backend_indices[dk]})
-            else:
-                combined_backend_indices[dk] = {
-                    **combined_backend_indices[dk],
-                    **custom_ops_backend_indices[dk],
-                }
-
-        combined_yaml = ParsedYaml(
-            combined_functions, convert_backend_indices(combined_backend_indices)
+        combined_kernel_index: ETKernelIndex = ETKernelIndex.from_backend_indices(
+            translated_backend_indices
+        ).grow(custom_ops_backend_indices)
+        custom_ops_kernel_index: ETKernelIndex = ETKernelIndex.from_backend_indices(
+            custom_ops_backend_indices
         )
-        custom_ops_parsed_yaml = ParsedYaml(
-            custom_ops_functions, convert_backend_indices(custom_ops_backend_indices)
+        combined_yaml = ETParsedYaml(combined_functions, combined_kernel_index)
+        custom_ops_parsed_yaml = ETParsedYaml(
+            custom_ops_functions, custom_ops_kernel_index
         )
     return combined_yaml, custom_ops_parsed_yaml
 
@@ -759,9 +778,9 @@ def main() -> None:
         selector=selector,
         use_aten_lib=options.use_aten_lib,
     )
-    native_functions, backend_indices = (
+    native_functions, kernel_index = (
         parsed_yaml.native_functions,
-        parsed_yaml.backend_indices,
+        parsed_yaml.kernel_index,
     )
     custom_ops_native_functions = (
         custom_ops_parsed_yaml.native_functions if custom_ops_parsed_yaml else []
@@ -769,17 +788,14 @@ def main() -> None:
 
     cpu_fm = make_file_manager(options=options)
 
-    static_dispatch_idx: List[BackendIndex] = [backend_indices[DispatchKey.CPU]]
-
     if "headers" in options.generate:
         # generate CustomOpsNativeFunctions.h when custom_ops.yaml is present, to match the build system.
         gen_headers(
             native_functions=native_functions,
             gen_custom_ops_header=options.custom_ops_yaml_path,
             custom_ops_native_functions=custom_ops_native_functions,
-            static_dispatch_idx=static_dispatch_idx,
             selector=selector,
-            backend_indices=backend_indices,
+            kernel_index=kernel_index,
             cpu_fm=cpu_fm,
             use_aten_lib=options.use_aten_lib,
         )
@@ -795,7 +811,7 @@ def main() -> None:
             gen_custom_ops(
                 native_functions=custom_ops_native_functions,
                 selector=selector,
-                backend_indices=backend_indices,
+                kernel_index=kernel_index,
                 cpu_fm=cpu_fm,
                 rocm=options.rocm,
             )


### PR DESCRIPTION
Summary:
keys and change codegen to take ETKernelIndex

We are adding support for dtype and dim order specialized kernel registration. This requires us to reorganize `BackendIndex` (which is a `Dict[DispatchKey, Dict[OperatorName, BackendMetadata]]`) to be `Dict[OperatorName, Dict[ETKernelKey, BackendMetadata]]`. This PR adds new data structures in order to support this change:

* `ETKernelKey` to retrieve a certain kernel from the registry.
* `ETKernelIndex`, the dictionary from operator name to kernel key to kernel mapping.

Note that the codegen logic is not changed yet, we need subsequent diffs to actually generate code for different kernel keys.

Test Plan: Added tests

Reviewed By: Jack-Khuu

Differential Revision: D46407096

