### PR TITLE
[inductor] add a few tests to verify view_to_reshape pass is safe

### DIFF
--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -167,6 +167,43 @@ class TestLayoutOptim(TestCase):
     def test_training_acc(self):
         self.verify_accuracy_for_train(Model2Conv)
 
+    def test_mutate_view(self):
+        """
+        The GraphModule passed to GraphLowering init method is like:
+        https://gist.github.com/shunting314/07228313fd017e2267101ff32edc6d64
+
+        It shows that we will call copy_ to update the argument in the end. This
+        guarantees the correctnesss.
+        """
+
+        @torch.compile
+        def f(x):
+            y = x.view(3, 2)
+            y.mul_(2)
+
+        x = torch.ones(2, 3).cuda()
+        f(x)
+        self.assertTrue(torch.equal(x, torch.ones(2, 3).cuda() * 2))
+
+    def test_mutate_base(self):
+        """
+        The GraphModule passed to GraphLowering init method is like:
+        https://gist.github.com/shunting314/fd60fe11d1f844c6db76aba7b06811bc
+
+        It shows that the output of the graph is the mul node which contains
+        the update we applied to the base tensor.
+        """
+
+        @torch.compile
+        def f(x):
+            y = x.view(3, 2)
+            x.mul_(2)
+            return y
+
+        x = torch.ones(2, 3).cuda()
+        y = f(x)
+        self.assertTrue(torch.equal(y, torch.ones(3, 2).cuda() * 2))
+
 
 if __name__ == "__main__":
     if HAS_CUDA and not TEST_WITH_ROCM:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103034

This PR follows up on issue https://github.com/pytorch/pytorch/issues/102229 . I added 2 unit tests and verified that autoaugorad/functionalization already handles view properly. The view_to_reshape pass does not cause an issues.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @bertmaher