### PR TITLE
Optimize sparse.mm reduce in BFloat16 data type in CPU backend

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceUtils.h
+++ b/aten/src/ATen/native/cpu/ReduceUtils.h
@@ -8,6 +8,7 @@
 #include <c10/util/irange.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/cpu/utils.h>
+#include <ATen/OpMathType.h>
 
 namespace at::native {
 inline namespace CPU_CAPABILITY {

--- a/aten/src/ATen/native/cpu/ReduceUtils.h
+++ b/aten/src/ATen/native/cpu/ReduceUtils.h
@@ -7,6 +7,7 @@
 #include <ATen/native/ReductionType.h>
 #include <c10/util/irange.h>
 #include <ATen/OpMathType.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at::native {
 inline namespace CPU_CAPABILITY {
@@ -104,7 +105,8 @@ inline void _init(scalar_t* self_ptr, at::opmath_type<scalar_t>* buffer_ptr, int
 }
 
 template <typename scalar_t>
-inline scalar_t _max(const scalar_t& x, const scalar_t& y) {
+inline typename std::enable_if<!std::is_same<scalar_t, Vec2>::value, scalar_t>::type
+_max(const scalar_t& x, const scalar_t& y) {
   return at::_isnan(y) ? y : std::max(x, y);
 }
 
@@ -115,7 +117,15 @@ inline Vectorized<scalar_t> _max(const Vectorized<scalar_t>& x, const Vectorized
 }
 
 template <typename scalar_t>
-inline scalar_t _min(const scalar_t& x, const scalar_t& y) {
+inline typename std::enable_if<std::is_same<scalar_t, Vec2>::value, Vec2>::type
+_max(const scalar_t& x, const scalar_t& y) {
+  // vec::maximum propagates NaN
+  return maximum(x, y);
+}
+
+template <typename scalar_t>
+inline typename std::enable_if<!std::is_same<scalar_t, Vec2>::value, scalar_t>::type
+_min(const scalar_t& x, const scalar_t& y) {
   return at::_isnan(y) ? y : std::min(x, y);
 }
 
@@ -123,6 +133,13 @@ template <typename scalar_t>
 inline Vectorized<scalar_t> _min(const Vectorized<scalar_t>& x, const Vectorized<scalar_t>& y) {
   // vec::minimum propagates NaN
   return vec::minimum(x, y);
+}
+
+template <typename scalar_t>
+inline typename std::enable_if<std::is_same<scalar_t, Vec2>::value, Vec2>::type
+_min(const scalar_t& x, const scalar_t& y) {
+  // vec::minimum propagates NaN
+  return minimum(x, y);
 }
 
 template <typename scalar_t, typename accumut, typename Op,

--- a/aten/src/ATen/native/cpu/ReduceUtils.h
+++ b/aten/src/ATen/native/cpu/ReduceUtils.h
@@ -116,9 +116,9 @@ inline Vectorized<scalar_t> _max(const Vectorized<scalar_t>& x, const Vectorized
   return vec::maximum(x, y);
 }
 
-template <typename scalar_t>
-inline typename std::enable_if<std::is_same<scalar_t, Vec2>::value, Vec2>::type
-_max(const scalar_t& x, const scalar_t& y) {
+template <typename vec_t>
+inline typename std::enable_if<std::is_same<vec_t, Vec2>::value, Vec2>::type
+_max(const vec_t& x, const vec_t& y) {
   // vec::maximum propagates NaN
   return maximum(x, y);
 }
@@ -135,9 +135,9 @@ inline Vectorized<scalar_t> _min(const Vectorized<scalar_t>& x, const Vectorized
   return vec::minimum(x, y);
 }
 
-template <typename scalar_t>
-inline typename std::enable_if<std::is_same<scalar_t, Vec2>::value, Vec2>::type
-_min(const scalar_t& x, const scalar_t& y) {
+template <typename vec_t>
+inline typename std::enable_if<std::is_same<vec_t, Vec2>::value, Vec2>::type
+_min(const vec_t& x, const vec_t& y) {
   // vec::minimum propagates NaN
   return minimum(x, y);
 }

--- a/aten/src/ATen/native/cpu/SpmmReduceKernel.cpp
+++ b/aten/src/ATen/native/cpu/SpmmReduceKernel.cpp
@@ -66,126 +66,176 @@ void spmm_reduce_kernel_impl(
       }
 
       // step 2: reduce, do blocking on rowwise to reduce write memory bandwidth
-      if (at::isReducedFloatingType(other_.scalar_type())) {
-        using Vec = vec::Vectorized<BFloat16>;
-        for (int64_t e0 = row_start; e0 < row_end; e0 += CHUNK_SIZE) {
-          int64_t e1 = std::min(e0 + CHUNK_SIZE, row_end);
+      for (int64_t e0 = row_start; e0 < row_end; e0 += CHUNK_SIZE) {
+        int64_t e1 = std::min(e0 + CHUNK_SIZE, row_end);
 
-          int64_t k = 0;
-          for (; k < K - (K % kVLEN); k += kVLEN) {
-            Vec out_vec0 = Vec::loadu(out_ptr + k);
-            Vectorized<float> out_vec0_0, out_vec0_1;
-            std::tie(out_vec0_0, out_vec0_1) = convert_to_float<BFloat16>(out_vec0);
-            Vec out_vec1 = Vec::loadu(out_ptr + k + kVecSize);
-            Vectorized<float> out_vec1_0, out_vec1_1;
-            std::tie(out_vec1_0, out_vec1_1) = convert_to_float<BFloat16>(out_vec1);
-            Vec out_vec2 = Vec::loadu(out_ptr + k + kVecSize * 2);
-            Vectorized<float> out_vec2_0, out_vec2_1;
-            std::tie(out_vec2_0, out_vec2_1) = convert_to_float<BFloat16>(out_vec2);
-            Vec out_vec3 = Vec::loadu(out_ptr + k + kVecSize * 3);
-            Vectorized<float> out_vec3_0, out_vec3_1;
-            std::tie(out_vec3_0, out_vec3_1) = convert_to_float<BFloat16>(out_vec3);
+        int64_t k = 0;
+        for (; k < K - (K % kVLEN); k += kVLEN) {
+          Vec out_vec0 = Vec::loadu(out_ptr + k);
+          Vec out_vec1 = Vec::loadu(out_ptr + k + kVecSize);
+          Vec out_vec2 = Vec::loadu(out_ptr + k + kVecSize * 2);
+          Vec out_vec3 = Vec::loadu(out_ptr + k + kVecSize * 3);
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            scalar_t val = val_data[e];
+            scalar_t* other_ptr = other_data + c * K + k;
 
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              Vectorized<float> val = Vectorized<float>(float(val_data[e]));
-              scalar_t* other_ptr = other_data + c * K + k;
-
-              Vectorized<float> other_vec0_0, other_vec0_1;
-              std::tie(other_vec0_0, other_vec0_1) = convert_to_float<BFloat16>(Vec::loadu(other_ptr));
-              out_vec0_0 = update<Vectorized<float>, reduce>(out_vec0_0, other_vec0_0 * val);
-              out_vec0_1 = update<Vectorized<float>, reduce>(out_vec0_1, other_vec0_1 * val);
-              Vectorized<float> other_vec1_0, other_vec1_1;
-              std::tie(other_vec1_0, other_vec1_1) = convert_to_float<BFloat16>(Vec::loadu(other_ptr + kVecSize));
-              out_vec1_0 = update<Vectorized<float>, reduce>(out_vec1_0, other_vec1_0 * val);
-              out_vec1_1 = update<Vectorized<float>, reduce>(out_vec1_1, other_vec1_1 * val);
-              Vectorized<float> other_vec2_0, other_vec2_1;
-              std::tie(other_vec2_0, other_vec2_1) = convert_to_float<BFloat16>(Vec::loadu(other_ptr + kVecSize * 2));
-              out_vec2_0 = update<Vectorized<float>, reduce>(out_vec2_0, other_vec2_0 * val);
-              out_vec2_1 = update<Vectorized<float>, reduce>(out_vec2_1, other_vec2_1 * val);
-              Vectorized<float> other_vec3_0, other_vec3_1;
-              std::tie(other_vec3_0, other_vec3_1) = convert_to_float<BFloat16>(Vec::loadu(other_ptr + kVecSize * 3));
-              out_vec3_0 = update<Vectorized<float>, reduce>(out_vec3_0, other_vec3_0 * val);
-              out_vec3_1 = update<Vectorized<float>, reduce>(out_vec3_1, other_vec3_1 * val);
-            }
-            convert_from_float<BFloat16>(out_vec0_0, out_vec0_1).store(out_ptr + k);
-            convert_from_float<BFloat16>(out_vec1_0, out_vec1_1).store(out_ptr + k + kVecSize);
-            convert_from_float<BFloat16>(out_vec2_0, out_vec2_1).store(out_ptr + k + kVecSize * 2);
-            convert_from_float<BFloat16>(out_vec3_0, out_vec3_1).store(out_ptr + k + kVecSize * 3);
+            out_vec0 = update<Vec, reduce>(out_vec0, Vec::loadu(other_ptr) * Vec(val));
+            out_vec1 = update<Vec, reduce>(out_vec1, Vec::loadu(other_ptr + kVecSize) * Vec(val));
+            out_vec2 = update<Vec, reduce>(out_vec2, Vec::loadu(other_ptr + kVecSize * 2) * Vec(val));
+            out_vec3 = update<Vec, reduce>(out_vec3, Vec::loadu(other_ptr + kVecSize * 3) * Vec(val));
           }
-          for (; k < K - (K % kVecSize); k += kVecSize) {
-            Vec out_vec = Vec::loadu(out_ptr + k);
-            Vectorized<float> out_vec_0, out_vec_1;
-            std::tie(out_vec_0, out_vec_1) = convert_to_float<BFloat16>(out_vec);
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              Vectorized<float> val = Vectorized<float>(float(val_data[e]));
-              scalar_t* other_ptr = other_data + c * K;
-              Vectorized<float> other_vec_0, other_vec_1;
-              std::tie(other_vec_0, other_vec_1) = convert_to_float<BFloat16>(Vec::loadu(other_ptr + k));
-              out_vec_0 = update<Vectorized<float>, reduce>(out_vec_0, other_vec_0 * val);
-              out_vec_1 = update<Vectorized<float>, reduce>(out_vec_1, other_vec_1 * val);
-            }
-            convert_from_float<BFloat16>(out_vec_0, out_vec_1).store(out_ptr + k);
-          }
-          for (; k < K; k++) {
-            float out_val = float(out_ptr[k]);
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              float val = float(val_data[e]);
-              scalar_t* other_ptr = other_data + c * K;
-              out_val = update<float, reduce>(out_val, float(other_ptr[k]) * val);
-            }
-            out_ptr[k] = scalar_t(out_val);
-          }
+          out_vec0.store(out_ptr + k);
+          out_vec1.store(out_ptr + k + kVecSize);
+          out_vec2.store(out_ptr + k + kVecSize * 2);
+          out_vec3.store(out_ptr + k + kVecSize * 3);
         }
-      } else {
-        for (int64_t e0 = row_start; e0 < row_end; e0 += CHUNK_SIZE) {
-          int64_t e1 = std::min(e0 + CHUNK_SIZE, row_end);
-
-          int64_t k = 0;
-          for (; k < K - (K % kVLEN); k += kVLEN) {
-            Vec out_vec0 = Vec::loadu(out_ptr + k);
-            Vec out_vec1 = Vec::loadu(out_ptr + k + kVecSize);
-            Vec out_vec2 = Vec::loadu(out_ptr + k + kVecSize * 2);
-            Vec out_vec3 = Vec::loadu(out_ptr + k + kVecSize * 3);
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              scalar_t val = val_data[e];
-              scalar_t* other_ptr = other_data + c * K + k;
-
-              out_vec0 = update<Vec, reduce>(out_vec0, Vec::loadu(other_ptr) * Vec(val));
-              out_vec1 = update<Vec, reduce>(out_vec1, Vec::loadu(other_ptr + kVecSize) * Vec(val));
-              out_vec2 = update<Vec, reduce>(out_vec2, Vec::loadu(other_ptr + kVecSize * 2) * Vec(val));
-              out_vec3 = update<Vec, reduce>(out_vec3, Vec::loadu(other_ptr + kVecSize * 3) * Vec(val));
-            }
-            out_vec0.store(out_ptr + k);
-            out_vec1.store(out_ptr + k + kVecSize);
-            out_vec2.store(out_ptr + k + kVecSize * 2);
-            out_vec3.store(out_ptr + k + kVecSize * 3);
+        for (; k < K - (K % kVecSize); k += kVecSize) {
+          Vec out_vec = Vec::loadu(out_ptr + k);
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            scalar_t val = val_data[e];
+            scalar_t* other_ptr = other_data + c * K;
+            out_vec = update<Vec, reduce>(out_vec, Vec::loadu(other_ptr + k) * Vec(val));
           }
-          for (; k < K - (K % kVecSize); k += kVecSize) {
-            Vec out_vec = Vec::loadu(out_ptr + k);
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              scalar_t val = val_data[e];
-              scalar_t* other_ptr = other_data + c * K;
-              out_vec = update<Vec, reduce>(out_vec, Vec::loadu(other_ptr + k) * Vec(val));
-            }
-            out_vec.store(out_ptr + k);
+          out_vec.store(out_ptr + k);
+        }
+        for (; k < K; k++) {
+          scalar_t out_val = out_ptr[k];
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            scalar_t val = val_data[e];
+            scalar_t* other_ptr = other_data + c * K;
+            out_val = update<scalar_t, reduce>(out_val, other_ptr[k] * val);
           }
-          for (; k < K; k++) {
-            scalar_t out_val = out_ptr[k];
-            for (const auto e : c10::irange(e0, e1)) {
-              c = col_data[e];
-              scalar_t val = val_data[e];
-              scalar_t* other_ptr = other_data + c * K;
-              out_val = update<scalar_t, reduce>(out_val, other_ptr[k] * val);
-            }
-            out_ptr[k] = out_val;
-          }
+          out_ptr[k] = out_val;
         }
       }
+
+      // step 3: finalize
+      write<scalar_t, reduce>(out_ptr, count, K);
+    }
+  });
+}
+
+
+template <typename scalar_t, typename index_t, ReductionType reduce>
+void spmm_reduce_kernel_impl_reduction(
+    const Tensor& out,
+    const Tensor& crow_indices,
+    const Tensor& col_indices,
+    const Tensor& values,
+    const Tensor& other_) {
+
+  int64_t nnz = values.numel();
+  if (nnz == 0) {
+    return;
+  }
+
+  auto other = other_.contiguous();
+
+  // access `crow_indices`, `col_indices` and `values` via TessorAccessor
+  scalar_t* out_data = out.data_ptr<scalar_t>();
+  auto csr_data = crow_indices.accessor<index_t, 1>();
+  auto col_data = col_indices.accessor<index_t, 1>();
+  auto val_data = values.accessor<scalar_t, 1>();
+  scalar_t* other_data = other.data_ptr<scalar_t>();
+
+  int64_t M = crow_indices.numel() - 1;
+  int64_t K = other.size(-1);
+
+  using Vec = vec::Vectorized<scalar_t>;
+  utils::parallel_sparse_csr(csr_data, M, nnz, [&](int64_t begin, int64_t end) {
+    int64_t row_start, row_end, c;
+    for (const auto m : c10::irange(begin, end)) {
+      row_start = csr_data[m];
+      row_end = csr_data[m + 1];
+
+      scalar_t* out_ptr = out_data + m * K;
+
+      constexpr int64_t kVecSize = Vec::size();
+      constexpr int64_t kVLEN = kVecSize * 4;
+      constexpr int64_t CHUNK_SIZE = 16;
+
+      // step 1: reinit the output row for reduce type 'amax' and 'amin'
+      int64_t count = row_end - row_start;
+      if (count != 0) {
+        init<scalar_t, reduce>(out_ptr, K, /*include_self*/false);
+      }
+
+      // step 2: reduce, do blocking on rowwise to reduce write memory bandwidth
+      for (int64_t e0 = row_start; e0 < row_end; e0 += CHUNK_SIZE) {
+        int64_t e1 = std::min(e0 + CHUNK_SIZE, row_end);
+
+        int64_t k = 0;
+        for (; k < K - (K % kVLEN); k += kVLEN) {
+          Vec out_vec0 = Vec::loadu(out_ptr + k);
+          Vectorized<float> out_vec0_0, out_vec0_1;
+          std::tie(out_vec0_0, out_vec0_1) = convert_to_float<scalar_t>(out_vec0);
+          Vec out_vec1 = Vec::loadu(out_ptr + k + kVecSize);
+          Vectorized<float> out_vec1_0, out_vec1_1;
+          std::tie(out_vec1_0, out_vec1_1) = convert_to_float<scalar_t>(out_vec1);
+          Vec out_vec2 = Vec::loadu(out_ptr + k + kVecSize * 2);
+          Vectorized<float> out_vec2_0, out_vec2_1;
+          std::tie(out_vec2_0, out_vec2_1) = convert_to_float<scalar_t>(out_vec2);
+          Vec out_vec3 = Vec::loadu(out_ptr + k + kVecSize * 3);
+          Vectorized<float> out_vec3_0, out_vec3_1;
+          std::tie(out_vec3_0, out_vec3_1) = convert_to_float<scalar_t>(out_vec3);
+
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            Vectorized<float> val = Vectorized<float>(float(val_data[e]));
+            scalar_t* other_ptr = other_data + c * K + k;
+
+            Vectorized<float> other_vec0_0, other_vec0_1;
+            std::tie(other_vec0_0, other_vec0_1) = convert_to_float<scalar_t>(Vec::loadu(other_ptr));
+            out_vec0_0 = update<Vectorized<float>, reduce>(out_vec0_0, other_vec0_0 * val);
+            out_vec0_1 = update<Vectorized<float>, reduce>(out_vec0_1, other_vec0_1 * val);
+            Vectorized<float> other_vec1_0, other_vec1_1;
+            std::tie(other_vec1_0, other_vec1_1) = convert_to_float<scalar_t>(Vec::loadu(other_ptr + kVecSize));
+            out_vec1_0 = update<Vectorized<float>, reduce>(out_vec1_0, other_vec1_0 * val);
+            out_vec1_1 = update<Vectorized<float>, reduce>(out_vec1_1, other_vec1_1 * val);
+            Vectorized<float> other_vec2_0, other_vec2_1;
+            std::tie(other_vec2_0, other_vec2_1) = convert_to_float<scalar_t>(Vec::loadu(other_ptr + kVecSize * 2));
+            out_vec2_0 = update<Vectorized<float>, reduce>(out_vec2_0, other_vec2_0 * val);
+            out_vec2_1 = update<Vectorized<float>, reduce>(out_vec2_1, other_vec2_1 * val);
+            Vectorized<float> other_vec3_0, other_vec3_1;
+            std::tie(other_vec3_0, other_vec3_1) = convert_to_float<scalar_t>(Vec::loadu(other_ptr + kVecSize * 3));
+            out_vec3_0 = update<Vectorized<float>, reduce>(out_vec3_0, other_vec3_0 * val);
+            out_vec3_1 = update<Vectorized<float>, reduce>(out_vec3_1, other_vec3_1 * val);
+          }
+          convert_from_float<scalar_t>(out_vec0_0, out_vec0_1).store(out_ptr + k);
+          convert_from_float<scalar_t>(out_vec1_0, out_vec1_1).store(out_ptr + k + kVecSize);
+          convert_from_float<scalar_t>(out_vec2_0, out_vec2_1).store(out_ptr + k + kVecSize * 2);
+          convert_from_float<scalar_t>(out_vec3_0, out_vec3_1).store(out_ptr + k + kVecSize * 3);
+        }
+        for (; k < K - (K % kVecSize); k += kVecSize) {
+          Vec out_vec = Vec::loadu(out_ptr + k);
+          Vectorized<float> out_vec_0, out_vec_1;
+          std::tie(out_vec_0, out_vec_1) = convert_to_float<scalar_t>(out_vec);
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            Vectorized<float> val = Vectorized<float>(float(val_data[e]));
+            scalar_t* other_ptr = other_data + c * K;
+            Vectorized<float> other_vec_0, other_vec_1;
+            std::tie(other_vec_0, other_vec_1) = convert_to_float<scalar_t>(Vec::loadu(other_ptr + k));
+            out_vec_0 = update<Vectorized<float>, reduce>(out_vec_0, other_vec_0 * val);
+            out_vec_1 = update<Vectorized<float>, reduce>(out_vec_1, other_vec_1 * val);
+          }
+          convert_from_float<scalar_t>(out_vec_0, out_vec_1).store(out_ptr + k);
+        }
+        for (; k < K; k++) {
+          float out_val = float(out_ptr[k]);
+          for (const auto e : c10::irange(e0, e1)) {
+            c = col_data[e];
+            float val = float(val_data[e]);
+            scalar_t* other_ptr = other_data + c * K;
+            out_val = update<float, reduce>(out_val, float(other_ptr[k]) * val);
+          }
+          out_ptr[k] = scalar_t(out_val);
+        }
+      }
+
       // step 3: finalize
       write<scalar_t, reduce>(out_ptr, count, K);
     }
@@ -455,14 +505,25 @@ void spmm_reduce_kernel(
     const Tensor& values,
     const Tensor& other,
     ReductionType reduce_op) {
-  AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, values.scalar_type(), "spmm_reduce_kernel", [&]() {
-    AT_DISPATCH_INDEX_TYPES(col_indices.scalar_type(), "spmm_reduce_indices", [&]() {
-      AT_DISPATCH_REDUCTION_TYPES(reduce_op, [&]() {
-        spmm_reduce_kernel_impl<scalar_t, index_t, reduce>(
-            out, crow_indices, col_indices, values, other);
+  if (at::isReducedFloatingType(values.scalar_type())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(values.scalar_type(), "spmm_reduce_kernel", [&]() {
+      AT_DISPATCH_INDEX_TYPES(col_indices.scalar_type(), "spmm_reduce_indices", [&]() {
+        AT_DISPATCH_REDUCTION_TYPES(reduce_op, [&]() {
+          spmm_reduce_kernel_impl_reduction<scalar_t, index_t, reduce>(
+              out, crow_indices, col_indices, values, other);
+        });
       });
     });
-  });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES(values.scalar_type(), "spmm_reduce_kernel", [&]() {
+      AT_DISPATCH_INDEX_TYPES(col_indices.scalar_type(), "spmm_reduce_indices", [&]() {
+        AT_DISPATCH_REDUCTION_TYPES(reduce_op, [&]() {
+          spmm_reduce_kernel_impl<scalar_t, index_t, reduce>(
+              out, crow_indices, col_indices, values, other);
+        });
+      });
+    });
+  }
 }
 
 void spmm_reduce_arg_kernel(

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -50,9 +50,16 @@ struct Vec2 {
     std::tie(v0, v1) = convert_bfloat16_float(Vectorized<BFloat16>::loadu(ptr));
     return {v0, v1};
   }
+  static Vec2 loadu(const float* ptr) {
+    return {Vectorized<float>::loadu(ptr), Vectorized<float>::loadu(ptr + Vectorized<float>::size())};
+  }
   void store(BFloat16* ptr) const {
     Vectorized<BFloat16> val = convert_float_bfloat16(val0, val1);
     val.store(ptr);
+  }
+  void store(float* ptr) const {
+    val0.store(ptr);
+    val1.store(ptr + Vectorized<float>::size());
   }
 };
 inline Vec2 operator+(const Vec2& a, const Vec2& b) { return {a.val0 + b.val0, a.val1 + b.val1}; }

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -57,6 +57,10 @@ struct Vec2 {
 };
 inline Vec2 operator+(const Vec2& a, const Vec2& b) { return {a.val0 + b.val0, a.val1 + b.val1}; }
 inline Vec2 operator*(const Vec2& a, const Vec2& b) { return {a.val0 * b.val0, a.val1 * b.val1}; }
+inline Vec2 operator-(const Vec2& a, const Vec2& b) { return {a.val0 - b.val0, a.val1 - b.val1}; }
+inline Vec2 operator/(const Vec2& a, const Vec2& b) { return {a.val0 / b.val0, a.val1 / b.val1}; }
+inline Vec2 maximum(const Vec2& a, const Vec2& b) { return {vec::maximum(a.val0, b.val0), vec::maximum(a.val1, b.val1)}; }
+inline Vec2 minimum(const Vec2& a, const Vec2& b) { return {vec::minimum(a.val0, b.val0), vec::minimum(a.val1, b.val1)}; }
 
 template <typename scalar_t> struct VectorizedType { using type = Vectorized<scalar_t>; };
 template <> struct VectorizedType<BFloat16> { using type = Vec2; };


### PR DESCRIPTION
### Description

This PR is to optimize sparse.mm reduce of BFloat16 data type in CPU backend, which is one task in https://github.com/pyg-team/pytorch_geometric/issues/7057. Half support (need support addmm Half implementation) will be done once https://github.com/pytorch/pytorch/pull/99498 upstream.

Next step:
- [x] Add benchmarks 
- [x] Update UTs
- [x] Check backward behaviors
- [x] Refactor code

### Performance test (Updated)

Test BFloat16 in Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz
With jemalloc and iomp

Single socket (40C)
![image](https://github.com/pytorch/pytorch/assets/61222868/509e8482-9160-4b85-bc39-5b6aad510283)


Single core
![image](https://github.com/pytorch/pytorch/assets/61222868/c953a494-8f8e-4dbd-a8a7-421d8c22e946)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10