### PR TITLE
[inductor] fix a numel expr codegen issue

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -252,6 +252,11 @@ if RUN_CUDA:
             device=None,
             tests=test_select_algorithm.TestSelectAlgorithm(),
         ),
+        BaseTest(
+            "test_convolution1",
+            device=None,
+            tests=test_select_algorithm.TestSelectAlgorithm(),
+        ),
     ]:
         make_test_case(item.name, item.device, item.tests)
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -211,7 +211,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(34, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.check_counter(counters["inductor"]["select_algorithm_autotune"], 1)
 
     @patches
     def test_mm_dropout(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6,7 +6,7 @@ import itertools
 import logging
 import math
 import operator
-from typing import Any, Dict, Iterable, List, Set
+from typing import Dict, Iterable, List, Set
 
 import sympy
 
@@ -450,14 +450,6 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     def ceil(x):
         return f"tl.math.ceil({x})"
-
-
-@dataclasses.dataclass
-class SymbolicCallArg:
-    inner: Any
-
-    def __str__(self):
-        return str(self.inner)
 
 
 @dataclasses.dataclass
@@ -1728,24 +1720,7 @@ class TritonKernel(Kernel):
             if isinstance(tree.numel, (sympy.Integer, sympy.Symbol)):
                 expr = tree.numel
             else:
-                expr = f"{name}_{tree.prefix}numel"
-                # TODO(voz): Tragic. This should at the very least be a util to slapp on declare and ending.
-                # The real fix here is to revisit our cross language calling convention.
-                if expr not in wrapper.kenel_numel_expr:
-                    wrapper.kenel_numel_expr.add(expr)
-                    wrapper.writeline(
-                        f"{wrapper.declare}{expr} = {pexpr(tree.numel)}{wrapper.ending}"
-                    )
-                else:
-                    wrapper.writeline(f"{expr} = {pexpr(tree.numel)}{wrapper.ending}")
-                # We can get symbolic expressions here, like s0*64
-                # It is fine to have them here, but we need to handle them correctly as their own type
-                # This is tricky to do, so we wrap in a custom type, distinct from scalars, but also from sympy*
-                # scalars as well.
-                # This is handled in `generate_args_decl` which has a correct comment of: TODO: only works for
-                # constant now, need type info. I agree, this needs type info, and while this is not true type info
-                # it suffices as a type hint for the purposes of producing the correct code for this type.
-                expr = SymbolicCallArg(expr)
+                expr = wrapper.generate_numel_expr(name, tree)
 
             if tree.prefix != "r" or self.inside_reduction:
                 call_args.append(expr)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -862,7 +862,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.call_func_name = "inductor_entry_cpp"
         self.cuda = False
         self.supports_intermediate_hooks = False
-        self.expr_printer = torch._inductor.codegen.cpp.cexpr
+
+        from .cpp import cexpr
+
+        self.expr_printer = cexpr
 
     def write_header(self):
         if V.graph.aot_mode:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -668,7 +668,7 @@ class WrapperCodeGen(CodeGen):
                 f"{self.declare}{expr} = {self.expr_printer(tree.numel)}{self.ending}"
             )
         else:
-            self.writeline(f"{expr} = {self.expr_printer(self.numel)}{self.ending}")
+            self.writeline(f"{expr} = {self.expr_printer(tree.numel)}{self.ending}")
         # We can get symbolic expressions here, like s0*64
         # It is fine to have them here, but we need to handle them correctly as their own type
         # This is tricky to do, so we wrap in a custom type, distinct from scalars, but also from sympy*

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -111,6 +111,14 @@ SUPPORTED_FALLBACK_CPP_WRAPPER = [
 ]
 
 
+@dataclasses.dataclass
+class SymbolicCallArg:
+    inner: Any
+
+    def __str__(self):
+        return str(self.inner)
+
+
 class MemoryPlanningState:
     def __init__(self):
         super().__init__()
@@ -265,6 +273,7 @@ class WrapperCodeGen(CodeGen):
         self.stride = "stride()"
         self.first_device_guard = True
         self.supports_intermediate_hooks = True
+        self.expr_printer = pexpr
 
         self.write_header()
         self.write_prefix()
@@ -557,7 +566,7 @@ class WrapperCodeGen(CodeGen):
         with self.prefix.indent():
             for sym, expr in V.graph.sizevars.inv_precomputed_replacements.items():
                 self.prefix.writeline(
-                    f"{self.declare}{sym} = {pexpr(expr)}{self.ending}"
+                    f"{self.declare}{sym} = {self.expr_printer(expr)}{self.ending}"
                 )
 
     def codegen_python_sizevar(self, x: Expr) -> str:
@@ -650,6 +659,24 @@ class WrapperCodeGen(CodeGen):
     ):
         metadata_comment = f"{metadata}\n" if metadata else ""
         self.header.splice(f"\n\n{metadata_comment}{name} = {kernel}")
+
+    def generate_numel_expr(self, kernel_name: str, tree):
+        expr = f"{kernel_name}_{tree.prefix}numel"
+        if expr not in self.kenel_numel_expr:
+            self.kenel_numel_expr.add(expr)
+            self.writeline(
+                f"{self.declare}{expr} = {self.expr_printer(tree.numel)}{self.ending}"
+            )
+        else:
+            self.writeline(f"{expr} = {self.expr_printer(self.numel)}{self.ending}")
+        # We can get symbolic expressions here, like s0*64
+        # It is fine to have them here, but we need to handle them correctly as their own type
+        # This is tricky to do, so we wrap in a custom type, distinct from scalars, but also from sympy*
+        # scalars as well.
+        # This is handled in `generate_args_decl` which has a correct comment of: TODO: only works for
+        # constant now, need type info. I agree, this needs type info, and while this is not true type info
+        # it suffices as a type hint for the purposes of producing the correct code for this type.
+        return SymbolicCallArg(expr)
 
     def wrap_kernel_call(self, name, call_args):
         return f"{name}({', '.join(call_args)}){self.ending}"
@@ -835,6 +862,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.call_func_name = "inductor_entry_cpp"
         self.cuda = False
         self.supports_intermediate_hooks = False
+        self.expr_printer = torch._inductor.codegen.cpp.cexpr
 
     def write_header(self):
         if V.graph.aot_mode:
@@ -976,9 +1004,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         super().add_benchmark_harness(output)
 
     def codegen_sizevar(self, x: Expr) -> str:
-        from .cpp import cexpr
-
-        return cexpr(V.graph.sizevars.simplify(x))
+        return self.expr_printer(V.graph.sizevars.simplify(x))
 
     def codegen_tuple_access(self, basename: str, index: str) -> str:
         return f"std::get<{index}>({basename})"
@@ -1089,6 +1115,7 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
         super().write_header()
         self.prefix.splice(
             """
+            #include <ATen/native/BinaryOps.h>
             #include <c10/util/Exception.h>
             #include <c10/cuda/CUDAGuard.h>
 
@@ -1162,7 +1189,7 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 (
                     sympy.Integer,
                     sympy.Symbol,
-                    torch._inductor.codegen.triton.SymbolicCallArg,
+                    SymbolicCallArg,
                 ),
             ):
                 self.writeline(f"auto {var_name} = {arg};")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103005
* #103004
* #103003

Summary: Correctly use pexpr or cexpr for generating symbolic expression
during wrapper codegen.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @bertmaher