### PR TITLE
[inductor] Turn off autotune_cublasLt for cpp_wrapper

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -247,6 +247,11 @@ if RUN_CUDA:
             device=None,
             tests=test_select_algorithm.TestSelectAlgorithm(),
         ),
+        BaseTest(
+            "test_linear_relu",
+            device=None,
+            tests=test_select_algorithm.TestSelectAlgorithm(),
+        ),
     ]:
         make_test_case(item.name, item.device, item.tests)
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -62,7 +62,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(16, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.check_counter(counters["inductor"]["select_algorithm_autotune"], 1)
         # It would be nice to assert this got fused into a single kernel, but that
         # only happens if we select a triton template (and not aten).
 
@@ -108,7 +108,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(8, 32, device="cuda"),
             torch.randn(32, 8, device="cuda"),
         )
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.check_counter(counters["inductor"]["select_algorithm_autotune"], 1)
 
     @patches
     def test__int_mm(self):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -658,7 +658,13 @@ def compile_fx(
 
     if config.cpp_wrapper:
         # CudaWrapperCodeGen relies on kernel name to find the autotuned cubin file
-        with config.patch({"cpp_wrapper": False, "triton.unique_kernel_names": True}):
+        with config.patch(
+            {
+                "cpp_wrapper": False,
+                "triton.unique_kernel_names": True,
+                "triton.autotune_cublasLt": False,
+            }
+        ):
             return compile_fx(
                 model_,
                 example_inputs_,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -279,6 +279,9 @@ class triton:
     # this should only be disabled for debugging/testing
     autotune_pointwise = True
 
+    # max autotune gemm with cublasLt
+    autotune_cublasLt = True
+
     # should we stop a fusion to allow better tiling?
     tiling_prevents_pointwise_fusion = True
     tiling_prevents_reduction_fusion = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103005
* __->__ #103004
* #103003

Summary: bias_addmm is not backed up by a cpp funciton, so turn
autotune_cublasLt for cpp_wrapper + max_autotune. We can add a cpp
function implementation if there is a performance need.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @bertmaher