### PR TITLE
Windows FileStore skip timeout if the file path is invalid

### DIFF
--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -9,6 +9,7 @@
 #include <c10/util/win32-headers.h>
 #include <fileapi.h>
 #include <io.h>
+#include <filesystem>
 #else
 #include <sys/file.h>
 #include <unistd.h>
@@ -154,6 +155,13 @@ class File {
       if (fd_ >= 0 || errno != ENOENT) {
         break;
       }
+#ifdef _WIN32
+      // if the parent folder doesn't exist it will never be able to create the
+      // file so we can skip the retry
+      if (!std::filesystem::exists(std::filesystem::path(path).parent_path())) {
+        break;
+      }
+#endif
       const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
           std::chrono::steady_clock::now() - start);
       if (timeout != c10d::Store::kNoTimeout && elapsed > timeout) {


### PR DESCRIPTION
On Windows in FileStore if the path to the file to be created is not valid then it will get stuck there trying to create the file until the timeout is reached.
This PR checks if the path is invalid and if it is then it will leave the loop instantly. 

Fixes #48475
