### PR TITLE
docs: Render bullet points correctly

### DIFF
--- a/docs/source/community/build_ci_governance.rst
+++ b/docs/source/community/build_ci_governance.rst
@@ -13,6 +13,7 @@ To add a qualified person to the maintainers' list, please create
 a PR that adds a person to the `persons of interests <https://pytorch.org/docs/main/community/persons_of_interest.html>`__ page and
 `merge_rules <https://github.com/pytorch/pytorch/blob/main/.github/merge_rules.yaml>`__ files. Current maintainers will cast their votes of
 support. Decision criteria for approving the PR:
+
 * Not earlier than two business days passed before merging (ensure the majority of the contributors have seen it)
 * PR has the correct label (`module: ci`)
 * There are no objections from the current maintainers


### PR DESCRIPTION
This wasn't rendering correctly on the website, this should make it so that the bullet points actually show correctly now.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>
