### PR TITLE
Masked loss funcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ venv/
 # Log files
 *.log
 sweep/
+
+# Conda envnironment file
+env.yml


### PR DESCRIPTION
Adds masked losses for use with `torch.nn.rnn` that lets users calculate some losses with a padded sequence. Example of usage (before this PR) is in the [GitHub Gist][Github Gist] shown in [PackedSequences on MPS accelerator][PackedSequences on MPS accelerator].

[clarification for initialization strategies]: https://github.com/pytorch/pytorch/issues/102730
[Github Gist]: https://gist.github.com/dsm-72/1cea0601145a8b92155d8d08c90bf998
[PackedSequences on MPS accelerator]: https://github.com/pytorch/pytorch/issues/102911