### PR TITLE
[Pytorch] aten::zero_

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/zero_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/zero_.glsl
@@ -1,0 +1,23 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/*
+ * Output Image
+ */
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+
+/*
+ * Local Work Group Size
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Returns the input tensor, filled with zeros
+ */
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  imageStore(uOutput, pos, vec4(0, 0, 0, 0));
+}

--- a/aten/src/ATen/native/vulkan/ops/Zero.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Zero.cpp
@@ -1,0 +1,56 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor& zero_(at::Tensor& self) {
+  TORCH_CHECK(self.dim() <= 4, "Vulkan zero_ supports up to 4d tensors");
+
+  vTensor& v_self = convert(self);
+
+  // Get the global Vulkan context
+  api::Context* const context = api::context();
+
+  // Required to determine how to insert memory barriers in the command buffer
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      VK_KERNEL(zero_),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_self.extents(),
+      // local work group size
+      adaptive_work_group_size(v_self.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_self.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::READ | api::MemoryAccessType::WRITE));
+
+  return self;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::zero_"), TORCH_FN(zero_));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -5021,6 +5021,27 @@ TEST_F(VulkanAPITest, stack_from_1_to_20_tensors) {
   }
 }
 
+void test_zero_(const at::IntArrayRef input_shape) {
+  auto cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  auto vulkan = cpu.vulkan();
+
+  cpu.zero_();
+  vulkan.zero_();
+
+  const auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, zero_) {
+  test_zero_({5});
+  test_zero_({5, 7});
+  test_zero_({9, 7, 5});
+  test_zero_({22, 11, 19, 17});
+}
+
 TEST_F(VulkanAPITest, clone_success) {
   // Arrange
   std::multimap<c10::optional<c10::MemoryFormat>, std::vector<int64_t>> mem2sizes {


### PR DESCRIPTION
Summary: aten::zero_: https://pytorch.org/docs/stable/generated/torch.Tensor.zero_.html

Test Plan:
clang-format on zero_.glsl and Zero.cpp

```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*zero*"
Downloaded 0/48 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 40.5 sec (100%) 525/525 jobs, 12/525 updated
  Total time: 40.5 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *zero*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VulkanAPITest
[ RUN      ] VulkanAPITest.zero_
[       OK ] VulkanAPITest.zero_ (59 ms)
[----------] 1 test from VulkanAPITest (59 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (59 ms total)
[  PASSED  ] 1 test.
```

Differential Revision: D46403983

