### PR TITLE
Init dec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ venv/
 # Log files
 *.log
 sweep/
+
+# Conda envnironment file
+env.yml


### PR DESCRIPTION
Adds utility decorators for `torch.nn.init` that lets users easy change default module initalization strategy. Example of usage (before this PR) is in the [GitHub Gist][Github Gist] shown in [PackedSequences on MPS accelerator][PackedSequences on MPS accelerator] and was previously mentioned in [clarification for initialization strategies][clarification for initialization strategies].

Example:

```python
@kaiming_init
class KGRU(nn.GRU):
    pass

@kaiming_init
class KLSTM(nn.LSTM):
    pass

@kaiming_init
class KLinear(nn.Linear):
    pass
```

[clarification for initialization strategies]: https://github.com/pytorch/pytorch/issues/102730
[Github Gist]: https://gist.github.com/dsm-72/1cea0601145a8b92155d8d08c90bf998
[PackedSequences on MPS accelerator]: https://github.com/pytorch/pytorch/issues/102911