### PR TITLE
Enable torch._C._get_privateuse1_backend_name in Dynamo tracing 

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -459,8 +459,11 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return x - 1
 
     @make_test
-    def test_get_privateuse1_name():
-        return torch._C._get_privateuse1_backend_name == "privateuseone"
+    def test_get_privateuse1_name(x):
+        if torch._C._get_privateuse1_backend_name == "privateuseone":
+            return x + 1
+        else:
+            return x - 1
 
     @make_test
     def test_device(x):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -459,6 +459,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return x - 1
 
     @make_test
+    def test_get_privateuse1_name():
+        return torch._C._get_privateuse1_backend_name == "privateuseone"
+
+    @make_test
     def test_device(x):
         if not x.is_cuda:
             return x + 1

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -460,7 +460,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_get_privateuse1_name(x):
-        if torch._C._get_privateuse1_backend_name == "privateuseone":
+        if torch._C._get_privateuse1_backend_name() == "privateuseone":
             return x + 1
         else:
             return x - 1

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -77,6 +77,7 @@ constant_fold_functions = [
     torch.is_complex,
     torch.is_floating_point,
     torch.nn.functional._Reduction.get_enum,
+    torch._C._get_privateuse1_backend_name,
 ]
 
 constant_processgroup_functions = []

--- a/torch/utils/_foreach_utils.py
+++ b/torch/utils/_foreach_utils.py
@@ -9,13 +9,13 @@ def _get_foreach_kernels_supported_devices() -> List[str]:
     r"""
     Return the device type list that supports foreach kernels.
     """
-    return ["cuda", torch.utils.backend_registration._privateuse1_backend_name]
+    return ["cuda", torch._C._get_privateuse1_backend_name()]
 
 def _get_fused_kernels_supported_devices() -> List[str]:
     r"""
     Return the device type list that supports fused kernels in optimizer.
     """
-    return ["cuda", torch.utils.backend_registration._privateuse1_backend_name]
+    return ["cuda", torch._C._get_privateuse1_backend_name()]
 
 # This util function splits tensors into groups by device and dtype, which is useful before sending
 # tensors off to a foreach implementation, which requires tensors to be on one device and dtype.

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -4,14 +4,6 @@ from typing import List, Optional, Union
 
 __all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend"]
 
-# TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
-# renamed-backend name for `privateuse1`, but the func will cause a
-# graph break in inductor test, so we use the global variable named
-# `_privateuse1_backend_name`. Once we solve the graph break, we need
-# to remove the variable and use the func named
-# `torch._C._get_privateuse1_backend_name()` instead.
-_privateuse1_backend_name = "privateuseone"
-
 def rename_privateuse1_backend(backend_name: str) -> None:
     r"""
     rename_privateuse1_backend(backend_name) -> None
@@ -85,9 +77,7 @@ def rename_privateuse1_backend(backend_name: str) -> None:
         # to implement torch.ones.
         >>> a = torch.ones(2, device="foo")
         """
-    _rename_privateuse1_backend(backend_name)
-    global _privateuse1_backend_name
-    _privateuse1_backend_name = backend_name
+    return _rename_privateuse1_backend(backend_name)
 
 
 def _check_register_once(module, attr):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/103125
torch._C._get_privateuse1_backend_name()  will cause graph break, so I add it to the functions.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @aakhundov