### PR TITLE
[nccl] Do no skip send/recv 0 byte tensor

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -537,6 +537,25 @@ struct GetSecondArgType<R(Arg0, Arg1, Args...)> {
 
 constexpr auto count_max =
     std::numeric_limits<GetSecondArgType<decltype(ncclBcast)>::type>::max();
+
+// Since NCCL 2.12.10, NCCL supports send/recv 0 byte:
+// https://github.com/NVIDIA/nccl/issues/696. The issue of skipping send/recv
+// is that it can cause deadlock when a rank send and recv 0 bytes so it's
+// completely skipping the collective, causing mismatch across ranks
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR > 13)))
+template <typename T>
+constexpr bool _nccl_should_send_recv(C10_UNUSED T _unused_) {
+  return true;
+}
+#else
+// old NCCL uses 0 byte message for synchronization
+// Avoid send/recv when message size is zero
+template <typename T>
+inline bool _nccl_should_send_recv(T value) {
+  return value != 0;
+}
+#endif
 } // namespace
 
 size_t get_max_count() {
@@ -786,8 +805,8 @@ void all2all_single_equal_split(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && \
-    (NCCL_MAJOR * 10 + NCCL_MINOR) >= 27
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   int numranks;
@@ -803,9 +822,7 @@ void all2all_single_equal_split(
   NCCL_CHECK(ncclCommCount(comm, &numranks));
   NCCL_CHECK(ncclGroupStart());
   for (const auto r : c10::irange(numranks)) {
-    // NCCL uses 0 byte message for synchronization
-    // Avoid send/recv when message size is zero
-    if (count != 0) {
+    if (_nccl_should_send_recv(count)) {
       NCCL_CHECK(
           ncclSend(sendbuff + r * rankdiff, count, type, r, comm, stream));
       NCCL_CHECK(
@@ -838,8 +855,8 @@ void all2all_single_unequal_split(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && \
-    (NCCL_MAJOR * 10 + NCCL_MINOR) >= 27
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto type = to_nccl_data_type(_type);
@@ -848,9 +865,7 @@ void all2all_single_unequal_split(
   NCCL_CHECK(ncclCommCount(comm, &numranks));
   NCCL_CHECK(ncclGroupStart());
   for (const auto r : c10::irange(numranks)) {
-    // NCCL uses 0 byte message for synchronization
-    // Avoid send/recv when message size is zero
-    if (sendcounts[r] != 0) {
+    if (_nccl_should_send_recv(sendcounts[r])) {
       NCCL_CHECK(ncclSend(
           ((char*)sendbuff) + senddispls[r] * size,
           sendcounts[r],
@@ -859,7 +874,7 @@ void all2all_single_unequal_split(
           comm,
           stream));
     }
-    if (recvcounts[r] != 0) {
+    if (_nccl_should_send_recv(recvcounts[r])) {
       NCCL_CHECK(ncclRecv(
           ((char*)recvbuff) + recvdispls[r] * size,
           recvcounts[r],
@@ -888,8 +903,8 @@ void all2all(
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && \
-    (NCCL_MAJOR * 10 + NCCL_MINOR) >= 27
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
   auto comm = to_nccl_comm(_comm);
 
@@ -897,7 +912,8 @@ void all2all(
   for (const auto r : c10::irange(outputTensors.size())) {
     at::Tensor& input = inputTensors[r];
     at::Tensor& output = outputTensors[r];
-    if (input.numel() != 0) {
+
+    if (_nccl_should_send_recv(input.numel())) {
       NCCL_CHECK(ncclSend(
           input.data_ptr(),
           input.numel(),
@@ -906,7 +922,7 @@ void all2all(
           comm,
           stream.stream()));
     }
-    if (output.numel() != 0) {
+    if (_nccl_should_send_recv(output.numel())) {
       NCCL_CHECK(ncclRecv(
           output.data_ptr(),
           output.numel(),
@@ -935,8 +951,8 @@ void send(
     at::cuda::CUDAStream stream,
     int dst) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
-    (NCCL_MINOR >= 7)
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 #ifndef NCCL_HAS_COMM_NONBLOCKING
   NCCL_CHECK(ncclSend(
@@ -971,8 +987,8 @@ void recv(
     at::cuda::CUDAStream stream,
     int src) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
-    (NCCL_MINOR >= 7)
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 #ifndef NCCL_HAS_COMM_NONBLOCKING
   NCCL_CHECK(ncclRecv(
@@ -1008,8 +1024,8 @@ void gather(
     at::cuda::CUDAStream& stream,
     int32_t root) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && \
-    (NCCL_MAJOR * 10 + NCCL_MINOR) >= 27
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto comm = to_nccl_comm(_comm);
@@ -1057,8 +1073,8 @@ void scatter(
     at::cuda::CUDAStream& stream,
     int32_t root) {
 #ifdef USE_NCCL
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && \
-    (NCCL_MAJOR * 10 + NCCL_MINOR) >= 27
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR >= 7)))
   using namespace torch::cuda::nccl::detail;
 
   auto comm = to_nccl_comm(_comm);


### PR DESCRIPTION
Summary:
Since NCCL 2.12.10, NCCL supports send/recv 0 byte: https://github.com/NVIDIA/nccl/issues/696. Therefore we don't have to skip.

One issue is that if a rank has 0 bytes to send and 0 bytes to recv, it'll skip send/recv completely. And it'll proceed to the next collective which it can send/recv something, making it confusing to the other ranks. Another solution is to add a barrier but that's very expensive.

Test Plan: will add a unit test

Differential Revision: D46507785



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @anijain2305