### PR TITLE
[ROCm] force HIP context initialization for inductor UTs

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -834,7 +834,9 @@ def get_fast_op_impls():
 def init_cuda_context():
     # Backward will error with cuda Fake Tensors if no cuda tensors have been initialized first
     if torch.cuda.is_available():
-        torch.empty(1, device="cuda")
+        torch.empty(1, device="cuda") if torch.version.hip is None else torch.randn(
+            1, device="cuda"
+        )
 
 
 @contextlib.contextmanager

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -834,7 +834,7 @@ def get_fast_op_impls():
 def init_cuda_context():
     # Backward will error with cuda Fake Tensors if no cuda tensors have been initialized first
     if torch.cuda.is_available():
-        torch.empty(1, device="cuda") if torch.version.hip is None else torch.randn(
+        torch.empty(1, device="cuda") if torch.version.hip is None else torch.zeros(
             1, device="cuda"
         )
 


### PR DESCRIPTION
Workaround for https://github.com/pytorch/pytorch/issues/102886
related to: https://github.com/pytorch/pytorch/issues/102476 https://github.com/pytorch/pytorch/issues/102475 https://github.com/pytorch/pytorch/issues/102474 https://github.com/pytorch/pytorch/issues/102473 https://github.com/pytorch/pytorch/issues/102473 https://github.com/pytorch/pytorch/issues/102472

Since https://github.com/pytorch/pytorch/commit/9aaa12e32855a711ba6e3135138a46e63402cbbe the first inductor (CPU) UT fails until the GPU context is correct initialised and the subsequent UTs pass. CUDA observes the same issue and a workaround was pushed to force initialisation of cuda context by declaring an empty tensor https://github.com/pytorch/pytorch/issues/92627, we have adopted the same approach but have opted for `torch.zeros` which correctly activates the HIP context after the kernel launch.

**Reproducer:**
```
import torch
from torch._subclasses.fake_tensor import FakeTensorMode
import argparse
if __name__ == '__main__':
    parser = argparse.ArgumentParser(description='Swap between torch.empty and torch.randn operations.')
    parser.add_argument('--empty', action='store_true', help='Use torch.empty operation')
    parser.add_argument('--rand', action='store_true', help='Use torch.randn operation')
    args = parser.parse_args()

    torch.cuda.set_device(0)
    if args.empty:
        torch.empty(1, device="cuda")
    elif args.rand:
        torch.rand(1, device="cuda")
    print(f": hasPrimaryContext: {torch._C._cuda_hasPrimaryContext(0)")
    with FakeTensorMode():
        p = torch.randn(4, 2, requires_grad=True, device='cuda')
        x = torch.randn(8, 4, device='cuda')
        y = torch.mm(x, p).square().sum()
        y.backward()
```

**ROCm python repro.py --empty**
0: hasPrimaryContext: False

**ROCm python repro.py --rand**
0: hasPrimaryContext: True

**CUDA python repro.py --empty**
0: hasPrimaryContext: True

**CUDA python repro.py --rand**
0: hasPrimaryContext: True

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @anijain2305