### PR TITLE
[Profiler][Easy] Add log msg to assertEqual for flaky test_memory_timeline_no_id

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1595,9 +1595,11 @@ class TestMemoryProfilerE2E(TestCase):
         if not torch.cuda.is_available():
             expected = expected[2:]
 
+        actual = [(action, size) for _, action, _, size in memory_profile.timeline]
         self.assertEqual(
-            [(action, size) for _, action, _, size in memory_profile.timeline],
+            actual,
             expected,
+            f"expected does not match actual: {actual}",
         )
 
 


### PR DESCRIPTION
Summary: Add msg to assertEqual field in the flaky test of test_memory_timeline_no_id, so that we print the actual tuple for debugging.

Test Plan: CI

Differential Revision: D46596242

Pulled By: aaronenyeshi

