### PR TITLE
Integrate hipsolver batched linalg drivers 

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1452,7 +1452,7 @@ void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>)) {
 
 
 template <>
-void getrsBatched<float>(HIPBLAS_GETRS_ARGTYPES(float)) {
+void getrsBatched<float>(HIPBLAS_GETRS_BATCHED_ARGTYPES(float)) {
   TORCH_HIPBLAS_CHECK(cublasSgetrsBatched(
       handle,
       trans,
@@ -1468,7 +1468,7 @@ void getrsBatched<float>(HIPBLAS_GETRS_ARGTYPES(float)) {
 }
 
 template <>
-void getrsBatched<double>(HIPBLAS_GETRS_ARGTYPES(double)) {
+void getrsBatched<double>(HIPBLAS_GETRS_BATCHED_ARGTYPES(double)) {
   TORCH_HIPBLAS_CHECK(cublasDgetrsBatched(
       handle,
       trans,
@@ -1485,7 +1485,7 @@ void getrsBatched<double>(HIPBLAS_GETRS_ARGTYPES(double)) {
 
 
 template <>
-void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<float>)) {
+void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_BATCHED_ARGTYPES(c10::complex<float>)) {
   TORCH_HIPBLAS_CHECK(cublasCgetrsBatched(
       handle,
       trans,
@@ -1501,7 +1501,7 @@ void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<float
 }
 
 template <>
-void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<double>)) {
+void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_BATCHED_ARGTYPES(c10::complex<double>)) {
   TORCH_HIPBLAS_CHECK(cublasZgetrsBatched(
       handle,
       trans,
@@ -1519,7 +1519,7 @@ void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<doub
 #else
 
 template <>
-void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float)) {
+void getrsBatched<float>(CUDABLAS_GETRS_BATCHED_ARGTYPES(float)) {
   TORCH_CUDABLAS_CHECK(cublasSgetrsBatched(
       handle,
       trans,
@@ -1535,7 +1535,7 @@ void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float)) {
 }
 
 template <>
-void getrsBatched<double>(CUDABLAS_GETRS_ARGTYPES(double)) {
+void getrsBatched<double>(CUDABLAS_GETRS_BATCHED_ARGTYPES(double)) {
   TORCH_CUDABLAS_CHECK(cublasDgetrsBatched(
       handle,
       trans,
@@ -1551,7 +1551,7 @@ void getrsBatched<double>(CUDABLAS_GETRS_ARGTYPES(double)) {
 }
 
 template <>
-void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<float>)) {
+void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_BATCHED_ARGTYPES(c10::complex<float>)) {
   TORCH_CUDABLAS_CHECK(cublasCgetrsBatched(
       handle,
       trans,
@@ -1567,7 +1567,7 @@ void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<floa
 }
 
 template <>
-void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<double>)) {
+void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_BATCHED_ARGTYPES(c10::complex<double>)) {
   TORCH_CUDABLAS_CHECK(cublasZgetrsBatched(
       handle,
       trans,
@@ -1902,9 +1902,7 @@ void gelsBatched<c10::complex<float>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex
       batchSize));
 }
 
-#else
-
-#ifdef CUDART_VERSION
+#elif defined(CUDART_VERSION)
 
 template <>
 void gelsBatched<double>(CUDABLAS_GELS_BATCHED_ARGTYPES(double)) {
@@ -1946,7 +1944,6 @@ void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::comple
       batchSize));
 }
 
-#endif //CUDART_VERSION
 #endif //USE_ROCM
 
 

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1476,9 +1476,9 @@ void geqrfBatched<c10::complex<float>>(
       handle,
       m,
       n,
-      reinterpret_cast<double*const*>(A_array),
+      reinterpret_cast<hipblasComplex**>(A_array),
       lda,
-      reinterpret_cast<double*const*>(tau_array),
+      reinterpret_cast<hipblasComplex**>(tau_array),
       info,
       batchsize));
 }

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -983,6 +983,133 @@ void int8_gemm(
 }
 #endif // !defined(USE_ROCM) && !defined(_MSC_VER)
 
+
+#ifdef USE_ROCM
+
+template <>
+void trsm<float>(HIPBLAS_TRSM_ARGTYPES(float)) {
+  TORCH_HIPBLAS_CHECK(cublasStrsm(
+      handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb));
+}
+
+template <>
+void trsm<double>(HIPBLAS_TRSM_ARGTYPES(double)) {
+  TORCH_HIPBLAS_CHECK(cublasDtrsm(
+      handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb));
+}
+
+template <>
+void trsm<c10::complex<float>>(HIPBLAS_TRSM_ARGTYPES(c10::complex<float>)) {
+  TORCH_HIPBLAS_CHECK(cublasCtrsm(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      reinterpret_cast<const hipblasComplex*>(alpha),
+      reinterpret_cast<hipblasComplex*>(A),
+      lda,
+      reinterpret_cast<hipblasComplex*>(B),
+      ldb));
+}
+
+template <>
+void trsm<c10::complex<double>>(HIPBLAS_TRSM_ARGTYPES(c10::complex<double>)) {
+  TORCH_HIPBLAS_CHECK(cublasZtrsm(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      reinterpret_cast<const hipblasDoubleComplex*>(alpha),
+      reinterpret_cast<hipblasDoubleComplex*>(A),
+      lda,
+      reinterpret_cast<hipblasDoubleComplex*>(B),
+      ldb));
+}
+
+template <>
+void trsmBatched<float>(HIPBLAS_TRSM_BATCHED_ARGTYPES(float)) {
+  TORCH_HIPBLAS_CHECK(cublasStrsmBatched(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      alpha,
+      A,
+      lda,
+      B,
+      ldb,
+      batchCount));
+}
+
+template <>
+void trsmBatched<double>(HIPBLAS_TRSM_BATCHED_ARGTYPES(double)) {
+  TORCH_HIPBLAS_CHECK(cublasDtrsmBatched(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      alpha,
+      A,
+      lda,
+      B,
+      ldb,
+      batchCount));
+}
+
+template <>
+void trsmBatched<c10::complex<float>>(
+    HIPBLAS_TRSM_BATCHED_ARGTYPES(c10::complex<float>)) {
+  TORCH_HIPBLAS_CHECK(cublasCtrsmBatched(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      reinterpret_cast<const hipblasComplex*>(alpha),
+      reinterpret_cast<hipblasComplex**>(A),
+      lda,
+      reinterpret_cast<hipblasComplex**>(B),
+      ldb,
+      batchCount));
+}
+
+template <>
+void trsmBatched<c10::complex<double>>(
+    HIPBLAS_TRSM_BATCHED_ARGTYPES(c10::complex<double>)) {
+  TORCH_HIPBLAS_CHECK(cublasZtrsmBatched(
+      handle,
+      side,
+      uplo,
+      trans,
+      diag,
+      m,
+      n,
+      reinterpret_cast<const hipblasDoubleComplex*>(alpha),
+      reinterpret_cast<hipblasDoubleComplex**>(A),
+      lda,
+      reinterpret_cast<hipblasDoubleComplex**>(B),
+      ldb,
+      batchCount));
+}
+
+
+
+#else
+
 template <>
 void trsm<float>(CUDABLAS_TRSM_ARGTYPES(float)) {
   TORCH_CUDABLAS_CHECK(cublasStrsm(
@@ -1102,6 +1229,8 @@ void trsmBatched<c10::complex<double>>(
       ldb,
       batchCount));
 }
+
+#endif // USE_ROCM
 
 /* LEVEL 2 BLAS FUNCTIONS */
 

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -138,6 +138,53 @@ void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half));
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16));
 
+
+#ifdef USE_ROCM
+
+#define HIPBLAS_TRSM_ARGTYPES(Dtype)                                  \
+  hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, \
+      hipblasOperation_t trans, hipblasDiagType_t diag, int m, int n,    \
+      const Dtype *alpha, Dtype *A, int lda, Dtype *B, int ldb
+
+template <typename Dtype>
+inline void trsm(HIPBLAS_TRSM_ARGTYPES(Dtype)) {
+  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::trsm: not implemented for ", typeid(Dtype).name());
+}
+
+template <>
+TORCH_CUDA_CU_API void trsm<float>(HIPBLAS_TRSM_ARGTYPES(float));
+template <>
+TORCH_CUDA_CU_API void trsm<double>(HIPBLAS_TRSM_ARGTYPES(double));
+template <>
+TORCH_CUDA_CU_API void trsm<c10::complex<float>>(HIPBLAS_TRSM_ARGTYPES(c10::complex<float>));
+template <>
+TORCH_CUDA_CU_API void trsm<c10::complex<double>>(HIPBLAS_TRSM_ARGTYPES(c10::complex<double>));
+
+#define HIPBLAS_TRSM_BATCHED_ARGTYPES(Dtype)                          \
+  hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, \
+      hipblasOperation_t trans, hipblasDiagType_t diag, int m, int n,    \
+      const Dtype *alpha, Dtype *A[], int lda, Dtype *B[], int ldb,    \
+      int batchCount
+
+template <typename Dtype>
+inline void trsmBatched(HIPBLAS_TRSM_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "at::cuda::blas::trsmBatched: not implemented for ",
+      typeid(Dtype).name());
+}
+
+template <>
+TORCH_CUDA_CU_API void trsmBatched<float>(HIPBLAS_TRSM_BATCHED_ARGTYPES(float));
+template <>
+TORCH_CUDA_CU_API void trsmBatched<double>(HIPBLAS_TRSM_BATCHED_ARGTYPES(double));
+template <>
+TORCH_CUDA_CU_API void trsmBatched<c10::complex<float>>(HIPBLAS_TRSM_BATCHED_ARGTYPES(c10::complex<float>));
+template <>
+TORCH_CUDA_CU_API void trsmBatched<c10::complex<double>>(HIPBLAS_TRSM_BATCHED_ARGTYPES(c10::complex<double>));
+
+#else
+
 #define CUDABLAS_TRSM_ARGTYPES(Dtype)                                  \
   cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, \
       cublasOperation_t trans, cublasDiagType_t diag, int m, int n,    \
@@ -179,6 +226,8 @@ template <>
 TORCH_CUDA_CU_API void trsmBatched<c10::complex<float>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<float>));
 template <>
 TORCH_CUDA_CU_API void trsmBatched<c10::complex<double>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<double>));
+
+#endif
 
 /* LEVEL 2 BLAS FUNCTIONS */
 

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -428,9 +428,8 @@ TORCH_CUDA_CU_API void gelsBatched<c10::complex<double>>(HIPBLAS_GELS_BATCHED_AR
 template<>
 TORCH_CUDA_CU_API void gelsBatched<c10::complex<float>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
 
-#else
+#elif defined(CUDART_VERSION)
 
-#ifdef CUDART_VERSION
 
 #define CUDABLAS_GELS_BATCHED_ARGTYPES(Dtype)  \
   cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, Dtype** dA_array, int ldda, Dtype** dC_array, int lddc, int* info, int *devInfoArray, int batchSize
@@ -450,7 +449,6 @@ template<>
 TORCH_CUDA_CU_API void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
 
 #endif //CUDART_VERSION
-#endif //USE_ROCM
 
 
 } // namespace blas

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -292,46 +292,46 @@ void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>));
 #ifdef USE_ROCM
 
 
-#define HIPBLAS_GETRS_ARGTYPES(Dtype)  \
+#define HIPBLAS_GETRS_BATCHED_ARGTYPES(Dtype)  \
   hipblasHandle_t handle, hipblasOperation_t trans, \
   int n, int nrhs, Dtype** dA_array, int lda, int* ipiv_array, \
   Dtype** dB_array, int ldb, int* info_array, int batchsize
 
 template<class Dtype>
-void getrsBatched(HIPBLAS_GETRS_ARGTYPES(Dtype)) {
+void getrsBatched(HIPBLAS_GETRS_BATCHED_ARGTYPES(Dtype)) {
   TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::getrsBatched: not implemented for ",
     typeid(Dtype).name());
 }
 template<>
-TORCH_CUDA_CU_API void getrsBatched<float>(HIPBLAS_GETRS_ARGTYPES(float));
+TORCH_CUDA_CU_API void getrsBatched<float>(HIPBLAS_GETRS_BATCHED_ARGTYPES(float));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<double>(HIPBLAS_GETRS_ARGTYPES(double));
+TORCH_CUDA_CU_API void getrsBatched<double>(HIPBLAS_GETRS_BATCHED_ARGTYPES(double));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_BATCHED_ARGTYPES(c10::complex<float>));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_BATCHED_ARGTYPES(c10::complex<double>));
 
 
-#else
+#elif defined(CUDART_VERSION)
 
-#define CUDABLAS_GETRS_ARGTYPES(Dtype)  \
+#define CUDABLAS_GETRS_BATCHED_ARGTYPES(Dtype)  \
   cublasHandle_t handle, cublasOperation_t trans, \
   int n, int nrhs, Dtype** dA_array, int lda, int* ipiv_array, \
   Dtype** dB_array, int ldb, int* info_array, int batchsize
 
 template<class Dtype>
-void getrsBatched(CUDABLAS_GETRS_ARGTYPES(Dtype)) {
+void getrsBatched(CUDABLAS_GETRS_BATCHED_ARGTYPES(Dtype)) {
   TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::getrsBatched: not implemented for ",
     typeid(Dtype).name());
 }
 template<>
-TORCH_CUDA_CU_API void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float));
+TORCH_CUDA_CU_API void getrsBatched<float>(CUDABLAS_GETRS_BATCHED_ARGTYPES(float));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<double>(CUDABLAS_GETRS_ARGTYPES(double));
+TORCH_CUDA_CU_API void getrsBatched<double>(CUDABLAS_GETRS_BATCHED_ARGTYPES(double));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_BATCHED_ARGTYPES(c10::complex<float>));
 template<>
-TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_BATCHED_ARGTYPES(c10::complex<double>));
 
 #endif
 
@@ -357,7 +357,9 @@ TORCH_CUDA_CU_API void geqrfBatched<c10::complex<double>>(
 template <>
 TORCH_CUDA_CU_API void geqrfBatched<c10::complex<float>>(
     HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>));
-#else
+
+#elif defined(CUDART_VERSION)
+
 #define CUDABLAS_GEQRF_BATCHED_ARGTYPES(Dtype)                   \
   cublasHandle_t handle, int m, int n, Dtype **A_array, int lda, \
       Dtype **tau_array, int *info, int batchsize
@@ -397,7 +399,7 @@ TORCH_CUDA_CU_API void getrfBatched<c10::complex<double>>(HIPBLAS_GETRF_BATCHED_
 template<>
 TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(HIPBLAS_GETRF_BATCHED_ARGTYPES(c10::complex<float>));
 
-#else
+#elif defined(CUDART_VERSION)
 
 #define CUDABLAS_GETRF_BATCHED_ARGTYPES(Dtype)  \
   int n, Dtype** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize
@@ -435,7 +437,7 @@ template<>
 TORCH_CUDA_CU_API void getriBatched<c10::complex<float>>(HIPBLAS_GETRI_BATCHED_ARGTYPES(c10::complex<float>));
 
 
-#else
+#elif defined(CUDART_VERSION)
 
 
 #define CUDABLAS_GETRI_BATCHED_ARGTYPES(Dtype)  \

--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -12,6 +12,9 @@
 #include <c10/util/Exception.h>
 #include <c10/cuda/CUDAException.h>
 
+#ifdef USE_ROCM
+#include <hipblas/hipblas.h>
+#endif
 
 namespace c10 {
 
@@ -52,6 +55,17 @@ C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error);
                 at::cuda::blas::_cublasGetErrorEnum(__err),     \
                 " when calling `" #EXPR "`");                   \
   } while (0)
+
+#ifdef USE_ROCM
+#define TORCH_HIPBLAS_CHECK(EXPR)								\
+  do {															\
+	hipblasStatus_t __err = EXPR;								\
+	TORCH_CHECK(__err == HIPBLAS_STATUS_SUCCESS,				\
+				"CUDA error: ",									\
+				" when calling `" #EXPR "`");					\
+  } while (0)
+#endif
+
 
 const char *cusparseGetErrorString(cusparseStatus_t status);
 

--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -57,12 +57,12 @@ C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error);
   } while (0)
 
 #ifdef USE_ROCM
-#define TORCH_HIPBLAS_CHECK(EXPR)								\
-  do {															\
-	hipblasStatus_t __err = EXPR;								\
-	TORCH_CHECK(__err == HIPBLAS_STATUS_SUCCESS,				\
-				"CUDA error: ",									\
-				" when calling `" #EXPR "`");					\
+#define TORCH_HIPBLAS_CHECK(EXPR)                               \
+  do {                                                          \
+    hipblasStatus_t __err = EXPR;                               \
+    TORCH_CHECK(__err == HIPBLAS_STATUS_SUCCESS,                \
+                "CUDA error: ",                                 \
+                " when calling `" #EXPR "`");                   \
   } while (0)
 #endif
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1622,10 +1622,10 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
 #ifdef USE_CUSOLVER
     constexpr bool looped_correct = CUSOLVER_VERSION >= 11100;
 #else
-	bool looped_correct = true;
+    bool looped_correct = true;
 #endif
 
-	if (m != n || (looped_correct && (batch_size == 1 || m >= 512))) {
+    if (m != n || (looped_correct && (batch_size == 1 || m >= 512))) {
       lu_factor_looped_cusolver(input, pivots, infos, compute_pivots);
     } else {
       lu_factor_batched_cublas(input, pivots, infos, compute_pivots);
@@ -1645,8 +1645,8 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
     // If magma batched is buggy, we use cusolver
     // otherwise, lu_factor just works for square matrices, for non-square matrices magma batched is the fastest
     // otherwise (i.e. for square matrices), we choose between cusolver and magma using a heuristic
-	// ROCm: magma_batched is buggy on rocm also. If we are here, we have access to hipSOLVER so always use 
-	// it instead of magma
+    // ROCm: magma_batched is buggy on rocm also. If we are here, we have access to hipSOLVER so always use
+    // it instead of magma
 #if defined(USE_ROCM)
     lu_factor_cusolver(input, pivots, infos, compute_pivots);
 #else

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2487,11 +2487,13 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
     }
   };
 
+#if defined(USE_LINALG_SOLVER)
   auto lu_solve_batched_cublas_fn = [](const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
     auto LU_ = maybe_expand_lu(B, LU);
     auto pivots_ = maybe_expand_pivots(B, pivots);
     lu_solve_batched_cublas(*LU_, *pivots_, B, trans);
   };
+#endif
 
   auto lu_solve_batched_magma_fn = [](const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
     auto LU_ = maybe_expand_lu(B, LU);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -408,6 +408,8 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
   // Cannot auto-hipifiy this piece of code, because in other functions
   // CUBLAS_OP_N must be translated to HIPSOLVER_OP_N
   auto trans = HIPBLAS_OP_N;
+#elif defined(ROCM_VERSION) && (ROCM_VERSION < 50400)
+  auto trans = rocblas_operation_none;
 #else
   auto trans = CUBLAS_OP_N;
 #endif

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -325,15 +325,16 @@ static void apply_triangular_solve(const Tensor& A, const Tensor& B, bool left, 
 #ifdef ROCM_VERSION
   // Cannot auto-hipifiy this piece of code, because in other functions the uplo
   // and other variables need to be hipSOLVER's type.
-  auto uplo = upper ? rocblas_fill_upper : rocblas_fill_lower;
-  const auto trans = (rocblas_operation)to_cublas(transpose);
-  rocblas_side side = left ? rocblas_side_left : rocblas_side_right;
+  auto uplo = upper ? HIPBLAS_FILL_MODE_UPPER : HIPBLAS_FILL_MODE_LOWER;
+  const auto trans = (hipblasOperation_t)to_cublas(transpose);
+  hipblasSideMode_t side = left ? HIPBLAS_SIDE_LEFT : HIPBLAS_SIDE_RIGHT;
+  hipblasDiagType_t diag = unitriangular ? HIPBLAS_DIAG_UNIT : HIPBLAS_DIAG_NON_UNIT;
 #else
   cublasFillMode_t uplo = upper ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
   const auto trans = to_cublas(transpose);
   cublasSideMode_t side = left ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
-#endif
   cublasDiagType_t diag = unitriangular ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
+#endif
 
   auto A_data = A.data_ptr<scalar_t>();
   auto B_data = B.data_ptr<scalar_t>();
@@ -367,15 +368,16 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
 #ifdef ROCM_VERSION
   // Cannot auto-hipifiy this piece of code, because in other functions the uplo
   // and other variables need to be hipSOLVER's type.
-  auto uplo = upper ? rocblas_fill_upper : rocblas_fill_lower;
-  const auto trans = (rocblas_operation)to_cublas(transpose);
-  rocblas_side side = left ? rocblas_side_left : rocblas_side_right;
+  auto uplo = upper ? HIPBLAS_FILL_MODE_UPPER : HIPBLAS_FILL_MODE_LOWER;
+  const auto trans = (hipblasOperation_t)to_cublas(transpose);
+  hipblasSideMode_t side = left ? HIPBLAS_SIDE_LEFT : HIPBLAS_SIDE_RIGHT;
+  hipblasDiagType_t diag = unitriangular ? HIPBLAS_DIAG_UNIT : HIPBLAS_DIAG_NON_UNIT;
 #else
   cublasFillMode_t uplo = upper ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
   const auto trans = to_cublas(transpose);
   cublasSideMode_t side = left ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
-#endif
   cublasDiagType_t diag = unitriangular ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
+#endif
 
   auto batch_size = cuda_int_cast(batchCount(A), "batch_size");
   // This allows to pass rectangular A and B when left = True

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
@@ -9,7 +9,13 @@
 #include <ATen/native/cuda/MiscUtils.h>
 
 #if (defined(CUDART_VERSION) && defined(CUSOLVER_VERSION)) || (defined(USE_ROCM) && ROCM_VERSION >= 50300)
+
 #define USE_LINALG_SOLVER
+
+#ifdef USE_ROCM
+#include <hipblas/hipblas.h>
+#endif
+
 #endif
 
 // cusolverDn<T>potrfBatched may have numerical issue before cuda 11.3 release,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -18,7 +18,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
-     setLinalgBackendsToDefaultFinally)
+     setLinalgBackendsToDefaultFinally, skipIfRocm)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, has_hipsolver,
      onlyCPU, skipCUDAIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
@@ -3625,10 +3625,13 @@ class TestLinalg(TestCase):
                                     "The QR decomposition is not differentiable when mode='complete' and nrows > ncols"):
             b.backward()
 
-    @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    @dtypesIfCUDA(*floating_types_and(
+                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
+                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
     def test_qr_batched(self, device, dtype):
+        torch.backends.cuda.preferred_linalg_library("cusolver")
         """
         test torch.linalg.qr vs numpy.linalg.qr. We need some special logic
         because numpy does not support batched qr
@@ -4487,6 +4490,9 @@ class TestLinalg(TestCase):
 
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
+    @dtypesIfCUDA(*floating_types_and(
+                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
+                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_ormqr(self, device, dtype):
 
@@ -4743,6 +4749,9 @@ class TestLinalg(TestCase):
 
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
+    @dtypesIfCUDA(*floating_types_and(
+                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
+                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_householder_product(self, device, dtype):
         def generate_reflectors_and_tau(A):
@@ -7137,6 +7146,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_lu_solve_batched(self, device, dtype):
+        torch.backends.cuda.preferred_linalg_library('cusolver')
         def sub_test(pivot):
             def lu_solve_batch_test_helper(A_dims, b_dims, pivot):
                 b, A, LU_data, LU_pivots = self.lu_solve_test_helper(A_dims, b_dims, pivot, device, dtype)
@@ -7314,6 +7324,9 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
+    @dtypesIfCUDA(*floating_types_and(
+                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
+                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_geqrf(self, device, dtype):
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4057,6 +4057,7 @@ class TestLinalg(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
     @skipCUDAIfNoMagma  # Magma needed for the PLU decomposition
+    @skipCUDAIfRocm
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,
                         torch.float64: 1e-8, torch.complex128: 1e-8})

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2,7 +2,6 @@
 
 import torch
 import numpy as np
-import sys
 import unittest
 import itertools
 import warnings

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3623,6 +3623,7 @@ class TestLinalg(TestCase):
                                     "The QR decomposition is not differentiable when mode='complete' and nrows > ncols"):
             b.backward()
 
+    @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_qr_batched(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2,7 +2,7 @@
 
 import torch
 import numpy as np
-
+import sys
 import unittest
 import itertools
 import warnings
@@ -2776,7 +2776,6 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
     @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
-    @skipCUDAIfRocm
     @dtypes(*floating_and_complex_types())
     def test_inverse_errors_large(self, device, dtype):
         # Test batched inverse of singular matrices reports errors without crashing (gh-51930)
@@ -3628,8 +3627,7 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
-                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
+                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     def test_qr_batched(self, device, dtype):
         torch.backends.cuda.preferred_linalg_library("cusolver")
         """
@@ -4063,7 +4061,6 @@ class TestLinalg(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
     @skipCUDAIfNoMagma  # Magma needed for the PLU decomposition
-    @skipCUDAIfRocm  # There is a memory access bug in rocBLAS in the (non-batched) solve_triangular
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
@@ -4491,8 +4488,7 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
     @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
-                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
+                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_ormqr(self, device, dtype):
 
@@ -4750,8 +4746,7 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
     @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
-                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
+                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_householder_product(self, device, dtype):
         def generate_reflectors_and_tau(A):
@@ -7146,7 +7141,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_lu_solve_batched(self, device, dtype):
-        torch.backends.cuda.preferred_linalg_library('cusolver')
         def sub_test(pivot):
             def lu_solve_batch_test_helper(A_dims, b_dims, pivot):
                 b, A, LU_data, LU_pivots = self.lu_solve_test_helper(A_dims, b_dims, pivot, device, dtype)
@@ -7325,8 +7319,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
     @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat] if not TEST_WITH_ROCM else [],
-                  *[torch.cdouble] if not TEST_WITH_ROCM else []))
+                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_geqrf(self, device, dtype):
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -18,7 +18,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
-     setLinalgBackendsToDefaultFinally, skipIfRocm)
+     setLinalgBackendsToDefaultFinally)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, has_hipsolver,
      onlyCPU, skipCUDAIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
@@ -3626,10 +3626,7 @@ class TestLinalg(TestCase):
 
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
-    @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     def test_qr_batched(self, device, dtype):
-        torch.backends.cuda.preferred_linalg_library("cusolver")
         """
         test torch.linalg.qr vs numpy.linalg.qr. We need some special logic
         because numpy does not support batched qr
@@ -4487,8 +4484,6 @@ class TestLinalg(TestCase):
 
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
-    @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_ormqr(self, device, dtype):
 
@@ -4745,8 +4740,6 @@ class TestLinalg(TestCase):
 
     @skipCPUIfNoLapack
     @skipCUDAIfNoCusolver
-    @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_householder_product(self, device, dtype):
         def generate_reflectors_and_tau(A):
@@ -7318,8 +7311,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
-    @dtypesIfCUDA(*floating_types_and(
-                  *[torch.cfloat, torch.cdouble] if not TEST_WITH_ROCM else []))
     @dtypes(*floating_and_complex_types())
     def test_geqrf(self, device, dtype):
 

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1583,7 +1583,6 @@ op_db: List[OpInfo] = [
                 _get_torch_cuda_version() < (11, 4), "not available before CUDA 11.3.1"
             ),
             skipCUDAIfNoCusolver,
-            skipCUDAIfRocm,
             skipCPUIfNoLapack,
         ],
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -23,7 +23,6 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIfNoMagma,
     skipCUDAIfNoMagmaAndNoCusolver,
     skipCUDAIfNoMagmaAndNoLinalgsolver,
-    skipCUDAIfRocm,
     tol,
     toleranceOverride,
 )

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -6547,51 +6547,51 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ("cublasZgeam", ("rocblas_zgeam", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         (
             "cublasSgetrfBatched",
-            ("rocblas_sgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgetrfBatched",
-            ("rocblas_dgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgetrfBatched",
-            ("rocblas_cgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgetrfBatched",
-            ("rocblas_zgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSgetriBatched",
-            ("rocblas_sgetri_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgetriBatched",
-            ("rocblas_dgetri_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgetriBatched",
-            ("rocblas_cgetri_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgetriBatched",
-            ("rocblas_zgetri_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSgetrsBatched",
-            ("rocblas_sgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgetrsBatched",
-            ("rocblas_dgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgetrsBatched",
-            ("rocblas_cgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgetrsBatched",
-            ("rocblas_zgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasStrsmBatched",
@@ -6627,19 +6627,19 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ),
         (
             "cublasSgeqrfBatched",
-            ("rocblas_sgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgeqrfBatched",
-            ("rocblas_dgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgeqrfBatched",
-            ("rocblas_cgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgeqrfBatched",
-            ("rocblas_zgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSgelsBatched",

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -6635,7 +6635,7 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ),
         (
             "cublasCgeqrfBatched",
-            ("hipblasDgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgeqrfBatched",

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -6517,25 +6517,25 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ("cublasZsymm", ("rocblas_zsymm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         ("cublasChemm", ("rocblas_chemm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         ("cublasZhemm", ("rocblas_zhemm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
-        ("cublasStrsm", ("rocblas_strsm", CONV_MATH_FUNC, API_BLAS)),
-        ("cublasDtrsm", ("rocblas_dtrsm", CONV_MATH_FUNC, API_BLAS)),
-        ("cublasCtrsm", ("rocblas_ctrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
-        ("cublasZtrsm", ("rocblas_ztrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
+        ("cublasStrsm", ("hipblasStrsm", CONV_MATH_FUNC, API_BLAS)),
+        ("cublasDtrsm", ("hipblasDtrsm", CONV_MATH_FUNC, API_BLAS)),
+        ("cublasCtrsm", ("hipblasCtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
+        ("cublasZtrsm", ("hipblasZtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         (
             "cublasStrsmBatched",
-            ("rocblas_strsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasStrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDtrsmBatched",
-            ("rocblas_dtrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCtrsmBatched",
-            ("rocblas_ctrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZtrsmBatched",
-            ("rocblas_ztrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         ("cublasStrmm", ("rocblas_strmm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         ("cublasDtrmm", ("rocblas_dtrmm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
@@ -6595,19 +6595,19 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ),
         (
             "cublasStrsmBatched",
-            ("rocblas_strsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasStrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDtrsmBatched",
-            ("rocblas_dtrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCtrsmBatched",
-            ("rocblas_ctrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZtrsmBatched",
-            ("rocblas_ztrsm_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZtrsmBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSmatinvBatched",
@@ -7068,19 +7068,19 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ),
         (
             "cublasStrsm_v2",
-            ("rocblas_strsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasStrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDtrsm_v2",
-            ("rocblas_dtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCtrsm_v2",
-            ("rocblas_ctrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZtrsm_v2",
-            ("rocblas_ztrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZtrsm", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasStrmm_v2",


### PR DESCRIPTION
Enables the following tests for ROCm along with support for various batched linalg drivers:
test_inverse_errors_large_cuda*
test_qr_batched_cuda*
test_linalg_solve_triangular_large_cuda*
test_ormqr_cuda_complex*
test_householder_product_cuda_complex*
test_geqrf_cuda_complex*

