### PR TITLE
fx pass for grouping layer norm

### DIFF
--- a/test/inductor/test_group_fusion_fx_passes.py
+++ b/test/inductor/test_group_fusion_fx_passes.py
@@ -1,0 +1,83 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.utils import counters
+from torch.testing._internal.common_utils import IS_LINUX, TEST_WITH_ROCM
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+class TestGroupFusionFxPasses(TestCase):
+    @torch._inductor.config.patch(group_fusion_fx_passes=True)
+    @torch._inductor.config.patch(split_cat_fx_passes=True)
+    def test_group_layer_norm(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1_ws = [torch.nn.Parameter(torch.randn(10)) for _ in range(5)]
+                self.l1_bs = [torch.nn.Parameter(torch.randn(10)) for _ in range(5)]
+                self.l2_ws = [torch.nn.Parameter(torch.randn(5, 10)) for _ in range(5)]
+                self.l2_bs = [torch.nn.Parameter(torch.randn(5, 10)) for _ in range(5)]
+
+            def forward(self, x):
+                post_l1 = []
+                for l1_out, l1_w, l1_b in zip(
+                    torch.split(x, 10, dim=2), self.l1_ws, self.l1_bs
+                ):
+                    post_l1.append(
+                        torch.nn.functional.layer_norm(
+                            l1_out, (10,), weight=l1_w, bias=l1_b
+                        )
+                    )
+
+                l1_out = torch.cat(post_l1, dim=2)
+
+                post_l2 = []
+                for l2_out, l2_w, l2_b in zip(
+                    torch.split(l1_out, 10, dim=2), self.l2_ws, self.l2_bs
+                ):
+                    post_l2.append(
+                        torch.nn.functional.layer_norm(
+                            l2_out,
+                            (
+                                5,
+                                10,
+                            ),
+                            weight=l2_w,
+                            bias=l2_b,
+                        )
+                    )
+
+                return torch.cat(post_l2, dim=2)
+
+        args = [
+            torch.randn(2, 5, 50),
+        ]
+
+        module = TestModule()
+
+        expected = module(*args)
+        actual = torch.compile(module, dynamic=True)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(
+            counters["inductor"]["layer_norm_removed"],
+            10,
+        )
+        self.assertEqual(
+            counters["inductor"]["layer_norm_added"],
+            2,
+        )
+        self.assertEqual(
+            counters["inductor"]["scmerge_split_removed"],
+            2,
+        )
+        self.assertEqual(
+            counters["inductor"]["scmerge_cat_removed"],
+            2,
+        )
+        counters.clear()
+
+
+if __name__ == "__main__":
+    if IS_LINUX and HAS_CUDA and not TEST_WITH_ROCM:
+        run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -48,6 +48,9 @@ pattern_matcher = True
 # Optimize away split cat patterns (Experimental)
 split_cat_fx_passes = True
 
+# Enable fx passes which group similar ops across the graph
+group_fusion_fx_passes = False
+
 # enable reordering pass
 reordering = True
 

--- a/torch/_inductor/fx_passes/group_fusion.py
+++ b/torch/_inductor/fx_passes/group_fusion.py
@@ -1,0 +1,194 @@
+import logging
+import operator
+from typing import List
+
+import networkx
+
+import torch
+from torch._dynamo.utils import counters
+
+from ..pattern_matcher import (
+    CallFunctionVarArgs,
+    config_flag,
+    get_arg_value,
+    get_mutation_region_id,
+    stable_topological_sort,
+)
+
+log = logging.getLogger(__name__)
+
+
+def get_nx_graph_from_fx_graph(graph: torch.fx.Graph) -> networkx.DiGraph:
+    nx_graph = networkx.DiGraph()
+    for node in graph.nodes:
+        nx_graph.add_node(node)
+        for user in node.users:
+            nx_graph.add_edge(node, user)
+    return nx_graph
+
+
+class GroupFusionPass:
+    """
+    `GroupFusionPass` implements an Fx pass which groups together similar nodes into a fused op. Unlike `PatternMatcherPass`
+    which can only match local patterns in a graph, this pass can group together nodes across the graph. The only restriction
+    imposed is that the nodes being fused must not have a path in between each other (which would lead to a cycle). Additional
+    checks such as `extra_check` (at a node level), or `pair_check` can be added to pose additional restrictions on
+    nodes to be fused.
+    """
+
+    def __init__(
+        self,
+        pattern,
+        pair_check,
+        replacement_fn,
+        extra_check=lambda m: True,
+        *,
+        prevent_match_across_mutations,
+    ):
+        """
+        Args:
+            pattern (torch.fx.Graph): A pattern to match nodes against. this pattern is used to filter nodes to be fused
+            pair_check (Callable[[torch.fx.Node, torch.fx.Node], bool]): A function to check if a pair of nodes can be fused
+            replacement_fn (Callable[[torch.fx.Graph, List[torch.fx.Node]]]): Function which does the actual replacement
+            extra_check (Callable[[torch.fx.Node], bool]): Extra check to filter the nodes
+            prevent_match_across_mutations (bool): Prevent matching across mutations.
+        """
+        self.pattern = pattern
+        self.extra_check = extra_check
+        self.pair_check = pair_check
+        self.replacement_fn = replacement_fn
+        self.prevent_match_across_mutations = prevent_match_across_mutations
+
+    def apply(self, graph):
+        target_nodes = []
+        for node in graph.nodes:
+            if m := self.pattern.match(node):
+                if self.extra_check(m):
+                    target_nodes.append(node)
+
+        if len(target_nodes) <= 1:
+            return
+
+        seen_nodes = set()
+        nx_graph = get_nx_graph_from_fx_graph(graph)
+
+        for i, target_node in enumerate(target_nodes):
+            nodes_to_fuse = []
+            if target_node not in seen_nodes:
+                seen_nodes.add(target_node)
+                nodes_to_fuse.append(target_node)
+
+                for j in range(i + 1, len(target_nodes)):
+                    if target_nodes[j] in seen_nodes:
+                        continue
+                    can_be_fused = self.pair_check(target_node, target_nodes[j]) and (
+                        not self.prevent_match_across_mutations
+                        or get_mutation_region_id(graph, target_node)
+                        == get_mutation_region_id(graph, target_nodes[j])
+                    )
+                    if (
+                        can_be_fused
+                    ):  # Check no conflict with any other nodes being fused
+                        for node_to_fuse in nodes_to_fuse:
+                            if networkx.has_path(
+                                nx_graph, node_to_fuse, target_nodes[j]
+                            ) or networkx.has_path(
+                                nx_graph, target_nodes[j], node_to_fuse
+                            ):
+                                can_be_fused = False
+                                break
+                    if can_be_fused:
+                        nodes_to_fuse.append(target_nodes[j])
+                        seen_nodes.add(target_nodes[j])
+                if len(nodes_to_fuse) == 1:
+                    continue
+                self.replacement_fn(graph, nodes_to_fuse)
+                nx_graph = get_nx_graph_from_fx_graph(graph)
+
+
+def layer_norm_replacement(graph: torch.fx.Graph, nodes_to_fuse: List[torch.fx.Node]):
+    """
+    Replace multiple `layer_norm` with a single `layer_norm`.
+    """
+    inputs = []
+    shapes = []
+    weights = []
+    biases = []
+    epss = []
+
+    for ln in nodes_to_fuse:
+        inputs.append(get_arg_value(ln, 0, "input"))
+        shapes.append(get_arg_value(ln, 1, "normalized_shape"))
+        weights.append(get_arg_value(ln, 2, "weight"))
+        biases.append(get_arg_value(ln, 3, "bias"))
+        eps = get_arg_value(ln, 4, "eps")
+        if eps is None:
+            eps = 1e-5
+        epss.append(eps)
+        counters["inductor"]["layer_norm_removed"] += 1
+
+    stack_dim = -1 - len(shapes[-1])
+
+    with graph.inserting_before(nodes_to_fuse[0]):
+        # Stack inputs
+        stack_input = graph.call_function(torch.stack, args=(inputs, stack_dim))
+
+        # Stack weight
+        stack_weight = graph.call_function(torch.stack, args=(weights,))
+
+        # Stack bias
+        stack_bias = graph.call_function(torch.stack, args=(biases,))
+
+        group_layer_norm = graph.call_function(
+            torch.nn.functional.layer_norm,
+            args=(stack_input, shapes[-1]),
+            kwargs={"eps": epss[-1]},
+        )
+
+        group_layer_norm = graph.call_function(
+            torch.addcmul, args=(stack_bias, stack_weight, group_layer_norm)
+        )
+
+        group_layer_norm = graph.call_function(
+            torch.unbind, args=(group_layer_norm,), kwargs={"dim": stack_dim}
+        )
+
+        counters["inductor"]["layer_norm_added"] += 1
+        for i, ln in enumerate(nodes_to_fuse):
+            getitem = graph.call_function(operator.getitem, args=(group_layer_norm, i))
+            ln.replace_all_uses_with(getitem)
+            getitem.meta.update(ln.meta)
+
+        for ln in nodes_to_fuse:
+            graph.erase_node(ln)
+
+        log.info("Fused %d layer norms", len(nodes_to_fuse))
+
+        stable_topological_sort(graph)
+
+
+def layer_norm_pair_check(ln1, ln2):
+    """
+    Check if two `layer_norm` nodes can be fused
+    """
+    return (
+        ln1.meta["example_value"].shape == ln2.meta["example_value"].shape
+        and get_arg_value(ln1, 1, "normalized_shape")
+        == get_arg_value(ln2, 1, "normalized_shape")
+        and get_arg_value(ln1, 4, "eps") == get_arg_value(ln2, 4, "eps")
+    )
+
+
+def layer_norm_extra_check(ln):
+    # Current implementation requires weight and bias to be present
+    return bool(get_arg_value(ln, 2, "weight")) and bool(get_arg_value(ln, 3, "bias"))
+
+
+layer_norm_fusion_pass = GroupFusionPass(
+    pattern=CallFunctionVarArgs(torch.nn.functional.layer_norm),
+    extra_check=lambda m: config_flag("group_fusion_fx_passes")(m)
+    and layer_norm_extra_check(m),
+    pair_check=layer_norm_pair_check,
+    replacement_fn=layer_norm_replacement,
+    prevent_match_across_mutations=True,
+)

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -19,6 +19,7 @@ from ..fx_utils import matches_module_function_pattern
 from ..mkldnn import mkldnn_fuse_fx
 from ..pattern_matcher import init_once_fakemode, PatternMatcherPass
 from ..utils import is_cpu_device
+from .group_fusion import layer_norm_fusion_pass
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ split_cat_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 unbind_stack_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 
 pattern_matcher_passes: List[PatternMatcherPass] = [
+    layer_norm_fusion_pass,
     normalization_pass,
     merge_splits_pass,
     split_cat_pass,


### PR DESCRIPTION
Summary:
This diff adds an fx pass for grouping together `torch.nn.functional.layer_norm`. This pass is different from other pattern matcher passes, as we combine together layer_norms from different places in the graph. We're calling such fusions as "group fusions". This shows promising results for internal models.

In this diff, we also add a new type of pattern matcher pass called `GroupFusionPass`, which can be used for more types of group fusions

Differential Revision: D46124324



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @bertmaher