### PR TITLE
Fix graph break on boolean mask better

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1662,6 +1662,18 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         y = torch.randn(2, requires_grad=True)
         opt_fn(x, b, y)
 
+    def test_setitem_tuple_boolean_mask_diff(self):
+        def fn(x, b, y):
+            x = x.clone()
+            x[:, b] = y
+            return x
+
+        opt_fn = torch._dynamo.optimize("aot_eager")(fn)
+        x = torch.randn(8, 4, requires_grad=True)
+        b = torch.tensor([True, False, True, False])
+        y = torch.randn(2, requires_grad=True)
+        opt_fn(x, b, y)
+
     def test_torch_tensor_ops(self):
         def fn(x):
             return torch.Tensor.abs_(x)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -421,16 +421,20 @@ class TensorVariable(VariableTracker):
         elif name == "__len__":
             return self.call_method(tx, "size", [ConstantVariable(0, **options)], {})
         elif name == "__setitem__":
+            key, value = args
+
+            def has_bool_key(v):
+                if isinstance(v, TensorVariable):
+                    return v.dtype in (torch.bool, torch.int8)
+                elif isinstance(v, TupleVariable):
+                    return any(has_bool_key(item) for item in v.items)
+                else:
+                    return False
+
             if (
                 not config.capture_dynamic_output_shape_ops
-                # NB: the bool tensor and the requires_grad tensor are
-                # never the same tensor!
-                and any(
-                    isinstance(a, TensorVariable)
-                    and a.dtype in (torch.bool, torch.int8)
-                    for a in args
-                )
-                and any(isinstance(a, TensorVariable) and a.requires_grad for a in args)
+                and has_bool_key(key)
+                and isinstance(value, TensorVariable) and value.requires_grad
             ):
                 unimplemented(
                     "boolean masking setitem backwards requires dynamic shapes"

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -434,7 +434,8 @@ class TensorVariable(VariableTracker):
             if (
                 not config.capture_dynamic_output_shape_ops
                 and has_bool_key(key)
-                and isinstance(value, TensorVariable) and value.requires_grad
+                and isinstance(value, TensorVariable)
+                and value.requires_grad
             ):
                 unimplemented(
                     "boolean masking setitem backwards requires dynamic shapes"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103152
* __->__ #103052

Previously I accidentally thought setitem takes each argument as a
list.  But if you write x[:, b] that actually is passed in as a tuple.
Try harder.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy