### PR TITLE
Small operatorbench improvements

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/operatorbench.py
+++ b/benchmarks/dynamo/microbenchmarks/operatorbench.py
@@ -8,6 +8,7 @@ from torch._dynamo.backends.cudagraphs import cudagraphs_inner
 from torch._dynamo.testing import same
 from torch._inductor.compile_fx import compile_fx
 from torch._inductor.decomposition import decompositions
+from torch._inductor.lowering import lowerings
 from torch._inductor.utils import gen_gm_and_inputs
 from torch.utils._pytree import tree_map_only
 

--- a/benchmarks/dynamo/microbenchmarks/operatorbench.py
+++ b/benchmarks/dynamo/microbenchmarks/operatorbench.py
@@ -8,9 +8,8 @@ from torch._dynamo.backends.cudagraphs import cudagraphs_inner
 from torch._dynamo.testing import same
 from torch._inductor.compile_fx import compile_fx
 from torch._inductor.decomposition import decompositions
-from torch._inductor.lowering import fallbacks, lowerings
 from torch._inductor.utils import gen_gm_and_inputs
-
+from torch.utils._pytree import tree_map_only
 
 aten = torch.ops.aten
 
@@ -36,6 +35,8 @@ def compute_speedups(
         for m, model in enumerate(models):
             if device == "cuda":
                 import triton
+
+                model(*example_inputs)
 
                 # do_bench() clears L2 cache to hide the latency of CPU launch time
                 # along with cuda synchronization
@@ -70,6 +71,10 @@ def convert_to_jit(gm, gm_args):
     return torch.jit.trace(gm, gm_args)
 
 
+def to_channels_last(ten):
+    return ten if ten.ndim != 4 else ten.to(memory_format=torch.channels_last)
+
+
 def microbenchmark(
     operator, args, kwargs, dtype, accuracy_checking, repeats, measure_nvfuser, device
 ):
@@ -78,15 +83,22 @@ def microbenchmark(
         torch.ops.aten.convolution_backward.default, "aten::convolution_backward"
     )
     if device == "cuda":
-        cudagraphs_eager = cudagraphs_inner(gm, gm_args, copy_outputs=False)
+        cudagraphs_eager = cudagraphs_inner(
+            gm, gm_args, copy_outputs=False, copy_inputs=False
+        )
         compiled_fn = compile_fx(gm, gm_args)
-        compiled = [cudagraphs_eager, compiled_fn]
+        cudagraphs_compiled = cudagraphs_inner(
+            compiled_fn, gm_args, copy_outputs=False, copy_inputs=False
+        )
+        compiled = [cudagraphs_eager, cudagraphs_compiled]
     else:
         compiled_fn = compile_fx(gm, gm_args)
         compiled = [gm, compiled_fn]
     if measure_nvfuser:
         g = convert_to_jit(gm, gm_args)
-        cudagraphs_jit = cudagraphs_inner(g, gm_args, copy_outputs=False)
+        cudagraphs_jit = cudagraphs_inner(
+            g, gm_args, copy_outputs=False, copy_inputs=False
+        )
         compiled += [cudagraphs_jit]
     if accuracy_checking:
         repeats = 1
@@ -122,9 +134,8 @@ def skip_operator(operator):
     if isinstance(operator, torch._ops.OpOverload):
         op_impls.append(operator.overloadpacket)
 
-    if any(op in fallbacks for op in op_impls):
-        print(f"Skipping {operator}, no inductor impl")
-        return True
+    # TODO - skip benchmarking fallbacks. for some ops we have both lowerings and fallbacks
+    # so its not clear just from operator what will be lowered.
 
     if all(op not in decompositions and op not in lowerings for op in op_impls):
         print(f"Skipping {operator}, no inductor impl")
@@ -155,6 +166,9 @@ def skip_operator(operator):
 @click.option("--device", help="cpu or cuda", default="cuda")
 @click.option("--inp-file", help="use custom input file instead of suite", default=None)
 @click.option("--start-idx", help="specify start index of samples", default=0)
+@click.option(
+    "--channels-last", help="force inputs to channels last", is_flag=True, default=False
+)
 def benchmark(
     suite,
     op,
@@ -166,6 +180,7 @@ def benchmark(
     device,
     inp_file,
     start_idx,
+    channels_last,
 ):
     if inp_file is not None:
         loader = OperatorInputsLoader(inp_file)
@@ -209,6 +224,11 @@ def benchmark(
                     continue
                 print(f"Iter {i}")
                 args, kwargs = inps
+                if channels_last:
+                    args, kwargs = tree_map_only(
+                        torch.Tensor, to_channels_last, (args, kwargs)
+                    )
+
             except StopIteration:
                 break
             try:

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -145,10 +145,13 @@ aot_cudagraphs = aot_autograd(fw_compiler=cudagraphs, bw_compiler=cudagraphs)
 register_backend(name="cudagraphs", compiler_fn=aot_cudagraphs)
 
 
-def cudagraphs_inner(model, inputs, copy_outputs=True):
+def cudagraphs_inner(model, inputs, copy_outputs=True, copy_inputs=True):
     """This isn't registered as a backend, but is used in some benchmarks"""
     assert isinstance(inputs, (list, tuple))
-    static_inputs = [torch.zeros_like(x) for x in inputs]
+    if copy_inputs:
+        static_inputs = [torch.zeros_like(x) for x in inputs]
+    else:
+        static_inputs = inputs
 
     # warmup
     torch.cuda.synchronize()
@@ -169,8 +172,9 @@ def cudagraphs_inner(model, inputs, copy_outputs=True):
 
     def run(*new_inputs):
         assert len(static_inputs) == len(new_inputs)
-        for dst, src in zip(static_inputs, new_inputs):
-            dst.copy_(src)
+        if copy_inputs:
+            for dst, src in zip(static_inputs, new_inputs):
+                dst.copy_(src)
         graph.replay()
         if copy_outputs:
             return [x.clone() for x in static_outputs]

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -151,7 +151,7 @@ def cudagraphs_inner(model, inputs, copy_outputs=True, copy_inputs=True):
     if copy_inputs:
         static_inputs = [torch.zeros_like(x) for x in inputs]
     else:
-        static_inputs = [x for x in inputs]
+        static_inputs = list(inputs)
 
     # warmup
     torch.cuda.synchronize()

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -151,7 +151,7 @@ def cudagraphs_inner(model, inputs, copy_outputs=True, copy_inputs=True):
     if copy_inputs:
         static_inputs = [torch.zeros_like(x) for x in inputs]
     else:
-        static_inputs = inputs
+        static_inputs = [x for x in inputs]
 
     # warmup
     torch.cuda.synchronize()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103110

- Don't copy inputs in cudagraphs wrapping, since the copies will distorts timing and triton do_bench will clear cache anyway
- Don't skip op if there is a fallback, since we have both fallbacks and lowerings for some ops
- Add option for channels last


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy