### PR TITLE
[data_loader] Extra signal handlers in DataLoader.cpp should be added on top rather than replacing defaults

### DIFF
--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -103,17 +103,16 @@ static void handler_SIGTERM(int sig, siginfo_t* info, void* ctx) {
   }
 }
 
-__attribute__((weak)) void setDataLoaderSignalHandlers() {
-  setSignalHandler(SIGBUS, &handler_SIGBUS, nullptr);
-  setSignalHandler(SIGSEGV, &handler_SIGSEGV, nullptr);
-  setSignalHandler(SIGTERM, &handler_SIGTERM, nullptr);
-  setSignalHandler(SIGFPE, &handler_SIGFPE, nullptr);
-}
+__attribute__((weak)) void setDataLoaderSignalHandlers() {}
 
 static PyObject* THPModule_setWorkerSignalHandlers(
     PyObject* module,
     PyObject* arg) {
   HANDLE_TH_ERRORS
+  setSignalHandler(SIGBUS, &handler_SIGBUS, nullptr);
+  setSignalHandler(SIGSEGV, &handler_SIGSEGV, nullptr);
+  setSignalHandler(SIGTERM, &handler_SIGTERM, nullptr);
+  setSignalHandler(SIGFPE, &handler_SIGFPE, nullptr);
   setDataLoaderSignalHandlers();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS


### PR DESCRIPTION
Summary: DataLoader.cpp signal handlers are adding some special behavior (e.g. exit(0) on SIGTERM under certain conditions). To preserve this behavior we should install additional signal handlers on top of default ones, rather than completely replacing them.

Test Plan: unit tests

Reviewed By: drej82

Differential Revision: D46525348

