### PR TITLE
Get device module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ venv/
 # Log files
 *.log
 sweep/
+
+# Conda envnironment file
+env.yml

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -812,3 +812,15 @@ def classproperty(func):
 # Whether we are compiling with torch.compile or not
 def is_compiling():
     return False
+
+
+def get_device_of_module(module:torch.nn.Module) -> torch.types.Device:
+    # NOTE: `torch.get_device()` is only valid for Tensors
+    try:
+        device = next(module.parameters()).device 
+
+    except Exception as err:
+        # NOTE: use default device if no parameters are found
+        device = torch.empty([]).device
+
+    return device  

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -956,6 +956,42 @@ class Module:
             Module: self
         """
         return self._apply(lambda t: t.cpu())
+    
+    # TODO: add support for `MPS` and other devices
+    def mps(self: T) -> T:
+        r"""Moves all model parameters and buffers to the MPS.
+
+        .. note::
+            This method modifies the module in-place.
+
+        Returns:
+            Module: self
+        """
+        return self._apply(lambda t: t.mps())
+    
+    
+    @property
+    def device(self) -> torch.types.Device:
+        r"""Moves all model parameters and buffers to the MPS.
+
+        .. note::
+            This method modifies the module in-place.
+
+        Returns:
+            Module: self
+        """
+        try:
+            return self._device
+        
+        except AttributeError:
+            # NOTE: `torch.get_device(...)` is only valid for Tensors
+            try:
+                device = next(self.parameters()).device            
+            except Exception as err:
+                # NOTE: use default device if no parameters are found
+                self._device = torch.empty([]).device
+            self._device = device 
+            return device            
 
     def type(self: T, dst_type: Union[dtype, str]) -> T:
         r"""Casts all parameters and buffers to :attr:`dst_type`.


### PR DESCRIPTION
Doesn't;t fix any particular issue. However `torch.get_device` is not implemented for `nn.Module`s and this just makes `Module`s compatible