### PR TITLE
Package `torch/*.pyi` type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1052,6 +1052,7 @@ def main():
         'py.typed',
         'bin/*',
         'test/*',
+        '*.pyi',
         '_C/*.pyi',
         'cuda/*.pyi',
         'fx/*.pyi',


### PR DESCRIPTION
Including `torch._VF` and `torch.return_types`

These are generated by:
https://github.com/pytorch/pytorch/blob/4003e96ca1e54df58772870eb779c66e4b6e51fb/tools/pyi/gen_pyi.py#L1139-L1155

Ref #99541