### PR TITLE
Add "c10" to the default value of contiguous format

### DIFF
--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -309,7 +309,7 @@ JIT_TO_CPP_DEFAULT = {
     "None": "c10::nullopt",  # UGH this one is type directed
     "Mean": "at::Reduction::Mean",
     "[]": "{}",
-    "contiguous_format": "MemoryFormat::Contiguous",
+    "contiguous_format": "c10::MemoryFormat::Contiguous",
     "long": "at::kLong",
 }
 


### PR DESCRIPTION
I use the function `gen_dispatchkey_nativefunc_headers` and the file `DispatchKeyNativeFunctions.h` to generate my own header file. My team have a module like `libtorch`, others may call the function in that header file directly. So we want to add default value to the argument in my header file. 
But my namespace is not `c10`, so I change `MemoryFormat::Contiguous`  to `c10::MemoryFormat::Contiguous`.