### PR TITLE
Enable test sparse allreduce basics Windows

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -693,7 +693,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 self.assertEqual(tensors, outputs)
                 self.assertEqual(result, outputs)
 
-    @skip_but_pass_in_sandcastle("intermittent failures on Windows, in CI")
     @requires_gloo()
     def test_sparse_allreduce_basics(self):
         self._test_sparse_allreduce_basics(lambda t: t)


### PR DESCRIPTION
The test was marked as flaky in #59965. However, it is not failing anymore so it can be enabled.

This PR enables only one test, but it will only run in local tests because the test suite is disabled in CI.

#94495 is a superset of this PR which enables the full test suite. The CI run there shows this test passing.

Fixes #59965