### PR TITLE
Debug Windows locked files

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -96,9 +96,8 @@ runs:
         Set-MpPreference -DisableRealtimeMonitoring $True
 
     - name: Install sysinternals handle tool
+      continue-on-error: true
       shell: powershell
       run: |
         choco install handle -y
-
-        # Testing
         handle C:\actions-runner\_work\

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -94,3 +94,11 @@ runs:
         # Let's both exclude the path and disable Windows Defender completely just to be sure
         # that it doesn't interfere
         Set-MpPreference -DisableRealtimeMonitoring $True
+
+    - name: Install sysinternals handle tool
+      shell: powershell
+      run: |
+        choco install handle -y
+
+        # Testing
+        handle C:\actions-runner\_work\

--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -50,3 +50,8 @@ runs:
           fi
 
           rm -rf ./*
+
+    - name: Debug locked files
+      shell: powershell
+      run: |
+        handle C:\actions-runner\_work\

--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -51,7 +51,8 @@ runs:
 
           rm -rf ./*
 
-    - name: Debug locked files
+    - name: Print all processes locking the runner workspace
+      continue-on-error: true
       shell: powershell
       run: |
         handle C:\actions-runner\_work\


### PR DESCRIPTION
This PR temporally installs SysInternal https://learn.microsoft.com/en-us/sysinternals/downloads/handle and prints which processes locking `C:\action-runner\work` folder.  This is needed to debug the elusive Windows locked file issues https://github.com/pytorch/pytorch/actions/runs/5216626202/jobs/9415560483.  This will be reverted once the investigation is done.  If the tool proves to be useful, we can add it to the AMI later on
