### PR TITLE
Optimize the copy of Half to Float and Float to Half on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -14,7 +14,6 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
-#include <ATen/cpu/vec/functional.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/Parallel.h>

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -9,11 +9,44 @@
 #include <ATen/native/cpu/zmath.h>
 #include <ATen/TensorIteratorInternal.h>
 #include <ATen/Parallel.h>
-
+#include <ATen/cpu/vec/functional.h>
 namespace at::native {
 inline namespace CPU_CAPABILITY {
 
-static void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
+namespace {
+static bool reduced_input(ScalarType input_t, ScalarType output_t) {
+  return !at::isFloat8Type(input_t) && at::isReducedFloatingType(input_t) &&
+      output_t == kFloat;
+}
+
+static bool reduced_output(ScalarType input_t, ScalarType output_t) {
+  return !at::isFloat8Type(output_t) && at::isReducedFloatingType(output_t) &&
+      input_t == kFloat;
+}
+} // namespace
+
+static bool reduced_float_type_copy(
+    bool requires_conj,
+    TensorIteratorBase& iter) {
+  auto strides_out = iter.strides(0);
+  auto strides_in = iter.strides(1);
+
+  // Check whether input is in BFloat16/Half data type and output is in float
+  // data type, or input is in float data type and output is in BFloat16/Half
+  // data type. In addition, input and output need contiguous parts to utilize
+  // vectorization.
+  return (
+      !requires_conj &&
+      ((reduced_input(iter.dtype(1), iter.dtype(0)) &&
+        sizeof(float) == strides_out[0] &&
+        (static_cast<int64_t>(elementSize(iter.dtype(1))) == strides_in[0] ||
+         strides_in[0] == 0)) ||
+       (reduced_output(iter.dtype(1), iter.dtype(0)) &&
+        static_cast<int64_t>(elementSize(iter.dtype(0))) == strides_out[0] &&
+        (sizeof(float) == strides_in[0] || strides_in[0] == 0))));
+}
+
+static void reduced_float_copy_kernel(TensorIteratorBase &iter, bool requires_neg) {
   auto strides_out = iter.strides(0);
   auto strides_in = iter.strides(1);
   auto shape = iter.shape();
@@ -30,137 +63,139 @@ static void float_bfloat16_copy_kernel(TensorIteratorBase &iter, bool requires_n
       }
     };
   get_strides(strides.data(), strides_out, strides_in, iter.ndim());
-  if ((iter.dtype(0) == kFloat) && (iter.dtype(1) == kBFloat16)) {
-    using dest_t = float;
-    using scalar_t = BFloat16;
-    using Vecd = Vectorized<dest_t>;
-    using Vecs = Vectorized<scalar_t>;
-    c10::SmallBuffer<char*, 2> ptrs(2);
-    dest_t* output_data = iter.tensor_base(0).data_ptr<dest_t>();
-    scalar_t* input_data = iter.tensor_base(1).data_ptr<scalar_t>();
-    ptrs[0] = reinterpret_cast<char*>(output_data);
-    ptrs[1] = reinterpret_cast<char*>(input_data);
+  if (reduced_input(iter.dtype(1), iter.dtype(0))) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.dtype(1), "copy_kernel", [&]() {
+      using dest_t = float;
+      using Vecd = Vectorized<dest_t>;
+      using Vecs = Vectorized<scalar_t>;
+      c10::SmallBuffer<char*, 2> ptrs(2);
+      dest_t* output_data = iter.tensor_base(0).data_ptr<dest_t>();
+      scalar_t* input_data = iter.tensor_base(1).data_ptr<scalar_t>();
+      ptrs[0] = reinterpret_cast<char*>(output_data);
+      ptrs[1] = reinterpret_cast<char*>(input_data);
 
-    int64_t grain_size = at::internal::GRAIN_SIZE;
+      int64_t grain_size = at::internal::GRAIN_SIZE;
 
-    auto loop = [strides_in, requires_neg](char** base, const int64_t* strides, int64_t size0, int64_t size1) {
-      std::array<char*, 2> data;
-      std::copy_n(base, 2, data.data());
-      const int64_t *outer_strides = &strides[2];
+      auto loop = [strides_in, requires_neg](char** base, const int64_t* strides, int64_t size0, int64_t size1) {
+        std::array<char*, 2> data;
+        std::copy_n(base, 2, data.data());
+        const int64_t *outer_strides = &strides[2];
 
-      for (const auto it C10_UNUSED : c10::irange(size1)) {
-        Vecd dst_s;
-        if (strides_in[0] == 0) {
-          dst_s = Vecd(dest_t(*((scalar_t*)data[1])));
-          if (requires_neg) {
-            dst_s = dst_s.neg();
-          }
-        }
-        int64_t i = 0;
-        for (; i <= size0 - Vecs::size(); i += Vecs::size()) {
-          if (strides_in[0] != 0) {
-            Vecs data_vec = Vecs::loadu(data[1] + i * sizeof(scalar_t));
-            Vecd data_vec0, data_vec1;
-            std::tie(data_vec0, data_vec1) = convert_bfloat16_float(data_vec);
+        for (const auto it C10_UNUSED : c10::irange(size1)) {
+          Vecd dst_s;
+          if (strides_in[0] == 0) {
+            dst_s = Vecd(dest_t(*((scalar_t*)data[1])));
             if (requires_neg) {
-              data_vec0 = data_vec0.neg();
-              data_vec1 = data_vec1.neg();
+              dst_s = dst_s.neg();
             }
-            data_vec0.store(data[0] + i * sizeof(dest_t));
-            data_vec1.store(data[0] + (i + Vecd::size()) * sizeof(dest_t));
-          } else {
-            dst_s.store(data[0] + i * sizeof(dest_t));
-            dst_s.store(data[0] + (i + Vecd::size()) * sizeof(dest_t));
           }
-        }
-        if (i < size0) {
-          if (strides_in[0] != 0) {
-            Vecs data_vec = Vecs::loadu(data[1] + i * sizeof(scalar_t), size0 - i);
-            Vecd data_vec0, data_vec1;
-            std::tie(data_vec0, data_vec1) = convert_bfloat16_float(data_vec);
-            if (requires_neg) {
-              data_vec0 = data_vec0.neg();
-              data_vec1 = data_vec1.neg();
+          int64_t i = 0;
+          for (; i <= size0 - Vecs::size(); i += Vecs::size()) {
+            if (strides_in[0] != 0) {
+              Vecs data_vec = Vecs::loadu(data[1] + i * sizeof(scalar_t));
+              auto [data_vec0, data_vec1] = convert_to_float<scalar_t>(data_vec);
+              if (requires_neg) {
+                data_vec0 = data_vec0.neg();
+                data_vec1 = data_vec1.neg();
+              }
+              data_vec0.store(data[0] + i * sizeof(dest_t));
+              data_vec1.store(data[0] + (i + Vecd::size()) * sizeof(dest_t));
+            } else {
+              dst_s.store(data[0] + i * sizeof(dest_t));
+              dst_s.store(data[0] + (i + Vecd::size()) * sizeof(dest_t));
             }
-            data_vec0.store(data[0] + i * sizeof(dest_t), ((size0 - i) > Vecd::size())?  Vecd::size() : (size0 - i));
-            data_vec1.store(data[0] + (i + Vecd::size()) * sizeof(dest_t), ((size0 - i) > Vecd::size())? (size0 - i - Vecd::size()) : 0);
-          } else {
-            dst_s.store(data[0] + i * sizeof(dest_t), ((size0 - i) > Vecd::size())?  Vecd::size() : (size0 - i));
-            dst_s.store(data[0] + (i + Vecd::size()) * sizeof(dest_t), ((size0 - i) > Vecd::size())? (size0 - i - Vecd::size()) : 0);
           }
+          if (i < size0) {
+            if (strides_in[0] != 0) {
+              Vecs data_vec = Vecs::loadu(data[1] + i * sizeof(scalar_t), size0 - i);
+              auto [data_vec0, data_vec1] = convert_to_float<scalar_t>(data_vec);
+              if (requires_neg) {
+                data_vec0 = data_vec0.neg();
+                data_vec1 = data_vec1.neg();
+              }
+              data_vec0.store(data[0] + i * sizeof(dest_t), ((size0 - i) > Vecd::size())?  Vecd::size() : (size0 - i));
+              data_vec1.store(data[0] + (i + Vecd::size()) * sizeof(dest_t), ((size0 - i) > Vecd::size())? (size0 - i - Vecd::size()) : 0);
+            } else {
+              dst_s.store(data[0] + i * sizeof(dest_t), ((size0 - i) > Vecd::size())?  Vecd::size() : (size0 - i));
+              dst_s.store(data[0] + (i + Vecd::size()) * sizeof(dest_t), ((size0 - i) > Vecd::size())? (size0 - i - Vecd::size()) : 0);
+            }
+          }
+          data[0] += outer_strides[0];
+          data[1] += outer_strides[1];
         }
-        data[0] += outer_strides[0];
-        data[1] += outer_strides[1];
-      }
 
-    };
+      };
 
-    parallel_for(0, iter.numel(), grain_size, [&] (int64_t begin, int64_t end) {
-      at::internal::serial_for_each(shape, strides, ptrs.data(), 2, loop, {begin, end});
+      parallel_for(0, iter.numel(), grain_size, [&] (int64_t begin, int64_t end) {
+        at::internal::serial_for_each(shape, strides, ptrs.data(), 2, loop, {begin, end});
+      });
     });
-  } else if ((iter.dtype(0) == kBFloat16) && (iter.dtype(1) == kFloat)) {
-    using dest_t = BFloat16;
-    using scalar_t = float;
-    using Vecd = Vectorized<dest_t>;
-    using Vecs = Vectorized<scalar_t>;
-    c10::SmallBuffer<char*, 2> ptrs(2);
-    dest_t* output_data = iter.tensor_base(0).data_ptr<dest_t>();
-    scalar_t* input_data = iter.tensor_base(1).data_ptr<scalar_t>();
+  } else if (reduced_output(iter.dtype(1), iter.dtype(0))) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.dtype(0), "copy_kernel", [&]() {
+      using dest_t = scalar_t;
+      using source_t = float;
+      using Vecd = Vectorized<dest_t>;
+      using Vecs = Vectorized<source_t>;
+      c10::SmallBuffer<char*, 2> ptrs(2);
+      dest_t* output_data = iter.tensor_base(0).data_ptr<dest_t>();
+      source_t* input_data = iter.tensor_base(1).data_ptr<source_t>();
 
-    ptrs[0] = reinterpret_cast<char*>(output_data);
-    ptrs[1] = reinterpret_cast<char*>(input_data);
+      ptrs[0] = reinterpret_cast<char*>(output_data);
+      ptrs[1] = reinterpret_cast<char*>(input_data);
 
-    int64_t grain_size = at::internal::GRAIN_SIZE;
+      int64_t grain_size = at::internal::GRAIN_SIZE;
 
-    auto loop = [strides_in, requires_neg](char** base, const int64_t* strides, int64_t size0, int64_t size1) {
-      std::array<char*, 2> data;
-      std::copy_n(base, 2, data.data());
-      const int64_t *outer_strides = &strides[2];
+      auto loop = [strides_in, requires_neg](char** base, const int64_t* strides, int64_t size0, int64_t size1) {
+        std::array<char*, 2> data;
+        std::copy_n(base, 2, data.data());
+        const int64_t *outer_strides = &strides[2];
 
-      for (const auto it C10_UNUSED : c10::irange(size1)) {
-        Vecd dst_s;
-        if (strides_in[0] == 0) {
-          dst_s = Vecd(dest_t(*((scalar_t*)data[1])));
-          if (requires_neg) {
-            dst_s = dst_s.neg();
-          }
-        }
-        int64_t i = 0;
-        for (; i <= size0 - 2 * Vecs::size(); i += 2 * Vecs::size()) {
-          if (strides_in[0] != 0) {
-            Vecs data_vec0 = Vecs::loadu(data[1] + i * sizeof(scalar_t));
-            Vecs data_vec1 = Vecs::loadu(data[1] + (i + Vecs::size()) * sizeof(scalar_t));
-            auto data_vec = convert_float_bfloat16(data_vec0, data_vec1);
+        for (const auto it C10_UNUSED : c10::irange(size1)) {
+          Vecd dst_s;
+          if (strides_in[0] == 0) {
+            dst_s = Vecd(dest_t(*((source_t*)data[1])));
             if (requires_neg) {
-              data_vec = data_vec.neg();
+              dst_s = dst_s.neg();
             }
-            data_vec.store(data[0] + i * sizeof(dest_t));
-          } else {
-            dst_s.store(data[0] + i * sizeof(dest_t));
           }
-
-        }
-        if (i < size0) {
-          if (strides_in[0] != 0) {
-            Vecs data_vec0 = Vecs::loadu(data[1] + i * sizeof(scalar_t), ((size0 - i) > Vecs::size())?  Vecs::size() : (size0 - i));
-            Vecs data_vec1 = Vecs::loadu(data[1] + (i + Vecs::size()) * sizeof(scalar_t), ((size0 - i) > Vecs::size())?  (size0 - i - Vecs::size()) : 0);
-            auto data_vec = convert_float_bfloat16(data_vec0, data_vec1);
-            if (requires_neg) {
-              data_vec = data_vec.neg();
+          int64_t i = 0;
+          for (; i <= size0 - 2 * Vecs::size(); i += 2 * Vecs::size()) {
+            if (strides_in[0] != 0) {
+              Vecs data_vec0 = Vecs::loadu(data[1] + i * sizeof(source_t));
+              Vecs data_vec1 = Vecs::loadu(data[1] + (i + Vecs::size()) * sizeof(source_t));
+              auto data_vec = convert_from_float<dest_t>(data_vec0, data_vec1);
+              if (requires_neg) {
+                data_vec = data_vec.neg();
+              }
+              data_vec.store(data[0] + i * sizeof(dest_t));
+            } else {
+              dst_s.store(data[0] + i * sizeof(dest_t));
             }
-            data_vec.store(data[0] + i * sizeof(dest_t), size0 - i);
-          } else {
-            dst_s.store(data[0] + i * sizeof(dest_t), size0 - i);
-          }
-        }
-        data[0] += outer_strides[0];
-        data[1] += outer_strides[1];
-      }
 
-    };
-    parallel_for(0, iter.numel(), grain_size, [&] (int64_t begin, int64_t end) {
-      at::internal::serial_for_each(shape, strides, ptrs.data(), 2, loop, {begin, end});
+          }
+          if (i < size0) {
+            if (strides_in[0] != 0) {
+              Vecs data_vec0 = Vecs::loadu(data[1] + i * sizeof(source_t), ((size0 - i) > Vecs::size())?  Vecs::size() : (size0 - i));
+              Vecs data_vec1 = Vecs::loadu(data[1] + (i + Vecs::size()) * sizeof(source_t), ((size0 - i) > Vecs::size())?  (size0 - i - Vecs::size()) : 0);
+              auto data_vec = convert_from_float<dest_t>(data_vec0, data_vec1);
+              if (requires_neg) {
+                data_vec = data_vec.neg();
+              }
+              data_vec.store(data[0] + i * sizeof(dest_t), size0 - i);
+            } else {
+              dst_s.store(data[0] + i * sizeof(dest_t), size0 - i);
+            }
+          }
+          data[0] += outer_strides[0];
+          data[1] += outer_strides[1];
+        }
+
+      };
+      parallel_for(0, iter.numel(), grain_size, [&] (int64_t begin, int64_t end) {
+        at::internal::serial_for_each(shape, strides, ptrs.data(), 2, loop, {begin, end});
+      });
     });
+
   }
 }
 
@@ -247,15 +282,10 @@ void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
       isComplexType(dtype) && (iter.tensor_base(0).is_conj() != iter.tensor_base(1).is_conj()));
   const bool requires_neg = (iter.tensor_base(0).is_neg() != iter.tensor_base(1).is_neg());
 
-  auto strides_out = iter.strides(0);
-  auto strides_in = iter.strides(1);
   if (dtype == iter.dtype(1)) {
     copy_same_dtype(iter, requires_conj, requires_neg);
-  } else if (!requires_conj && ((iter.dtype(1) == kBFloat16 && iter.dtype(0) == kFloat &&
-     sizeof(float) == strides_out[0] && (sizeof(BFloat16) == strides_in[0] || strides_in[0] == 0)) ||
-    (iter.dtype(1) == kFloat && iter.dtype(0) == kBFloat16 &&
-    sizeof(BFloat16) == strides_out[0] && (sizeof(float) == strides_in[0] || strides_in[0] == 0)))) {
-    float_bfloat16_copy_kernel(iter, requires_neg);
+  } else if (reduced_float_type_copy(requires_conj, iter)) {
+    reduced_float_copy_kernel(iter, requires_neg);
   } else {
     _AT_DISPATCH_ALL_TYPES(dtype, "copy_", [&] {
       using dest_t = scalar_t;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3094,17 +3094,18 @@ else:
         self.assertEqual(src.abs().bfloat16(), src_bf16.abs())
 
     @onlyCPU
-    def test_bfloat16_float_copy(self, device):
+    @dtypes(torch.bfloat16, torch.half)
+    def test_reduced_type_float_copy(self, device, dtype):
         for shape in [(20, 7), (249, 137), (1029, 917), (1, 7, 19, 17), (3, 77, 1091)]:
             input = torch.randn(shape, dtype=torch.float, device=device)
-            out1 = input.to(torch.bfloat16)
-            self.assertEqual(input, out1, atol=0, rtol=1e-2, exact_dtype=False)
+            out1 = input.to(dtype=dtype)
+            self.assertEqual(input, out1, atol=None, rtol=None, exact_dtype=False)
             out2 = out1.to(torch.float)
             self.assertEqual(out2, out1, atol=0, rtol=0, exact_dtype=False)
 
             input_s = input[..., ::2, :]
-            out1 = input_s.to(torch.bfloat16)
-            self.assertEqual(input_s, out1, atol=0, rtol=1e-2, exact_dtype=False)
+            out1 = input_s.to(dtype=dtype)
+            self.assertEqual(input_s, out1, atol=None, rtol=None, exact_dtype=False)
             out2 = out1.to(torch.float)
             self.assertEqual(out2, out1, atol=0, rtol=0, exact_dtype=False)
 


### PR DESCRIPTION
### Description
Optimize the copy of Half to Float and Float to Half on CPU.

### Testing

Single core:
shape | fp16 -> fp32 / ms | fp32 -> fp16 / ms | bf16 -> fp32 / ms | fp32 -> bf16 / ms
-- | -- | -- | -- | --
size: (1, 777) | 0.00345 | 0.00344 | 0.00411 | 0.00410
size: (2, 512) | 0.00355 | 0.00344 | 0.00431 | 0.00400
size: (10, 555) | 0.00473 | 0.00391 | 0.00562 | 0.00477
size: (1, 2048, 1024) | 0.488 | 0.480 | 0.498 | 0.499
size: (32, 100, 777) | 0.584 | 0.568 | 0.571 | 0.587

28 cores:
shape | fp16 -> fp32 / ms | fp32 -> fp16 / ms | bf16 -> fp32 / ms | fp32 -> bf16 / ms
-- | -- | -- | -- | --
size: (10, 555) |  0.00472 | 0.00369 | 0.00576 |  0.00481
size: (1, 2048, 1024) |  0.0189 | 0.0188 | 0.0173 | 0.0251
size: (64, 512, 1024) | 3.159 | 2.375 |  3.152 | 2.358
size: (32, 100, 777) | 0.0225 | 0.0195 | 0.0193 | 0.0261

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10
