### PR TITLE
AOT Inductor load in python

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4,6 +4,7 @@ import functools
 import getpass
 import hashlib
 import importlib
+from importlib import abc
 import json
 import logging
 import multiprocessing
@@ -855,7 +856,7 @@ class CppWrapperCodeCache:
                     spec = importlib.util.spec_from_file_location(name, filepath)
                     assert spec is not None
                     mod = importlib.util.module_from_spec(spec)
-                    assert isinstance(spec.loader, importlib.abc.Loader)
+                    assert isinstance(spec.loader, abc.Loader)
                     spec.loader.exec_module(mod)
                     log.debug("Cpp wrapper done loading %s", filepath)
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -485,6 +485,8 @@ class WrapperCodeGen(CodeGen):
 
         self.add_benchmark_harness(result)
 
+        self.add_export_harness(result)
+
         return result.getvaluewithlinemap()
 
     def codegen_inputs(self, code: IndentedBuffer, graph_inputs: Dict[str, ir.Buffer]):
@@ -616,6 +618,15 @@ class WrapperCodeGen(CodeGen):
             output.writeline(
                 f"return print_performance(lambda: {call_str}, times=times, repeat=repeat)"
             )
+
+    def add_export_harness(self, output):
+        if not config.py_aot_export:
+            return 
+        
+        print("model saved")
+        output.writelines(["", "", '__all__ = ["call"]'])
+
+
 
     def add_benchmark_harness(self, output):
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -34,7 +34,10 @@ inplace_buffers = True
 allow_buffer_reuse = True
 
 # codegen benchmark harness
-benchmark_harness = True
+benchmark_harness = False
+
+# AOT export harness
+py_aot_export = True
 
 # fuse pointwise into templates
 epilogue_fusion = True


### PR DESCRIPTION
So now this works if you run your `model.py` with `TORCH_LOGS=output_code python model.py` it will print a `tmp/sdaoisdaosbdasd/something.py` which you can import like a module

Also need to set 'config.cpp_wrapper'

this just a draft PR to collect feedback, will work next on polishing the UX

```python
from model_aot import call
import torch
out = call(torch.randn(64,10))
print(out)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov