### PR TITLE
Add selector.is_et_kernel_key_selected

### DIFF
--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -298,3 +298,21 @@ operators:
             valid_tags=set(),
         )
         self.assertTrue(selector.is_native_function_selected(native_function))
+
+class TestExecuTorchSelectiveBuild(unittest.TestCase):
+      def test_et_kernel_selected(self):
+        yaml_config = """
+et_kernel_metadata:
+  aten::add.out:
+   - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
+  aten::sub.out:
+   - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
+"""
+        selector = SelectiveBuilder.from_yaml_str(yaml_config)
+        self.assertTrue(selector.is_et_kernel_selected("aten::add.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"))
+        self.assertTrue(selector.is_et_kernel_selected("aten::sub.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"))
+        self.assertFalse(selector.is_et_kernel_selected("aten::mul.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"))
+        self.assertFalse(selector.is_et_kernel_selected("aten::add.out", "v1/3;0,1|3;0,1|3;0,1|3;0,1"))
+        self.assertFalse(selector.is_et_kernel_selected("aten::add.out", "v1/6;1,0|6;0,1|6;0,1|6;0,1"))
+        # We don't use version for now.
+        self.assertTrue(selector.is_et_kernel_selected("aten::add.out", "v2/6;0,1|6;0,1|6;0,1|6;0,1"))

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -42,7 +42,8 @@ class SelectiveBuilder:
 
     # ExecuTorch only. A dictionary of kernel tag -> list of (list of input
     # dtypes for tensor-like input args).
-    et_kernel_metadata: Dict[str, List[List[str]]]
+    # This is from selective.yaml
+    et_kernel_metadata: Dict[str, List[str]]
 
     # A set of all the custom torch bind classes used by the selected models
     # Stored as a set internally to remove duplicates proactively, but written
@@ -107,8 +108,7 @@ class SelectiveBuilder:
         for k, v in kernel_metadata_dict.items():
             kernel_metadata[str(k)] = [str(dtype) for dtype in v]
 
-        # TODO(T149265497): Need to parse the et kernel metadata
-        et_kernel_metadata: Dict[str, List[List[str]]] = {}
+        et_kernel_metadata = data.get("et_kernel_metadata", {})
 
         custom_classes = data.get("custom_classes", [])
         assert isinstance(custom_classes, Iterable)
@@ -229,6 +229,18 @@ class SelectiveBuilder:
             and dtype in self.kernel_metadata[kernel_tag]
         )
 
+    def is_et_kernel_selected(self, op_name: str, kernel_key: str) -> bool:
+        if op_name not in self.et_kernel_metadata:
+            return False
+        # Don't compare the version for now
+        tensor_metadata = kernel_key.split("/")[1]
+
+        for model_kernel_keys in self.et_kernel_metadata[op_name]:
+            if tensor_metadata == model_kernel_keys.split("/")[1]:
+                return True
+
+        return False
+
     def to_dict(self) -> Dict[str, object]:
         ret: Dict[str, object] = {
             "include_all_non_op_selectives": self.include_all_non_op_selectives,
@@ -276,7 +288,7 @@ def combine_selective_builders(
     operators = merge_operator_dicts(lhs.operators, rhs.operators)
     kernel_metadata = merge_kernel_metadata(lhs.kernel_metadata, rhs.kernel_metadata)
     # TODO(T149265497): Need to parse the et kernel metadata
-    et_kernel_metadata: Dict[str, List[List[str]]] = {}
+    et_kernel_metadata: Dict[str, List[str]] = {}
     include_all_non_op_selectives = (
         lhs.include_all_non_op_selectives or rhs.include_all_non_op_selectives
     )


### PR DESCRIPTION
Summary: This API is used by the gen_executorch.py to check whether a kernel with specified kernel key is used or not.

Test Plan:
```
buck test xplat/caffe2/tools:test_torchgen_executorch
buck run fbcode//executorch/codegen/tools:test_gen_oplist_real_model
```

Reviewed By: larryliu0820

Differential Revision: D46495966



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305