### PR TITLE
[inductor] Support select_algorithm with cpp_wrapper

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -22,6 +22,7 @@ try:
             test_foreach,
             test_mkldnn_pattern_matcher,
             test_pattern_matcher,
+            test_select_algorithm,
             test_torchinductor,
             test_torchinductor_dynamic_shapes,
         )
@@ -30,6 +31,7 @@ try:
         import test_foreach
         import test_mkldnn_pattern_matcher
         import test_pattern_matcher
+        import test_select_algorithm
         import test_torchinductor
         import test_torchinductor_dynamic_shapes
 except unittest.SkipTest:
@@ -239,6 +241,11 @@ if RUN_CUDA:
             "test_cat_slice_cat",
             device=None,
             tests=test_pattern_matcher.TestPaternMatcher(),
+        ),
+        BaseTest(
+            "test_addmm",
+            device=None,
+            tests=test_select_algorithm.TestSelectAlgorithm(),
         ),
     ]:
         make_test_case(item.name, item.device, item.tests)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2181,7 +2181,6 @@ class TritonScheduling:
             src_code = src_code.replace("#pragma CMT", "#")
 
             basename, _, kernel_path = get_code_path(src_code, "py", extra="")
-            wrapper.kernel_to_hash[kernel_name] = basename
 
             compile_wrapper = IndentedBuffer()
             compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -252,7 +252,6 @@ class WrapperCodeGen(CodeGen):
         self.prefix = IndentedBuffer()
         self.wrapper_call = IndentedBuffer()
         self.src_to_kernel = {}
-        self.kernel_to_hash = {}
         self.kenel_numel_expr = set()
         self.lines = []
         self.declare = ""
@@ -1187,10 +1186,10 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 name, call_args, grid, device_index, cuda
             )
 
-        params = CudaKernelParamCache.get(self.kernel_to_hash.get(name, None))
+        params = CudaKernelParamCache.get(name)
         assert (
             params is not None
-        ), "cuda kernel parameters should already exist at this moment"
+        ), f"cuda kernel parameters for {name} should already exist at this moment"
 
         self.generate_load_kernel(name, params)
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -657,7 +657,8 @@ def compile_fx(
             )
 
     if config.cpp_wrapper:
-        with config.patch({"cpp_wrapper": False}):
+        # CudaWrapperCodeGen relies on kernel name to find the autotuned cubin file
+        with config.patch({"cpp_wrapper": False, "triton.unique_kernel_names": True}):
             return compile_fx(
                 model_,
                 example_inputs_,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -258,7 +258,7 @@ class CachingAutotuner(KernelInterface):
         else:
             grid_x, grid_y, grid_z = grid
 
-        key = launcher.fn.module.split(".")[-1]
+        key = launcher.fn.fn.__qualname__  # unique kernel name
         params = {
             "mangled_name": launcher.bin.metadata["name"],
             "grid_x": grid_x,
@@ -334,7 +334,7 @@ class CachingAutotuner(KernelInterface):
 
         (launcher,) = self.launchers
         if launcher.store_cubin:
-            self.save_cuda_kernel(grid, stream, self.launchers[0])
+            self.save_cuda_kernel(grid, stream, launcher)
 
         if launcher.config.pre_hook is not None:
             launcher.config.pre_hook(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103005
* #103004
* __->__ #103003

Summary: This is one step towards getting cpp_wrapper work with max_autotune.
Switch to use unique kernel name to cache generated cubin file.

This is a copy of https://github.com/pytorch/pytorch/pull/102738 to solve a ghstack issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @bertmaher