### PR TITLE
[BE] Fix `lintrunner init` on python 3.11

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -148,7 +148,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'numpy==1.23.1',
+    'numpy==1.24.3',
     'expecttest==0.1.3',
     'mypy==0.960',
     'types-requests==2.27.25',


### PR DESCRIPTION
Makes the `lintrunner init` command work with python 3.11

The old version of numpy would fail to install on python 3.11, where setup would fail to build wheels with the error `AttributeError: fcompiler. Did you mean: 'compiler'?`

The latest version of numpy installs just fine however, so switching to that.

More details in https://github.com/numpy/numpy/pull/22102