### PR TITLE
Enable clang-format on foreach / multi_tensor_apply files

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -55,7 +55,7 @@ include_patterns = [
     'aten/src/ATen/native/vulkan/**/*.h',
     'aten/src/ATen/native/vulkan/**/*.cpp',
     'aten/src/ATen/native/cuda/MultiTensorApply.cuh',
-    'aten/src/ATen/native/cuda/Foreach*.*',
+    'aten/src/ATen/native/**/Foreach*.*',
     'c10/**/*.h',
     'c10/**/*.cpp',
     'torch/csrc/**/*.h',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -54,6 +54,8 @@ include_patterns = [
     'aten/src/ATen/native/mps/**/*.mm',
     'aten/src/ATen/native/vulkan/**/*.h',
     'aten/src/ATen/native/vulkan/**/*.cpp',
+    'aten/src/ATen/native/cuda/MultiTensorApply.cuh',
+    'aten/src/ATen/native/cuda/Foreach*.*',
     'c10/**/*.h',
     'c10/**/*.cpp',
     'torch/csrc/**/*.h',

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -17,6 +17,8 @@
 #include <ATen/ops/_foreach_asin_native.h>
 #include <ATen/ops/_foreach_atan_native.h>
 #include <ATen/ops/_foreach_ceil_native.h>
+#include <ATen/ops/_foreach_clamp_max_native.h>
+#include <ATen/ops/_foreach_clamp_min_native.h>
 #include <ATen/ops/_foreach_cos_native.h>
 #include <ATen/ops/_foreach_cosh_native.h>
 #include <ATen/ops/_foreach_div_native.h>
@@ -37,6 +39,7 @@
 #include <ATen/ops/_foreach_mul_native.h>
 #include <ATen/ops/_foreach_neg_native.h>
 #include <ATen/ops/_foreach_norm_native.h>
+#include <ATen/ops/_foreach_pow_native.h>
 #include <ATen/ops/_foreach_reciprocal_native.h>
 #include <ATen/ops/_foreach_round_native.h>
 #include <ATen/ops/_foreach_sigmoid_native.h>
@@ -48,183 +51,204 @@
 #include <ATen/ops/_foreach_tanh_native.h>
 #include <ATen/ops/_foreach_trunc_native.h>
 #include <ATen/ops/_foreach_zero_native.h>
-#include <ATen/ops/_foreach_clamp_min_native.h>
-#include <ATen/ops/_foreach_clamp_max_native.h>
-#include <ATen/ops/_foreach_pow_native.h>
 #include <ATen/ops/linalg_vector_norm.h>
 #include <ATen/ops/maximum.h>
 #include <ATen/ops/minimum.h>
-#include <ATen/ops/zeros_like_ops.h>
 #include <ATen/ops/pow.h>
+#include <ATen/ops/zeros_like_ops.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
-#define FOREACH_BINARY_OP_SCALAR(OP)                                                                      \
-void foreach_tensor_##OP##_scalar_kernel_slow_(TensorList tensors, const Scalar& scalar) {                       \
-  check_foreach_api_restrictions(tensors);                                                                \
-                                                                                                          \
-  for (auto& t: tensors) {                                                                                \
-    t.OP##_(scalar);                                                                                      \
-  }                                                                                                       \
-}                                                                                                         \
-                                                                                                          \
-std::vector<Tensor> foreach_tensor_##OP##_scalar_kernel_slow(TensorList tensors, const Scalar& scalar) {         \
-  check_foreach_api_restrictions(tensors);                                                                \
-                                                                                                          \
-  std::vector<Tensor> result;                                                                             \
-  result.reserve(tensors.size());                                                                         \
-  for (const auto& t: tensors) {                                                                          \
-    result.emplace_back(t.OP(scalar));                                                                    \
-  }                                                                                                       \
-                                                                                                          \
-  return result;                                                                                          \
-}
+#define FOREACH_BINARY_OP_SCALAR(OP)                            \
+  void foreach_tensor_##OP##_scalar_kernel_slow_(               \
+      TensorList tensors, const Scalar& scalar) {               \
+    check_foreach_api_restrictions(tensors);                    \
+                                                                \
+    for (auto& t : tensors) {                                   \
+      t.OP##_(scalar);                                          \
+    }                                                           \
+  }                                                             \
+                                                                \
+  std::vector<Tensor> foreach_tensor_##OP##_scalar_kernel_slow( \
+      TensorList tensors, const Scalar& scalar) {               \
+    check_foreach_api_restrictions(tensors);                    \
+                                                                \
+    std::vector<Tensor> result;                                 \
+    result.reserve(tensors.size());                             \
+    for (const auto& t : tensors) {                             \
+      result.emplace_back(t.OP(scalar));                        \
+    }                                                           \
+                                                                \
+    return result;                                              \
+  }
 
-#define FOREACH_BINARY_OP_SCALARLIST(OP)                                                                                \
-void foreach_tensor_##OP##_scalarlist_kernel_slow_(TensorList tensors, at::ArrayRef<Scalar> scalars) {                  \
-  check_foreach_api_restrictions(tensors, scalars);                                                                     \
-                                                                                                                        \
-  for (const auto i : c10::irange(tensors.size())) {                                                                    \
-      tensors[i].OP##_(scalars[i]);                                                                                     \
-    }                                                                                                                   \
-}                                                                                                                       \
-                                                                                                                        \
-std::vector<Tensor> foreach_tensor_##OP##_scalarlist_kernel_slow(TensorList tensors, at::ArrayRef<Scalar> scalars) {    \
-  check_foreach_api_restrictions(tensors, scalars);                                                                     \
-  std::vector<Tensor> result;                                                                                           \
-  result.reserve(tensors.size());                                                                                       \
-  for (const auto i : c10::irange(tensors.size())) {                                                                    \
-    result.emplace_back(tensors[i].OP(scalars[i]));                                                                     \
-  }                                                                                                                     \
-                                                                                                                        \
-  return result;                                                                                                        \
-}
+#define FOREACH_BINARY_OP_SCALARLIST(OP)                            \
+  void foreach_tensor_##OP##_scalarlist_kernel_slow_(               \
+      TensorList tensors, at::ArrayRef<Scalar> scalars) {           \
+    check_foreach_api_restrictions(tensors, scalars);               \
+                                                                    \
+    for (const auto i : c10::irange(tensors.size())) {              \
+      tensors[i].OP##_(scalars[i]);                                 \
+    }                                                               \
+  }                                                                 \
+                                                                    \
+  std::vector<Tensor> foreach_tensor_##OP##_scalarlist_kernel_slow( \
+      TensorList tensors, at::ArrayRef<Scalar> scalars) {           \
+    check_foreach_api_restrictions(tensors, scalars);               \
+    std::vector<Tensor> result;                                     \
+    result.reserve(tensors.size());                                 \
+    for (const auto i : c10::irange(tensors.size())) {              \
+      result.emplace_back(tensors[i].OP(scalars[i]));               \
+    }                                                               \
+                                                                    \
+    return result;                                                  \
+  }
 
-#define FOREACH_BINARY_OP_LIST(OP)                                                                        \
-std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, TensorList tensors2) {    \
-  check_foreach_api_restrictions(tensors1, tensors2);                                                     \
-                                                                                                          \
-  std::vector<Tensor> result;                                                                             \
-  result.reserve(tensors1.size());                                                                        \
-  for (const auto i : c10::irange(tensors1.size())) {                                                     \
-    result.emplace_back(tensors1[i].OP(tensors2[i]));                                                     \
-  }                                                                                                       \
-                                                                                                          \
-  return result;                                                                                          \
-}                                                                                                         \
-                                                                                                          \
-void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList tensors2) {                  \
-  check_foreach_api_restrictions(tensors1, tensors2);                                                     \
-                                                                                                          \
-  for (const auto i : c10::irange(tensors1.size())) {                                                     \
-    tensors1[i].OP##_(tensors2[i]);                                                                       \
-  }                                                                                                       \
-}
+#define FOREACH_BINARY_OP_LIST(OP)                            \
+  std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow( \
+      TensorList tensors1, TensorList tensors2) {             \
+    check_foreach_api_restrictions(tensors1, tensors2);       \
+                                                              \
+    std::vector<Tensor> result;                               \
+    result.reserve(tensors1.size());                          \
+    for (const auto i : c10::irange(tensors1.size())) {       \
+      result.emplace_back(tensors1[i].OP(tensors2[i]));       \
+    }                                                         \
+                                                              \
+    return result;                                            \
+  }                                                           \
+                                                              \
+  void foreach_tensor_##OP##_list_kernel_slow_(               \
+      TensorList tensors1, TensorList tensors2) {             \
+    check_foreach_api_restrictions(tensors1, tensors2);       \
+                                                              \
+    for (const auto i : c10::irange(tensors1.size())) {       \
+      tensors1[i].OP##_(tensors2[i]);                         \
+    }                                                         \
+  }
 
-#define FOREACH_BINARY_OP_LIST_ALPHA(OP)                                                                                \
-std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, TensorList tensors2, const Scalar& alpha) {    \
-  check_foreach_api_restrictions(tensors1, tensors2);                                                                   \
-                                                                                                                        \
-  std::vector<Tensor> result;                                                                                           \
-  result.reserve(tensors1.size());                                                                                      \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                   \
-    result.emplace_back(tensors1[i].OP(tensors2[i], alpha));                                                            \
-  }                                                                                                                     \
-                                                                                                                        \
-  return result;                                                                                                        \
-}                                                                                                                       \
-                                                                                                                        \
-void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList tensors2, const Scalar& alpha) {                  \
-  check_foreach_api_restrictions(tensors1, tensors2);                                                                   \
-                                                                                                                        \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                   \
-    tensors1[i].OP##_(tensors2[i], alpha);                                                                              \
-  }                                                                                                                     \
-}
+#define FOREACH_BINARY_OP_LIST_ALPHA(OP)                               \
+  std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(          \
+      TensorList tensors1, TensorList tensors2, const Scalar& alpha) { \
+    check_foreach_api_restrictions(tensors1, tensors2);                \
+                                                                       \
+    std::vector<Tensor> result;                                        \
+    result.reserve(tensors1.size());                                   \
+    for (const auto i : c10::irange(tensors1.size())) {                \
+      result.emplace_back(tensors1[i].OP(tensors2[i], alpha));         \
+    }                                                                  \
+                                                                       \
+    return result;                                                     \
+  }                                                                    \
+                                                                       \
+  void foreach_tensor_##OP##_list_kernel_slow_(                        \
+      TensorList tensors1, TensorList tensors2, const Scalar& alpha) { \
+    check_foreach_api_restrictions(tensors1, tensors2);                \
+                                                                       \
+    for (const auto i : c10::irange(tensors1.size())) {                \
+      tensors1[i].OP##_(tensors2[i], alpha);                           \
+    }                                                                  \
+  }
 
-#define FOREACH_UNARY_OP(OP)                                               \
-std::vector<Tensor> foreach_tensor_##OP##_slow(TensorList tensors) {       \
-  check_foreach_api_restrictions(tensors);                                 \
-                                                                           \
-  std::vector<Tensor> result;                                              \
-  result.reserve(tensors.size());                                          \
-  for (const auto& t : tensors) {                                          \
-    result.emplace_back(t.OP());                                           \
-  }                                                                        \
-                                                                           \
-  return result;                                                           \
-}                                                                          \
-                                                                           \
-void foreach_tensor_##OP##_slow_(TensorList tensors) {                     \
-  check_foreach_api_restrictions(tensors);                                 \
-                                                                           \
-  for (auto& t : tensors) {                                                \
-    t.OP##_();                                                             \
-  }                                                                        \
-}
+#define FOREACH_UNARY_OP(OP)                                           \
+  std::vector<Tensor> foreach_tensor_##OP##_slow(TensorList tensors) { \
+    check_foreach_api_restrictions(tensors);                           \
+                                                                       \
+    std::vector<Tensor> result;                                        \
+    result.reserve(tensors.size());                                    \
+    for (const auto& t : tensors) {                                    \
+      result.emplace_back(t.OP());                                     \
+    }                                                                  \
+                                                                       \
+    return result;                                                     \
+  }                                                                    \
+                                                                       \
+  void foreach_tensor_##OP##_slow_(TensorList tensors) {               \
+    check_foreach_api_restrictions(tensors);                           \
+                                                                       \
+    for (auto& t : tensors) {                                          \
+      t.OP##_();                                                       \
+    }                                                                  \
+  }
 
-#define FOREACH_POINTWISE_OP_SCALAR(OP)                                                                                              \
-std::vector<Tensor> foreach_tensor_##OP##_scalar_slow(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {   \
-  check_foreach_api_restrictions(input, tensors1, tensors2);                                                                         \
-                                                                                                                                     \
-  std::vector<Tensor> result;                                                                                                        \
-  for(const auto i : c10::irange(input.size())) {                                                                                    \
-    result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalar));                                                              \
-  }                                                                                                                                  \
-                                                                                                                                     \
-  return result;                                                                                                                     \
-}                                                                                                                                    \
-                                                                                                                                     \
-void foreach_tensor_##OP##_scalar_slow_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                 \
-  check_foreach_api_restrictions(input, tensors1, tensors2);                                                                         \
-                                                                                                                                     \
-  for(const auto i : c10::irange(input.size())) {                                                                                    \
-    input[i].OP##_(tensors1[i], tensors2[i], scalar);                                                                                \
-  }                                                                                                                                  \
-}                                                                                                                                    \
+#define FOREACH_POINTWISE_OP_SCALAR(OP)                                   \
+  std::vector<Tensor> foreach_tensor_##OP##_scalar_slow(                  \
+      TensorList input,                                                   \
+      TensorList tensors1,                                                \
+      TensorList tensors2,                                                \
+      const Scalar& scalar) {                                             \
+    check_foreach_api_restrictions(input, tensors1, tensors2);            \
+                                                                          \
+    std::vector<Tensor> result;                                           \
+    for (const auto i : c10::irange(input.size())) {                      \
+      result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalar)); \
+    }                                                                     \
+                                                                          \
+    return result;                                                        \
+  }                                                                       \
+                                                                          \
+  void foreach_tensor_##OP##_scalar_slow_(                                \
+      TensorList input,                                                   \
+      TensorList tensors1,                                                \
+      TensorList tensors2,                                                \
+      const Scalar& scalar) {                                             \
+    check_foreach_api_restrictions(input, tensors1, tensors2);            \
+                                                                          \
+    for (const auto i : c10::irange(input.size())) {                      \
+      input[i].OP##_(tensors1[i], tensors2[i], scalar);                   \
+    }                                                                     \
+  }
 
-#define FOREACH_POINTWISE_OP_SCALARLIST(OP)                                                                                                             \
-std::vector<Tensor> foreach_tensor_##OP##_scalarlist_slow(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {   \
-  check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                   \
-                                                                                                                                                        \
-  std::vector<Tensor> result;                                                                                                                           \
-  for(const auto i : c10::irange(input.size())) {                                                                                                       \
-    result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalars[i]));                                                                             \
-  }                                                                                                                                                     \
-                                                                                                                                                        \
-  return result;                                                                                                                                        \
-}                                                                                                                                                       \
-                                                                                                                                                        \
-void foreach_tensor_##OP##_scalarlist_slow_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                 \
-  check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                   \
-                                                                                                                                                        \
-  for(const auto i : c10::irange(input.size())) {                                                                                                       \
-    input[i].OP##_(tensors1[i], tensors2[i], scalars[i]);                                                                                               \
-  }                                                                                                                                                     \
-}
+#define FOREACH_POINTWISE_OP_SCALARLIST(OP)                                   \
+  std::vector<Tensor> foreach_tensor_##OP##_scalarlist_slow(                  \
+      TensorList input,                                                       \
+      TensorList tensors1,                                                    \
+      TensorList tensors2,                                                    \
+      at::ArrayRef<Scalar> scalars) {                                         \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);       \
+                                                                              \
+    std::vector<Tensor> result;                                               \
+    for (const auto i : c10::irange(input.size())) {                          \
+      result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalars[i])); \
+    }                                                                         \
+                                                                              \
+    return result;                                                            \
+  }                                                                           \
+                                                                              \
+  void foreach_tensor_##OP##_scalarlist_slow_(                                \
+      TensorList input,                                                       \
+      TensorList tensors1,                                                    \
+      TensorList tensors2,                                                    \
+      at::ArrayRef<Scalar> scalars) {                                         \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);       \
+                                                                              \
+    for (const auto i : c10::irange(input.size())) {                          \
+      input[i].OP##_(tensors1[i], tensors2[i], scalars[i]);                   \
+    }                                                                         \
+  }
 
-#define FOREACH_POINTWISE_OP_TENSOR(OP)                                    \
-  std::vector<Tensor> foreach_tensor_##OP##_tensor_slow(                   \
-      TensorList input,                                                    \
-      TensorList tensors1,                                                 \
-      TensorList tensors2,                                                 \
-      const Tensor& scalars_) {                                            \
-    auto scalars = convert_tensor_to_scalar_list(scalars_, input.size());  \
-    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);    \
-    return foreach_tensor_##OP##_scalarlist_slow(                          \
-        input, tensors1, tensors2, scalars);                               \
-  }                                                                        \
-                                                                           \
-  void foreach_tensor_##OP##_tensor_slow_(                                 \
-      TensorList input,                                                    \
-      TensorList tensors1,                                                 \
-      TensorList tensors2,                                                 \
-      const Tensor& scalars_) {                                            \
-    auto scalars = convert_tensor_to_scalar_list(scalars_, input.size());  \
-    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);    \
-    foreach_tensor_##OP##_scalarlist_slow_(                                \
-        input, tensors1, tensors2, scalars);                               \
+#define FOREACH_POINTWISE_OP_TENSOR(OP)                                   \
+  std::vector<Tensor> foreach_tensor_##OP##_tensor_slow(                  \
+      TensorList input,                                                   \
+      TensorList tensors1,                                                \
+      TensorList tensors2,                                                \
+      const Tensor& scalars_) {                                           \
+    auto scalars = convert_tensor_to_scalar_list(scalars_, input.size()); \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);   \
+    return foreach_tensor_##OP##_scalarlist_slow(                         \
+        input, tensors1, tensors2, scalars);                              \
+  }                                                                       \
+                                                                          \
+  void foreach_tensor_##OP##_tensor_slow_(                                \
+      TensorList input,                                                   \
+      TensorList tensors1,                                                \
+      TensorList tensors2,                                                \
+      const Tensor& scalars_) {                                           \
+    auto scalars = convert_tensor_to_scalar_list(scalars_, input.size()); \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);   \
+    foreach_tensor_##OP##_scalarlist_slow_(                               \
+        input, tensors1, tensors2, scalars);                              \
   }
 
 FOREACH_BINARY_OP_LIST_ALPHA(add);
@@ -291,22 +315,24 @@ FOREACH_POINTWISE_OP_SCALARLIST(addcmul);
 FOREACH_POINTWISE_OP_TENSOR(addcdiv);
 FOREACH_POINTWISE_OP_TENSOR(addcmul);
 
-#define FOREACH_TERNARY_OP(OP)                                                                                           \
-std::vector<Tensor> foreach_tensor_ternary_##OP##_slow(TensorList tensors1, TensorList tensors2, TensorList tensors3) {  \
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
-  std::vector<Tensor> result;                                                                                            \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
-    result.emplace_back(tensors1[i].OP(tensors2[i], tensors3[i]));                                                       \
-  }                                                                                                                      \
-  return result;                                                                                                         \
-}                                                                                                                        \
-                                                                                                                         \
-void foreach_tensor_ternary_##OP##_slow_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {                \
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
-    tensors1[i].OP##_(tensors2[i], tensors3[i]);                                                                         \
-  }                                                                                                                      \
-}                                                                                                                        \
+#define FOREACH_TERNARY_OP(OP)                                         \
+  std::vector<Tensor> foreach_tensor_ternary_##OP##_slow(              \
+      TensorList tensors1, TensorList tensors2, TensorList tensors3) { \
+    check_foreach_api_restrictions(tensors1, tensors2, tensors3);      \
+    std::vector<Tensor> result;                                        \
+    for (const auto i : c10::irange(tensors1.size())) {                \
+      result.emplace_back(tensors1[i].OP(tensors2[i], tensors3[i]));   \
+    }                                                                  \
+    return result;                                                     \
+  }                                                                    \
+                                                                       \
+  void foreach_tensor_ternary_##OP##_slow_(                            \
+      TensorList tensors1, TensorList tensors2, TensorList tensors3) { \
+    check_foreach_api_restrictions(tensors1, tensors2, tensors3);      \
+    for (const auto i : c10::irange(tensors1.size())) {                \
+      tensors1[i].OP##_(tensors2[i], tensors3[i]);                     \
+    }                                                                  \
+  }
 
 FOREACH_TERNARY_OP(lerp);
 
@@ -318,7 +344,9 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
   }
 }
 
-std::vector<Tensor> foreach_tensor_norm_slow(TensorList tensors, const Scalar& ord) {
+std::vector<Tensor> foreach_tensor_norm_slow(
+    TensorList tensors,
+    const Scalar& ord) {
   check_foreach_api_restrictions(tensors);
   std::vector<Tensor> result;
   for (const auto& t : tensors) {
@@ -327,14 +355,16 @@ std::vector<Tensor> foreach_tensor_norm_slow(TensorList tensors, const Scalar& o
   return result;
 }
 
-std::vector<Tensor> foreach_scalar_pow_list_kernel_slow(const Scalar& self, TensorList exponent) {
+std::vector<Tensor> foreach_scalar_pow_list_kernel_slow(
+    const Scalar& self,
+    TensorList exponent) {
   check_foreach_api_restrictions(exponent);
   std::vector<Tensor> result;
   result.reserve(exponent.size());
-  for (const auto & t : exponent) {
+  for (const auto& t : exponent) {
     result.emplace_back(at::pow(self, t));
   }
   return result;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
 #include <c10/util/irange.h>
-#include <ATen/Dispatch.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
@@ -10,18 +10,20 @@
 #include <ATen/ops/result_type_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 // Check if tensor list has either a boolean tensor or a integer tensor
 bool has_integral_tensor(TensorList tensors, const bool includeBool) {
-  return std::any_of(tensors.begin(), tensors.end(),
-    [&includeBool](const auto & t) { return at::isIntegralType(t.scalar_type(), includeBool); });
+  return std::any_of(
+      tensors.begin(), tensors.end(), [&includeBool](const auto& t) {
+        return at::isIntegralType(t.scalar_type(), includeBool);
+      });
 }
 // check if tensor list has bool tensors
 bool has_bool_tensor(TensorList tensors) {
-  return std::any_of(tensors.begin(), tensors.end(),
-    [](const auto & t) -> bool { return t.scalar_type() == ScalarType::Bool; });
+  return std::any_of(tensors.begin(), tensors.end(), [](const auto& t) -> bool {
+    return t.scalar_type() == ScalarType::Bool;
+  });
 }
 
 // Check foreach API restrictions
@@ -32,28 +34,59 @@ void check_foreach_api_restrictions(TensorList tensors) {
   TORCH_CHECK(!tensors.empty(), "Tensor list must have at least one tensor.");
 }
 
-void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars) {
+void check_foreach_api_restrictions(
+    TensorList tensors,
+    ArrayRef<Scalar> scalars) {
   check_foreach_api_restrictions(tensors);
-  TORCH_CHECK(tensors.size() == scalars.size(), "Tensor list must have same number of elements as scalar list.");
+  TORCH_CHECK(
+      tensors.size() == scalars.size(),
+      "Tensor list must have same number of elements as scalar list.");
 }
 
 void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
   TORCH_CHECK(!tensors1.empty(), "Tensor list must have at least one tensor.");
   TORCH_CHECK(!tensors2.empty(), "Tensor list must have at least one tensor.");
-  TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
+  TORCH_CHECK(
+      tensors1.size() == tensors2.size(),
+      "Tensor lists must have the same number of tensors, got ",
+      tensors1.size(),
+      " and ",
+      tensors2.size());
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+void check_foreach_api_restrictions(
+    TensorList tensors1,
+    TensorList tensors2,
+    TensorList tensors3) {
   TORCH_CHECK(!tensors1.empty(), "Tensor list must have at least one tensor.");
   TORCH_CHECK(!tensors2.empty(), "Tensor list must have at least one tensor.");
   TORCH_CHECK(!tensors3.empty(), "Tensor list must have at least one tensor.");
-  TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
-  TORCH_CHECK(tensors1.size() == tensors3.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors3.size());
+  TORCH_CHECK(
+      tensors1.size() == tensors2.size(),
+      "Tensor lists must have the same number of tensors, got ",
+      tensors1.size(),
+      " and ",
+      tensors2.size());
+  TORCH_CHECK(
+      tensors1.size() == tensors3.size(),
+      "Tensor lists must have the same number of tensors, got ",
+      tensors1.size(),
+      " and ",
+      tensors3.size());
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, ArrayRef<Scalar> scalars) {
+void check_foreach_api_restrictions(
+    TensorList tensors1,
+    TensorList tensors2,
+    TensorList tensors3,
+    ArrayRef<Scalar> scalars) {
   check_foreach_api_restrictions(tensors1, tensors2, tensors3);
-  TORCH_CHECK(tensors1.size() == scalars.size(), "Tensor list must have same number of elements as scalar list, got ", tensors1.size(), " and ", scalars.size());
+  TORCH_CHECK(
+      tensors1.size() == scalars.size(),
+      "Tensor list must have same number of elements as scalar list, got ",
+      tensors1.size(),
+      " and ",
+      scalars.size());
 }
 
 // To go via 'fast' path, several conditions must be satisfied
@@ -63,65 +96,67 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, Te
 // - All tensors must be non-overlapping and dense
 // - Resulting tensor must have the same dtype as the input one
 
-// Please, make sure to call check_foreach_api_restrictions before calling this method.
-// There is a set of preconditions that have to be satisfied.
+// Please, make sure to call check_foreach_api_restrictions before calling this
+// method. There is a set of preconditions that have to be satisfied.
 bool check_fast_path_restrictions(
-  ArrayRef<TensorList> tensorLists,
-  ArrayRef<Scalar> scalarList = {},
-  bool does_op_promote_integer_inputs_to_float = false) {
-    const auto expected_dtype = tensorLists[0][0].dtype();
-    const auto expected_device = tensorLists[0][0].device();
+    ArrayRef<TensorList> tensorLists,
+    ArrayRef<Scalar> scalarList = {},
+    bool does_op_promote_integer_inputs_to_float = false) {
+  const auto expected_dtype = tensorLists[0][0].dtype();
+  const auto expected_device = tensorLists[0][0].device();
 
-    auto is_tensor_okay = [&](const Tensor& tensor) {
-      return tensor.dtype() == expected_dtype &&
-             tensor.device() == expected_device &&
-             tensor.layout() == at::kStrided &&
-             tensor.is_non_overlapping_and_dense();
-    };
+  auto is_tensor_okay = [&](const Tensor& tensor) {
+    return tensor.dtype() == expected_dtype &&
+        tensor.device() == expected_device && tensor.layout() == at::kStrided &&
+        tensor.is_non_overlapping_and_dense();
+  };
 
-    for (const auto& tensorList : tensorLists) {
-      for (const auto& tensor : tensorList) {
-        if (!is_tensor_okay(tensor)) {
-          return false;
-        }
+  for (const auto& tensorList : tensorLists) {
+    for (const auto& tensor : tensorList) {
+      if (!is_tensor_okay(tensor)) {
+        return false;
       }
     }
+  }
 
-    // Check if corresponding tensors in tensor lists have the same sizes and strides.
-    for (const auto& tensor_list : tensorLists) {
-      for (const auto j : c10::irange(tensorLists[0].size())) {
-        if (tensorLists[0][j].sizes() != tensor_list[j].sizes()) {
-          return false;
-        }
-        if (tensorLists[0][j].strides() != tensor_list[j].strides()) {
-          return false;
-        }
+  // Check if corresponding tensors in tensor lists have the same sizes and
+  // strides.
+  for (const auto& tensor_list : tensorLists) {
+    for (const auto j : c10::irange(tensorLists[0].size())) {
+      if (tensorLists[0][j].sizes() != tensor_list[j].sizes()) {
+        return false;
+      }
+      if (tensorLists[0][j].strides() != tensor_list[j].strides()) {
+        return false;
       }
     }
+  }
 
-    // This function has already checked that `tensorList[j][i]` for all j, i has the same dtype
-    // using `is_tensor_okay` function above.
-    // This means we only need to check if {tensorList[0][0], tensorList[0][1], tensorList[0][2], ...}
-    // do type promotion with scalarLIst.
-    for (const auto i : c10::irange(tensorLists[0].size())) {
-      // For division, integer inputs will result in float.
-      if (does_op_promote_integer_inputs_to_float) {
-        if (at::isIntegralType(tensorLists[0][i].scalar_type(), /*includeBool*/ true)) {
-          return false;
-        }
-      }
-      if (!scalarList.empty()) {
-        const auto& scalar = scalarList.size() == 1 ? scalarList[0] : scalarList[i];
-        const auto& tensor = tensorLists[0][i];
-        // note(mkozuki): This check might be responsible for `_foreach_add(bool_tensors, bool_tensors)`
-        // being pushed to slow path.
-        if (tensor.scalar_type() != at::native::result_type(scalar, tensor)) {
-          return false;
-        }
+  // This function has already checked that `tensorList[j][i]` for all j, i has
+  // the same dtype using `is_tensor_okay` function above. This means we only
+  // need to check if {tensorList[0][0], tensorList[0][1], tensorList[0][2],
+  // ...} do type promotion with scalarLIst.
+  for (const auto i : c10::irange(tensorLists[0].size())) {
+    // For division, integer inputs will result in float.
+    if (does_op_promote_integer_inputs_to_float) {
+      if (at::isIntegralType(
+              tensorLists[0][i].scalar_type(), /*includeBool*/ true)) {
+        return false;
       }
     }
+    if (!scalarList.empty()) {
+      const auto& scalar =
+          scalarList.size() == 1 ? scalarList[0] : scalarList[i];
+      const auto& tensor = tensorLists[0][i];
+      // note(mkozuki): This check might be responsible for
+      // `_foreach_add(bool_tensors, bool_tensors)` being pushed to slow path.
+      if (tensor.scalar_type() != at::native::result_type(scalar, tensor)) {
+        return false;
+      }
+    }
+  }
 
-    return true;
+  return true;
 }
 
 std::vector<c10::Scalar> convert_tensor_to_scalar_list(
@@ -163,15 +198,21 @@ std::vector<c10::Scalar> convert_tensor_to_scalar_list(
   return scalarList;
 }
 
-bool can_use_fast_route(ArrayRef<TensorList> tensorLists,
-                        ArrayRef<Scalar> scalarList = {},
-                        bool does_op_promote_integer_inputs_to_float = false) {
-  return check_fast_path_restrictions(tensorLists, scalarList, does_op_promote_integer_inputs_to_float);
+bool can_use_fast_route(
+    ArrayRef<TensorList> tensorLists,
+    ArrayRef<Scalar> scalarList = {},
+    bool does_op_promote_integer_inputs_to_float = false) {
+  return check_fast_path_restrictions(
+      tensorLists, scalarList, does_op_promote_integer_inputs_to_float);
 }
 
-bool can_use_fast_route(TensorList tensors1, TensorList tensors2, bool does_op_promote_integer_inputs_to_float = false) {
-  return can_use_fast_route({tensors1, tensors2}, {}, does_op_promote_integer_inputs_to_float);
+bool can_use_fast_route(
+    TensorList tensors1,
+    TensorList tensors2,
+    bool does_op_promote_integer_inputs_to_float = false) {
+  return can_use_fast_route(
+      {tensors1, tensors2}, {}, does_op_promote_integer_inputs_to_float);
 }
 
-}
-}} // at::native
+} // namespace
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -8,149 +8,244 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_foreach_add_native.h>
+#include <ATen/ops/_foreach_clamp_max_native.h>
+#include <ATen/ops/_foreach_clamp_min_native.h>
 #include <ATen/ops/_foreach_div_native.h>
 #include <ATen/ops/_foreach_mul_native.h>
-#include <ATen/ops/_foreach_sub_native.h>
-#include <ATen/ops/_foreach_clamp_min_native.h>
-#include <ATen/ops/_foreach_clamp_max_native.h>
 #include <ATen/ops/_foreach_pow_native.h>
+#include <ATen/ops/_foreach_sub_native.h>
 
 #include <ATen/ops/empty_like_native.h>
 #endif
 
 namespace at::native {
 
-template<typename T, template<class> class Op>
-std::vector<Tensor> foreach_tensor_list_op(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(tensors1.size());
-    for (const auto& t: tensors1) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <typename T, template <class> class Op>
+std::vector<Tensor> foreach_tensor_list_op(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors1.size());
+  for (const auto& t : tensors1) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
-    tensor_lists.emplace_back(std::move(vec_res));
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<3>(tensor_lists,
-                          BinaryOpListAlphaFunctor<T,
-                                                   /* depth */ 3,
-                                                   /* r_args_depth */ 2,
-                                                   /* res_arg_index */ 2>(),
-                          Op<opmath_t>(),
-                          alpha.to<opmath_t>());
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<3>(
+      tensor_lists,
+      BinaryOpListAlphaFunctor<
+          T,
+          /* depth */ 3,
+          /* r_args_depth */ 2,
+          /* res_arg_index */ 2>(),
+      Op<opmath_t>(),
+      alpha.to<opmath_t>());
 
-    return tensor_lists[2];
+  return tensor_lists[2];
 }
 
-template<typename T, template<class> class Op>
-void foreach_tensor_list_op_(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
+template <typename T, template <class> class Op>
+void foreach_tensor_list_op_(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<2>(tensor_lists,
-                          BinaryOpListAlphaFunctor<T,
-                                                   /* depth */ 2,
-                                                   /* r_args_depth */ 2,
-                                                   /* res_arg_index */ 0>(),
-                          Op<opmath_t>(),
-                          alpha.to<opmath_t>());
-    increment_version(tensors1);
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<2>(
+      tensor_lists,
+      BinaryOpListAlphaFunctor<
+          T,
+          /* depth */ 2,
+          /* r_args_depth */ 2,
+          /* res_arg_index */ 0>(),
+      Op<opmath_t>(),
+      alpha.to<opmath_t>());
+  increment_version(tensors1);
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda", [&]() {
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda",
+      [&]() {
         return foreach_tensor_list_op<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-template<template<class> class Op>
-void all_types_complex_bool_half_bfloat16_(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda_", [&]() {
+template <template <class> class Op>
+void all_types_complex_bool_half_bfloat16_(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda_",
+      [&]() {
         foreach_tensor_list_op_<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    return AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda", [&]() {
+template <template <class> class Op>
+std::vector<Tensor> all_types_half_bfloat16(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  return AT_DISPATCH_ALL_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda",
+      [&]() {
         return foreach_tensor_list_op<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-template<template<class> class Op>
-void all_types_complex_half_bfloat16_(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda_", [&]() {
+template <template <class> class Op>
+void all_types_complex_half_bfloat16_(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda_",
+      [&]() {
         foreach_tensor_list_op_<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-template<template<class> class Op>
-void all_types_half_bfloat16_(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda_", [&]() {
+template <template <class> class Op>
+void all_types_half_bfloat16_(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda_",
+      [&]() {
         foreach_tensor_list_op_<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, tensors1[0].scalar_type(), "foreach_binary_op_list_cuda", [&]() {
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_half_bfloat16(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& alpha = 1) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kBFloat16,
+      kHalf,
+      tensors1[0].scalar_type(),
+      "foreach_binary_op_list_cuda",
+      [&]() {
         return foreach_tensor_list_op<scalar_t, Op>(tensors1, tensors2, alpha);
-    });
+      });
 }
 
-#define FOREACH_BINARY_OP_LIST(FUNCTION, NAME, OP, DIVISION_OP)                                             \
-void foreach_tensor_##NAME##_list_kernel_cuda_(TensorList tensors1, TensorList tensors2) {                  \
-    check_foreach_api_restrictions(tensors1, tensors2);                                                     \
-    if (!can_use_fast_route(tensors1, tensors2, DIVISION_OP)) {                                             \
-        return at::native::foreach_tensor_##NAME##_list_kernel_slow_(tensors1, tensors2);                   \
-    }                                                                                                       \
-                                                                                                            \
-    FUNCTION##_<OP>(tensors1, tensors2);                                                                    \
-}                                                                                                           \
-                                                                                                            \
-std::vector<Tensor> foreach_tensor_##NAME##_list_kernel_cuda(TensorList tensors1, TensorList tensors2) {    \
-    check_foreach_api_restrictions(tensors1, tensors2);                                                     \
-    if (!can_use_fast_route(tensors1, tensors2, DIVISION_OP)) {                                             \
-        return at::native::foreach_tensor_##NAME##_list_kernel_slow(tensors1, tensors2);                    \
-    }                                                                                                       \
-                                                                                                            \
-    return FUNCTION<OP>(tensors1, tensors2);                                                                \
-}
+#define FOREACH_BINARY_OP_LIST(FUNCTION, NAME, OP, DIVISION_OP)     \
+  void foreach_tensor_##NAME##_list_kernel_cuda_(                   \
+      TensorList tensors1, TensorList tensors2) {                   \
+    check_foreach_api_restrictions(tensors1, tensors2);             \
+    if (!can_use_fast_route(tensors1, tensors2, DIVISION_OP)) {     \
+      return at::native::foreach_tensor_##NAME##_list_kernel_slow_( \
+          tensors1, tensors2);                                      \
+    }                                                               \
+                                                                    \
+    FUNCTION##_<OP>(tensors1, tensors2);                            \
+  }                                                                 \
+                                                                    \
+  std::vector<Tensor> foreach_tensor_##NAME##_list_kernel_cuda(     \
+      TensorList tensors1, TensorList tensors2) {                   \
+    check_foreach_api_restrictions(tensors1, tensors2);             \
+    if (!can_use_fast_route(tensors1, tensors2, DIVISION_OP)) {     \
+      return at::native::foreach_tensor_##NAME##_list_kernel_slow(  \
+          tensors1, tensors2);                                      \
+    }                                                               \
+                                                                    \
+    return FUNCTION<OP>(tensors1, tensors2);                        \
+  }
 
-#define FOREACH_BINARY_OP_LIST_ALPHA(FUNCTION, NAME, OP)                                                                \
-void foreach_tensor_##NAME##_list_kernel_cuda_(TensorList tensors1, TensorList tensors2, const Scalar& alpha) {         \
-    check_foreach_api_restrictions(tensors1, tensors2);                                                                 \
-    if (!can_use_fast_route({tensors1, tensors2}, alpha)) {                                                             \
-        return at::native::foreach_tensor_##NAME##_list_kernel_slow_(tensors1, tensors2, alpha);                        \
-    }                                                                                                                   \
-                                                                                                                        \
-    FUNCTION##_<OP>(tensors1, tensors2, alpha);                                                                         \
-}                                                                                                                       \
-                                                                                                                        \
-std::vector<Tensor> foreach_tensor_##NAME##_list_kernel_cuda(TensorList tensors1, TensorList tensors2, const Scalar& alpha) {  \
-    check_foreach_api_restrictions(tensors1, tensors2);                                                                 \
-    if (!can_use_fast_route({tensors1, tensors2}, alpha)) {                                                             \
-        return at::native::foreach_tensor_##NAME##_list_kernel_slow(tensors1, tensors2, alpha);                         \
-    }                                                                                                                   \
-                                                                                                                        \
-    return FUNCTION<OP>(tensors1, tensors2, alpha);                                                                     \
-}
+#define FOREACH_BINARY_OP_LIST_ALPHA(FUNCTION, NAME, OP)               \
+  void foreach_tensor_##NAME##_list_kernel_cuda_(                      \
+      TensorList tensors1, TensorList tensors2, const Scalar& alpha) { \
+    check_foreach_api_restrictions(tensors1, tensors2);                \
+    if (!can_use_fast_route({tensors1, tensors2}, alpha)) {            \
+      return at::native::foreach_tensor_##NAME##_list_kernel_slow_(    \
+          tensors1, tensors2, alpha);                                  \
+    }                                                                  \
+                                                                       \
+    FUNCTION##_<OP>(tensors1, tensors2, alpha);                        \
+  }                                                                    \
+                                                                       \
+  std::vector<Tensor> foreach_tensor_##NAME##_list_kernel_cuda(        \
+      TensorList tensors1, TensorList tensors2, const Scalar& alpha) { \
+    check_foreach_api_restrictions(tensors1, tensors2);                \
+    if (!can_use_fast_route({tensors1, tensors2}, alpha)) {            \
+      return at::native::foreach_tensor_##NAME##_list_kernel_slow(     \
+          tensors1, tensors2, alpha);                                  \
+    }                                                                  \
+                                                                       \
+    return FUNCTION<OP>(tensors1, tensors2, alpha);                    \
+  }
 
-FOREACH_BINARY_OP_LIST_ALPHA(all_types_complex_bool_half_bfloat16, add, std::plus);
-FOREACH_BINARY_OP_LIST_ALPHA(all_types_complex_bool_half_bfloat16, sub, std::minus);
-FOREACH_BINARY_OP_LIST(all_types_complex_bool_half_bfloat16, mul, std::multiplies, /*division_op*/ false);
-FOREACH_BINARY_OP_LIST(all_types_complex_bool_half_bfloat16, div, std::divides, /*division_op*/ true);
-FOREACH_BINARY_OP_LIST(all_types_half_bfloat16, clamp_max, minimum, /*division_op*/ false);
-FOREACH_BINARY_OP_LIST(all_types_half_bfloat16, clamp_min, maximum, /*division_op*/ false);
+FOREACH_BINARY_OP_LIST_ALPHA(
+    all_types_complex_bool_half_bfloat16,
+    add,
+    std::plus);
+FOREACH_BINARY_OP_LIST_ALPHA(
+    all_types_complex_bool_half_bfloat16,
+    sub,
+    std::minus);
+FOREACH_BINARY_OP_LIST(
+    all_types_complex_bool_half_bfloat16,
+    mul,
+    std::multiplies,
+    /*division_op*/ false);
+FOREACH_BINARY_OP_LIST(
+    all_types_complex_bool_half_bfloat16,
+    div,
+    std::divides,
+    /*division_op*/ true);
+FOREACH_BINARY_OP_LIST(
+    all_types_half_bfloat16,
+    clamp_max,
+    minimum,
+    /*division_op*/ false);
+FOREACH_BINARY_OP_LIST(
+    all_types_half_bfloat16,
+    clamp_min,
+    maximum,
+    /*division_op*/ false);
 // NOTE(crcrpar): [Why is foreach_pow's division_op=true?]
-// To push integer inputs to slow path. This is because with integer type inputs the fast path behaves differently
-// from the slow one. Need to investigate later.
-FOREACH_BINARY_OP_LIST(all_types_complex_half_bfloat16, pow, power_functor, /*division_op*/ true);
+// To push integer inputs to slow path. This is because with integer type inputs
+// the fast path behaves differently from the slow one. Need to investigate
+// later.
+FOREACH_BINARY_OP_LIST(
+    all_types_complex_half_bfloat16,
+    pow,
+    power_functor,
+    /*division_op*/ true);
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
@@ -1,167 +1,242 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/ForeachUtils.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
-#include <ATen/native/BinaryOps.h>
 #include <ATen/native/cuda/ForeachMinMaxFunctors.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_foreach_add_native.h>
+#include <ATen/ops/_foreach_clamp_max_native.h>
+#include <ATen/ops/_foreach_clamp_min_native.h>
 #include <ATen/ops/_foreach_div_native.h>
 #include <ATen/ops/_foreach_mul_native.h>
-#include <ATen/ops/_foreach_sub_native.h>
-#include <ATen/ops/_foreach_clamp_min_native.h>
-#include <ATen/ops/_foreach_clamp_max_native.h>
 #include <ATen/ops/_foreach_pow_native.h>
+#include <ATen/ops/_foreach_sub_native.h>
 
 #include <ATen/ops/empty_like_native.h>
 #endif
 
 namespace at::native {
 
-template<typename T, template<class> class Op>
-std::vector<Tensor> foreach_binary_op(TensorList tensors, const Scalar& scalar) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(tensors.size());
-    for (const auto& t: tensors) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <typename T, template <class> class Op>
+std::vector<Tensor> foreach_binary_op(
+    TensorList tensors,
+    const Scalar& scalar) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(tensors.vec());
-    tensor_lists.emplace_back(std::move(vec_res));
+  tensor_lists.emplace_back(tensors.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<2>(tensor_lists,
-                          BinaryOpScalarFunctor<T,
-                                                /* depth */ 2,
-                                                /* r_args_depth */ 1,
-                                                /* res_arg_index */ 1>(),
-                          Op<opmath_t>(),
-                          scalar.to<opmath_t>());
-    return tensor_lists[1];
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<2>(
+      tensor_lists,
+      BinaryOpScalarFunctor<
+          T,
+          /* depth */ 2,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 1>(),
+      Op<opmath_t>(),
+      scalar.to<opmath_t>());
+  return tensor_lists[1];
 }
 
-template<typename T, template<class> class Op>
+template <typename T, template <class> class Op>
 void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(tensors.vec());
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(tensors.vec());
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<1>(tensor_lists,
-                          BinaryOpScalarFunctor<T,
-                                                /* depth */ 1,
-                                                /* r_args_depth */ 1,
-                                                /* res_arg_index */ 0>(),
-                                                Op<opmath_t>(),
-                          scalar.to<opmath_t>());
-    increment_version(tensors);
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<1>(
+      tensor_lists,
+      BinaryOpScalarFunctor<
+          T,
+          /* depth */ 1,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 0>(),
+      Op<opmath_t>(),
+      scalar.to<opmath_t>());
+  increment_version(tensors);
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(TensorList tensors, const Scalar& scalar) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalar);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+    TensorList tensors,
+    const Scalar& scalar) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalar); });
 }
 
-template<template<class> class Op>
-void all_types_complex_bool_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalar);
-    });
+template <template <class> class Op>
+void all_types_complex_bool_half_bfloat16_(
+    TensorList tensors,
+    const Scalar& scalar) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalar); });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(TensorList tensors, const Scalar& scalar) {
-    return AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalar);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_half_bfloat16(
+    TensorList tensors,
+    const Scalar& scalar) {
+  return AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalar); });
 }
 
-template<template<class> class Op>
+template <template <class> class Op>
 void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
-    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalar);
-    });
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalar); });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(TensorList tensors, const Scalar& scalar) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalar);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_half_bfloat16(
+    TensorList tensors,
+    const Scalar& scalar) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalar); });
 }
 
-template<template<class> class Op>
-void all_types_complex_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalar);
-    });
+template <template <class> class Op>
+void all_types_complex_half_bfloat16_(
+    TensorList tensors,
+    const Scalar& scalar) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalar); });
 }
 
-#define FOREACH_BINARY_OP_SCALAR(FUNCTION, NAME, OP, DIVISION_OP)                                   \
-void foreach_tensor_##NAME##_scalar_kernel_cuda_(TensorList tensors, const Scalar& scalar) {        \
-    check_foreach_api_restrictions(tensors);                                                        \
-    if (!can_use_fast_route(tensors, scalar, DIVISION_OP)) {                                        \
-        return at::native::foreach_tensor_##NAME##_scalar_kernel_slow_(tensors, scalar);            \
-    }                                                                                               \
-                                                                                                    \
-    FUNCTION##_<OP>(tensors, scalar);                                                               \
-}                                                                                                   \
-                                                                                                    \
-std::vector<Tensor> foreach_tensor_##NAME##_scalar_kernel_cuda(TensorList tensors, const Scalar& scalar) { \
-    check_foreach_api_restrictions(tensors);                                                        \
-    if (!can_use_fast_route(tensors, scalar, DIVISION_OP)) {                                        \
-        return at::native::foreach_tensor_##NAME##_scalar_kernel_slow(tensors, scalar);             \
-    }                                                                                               \
-                                                                                                    \
-    return FUNCTION<OP>(tensors, scalar);                                                           \
-}
+#define FOREACH_BINARY_OP_SCALAR(FUNCTION, NAME, OP, DIVISION_OP)     \
+  void foreach_tensor_##NAME##_scalar_kernel_cuda_(                   \
+      TensorList tensors, const Scalar& scalar) {                     \
+    check_foreach_api_restrictions(tensors);                          \
+    if (!can_use_fast_route(tensors, scalar, DIVISION_OP)) {          \
+      return at::native::foreach_tensor_##NAME##_scalar_kernel_slow_( \
+          tensors, scalar);                                           \
+    }                                                                 \
+                                                                      \
+    FUNCTION##_<OP>(tensors, scalar);                                 \
+  }                                                                   \
+                                                                      \
+  std::vector<Tensor> foreach_tensor_##NAME##_scalar_kernel_cuda(     \
+      TensorList tensors, const Scalar& scalar) {                     \
+    check_foreach_api_restrictions(tensors);                          \
+    if (!can_use_fast_route(tensors, scalar, DIVISION_OP)) {          \
+      return at::native::foreach_tensor_##NAME##_scalar_kernel_slow(  \
+          tensors, scalar);                                           \
+    }                                                                 \
+                                                                      \
+    return FUNCTION<OP>(tensors, scalar);                             \
+  }
 
-FOREACH_BINARY_OP_SCALAR(all_types_complex_bool_half_bfloat16, add, std::plus, /*div_op*/ false);
-FOREACH_BINARY_OP_SCALAR(all_types_complex_bool_half_bfloat16, mul, std::multiplies, /*div_op*/ false);
+FOREACH_BINARY_OP_SCALAR(
+    all_types_complex_bool_half_bfloat16,
+    add,
+    std::plus,
+    /*div_op*/ false);
+FOREACH_BINARY_OP_SCALAR(
+    all_types_complex_bool_half_bfloat16,
+    mul,
+    std::multiplies,
+    /*div_op*/ false);
 // See [Why is foreach_pow's division_op=true?]
-FOREACH_BINARY_OP_SCALAR(all_types_complex_half_bfloat16, pow, power_functor, /*div_op*/ true);
-std::vector<Tensor> foreach_scalar_pow_list_kernel_cuda(const Scalar& scalar, TensorList exponent) {
+FOREACH_BINARY_OP_SCALAR(
+    all_types_complex_half_bfloat16,
+    pow,
+    power_functor,
+    /*div_op*/ true);
+std::vector<Tensor> foreach_scalar_pow_list_kernel_cuda(
+    const Scalar& scalar,
+    TensorList exponent) {
   check_foreach_api_restrictions(exponent);
   if (!can_use_fast_route(exponent)) {
     return at::native::foreach_scalar_pow_list_kernel_slow(scalar, exponent);
   }
-  return all_types_complex_half_bfloat16<reverse_power_functor>(exponent, scalar);
+  return all_types_complex_half_bfloat16<reverse_power_functor>(
+      exponent, scalar);
 }
 
 // In the case of division, integer inputs will result in float.
-// Currently multi tensor apply can only return result of the same type as input.
-FOREACH_BINARY_OP_SCALAR(all_types_complex_bool_half_bfloat16, div, std::divides, /*div_op*/ true);
+// Currently multi tensor apply can only return result of the same type as
+// input.
+FOREACH_BINARY_OP_SCALAR(
+    all_types_complex_bool_half_bfloat16,
+    div,
+    std::divides,
+    /*div_op*/ true);
 
-// In the case of subtraction, we dont allow scalar to be boolean following the torch.sub logic
-void foreach_tensor_sub_scalar_kernel_cuda_(TensorList tensors, const Scalar& scalar) {
-    check_foreach_api_restrictions(tensors);
-    at::native::sub_check(tensors[0], scalar);
+// In the case of subtraction, we dont allow scalar to be boolean following the
+// torch.sub logic
+void foreach_tensor_sub_scalar_kernel_cuda_(
+    TensorList tensors,
+    const Scalar& scalar) {
+  check_foreach_api_restrictions(tensors);
+  at::native::sub_check(tensors[0], scalar);
 
-    if (!can_use_fast_route(tensors, scalar)) {
-        return at::native::foreach_tensor_sub_scalar_kernel_slow_(tensors, scalar);
-    }
+  if (!can_use_fast_route(tensors, scalar)) {
+    return at::native::foreach_tensor_sub_scalar_kernel_slow_(tensors, scalar);
+  }
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, std::minus>(tensors, scalar);
-    });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, std::minus>(tensors, scalar); });
 }
 
-std::vector<Tensor> foreach_tensor_sub_scalar_kernel_cuda(TensorList tensors, const Scalar& scalar) {
-    check_foreach_api_restrictions(tensors);
-    at::native::sub_check(tensors[0], scalar);
+std::vector<Tensor> foreach_tensor_sub_scalar_kernel_cuda(
+    TensorList tensors,
+    const Scalar& scalar) {
+  check_foreach_api_restrictions(tensors);
+  at::native::sub_check(tensors[0], scalar);
 
-    if (!can_use_fast_route(tensors, scalar)) {
-        return at::native::foreach_tensor_sub_scalar_kernel_slow(tensors, scalar);
-    }
+  if (!can_use_fast_route(tensors, scalar)) {
+    return at::native::foreach_tensor_sub_scalar_kernel_slow(tensors, scalar);
+  }
 
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalar_cuda", [&]() {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalar_cuda",
+      [&]() {
         return foreach_binary_op<scalar_t, std::minus>(tensors, scalar);
-    });
+      });
 }
 
 FOREACH_BINARY_OP_SCALAR(all_types_half_bfloat16, clamp_max, minimum, false);

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
@@ -1,166 +1,249 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/ForeachUtils.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
-#include <ATen/native/BinaryOps.h>
 #include <ATen/native/cuda/ForeachMinMaxFunctors.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_foreach_add_native.h>
+#include <ATen/ops/_foreach_clamp_max_native.h>
+#include <ATen/ops/_foreach_clamp_min_native.h>
 #include <ATen/ops/_foreach_div_native.h>
 #include <ATen/ops/_foreach_mul_native.h>
-#include <ATen/ops/_foreach_sub_native.h>
-#include <ATen/ops/_foreach_clamp_min_native.h>
-#include <ATen/ops/_foreach_clamp_max_native.h>
 #include <ATen/ops/_foreach_pow_native.h>
+#include <ATen/ops/_foreach_sub_native.h>
 
 #include <ATen/ops/empty_like_native.h>
 #endif
 
 namespace at::native {
 
-template<typename T, template<class> class Op>
-std::vector<Tensor> foreach_binary_op(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(tensors.size());
-    for (const auto& t: tensors) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <typename T, template <class> class Op>
+std::vector<Tensor> foreach_binary_op(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(tensors.vec());
-    tensor_lists.emplace_back(vec_res);
+  tensor_lists.emplace_back(tensors.vec());
+  tensor_lists.emplace_back(vec_res);
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<2, opmath_t>(tensor_lists,
-                                    scalars,
-                                    BinaryOpScalarListFunctor<T,
-                                                              /* depth */ 2,
-                                                              /* r_args_depth */ 1,
-                                                              /* res_arg_index */ 1>(),
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<2, opmath_t>(
+      tensor_lists,
+      scalars,
+      BinaryOpScalarListFunctor<
+          T,
+          /* depth */ 2,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 1>(),
 
-                                    Op<opmath_t>());
-    return tensor_lists[1];
+      Op<opmath_t>());
+  return tensor_lists[1];
 }
 
-template<typename T, template<class> class Op>
+template <typename T, template <class> class Op>
 void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(tensors.vec());
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(tensors.vec());
 
-    using opmath_t = at::opmath_type<T>;
-    multi_tensor_apply<1, opmath_t>(tensor_lists,
-                                    scalars,
-                                    BinaryOpScalarListFunctor<T,
-                                                              /* depth */ 1,
-                                                              /* r_args_depth */ 1,
-                                                              /* res_arg_index */ 0>(),
-                                    Op<opmath_t>());
-    increment_version(tensors);
+  using opmath_t = at::opmath_type<T>;
+  multi_tensor_apply<1, opmath_t>(
+      tensor_lists,
+      scalars,
+      BinaryOpScalarListFunctor<
+          T,
+          /* depth */ 1,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 0>(),
+      Op<opmath_t>());
+  increment_version(tensors);
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalars); });
 }
 
-template<template<class> class Op>
-void all_types_complex_bool_half_bfloat16_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+void all_types_complex_bool_half_bfloat16_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalars); });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    return AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_half_bfloat16(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  return AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalars); });
 }
 
-template<template<class> class Op>
-void all_types_half_bfloat16_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+void all_types_half_bfloat16_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalars); });
 }
 
-template<template<class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda", [&]() {
-        return foreach_binary_op<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+std::vector<Tensor> all_types_complex_half_bfloat16(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda",
+      [&]() { return foreach_binary_op<scalar_t, Op>(tensors, scalars); });
 }
 
-template<template<class> class Op>
-void all_types_complex_half_bfloat16_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, Op>(tensors, scalars);
-    });
+template <template <class> class Op>
+void all_types_complex_half_bfloat16_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, Op>(tensors, scalars); });
 }
 
-#define FOREACH_BINARY_OP_SCALARLIST(FUNCTION, NAME, OP, DIV_OP)                                                         \
-void foreach_tensor_##NAME##_scalarlist_kernel_cuda_(TensorList tensors, at::ArrayRef<Scalar> scalars) {                 \
-    check_foreach_api_restrictions(tensors, scalars);                                                                    \
-    if (!can_use_fast_route(tensors, scalars, DIV_OP)) {                                                                 \
-        return at::native::foreach_tensor_##NAME##_scalarlist_kernel_slow_(tensors, scalars);                            \
-    }                                                                                                                    \
-                                                                                                                         \
-    FUNCTION##_<OP>(tensors, scalars);                                                                                   \
-}                                                                                                                        \
-                                                                                                                         \
-std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_kernel_cuda(TensorList tensors, at::ArrayRef<Scalar> scalars) {   \
-    check_foreach_api_restrictions(tensors, scalars);                                                                    \
-    if (!can_use_fast_route(tensors, scalars, DIV_OP)) {                                                                 \
-        return at::native::foreach_tensor_##NAME##_scalarlist_kernel_slow(tensors, scalars);                             \
-    }                                                                                                                    \
-                                                                                                                         \
-    return FUNCTION<OP>(tensors, scalars);                                                                               \
-}
+#define FOREACH_BINARY_OP_SCALARLIST(FUNCTION, NAME, OP, DIV_OP)          \
+  void foreach_tensor_##NAME##_scalarlist_kernel_cuda_(                   \
+      TensorList tensors, at::ArrayRef<Scalar> scalars) {                 \
+    check_foreach_api_restrictions(tensors, scalars);                     \
+    if (!can_use_fast_route(tensors, scalars, DIV_OP)) {                  \
+      return at::native::foreach_tensor_##NAME##_scalarlist_kernel_slow_( \
+          tensors, scalars);                                              \
+    }                                                                     \
+                                                                          \
+    FUNCTION##_<OP>(tensors, scalars);                                    \
+  }                                                                       \
+                                                                          \
+  std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_kernel_cuda(     \
+      TensorList tensors, at::ArrayRef<Scalar> scalars) {                 \
+    check_foreach_api_restrictions(tensors, scalars);                     \
+    if (!can_use_fast_route(tensors, scalars, DIV_OP)) {                  \
+      return at::native::foreach_tensor_##NAME##_scalarlist_kernel_slow(  \
+          tensors, scalars);                                              \
+    }                                                                     \
+                                                                          \
+    return FUNCTION<OP>(tensors, scalars);                                \
+  }
 
-FOREACH_BINARY_OP_SCALARLIST(all_types_complex_bool_half_bfloat16, add, std::plus, /*div_op*/ false);
-FOREACH_BINARY_OP_SCALARLIST(all_types_complex_bool_half_bfloat16, mul, std::multiplies, /*div_op*/ false);
-FOREACH_BINARY_OP_SCALARLIST(all_types_complex_bool_half_bfloat16, div, std::divides, /*div_op*/ true);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_complex_bool_half_bfloat16,
+    add,
+    std::plus,
+    /*div_op*/ false);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_complex_bool_half_bfloat16,
+    mul,
+    std::multiplies,
+    /*div_op*/ false);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_complex_bool_half_bfloat16,
+    div,
+    std::divides,
+    /*div_op*/ true);
 // See [Why is foreach_pow's division_op=true?]
-FOREACH_BINARY_OP_SCALARLIST(all_types_complex_half_bfloat16, pow, power_functor, /*div_op*/ true);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_complex_half_bfloat16,
+    pow,
+    power_functor,
+    /*div_op*/ true);
 
 // This does not use FOREACH_BINARY_OP_SCALARLIST because
-// In the case of subtraction, we dont allow scalar to be boolean following the torch.sub logic
-void foreach_tensor_sub_scalarlist_kernel_cuda_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    check_foreach_api_restrictions(tensors, scalars);
-    for (const auto i: c10::irange(tensors.size())) {
-        sub_check(tensors[i], scalars[i]);
-    }
+// In the case of subtraction, we dont allow scalar to be boolean following the
+// torch.sub logic
+void foreach_tensor_sub_scalarlist_kernel_cuda_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  check_foreach_api_restrictions(tensors, scalars);
+  for (const auto i : c10::irange(tensors.size())) {
+    sub_check(tensors[i], scalars[i]);
+  }
 
-    if (!can_use_fast_route({tensors}, scalars)) {
-        return at::native::foreach_tensor_sub_scalarlist_kernel_slow_(tensors, scalars);
-    }
+  if (!can_use_fast_route({tensors}, scalars)) {
+    return at::native::foreach_tensor_sub_scalarlist_kernel_slow_(
+        tensors, scalars);
+  }
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
-        foreach_binary_op_<scalar_t, std::minus>(tensors, scalars);
-    });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda_",
+      [&]() { foreach_binary_op_<scalar_t, std::minus>(tensors, scalars); });
 }
 
-std::vector<Tensor> foreach_tensor_sub_scalarlist_kernel_cuda(TensorList tensors, at::ArrayRef<Scalar> scalars) {
-    check_foreach_api_restrictions(tensors, scalars);
-    for (const auto i: c10::irange(tensors.size())) {
-        sub_check(tensors[i], scalars[i]);
-    }
+std::vector<Tensor> foreach_tensor_sub_scalarlist_kernel_cuda(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
+  check_foreach_api_restrictions(tensors, scalars);
+  for (const auto i : c10::irange(tensors.size())) {
+    sub_check(tensors[i], scalars[i]);
+  }
 
-    if (!can_use_fast_route({tensors}, scalars)) {
-        return at::native::foreach_tensor_sub_scalarlist_kernel_slow(tensors, scalars);
-    }
+  if (!can_use_fast_route({tensors}, scalars)) {
+    return at::native::foreach_tensor_sub_scalarlist_kernel_slow(
+        tensors, scalars);
+  }
 
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      kBool,
+      kHalf,
+      kBFloat16,
+      tensors[0].scalar_type(),
+      "foreach_binary_op_scalarlist_cuda_",
+      [&]() {
         return foreach_binary_op<scalar_t, std::minus>(tensors, scalars);
-    });
+      });
 }
 
-FOREACH_BINARY_OP_SCALARLIST(all_types_half_bfloat16, clamp_max, minimum, false);
-FOREACH_BINARY_OP_SCALARLIST(all_types_half_bfloat16, clamp_min, maximum, false);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_half_bfloat16,
+    clamp_max,
+    minimum,
+    false);
+FOREACH_BINARY_OP_SCALARLIST(
+    all_types_half_bfloat16,
+    clamp_min,
+    maximum,
+    false);
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -1,105 +1,116 @@
 #pragma once
+#include <ATen/OpMathType.h>
 #include <ATen/native/ForeachUtils.h>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/Pow.cuh>
-#include <ATen/OpMathType.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
 // TODO(crcrpar): Handle version bump in codegen.
-// rel: https://github.com/pytorch/pytorch/blob/9cf84347767c8abb8feba18a9a1baba321eeb8b9/tools/autograd/gen_inplace_or_view_type.py#L481-L482
+// rel:
+// https://github.com/pytorch/pytorch/blob/9cf84347767c8abb8feba18a9a1baba321eeb8b9/tools/autograd/gen_inplace_or_view_type.py#L481-L482
 inline void increment_version(TensorList tensors) {
-  for (const auto & t : tensors) {
+  for (const auto& t : tensors) {
     t.unsafeGetTensorImpl()->bump_version();
   }
 }
 
 // Initializes args and checks if all args are aligned
-template<int depth, typename T>
+template <int depth, typename T>
 __device__ bool init_args(
     T** args,
     TensorListMetadata<depth>& tl,
     const int64_t chunk_idx,
     const int64_t chunk_size,
     const int64_t tensor_loc) {
-        bool all_aligned = true;
-        for (int i = 0; i < depth; i++) {
-            args[i] =  (T*)tl.addresses[i][tensor_loc];
-            args[i] += chunk_idx * chunk_size;
+  bool all_aligned = true;
+  for (int i = 0; i < depth; i++) {
+    args[i] = (T*)tl.addresses[i][tensor_loc];
+    args[i] += chunk_idx * chunk_size;
 
-            if (!is_aligned(args[i])) {
-                all_aligned = false;
-            }
-        }
-        return all_aligned;
+    if (!is_aligned(args[i])) {
+      all_aligned = false;
+    }
+  }
+  return all_aligned;
 }
 
 // Initializes args and checks if all args are aligned
-template<int depth, typename T, typename T2>
+template <int depth, typename T, typename T2>
 __device__ bool init_args(
     T** args,
     TensorListScalarListMetadata<T2, depth>& tl,
     const int64_t chunk_idx,
     const int64_t chunk_size,
     const int64_t tensor_loc) {
-        bool all_aligned = true;
-        for (int i = 0; i < depth; i++) {
-            args[i] =  (T*)tl.addresses[i][tensor_loc];
-            args[i] += chunk_idx * chunk_size;
+  bool all_aligned = true;
+  for (int i = 0; i < depth; i++) {
+    args[i] = (T*)tl.addresses[i][tensor_loc];
+    args[i] += chunk_idx * chunk_size;
 
-            if (!is_aligned(args[i])) {
-                all_aligned = false;
-            }
-        }
-        return all_aligned;
+    if (!is_aligned(args[i])) {
+      all_aligned = false;
+    }
+  }
+  return all_aligned;
 }
 
-template<int depth, typename T>
+template <int depth, typename T>
 __device__ bool init_args(
     T** args,
     FusedOptimizerTensorListMetadata<depth>& tl,
     const int64_t chunk_idx,
     const int64_t chunk_size,
     const int64_t tensor_loc) {
-        bool all_aligned = true;
-        for (int i = 0; i < depth; i++) {
-            args[i] =  (T*)tl.addresses[i][tensor_loc];
-            args[i] += chunk_idx * chunk_size;
+  bool all_aligned = true;
+  for (int i = 0; i < depth; i++) {
+    args[i] = (T*)tl.addresses[i][tensor_loc];
+    args[i] += chunk_idx * chunk_size;
 
-            if (!is_aligned(args[i])) {
-                all_aligned = false;
-            }
-        }
-        return all_aligned;
-}
-
-template<int depth, typename T>
-__device__ void load_args(T r_args[][kILP], T** args, const int64_t i_start, const int64_t chunk_size, const int64_t n) {
-#pragma unroll
-    for(int ii = 0; ii < kILP; ii++) {
-        const auto i = i_start + threadIdx.x + ii * blockDim.x;
-        for (int r_index = 0; r_index < depth; r_index++) {
-            r_args[r_index][ii] = 0;
-            if(i < n && i < chunk_size) {
-                r_args[r_index][ii] = args[r_index][i];
-            }
-        }
+    if (!is_aligned(args[i])) {
+      all_aligned = false;
     }
+  }
+  return all_aligned;
 }
 
-template<typename T>
-__device__ void store_args(T* dst, T* src, const int64_t i_start, const int64_t chunk_size, const int64_t n) {
+template <int depth, typename T>
+__device__ void load_args(
+    T r_args[][kILP],
+    T** args,
+    const int64_t i_start,
+    const int64_t chunk_size,
+    const int64_t n) {
 #pragma unroll
-    for(int ii = 0; ii < kILP; ii++) {
-        const int64_t i = i_start + threadIdx.x + ii * blockDim.x;
-        if(i < n && i < chunk_size)
-            dst[i] = src[ii];
+  for (int ii = 0; ii < kILP; ii++) {
+    const auto i = i_start + threadIdx.x + ii * blockDim.x;
+    for (int r_index = 0; r_index < depth; r_index++) {
+      r_args[r_index][ii] = 0;
+      if (i < n && i < chunk_size) {
+        r_args[r_index][ii] = args[r_index][i];
+      }
     }
+  }
 }
 
-template<int res_arg_index, typename Op, typename T, typename opmath_t>
+template <typename T>
+__device__ void store_args(
+    T* dst,
+    T* src,
+    const int64_t i_start,
+    const int64_t chunk_size,
+    const int64_t n) {
+#pragma unroll
+  for (int ii = 0; ii < kILP; ii++) {
+    const int64_t i = i_start + threadIdx.x + ii * blockDim.x;
+    if (i < n && i < chunk_size)
+      dst[i] = src[ii];
+  }
+}
+
+template <int res_arg_index, typename Op, typename T, typename opmath_t>
 __device__ __forceinline__ void binary_op_scalar(
     T r_args[][kILP],
     T** args,
@@ -108,35 +119,40 @@ __device__ __forceinline__ void binary_op_scalar(
     const int64_t chunk_size,
     const bool all_aligned,
     Op op) {
-        // to make things simple, we put aligned case in a different code path
-        if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-            for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-                // load
-                load_store(r_args[0], args[0], 0, i_start);
+  // to make things simple, we put aligned case in a different code path
+  if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+    for (int64_t i_start = threadIdx.x;
+         i_start * kILP < n && i_start * kILP < chunk_size;
+         i_start += blockDim.x) {
+      // load
+      load_store(r_args[0], args[0], 0, i_start);
 #pragma unroll
-                for(int ii = 0; ii < kILP; ii++) {
-                    r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                      static_cast<opmath_t>(scalar)));
-                }
-                // store
-                load_store(args[res_arg_index], r_args[0], i_start, 0);
-            }
-        }
-        else {
-            for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                // Regardless if depth is 1 (for inplace) or 2 (for out of place), r_args has depth 1
-                load_args<1>(r_args, args, i_start, chunk_size, n);
+      for (int ii = 0; ii < kILP; ii++) {
+        r_args[0][ii] = static_cast<T>(
+            op(static_cast<opmath_t>(r_args[0][ii]),
+               static_cast<opmath_t>(scalar)));
+      }
+      // store
+      load_store(args[res_arg_index], r_args[0], i_start, 0);
+    }
+  } else {
+    for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+         i_start += blockDim.x * kILP) {
+      // Regardless if depth is 1 (for inplace) or 2 (for out of place), r_args
+      // has depth 1
+      load_args<1>(r_args, args, i_start, chunk_size, n);
 #pragma unroll
-                for(int ii = 0; ii < kILP; ii++) {
-                    r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                      static_cast<opmath_t>(scalar)));
-                }
-                store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-            }
-        }
+      for (int ii = 0; ii < kILP; ii++) {
+        r_args[0][ii] = static_cast<T>(
+            op(static_cast<opmath_t>(r_args[0][ii]),
+               static_cast<opmath_t>(scalar)));
+      }
+      store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+    }
+  }
 }
 
-template<int res_arg_index, typename Op, typename T, typename opmath_t>
+template <int res_arg_index, typename Op, typename T, typename opmath_t>
 __device__ __forceinline__ void pointwise_op_scalar(
     T r_args[][kILP],
     T** args,
@@ -145,307 +161,348 @@ __device__ __forceinline__ void pointwise_op_scalar(
     const int64_t chunk_size,
     const bool all_aligned,
     Op op) {
-        // to make things simple, we put aligned case in a different code path
-        if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-            for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-                // load
-                load_store(r_args[0], args[0], 0, i_start);
-                load_store(r_args[1], args[1], 0, i_start);
-                load_store(r_args[2], args[2], 0, i_start);
+  // to make things simple, we put aligned case in a different code path
+  if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+    for (int64_t i_start = threadIdx.x;
+         i_start * kILP < n && i_start * kILP < chunk_size;
+         i_start += blockDim.x) {
+      // load
+      load_store(r_args[0], args[0], 0, i_start);
+      load_store(r_args[1], args[1], 0, i_start);
+      load_store(r_args[2], args[2], 0, i_start);
 #pragma unroll
-                for(int ii = 0; ii < kILP; ii++) {
-                    r_args[0][ii] = static_cast<T>(static_cast<opmath_t>(r_args[0][ii]) +
-                                                   scalar * op(static_cast<opmath_t>(r_args[1][ii]),
-                                                               static_cast<opmath_t>(r_args[2][ii])));
-                }
-                // store
-                load_store(args[res_arg_index], r_args[0], i_start, 0);
-            }
-        }
-        else {
-            for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                // Regardless if depth is 3 (for inplace) or 4 (for out of place), r_args has depth 3
-                load_args<3>(r_args, args, i_start, chunk_size, n);
+      for (int ii = 0; ii < kILP; ii++) {
+        r_args[0][ii] = static_cast<T>(
+            static_cast<opmath_t>(r_args[0][ii]) +
+            scalar *
+                op(static_cast<opmath_t>(r_args[1][ii]),
+                   static_cast<opmath_t>(r_args[2][ii])));
+      }
+      // store
+      load_store(args[res_arg_index], r_args[0], i_start, 0);
+    }
+  } else {
+    for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+         i_start += blockDim.x * kILP) {
+      // Regardless if depth is 3 (for inplace) or 4 (for out of place), r_args
+      // has depth 3
+      load_args<3>(r_args, args, i_start, chunk_size, n);
 #pragma unroll
-                for(int ii = 0; ii < kILP; ii++) {
-                    r_args[0][ii] = static_cast<T>(static_cast<opmath_t>(r_args[0][ii]) +
-                                                   scalar * op(static_cast<opmath_t>(r_args[1][ii]),
-                                                               static_cast<opmath_t>(r_args[2][ii])));
-                }
-                store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-            }
-        }
+      for (int ii = 0; ii < kILP; ii++) {
+        r_args[0][ii] = static_cast<T>(
+            static_cast<opmath_t>(r_args[0][ii]) +
+            scalar *
+                op(static_cast<opmath_t>(r_args[1][ii]),
+                   static_cast<opmath_t>(r_args[2][ii])));
+      }
+      store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+    }
+  }
 }
 
 //
 // Binary Functors
 //
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpScalarFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<depth>& tl,
-        Op op,
-        opmath_t scalar) {
-            const int tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const int chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t scalar) {
+    const int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            binary_op_scalar<res_arg_index>(r_args, args, scalar, n, chunk_size, all_aligned, op);
-        }
+    binary_op_scalar<res_arg_index>(
+        r_args, args, scalar, n, chunk_size, all_aligned, op);
+  }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpScalarListFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListScalarListMetadata<opmath_t, depth>& tl,
-        Op op) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListScalarListMetadata<opmath_t, depth>& tl,
+      Op op) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            opmath_t scalar = tl.scalar_vals[tensor_loc];
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    opmath_t scalar = tl.scalar_vals[tensor_loc];
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            binary_op_scalar<res_arg_index>(r_args, args, scalar, n, chunk_size, all_aligned, op);
-        }
+    binary_op_scalar<res_arg_index>(
+        r_args, args, scalar, n, chunk_size, all_aligned, op);
+  }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpListAlphaFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<depth>& tl,
-        Op op,
-        opmath_t alpha) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t alpha) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            // to make things simple, we put aligned case in a different code path
-            if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-                for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-                    // load
-                    load_store(r_args[0], args[0], 0, i_start);
-                    load_store(r_args[1], args[1], 0, i_start);
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
+        // load
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
 #pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                          alpha * static_cast<opmath_t>(r_args[1][ii])));
-                    }
-                    // store
-                    load_store(args[res_arg_index], r_args[0], i_start , 0);
-                }
-            }
-            else {
-                for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                    load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
-#pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                          alpha * static_cast<opmath_t>(r_args[1][ii])));
-                    }
-                    store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-                }
-            }
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = static_cast<T>(
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 alpha * static_cast<opmath_t>(r_args[1][ii])));
         }
+        // store
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = static_cast<T>(
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 alpha * static_cast<opmath_t>(r_args[1][ii])));
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
 };
 
 //
 // Unary Functors
 //
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct ZeroFunctor {
-    __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<1>& tl) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<1>& tl) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const auto all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const auto all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            // to make things simple, we put aligned case in a different code path
-            if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-                for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
 #pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = 0;
-                    }
-                    // store
-                    load_store(args[0], r_args[0], i_start, 0);
-                }
-            }
-            else {
-                for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-#pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = 0;
-                    }
-                    store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-                }
-            }
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = 0;
         }
+        // store
+        load_store(args[0], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = 0;
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct UnaryOpFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<depth>& tl,
-        Op op) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            // to make things simple, we put aligned case in a different code path
-            if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-                for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-                    // load
-                    load_store(r_args[0], args[0], 0, i_start);
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
+        // load
+        load_store(r_args[0], args[0], 0, i_start);
 #pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii])));
-                    }
-                    // store
-                    load_store(args[res_arg_index], r_args[0], i_start, 0);
-                }
-            }
-            else {
-                for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                    load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
-#pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii])));
-                    }
-                    store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-                }
-            }
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] =
+              static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii])));
         }
+        // store
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] =
+              static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii])));
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
 };
 
 //
 // Pointwise Functors
 //
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct PointwiseOpScalarFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<depth>& tl,
-        Op op,
-        opmath_t scalar) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t scalar) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            pointwise_op_scalar<res_arg_index>(r_args, args, scalar, n, chunk_size, all_aligned, op);
-        }
+    pointwise_op_scalar<res_arg_index>(
+        r_args, args, scalar, n, chunk_size, all_aligned, op);
+  }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct PointwiseOpScalarListFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListScalarListMetadata<opmath_t, depth>& tl,
-        Op op) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListScalarListMetadata<opmath_t, depth>& tl,
+      Op op) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            opmath_t scalar = tl.scalar_vals[tensor_loc];
-            n -= chunk_idx * chunk_size;
-            T r_args[r_args_depth][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    opmath_t scalar = tl.scalar_vals[tensor_loc];
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
 
-            pointwise_op_scalar<res_arg_index>(r_args, args, scalar, n, chunk_size, all_aligned, op);
-        }
+    pointwise_op_scalar<res_arg_index>(
+        r_args, args, scalar, n, chunk_size, all_aligned, op);
+  }
 };
 
-template<typename T, int depth>
+template <typename T, int depth>
 struct PointwiseOpListFunctor {
-    using opmath_t = at::opmath_type<T>;
-    template<typename Op> __device__ __forceinline__ void operator() (
-        int chunk_size,
-        TensorListMetadata<depth>& tl,
-        Op op) {
-            const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
-            const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
-            auto n = tl.numel_for_tensor[tensor_loc];
+  using opmath_t = at::opmath_type<T>;
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op) {
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    auto n = tl.numel_for_tensor[tensor_loc];
 
-            T* args[depth];
-            const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-            n -= chunk_idx * chunk_size;
-            T r_args[depth - 1][kILP];
+    T* args[depth];
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[depth - 1][kILP];
 
-            // to make things simple, we put aligned case in a different code path
-            if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-                for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-                    // load
-                    load_store(r_args[0], args[0], 0, i_start);
-                    load_store(r_args[1], args[1], 0, i_start);
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
+        // load
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
 #pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                          static_cast<opmath_t>(r_args[1][ii])));
-                    }
-                    // store
-                    load_store(args[2], r_args[0], i_start , 0);
-                }
-            }
-            else {
-                for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                    load_args<depth - 1>(r_args, args, i_start, chunk_size, n);
-#pragma unroll
-                    for(int ii = 0; ii < kILP; ii++) {
-                        r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),
-                                                          static_cast<opmath_t>(r_args[1][ii])));
-                    }
-                    store_args(args[2], r_args[0], i_start, chunk_size, n);
-                }
-            }
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = static_cast<T>(
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii])));
         }
+        // store
+        load_store(args[2], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
+        load_args<depth - 1>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = static_cast<T>(
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii])));
+        }
+        store_args(args[2], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct TernaryOpListFunctor {
   using opmath_t = at::opmath_type<T>;
-  template<typename Op> __device__ __forceinline__ void operator() (
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
       Op op) {
@@ -457,35 +514,37 @@ struct TernaryOpListFunctor {
     auto n = tl.numel_for_tensor[tensor_loc];
 
     T* args[depth];
-    const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
     n -= chunk_idx * chunk_size;
     T r_args[r_args_depth][kILP];
 
     if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-      for (int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
         load_store(r_args[0], args[0], 0, i_start);
         load_store(r_args[1], args[1], 0, i_start);
         load_store(r_args[2], args[2], 0, i_start);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              static_cast<opmath_t>(r_args[2][ii])
-          );
+          r_args[0][ii] =
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii]),
+                 static_cast<opmath_t>(r_args[2][ii]));
         }
         load_store(args[res_arg_index], r_args[0], i_start, 0);
       }
     } else {
-      for (int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
         load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              static_cast<opmath_t>(r_args[2][ii])
-          );
+          r_args[0][ii] =
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii]),
+                 static_cast<opmath_t>(r_args[2][ii]));
         }
         store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
       }
@@ -493,10 +552,11 @@ struct TernaryOpListFunctor {
   }
 };
 
-template<typename T, int depth, int r_args_depth, int res_arg_index>
+template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct TernaryOpScalarFunctor {
   using opmath_t = at::opmath_type<T>;
-  template<typename Op> __device__ __forceinline__ void operator() (
+  template <typename Op>
+  __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
       Op op,
@@ -509,38 +569,39 @@ struct TernaryOpScalarFunctor {
     auto n = tl.numel_for_tensor[tensor_loc];
 
     T* args[depth];
-    const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    const bool all_aligned =
+        init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
     n -= chunk_idx * chunk_size;
     T r_args[r_args_depth][kILP];
 
     // to make things simple, we put aligned case in a different code path
     if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-      for(int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
         // load
         load_store(r_args[0], args[0], 0, i_start);
         load_store(r_args[1], args[1], 0, i_start);
 #pragma unroll
-        for(int ii = 0; ii < kILP; ii++) {
-            r_args[0][ii] = op(
-                static_cast<opmath_t>(r_args[0][ii]),
-                static_cast<opmath_t>(r_args[1][ii]),
-                alpha
-            );
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] =
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii]),
+                 alpha);
         }
         // store
-        load_store(args[res_arg_index], r_args[0], i_start , 0);
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
       }
-    }
-    else {
-      for(int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+    } else {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
         load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
 #pragma unroll
-        for(int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              alpha
-          );
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] =
+              op(static_cast<opmath_t>(r_args[0][ii]),
+                 static_cast<opmath_t>(r_args[1][ii]),
+                 alpha);
         }
         store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
       }
@@ -563,4 +624,4 @@ struct reverse_power_functor {
 };
 
 } // namespace
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachMinMaxFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachMinMaxFunctors.cuh
@@ -2,18 +2,21 @@
 
 #include <ATen/NumericUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // std:: does not have clamp functors
 template <typename T>
 struct minimum {
-    __device__ T operator()(const T& a, const T& b) const { return (_isnan(a) || a < b) ? a : b; }
+  __device__ T operator()(const T& a, const T& b) const {
+    return (_isnan(a) || a < b) ? a : b;
+  }
 };
 
 template <typename T>
 struct maximum {
-    __device__ T operator()(const T& a, const T& b) const { return (_isnan(a) || a > b) ? a : b; }
+  __device__ T operator()(const T& a, const T& b) const {
+    return (_isnan(a) || a > b) ? a : b;
+  }
 };
 
-}} // at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -1,8 +1,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/NumericUtils.h>
 #include <ATen/native/ForeachUtils.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
-#include <ATen/NumericUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
@@ -21,146 +21,213 @@
 
 namespace at::native {
 
-template<template<class> class Op>
-std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(input.size());
-    for (const auto& t: input) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <template <class> class Op>
+std::vector<Tensor> foreach_pointwise_op(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& scalar) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(input.size());
+  for (const auto& t : input) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(input.vec());
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
-    tensor_lists.emplace_back(std::move(vec_res));
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op_cuda",
+      [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        multi_tensor_apply<4>(tensor_lists,
-                              PointwiseOpScalarFunctor<scalar_t,
-                                                       /* depth */ 4,
-                                                       /* r_args_depth */ 3,
-                                                       /* res_arg_index */ 3>(),
-                              Op<opmath_t>(),
-                              scalar.to<opmath_t>());
-    });
+        multi_tensor_apply<4>(
+            tensor_lists,
+            PointwiseOpScalarFunctor<
+                scalar_t,
+                /* depth */ 4,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 3>(),
+            Op<opmath_t>(),
+            scalar.to<opmath_t>());
+      });
 
-    return tensor_lists[3];
+  return tensor_lists[3];
 }
 
-template<template<class> class Op>
-void foreach_pointwise_op_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(input.vec());
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
+template <template <class> class Op>
+void foreach_pointwise_op_(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& scalar) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op__cuda",
+      [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        multi_tensor_apply<3>(tensor_lists,
-                              PointwiseOpScalarFunctor<scalar_t,
-                                                       /* depth */ 3,
-                                                       /* r_args_depth */ 3,
-                                                       /* res_arg_index */ 0>(),
-                              Op<opmath_t>(),
-                              scalar.to<opmath_t>());
-    });
-    increment_version(input);
+        multi_tensor_apply<3>(
+            tensor_lists,
+            PointwiseOpScalarFunctor<
+                scalar_t,
+                /* depth */ 3,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 0>(),
+            Op<opmath_t>(),
+            scalar.to<opmath_t>());
+      });
+  increment_version(input);
 }
 
-template<template<class> class Op>
-void foreach_pointwise_op_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.reserve(3);
-    tensor_lists.emplace_back(input.vec());
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
+template <template <class> class Op>
+void foreach_pointwise_op_(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    at::ArrayRef<Scalar> scalars) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.reserve(3);
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op__cuda",
+      [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        multi_tensor_apply<3, opmath_t>(tensor_lists,
-                                        scalars,
-                                        PointwiseOpScalarListFunctor<scalar_t,
-                                                                     /* depth */ 3,
-                                                                     /* r_args_depth */ 3,
-                                                                     /* res_arg_index */ 0>(),
-                                        Op<opmath_t>());
-    });
-    increment_version(input);
+        multi_tensor_apply<3, opmath_t>(
+            tensor_lists,
+            scalars,
+            PointwiseOpScalarListFunctor<
+                scalar_t,
+                /* depth */ 3,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 0>(),
+            Op<opmath_t>());
+      });
+  increment_version(input);
 }
 
-template<template<class> class Op>
-std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.reserve(4);
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(input.size());
-    for (const auto& t: input) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <template <class> class Op>
+std::vector<Tensor> foreach_pointwise_op(
+    TensorList input,
+    TensorList tensors1,
+    TensorList tensors2,
+    at::ArrayRef<Scalar> scalars) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.reserve(4);
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(input.size());
+  for (const auto& t : input) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(input.vec());
-    tensor_lists.emplace_back(tensors1.vec());
-    tensor_lists.emplace_back(tensors2.vec());
-    tensor_lists.emplace_back(std::move(vec_res));
+  tensor_lists.emplace_back(input.vec());
+  tensor_lists.emplace_back(tensors1.vec());
+  tensor_lists.emplace_back(tensors2.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      kHalf,
+      kBFloat16,
+      input[0].scalar_type(),
+      "foreach_pointwise_op_cuda",
+      [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
-        multi_tensor_apply<4, opmath_t>(tensor_lists,
-                                        scalars,
-                                        PointwiseOpScalarListFunctor<scalar_t,
-                                                                     /* depth */ 4,
-                                                                     /* r_args_depth */ 3,
-                                                                     /* res_arg_index */ 3>(),
-                                        Op<opmath_t>());
-    });
+        multi_tensor_apply<4, opmath_t>(
+            tensor_lists,
+            scalars,
+            PointwiseOpScalarListFunctor<
+                scalar_t,
+                /* depth */ 4,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 3>(),
+            Op<opmath_t>());
+      });
 
-    return tensor_lists[3];
+  return tensor_lists[3];
 }
 
-#define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                                                                                         \
-std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {  \
-    check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
-                                                                                                                                      \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral_tensor(input, /* includeBool */ true)) {             \
-        return at::native::foreach_tensor_##NAME##_scalar_slow(input, tensors1, tensors2, scalar);                                    \
-    }                                                                                                                                 \
-                                                                                                                                      \
-    return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalar);                                                               \
-}                                                                                                                                     \
-                                                                                                                                      \
-void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                \
-    check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
-                                                                                                                                      \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral_tensor(input, /* includeBool */ true)) {             \
-        return at::native::foreach_tensor_##NAME##_scalar_slow_(input, tensors1, tensors2, scalar);                                   \
-    }                                                                                                                                 \
-                                                                                                                                      \
-    foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalar);                                                                     \
-}
+#define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                           \
+  std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(              \
+      TensorList input,                                                 \
+      TensorList tensors1,                                              \
+      TensorList tensors2,                                              \
+      const Scalar& scalar) {                                           \
+    check_foreach_api_restrictions(input, tensors1, tensors2);          \
+                                                                        \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) ||     \
+        has_integral_tensor(input, /* includeBool */ true)) {           \
+      return at::native::foreach_tensor_##NAME##_scalar_slow(           \
+          input, tensors1, tensors2, scalar);                           \
+    }                                                                   \
+                                                                        \
+    return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalar); \
+  }                                                                     \
+                                                                        \
+  void foreach_tensor_##NAME##_scalar_cuda_(                            \
+      TensorList input,                                                 \
+      TensorList tensors1,                                              \
+      TensorList tensors2,                                              \
+      const Scalar& scalar) {                                           \
+    check_foreach_api_restrictions(input, tensors1, tensors2);          \
+                                                                        \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) ||     \
+        has_integral_tensor(input, /* includeBool */ true)) {           \
+      return at::native::foreach_tensor_##NAME##_scalar_slow_(          \
+          input, tensors1, tensors2, scalar);                           \
+    }                                                                   \
+                                                                        \
+    foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalar);       \
+  }
 
-
-#define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                                                                                                        \
-std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {  \
-    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
-                                                                                                                                                         \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral_tensor(input, /* includeBool */ true)) {                               \
-        return at::native::foreach_tensor_##NAME##_scalarlist_slow(input, tensors1, tensors2, scalars);                                                  \
-    }                                                                                                                                                    \
-                                                                                                                                                         \
-    return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalars);                                                                                 \
-}                                                                                                                                                        \
-                                                                                                                                                         \
-void foreach_tensor_##NAME##_scalarlist_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                \
-    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
-                                                                                                                                                         \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral_tensor(input, /* includeBool */ true)) {                               \
-        return at::native::foreach_tensor_##NAME##_scalarlist_slow_(input, tensors1, tensors2, scalars);                                                 \
-    }                                                                                                                                                    \
-                                                                                                                                                         \
-    foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalars);                                                                                       \
-}
+#define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                        \
+  std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(           \
+      TensorList input,                                                  \
+      TensorList tensors1,                                               \
+      TensorList tensors2,                                               \
+      at::ArrayRef<Scalar> scalars) {                                    \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);  \
+                                                                         \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) ||     \
+        has_integral_tensor(input, /* includeBool */ true)) {            \
+      return at::native::foreach_tensor_##NAME##_scalarlist_slow(        \
+          input, tensors1, tensors2, scalars);                           \
+    }                                                                    \
+                                                                         \
+    return foreach_pointwise_op<OP>(input, tensors1, tensors2, scalars); \
+  }                                                                      \
+                                                                         \
+  void foreach_tensor_##NAME##_scalarlist_cuda_(                         \
+      TensorList input,                                                  \
+      TensorList tensors1,                                               \
+      TensorList tensors2,                                               \
+      at::ArrayRef<Scalar> scalars) {                                    \
+    check_foreach_api_restrictions(input, tensors1, tensors2, scalars);  \
+                                                                         \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) ||     \
+        has_integral_tensor(input, /* includeBool */ true)) {            \
+      return at::native::foreach_tensor_##NAME##_scalarlist_slow_(       \
+          input, tensors1, tensors2, scalars);                           \
+    }                                                                    \
+                                                                         \
+    foreach_pointwise_op_<OP>(input, tensors1, tensors2, scalars);       \
+  }
 
 #define FOREACH_POINTWISE_OP_TENSOR(NAME, OP)                             \
   std::vector<Tensor> foreach_tensor_##NAME##_tensor_cuda(                \

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -1,12 +1,12 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/Dispatch.h>
 #include <ATen/AccumulateType.h>
+#include <ATen/Dispatch.h>
 #include <ATen/OpMathType.h>
-#include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/native/ForeachUtils.h>
-#include <ATen/native/cuda/block_reduce.cuh>
+#include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
+#include <ATen/native/cuda/block_reduce.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -14,23 +14,28 @@
 #else
 #include <ATen/ops/_foreach_norm_native.h>
 
-#include <ATen/ops/zeros.h>
 #include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
 #endif
-
 
 namespace at::native {
 
-template<typename T, int NormType, int depth=1, int r_args_depth=1, int res_arg_index=0>
+template <
+    typename T,
+    int NormType,
+    int depth = 1,
+    int r_args_depth = 1,
+    int res_arg_index = 0>
 struct LpNormFunctor {
-  static_assert(NormType == 1 || NormType == 2, "foreach_norm supports only L1 and L2 norm");
+  static_assert(
+      NormType == 1 || NormType == 2,
+      "foreach_norm supports only L1 and L2 norm");
   using opmath_t = typename at::opmath_type<T>;
-  __device__ __forceinline__ void operator() (
+  __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
       opmath_t* output_per_tensor,
-      const int max_chunks_per_tensor
-  ) {
+      const int max_chunks_per_tensor) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
     auto n = tl.numel_for_tensor[tensor_loc];
@@ -48,17 +53,20 @@ struct LpNormFunctor {
     }
 
     if (n % kILP == 0 && (chunk_size & kILP) == 0 && is_aligned(x)) {
-      for (int64_t i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+      for (int64_t i_start = threadIdx.x;
+           i_start * kILP < n && i_start * kILP < chunk_size;
+           i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
           opmath_t next = static_cast<opmath_t>(r_x[ii]);
-          vals[ii] += NormType == 1 ? ::abs(next)  : next * next;
+          vals[ii] += NormType == 1 ? ::abs(next) : next * next;
         }
       }
     } else {
-      for (int64_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+      for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
+           i_start += blockDim.x * kILP) {
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
           int i = i_start + threadIdx.x + ii * blockDim.x;
@@ -77,48 +85,56 @@ struct LpNormFunctor {
     auto final = at::native::cuda_utils::BlockReduceSum(val, s_vals);
 
     if (threadIdx.x == 0) {
-      output_per_tensor[(tl.start_tensor_this_launch + tensor_loc) * max_chunks_per_tensor + chunk_idx] = final;
+      output_per_tensor
+          [(tl.start_tensor_this_launch + tensor_loc) * max_chunks_per_tensor +
+           chunk_idx] = final;
     }
   }
 };
 
-template<typename T, int NormType, typename opmath_t = at::opmath_type<T>>
+template <typename T, int NormType, typename opmath_t = at::opmath_type<T>>
 __global__ void lpnorm_cleanup(
     const opmath_t* output_per_tensor,
     T* ret_per_tensor,
     int max_chunks_per_tensor) {
   __shared__ opmath_t vals[512];
 
-  const opmath_t* output_this_tensor = output_per_tensor + blockIdx.x*max_chunks_per_tensor;
+  const opmath_t* output_this_tensor =
+      output_per_tensor + blockIdx.x * max_chunks_per_tensor;
   opmath_t val = 0;
   for (int i = threadIdx.x; i < max_chunks_per_tensor; i += blockDim.x) {
     val += output_this_tensor[i];
   }
   opmath_t final = at::native::cuda_utils::BlockReduceSum<opmath_t>(val, vals);
-  if(threadIdx.x == 0) {
+  if (threadIdx.x == 0) {
     ret_per_tensor[blockIdx.x] = NormType == 1 ? final : ::sqrt(final);
   }
 }
 
 // note(mkozuki): Why excluding Int and Complex from fast path
 // - Int: at::norm does not support.
-// - Complex: __shfl_down_sync does not support complex and foreach does not support functions whose inputs dtypes and output dtype are different.
-std::vector<Tensor> foreach_tensor_norm_cuda(TensorList tensors, const Scalar& ord) {
+// - Complex: __shfl_down_sync does not support complex and foreach does not
+// support functions whose inputs dtypes and output dtype are different.
+std::vector<Tensor> foreach_tensor_norm_cuda(
+    TensorList tensors,
+    const Scalar& ord) {
   double p;
   if (ord.isIntegral(false)) {
     p = ord.to<int64_t>();
   } else if (ord.isFloatingPoint()) {
     p = ord.to<double>();
   } else {
-    TORCH_CHECK(false, "foreach_tensor_norm_cuda expects ord to be integer or float");
+    TORCH_CHECK(
+        false, "foreach_tensor_norm_cuda expects ord to be integer or float");
   }
   check_foreach_api_restrictions(tensors);
-  const bool has_int_or_complex = std::any_of(tensors.begin(), tensors.end(), [](const auto & t) {
-      const auto scalar_type = t.scalar_type();
-      return at::isIntegralType(scalar_type, /*includeBool*/true) || at::isComplexType(scalar_type);
-  });
-  if (!can_use_fast_route(tensors) ||
-      has_int_or_complex ||
+  const bool has_int_or_complex =
+      std::any_of(tensors.begin(), tensors.end(), [](const auto& t) {
+        const auto scalar_type = t.scalar_type();
+        return at::isIntegralType(scalar_type, /*includeBool*/ true) ||
+            at::isComplexType(scalar_type);
+      });
+  if (!can_use_fast_route(tensors) || has_int_or_complex ||
       !(p == static_cast<double>(1) || p == static_cast<double>(2))) {
     return foreach_tensor_norm_slow(tensors, ord);
   }
@@ -127,54 +143,70 @@ std::vector<Tensor> foreach_tensor_norm_cuda(TensorList tensors, const Scalar& o
   int max_chunks_per_tensor = -1;
 
   for (int t = 0; t < ntensors; t++) {
-    int max_chunks_this_tensor = (tensors[t].numel() + kChunkSize - 1) / kChunkSize;
-    if(max_chunks_this_tensor > max_chunks_per_tensor) {
+    int max_chunks_this_tensor =
+        (tensors[t].numel() + kChunkSize - 1) / kChunkSize;
+    if (max_chunks_this_tensor > max_chunks_per_tensor) {
       max_chunks_per_tensor = max_chunks_this_tensor;
     }
   }
   const auto options = tensors[0].options();
-  auto output_per_tensor = at::zeros({ntensors*max_chunks_per_tensor}, options.dtype(toOpMathType(tensors[0].scalar_type())));
+  auto output_per_tensor = at::zeros(
+      {ntensors * max_chunks_per_tensor},
+      options.dtype(toOpMathType(tensors[0].scalar_type())));
   auto ret_per_tensor = at::empty({ntensors}, options);
 
   auto tensor_lists = std::vector<std::vector<Tensor>>{tensors.vec()};
   if (p == static_cast<double>(1)) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "foreach_tensor_norm_cuda", [&]() {
-        using opmath_t = typename at::opmath_type<scalar_t>;
-        multi_tensor_apply<1>(
-          tensor_lists,
-          LpNormFunctor<scalar_t, 1>(),
-          output_per_tensor.mutable_data_ptr<opmath_t>(),
-          max_chunks_per_tensor);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
-        auto stream = at::cuda::getCurrentCUDAStream();
-        lpnorm_cleanup<scalar_t, 1><<<ntensors, 512, 0, stream>>>(
-          output_per_tensor.const_data_ptr<opmath_t>(),
-          ret_per_tensor.mutable_data_ptr<scalar_t>(),
-          max_chunks_per_tensor);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
+        kHalf,
+        kBFloat16,
+        tensor_lists[0][0].scalar_type(),
+        "foreach_tensor_norm_cuda",
+        [&]() {
+          using opmath_t = typename at::opmath_type<scalar_t>;
+          multi_tensor_apply<1>(
+              tensor_lists,
+              LpNormFunctor<scalar_t, 1>(),
+              output_per_tensor.mutable_data_ptr<opmath_t>(),
+              max_chunks_per_tensor);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          const at::cuda::OptionalCUDAGuard device_guard(
+              device_of(output_per_tensor));
+          auto stream = at::cuda::getCurrentCUDAStream();
+          lpnorm_cleanup<scalar_t, 1><<<ntensors, 512, 0, stream>>>(
+              output_per_tensor.const_data_ptr<opmath_t>(),
+              ret_per_tensor.mutable_data_ptr<scalar_t>(),
+              max_chunks_per_tensor);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        });
   } else if (p == static_cast<double>(2)) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "foreach_tensor_norm_cuda", [&]() {
-        using opmath_t = typename at::opmath_type<scalar_t>;
-        multi_tensor_apply<1>(
-          tensor_lists,
-          LpNormFunctor<scalar_t, 2>(),
-          output_per_tensor.mutable_data_ptr<opmath_t>(),
-          max_chunks_per_tensor);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
-        auto stream = at::cuda::getCurrentCUDAStream();
-        lpnorm_cleanup<scalar_t, 2><<<ntensors, 512, 0, stream>>>(
-          output_per_tensor.const_data_ptr<opmath_t>(),
-          ret_per_tensor.mutable_data_ptr<scalar_t>(),
-          max_chunks_per_tensor);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
+        kHalf,
+        kBFloat16,
+        tensor_lists[0][0].scalar_type(),
+        "foreach_tensor_norm_cuda",
+        [&]() {
+          using opmath_t = typename at::opmath_type<scalar_t>;
+          multi_tensor_apply<1>(
+              tensor_lists,
+              LpNormFunctor<scalar_t, 2>(),
+              output_per_tensor.mutable_data_ptr<opmath_t>(),
+              max_chunks_per_tensor);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          const at::cuda::OptionalCUDAGuard device_guard(
+              device_of(output_per_tensor));
+          auto stream = at::cuda::getCurrentCUDAStream();
+          lpnorm_cleanup<scalar_t, 2><<<ntensors, 512, 0, stream>>>(
+              output_per_tensor.const_data_ptr<opmath_t>(),
+              ret_per_tensor.mutable_data_ptr<scalar_t>(),
+              max_chunks_per_tensor);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        });
   } else {
-    TORCH_CHECK(false, "foreach_tensor_norm_cuda fast path got unexpected ord value: ", p);
+    TORCH_CHECK(
+        false,
+        "foreach_tensor_norm_cuda fast path got unexpected ord value: ",
+        p);
   }
 
   std::vector<Tensor> result;

--- a/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
@@ -22,7 +22,10 @@ struct LerpFunctor {
   }
 };
 
-std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(
+    TensorList tensors1,
+    TensorList tensors2,
+    TensorList tensors3) {
   check_foreach_api_restrictions(tensors1, tensors2, tensors3);
   if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
     return foreach_tensor_ternary_lerp_slow(tensors1, tensors2, tensors3);
@@ -33,43 +36,63 @@ std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(TensorList tensors1, Te
   for (const auto& t : tensors1) {
     vec_res.emplace_back(at::native::empty_like(t));
   }
-  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), tensors3.vec(), vec_res};
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+      tensors1.vec(), tensors2.vec(), tensors3.vec(), vec_res};
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-      at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_ternary_cuda",
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors1[0].scalar_type(),
+      "foreach_tensor_lerp_ternary_cuda",
       [&]() {
-          using opmath_t = typename at::opmath_type<scalar_t>;
-          multi_tensor_apply<4>(
-              tensor_lists,
-              TernaryOpListFunctor<scalar_t, /* depth */ 4, /* r_args_depth */ 3, /* res_arg_index */ 3>(),
-              LerpFunctor<opmath_t>());
-      }
-  );
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<4>(
+            tensor_lists,
+            TernaryOpListFunctor<
+                scalar_t,
+                /* depth */ 4,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 3>(),
+            LerpFunctor<opmath_t>());
+      });
 
   return tensor_lists[3];
 }
 
-void foreach_tensor_lerp_ternary_cuda_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+void foreach_tensor_lerp_ternary_cuda_(
+    TensorList tensors1,
+    TensorList tensors2,
+    TensorList tensors3) {
   check_foreach_api_restrictions(tensors1, tensors2, tensors3);
   if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
     return foreach_tensor_ternary_lerp_slow_(tensors1, tensors2, tensors3);
   }
 
-  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), tensors3.vec()};
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+      tensors1.vec(), tensors2.vec(), tensors3.vec()};
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-        at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_ternary_cuda_",
-        [&]() {
-            using opmath_t = typename at::opmath_type<scalar_t>;
-            multi_tensor_apply<3>(
-                tensor_lists,
-                TernaryOpListFunctor<scalar_t, /* depth */ 3, /* r_args_depth */ 3, /* res_arg_index */ 0>(),
-                LerpFunctor<opmath_t>());
-        }
-  );
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors1[0].scalar_type(),
+      "foreach_tensor_lerp_ternary_cuda_",
+      [&]() {
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<3>(
+            tensor_lists,
+            TernaryOpListFunctor<
+                scalar_t,
+                /* depth */ 3,
+                /* r_args_depth */ 3,
+                /* res_arg_index */ 0>(),
+            LerpFunctor<opmath_t>());
+      });
   increment_version(tensors1);
 }
 
-std::vector<at::Tensor> foreach_tensor_lerp_list_cuda(TensorList tensors1, TensorList tensors2, const Scalar& weight) {
+std::vector<at::Tensor> foreach_tensor_lerp_list_cuda(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& weight) {
   check_foreach_api_restrictions(tensors1, tensors2);
   if (!can_use_fast_route({tensors1, tensors2})) {
     return foreach_tensor_lerp_list_kernel_slow(tensors1, tensors2, weight);
@@ -80,40 +103,57 @@ std::vector<at::Tensor> foreach_tensor_lerp_list_cuda(TensorList tensors1, Tenso
   for (const auto& t : tensors1) {
     vec_res.emplace_back(at::native::empty_like(t));
   }
-  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), vec_res};
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+      tensors1.vec(), tensors2.vec(), vec_res};
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-      at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_scalar_cuda",
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors1[0].scalar_type(),
+      "foreach_tensor_lerp_scalar_cuda",
       [&]() {
-          using opmath_t = typename at::opmath_type<scalar_t>;
-          multi_tensor_apply<3>(
-              tensor_lists,
-              TernaryOpScalarFunctor<scalar_t, /* depth */ 3, /* r_args_depth */ 2, /* res_arg_index */ 2>(),
-              LerpFunctor<opmath_t>(),
-              weight.to<opmath_t>());
-      }
-  );
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<3>(
+            tensor_lists,
+            TernaryOpScalarFunctor<
+                scalar_t,
+                /* depth */ 3,
+                /* r_args_depth */ 2,
+                /* res_arg_index */ 2>(),
+            LerpFunctor<opmath_t>(),
+            weight.to<opmath_t>());
+      });
 
   return tensor_lists[2];
 }
 
-void foreach_tensor_lerp_list_cuda_(TensorList tensors1, TensorList tensors2, const Scalar& weight) {
+void foreach_tensor_lerp_list_cuda_(
+    TensorList tensors1,
+    TensorList tensors2,
+    const Scalar& weight) {
   check_foreach_api_restrictions(tensors1, tensors2);
   if (!can_use_fast_route({tensors1, tensors2})) {
     return foreach_tensor_lerp_list_kernel_slow_(tensors1, tensors2, weight);
   }
 
-  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec()};
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+      tensors1.vec(), tensors2.vec()};
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-        at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_scalar_cuda_",
-        [&]() {
-            using opmath_t = typename at::opmath_type<scalar_t>;
-            multi_tensor_apply<2>(
-                tensor_lists,
-                TernaryOpScalarFunctor<scalar_t, /* depth */ 2, /* r_args_depth */ 2, /* res_arg_index */ 0>(),
-                LerpFunctor<opmath_t>(),
-                weight.to<opmath_t>());
-        }
-  );
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors1[0].scalar_type(),
+      "foreach_tensor_lerp_scalar_cuda_",
+      [&]() {
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<2>(
+            tensor_lists,
+            TernaryOpScalarFunctor<
+                scalar_t,
+                /* depth */ 2,
+                /* r_args_depth */ 2,
+                /* res_arg_index */ 0>(),
+            LerpFunctor<opmath_t>(),
+            weight.to<opmath_t>());
+      });
 }
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -41,154 +41,198 @@
 
 namespace at::native {
 
-template <typename scalar_t, template<class> class Op> std::vector<Tensor> foreach_unary_op(TensorList tensors) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    std::vector<at::Tensor> vec_res;
-    vec_res.reserve(tensors.size());
-    for (const auto& t: tensors) {
-        vec_res.emplace_back(at::native::empty_like(t));
-    }
+template <typename scalar_t, template <class> class Op>
+std::vector<Tensor> foreach_unary_op(TensorList tensors) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
 
-    tensor_lists.emplace_back(tensors.vec());
-    tensor_lists.emplace_back(std::move(vec_res));
+  tensor_lists.emplace_back(tensors.vec());
+  tensor_lists.emplace_back(std::move(vec_res));
 
-    using opmath_t = typename at::opmath_type<scalar_t>;
-    multi_tensor_apply<2>(tensor_lists,
-                          UnaryOpFunctor<scalar_t,
-                                         /* depth */ 2,
-                                         /* r_args_depth */ 1,
-                                         /* res_arg_index */ 1>(),
-                          Op<opmath_t>());
+  using opmath_t = typename at::opmath_type<scalar_t>;
+  multi_tensor_apply<2>(
+      tensor_lists,
+      UnaryOpFunctor<
+          scalar_t,
+          /* depth */ 2,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 1>(),
+      Op<opmath_t>());
 
-    return tensor_lists[1];
+  return tensor_lists[1];
 }
 
-template <typename scalar_t, template<class> class Op> void foreach_unary_op_(TensorList tensors) {
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(tensors.vec());
-    using opmath_t = typename at::opmath_type<scalar_t>;
-    multi_tensor_apply<1>(tensor_lists,
-                          UnaryOpFunctor<scalar_t,
-                                         /* depth */ 1,
-                                         /* r_args_depth */ 1,
-                                         /* res_arg_index */ 0>(),
-                          Op<opmath_t>());
-    increment_version(tensors);
+template <typename scalar_t, template <class> class Op>
+void foreach_unary_op_(TensorList tensors) {
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(tensors.vec());
+  using opmath_t = typename at::opmath_type<scalar_t>;
+  multi_tensor_apply<1>(
+      tensor_lists,
+      UnaryOpFunctor<
+          scalar_t,
+          /* depth */ 1,
+          /* r_args_depth */ 1,
+          /* res_arg_index */ 0>(),
+      Op<opmath_t>());
+  increment_version(tensors);
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> floating_complex_half(TensorList tensors) {
-    return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(ScalarType::Half,  tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
+      ScalarType::Half,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void floating_complex_half_(TensorList tensors) {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(ScalarType::Half, tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
-        foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
+      ScalarType::Half,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda_",
+      [&]() { foreach_unary_op_<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> all_types_complex_bfloat16_half_bool(TensorList tensors) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Bool, tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      ScalarType::Bool,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Bool, tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      ScalarType::Bool,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { foreach_unary_op_<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
-    return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void floating_complex_half_bfloat16_(TensorList tensors) {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
-        foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda_",
+      [&]() { foreach_unary_op_<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
-    return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(ScalarType::Half, at::ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void all_types_half_complex_bfloat16_(TensorList tensors) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(ScalarType::Half, at::ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
-        foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+      ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda_",
+      [&]() { foreach_unary_op_<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> floating_half(TensorList tensors) {
-    return AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::Half,  tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_FLOATING_TYPES_AND(
+      ScalarType::Half,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void floating_half_(TensorList tensors) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
         foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+      });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
-    return AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16,  tensors[0].scalar_type(), "foreach_unary_op_cuda", [&]() {
-        return foreach_unary_op<scalar_t, Op>(tensors);
-    });
+  return AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda",
+      [&]() { return foreach_unary_op<scalar_t, Op>(tensors); });
 }
 
-template <template<class> class Op>
+template <template <class> class Op>
 void floating_half_bfloat16_(TensorList tensors) {
-    AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
-        foreach_unary_op_<scalar_t, Op>(tensors);
-    });
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_unary_op_cuda_",
+      [&]() { foreach_unary_op_<scalar_t, Op>(tensors); });
 }
 
 // makes the functor
-#define STD_FUNCTOR(op_name, functor_name)                           \
-template<typename T>                                                 \
-struct functor_name {                                                \
-    __device__ T operator()(T t) const { return std::op_name(t); }   \
-};                                                                   \
+#define STD_FUNCTOR(op_name, functor_name) \
+  template <typename T>                    \
+  struct functor_name {                    \
+    __device__ T operator()(T t) const {   \
+      return std::op_name(t);              \
+    }                                      \
+  };
 
-// given a functor and a "dispatch function", creates the outplace and inplace operations
-#define OP_CUSTOM_FUNCTOR(function, op_name, functor_name)                \
-std::vector<Tensor> foreach_tensor_##op_name##_cuda(TensorList tensors) { \
-    check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors) || has_integral_tensor(tensors, /* includeBool */ true)) { \
-        return at::native::foreach_tensor_##op_name##_slow(tensors);      \
-    }                                                                     \
-    return function<functor_name>(tensors);                               \
-}                                                                         \
-void foreach_tensor_##op_name##_cuda_(TensorList tensors) {               \
-    check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors) || has_integral_tensor(tensors, /* includeBool */ true)) { \
-        return at::native::foreach_tensor_##op_name##_slow_(tensors);     \
-    }                                                                     \
-                                                                          \
-    function##_<functor_name>(tensors);                                   \
-}
+// given a functor and a "dispatch function", creates the outplace and inplace
+// operations
+#define OP_CUSTOM_FUNCTOR(function, op_name, functor_name)                  \
+  std::vector<Tensor> foreach_tensor_##op_name##_cuda(TensorList tensors) { \
+    check_foreach_api_restrictions(tensors);                                \
+    if (!can_use_fast_route(tensors) ||                                     \
+        has_integral_tensor(tensors, /* includeBool */ true)) {             \
+      return at::native::foreach_tensor_##op_name##_slow(tensors);          \
+    }                                                                       \
+    return function<functor_name>(tensors);                                 \
+  }                                                                         \
+  void foreach_tensor_##op_name##_cuda_(TensorList tensors) {               \
+    check_foreach_api_restrictions(tensors);                                \
+    if (!can_use_fast_route(tensors) ||                                     \
+        has_integral_tensor(tensors, /* includeBool */ true)) {             \
+      return at::native::foreach_tensor_##op_name##_slow_(tensors);         \
+    }                                                                       \
+                                                                            \
+    function##_<functor_name>(tensors);                                     \
+  }
 
 // creates a functor, outplace version, and inplace version.
-#define OP(function, op_name, functor_name)         \
-STD_FUNCTOR(op_name, functor_name);                 \
-OP_CUSTOM_FUNCTOR(function, op_name, functor_name); \
+#define OP(function, op_name, functor_name) \
+  STD_FUNCTOR(op_name, functor_name);       \
+  OP_CUSTOM_FUNCTOR(function, op_name, functor_name);
 
 OP(floating_half_bfloat16, erfc, Erfc);
 OP(floating_half, lgamma, Lgamma);
@@ -218,28 +262,37 @@ OP(floating_half_bfloat16, erf, Erf);
 
 //
 // Special cases
-// These functions must be special cased as they can't be written as std::functor_name in OP macro
+// These functions must be special cased as they can't be written as
+// std::functor_name in OP macro
 //
-template<typename T>
+template <typename T>
 struct Sigmoid {
-    T one = T(1);
-    __device__ T operator()(T t) const { return (one / (one + std::exp(-t))); }
+  T one = T(1);
+  __device__ T operator()(T t) const {
+    return (one / (one + std::exp(-t)));
+  }
 };
 
-template<typename T>
+template <typename T>
 struct Round {
-    __device__ T operator()(T t) const { return std::nearbyint(t); }
+  __device__ T operator()(T t) const {
+    return std::nearbyint(t);
+  }
 };
 
-template<typename T>
+template <typename T>
 struct Trunc {
-    __device__ T operator()(T t) const { return t - std::trunc(t); }
+  __device__ T operator()(T t) const {
+    return t - std::trunc(t);
+  }
 };
 
-template<typename T>
+template <typename T>
 struct Reciprocal {
-    T one = T(1);
-    __device__ T operator()(T t) const { return (one / t); }
+  T one = T(1);
+  __device__ T operator()(T t) const {
+    return (one / t);
+  }
 };
 
 OP_CUSTOM_FUNCTOR(floating_half_bfloat16, sigmoid, Sigmoid)
@@ -248,83 +301,97 @@ OP_CUSTOM_FUNCTOR(floating_half_bfloat16, frac, Trunc)
 OP_CUSTOM_FUNCTOR(floating_complex_half_bfloat16, reciprocal, Reciprocal)
 
 // note(mkozuki): tensor dtype checks of `neg` kernels.
-// Since `check_foreach_api_restrictions` don't require all the tensors to have the same dtype,
-// I think it safer to check every single tensor's dtype inside negation kernels.
+// Since `check_foreach_api_restrictions` don't require all the tensors to have
+// the same dtype, I think it safer to check every single tensor's dtype inside
+// negation kernels.
 std::vector<Tensor> foreach_tensor_neg_cuda(TensorList tensors) {
-    check_foreach_api_restrictions(tensors);
+  check_foreach_api_restrictions(tensors);
 
-    if (!can_use_fast_route(tensors)) {
-        return at::native::foreach_tensor_neg_slow(tensors);
-    }
+  if (!can_use_fast_route(tensors)) {
+    return at::native::foreach_tensor_neg_slow(tensors);
+  }
 
-    TORCH_CHECK(tensors[0].scalar_type() != kBool,
-                "Negation, the `-` operator, on a bool tensor is not supported. "
-                "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
-    return all_types_half_complex_bfloat16<std::negate>(tensors);
+  TORCH_CHECK(
+      tensors[0].scalar_type() != kBool,
+      "Negation, the `-` operator, on a bool tensor is not supported. "
+      "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
+  return all_types_half_complex_bfloat16<std::negate>(tensors);
 }
 
 void foreach_tensor_neg_cuda_(TensorList tensors) {
-    check_foreach_api_restrictions(tensors);
+  check_foreach_api_restrictions(tensors);
 
-    if (!can_use_fast_route(tensors)) {
-        return at::native::foreach_tensor_neg_slow_(tensors);
-    }
+  if (!can_use_fast_route(tensors)) {
+    return at::native::foreach_tensor_neg_slow_(tensors);
+  }
 
-    TORCH_CHECK(tensors[0].scalar_type() != kBool,
-                "Negation, the `-` operator, on a bool tensor is not supported. "
-                "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
-    all_types_half_complex_bfloat16_<std::negate>(tensors);
+  TORCH_CHECK(
+      tensors[0].scalar_type() != kBool,
+      "Negation, the `-` operator, on a bool tensor is not supported. "
+      "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
+  all_types_half_complex_bfloat16_<std::negate>(tensors);
 }
 
 // Abs have to go via slow path in case of a complex type.
-// This is because foreach kernels can't return a different dtype than passed, while
-// abs with complex inputs will produce float output.
-template<typename T>
+// This is because foreach kernels can't return a different dtype than passed,
+// while abs with complex inputs will produce float output.
+template <typename T>
 struct Abs {
-    __device__ T operator()(T t) const { return std::abs(t); }
+  __device__ T operator()(T t) const {
+    return std::abs(t);
+  }
 };
 
 std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
-    check_foreach_api_restrictions(tensors);
-    const bool has_complex = std::any_of(
-        tensors.begin(), tensors.end(),
-        [](const auto & t) { return at::isComplexType(t.scalar_type()); });
-    if (!can_use_fast_route(tensors) || has_complex) {
-        return at::native::foreach_tensor_abs_slow(tensors);
-    }
+  check_foreach_api_restrictions(tensors);
+  const bool has_complex =
+      std::any_of(tensors.begin(), tensors.end(), [](const auto& t) {
+        return at::isComplexType(t.scalar_type());
+      });
+  if (!can_use_fast_route(tensors) || has_complex) {
+    return at::native::foreach_tensor_abs_slow(tensors);
+  }
 
-    return all_types_complex_bfloat16_half_bool<Abs>(tensors);
+  return all_types_complex_bfloat16_half_bool<Abs>(tensors);
 }
 
 void foreach_tensor_abs_cuda_(TensorList tensors) {
-    check_foreach_api_restrictions(tensors);
-    const bool has_complex = std::any_of(
-        tensors.begin(), tensors.end(),
-        [](const auto & t) { return at::isComplexType(t.scalar_type()); });
-    if (!can_use_fast_route(tensors) || has_complex) {
-        return at::native::foreach_tensor_abs_slow_(tensors);
-    }
+  check_foreach_api_restrictions(tensors);
+  const bool has_complex =
+      std::any_of(tensors.begin(), tensors.end(), [](const auto& t) {
+        return at::isComplexType(t.scalar_type());
+      });
+  if (!can_use_fast_route(tensors) || has_complex) {
+    return at::native::foreach_tensor_abs_slow_(tensors);
+  }
 
-    all_types_complex_bfloat16_half_bool_<Abs>(tensors);
+  all_types_complex_bfloat16_half_bool_<Abs>(tensors);
 }
 
 void foreach_tensor_zero_cuda_(TensorList tensors) {
-    check_foreach_api_restrictions(tensors);
+  check_foreach_api_restrictions(tensors);
 
-    if (!can_use_fast_route(tensors)) {
-        return at::native::foreach_tensor_zero_slow_(tensors);
-    }
+  if (!can_use_fast_route(tensors)) {
+    return at::native::foreach_tensor_zero_slow_(tensors);
+  }
 
-    std::vector<std::vector<at::Tensor>> tensor_lists;
-    tensor_lists.emplace_back(tensors.vec());
+  std::vector<std::vector<at::Tensor>> tensor_lists;
+  tensor_lists.emplace_back(tensors.vec());
 
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, tensors[0].scalar_type(), "foreach_zero_cuda_", [&]() {
-        multi_tensor_apply<1>(tensor_lists,
-                              ZeroFunctor<scalar_t,
-                                          /* depth */ 1,
-                                          /* r_args_depth */ 1,
-                                          /* res_arg_index */ 0>());
-    });
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      tensors[0].scalar_type(),
+      "foreach_zero_cuda_",
+      [&]() {
+        multi_tensor_apply<1>(
+            tensor_lists,
+            ZeroFunctor<
+                scalar_t,
+                /* depth */ 1,
+                /* r_args_depth */ 1,
+                /* res_arg_index */ 0>());
+      });
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -6,7 +6,7 @@
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <vector>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -19,71 +19,90 @@ static constexpr int64_t kBlockSize = 512;
 static constexpr int depth_to_max_tensors[5] = {110, 64, 48, 36, 30};
 static constexpr int depth_to_max_blocks[5] = {320, 320, 320, 320, 320};
 static constexpr int depth_to_max_tensors_scalarlist[5] = {96, 64, 48, 36, 30};
-static constexpr int depth_to_max_tensors_scalarlist_of_complex_double[2] = {72, 60};
+static constexpr int depth_to_max_tensors_scalarlist_of_complex_double[2] = {
+    72,
+    60};
 
-template<typename T>
-__device__ __forceinline__ bool is_aligned(T* p){
+template <typename T>
+__device__ __forceinline__ bool is_aligned(T* p) {
   return ((uint64_t)p) % (kILP * sizeof(T)) == 0;
 }
 
-template<typename T>
-__device__ __forceinline__ void load_store(T* dst, T* src, int64_t dst_offset, int64_t src_offset){
+template <typename T>
+__device__ __forceinline__ void load_store(
+    T* dst,
+    T* src,
+    int64_t dst_offset,
+    int64_t src_offset) {
   using LT = at::native::memory::aligned_vector<T, kILP>;
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template<int n> struct TensorListMetadata {
-  const void* addresses[n][depth_to_max_tensors[n-1]];
-  int64_t numel_for_tensor[depth_to_max_tensors[n-1]];
-  unsigned char block_to_tensor[depth_to_max_blocks[n-1]];
-  int block_to_chunk[depth_to_max_blocks[n-1]];
+template <int n>
+struct TensorListMetadata {
+  const void* addresses[n][depth_to_max_tensors[n - 1]];
+  int64_t numel_for_tensor[depth_to_max_tensors[n - 1]];
+  unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
+  int block_to_chunk[depth_to_max_blocks[n - 1]];
   int start_tensor_this_launch;
 };
 
-template<typename scalar_vals_t, int n> struct TensorListScalarListMetadata {
-  const void* addresses[n][depth_to_max_tensors_scalarlist[n-1]];
-  int64_t numel_for_tensor[depth_to_max_tensors_scalarlist[n-1]];
-  scalar_vals_t scalar_vals[depth_to_max_tensors_scalarlist[n-1]];
-  unsigned char block_to_tensor[depth_to_max_blocks[n-1]];
-  int block_to_chunk[depth_to_max_blocks[n-1]];
+template <typename scalar_vals_t, int n>
+struct TensorListScalarListMetadata {
+  const void* addresses[n][depth_to_max_tensors_scalarlist[n - 1]];
+  int64_t numel_for_tensor[depth_to_max_tensors_scalarlist[n - 1]];
+  scalar_vals_t scalar_vals[depth_to_max_tensors_scalarlist[n - 1]];
+  unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
+  int block_to_chunk[depth_to_max_blocks[n - 1]];
 };
 
-// note(mkozuki): `n` of 1&2 violate the limit of cuda kernel argument size of 4kb with `c10::complex<double>`
-template<> struct TensorListScalarListMetadata<c10::complex<double>, 1> {
-  const void* addresses[1][depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  int64_t numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  c10::complex<double> scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  unsigned char block_to_tensor[depth_to_max_blocks[1-1]];
-  int block_to_chunk[depth_to_max_blocks[1-1]];
+// note(mkozuki): `n` of 1&2 violate the limit of cuda kernel argument size of
+// 4kb with `c10::complex<double>`
+template <>
+struct TensorListScalarListMetadata<c10::complex<double>, 1> {
+  const void* addresses[1]
+                       [depth_to_max_tensors_scalarlist_of_complex_double[0]];
+  int64_t
+      numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[0]];
+  c10::complex<double>
+      scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[0]];
+  unsigned char block_to_tensor[depth_to_max_blocks[1 - 1]];
+  int block_to_chunk[depth_to_max_blocks[1 - 1]];
 };
 
-template<> struct TensorListScalarListMetadata<c10::complex<double>, 2> {
-  const void* addresses[2][depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  int64_t numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  c10::complex<double> scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  unsigned char block_to_tensor[depth_to_max_blocks[2-1]];
-  int block_to_chunk[depth_to_max_blocks[2-1]];
+template <>
+struct TensorListScalarListMetadata<c10::complex<double>, 2> {
+  const void* addresses[2]
+                       [depth_to_max_tensors_scalarlist_of_complex_double[1]];
+  int64_t
+      numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[1]];
+  c10::complex<double>
+      scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[1]];
+  unsigned char block_to_tensor[depth_to_max_blocks[2 - 1]];
+  int block_to_chunk[depth_to_max_blocks[2 - 1]];
 };
 
 // NOTE(crcrpar): This is a conservative resolution to handle `state_steps`
-// whose each element is `at::Tensor` of 1 element representing the number of `step`s called so far.
-template<int n> struct FusedOptimizerTensorListMetadata {
-  const void* addresses[n][depth_to_max_tensors[n-1]];
-  int64_t numel_for_tensor[depth_to_max_tensors[n-1]];
-  const void* state_steps_addresses[depth_to_max_tensors_scalarlist[n-1]];
-  unsigned char block_to_tensor[depth_to_max_blocks[n-1]];
-  int block_to_chunk[depth_to_max_blocks[n-1]];
+// whose each element is `at::Tensor` of 1 element representing the number of
+// `step`s called so far.
+template <int n>
+struct FusedOptimizerTensorListMetadata {
+  const void* addresses[n][depth_to_max_tensors[n - 1]];
+  int64_t numel_for_tensor[depth_to_max_tensors[n - 1]];
+  const void* state_steps_addresses[depth_to_max_tensors_scalarlist[n - 1]];
+  unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
+  int block_to_chunk[depth_to_max_blocks[n - 1]];
   int start_tensor_this_launch;
 };
 
-template<typename T, typename U, typename... ArgTypes>
+template <typename T, typename U, typename... ArgTypes>
 C10_LAUNCH_BOUNDS_1(kBlockSize)
-__global__ void
-multi_tensor_apply_kernel(
+__global__ void multi_tensor_apply_kernel(
     T tensorListMeta,
     U callable,
     ArgTypes... args) {
-  // Hand the chunk information to the user-supplied functor to process however it likes.
+  // Hand the chunk information to the user-supplied functor to process however
+  // it likes.
   callable(kChunkSize, tensorListMeta, args...);
 }
 
@@ -91,191 +110,71 @@ multi_tensor_apply_kernel(
 
 // NOTE(crcrpar): [Handling of zero-size tensors]
 // Basically we want to skip any index whose tesor(s) are zero-size
-// but if it's the last index, we have to check if there are any non-zero tensors
-// in order to avoid not applying any math.
-template<int depth, typename scalar_T, typename T, typename... ArgTypes>
+// but if it's the last index, we have to check if there are any non-zero
+// tensors in order to avoid not applying any math.
+template <int depth, typename scalar_T, typename T, typename... ArgTypes>
 void multi_tensor_apply(
     std::vector<std::vector<at::Tensor>>& tensor_lists,
     at::ArrayRef<Scalar> scalars,
     T callable,
     ArgTypes... args) {
-        TORCH_CHECK(tensor_lists.size() == depth, "Number of tensor lists has to match the depth.");
-        const size_t n_tensors = tensor_lists[0].size();
-        size_t n_zero_tensors = 0;
-        using scalar_vals_t = typename T::opmath_t;
-        TensorListScalarListMetadata<scalar_vals_t, depth> tensorListMeta;
-
-        int loc_block_info = 0;
-        int loc_tensor_info = 0;
-        for(size_t t = 0; t < n_tensors; t++) {
-            if (tensor_lists[0][t].numel() == 0) {
-                n_zero_tensors++;
-                if (t != n_tensors - 1) {
-                    continue;
-                }
-            } else {
-                tensorListMeta.scalar_vals[loc_tensor_info] = scalars[t].to<scalar_T>();
-                tensorListMeta.numel_for_tensor[loc_tensor_info] = tensor_lists[0][t].numel();
-                for (int d = 0; d < depth; d++) {
-                    tensorListMeta.addresses[d][loc_tensor_info] = tensor_lists[d][t].const_data_ptr();
-                }
-                loc_tensor_info++;
-            }
-
-            if (n_zero_tensors == n_tensors) {
-                continue;
-            }
-            const auto chunks = (tensor_lists[0][t - static_cast<size_t>((t == n_tensors - 1) && (tensor_lists[0][t].numel() == 0))].numel() + kChunkSize - 1)/kChunkSize;
-            for (auto chunk = 0; chunk < chunks; chunk++) {
-                tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
-                tensorListMeta.block_to_chunk[loc_block_info] = chunk;
-                loc_block_info++;
-
-                const bool tensors_full = (loc_tensor_info == depth_to_max_tensors_scalarlist[depth-1] &&
-                    chunk == chunks - 1);
-                const bool blocks_full = (loc_block_info == depth_to_max_blocks[depth-1]);
-                const bool last_chunk = (t == n_tensors - 1 && chunk == chunks - 1);
-
-                if (tensors_full || blocks_full || last_chunk) {
-                    multi_tensor_apply_kernel<<<loc_block_info, kBlockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
-                        tensorListMeta,
-                        callable,
-                        args...);
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-                    // Reset.
-                    loc_block_info = 0;
-                    if(chunk == chunks - 1) {
-                        loc_tensor_info = 0;
-                    }
-                    else {
-                        tensorListMeta.numel_for_tensor[0] = tensorListMeta.numel_for_tensor[loc_tensor_info-1];
-                        tensorListMeta.scalar_vals[0] = tensorListMeta.scalar_vals[loc_tensor_info-1];
-                        for(int d = 0; d < depth; d++) {
-                            tensorListMeta.addresses[d][0] = tensorListMeta.addresses[d][loc_tensor_info-1];
-                        }
-                        loc_tensor_info = 1;
-                    }
-                }
-            }
-        }
-    }
-
-
-template<int depth, typename T, typename... ArgTypes>
-void multi_tensor_apply(
-    std::vector<std::vector<at::Tensor>>& tensor_lists,
-    T callable,
-    ArgTypes... args) {
-        TORCH_CHECK(tensor_lists.size() == depth, "Number of tensor lists has to match the depth.");
-        const size_t n_tensors = tensor_lists[0].size();
-        size_t n_zero_tensors = 0;
-        TensorListMetadata<depth> tensorListMeta;
-        tensorListMeta.start_tensor_this_launch = 0;
-
-        int loc_block_info = 0;
-        int loc_tensor_info = 0;
-        for(size_t t = 0; t < n_tensors; t++) {
-            if (tensor_lists[0][t].numel() == 0) {
-                n_zero_tensors++;
-                if (t != n_tensors - 1) {
-                    continue;
-                }
-            } else {
-                tensorListMeta.numel_for_tensor[loc_tensor_info] = tensor_lists[0][t].numel();
-                for (int d = 0; d < depth; d++) {
-                    tensorListMeta.addresses[d][loc_tensor_info] = tensor_lists[d][t].const_data_ptr();
-                }
-                loc_tensor_info++;
-            }
-
-            if (n_zero_tensors == n_tensors) {
-                continue;
-            }
-            const auto chunks = (tensor_lists[0][t - static_cast<size_t>((t == n_tensors - 1) && (tensor_lists[0][t].numel() == 0))].numel() + kChunkSize - 1)/kChunkSize;
-            for (auto chunk = 0; chunk < chunks; chunk++) {
-                tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
-                tensorListMeta.block_to_chunk[loc_block_info] = chunk;
-                loc_block_info++;
-
-                const bool tensors_full = (loc_tensor_info == depth_to_max_tensors[depth-1] &&
-                    chunk == chunks - 1);
-                const bool blocks_full = (loc_block_info == depth_to_max_blocks[depth-1]);
-                const bool last_chunk = (t == n_tensors - 1 && chunk == chunks - 1);
-
-                if (tensors_full || blocks_full || last_chunk) {
-                    multi_tensor_apply_kernel<<<loc_block_info, kBlockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
-                        tensorListMeta,
-                        callable,
-                        args...);
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-                    // Reset.
-                    loc_block_info = 0;
-                    if(chunk == chunks - 1) {
-                        loc_tensor_info = 0;
-                        tensorListMeta.start_tensor_this_launch = t + 1;
-                    }
-                    else {
-                        tensorListMeta.numel_for_tensor[0] = tensorListMeta.numel_for_tensor[loc_tensor_info-1];
-                        for(int d = 0; d < depth; d++) {
-                            tensorListMeta.addresses[d][0] = tensorListMeta.addresses[d][loc_tensor_info-1];
-                        }
-                        loc_tensor_info = 1;
-                        tensorListMeta.start_tensor_this_launch = t;
-                    }
-                }
-            }
-        }
-}
-
-template<int depth, typename T, typename... ArgTypes>
-void multi_tensor_apply_for_fused_optimizer(
-    std::vector<std::vector<at::Tensor>>& tensor_lists,
-    at::TensorList state_steps,
-    T callable,
-    ArgTypes... args) {
-  TORCH_CHECK(tensor_lists.size() == depth, "Number of tensor lists has to match the depth");
-  const auto num_tensors = tensor_lists[0].size();
-  auto num_zero_tensors = 0;
-  FusedOptimizerTensorListMetadata<depth> tensorListMeta;
+  TORCH_CHECK(
+      tensor_lists.size() == depth,
+      "Number of tensor lists has to match the depth.");
+  const size_t n_tensors = tensor_lists[0].size();
+  size_t n_zero_tensors = 0;
+  using scalar_vals_t = typename T::opmath_t;
+  TensorListScalarListMetadata<scalar_vals_t, depth> tensorListMeta;
 
   int loc_block_info = 0;
   int loc_tensor_info = 0;
-  for (const auto & tensor_index : c10::irange(num_tensors)) {
-    if (tensor_lists[0][tensor_index].numel() == 0) {
-      num_zero_tensors++;
-      if (tensor_index != num_tensors - 1) {
+  for (size_t t = 0; t < n_tensors; t++) {
+    if (tensor_lists[0][t].numel() == 0) {
+      n_zero_tensors++;
+      if (t != n_tensors - 1) {
         continue;
       }
     } else {
-      tensorListMeta.state_steps_addresses[loc_tensor_info] = state_steps[tensor_index].const_data_ptr();
-      tensorListMeta.numel_for_tensor[loc_tensor_info] = tensor_lists[0][tensor_index].numel();
-      for (const auto & d : c10::irange(depth)) {
-        tensorListMeta.addresses[d][loc_tensor_info] = tensor_lists[d][tensor_index].const_data_ptr();
+      tensorListMeta.scalar_vals[loc_tensor_info] = scalars[t].to<scalar_T>();
+      tensorListMeta.numel_for_tensor[loc_tensor_info] =
+          tensor_lists[0][t].numel();
+      for (int d = 0; d < depth; d++) {
+        tensorListMeta.addresses[d][loc_tensor_info] =
+            tensor_lists[d][t].const_data_ptr();
       }
       loc_tensor_info++;
     }
 
-    if (static_cast<decltype(num_tensors)>(num_zero_tensors) == num_tensors) {
+    if (n_zero_tensors == n_tensors) {
       continue;
     }
-    const int64_t chunks = (tensor_lists[0][tensor_index - static_cast<decltype(tensor_index)>((tensor_index == num_tensors - 1) && (tensor_lists[0][tensor_index].numel() == 0))].numel() + kChunkSize - 1) / kChunkSize;
-    TORCH_CHECK(chunks > -1);
-    for (const auto & chunk : c10::irange(chunks)) {
+    const auto chunks = (tensor_lists[0]
+                                     [t -
+                                      static_cast<size_t>(
+                                          (t == n_tensors - 1) &&
+                                          (tensor_lists[0][t].numel() == 0))]
+                                         .numel() +
+                         kChunkSize - 1) /
+        kChunkSize;
+    for (auto chunk = 0; chunk < chunks; chunk++) {
       tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
       tensorListMeta.block_to_chunk[loc_block_info] = chunk;
       loc_block_info++;
 
-      const auto tensor_full = (loc_tensor_info == depth_to_max_tensors[depth - 1] && chunk == chunks - 1);
-      const auto blocks_full = loc_block_info == depth_to_max_blocks[depth - 1];
-      const auto last_chunk = (tensor_index == num_tensors - 1 && chunk == chunks - 1);
+      const bool tensors_full =
+          (loc_tensor_info == depth_to_max_tensors_scalarlist[depth - 1] &&
+           chunk == chunks - 1);
+      const bool blocks_full =
+          (loc_block_info == depth_to_max_blocks[depth - 1]);
+      const bool last_chunk = (t == n_tensors - 1 && chunk == chunks - 1);
 
-      if (tensor_full || blocks_full || last_chunk) {
-        multi_tensor_apply_kernel<<<loc_block_info, kBlockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
-            tensorListMeta,
-            callable,
-            args...);
+      if (tensors_full || blocks_full || last_chunk) {
+        multi_tensor_apply_kernel<<<
+            loc_block_info,
+            kBlockSize,
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            tensorListMeta, callable, args...);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
 
         // Reset.
@@ -283,10 +182,13 @@ void multi_tensor_apply_for_fused_optimizer(
         if (chunk == chunks - 1) {
           loc_tensor_info = 0;
         } else {
-          tensorListMeta.numel_for_tensor[0] = tensorListMeta.numel_for_tensor[loc_tensor_info - 1];
-          tensorListMeta.state_steps_addresses[0] = tensorListMeta.state_steps_addresses[loc_tensor_info - 1];
-          for (const auto & d : c10::irange(depth)) {
-            tensorListMeta.addresses[d][0] = tensorListMeta.addresses[d][loc_tensor_info - 1];
+          tensorListMeta.numel_for_tensor[0] =
+              tensorListMeta.numel_for_tensor[loc_tensor_info - 1];
+          tensorListMeta.scalar_vals[0] =
+              tensorListMeta.scalar_vals[loc_tensor_info - 1];
+          for (int d = 0; d < depth; d++) {
+            tensorListMeta.addresses[d][0] =
+                tensorListMeta.addresses[d][loc_tensor_info - 1];
           }
           loc_tensor_info = 1;
         }
@@ -295,4 +197,174 @@ void multi_tensor_apply_for_fused_optimizer(
   }
 }
 
-}} // at::native
+template <int depth, typename T, typename... ArgTypes>
+void multi_tensor_apply(
+    std::vector<std::vector<at::Tensor>>& tensor_lists,
+    T callable,
+    ArgTypes... args) {
+  TORCH_CHECK(
+      tensor_lists.size() == depth,
+      "Number of tensor lists has to match the depth.");
+  const size_t n_tensors = tensor_lists[0].size();
+  size_t n_zero_tensors = 0;
+  TensorListMetadata<depth> tensorListMeta;
+  tensorListMeta.start_tensor_this_launch = 0;
+
+  int loc_block_info = 0;
+  int loc_tensor_info = 0;
+  for (size_t t = 0; t < n_tensors; t++) {
+    if (tensor_lists[0][t].numel() == 0) {
+      n_zero_tensors++;
+      if (t != n_tensors - 1) {
+        continue;
+      }
+    } else {
+      tensorListMeta.numel_for_tensor[loc_tensor_info] =
+          tensor_lists[0][t].numel();
+      for (int d = 0; d < depth; d++) {
+        tensorListMeta.addresses[d][loc_tensor_info] =
+            tensor_lists[d][t].const_data_ptr();
+      }
+      loc_tensor_info++;
+    }
+
+    if (n_zero_tensors == n_tensors) {
+      continue;
+    }
+    const auto chunks = (tensor_lists[0]
+                                     [t -
+                                      static_cast<size_t>(
+                                          (t == n_tensors - 1) &&
+                                          (tensor_lists[0][t].numel() == 0))]
+                                         .numel() +
+                         kChunkSize - 1) /
+        kChunkSize;
+    for (auto chunk = 0; chunk < chunks; chunk++) {
+      tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
+      tensorListMeta.block_to_chunk[loc_block_info] = chunk;
+      loc_block_info++;
+
+      const bool tensors_full =
+          (loc_tensor_info == depth_to_max_tensors[depth - 1] &&
+           chunk == chunks - 1);
+      const bool blocks_full =
+          (loc_block_info == depth_to_max_blocks[depth - 1]);
+      const bool last_chunk = (t == n_tensors - 1 && chunk == chunks - 1);
+
+      if (tensors_full || blocks_full || last_chunk) {
+        multi_tensor_apply_kernel<<<
+            loc_block_info,
+            kBlockSize,
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            tensorListMeta, callable, args...);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        // Reset.
+        loc_block_info = 0;
+        if (chunk == chunks - 1) {
+          loc_tensor_info = 0;
+          tensorListMeta.start_tensor_this_launch = t + 1;
+        } else {
+          tensorListMeta.numel_for_tensor[0] =
+              tensorListMeta.numel_for_tensor[loc_tensor_info - 1];
+          for (int d = 0; d < depth; d++) {
+            tensorListMeta.addresses[d][0] =
+                tensorListMeta.addresses[d][loc_tensor_info - 1];
+          }
+          loc_tensor_info = 1;
+          tensorListMeta.start_tensor_this_launch = t;
+        }
+      }
+    }
+  }
+}
+
+template <int depth, typename T, typename... ArgTypes>
+void multi_tensor_apply_for_fused_optimizer(
+    std::vector<std::vector<at::Tensor>>& tensor_lists,
+    at::TensorList state_steps,
+    T callable,
+    ArgTypes... args) {
+  TORCH_CHECK(
+      tensor_lists.size() == depth,
+      "Number of tensor lists has to match the depth");
+  const auto num_tensors = tensor_lists[0].size();
+  auto num_zero_tensors = 0;
+  FusedOptimizerTensorListMetadata<depth> tensorListMeta;
+
+  int loc_block_info = 0;
+  int loc_tensor_info = 0;
+  for (const auto& tensor_index : c10::irange(num_tensors)) {
+    if (tensor_lists[0][tensor_index].numel() == 0) {
+      num_zero_tensors++;
+      if (tensor_index != num_tensors - 1) {
+        continue;
+      }
+    } else {
+      tensorListMeta.state_steps_addresses[loc_tensor_info] =
+          state_steps[tensor_index].const_data_ptr();
+      tensorListMeta.numel_for_tensor[loc_tensor_info] =
+          tensor_lists[0][tensor_index].numel();
+      for (const auto& d : c10::irange(depth)) {
+        tensorListMeta.addresses[d][loc_tensor_info] =
+            tensor_lists[d][tensor_index].const_data_ptr();
+      }
+      loc_tensor_info++;
+    }
+
+    if (static_cast<decltype(num_tensors)>(num_zero_tensors) == num_tensors) {
+      continue;
+    }
+    const int64_t chunks =
+        (tensor_lists[0]
+                     [tensor_index -
+                      static_cast<decltype(tensor_index)>(
+                          (tensor_index == num_tensors - 1) &&
+                          (tensor_lists[0][tensor_index].numel() == 0))]
+                         .numel() +
+         kChunkSize - 1) /
+        kChunkSize;
+    TORCH_CHECK(chunks > -1);
+    for (const auto& chunk : c10::irange(chunks)) {
+      tensorListMeta.block_to_tensor[loc_block_info] = loc_tensor_info - 1;
+      tensorListMeta.block_to_chunk[loc_block_info] = chunk;
+      loc_block_info++;
+
+      const auto tensor_full =
+          (loc_tensor_info == depth_to_max_tensors[depth - 1] &&
+           chunk == chunks - 1);
+      const auto blocks_full = loc_block_info == depth_to_max_blocks[depth - 1];
+      const auto last_chunk =
+          (tensor_index == num_tensors - 1 && chunk == chunks - 1);
+
+      if (tensor_full || blocks_full || last_chunk) {
+        multi_tensor_apply_kernel<<<
+            loc_block_info,
+            kBlockSize,
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            tensorListMeta, callable, args...);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        // Reset.
+        loc_block_info = 0;
+        if (chunk == chunks - 1) {
+          loc_tensor_info = 0;
+        } else {
+          tensorListMeta.numel_for_tensor[0] =
+              tensorListMeta.numel_for_tensor[loc_tensor_info - 1];
+          tensorListMeta.state_steps_addresses[0] =
+              tensorListMeta.state_steps_addresses[loc_tensor_info - 1];
+          for (const auto& d : c10::irange(depth)) {
+            tensorListMeta.addresses[d][0] =
+                tensorListMeta.addresses[d][loc_tensor_info - 1];
+          }
+          loc_tensor_info = 1;
+        }
+      }
+    }
+  }
+}
+
+} // namespace at::native


### PR DESCRIPTION
As per title.

I don't think it's good to have multiple styles of line breaks, indents, etc. in a file.
I'll submit a pull request to update https://github.com/pytorch/pytorch/blob/main/.git-blame-ignore-revs once this landed.

cc @albanD @ptrblck 