### PR TITLE
Add device range helper and remove sm86 specific check for memory efficient attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -36,8 +36,9 @@ bool input_requires_grad(sdp_params params) {
 }
 
 bool has_for_nested_inputs(sdp_params params) {
-  return (params.query.is_nested() || params.key.is_nested() ||
-          params.value.is_nested());
+  return (
+      params.query.is_nested() || params.key.is_nested() ||
+      params.value.is_nested());
 }
 
 std::array<SDPBackend, num_backends> priority_order(sdp_params params) {
@@ -453,13 +454,39 @@ bool check_runtime_disabled_mem_efficient(sdp_params params, bool debug) {
   return true;
 }
 
+template <int Major, int Minor>
+struct SMVersion {
+  static constexpr int major = Major;
+  static constexpr int minor = Minor;
+  constexpr SMVersion() = default;
+};
+
+/**
+ * Checks if the current CUDA device architecture is inclusively within the specified range.
+ *
+ * @param lower_bound The lower bound of the CUDA device architecture range.
+ * @param upper_bound The upper bound of the CUDA device architecture range.
+ * @param params The parameters for the current operation.
+ * @return True if the current CUDA device architecture is within the specified range, false otherwise.
+ */
+template <typename lower_bound, typename upper_bound>
+bool check_sm_version(sdp_params params) {
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool is_gte_lower_bound = dprops->major > lower_bound::major ||
+      (dprops->major == lower_bound::major &&
+       dprops->minor >= lower_bound::minor);
+  bool is_lte_upper_bound = dprops->major < upper_bound::major ||
+      (dprops->major == upper_bound::major &&
+       dprops->minor <= upper_bound::minor);
+  return is_gte_lower_bound && is_lte_upper_bound;
+}
+
 bool check_gpu_sm75_or_greater(sdp_params params, bool debug) {
   // Check that the gpu is capable of running flash attention
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
-  bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
-  bool is_sm90 = dprops->major == 9 && dprops->minor == 0;
-  if (!(is_sm90 || is_sm8x || is_sm75)) {
+  using sm75 = SMVersion<7, 5>;
+  using sm90 = SMVersion<9, 0>;
+  if (!check_sm_version<sm75, sm90>(params)) {
+    auto dprops = at::cuda::getCurrentDeviceProperties();
     if (debug) {
       TORCH_WARN(
           "Flash attention only supports {sm75, sm8x, sm90} gpu architectures. Attempting to run on a sm ",
@@ -475,11 +502,11 @@ bool check_gpu_sm75_or_greater(sdp_params params, bool debug) {
 
 bool check_mem_efficient_hardware_support(sdp_params params, bool debug) {
   // Mem Efficient attention supports hardware in the range [sm_50, sm_90]
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  bool is_gte_sm50 = dprops->major >= 5;
-  bool is_lte_sm90 = dprops->major <= 9;
-  if (!(is_gte_sm50 && is_lte_sm90)) {
+  using sm50 = SMVersion<5, 0>;
+  using sm90 = SMVersion<9, 0>;
+  if (!check_sm_version<sm50, sm90>(params)) {
     if (debug) {
+      auto dprops = at::cuda::getCurrentDeviceProperties();
       TORCH_WARN(
           "Mem Efficient Attention only supported gpu architectures in the range [sm50, sm90]. Attempting to run on a sm ",
           dprops->major,
@@ -492,37 +519,26 @@ bool check_mem_efficient_hardware_support(sdp_params params, bool debug) {
   return true;
 }
 
-bool check_head_dim_gt64_and_sm_ge86_lt90(sdp_params params, bool debug) {
-  // Memory Efficient Attention is throwing a cuda illegal memory error
-  // on sm86 or newer when head_dim is greater than 64.
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  bool is_sm86_or_newer = (dprops->major == 8) && (dprops->minor >= 6);
-  if (is_sm86_or_newer && (params.query.sym_size(-1) > 64)) {
-    if (debug) {
-      TORCH_WARN(
-          "Memory Efficient Attention does not currently support head_dim greater than 64 on sm86 or newer");
-    }
-    return false;
-  }
-  return true;
-}
-
 bool check_requires_grad_and_head_dim_gt64_and_sm_ge86_lt90(
     sdp_params params,
     bool debug) {
   // Flash Attention will raise an error in the backward pass if the head_dim
-  // size is greater than 64 And the device is sm86 or newer.
-  if (input_requires_grad(params) &&
-      !check_head_dim_gt64_and_sm_ge86_lt90(params, false)) {
+  // size is greater than 64 And the device is between in the range [sm86, sm89]
+  using sm86 = SMVersion<8, 6>;
+  using sm89 = SMVersion<8, 9>;
+  bool is_sm86_or_sm89 = check_sm_version<sm86, sm89>(params);
+  bool is_head_dim_gt64 = params.query.sym_size(-1) > 64;
+  if (input_requires_grad(params) && is_sm86_or_sm89 && is_head_dim_gt64) {
     if (debug) {
       TORCH_WARN(
-          "Flash attention currently doesn't support training with head_dim greater than 64 on sm86 or newer.");
+          "Flash attention currently doesn't support training with head_dim greater than 64 on [sm86, sm89] or newer.",
+          "Attempting to run with head_dim: ",
+          params.query.sym_size(-1));
     }
     return false;
   }
   return true;
 }
-
 
 bool use_flash_attention(sdp_params params, bool debug) {
 #ifndef USE_FLASH_ATTENTION
@@ -578,7 +594,6 @@ bool use_mem_efficient_attention(sdp_params params, bool debug) {
       check_batch_size_and_num_heads,
       check_for_attn_mask,
       check_head_dim_size_mem_efficient,
-      check_head_dim_gt64_and_sm_ge86_lt90,
       check_for_seq_len_0_nested_tensor,
       check_for_non_zero_dropout);
   for (auto& constraint : constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -470,7 +470,7 @@ struct SMVersion {
  * @return True if the current CUDA device architecture is within the specified range, false otherwise.
  */
 template <typename lower_bound, typename upper_bound>
-bool check_sm_version(sdp_params params) {
+bool check_sm_version() {
   auto dprops = at::cuda::getCurrentDeviceProperties();
   bool is_gte_lower_bound = dprops->major > lower_bound::major ||
       (dprops->major == lower_bound::major &&
@@ -485,7 +485,7 @@ bool check_gpu_sm75_or_greater(sdp_params params, bool debug) {
   // Check that the gpu is capable of running flash attention
   using sm75 = SMVersion<7, 5>;
   using sm90 = SMVersion<9, 0>;
-  if (!check_sm_version<sm75, sm90>(params)) {
+  if (!check_sm_version<sm75, sm90>()) {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     if (debug) {
       TORCH_WARN(
@@ -504,7 +504,7 @@ bool check_mem_efficient_hardware_support(sdp_params params, bool debug) {
   // Mem Efficient attention supports hardware in the range [sm_50, sm_90]
   using sm50 = SMVersion<5, 0>;
   using sm90 = SMVersion<9, 0>;
-  if (!check_sm_version<sm50, sm90>(params)) {
+  if (!check_sm_version<sm50, sm90>()) {
     if (debug) {
       auto dprops = at::cuda::getCurrentDeviceProperties();
       TORCH_WARN(
@@ -526,7 +526,7 @@ bool check_requires_grad_and_head_dim_gt64_and_sm_ge86_lt90(
   // size is greater than 64 And the device is between in the range [sm86, sm89]
   using sm86 = SMVersion<8, 6>;
   using sm89 = SMVersion<8, 9>;
-  bool is_sm86_or_sm89 = check_sm_version<sm86, sm89>(params);
+  bool is_sm86_or_sm89 = check_sm_version<sm86, sm89>();
   bool is_head_dim_gt64 = params.query.sym_size(-1) > 64;
   if (input_requires_grad(params) && is_sm86_or_sm89 && is_head_dim_gt64) {
     if (debug) {

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1106,20 +1106,6 @@ class TestSDPAFailureModes(NNTestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not isSM86or89Device,
                      "Does not support fused SDPA or not SM86+ hardware")
     @parametrize("head_dim", [72, 96, 128])
-    def test_memory_efficient_sm86_plus_failure(self, device, head_dim: int):
-        dtype = torch.float16
-        make_tensor = partial(rand_sdpa_tensor, type="dense", device=device, dtype=dtype)
-        # See check_head_dim_gt64_and_sm_ge86 in pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.h
-        size = (2, 2, 4, head_dim)
-        q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
-        with sdp_kernel(enable_mem_efficient=True, enable_flash=False, enable_math=False):
-            self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, None, 0.0, False))
-
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not isSM86or89Device,
-                     "Does not support fused SDPA or not SM86+ hardware")
-    @parametrize("head_dim", [72, 96, 128])
     def test_flash_backward_failure_sm86plus(self, device, head_dim: int):
         dtype = torch.float16
         make_tensor = partial(rand_sdpa_tensor, type="dense", device=device, dtype=dtype)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1891,8 +1891,9 @@ class TestSDPA(NNTestCase):
 
         # TODO: Investigate why grad_k needs larger tolerances
         grad_k_deviation = key_ref.grad - key_ref_lp.grad
-        grad_k_ref_atol = max(7 * torch.abs(grad_k_deviation).max().item(), 7 * default_atol[out.dtype])
-        grad_k_ref_rtol = max(7 * get_rtol(key_ref.grad, key_ref_lp.grad), 7 * default_rtol[out.dtype])
+        fudge_factor = 7 if not isSM86or89Device else 8
+        grad_k_ref_atol = max(fudge_factor * torch.abs(grad_k_deviation).max().item(), fudge_factor * default_atol[out.dtype])
+        grad_k_ref_rtol = max(fudge_factor * get_rtol(key_ref.grad, key_ref_lp.grad), fudge_factor * default_rtol[out.dtype])
 
         grad_v_deviation = value_ref.grad - value_ref_lp.grad
         grad_v_ref_atol = max(torch.abs(grad_v_deviation).max().item(), default_atol[out.dtype])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1859,15 +1859,7 @@ class TestSDPA(NNTestCase):
 
         # Create real output
         with sdp_kernel(enable_mem_efficient=True, enable_flash=False, enable_math=False):
-            # See check_head_dim_gt64_and_sm_ge86 in pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.h
-            if isSM86or89Device and head_dim in range(65, 129):
-                self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value,
-                                                                                       dropout_p=dropout_p,
-                                                                                       is_causal=is_causal, scale=scale))
-                return
-            else:
-                out = F.scaled_dot_product_attention(
-                    query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+            out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
 
         with sdp_kernel(enable_math=True, enable_flash=False, enable_mem_efficient=False):
             # High Precision Math Reference


### PR DESCRIPTION
# Summary
Since we have upstreamed the latest changes of memory efficient attetnion we can remove the sm86/sm89 specific check. All head_sizes (assuming correctly alignment) should work for sm86 and sm89 size and don't have a max capability. 

If head_size > 96 there will be a big drop in performance but should not error and still maintain memory savings by not materializing attention weights.