### PR TITLE
use clang-tidy to check c10/test/*cpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,7 @@ performance-*,
 -performance-unnecessary-value-param,
 readability-container-size-empty,
 '
-HeaderFilterRegex: '^(c10/(?!test)|torch/csrc/(?!deploy/interpreter/cpython)).*$'
+HeaderFilterRegex: '^(c10|torch/csrc/(?!deploy/interpreter/cpython)).*$'
 AnalyzeTemporaryDtors: false
 WarningsAsErrors: '*'
 ...

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -240,7 +240,6 @@ exclude_patterns = [
     # in a follow up PR.
     # that are not easily converted to accepted c++
     'c10/cuda/**/*.cpp',
-    'c10/test/**/*.cpp',
     'torch/csrc/jit/passes/onnx/helper.cpp',
     'torch/csrc/jit/passes/onnx/shape_type_inference.cpp',
     'torch/csrc/jit/serialization/onnx.cpp',

--- a/c10/test/core/CompileTimeFunctionPointer_test.cpp
+++ b/c10/test/core/CompileTimeFunctionPointer_test.cpp
@@ -2,42 +2,41 @@
 #include <gtest/gtest.h>
 
 namespace test_is_compile_time_function_pointer {
-static_assert(!c10::is_compile_time_function_pointer<void()>::value, "");
+static_assert(!c10::is_compile_time_function_pointer<void()>::value);
 
 void dummy() {}
 static_assert(
-    c10::is_compile_time_function_pointer<TORCH_FN_TYPE(dummy)>::value,
-    "");
+    c10::is_compile_time_function_pointer<TORCH_FN_TYPE(dummy)>::value);
 } // namespace test_is_compile_time_function_pointer
 
 namespace test_access_through_type {
 void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(dummy);
-static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value, "");
-static_assert(dummy_ptr::func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value, "");
+static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
+static_assert(dummy_ptr::func_ptr() == &dummy);
+static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
 } // namespace test_access_through_type
 
 namespace test_access_through_value {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(dummy);
-static_assert(dummy_ptr.func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value, "");
+static_assert(dummy_ptr.func_ptr() == &dummy);
+static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
 } // namespace test_access_through_value
 
 namespace test_access_through_type_also_works_if_specified_as_pointer {
 void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(&dummy);
-static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value, "");
-static_assert(dummy_ptr::func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value, "");
+static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
+static_assert(dummy_ptr::func_ptr() == &dummy);
+static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
 } // namespace test_access_through_type_also_works_if_specified_as_pointer
 
 namespace test_access_through_value_also_works_if_specified_as_pointer {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(&dummy);
-static_assert(dummy_ptr.func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value, "");
+static_assert(dummy_ptr.func_ptr() == &dummy);
+static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
 } // namespace test_access_through_value_also_works_if_specified_as_pointer
 
 namespace test_run_through_type {

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -400,7 +400,7 @@ TEST(DispatchKeySet, TestBackendComponentToString) {
 }
 
 TEST(DispatchKeySet, TestEndOfRuntimeBackendKeysAccurate) {
-  DispatchKey k;
+  DispatchKey k = DispatchKey::Undefined;
 #define SETTER(fullname, prefix) k = DispatchKey::EndOf##fullname##Backends;
   C10_FORALL_FUNCTIONALITY_KEYS(SETTER)
 #undef SETTER

--- a/c10/test/core/impl/InlineDeviceGuard_test.cpp
+++ b/c10/test/core/impl/InlineDeviceGuard_test.cpp
@@ -6,6 +6,7 @@
 using namespace c10;
 using namespace c10::impl;
 
+// NOLINTBEGIN(*narrowing-conversions*)
 constexpr auto TestDeviceType = DeviceType::CUDA;
 using TestGuardImpl = FakeGuardImpl<TestDeviceType>;
 
@@ -192,3 +193,4 @@ TEST(InlineOptionalDeviceGuard, SetIndex) {
   ASSERT_EQ(g.current_device(), make_optional(dev(i)));
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i);
 }
+// NOLINTEND(*narrowing-conversions*)

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -65,8 +65,8 @@ TEST(SizesAndStridesTest, Resize) {
   checkData(sz, {0, 0, 0, 0, 0}, {1, 0, 0, 0, 0});
 
   for (const auto ii : c10::irange(sz.size())) {
-    sz.size_at_unchecked(ii) = ii + 1;
-    sz.stride_at_unchecked(ii) = 2 * (ii + 1);
+    sz.size_at_unchecked(ii) = static_cast<int64_t>(ii + 1);
+    sz.stride_at_unchecked(ii) = static_cast<int64_t>(2 * (ii + 1));
   }
 
   checkData(sz, {1, 2, 3, 4, 5}, {2, 4, 6, 8, 10});
@@ -196,8 +196,8 @@ static SizesAndStrides makeBig(int offset = 0) {
   SizesAndStrides big;
   big.resize(8);
   for (const auto ii : c10::irange(big.size())) {
-    big.size_at_unchecked(ii) = ii - 1 + offset;
-    big.stride_at_unchecked(ii) = 2 * (ii - 1 + offset);
+    big.size_at_unchecked(ii) = static_cast<int64_t>(ii - 1 + offset);
+    big.stride_at_unchecked(ii) = static_cast<int64_t>(2 * (ii - 1 + offset));
   }
 
   return big;

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -10,7 +10,7 @@
 using namespace c10;
 using namespace c10::impl;
 
-// NOLINTBEGIN(*conversion*)
+// NOLINTBEGIN(*conversion*, *multiplication*)
 static void checkData(
     const SizesAndStrides& sz,
     IntArrayRef sizes,
@@ -419,4 +419,4 @@ TEST(SizesAndStridesTest, MoveAssignmentSelf) {
   selfMove(big, big);
   checkBig(big);
 }
-// NOLINTEND(*conversion*)
+// NOLINTEND(*conversion*, *multiplication*)

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -10,6 +10,7 @@
 using namespace c10;
 using namespace c10::impl;
 
+// NOLINTBEGIN(*conversion*)
 static void checkData(
     const SizesAndStrides& sz,
     IntArrayRef sizes,
@@ -65,8 +66,8 @@ TEST(SizesAndStridesTest, Resize) {
   checkData(sz, {0, 0, 0, 0, 0}, {1, 0, 0, 0, 0});
 
   for (const auto ii : c10::irange(sz.size())) {
-    sz.size_at_unchecked(ii) = static_cast<int64_t>(ii + 1);
-    sz.stride_at_unchecked(ii) = static_cast<int64_t>(2 * (ii + 1));
+    sz.size_at_unchecked(ii) = ii + 1;
+    sz.stride_at_unchecked(ii) = 2 * (ii + 1);
   }
 
   checkData(sz, {1, 2, 3, 4, 5}, {2, 4, 6, 8, 10});
@@ -196,8 +197,8 @@ static SizesAndStrides makeBig(int offset = 0) {
   SizesAndStrides big;
   big.resize(8);
   for (const auto ii : c10::irange(big.size())) {
-    big.size_at_unchecked(ii) = static_cast<int64_t>(ii - 1 + offset);
-    big.stride_at_unchecked(ii) = static_cast<int64_t>(2 * (ii - 1 + offset));
+    big.size_at_unchecked(ii) = ii - 1 + offset;
+    big.stride_at_unchecked(ii) = 2 * (ii - 1 + offset);
   }
 
   return big;
@@ -418,3 +419,4 @@ TEST(SizesAndStridesTest, MoveAssignmentSelf) {
   selfMove(big, big);
   checkBig(big);
 }
+// NOLINTEND(*conversion*)

--- a/c10/test/util/Array_test.cpp
+++ b/c10/test/util/Array_test.cpp
@@ -6,90 +6,88 @@ using c10::guts::to_array;
 
 namespace {
 namespace test_equals {
-static_assert(array<int, 0>{{}} == array<int, 0>{{}}, "");
-static_assert(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 4}}, "");
-static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{1, 3, 4}}), "");
-static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 1, 4}}), "");
-static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 1}}), "");
+static_assert(array<int, 0>{{}} == array<int, 0>{{}});
+static_assert(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 4}});
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{1, 3, 4}}));
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 1, 4}}));
+static_assert(!(array<int, 3>{{2, 3, 4}} == array<int, 3>{{2, 3, 1}}));
 } // namespace test_equals
 
 namespace test_notequals {
-static_assert(!(array<int, 0>{{}} != array<int, 0>{{}}), "");
-static_assert(!(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 4}}), "");
-static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{1, 3, 4}}, "");
-static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 1, 4}}, "");
-static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 1}}, "");
+static_assert(!(array<int, 0>{{}} != array<int, 0>{{}}));
+static_assert(!(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 4}}));
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{1, 3, 4}});
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 1, 4}});
+static_assert(array<int, 3>{{2, 3, 4}} != array<int, 3>{{2, 3, 1}});
 } // namespace test_notequals
 
 namespace test_lessthan {
-static_assert(!(array<int, 0>{{}} < array<int, 0>{{}}), "");
-static_assert(!(array<int, 1>{{2}} < array<int, 1>{{1}}), "");
-static_assert(array<int, 1>{{1}} < array<int, 1>{{2}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{2, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{0, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 3, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 1, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 4}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 2}}), "");
+static_assert(!(array<int, 0>{{}} < array<int, 0>{{}}));
+static_assert(!(array<int, 1>{{2}} < array<int, 1>{{1}}));
+static_assert(array<int, 1>{{1}} < array<int, 1>{{2}});
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{2, 2, 3}});
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{0, 2, 3}}));
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 3, 3}});
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 1, 3}}));
+static_assert(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 4}});
+static_assert(!(array<int, 3>{{1, 2, 3}} < array<int, 3>{{1, 2, 2}}));
 } // namespace test_lessthan
 
 namespace test_greaterthan {
-static_assert(!(array<int, 0>{{}} > array<int, 0>{{}}), "");
-static_assert(!(array<int, 1>{{1}} > array<int, 1>{{2}}), "");
-static_assert(array<int, 1>{{2}} > array<int, 1>{{1}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{2, 2, 3}} > array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{0, 2, 3}} > array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 3, 3}} > array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 1, 3}} > array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 4}} > array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 2}} > array<int, 3>{{1, 2, 3}}), "");
+static_assert(!(array<int, 0>{{}} > array<int, 0>{{}}));
+static_assert(!(array<int, 1>{{1}} > array<int, 1>{{2}}));
+static_assert(array<int, 1>{{2}} > array<int, 1>{{1}});
+static_assert(!(array<int, 3>{{1, 2, 3}} > array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{2, 2, 3}} > array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{0, 2, 3}} > array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{1, 3, 3}} > array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{1, 1, 3}} > array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{1, 2, 4}} > array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{1, 2, 2}} > array<int, 3>{{1, 2, 3}}));
 } // namespace test_greaterthan
 
 namespace test_lessequals {
-static_assert(array<int, 0>{{}} <= array<int, 0>{{}}, "");
-static_assert(!(array<int, 1>{{2}} <= array<int, 1>{{1}}), "");
-static_assert(array<int, 1>{{1}} <= array<int, 1>{{2}}, "");
-static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 3}}, "");
-static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{2, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{0, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 3, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 1, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 4}}, "");
-static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 2}}), "");
+static_assert(array<int, 0>{{}} <= array<int, 0>{{}});
+static_assert(!(array<int, 1>{{2}} <= array<int, 1>{{1}}));
+static_assert(array<int, 1>{{1}} <= array<int, 1>{{2}});
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 3}});
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{2, 2, 3}});
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{0, 2, 3}}));
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 3, 3}});
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 1, 3}}));
+static_assert(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 4}});
+static_assert(!(array<int, 3>{{1, 2, 3}} <= array<int, 3>{{1, 2, 2}}));
 } // namespace test_lessequals
 
 namespace test_greaterequals {
-static_assert(array<int, 0>{{}} >= array<int, 0>{{}}, "");
-static_assert(!(array<int, 1>{{1}} >= array<int, 1>{{2}}), "");
-static_assert(array<int, 1>{{2}} >= array<int, 1>{{1}}, "");
-static_assert(array<int, 3>{{1, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-static_assert(array<int, 3>{{2, 2, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{0, 2, 3}} >= array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 3, 3}} >= array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 1, 3}} >= array<int, 3>{{1, 2, 3}}), "");
-static_assert(array<int, 3>{{1, 2, 4}} >= array<int, 3>{{1, 2, 3}}, "");
-static_assert(!(array<int, 3>{{1, 2, 2}} >= array<int, 3>{{1, 2, 3}}), "");
+static_assert(array<int, 0>{{}} >= array<int, 0>{{}});
+static_assert(!(array<int, 1>{{1}} >= array<int, 1>{{2}}));
+static_assert(array<int, 1>{{2}} >= array<int, 1>{{1}});
+static_assert(array<int, 3>{{1, 2, 3}} >= array<int, 3>{{1, 2, 3}});
+static_assert(array<int, 3>{{2, 2, 3}} >= array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{0, 2, 3}} >= array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{1, 3, 3}} >= array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{1, 1, 3}} >= array<int, 3>{{1, 2, 3}}));
+static_assert(array<int, 3>{{1, 2, 4}} >= array<int, 3>{{1, 2, 3}});
+static_assert(!(array<int, 3>{{1, 2, 2}} >= array<int, 3>{{1, 2, 3}}));
 } // namespace test_greaterequals
 
 namespace test_tail {
-static_assert(array<int, 2>{{3, 4}} == tail(array<int, 3>{{2, 3, 4}}), "");
-static_assert(array<int, 0>{{}} == tail(array<int, 1>{{3}}), "");
+static_assert(array<int, 2>{{3, 4}} == tail(array<int, 3>{{2, 3, 4}}));
+static_assert(array<int, 0>{{}} == tail(array<int, 1>{{3}}));
 } // namespace test_tail
 
 namespace test_prepend {
-static_assert(
-    array<int, 3>{{2, 3, 4}} == prepend(2, array<int, 2>{{3, 4}}),
-    "");
-static_assert(array<int, 1>{{3}} == prepend(3, array<int, 0>{{}}), "");
+static_assert(array<int, 3>{{2, 3, 4}} == prepend(2, array<int, 2>{{3, 4}}));
+static_assert(array<int, 1>{{3}} == prepend(3, array<int, 0>{{}}));
 } // namespace test_prepend
 
 namespace test_to_std_array {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 constexpr int obj2[3] = {3, 5, 6};
-static_assert(array<int, 3>{{3, 5, 6}} == to_array(obj2), "");
-static_assert(array<int, 3>{{3, 5, 6}} == to_array<int, 3>({3, 5, 6}), "");
+static_assert(array<int, 3>{{3, 5, 6}} == to_array(obj2));
+static_assert(array<int, 3>{{3, 5, 6}} == to_array<int, 3>({3, 5, 6}));
 } // namespace test_to_std_array
 
 } // namespace

--- a/c10/test/util/C++17_test.cpp
+++ b/c10/test/util/C++17_test.cpp
@@ -5,18 +5,18 @@ namespace {
 
 namespace test_min {
 using c10::guts::min;
-static_assert(min(3, 5) == 3, "");
-static_assert(min(5, 3) == 3, "");
-static_assert(min(3, 3) == 3, "");
-static_assert(min(3.0, 3.1) == 3.0, "");
+static_assert(min(3, 5) == 3);
+static_assert(min(5, 3) == 3);
+static_assert(min(3, 3) == 3);
+static_assert(min(3.0, 3.1) == 3.0);
 } // namespace test_min
 
 namespace test_max {
 using c10::guts::max;
-static_assert(max(3, 5) == 5, "");
-static_assert(max(5, 3) == 5, "");
-static_assert(max(3, 3) == 3, "");
-static_assert(max(3.0, 3.1) == 3.1, "");
+static_assert(max(3, 5) == 5);
+static_assert(max(5, 3) == 5);
+static_assert(max(3, 3) == 3);
+static_assert(max(3.0, 3.1) == 3.1);
 } // namespace test_max
 
 } // namespace

--- a/c10/test/util/ConstexprCrc_test.cpp
+++ b/c10/test/util/ConstexprCrc_test.cpp
@@ -13,5 +13,5 @@ static_assert(
 
 // check concrete expected values (for CRC64 with Jones coefficients and an init
 // value of 0)
-static_assert(crc64_t{0} == crc64(""), "");
-static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"), "");
+static_assert(crc64_t{0} == crc64(""));
+static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"));

--- a/c10/test/util/LeftRight_test.cpp
+++ b/c10/test/util/LeftRight_test.cpp
@@ -34,7 +34,7 @@ TEST(LeftRightTest, givenVector_whenWritingReturnsValue_thenValueIsReturned) {
   LeftRight<vector<int>> obj;
 
   auto a = obj.write([](vector<int>&) -> int { return 5; });
-  static_assert(std::is_same<int, decltype(a)>::value, "");
+  static_assert(std::is_same<int, decltype(a)>::value);
   EXPECT_EQ(5, a);
 }
 

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -163,7 +163,7 @@ namespace test_tuple_map {
 TEST(MetaprogrammingTest, TupleMap_simple) {
   auto result = tuple_map(
       std::tuple<int32_t, int32_t, int32_t>(3, 4, 5),
-      [](int32_t a) -> int16_t { return a + 1; });
+      [](int32_t a) -> int16_t { return static_cast<int16_t>(a + 1); });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
           value);
@@ -175,7 +175,7 @@ TEST(MetaprogrammingTest, TupleMap_simple) {
 TEST(MetaprogrammingTest, TupleMap_mapperTakesDifferentButConvertibleType) {
   auto result = tuple_map(
       std::tuple<int32_t, int32_t, int32_t>(3, 4, 5),
-      [](int64_t a) -> int16_t { return a + 1; });
+      [](int64_t a) -> int16_t { return static_cast<int16_t>(a + 1); });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
           value);
@@ -187,7 +187,7 @@ TEST(MetaprogrammingTest, TupleMap_mapperTakesDifferentButConvertibleType) {
 TEST(MetaprogrammingTest, TupleMap_mapperTakesConstRef) {
   auto result = tuple_map(
       std::tuple<int32_t, int32_t, int32_t>(3, 4, 5),
-      [](const int32_t& a) -> int16_t { return a + 1; });
+      [](const int32_t& a) -> int16_t { return static_cast<int16_t>(a + 1); });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
           value);

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -8,62 +8,51 @@ using namespace c10::guts;
 namespace {
 
 namespace test_function_traits {
-static_assert(
-    std::is_same<
-        void,
-        typename function_traits<void(int, float)>::return_type>::value,
-    "");
-static_assert(
-    std::is_same<int, typename function_traits<int(int, float)>::return_type>::
-        value,
-    "");
+static_assert(std::is_same<
+              void,
+              typename function_traits<void(int, float)>::return_type>::value);
+static_assert(std::is_same<
+              int,
+              typename function_traits<int(int, float)>::return_type>::value);
 static_assert(
     std::is_same<
         typelist::typelist<int, float>,
-        typename function_traits<void(int, float)>::parameter_types>::value,
-    "");
+        typename function_traits<void(int, float)>::parameter_types>::value);
 static_assert(
     std::is_same<
         typelist::typelist<int, float>,
-        typename function_traits<int(int, float)>::parameter_types>::value,
-    "");
+        typename function_traits<int(int, float)>::parameter_types>::value);
 
 static_assert(
     std::is_same<
         bool,
         typename make_function_traits_t<bool, typelist::typelist<int, float>>::
-            return_type>::value,
-    "");
+            return_type>::value);
 static_assert(
     std::is_same<
         void,
         typename make_function_traits_t<void, typelist::typelist<int, float>>::
-            return_type>::value,
-    "");
+            return_type>::value);
 static_assert(
     std::is_same<
         typelist::typelist<int, float>,
         typename make_function_traits_t<bool, typelist::typelist<int, float>>::
-            parameter_types>::value,
-    "");
+            parameter_types>::value);
 static_assert(
     std::is_same<
         typelist::typelist<int, float>,
         typename make_function_traits_t<void, typelist::typelist<int, float>>::
-            parameter_types>::value,
-    "");
+            parameter_types>::value);
 static_assert(
     std::is_same<
         bool(int, float),
         typename make_function_traits_t<bool, typelist::typelist<int, float>>::
-            func_type>::value,
-    "");
+            func_type>::value);
 static_assert(
     std::is_same<
         void(int, float),
         typename make_function_traits_t<void, typelist::typelist<int, float>>::
-            func_type>::value,
-    "");
+            func_type>::value);
 } // namespace test_function_traits
 
 struct MovableOnly {
@@ -177,8 +166,7 @@ TEST(MetaprogrammingTest, TupleMap_simple) {
       [](int32_t a) -> int16_t { return a + 1; });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
-          value,
-      "");
+          value);
   EXPECT_EQ(4, std::get<0>(result));
   EXPECT_EQ(5, std::get<1>(result));
   EXPECT_EQ(6, std::get<2>(result));
@@ -190,8 +178,7 @@ TEST(MetaprogrammingTest, TupleMap_mapperTakesDifferentButConvertibleType) {
       [](int64_t a) -> int16_t { return a + 1; });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
-          value,
-      "");
+          value);
   EXPECT_EQ(4, std::get<0>(result));
   EXPECT_EQ(5, std::get<1>(result));
   EXPECT_EQ(6, std::get<2>(result));
@@ -203,8 +190,7 @@ TEST(MetaprogrammingTest, TupleMap_mapperTakesConstRef) {
       [](const int32_t& a) -> int16_t { return a + 1; });
   static_assert(
       std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::
-          value,
-      "");
+          value);
   EXPECT_EQ(4, std::get<0>(result));
   EXPECT_EQ(5, std::get<1>(result));
   EXPECT_EQ(6, std::get<2>(result));
@@ -221,8 +207,7 @@ TEST(MetaprogrammingTest, TupleMap_mapsToDifferentTypes) {
   };
   auto result = tuple_map(std::tuple<int32_t, std::string>(3, "4"), Mapper());
   static_assert(
-      std::is_same<std::tuple<std::string, int32_t>, decltype(result)>::value,
-      "");
+      std::is_same<std::tuple<std::string, int32_t>, decltype(result)>::value);
   EXPECT_EQ("3", std::get<0>(result));
   EXPECT_EQ(4, std::get<1>(result));
 }
@@ -242,8 +227,7 @@ TEST(MetaprogrammingTest, TupleMap_differentiatesLRValueReferences) {
       Mapper());
   static_assert(
       std::is_same<std::tuple<std::string, std::string>, decltype(result)>::
-          value,
-      "");
+          value);
   EXPECT_EQ("copied", std::get<0>(result));
   EXPECT_EQ("moved", std::get<1>(result));
 }
@@ -251,8 +235,7 @@ TEST(MetaprogrammingTest, TupleMap_differentiatesLRValueReferences) {
 TEST(MetaprogrammingTest, TupleMap_canWorkWithMovableOnlyType) {
   auto result = tuple_map(
       std::tuple<MovableOnly>(MovableOnly(7)), [](MovableOnly a) { return a; });
-  static_assert(
-      std::is_same<std::tuple<MovableOnly>, decltype(result)>::value, "");
+  static_assert(std::is_same<std::tuple<MovableOnly>, decltype(result)>::value);
   EXPECT_EQ(MovableOnly(7), std::get<0>(result));
 }
 
@@ -261,7 +244,7 @@ TEST(MetaprogrammingTest, TupleMap_doesntUnecessarilyCopyValues) {
       std::tuple<CopyCounting>(CopyCounting()),
       [](CopyCounting a) { return a; });
   static_assert(
-      std::is_same<std::tuple<CopyCounting>, decltype(result)>::value, "");
+      std::is_same<std::tuple<CopyCounting>, decltype(result)>::value);
   EXPECT_EQ(4, std::get<0>(result).move_count);
   EXPECT_EQ(0, std::get<0>(result).copy_count);
 }
@@ -272,7 +255,7 @@ TEST(MetaprogrammingTest, TupleMap_doesntUnecessarilyMoveValues) {
       std::tuple<CopyCounting&&>(std::move(a)),
       [](CopyCounting&& a) -> CopyCounting&& { return std::move(a); });
   static_assert(
-      std::is_same<std::tuple<CopyCounting&&>, decltype(result)>::value, "");
+      std::is_same<std::tuple<CopyCounting&&>, decltype(result)>::value);
   EXPECT_EQ(&a, &std::get<0>(result));
   EXPECT_EQ(0, std::get<0>(result).move_count);
   EXPECT_EQ(0, std::get<0>(result).copy_count);
@@ -292,8 +275,7 @@ TEST(MetaprogrammingTest, TupleMap_canBeUsedWithAutoLambdas) {
   auto result =
       tuple_map(std::make_tuple(A(), B()), [](auto a) { return a.func(); });
   static_assert(
-      std::is_same<std::tuple<int32_t, std::string>, decltype(result)>::value,
-      "");
+      std::is_same<std::tuple<int32_t, std::string>, decltype(result)>::value);
   EXPECT_EQ(5, std::get<0>(result));
   EXPECT_EQ("5", std::get<1>(result));
 }

--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -8,40 +8,34 @@ using c10::util::get_type_index;
 
 namespace {
 
-static_assert(get_type_index<int>() == get_type_index<int>(), "");
-static_assert(get_type_index<float>() == get_type_index<float>(), "");
-static_assert(get_type_index<int>() != get_type_index<float>(), "");
+static_assert(get_type_index<int>() == get_type_index<int>());
+static_assert(get_type_index<float>() == get_type_index<float>());
+static_assert(get_type_index<int>() != get_type_index<float>());
 static_assert(
     get_type_index<int(double, double)>() ==
-        get_type_index<int(double, double)>(),
-    "");
+    get_type_index<int(double, double)>());
 static_assert(
-    get_type_index<int(double, double)>() != get_type_index<int(double)>(),
-    "");
+    get_type_index<int(double, double)>() != get_type_index<int(double)>());
 static_assert(
     get_type_index<int(double, double)>() ==
-        get_type_index<int (*)(double, double)>(),
-    "");
+    get_type_index<int (*)(double, double)>());
 static_assert(
     get_type_index<std::function<int(double, double)>>() ==
-        get_type_index<std::function<int(double, double)>>(),
-    "");
+    get_type_index<std::function<int(double, double)>>());
 static_assert(
     get_type_index<std::function<int(double, double)>>() !=
-        get_type_index<std::function<int(double)>>(),
-    "");
+    get_type_index<std::function<int(double)>>());
 
-static_assert(get_type_index<int>() == get_type_index<int&>(), "");
-static_assert(get_type_index<int>() == get_type_index<int&&>(), "");
-static_assert(get_type_index<int>() == get_type_index<const int&>(), "");
-static_assert(get_type_index<int>() == get_type_index<const int>(), "");
-static_assert(get_type_index<const int>() == get_type_index<int&>(), "");
-static_assert(get_type_index<int>() != get_type_index<int*>(), "");
-static_assert(get_type_index<int*>() != get_type_index<int**>(), "");
+static_assert(get_type_index<int>() == get_type_index<int&>());
+static_assert(get_type_index<int>() == get_type_index<int&&>());
+static_assert(get_type_index<int>() == get_type_index<const int&>());
+static_assert(get_type_index<int>() == get_type_index<const int>());
+static_assert(get_type_index<const int>() == get_type_index<int&>());
+static_assert(get_type_index<int>() != get_type_index<int*>());
+static_assert(get_type_index<int*>() != get_type_index<int**>());
 static_assert(
     get_type_index<int(double&, double)>() !=
-        get_type_index<int(double, double)>(),
-    "");
+    get_type_index<int(double, double)>());
 
 struct Dummy final {};
 struct Functor final {
@@ -49,15 +43,12 @@ struct Functor final {
 };
 static_assert(
     get_type_index<int64_t(uint32_t, Dummy&&, const Dummy&)>() ==
-        get_type_index<
-            c10::guts::infer_function_traits_t<Functor>::func_type>(),
-    "");
+    get_type_index<c10::guts::infer_function_traits_t<Functor>::func_type>());
 
 namespace test_top_level_name {
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
-    string_view::npos != get_fully_qualified_type_name<Dummy>().find("Dummy"),
-    "");
+    string_view::npos != get_fully_qualified_type_name<Dummy>().find("Dummy"));
 #endif
 TEST(TypeIndex, TopLevelName) {
   EXPECT_NE(
@@ -71,8 +62,7 @@ struct Dummy final {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<Dummy>().find("test_nested_name::Dummy"),
-    "");
+    get_fully_qualified_type_name<Dummy>().find("test_nested_name::Dummy"));
 #endif
 TEST(TypeIndex, NestedName) {
   EXPECT_NE(
@@ -89,14 +79,12 @@ struct Inner final {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<Outer<Inner>>().find(
-            "test_type_template_parameter::Outer"),
-    "");
+    get_fully_qualified_type_name<Outer<Inner>>().find(
+        "test_type_template_parameter::Outer"));
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<Outer<Inner>>().find(
-            "test_type_template_parameter::Inner"),
-    "");
+    get_fully_qualified_type_name<Outer<Inner>>().find(
+        "test_type_template_parameter::Inner"));
 #endif
 TEST(TypeIndex, TypeTemplateParameter) {
   EXPECT_NE(
@@ -117,8 +105,7 @@ struct Class final {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<Class<38474355>>().find("38474355"),
-    "");
+    get_fully_qualified_type_name<Class<38474355>>().find("38474355"));
 #endif
 TEST(TypeIndex, NonTypeTemplateParameter) {
   EXPECT_NE(
@@ -136,20 +123,17 @@ struct Type final {
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<typename Type<int>::type>().find("int"),
-    "");
+    get_fully_qualified_type_name<typename Type<int>::type>().find("int"));
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<typename Type<int>::type>().find("*"),
-    "");
+    get_fully_qualified_type_name<typename Type<int>::type>().find("*"));
 
 // but with remove_pointer applied, there is no '*' in the type name anymore
 static_assert(
     string_view::npos ==
-        get_fully_qualified_type_name<
-            typename std::remove_pointer<typename Type<int>::type>::type>()
-            .find("*"),
-    "");
+    get_fully_qualified_type_name<
+        typename std::remove_pointer<typename Type<int>::type>::type>()
+        .find("*"));
 #endif
 TEST(TypeIndex, TypeComputationsAreResolved) {
   EXPECT_NE(
@@ -172,9 +156,8 @@ struct Functor final {
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     get_fully_qualified_type_name<std::string(int64_t, const Type<int>&)>() ==
-        get_fully_qualified_type_name<
-            typename c10::guts::infer_function_traits_t<Functor>::func_type>(),
-    "");
+    get_fully_qualified_type_name<
+        typename c10::guts::infer_function_traits_t<Functor>::func_type>());
 #endif
 TEST(TypeIndex, FunctionTypeComputationsAreResolved) {
   EXPECT_EQ(
@@ -190,14 +173,12 @@ class Dummy final {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<Dummy(int)>().find(
-            "test_function_arguments_and_returns::Dummy"),
-    "");
+    get_fully_qualified_type_name<Dummy(int)>().find(
+        "test_function_arguments_and_returns::Dummy"));
 static_assert(
     string_view::npos !=
-        get_fully_qualified_type_name<void(Dummy)>().find(
-            "test_function_arguments_and_returns::Dummy"),
-    "");
+    get_fully_qualified_type_name<void(Dummy)>().find(
+        "test_function_arguments_and_returns::Dummy"));
 #endif
 TEST(TypeIndex, FunctionArgumentsAndReturns) {
   EXPECT_NE(

--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -6,88 +6,69 @@ using namespace c10::guts::typelist;
 
 namespace test_size {
 class MyClass {};
-static_assert(0 == size<typelist<>>::value, "");
-static_assert(1 == size<typelist<int>>::value, "");
-static_assert(3 == size<typelist<int, float&, const MyClass&&>>::value, "");
+static_assert(0 == size<typelist<>>::value);
+static_assert(1 == size<typelist<int>>::value);
+static_assert(3 == size<typelist<int, float&, const MyClass&&>>::value);
 } // namespace test_size
 
 namespace test_from_tuple {
 class MyClass {};
-static_assert(
-    std::is_same<
-        typelist<int, float&, const MyClass&&>,
-        from_tuple_t<std::tuple<int, float&, const MyClass&&>>>::value,
-    "");
-static_assert(std::is_same<typelist<>, from_tuple_t<std::tuple<>>>::value, "");
+static_assert(std::is_same<
+              typelist<int, float&, const MyClass&&>,
+              from_tuple_t<std::tuple<int, float&, const MyClass&&>>>::value);
+static_assert(std::is_same<typelist<>, from_tuple_t<std::tuple<>>>::value);
 } // namespace test_from_tuple
 
 namespace test_to_tuple {
 class MyClass {};
-static_assert(
-    std::is_same<
-        std::tuple<int, float&, const MyClass&&>,
-        to_tuple_t<typelist<int, float&, const MyClass&&>>>::value,
-    "");
-static_assert(std::is_same<std::tuple<>, to_tuple_t<typelist<>>>::value, "");
+static_assert(std::is_same<
+              std::tuple<int, float&, const MyClass&&>,
+              to_tuple_t<typelist<int, float&, const MyClass&&>>>::value);
+static_assert(std::is_same<std::tuple<>, to_tuple_t<typelist<>>>::value);
 } // namespace test_to_tuple
 
 namespace test_concat {
 class MyClass {};
-static_assert(std::is_same<typelist<>, concat_t<>>::value, "");
-static_assert(std::is_same<typelist<>, concat_t<typelist<>>>::value, "");
+static_assert(std::is_same<typelist<>, concat_t<>>::value);
+static_assert(std::is_same<typelist<>, concat_t<typelist<>>>::value);
 static_assert(
-    std::is_same<typelist<>, concat_t<typelist<>, typelist<>>>::value,
-    "");
-static_assert(std::is_same<typelist<int>, concat_t<typelist<int>>>::value, "");
+    std::is_same<typelist<>, concat_t<typelist<>, typelist<>>>::value);
+static_assert(std::is_same<typelist<int>, concat_t<typelist<int>>>::value);
 static_assert(
-    std::is_same<typelist<int>, concat_t<typelist<int>, typelist<>>>::value,
-    "");
+    std::is_same<typelist<int>, concat_t<typelist<int>, typelist<>>>::value);
 static_assert(
-    std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int>,
-        concat_t<typelist<>, typelist<int>, typelist<>>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int, float&>,
-        concat_t<typelist<int>, typelist<float&>>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int, float&>,
-        concat_t<typelist<>, typelist<int, float&>, typelist<>>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int, float&, const MyClass&&>,
-        concat_t<
-            typelist<>,
-            typelist<int, float&>,
-            typelist<const MyClass&&>>>::value,
-    "");
+    std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>>>::value);
+static_assert(std::is_same<
+              typelist<int>,
+              concat_t<typelist<>, typelist<int>, typelist<>>>::value);
+static_assert(std::is_same<
+              typelist<int, float&>,
+              concat_t<typelist<int>, typelist<float&>>>::value);
+static_assert(std::is_same<
+              typelist<int, float&>,
+              concat_t<typelist<>, typelist<int, float&>, typelist<>>>::value);
+static_assert(std::is_same<
+              typelist<int, float&, const MyClass&&>,
+              concat_t<
+                  typelist<>,
+                  typelist<int, float&>,
+                  typelist<const MyClass&&>>>::value);
 } // namespace test_concat
 
 namespace test_filter {
 class MyClass {};
 static_assert(
-    std::is_same<typelist<>, filter_t<std::is_reference, typelist<>>>::value,
-    "");
+    std::is_same<typelist<>, filter_t<std::is_reference, typelist<>>>::value);
 static_assert(
     std::is_same<
         typelist<>,
         filter_t<std::is_reference, typelist<int, float, double, MyClass>>>::
-        value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<float&, const MyClass&&>,
-        filter_t<
-            std::is_reference,
-            typelist<int, float&, double, const MyClass&&>>>::value,
-    "");
+        value);
+static_assert(std::is_same<
+              typelist<float&, const MyClass&&>,
+              filter_t<
+                  std::is_reference,
+                  typelist<int, float&, double, const MyClass&&>>>::value);
 } // namespace test_filter
 
 namespace test_count_if {
@@ -95,10 +76,9 @@ class MyClass final {};
 static_assert(
     count_if<
         std::is_reference,
-        typelist<int, bool&, const MyClass&&, float, double>>::value == 2,
-    "");
-static_assert(count_if<std::is_reference, typelist<int, bool>>::value == 0, "");
-static_assert(count_if<std::is_reference, typelist<>>::value == 0, "");
+        typelist<int, bool&, const MyClass&&, float, double>>::value == 2);
+static_assert(count_if<std::is_reference, typelist<int, bool>>::value == 0);
+static_assert(count_if<std::is_reference, typelist<>>::value == 0);
 } // namespace test_count_if
 
 namespace test_true_for_each_type {
@@ -107,90 +87,69 @@ class Test;
 class MyClass {};
 static_assert(
     all<std::is_reference,
-        typelist<int&, const float&&, const MyClass&>>::value,
-    "");
-static_assert(
-    !all<std::is_reference, typelist<int&, const float, const MyClass&>>::value,
-    "");
-static_assert(all<std::is_reference, typelist<>>::value, "");
+        typelist<int&, const float&&, const MyClass&>>::value);
+static_assert(!all<
+              std::is_reference,
+              typelist<int&, const float, const MyClass&>>::value);
+static_assert(all<std::is_reference, typelist<>>::value);
 } // namespace test_true_for_each_type
 
 namespace test_true_for_any_type {
 template <class>
 class Test;
 class MyClass {};
-static_assert(
-    true_for_any_type<
-        std::is_reference,
-        typelist<int&, const float&&, const MyClass&>>::value,
-    "");
-static_assert(
-    true_for_any_type<
-        std::is_reference,
-        typelist<int&, const float, const MyClass&>>::value,
-    "");
-static_assert(
-    !true_for_any_type<
-        std::is_reference,
-        typelist<int, const float, const MyClass>>::value,
-    "");
-static_assert(!true_for_any_type<std::is_reference, typelist<>>::value, "");
+static_assert(true_for_any_type<
+              std::is_reference,
+              typelist<int&, const float&&, const MyClass&>>::value);
+static_assert(true_for_any_type<
+              std::is_reference,
+              typelist<int&, const float, const MyClass&>>::value);
+static_assert(!true_for_any_type<
+              std::is_reference,
+              typelist<int, const float, const MyClass>>::value);
+static_assert(!true_for_any_type<std::is_reference, typelist<>>::value);
 } // namespace test_true_for_any_type
 
 namespace test_map {
 class MyClass {};
-static_assert(
-    std::is_same<typelist<>, map_t<std::add_lvalue_reference_t, typelist<>>>::
-        value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int&>,
-        map_t<std::add_lvalue_reference_t, typelist<int>>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int&, double&, const MyClass&>,
-        map_t<
-            std::add_lvalue_reference_t,
-            typelist<int, double, const MyClass>>>::value,
-    "");
+static_assert(std::is_same<
+              typelist<>,
+              map_t<std::add_lvalue_reference_t, typelist<>>>::value);
+static_assert(std::is_same<
+              typelist<int&>,
+              map_t<std::add_lvalue_reference_t, typelist<int>>>::value);
+static_assert(std::is_same<
+              typelist<int&, double&, const MyClass&>,
+              map_t<
+                  std::add_lvalue_reference_t,
+                  typelist<int, double, const MyClass>>>::value);
 } // namespace test_map
 
 namespace test_head {
 class MyClass {};
-static_assert(std::is_same<int, head_t<typelist<int, double>>>::value, "");
+static_assert(std::is_same<int, head_t<typelist<int, double>>>::value);
+static_assert(std::is_same<
+              const MyClass&,
+              head_t<typelist<const MyClass&, double>>>::value);
 static_assert(
-    std::is_same<const MyClass&, head_t<typelist<const MyClass&, double>>>::
-        value,
-    "");
-static_assert(
-    std::is_same<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>::value,
-    "");
-static_assert(std::is_same<bool, head_t<typelist<bool>>>::value, "");
+    std::is_same<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>::value);
+static_assert(std::is_same<bool, head_t<typelist<bool>>>::value);
 } // namespace test_head
 
 namespace test_head_with_default {
 class MyClass {};
 static_assert(
-    std::is_same<int, head_with_default_t<bool, typelist<int, double>>>::value,
-    "");
+    std::is_same<int, head_with_default_t<bool, typelist<int, double>>>::value);
 static_assert(
     std::is_same<
         const MyClass&,
-        head_with_default_t<bool, typelist<const MyClass&, double>>>::value,
-    "");
+        head_with_default_t<bool, typelist<const MyClass&, double>>>::value);
+static_assert(std::is_same<
+              MyClass&&,
+              head_with_default_t<bool, typelist<MyClass&&, MyClass>>>::value);
 static_assert(
-    std::is_same<
-        MyClass&&,
-        head_with_default_t<bool, typelist<MyClass&&, MyClass>>>::value,
-    "");
-static_assert(
-    std::is_same<int, head_with_default_t<bool, typelist<int>>>::value,
-    "");
-static_assert(
-    std::is_same<bool, head_with_default_t<bool, typelist<>>>::value,
-    "");
+    std::is_same<int, head_with_default_t<bool, typelist<int>>>::value);
+static_assert(std::is_same<bool, head_with_default_t<bool, typelist<>>>::value);
 } // namespace test_head_with_default
 
 namespace test_reverse {
@@ -198,9 +157,8 @@ class MyClass {};
 static_assert(
     std::is_same<
         typelist<int, double, MyClass*, const MyClass&&>,
-        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>::value,
-    "");
-static_assert(std::is_same<typelist<>, reverse_t<typelist<>>>::value, "");
+        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>::value);
+static_assert(std::is_same<typelist<>, reverse_t<typelist<>>>::value);
 } // namespace test_reverse
 
 namespace test_map_types_to_values {
@@ -215,7 +173,7 @@ TEST(TypeListTest, MapTypesToValues_sametype) {
   auto sizes =
       map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
   std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
-  static_assert(std::is_same<decltype(expected), decltype(sizes)>::value, "");
+  static_assert(std::is_same<decltype(expected), decltype(sizes)>::value);
   EXPECT_EQ(expected, sizes);
 }
 
@@ -229,11 +187,9 @@ struct map_make_shared {
 TEST(TypeListTest, MapTypesToValues_differenttypes) {
   auto shared_ptrs =
       map_types_to_values<typelist<int, double>>(map_make_shared());
-  static_assert(
-      std::is_same<
-          std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>,
-          decltype(shared_ptrs)>::value,
-      "");
+  static_assert(std::is_same<
+                std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>,
+                decltype(shared_ptrs)>::value);
 }
 
 struct Class1 {
@@ -258,7 +214,7 @@ TEST(TypeListTest, MapTypesToValues_members) {
   auto result =
       map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
   std::tuple<int, double> expected(3, 2.0);
-  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  static_assert(std::is_same<decltype(expected), decltype(result)>::value);
   EXPECT_EQ(expected, result);
 }
 
@@ -273,107 +229,78 @@ TEST(TypeListTest, MapTypesToValues_empty) {
   auto result =
       map_types_to_values<typelist<>>(mapper_call_nonexistent_function());
   std::tuple<> expected;
-  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  static_assert(std::is_same<decltype(expected), decltype(result)>::value);
   EXPECT_EQ(expected, result);
 }
 } // namespace test_map_types_to_values
 
 namespace test_find_if {
-static_assert(0 == find_if<typelist<char&>, std::is_reference>::value, "");
+static_assert(0 == find_if<typelist<char&>, std::is_reference>::value);
 static_assert(
-    0 == find_if<typelist<char&, int, char&, int&>, std::is_reference>::value,
-    "");
+    0 == find_if<typelist<char&, int, char&, int&>, std::is_reference>::value);
 static_assert(
-    2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value,
-    "");
+    2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value);
 static_assert(
-    3 == find_if<typelist<char, int, char, int&>, std::is_reference>::value,
-    "");
+    3 == find_if<typelist<char, int, char, int&>, std::is_reference>::value);
 } // namespace test_find_if
 
 namespace test_contains {
-static_assert(contains<typelist<double>, double>::value, "");
-static_assert(contains<typelist<int, double>, double>::value, "");
-static_assert(!contains<typelist<int, double>, float>::value, "");
-static_assert(!contains<typelist<>, double>::value, "");
+static_assert(contains<typelist<double>, double>::value);
+static_assert(contains<typelist<int, double>, double>::value);
+static_assert(!contains<typelist<int, double>, float>::value);
+static_assert(!contains<typelist<>, double>::value);
 } // namespace test_contains
 
 namespace test_take {
-static_assert(std::is_same<typelist<>, take_t<typelist<>, 0>>::value, "");
+static_assert(std::is_same<typelist<>, take_t<typelist<>, 0>>::value);
+static_assert(std::is_same<typelist<>, take_t<typelist<int64_t>, 0>>::value);
 static_assert(
-    std::is_same<typelist<>, take_t<typelist<int64_t>, 0>>::value,
-    "");
+    std::is_same<typelist<int64_t>, take_t<typelist<int64_t>, 1>>::value);
 static_assert(
-    std::is_same<typelist<int64_t>, take_t<typelist<int64_t>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<typelist<>, take_t<typelist<int64_t, int32_t>, 0>>::value,
-    "");
-static_assert(
-    std::is_same<typelist<int64_t>, take_t<typelist<int64_t, int32_t>, 1>>::
-        value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int64_t, int32_t>,
-        take_t<typelist<int64_t, int32_t>, 2>>::value,
-    "");
+    std::is_same<typelist<>, take_t<typelist<int64_t, int32_t>, 0>>::value);
+static_assert(std::is_same<
+              typelist<int64_t>,
+              take_t<typelist<int64_t, int32_t>, 1>>::value);
+static_assert(std::is_same<
+              typelist<int64_t, int32_t>,
+              take_t<typelist<int64_t, int32_t>, 2>>::value);
 } // namespace test_take
 
 namespace test_drop {
-static_assert(std::is_same<typelist<>, drop_t<typelist<>, 0>>::value, "");
+static_assert(std::is_same<typelist<>, drop_t<typelist<>, 0>>::value);
 static_assert(
-    std::is_same<typelist<int64_t>, drop_t<typelist<int64_t>, 0>>::value,
-    "");
+    std::is_same<typelist<int64_t>, drop_t<typelist<int64_t>, 0>>::value);
+static_assert(std::is_same<typelist<>, drop_t<typelist<int64_t>, 1>>::value);
+static_assert(std::is_same<
+              typelist<int64_t, int32_t>,
+              drop_t<typelist<int64_t, int32_t>, 0>>::value);
+static_assert(std::is_same<
+              typelist<int32_t>,
+              drop_t<typelist<int64_t, int32_t>, 1>>::value);
 static_assert(
-    std::is_same<typelist<>, drop_t<typelist<int64_t>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int64_t, int32_t>,
-        drop_t<typelist<int64_t, int32_t>, 0>>::value,
-    "");
-static_assert(
-    std::is_same<typelist<int32_t>, drop_t<typelist<int64_t, int32_t>, 1>>::
-        value,
-    "");
-static_assert(
-    std::is_same<typelist<>, drop_t<typelist<int64_t, int32_t>, 2>>::value,
-    "");
+    std::is_same<typelist<>, drop_t<typelist<int64_t, int32_t>, 2>>::value);
 } // namespace test_drop
 
 namespace test_drop_if_nonempty {
 static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 0>>::value,
-    "");
+    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 0>>::value);
+static_assert(std::is_same<
+              typelist<int64_t>,
+              drop_if_nonempty_t<typelist<int64_t>, 0>>::value);
 static_assert(
-    std::is_same<typelist<int64_t>, drop_if_nonempty_t<typelist<int64_t>, 0>>::
-        value,
-    "");
+    std::is_same<typelist<>, drop_if_nonempty_t<typelist<int64_t>, 1>>::value);
+static_assert(std::is_same<
+              typelist<int64_t, int32_t>,
+              drop_if_nonempty_t<typelist<int64_t, int32_t>, 0>>::value);
+static_assert(std::is_same<
+              typelist<int32_t>,
+              drop_if_nonempty_t<typelist<int64_t, int32_t>, 1>>::value);
+static_assert(std::is_same<
+              typelist<>,
+              drop_if_nonempty_t<typelist<int64_t, int32_t>, 2>>::value);
 static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<int64_t>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int64_t, int32_t>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 0>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<int32_t>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 2>>::value,
-    "");
-static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<
-        typelist<>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 3>>::value,
-    "");
+    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 1>>::value);
+static_assert(std::is_same<
+              typelist<>,
+              drop_if_nonempty_t<typelist<int64_t, int32_t>, 3>>::value);
 } // namespace test_drop_if_nonempty

--- a/c10/test/util/TypeTraits_test.cpp
+++ b/c10/test/util/TypeTraits_test.cpp
@@ -145,16 +145,20 @@ struct MyStatelessConstFunctor final {
 };
 
 void func() {
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto stateless_lambda = [](int a) { return a; };
   static_assert(is_stateless_lambda<decltype(stateless_lambda)>::value);
 
   int b = 4;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto stateful_lambda_1 = [&](int a) { return a + b; };
   static_assert(!is_stateless_lambda<decltype(stateful_lambda_1)>::value);
 
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto stateful_lambda_2 = [=](int a) { return a + b; };
   static_assert(!is_stateless_lambda<decltype(stateful_lambda_2)>::value);
 
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   auto stateful_lambda_3 = [b](int a) { return a + b; };
   static_assert(!is_stateless_lambda<decltype(stateful_lambda_3)>::value);
 

--- a/c10/test/util/TypeTraits_test.cpp
+++ b/c10/test/util/TypeTraits_test.cpp
@@ -13,9 +13,9 @@ inline bool operator==(const EqualityComparable&, const EqualityComparable&) {
   return false;
 }
 
-static_assert(!is_equality_comparable<NotEqualityComparable>::value, "");
-static_assert(is_equality_comparable<EqualityComparable>::value, "");
-static_assert(is_equality_comparable<int>::value, "");
+static_assert(!is_equality_comparable<NotEqualityComparable>::value);
+static_assert(is_equality_comparable<EqualityComparable>::value);
+static_assert(is_equality_comparable<int>::value);
 
 // v_ just exists to silence a compiler warning about
 // operator==(EqualityComparable, EqualityComparable) not being needed
@@ -37,9 +37,9 @@ struct hash<test_is_hashable::Hashable> final {
 } // namespace std
 namespace {
 namespace test_is_hashable {
-static_assert(is_hashable<int>::value, "");
-static_assert(is_hashable<Hashable>::value, "");
-static_assert(!is_hashable<NotHashable>::value, "");
+static_assert(is_hashable<int>::value);
+static_assert(is_hashable<Hashable>::value);
+static_assert(!is_hashable<NotHashable>::value);
 } // namespace test_is_hashable
 
 namespace test_is_function_type {
@@ -56,26 +56,26 @@ bool func() {
 }
 bool func__ = func();
 
-static_assert(is_function_type<void()>::value, "");
-static_assert(is_function_type<int()>::value, "");
-static_assert(is_function_type<MyClass()>::value, "");
-static_assert(is_function_type<void(MyClass)>::value, "");
-static_assert(is_function_type<void(int)>::value, "");
-static_assert(is_function_type<void(void*)>::value, "");
-static_assert(is_function_type<int()>::value, "");
-static_assert(is_function_type<int(MyClass)>::value, "");
-static_assert(is_function_type<int(const MyClass&)>::value, "");
-static_assert(is_function_type<int(MyClass&&)>::value, "");
-static_assert(is_function_type < MyClass && () > ::value, "");
-static_assert(is_function_type < MyClass && (MyClass &&) > ::value, "");
-static_assert(is_function_type<const MyClass&(int, float, MyClass)>::value, "");
+static_assert(is_function_type<void()>::value);
+static_assert(is_function_type<int()>::value);
+static_assert(is_function_type<MyClass()>::value);
+static_assert(is_function_type<void(MyClass)>::value);
+static_assert(is_function_type<void(int)>::value);
+static_assert(is_function_type<void(void*)>::value);
+static_assert(is_function_type<int()>::value);
+static_assert(is_function_type<int(MyClass)>::value);
+static_assert(is_function_type<int(const MyClass&)>::value);
+static_assert(is_function_type<int(MyClass&&)>::value);
+static_assert(is_function_type < MyClass && () > ::value);
+static_assert(is_function_type < MyClass && (MyClass &&) > ::value);
+static_assert(is_function_type<const MyClass&(int, float, MyClass)>::value);
 
-static_assert(!is_function_type<void>::value, "");
-static_assert(!is_function_type<int>::value, "");
-static_assert(!is_function_type<MyClass>::value, "");
-static_assert(!is_function_type<void*>::value, "");
-static_assert(!is_function_type<const MyClass&>::value, "");
-static_assert(!is_function_type<MyClass&&>::value, "");
+static_assert(!is_function_type<void>::value);
+static_assert(!is_function_type<int>::value);
+static_assert(!is_function_type<MyClass>::value);
+static_assert(!is_function_type<void*>::value);
+static_assert(!is_function_type<const MyClass&>::value);
+static_assert(!is_function_type<MyClass&&>::value);
 
 static_assert(
     !is_function_type<void (*)()>::value,
@@ -97,45 +97,39 @@ class Double {};
 template <class... T>
 class Multiple {};
 
-static_assert(is_instantiation_of<Single, Single<void>>::value, "");
-static_assert(is_instantiation_of<Single, Single<MyClass>>::value, "");
-static_assert(is_instantiation_of<Single, Single<int>>::value, "");
-static_assert(is_instantiation_of<Single, Single<void*>>::value, "");
-static_assert(is_instantiation_of<Single, Single<int*>>::value, "");
-static_assert(is_instantiation_of<Single, Single<const MyClass&>>::value, "");
-static_assert(is_instantiation_of<Single, Single<MyClass&&>>::value, "");
-static_assert(is_instantiation_of<Double, Double<int, void>>::value, "");
+static_assert(is_instantiation_of<Single, Single<void>>::value);
+static_assert(is_instantiation_of<Single, Single<MyClass>>::value);
+static_assert(is_instantiation_of<Single, Single<int>>::value);
+static_assert(is_instantiation_of<Single, Single<void*>>::value);
+static_assert(is_instantiation_of<Single, Single<int*>>::value);
+static_assert(is_instantiation_of<Single, Single<const MyClass&>>::value);
+static_assert(is_instantiation_of<Single, Single<MyClass&&>>::value);
+static_assert(is_instantiation_of<Double, Double<int, void>>::value);
+static_assert(is_instantiation_of<Double, Double<const int&, MyClass*>>::value);
+static_assert(is_instantiation_of<Multiple, Multiple<>>::value);
+static_assert(is_instantiation_of<Multiple, Multiple<int>>::value);
+static_assert(is_instantiation_of<Multiple, Multiple<MyClass&, int>>::value);
 static_assert(
-    is_instantiation_of<Double, Double<const int&, MyClass*>>::value,
-    "");
-static_assert(is_instantiation_of<Multiple, Multiple<>>::value, "");
-static_assert(is_instantiation_of<Multiple, Multiple<int>>::value, "");
-static_assert(
-    is_instantiation_of<Multiple, Multiple<MyClass&, int>>::value,
-    "");
-static_assert(
-    is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass>>::value,
-    "");
-static_assert(
-    is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass, void*>>::
-        value,
-    "");
+    is_instantiation_of<Multiple, Multiple<MyClass&, int, MyClass>>::value);
+static_assert(is_instantiation_of<
+              Multiple,
+              Multiple<MyClass&, int, MyClass, void*>>::value);
 
-static_assert(!is_instantiation_of<Single, Double<int, int>>::value, "");
-static_assert(!is_instantiation_of<Single, Double<int, void>>::value, "");
-static_assert(!is_instantiation_of<Single, Multiple<int>>::value, "");
-static_assert(!is_instantiation_of<Double, Single<int>>::value, "");
-static_assert(!is_instantiation_of<Double, Multiple<int, int>>::value, "");
-static_assert(!is_instantiation_of<Double, Multiple<>>::value, "");
-static_assert(!is_instantiation_of<Multiple, Double<int, int>>::value, "");
-static_assert(!is_instantiation_of<Multiple, Single<int>>::value, "");
+static_assert(!is_instantiation_of<Single, Double<int, int>>::value);
+static_assert(!is_instantiation_of<Single, Double<int, void>>::value);
+static_assert(!is_instantiation_of<Single, Multiple<int>>::value);
+static_assert(!is_instantiation_of<Double, Single<int>>::value);
+static_assert(!is_instantiation_of<Double, Multiple<int, int>>::value);
+static_assert(!is_instantiation_of<Double, Multiple<>>::value);
+static_assert(!is_instantiation_of<Multiple, Double<int, int>>::value);
+static_assert(!is_instantiation_of<Multiple, Single<int>>::value);
 } // namespace test_is_instantiation_of
 
 namespace test_is_type_condition {
 template <class>
 class NotATypeCondition {};
-static_assert(is_type_condition<std::is_reference>::value, "");
-static_assert(!is_type_condition<NotATypeCondition>::value, "");
+static_assert(is_type_condition<std::is_reference>::value);
+static_assert(!is_type_condition<NotATypeCondition>::value);
 } // namespace test_is_type_condition
 } // namespace
 
@@ -152,17 +146,17 @@ struct MyStatelessConstFunctor final {
 
 void func() {
   auto stateless_lambda = [](int a) { return a; };
-  static_assert(is_stateless_lambda<decltype(stateless_lambda)>::value, "");
+  static_assert(is_stateless_lambda<decltype(stateless_lambda)>::value);
 
   int b = 4;
   auto stateful_lambda_1 = [&](int a) { return a + b; };
-  static_assert(!is_stateless_lambda<decltype(stateful_lambda_1)>::value, "");
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_1)>::value);
 
   auto stateful_lambda_2 = [=](int a) { return a + b; };
-  static_assert(!is_stateless_lambda<decltype(stateful_lambda_2)>::value, "");
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_2)>::value);
 
   auto stateful_lambda_3 = [b](int a) { return a + b; };
-  static_assert(!is_stateless_lambda<decltype(stateful_lambda_3)>::value, "");
+  static_assert(!is_stateless_lambda<decltype(stateful_lambda_3)>::value);
 
   static_assert(
       !is_stateless_lambda<MyStatelessFunctor<int, int>>::value,

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -41,7 +41,7 @@ TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
 
     // The relative error should be less than 1/(2^7) since BFloat16
     // has 7 bits mantissa.
-    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+    EXPECT_LE(std::fabs(out[i] - in[i]) / in[i], 1.0 / 128);
   }
 }
 
@@ -64,7 +64,7 @@ TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
 
     // The relative error should be less than 1/(2^7) since BFloat16
     // has 7 bits mantissa.
-    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+    EXPECT_LE(std::fabs(out[i] - in[i]) / in[i], 1.0 / 128);
   }
 }
 

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -87,7 +87,7 @@ class NullType2 final {
   }
 };
 SomeClass NullType2::singleton_;
-static_assert(NullType1::singleton() != NullType2::singleton(), "");
+static_assert(NullType1::singleton() != NullType2::singleton());
 } // namespace
 
 static_assert(

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -445,10 +445,7 @@ TEST(OrderedPreservingDictTest, test_swap_empty) {
   using std::swap;
   swap(map, map2);
 
-  TORCH_INTERNAL_ASSERT(
-      map ==
-      (ska_ordered::
-           order_preserving_flat_hash_map<std::int64_t, std::int64_t>{}));
+  TORCH_INTERNAL_ASSERT(map.empty());
   TORCH_INTERNAL_ASSERT(
       map2 ==
       (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{

--- a/c10/test/util/small_vector_test.cpp
+++ b/c10/test/util/small_vector_test.cpp
@@ -147,7 +147,6 @@ struct NonCopyable {
     return *this;
   }
 
- private:
   NonCopyable(const NonCopyable&) = delete;
   NonCopyable& operator=(const NonCopyable&) = delete;
 };
@@ -971,7 +970,6 @@ struct Emplaceable {
     return *this;
   }
 
- private:
   Emplaceable(const Emplaceable&) = delete;
   Emplaceable& operator=(const Emplaceable&) = delete;
 };

--- a/c10/test/util/small_vector_test.cpp
+++ b/c10/test/util/small_vector_test.cpp
@@ -13,7 +13,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/SmallVector.h>
 #include <gtest/gtest.h>
-#include <stdarg.h>
+#include <cstdarg>
 #include <list>
 
 using c10::SmallVector;
@@ -45,14 +45,13 @@ class Constructable {
     ++numConstructorCalls;
   }
 
-  Constructable(const Constructable& src) : constructed(true) {
-    value = src.value;
+  Constructable(const Constructable& src)
+      : constructed(true), value(src.value) {
     ++numConstructorCalls;
     ++numCopyConstructorCalls;
   }
 
-  Constructable(Constructable&& src) : constructed(true) {
-    value = src.value;
+  Constructable(Constructable&& src) : constructed(true), value(src.value) {
     src.value = 0;
     ++numConstructorCalls;
     ++numMoveConstructorCalls;
@@ -142,7 +141,7 @@ int Constructable::numCopyAssignmentCalls;
 int Constructable::numMoveAssignmentCalls;
 
 struct NonCopyable {
-  NonCopyable() {}
+  NonCopyable() = default;
   NonCopyable(NonCopyable&&) {}
   NonCopyable& operator=(NonCopyable&&) {
     return *this;
@@ -840,7 +839,7 @@ TYPED_TEST(DualSmallVectorsTest, MoveAssignment) {
   SCOPED_TRACE("MoveAssignTest-DualVectorTypes");
 
   // Set up our vector with four elements.
-  for (unsigned I = 0; I < 4; ++I)
+  for (int I = 0; I < 4; ++I)
     this->otherVector.push_back(Constructable(I));
 
   const Constructable* OrigDataPtr = this->otherVector.data();
@@ -885,7 +884,7 @@ TEST(SmallVectorCustomTest, NoAssignTest) {
   SmallVector<notassignable, 2> vec;
   vec.push_back(notassignable(x));
   x = 42;
-  EXPECT_EQ(42, vec.pop_back_val().x);
+  EXPECT_EQ(x, vec.pop_back_val().x);
 }
 
 struct MovedFrom {
@@ -927,7 +926,6 @@ struct EmplaceableArg {
 
   explicit EmplaceableArg(bool) : State(EAS_Arg) {}
 
- private:
   EmplaceableArg& operator=(EmplaceableArg&&) = delete;
   EmplaceableArg& operator=(const EmplaceableArg&) = delete;
 };

--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gmock/gmock.h>
 
+// NOLINTBEGIN(modernize-unary-static-assert)
 using c10::string_view;
 
 namespace {
@@ -1665,3 +1666,4 @@ TEST(StringViewTest, testHash) {
 } // namespace test_hash
 
 } // namespace
+// NOLINTEND(modernize-unary-static-assert)


### PR DESCRIPTION
This PR increases the coverage of clang-tidy to c10/test/*cpp and fixes some errors.
