### PR TITLE
[pytorch][vulkan] Add unused function annotation in vulkan perf test

### DIFF
--- a/aten/src/ATen/test/vulkan_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_perf_test.cpp
@@ -16,7 +16,7 @@
 namespace {
 
 namespace vulkan_api = at::native::vulkan::api;
-void report_pep(const std::string& name, const uint64_t duration) {
+[[maybe_unused]] void report_pep(const std::string& name, const uint64_t duration) {
   std::stringstream buffer;
   buffer << "PyTorchObserver {\"type\": \"";
   buffer << name << "\",";
@@ -31,7 +31,7 @@ void report_pep(const std::string& name, const uint64_t duration) {
   std::cout << buffer.str();
 }
 
-void report_aibench_res(vulkan_api::QueryPool& qpool) {
+[[maybe_unused]] void report_aibench_res(vulkan_api::QueryPool& qpool) {
   std::unordered_map<std::string, uint64_t> shader_runtimes;
   uint64_t num_additions = 0;
   auto result_aggregator =


### PR DESCRIPTION
Summary: as title

Test Plan:
#  Before

Android build failed because of `unused function`.

```
xplat/caffe2/aten/src/ATen/test/vulkan_perf_test.cpp:19:6: error: unused function 'report_pep' [-Werror,-Wunused-function]
void report_pep(const std::string& name, const uint64_t duration) {
     ^
1 error generated.
Command failed with exit code 1.
command: [/Users/yipjustin/fbsource/buck-out/gen/233b7bbc/xplat/toolchains/facebook-dt/tools/facebook-dt-15.x_clang_asserts_macos_genrule/usr/bin/clang, @/Users/yipjustin/fbsource/buck-out/bin/c0fa2acc/xplat/caffe2/pt_vulkan_perf_test_binAndroid#android-armv7,compile-vulkan_perf_test.cpp.ob82e9220/ppandcompile.argsfile]
stderr: xplat/caffe2/aten/src/ATen/test/vulkan_perf_test.cpp:19:6: error: unused function 'report_pep' [-Werror,-Wunused-function]
void report_pep(const std::string& name, const uint64_t duration) {
     ^
1 error generated.
    When running <c++ preprocess_and_compile>.
    When building rule //xplat/caffe2:pt_vulkan_perf_test_binAndroid#android-armv7,compile-vulkan_perf_test.cpp.ob82e9220 (ovr_config//platform/macos:arm64-fbsource).
Downloading... 0/4147 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building... 01:48.3 min (42%) 1342/3134 jobs, 349/3134 updated
     - //xplat/caffe2:torch_coreAndroid#android-armv7,compile-ir_emitter.cpp.oc1e2ca78... 21.2 sec (running artifact_compress[0.0 sec])
Command failed with exit code 1.
command: [/Users/yipjustin/fbsource/buck-out/gen/233b7bbc/xplat/toolchains/facebook-dt/tools/facebook-dt-15.x_clang_asserts_macos_genrule/usr/bin/clang, @/Users/yipjustin/fbsource/buck-out/bin/c0fa2acc/xplat/caffe2/pt_vulkan_perf_test_binAndroid#android-armv7,compile-vulkan_perf_test.cpp.ob82e9220/ppandcompile.argsfile]
stderr: xplat/caffe2/aten/src/ATen/test/vulkan_perf_test.cpp:19:6: error: unused function 'report_pep' [-Werror,-Wunused-function]
void report_pep(const std::string& name, const uint64_t duration) {
     ^
1 error generated.
    When running <c++ preprocess_and_compile>.
    When building rule //xplat/caffe2:pt_vulkan_perf_test_binAndroid#android-armv7,compile-vulkan_perf_test.cpp.ob82e9220 (ovr_config//platform/macos:arm64-fbsource).
```

# After

Only **non**-quantized path are verified. Quantized ops fails to run.

## Commenting the unused code, for android build

```
yipjustin@yipjustin-mac fbsource % buck build   -c ndk.custom_libcxx=false -c pt.enable_qpl=0   //xplat/caffe2:pt_vulkan_perf_test_binAndroid\#android-armv7
Building: finished in 0.4 sec (100%) 258/258 jobs, 0/258 updated
  Total time: 0.6 sec
More details at https://www.internalfb.com/intern/buck/build/0244f9d0-2c78-4186-8c0a-8560ed136baf
BUILD SUCCEEDED
```

Verify execution on Android device
```
1|hibiki:/data/local/tmp/vulkan_perf # ./pt_vulkan_perf_test_binAndroid\#android-armv7  --benchmark_filter="-_q_"
2023-02-13T17:48:13+00:00
Running ./pt_vulkan_perf_test_binAndroid#android-armv7
Run on (4 X 1708.8 MHz CPU s)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.

--------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------
add_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1             537 ms          542 ms          100
conv2d_op_benchmark/N:1/C:17/H:127/W:397/iterations:100/manual_time/threads:1         18.0 ms         16.5 ms          100
conv2dpw_op_benchmark/N:1/C:17/H:127/W:397/iterations:100/manual_time/threads:1        164 ms          153 ms          100
conv2ddw_op_benchmark/N:1/C:32/H:256/W:256/iterations:10/manual_time/threads:1         231 ms          207 ms           10
sub_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1             542 ms          542 ms          100
mul_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1             539 ms          540 ms          100
div_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1             548 ms          547 ms          100

```

## verify on mac OS

```
yipjustin@yipjustin-mac fbsource % buck run  -c pt.vulkan_full_precision=1  --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_perf_test_binAppleMac\#macosx-arm64 -- --benchmark_filter="-_q_"
...
Running /Users/yipjustin/fbsource/buck-out/gen/c0fa2acc/xplat/caffe2/pt_vulkan_perf_test_binAppleMac#macosx-arm64
Run on (20 X 24.121 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x20)
  L1 Instruction 128 KiB (x20)
  L2 Unified 4096 KiB (x10)
Load Average: 4.19, 4.34, 5.60
***WARNING*** Library was built as DEBUG. Timings may be affected.
--------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------
add_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1            5.47 ms         2.68 ms          100
conv2d_op_benchmark/N:1/C:17/H:127/W:397/iterations:100/manual_time/threads:1         1.01 ms        0.369 ms          100
conv2dpw_op_benchmark/N:1/C:17/H:127/W:397/iterations:100/manual_time/threads:1       1.92 ms         1.10 ms          100
conv2ddw_op_benchmark/N:1/C:32/H:256/W:256/iterations:10/manual_time/threads:1        2.78 ms         1.67 ms           10
sub_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1            5.28 ms         2.45 ms          100
mul_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1            5.32 ms         2.59 ms          100
div_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1            5.27 ms         2.50 ms          100
```

Differential Revision: D46465358

