### PR TITLE
[SDPA] Change autocast behavior

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -248,7 +248,7 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL_CUDA(rnn_tanh_cell, lower_precision_fp)
   KERNEL_CUDA(rnn_relu_cell, lower_precision_fp)
   KERNEL_CUDA(_scaled_dot_product_flash_attention, lower_precision_fp)
-  KERNEL_CUDA(scaled_dot_product_attention, lower_precision_fp)
+  KERNEL_CUDA(_scaled_dot_product_efficient_attention, lower_precision_fp)
 
   // fp32
   KERNEL_CUDA(acos, fp32)


### PR DESCRIPTION
# Summary
Currenlty we autocast the top level SDPA composite funciton. This means that every subsequent ops is done in the lower precision type for the math path. We likely want the softmax to be done in higher precision. This chanages makes that so:
```
$3: f32[1, 1, 3, 6] = aten.mul.Scalar($0, 0.6389431042462725)
$4: f32[1, 1, 6, 5] = aten.transpose.int($1, -2, -1)
$5: f32[1, 1, 6, 5] = aten.mul.Scalar($4, 0.6389431042462725)
$6: f16[1, 1, 3, 6] = aten._to_copy.default($3, dtype=torch.float16)
$7: f16[1, 1, 6, 5] = aten._to_copy.default($5, dtype=torch.float16)
$8: f16[1, 1, 3, 6] = aten.expand.default($6, [1, 1, 3, 6])
$9: f16[1, 3, 6] = aten.view.default($8, [1, 3, 6])
$10: f16[1, 1, 6, 5] = aten.expand.default($7, [1, 1, 6, 5])
$11: f16[1, 6, 5] = aten.view.default($10, [1, 6, 5])
$12: f16[1, 3, 5] = aten.bmm.default($9, $11)
$13: f16[1, 1, 3, 5] = aten._unsafe_view.default($12, [1, 1, 3, 5])
$14: f32[1, 1, 3, 5] = aten._softmax.default($13, -1, True)
$15: f16[1, 1, 3, 5] = aten._to_copy.default($14, dtype=torch.float16)
$16: f16[1, 1, 5, 6] = aten._to_copy.default($2, dtype=torch.float16)
$17: f16[1, 1, 3, 5] = aten.expand.default($15, [1, 1, 3, 5])
$18: f16[1, 3, 5] = aten.view.default($17, [1, 3, 5])
$19: f16[1, 1, 5, 6] = aten.expand.default($16, [1, 1, 5, 6])
$20: f16[1, 5, 6] = aten.view.default($19, [1, 5, 6])
$21: f16[1, 3, 6] = aten.bmm.default($18, $20)
```

However dispatchign and alignment will be checked on the higher precision type and not after casting so we need to do more work to check that

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5