### PR TITLE
[PT2][Quant] Update op names for decomposed quantized lib

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -6086,8 +6086,8 @@ class TestQuantizeFx(QuantizationTestCase):
         m_ref = convert_to_reference_fx(m_ref)
         m = _convert_to_reference_decomposed_fx(m)
         expected_occurrence = {
-            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 2,
-            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor): 2,
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor.default): 2,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default): 2,
         }
         self.checkGraphModuleNodes(
             m,
@@ -6147,11 +6147,11 @@ class TestQuantizeFx(QuantizationTestCase):
         m = _convert_to_reference_decomposed_fx(m)
         expected_occurrence = {
             # for input and output activations
-            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 2,
-            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor): 2,
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor.default): 2,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default): 2,
             # for weight
-            ns.call_function(torch.ops.quantized_decomposed.quantize_per_channel): 1,
-            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_channel): 1,
+            ns.call_function(torch.ops.quantized_decomposed.quantize_per_channel.default): 1,
+            ns.call_function(torch.ops.quantized_decomposed.dequantize_per_channel.default): 1,
         }
         self.checkGraphModuleNodes(
             m,

--- a/test/quantization/pt2e/test_quantize_pt2e_fx.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_fx.py
@@ -85,16 +85,16 @@ class TestQuantizePT2EFX(QuantizationTestCase):
             # first conv is quantized, second conv is not quantized
             node_occurrence = {
                 # two for input of the first conv, one for output for the first conv
-                ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 3,
+                ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor.default): 3,
                 ns.call_function(
-                    torch.ops.quantized_decomposed.dequantize_per_tensor
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default
                 ): 3,
             }
             node_list = [
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
                 ns.call_function(torch.ops.aten.convolution.default),
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
                 ns.call_function(torch.ops.aten.convolution.default),
             ]
             self.checkGraphModuleNodes(
@@ -138,16 +138,16 @@ class TestQuantizePT2EFX(QuantizationTestCase):
             # conv is quantized, linear is not quantized
             node_occurrence = {
                 # two for input and weight of the conv, one for output for the conv
-                ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor): 3,
+                ns.call_function(torch.ops.quantized_decomposed.quantize_per_tensor.default): 3,
                 ns.call_function(
-                    torch.ops.quantized_decomposed.dequantize_per_tensor
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default
                 ): 3,
             }
             node_list = [
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
                 ns.call_function(torch.ops.aten.convolution.default),
-                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor),
+                ns.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor.default),
                 ns.call_function(torch.ops.aten.addmm.default),
             ]
             self.checkGraphModuleNodes(m, expected_node_list=node_list)
@@ -367,25 +367,25 @@ class TestQuantizePT2EFXX86Inductor(QuantizationTestCase):
                     node_occurrence = {
                         # one for input and weight of the conv, one for output for the conv
                         ns.call_function(
-                            torch.ops.quantized_decomposed.quantize_per_tensor
+                            torch.ops.quantized_decomposed.quantize_per_tensor.default
                         ): 2,
                         ns.call_function(
-                            torch.ops.quantized_decomposed.quantize_per_channel
+                            torch.ops.quantized_decomposed.quantize_per_channel.default
                         ): 1,
                         ns.call_function(
-                            torch.ops.quantized_decomposed.dequantize_per_channel
+                            torch.ops.quantized_decomposed.dequantize_per_channel.default
                         ): 1,
                         ns.call_function(
-                            torch.ops.quantized_decomposed.dequantize_per_tensor
+                            torch.ops.quantized_decomposed.dequantize_per_tensor.default
                         ): 2,
                     }
                     if use_relu:
                         node_list = [
                             ns.call_function(
-                                torch.ops.quantized_decomposed.quantize_per_tensor
+                                torch.ops.quantized_decomposed.quantize_per_tensor.default
                             ),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.dequantize_per_tensor
+                                torch.ops.quantized_decomposed.dequantize_per_tensor.default
                             ),
                             ns.call_function(torch.ops.aten.convolution.default),
                             ns.call_function(
@@ -394,26 +394,26 @@ class TestQuantizePT2EFXX86Inductor(QuantizationTestCase):
                                 else torch.ops.aten.relu.default
                             ),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.quantize_per_tensor
+                                torch.ops.quantized_decomposed.quantize_per_tensor.default
                             ),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.dequantize_per_tensor
+                                torch.ops.quantized_decomposed.dequantize_per_tensor.default
                             ),
                         ]
                     else:
                         node_list = [
                             ns.call_function(
-                                torch.ops.quantized_decomposed.quantize_per_tensor
+                                torch.ops.quantized_decomposed.quantize_per_tensor.default
                             ),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.dequantize_per_tensor
+                                torch.ops.quantized_decomposed.dequantize_per_tensor.default
                             ),
                             ns.call_function(torch.ops.aten.convolution.default),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.quantize_per_tensor
+                                torch.ops.quantized_decomposed.quantize_per_tensor.default
                             ),
                             ns.call_function(
-                                torch.ops.quantized_decomposed.dequantize_per_tensor
+                                torch.ops.quantized_decomposed.dequantize_per_tensor.default
                             ),
                         ]
                     self.checkGraphModuleNodes(


### PR DESCRIPTION
Summary:
Dynamo trace, via dynamo.export, with aten_graph, generates graph with nodes
whose target is an isntance of torch._ops.OpOverload. Quantization workflow
inserting quantize/dequantize ops which are sometimes instances of
torch._ops.OpOverload (quantize_per_tensor.tensor) while other times instances
of torch._ops.OpOverloadPacket (quantizer_per_tensor) is a bit inconsistent.

Also not sure if it is a valid exported model, if it has nodes with target
of type torch._ops.OpOverloadPacket.

Without op overload name attached to the 'target', it fails during executorch
tracing. Reason is that executorch tracing expects node's targets to be
instances of torch._ops.OpOverload and not torch._ops.OpOverloadPacket.

So for consistency and tracing reasons, fixing convert pass to insert ops which
are torch._ops.OpOverload

Test Plan: CI

Reviewed By: jerryzh168

Differential Revision: D46342822

