### PR TITLE
[export] Change equality constraints to list of tuples

### DIFF
--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -95,7 +95,7 @@ class ExportTracer(PythonKeyTracer):
                     )
                     fake_tensor = None
                 return fake_tensor
-            elif isinstance(x, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+            elif isinstance(x, (torch.SymInt, torch.SymFloat, torch.SymBool, int)):
                 return x
             else:
                 return None

--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -75,7 +75,7 @@ class ExportTracer(PythonKeyTracer):
         # propagate the fake tensor or sym nodes
         def make_val(
             x: Argument,
-        ) -> Union[FakeTensor, torch.SymInt, torch.SymFloat, torch.SymBool, None]:
+        ) -> Union[FakeTensor, torch.SymInt, torch.SymFloat, torch.SymBool, int, None]:
             if isinstance(x, FakeTensor):
                 return x
             elif isinstance(x, torch.Tensor):

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -111,7 +111,7 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
             list(inputdim_to_node.values())[-1]
         ):
             self._insert_equality_assert_inplace(graph, inputdim_to_node)
-        
+
         # Add runtime asserts for inline constraints
         val = super().call(graph_module)
 

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -5,7 +5,7 @@ import operator
 import traceback
 from collections import OrderedDict
 from functools import partial
-from typing import Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import sympy
 
@@ -27,8 +27,8 @@ class InputDim(NamedTuple):
 
 @dataclass
 class RangeConstraint:
-    min_val: int
-    max_val: int
+    min_val: sympy.Integer
+    max_val: sympy.Integer
 
 
 def _convert_to_int(val):
@@ -55,11 +55,11 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
     def __init__(
         self,
         range_constraints: Dict[sympy.Symbol, RangeConstraint],
-        equality_constraints: Dict[InputDim, List[InputDim]],
+        equality_constraints: List[Tuple[InputDim, InputDim]],
     ):
         super().__init__()
         self.range_constraints: Dict[sympy.Symbol, RangeConstraint] = range_constraints
-        self.equality_constraints: Dict[InputDim, List[InputDim]] = equality_constraints
+        self.equality_constraints: List[Tuple[InputDim, InputDim]] = equality_constraints
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         graph_module = copy.deepcopy(graph_module)
@@ -68,12 +68,11 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         # Add runtime asserts for input shape constraints. We do this after all
         # placeholder nodes so that we can handle both (unary) predicates and
         # (binary) relations.
-        placeholder_nodes: Dict[str, torch.fx.Node] = OrderedDict()
+        inputdim_to_node: Dict[InputDim, torch.fx.Node] = OrderedDict()
         for node in graph.nodes:
             if node.op != "placeholder":
                 continue
 
-            placeholder_nodes[node.name] = node
             if (
                 "val" not in node.meta or
                 not isinstance(node.meta["val"], FakeTensor)
@@ -82,29 +81,34 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
 
             fake_tensor_shape = node.meta["val"].shape
             for dim, shape in enumerate(fake_tensor_shape):
+                with graph.inserting_after(node):
+                    dim_node = graph.call_function(
+                        torch.ops.aten.sym_size.int, (node, dim)
+                    )
+                input_dim = InputDim(node.name, dim)
+                inputdim_to_node[input_dim] = dim_node
+
                 if isinstance(shape, SymInt):
                     # If the shape is dynamic, add range assertions
                     symbol = shape.node._expr
                     assert symbol in self.range_constraints
 
-                    with graph.inserting_after(node):
-                        self._insert_range_assert_inplace(
-                            graph, node, dim, self.range_constraints[symbol]
-                        )
+                    self._insert_range_assert_inplace(
+                        graph, input_dim, dim_node, self.range_constraints[symbol]
+                    )
                 else:
                     # If no dynamism is specified, we assume all dimensions #
                     # are specialized
                     assert isinstance(shape, int)
-                    with graph.inserting_after(node):
-                        self._insert_specialized_shape_assert_inplace(
-                            graph, node, dim, shape,
-                        )
+                    self._insert_specialized_shape_assert_inplace(
+                        graph, input_dim, dim_node, shape,
+                    )
 
         # Add runtime assertions on equality constraints on the inputs
         with graph.inserting_after(
-            list(placeholder_nodes.values())[-1]
+            list(inputdim_to_node.values())[-1]
         ):
-            self._insert_equality_assert_inplace(graph, placeholder_nodes)
+            self._insert_equality_assert_inplace(graph, inputdim_to_node)
 
         # Add runtime asserts for inline constraints
         val = super().call(graph_module)
@@ -117,10 +121,9 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         return PassResult(val.graph_module, val.modified)
 
     def _insert_specialized_shape_assert_inplace(
-        self, graph: torch.fx.Graph, node: torch.fx.Node, dim: int, shape: int,
+        self, graph: torch.fx.Graph, input_dim: InputDim, dim_node: torch.fx.Node, shape: int,
     ):
-        assert_msg = f"Input {node.name}.shape[{dim}] is specialized at {shape}"
-        dim_node = graph.call_function(torch.ops.aten.sym_size.int, (node, dim))
+        assert_msg = f"Input {input_dim.input_name}.shape[{input_dim.dim}] is specialized at {shape}"
         with graph.inserting_after(dim_node):
             eq_node = graph.call_function(operator.eq, (dim_node, shape))
         with graph.inserting_after(eq_node):
@@ -129,7 +132,7 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
             _ = graph.call_function(torch.ops.aten._assert_async.msg, (tensor_eq_node, assert_msg))
 
     def _insert_range_assert_inplace(
-        self, graph: torch.fx.Graph, node: torch.fx.Node, dim: int, range: RangeConstraint
+        self, graph: torch.fx.Graph, input_dim: InputDim, dim_node: torch.fx.Node, range: RangeConstraint
     ):
         """
         Add runtime asserts for user-specified range constraints for
@@ -139,7 +142,7 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
         dim_node = graph.call_function(torch.ops.aten.sym_size.int, (node, dim))
         min_val, max_val = _convert_range_to_int(range)
         assert_msg = (
-            f"Input {node.name}.shape[{dim}] is "
+            f"Input {input_dim.input_name}.shape[{input_dim.dim}] is "
             f"outside of specified dynamic range [{min_val}, {max_val}]"
         )
         # TODO (tmanlaibaatar) we are making an assumption that graph generated for
@@ -161,31 +164,24 @@ class _AddRuntimeAssertionsForConstraintsPass(ExportPassBase):
     def _insert_equality_assert_inplace(
         self,
         graph: torch.fx.Graph,
-        placeholder_nodes: Dict[str, torch.fx.Node],
+        inputdim_to_node: Dict[InputDim, torch.fx.Node],
     ):
-        for input_dim, equalities in self.equality_constraints.items():
-            node = placeholder_nodes[input_dim.input_name]
-            dim_node = graph.call_function(
-                torch.ops.aten.sym_size.int, (node, input_dim.dim),
-            )
+        for input_dim, other_input_dim in self.equality_constraints:
+            dim_node = inputdim_to_node[input_dim]
             with graph.inserting_after(dim_node):
-                for other_input_dim in equalities:
-                    assert_msg = (
-                        f"Input {input_dim.input_name}.shape[{input_dim.dim}] is "
-                        f"not equal to input {other_input_dim.input_name}.shape[{other_input_dim.dim}]"
-                    )
-                    other_node = placeholder_nodes[other_input_dim.input_name]
-                    other_dim_node = graph.call_function(
-                        torch.ops.aten.sym_size.int, (other_node, other_input_dim.dim),
-                    )
+                assert_msg = (
+                    f"Input {input_dim.input_name}.shape[{input_dim.dim}] is "
+                    f"not equal to input {other_input_dim.input_name}.shape[{other_input_dim.dim}]"
+                )
 
-                    with graph.inserting_after(other_dim_node):
-                        self._insert_assert_async_inplace(
-                            graph,
-                            operator.eq,
-                            (dim_node, other_dim_node),
-                            assert_msg
-                        )
+                other_dim_node = inputdim_to_node[other_input_dim]
+                with graph.inserting_after(other_dim_node):
+                    self._insert_assert_async_inplace(
+                        graph,
+                        operator.eq,
+                        (dim_node, other_dim_node),
+                        assert_msg
+                    )
 
     def _create_dummy_node_metadata(self):
         return NodeMetadata({

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -160,12 +160,6 @@ class GraphSignature:
 
 
 @dataclass
-class RangeConstraint:
-    lower: int
-    upper: int
-
-
-@dataclass
 class GraphModule:
     graph: Graph
     buffers: Dict[str, TensorMeta]

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -160,6 +160,12 @@ class GraphSignature:
 
 
 @dataclass
+class RangeConstraint:
+    lower: int
+    upper: int
+
+
+@dataclass
 class GraphModule:
     graph: Graph
     buffers: Dict[str, TensorMeta]


### PR DESCRIPTION
Changed equality constraints to a list of tuples as the dictionary wasn't providing much value -- also makes creating constraints + serialization easier.