### PR TITLE
[PyTorch] add Vulkan support for `aten::repeat`

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Repeat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Repeat.cpp
@@ -1,0 +1,62 @@
+#include <ATen/native/vulkan/ops/Common.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/cat.h>
+#include <ATen/ops/unsqueeze.h>
+#endif
+
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor repeat(const Tensor& self, const IntArrayRef repeats) {
+  TORCH_CHECK(
+      self.dim() <= 4, "Vulkan repeat only supports tensors <= 4 dimensions");
+  auto in_ndims = safe_downcast<uint32_t>(self.dim());
+  auto out_ndims = safe_downcast<uint32_t>(repeats.size());
+  TORCH_CHECK(
+      out_ndims >= in_ndims,
+      "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor")
+  auto add_ndims = out_ndims - in_ndims;
+
+  at::Tensor tensor_to_repeat = self.clone();
+
+  for (const auto i : c10::irange(add_ndims)) {
+    (void)i;
+    tensor_to_repeat = at::unsqueeze(tensor_to_repeat, 0);
+  }
+
+  std::vector<at::Tensor> tensor_seq_to_concat;
+  for (const auto i : c10::irange(out_ndims)) {
+    for (const auto k : c10::irange(repeats[i])) {
+      (void)k;
+      tensor_seq_to_concat.emplace_back(tensor_to_repeat.clone());
+    }
+    tensor_to_repeat = at::cat(tensor_seq_to_concat, i);
+    tensor_seq_to_concat.clear();
+  }
+  return tensor_to_repeat;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::repeat"), TORCH_FN(repeat));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2771,6 +2771,84 @@ TEST_F(VulkanAPITest, reflection_pad2d) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, repeat_invalid_inputs_outputs_exceptions) {
+  // Arrange: Vulkan repeat only supports input of dims <= 4
+  {
+    const auto in_cpu =
+        at::rand({3, 9, 11, 7, 3}, at::device(at::kCPU).dtype(at::kFloat));
+    const at::IntArrayRef repeats = {5, 7, 3, 9, 2};
+
+    // Act
+    EXPECT_THROW(
+        { const auto out_vulkan = in_cpu.vulkan().repeat(repeats); },
+        ::c10::Error);
+  }
+
+  // Arrange: Number of dimensions of repeat dims can not be smaller than
+  // number of dimensions of tensor
+  {
+    const auto in_cpu =
+        at::rand({3, 5, 11, 13}, at::device(at::kCPU).dtype(at::kFloat));
+    const at::IntArrayRef repeats = {5, 7};
+
+    // Act
+    EXPECT_THROW(
+        { const auto out_vulkan = in_cpu.vulkan().repeat(repeats); },
+        ::c10::Error);
+  }
+
+  // Arrange: Vulkan repeat only supports output of dims <= 4
+  {
+    const auto in_cpu =
+        at::rand({3, 9, 11, 7}, at::device(at::kCPU).dtype(at::kFloat));
+    const at::IntArrayRef repeats = {5, 7, 3, 9, 2};
+
+    // Act
+    EXPECT_THROW(
+        { const auto out_vulkan = in_cpu.vulkan().repeat(repeats); },
+        ::c10::Error);
+  }
+}
+
+void test_repeat(
+    const at::IntArrayRef input_shape,
+    const at::IntArrayRef repeats) {
+  c10::InferenceMode mode;
+
+  at::Tensor in_cpu;
+  at::Tensor out_cpu;
+  at::Tensor in_vulkan;
+  at::Tensor out_vulkan;
+  at::IntArrayRef repeat;
+  bool check = true;
+  for (int idx_input = 1; (unsigned)idx_input < input_shape.size() + 1; ++idx_input) {
+    for (int idx_repeat = idx_input; (unsigned)idx_repeat < repeats.size() + 1;
+          ++idx_repeat) {
+      in_cpu = at::rand(
+          input_shape.slice(0, idx_input),
+          at::device(at::kCPU).dtype(at::kFloat));
+      repeat = repeats.slice(0, idx_repeat);
+      out_cpu = in_cpu.repeat(repeats);
+      in_vulkan = in_cpu.vulkan();
+      out_vulkan = in_vulkan.repeat(repeats);
+      bool local_check = almostEqual(out_cpu, out_vulkan.cpu());
+      if (!local_check) {
+        check = false;
+        std::cout << "Repeat test failed when input is of shape "
+                  << input_shape.slice(0, idx_input) << " and repeat of "
+                  << repeat << std::endl;
+        showRtol(out_cpu, out_vulkan.cpu());
+      }
+    }
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, repeat) {
+  test_repeat({13, 5, 13, 7}, {7, 2, 3, 5});
+}
+
 TEST_F(VulkanAPITest, replication_pad2d) {
   const auto a_cpu = at::rand({2, 3, 47, 63}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();


### PR DESCRIPTION
Summary: We implement `aten::repeat` on Vulkan backend through `aten::unsqueeze` and `aten::cat`. The behavior of `aten::repeat` is demonstrated here https://pytorch.org/docs/stable/generated/torch.Tensor.repeat.html

Test Plan:
`repeat_invalid_inputs_outputs_exceptions` check the following:
- if the input tensor has dim <= 4
- if the size of `repeats` is >= input.dim
- if the output tensor has dim <= 4

In `test_repeat` we check the following combinations: input is of dim between 1 and 4 and `repeats` is of size between `input.dim()` and 4. If a testcase failed, the shape info is printed, e.g. `Repeat test failed when input is of shape [13, 5, 13] and repeat of [7, 2, 3]`.

```
(base) luwei@luwei-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*repeat*"
Building: finished in 0.1 sec (100%) 263/2811 jobs, 0/2811 updated
  Total time: 0.1 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *repeat*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.repeat_invalid_inputs_outputs_exceptions
[       OK ] VulkanAPITest.repeat_invalid_inputs_outputs_exceptions (28 ms)
[ RUN      ] VulkanAPITest.repeat
[       OK ] VulkanAPITest.repeat (46 ms)
[----------] 2 tests from VulkanAPITest (75 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (75 ms total)
[  PASSED  ] 2 tests.
```

Reviewed By: yipjustin

Differential Revision: D46244750

