### PR TITLE
Bench 'MobileBert' instead of 'Albert' under --quick

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -123,7 +123,7 @@ DEFAULTS = {
     ],
     "quick": {
         "torchbench": '-k "resnet..$"',
-        "huggingface": "-k Albert",
+        "huggingface": "-k MobileBert",
         "timm_models": ' -k "^resnet" -k "^inception"',
     },
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103232

Attempts to fix #103231. `MobileBert` appears to run much faster.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @ipiszy