### PR TITLE
[PT2][Quant] Use composble quantizer for embedding + static conv + dynamic

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/embedding_quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/embedding_quantizer.py
@@ -69,7 +69,7 @@ class EmbeddingQuantizer(Quantizer):
             # just as an example of alternate ways of annotating
             if (
                 node.op == "call_function"
-                or node.target == torch.ops.aten.embedding.default
+                and node.target == torch.ops.aten.embedding.default
             ):
                 if embedding_config.config.weight is None:
                     raise ValueError(


### PR DESCRIPTION
Summary:
In this diff we test a module that does a) emedding lookup b) runs 1D
(converted to 2D) conv and c) runs linear on the output of 1d conv.

a is quantized using embedding quantizer.
c is quantized using dynamic quantization.
b is quantized using static quantization.

We compose quantizer from [a, c, b]. Tested it against similar fx config.

Test Plan: test_embedding_conv_linear_quantization

Reviewed By: jerryzh168

Differential Revision: D46267688

