### PR TITLE
[BE] Make XLA tests faster

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -765,7 +765,11 @@ test_xla() {
   SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
   # Set LD_LIBRARY_PATH for C++ tests
   export LD_LIBRARY_PATH="/opt/conda/lib/:${LD_LIBRARY_PATH}"
-  CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SKIP_MP_OP_TESTS=1 run_torch_xla_tests "$(pwd)" "$(pwd)/xla"
+  PYTORCH_DIR="$(pwd)"
+  XLA_DIR="$(pwd)/xla"
+  pushd "${XLA_DIR}"
+  CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SKIP_MP_OP_TESTS=1 run_torch_xla_tests "${PYTORCH_DIR}" "${XLA_DIR}"
+  popd
   assert_git_not_dirty
 }
 


### PR DESCRIPTION
By building and testing XLA Python and CPP using the same CXX ABI

Fixes #ISSUE_NUMBER
