### PR TITLE
[BE] Use `value_or`

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -56,7 +56,7 @@ CppFunction::~CppFunction() = default;
 Library::Library(Kind kind, std::string ns, c10::optional<c10::DispatchKey> k, const char* file, uint32_t line)
   : kind_(kind)
   , ns_(ns == "_" ? c10::nullopt : c10::make_optional(std::move(ns)))
-  , dispatch_key_(k.value_or(CatchAll) == CatchAll) ? c10::nullopt : k)
+  , dispatch_key_(k.value_or(CatchAll) == CatchAll ? c10::nullopt : k)
   , file_(file)
   , line_(line)
   {

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -38,7 +38,9 @@ namespace {
     }
     return "(unknown)";
   }
-}
+
+  constexpr auto CatchAll = c10::DispatchKey::CatchAll;
+} // anonymous namespace
 
 CppFunction::CppFunction(c10::KernelFunction func, c10::optional<c10::impl::CppSignature> cpp_signature, std::unique_ptr<c10::FunctionSchema> schema)
   : func_(std::move(func))
@@ -54,7 +56,7 @@ CppFunction::~CppFunction() = default;
 Library::Library(Kind kind, std::string ns, c10::optional<c10::DispatchKey> k, const char* file, uint32_t line)
   : kind_(kind)
   , ns_(ns == "_" ? c10::nullopt : c10::make_optional(std::move(ns)))
-  , dispatch_key_((!k.has_value() || *k == c10::DispatchKey::CatchAll) ? c10::nullopt : k)
+  , dispatch_key_(k.value_or(CatchAll) == CatchAll) ? c10::nullopt : k)
   , file_(file)
   , line_(line)
   {


### PR DESCRIPTION
`s/!k.has_value || *k == foo/k.value_or(foo) == foo/`

Which yields the same code see https://godbolt.org/z/6b35zYcYc

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 003c703</samp>

Simplify the logic for registering and looking up backend fallbacks in `library.cpp` by using a constant and an optional helper.

