### PR TITLE
[caffe2] Create deterministic zip archives

### DIFF
--- a/torch/utils/_zip.py
+++ b/torch/utils/_zip.py
@@ -54,10 +54,10 @@ if __name__ == "__main__":
     prepend_str = args.prepend_str
     zf = ZipFile(zip_file_name, mode='w')
 
-    for p in args.paths:
+    for p in sorted(args.paths):
         if os.path.isdir(p):
             files = glob.glob(p + "/**/*.py", recursive=True)
-            for file_path in files:
+            for file_path in sorted(files):
                 # strip the absolute path
                 write_to_zip(file_path, strip_file_dir + "/", zf, prepend_str=prepend_str)
         else:


### PR DESCRIPTION
Summary: Ensure that we create deterministic zip archives for the same inputs to make builds deterministic.

Test Plan: CI

Reviewed By: StanislavGlebik

Differential Revision: D46417033

