### PR TITLE
[Pytorch] Add Vulkan support for aten::unsqueeze, 1d->2d, 3d->4d

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/unsqueeze.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/unsqueeze.glsl
@@ -18,8 +18,9 @@ layout(set = 0, binding = 1) uniform PRECISION sampler3D uImage;
  * Params Buffer
  */
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // dim: dimension to insert at
-  ivec2 dim;
+  // info.x: dimension to insert at
+  // info.y: channels (for 3d->4d unsqueeze)
+  ivec2 info;
 }
 uBlock;
 
@@ -34,26 +35,39 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
  */
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
-  const int dim = uBlock.dim.x;
+  const int dim = uBlock.info.x;
+  const int channels = uBlock.info.y;
   vec4 out_texel = vec4(0, 0, 0, 0);
-  if (dim == 0 || dim == -3) {
+  if (dim == 0) {
     imageStore(uOutput, pos, texelFetch(uImage, pos, 0));
-  } else if (dim == 1 || dim == -2) {
+  } else if (dim == 1) {
     int src_x = pos.x;
-    int src_z = 0;
+    int src_y = pos.y;
     for (int i = 0; i < 4; i++) {
-      int src_y = pos.z * 4 + i;
+      int src_z = pos.z / (channels * 4);
+      int p = (pos.z / channels) % 4;
       const vec4 v = texelFetch(uImage, ivec3(src_x, src_y, src_z), 0);
-      out_texel[i] = v[0];
+      out_texel[i] = v[p];
     }
     imageStore(uOutput, pos, out_texel);
-  } else if (dim == 2 || dim == -1) {
-    int src_x = pos.y;
-    int src_z = 0;
+  } else if (dim == 2) {
+    int src_x = pos.x;
+    int src_z = pos.z / (channels * 4);
     for (int i = 0; i < 4; i++) {
-      int src_y = pos.z * 4 + i;
+      int src_y = i + (pos.z % channels) * 4;
+      int p = (pos.z / channels) % 4;
       const vec4 v = texelFetch(uImage, ivec3(src_x, src_y, src_z), 0);
-      out_texel[i] = v[0];
+      out_texel[i] = v[p];
+    }
+    imageStore(uOutput, pos, out_texel);
+  } else if (dim == 3) {
+    int src_x = pos.y;
+    int src_z = pos.z / (channels * 4);
+    for (int i = 0; i < 4; i++) {
+      int src_y = i + (pos.z % channels) * 4;
+      int p = (pos.z / channels) % 4;
+      const vec4 v = texelFetch(uImage, ivec3(src_x, src_y, src_z), 0);
+      out_texel[i] = v[p];
     }
     imageStore(uOutput, pos, out_texel);
   }

--- a/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
@@ -11,28 +11,40 @@ namespace {
 using namespace api::utils;
 
 struct Block final {
-  ivec2 dim;
+  ivec2 info;
 };
 
-Tensor unsqueeze_2dto3d(const at::Tensor& input_arg, int64_t dim) {
+Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
+  TORCH_CHECK(
+      self.dim() >= 1 || self.dim() <= 3,
+      "Vulkan unsqueeze supports 1d, 2d, 3d tensors as input!");
+  TORCH_CHECK(
+      dim >= -self.dim() - 1 && dim <= self.dim(),
+      "Vulkan unsqueeze dimension out of range expected to be in range of [",
+      -self.dim() - 1,
+      ",",
+      self.dim(),
+      "], but got ",
+      dim);
+
   // Get the global Vulkan context
   api::Context* const context = api::context();
 
   // Cast the input Tensor to a vTensor
-  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const Tensor input = self.is_vulkan() ? self : self.vulkan();
   const vTensor& v_input = convert(input);
 
   // Create the output texture. For unsqueeze, add a dimension.
-  std::vector<int64_t> output_size = input_arg.sizes().vec();
+  std::vector<int64_t> output_size = self.sizes().vec();
   if (dim < 0) {
-    dim += 3;
+    dim += (self.dim() + 1);
   }
   output_size.insert(output_size.begin() + dim, 1);
   // Create the output texture
   vTensor v_output{
       context,
       output_size,
-      input_arg.scalar_type(),
+      self.scalar_type(),
   };
 
   // Required to determine how to insert memory barriers in the command buffer
@@ -43,52 +55,72 @@ Tensor unsqueeze_2dto3d(const at::Tensor& input_arg, int64_t dim) {
   // Adaptively determine local work group size, will usually be {4, 4, 4}
   uvec3 local_size = adaptive_work_group_size(global_size);
 
-  // Create the params buffer
-  struct Block block {
-    {
-      static_cast<int32_t>(dim)
+  // When unsqueezing in the 0th dimension, only the metadata changes.
+  // So we can perform a copy.
+  if (dim == 0) {
+    const vTensor& v_self = convert(self);
+    uvec3 src_offset{};
+    uvec3 dst_offset{};
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
+        // pipeline barrier
+        pipeline_barrier,
+        // images
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::TRANSFER,
+            api::MemoryAccessType::WRITE),
+        // copy details
+        v_self.extents(),
+        src_offset,
+        dst_offset,
+        // fence handle
+        VK_NULL_HANDLE);
+    return convert(v_output);
+  }
+
+  else {
+    int channel_index = 1; // Channel dimension in a 3D tensor
+    // Shift dim and channel_index for 1D, 2D tensors
+    if (self.dim() < 3) {
+      dim += (3 - self.dim());
+      channel_index = 0;
     }
-  };
-  api::UniformParamsBuffer params(context, block);
 
-  context->submit_compute_job(
-      // shader descriptor
-      VK_KERNEL(unsqueeze_2dto3d),
-      // pipeline barrier
-      pipeline_barrier,
-      // global work group size
-      global_size,
-      // local work group size
-      local_size,
-      // fence handle
-      VK_NULL_HANDLE,
-      // shader arguments
-      v_output.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE,
-          api::MemoryAccessType::WRITE),
-      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-      // params buffer
-      params.buffer());
+    // Create the params buffer
+    struct Block block {
+      {
+        // Dimension to unsqueeze
+        static_cast<int32_t>(dim),
+            // Keep track of the channel in Image3D
+            static_cast<int32_t>(
+                std::ceil(static_cast<float>(output_size[channel_index]) / 4)),
+      }
+    };
 
-  return convert(v_output);
-}
+    api::UniformParamsBuffer params(context, block);
 
-Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
-  TORCH_CHECK(
-      self.dim() >= 1 || self.dim() <= 3,
-      "Vulkan unsqueeze supports 1d, 2d, 3d tensors as input!");
-  TORCH_CHECK(
-      dim >= -self.dim() - 1 && dim <= self.dim(),
-      "Vulkan unsqueeze dimension out of range (expected to be in range of [",
-      -self.dim() - 1,
-      ",",
-      self.dim(),
-      "], but got ",
-      dim);
-  // Remove this when 1d->2d and 3d->4d are supported.
-  TORCH_CHECK(self.dim() == 2, "Vulkan unsqueeze expects input dimension = 2!");
-  return unsqueeze_2dto3d(self, dim);
+    context->submit_compute_job(
+        // shader descriptor
+        VK_KERNEL(unsqueeze),
+        // pipeline barrier
+        pipeline_barrier,
+        // global work group size
+        global_size,
+        // local work group size
+        local_size,
+        // fence handle
+        VK_NULL_HANDLE,
+        // shader arguments
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::COMPUTE,
+            api::MemoryAccessType::WRITE),
+        v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        // params buffer
+        params.buffer());
+    return convert(v_output);
+  }
 }
 
 #ifdef USE_VULKAN_API

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3378,47 +3378,6 @@ TEST_F(VulkanAPITest, uniform) {
       (expected_per_bin * 0.05));
 }
 
-void test_unsqueeze(const at::IntArrayRef input_shape, int64_t dim) {
-  at::TensorOptions options(at::kCPU);
-  options = options.dtype(at::kFloat);
-
-  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
-  const auto out_cpu = at::unsqueeze(in_cpu, dim);
-
-  const auto in_vulkan = in_cpu.vulkan();
-  const auto out_vulkan = at::unsqueeze(in_vulkan, dim);
-
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, unsqueeze_dim0) {
-  c10::InferenceMode mode;
-  test_unsqueeze({5, 7}, 0);
-  test_unsqueeze({5, 7}, -3);
-  test_unsqueeze({111, 222}, 0);
-  test_unsqueeze({111, 222}, -3);
-}
-
-TEST_F(VulkanAPITest, unsqueeze_dim1) {
-  c10::InferenceMode mode;
-  test_unsqueeze({5, 7}, 1);
-  test_unsqueeze({5, 7}, -2);
-  test_unsqueeze({111, 222}, 1);
-  test_unsqueeze({111, 222}, -2);
-}
-
-TEST_F(VulkanAPITest, unsqueeze_dim2) {
-  c10::InferenceMode mode;
-  test_unsqueeze({5, 7}, 2);
-  test_unsqueeze({5, 7}, -1);
-  test_unsqueeze({111, 222}, 2);
-  test_unsqueeze({111, 222}, -1);
-}
-
 void test_t(const at::IntArrayRef input_shape) {
   const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
   const auto out_cpu = at::t(in_cpu);
@@ -3571,6 +3530,87 @@ TEST_F(VulkanAPITest, transpose_4d_depth_and_width_large) {
 
 TEST_F(VulkanAPITest, transpose_4d_height_and_width_large) {
   test_transpose({7, 51, 41, 3}, 2, 3);
+}
+
+void test_unsqueeze(const at::IntArrayRef input_shape, int64_t dim) {
+  c10::InferenceMode mode;
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = at::unsqueeze(in_cpu, dim);
+
+  const auto in_vulkan = in_cpu.vulkan();
+  const auto out_vulkan = at::unsqueeze(in_vulkan, dim);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+  ASSERT_TRUE(check);
+
+}
+
+TEST_F(VulkanAPITest, unsqueeze_1dto2d_dim0) {
+  test_unsqueeze({5}, 0);
+  test_unsqueeze({6}, -2);
+  test_unsqueeze({111}, 0);
+  test_unsqueeze({112}, -2);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_1dto2d_dim1) {
+  test_unsqueeze({5}, 1);
+  test_unsqueeze({6}, -1);
+  test_unsqueeze({111}, 1);
+  test_unsqueeze({112}, -1);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_2dto3d_dim0) {
+  test_unsqueeze({1, 5}, 2);
+  test_unsqueeze({5, 7}, 0);
+  test_unsqueeze({7, 5}, -3);
+  test_unsqueeze({111, 222}, 0);
+  test_unsqueeze({222, 111}, -3);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_2dto3d_dim1) {
+  test_unsqueeze({5, 7}, 1);
+  test_unsqueeze({7, 5}, -2);
+  test_unsqueeze({111, 222}, 1);
+  test_unsqueeze({222, 111}, -2);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_2dto3d_dim2) {
+  test_unsqueeze({5, 7}, 2);
+  test_unsqueeze({7, 5}, -1);
+  test_unsqueeze({111, 222}, 2);
+  test_unsqueeze({222, 111}, -1);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_3dto4d_dim0) {
+  test_unsqueeze({2, 3, 4}, 0);
+  test_unsqueeze({4, 3, 2}, -4);
+  test_unsqueeze({22, 33, 11}, 0);
+  test_unsqueeze({33, 11, 22}, -4);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_3dto4d_dim1) {
+  test_unsqueeze({2, 3, 4}, 1);
+  test_unsqueeze({4, 3, 2}, -3);
+  test_unsqueeze({22, 33, 11}, 1);
+  test_unsqueeze({33, 11, 22}, -3);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_3dto4d_dim2) {
+  test_unsqueeze({2, 3, 4}, 2);
+  test_unsqueeze({4, 3, 2}, -2);
+  test_unsqueeze({22, 33, 11}, 2);
+  test_unsqueeze({33, 11, 22}, -2);
+}
+
+TEST_F(VulkanAPITest, unsqueeze_3dto4d_dim3) {
+  test_unsqueeze({1, 5, 2}, 3);
+  test_unsqueeze({2, 3, 4}, 3);
+  test_unsqueeze({4, 3, 2}, -1);
+  test_unsqueeze({22, 33, 11}, 3);
+  test_unsqueeze({33, 11, 22}, -1);
 }
 
 TEST_F(VulkanAPITest, upsample_nearest2d) {


### PR DESCRIPTION
Summary:
Re-submitting D46057585 after revert from merge conflict

Add 1d->2d, 3d->4d unsqueeze

Unsqueeze operator: https://pytorch.org/docs/stable/generated/torch.unsqueeze.html#torch.unsqueeze

Test Plan:
Unsqueeze tests:
```
lfq@lfq-mbp xplat % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*unsqueeze*"
Downloaded 0/44 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 38.6 sec (100%) 523/523 jobs, 8/523 updated
  Total time: 38.6 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *unsqueeze*
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.unsqueeze_1dto2d_dim0
[       OK ] VulkanAPITest.unsqueeze_1dto2d_dim0 (76 ms)
[ RUN      ] VulkanAPITest.unsqueeze_1dto2d_dim1
[       OK ] VulkanAPITest.unsqueeze_1dto2d_dim1 (2 ms)
[ RUN      ] VulkanAPITest.unsqueeze_2dto3d_dim0
[       OK ] VulkanAPITest.unsqueeze_2dto3d_dim0 (9 ms)
[ RUN      ] VulkanAPITest.unsqueeze_2dto3d_dim1
[       OK ] VulkanAPITest.unsqueeze_2dto3d_dim1 (1 ms)
[ RUN      ] VulkanAPITest.unsqueeze_2dto3d_dim2
[       OK ] VulkanAPITest.unsqueeze_2dto3d_dim2 (1 ms)
[ RUN      ] VulkanAPITest.unsqueeze_3dto4d_dim0
[       OK ] VulkanAPITest.unsqueeze_3dto4d_dim0 (2 ms)
[ RUN      ] VulkanAPITest.unsqueeze_3dto4d_dim1
[       OK ] VulkanAPITest.unsqueeze_3dto4d_dim1 (1 ms)
[ RUN      ] VulkanAPITest.unsqueeze_3dto4d_dim2
[       OK ] VulkanAPITest.unsqueeze_3dto4d_dim2 (1 ms)
[ RUN      ] VulkanAPITest.unsqueeze_3dto4d_dim3
[       OK ] VulkanAPITest.unsqueeze_3dto4d_dim3 (1 ms)
[----------] 9 tests from VulkanAPITest (98 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test suite ran. (98 ms total)
[  PASSED  ] 9 tests.
```

clang-format on the glsl files

Reviewed By: copyrightly

Differential Revision: D46375157

