### PR TITLE
Use size_t in THManagedMapAllocator

### DIFF
--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -66,9 +66,11 @@ static PyObject* THPStorage_pyNewFilenameStorage(
     PyObject* _unused,
     PyObject* args) {
   HANDLE_TH_ERRORS
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  long long size;
+  long long size = 0;
   if (!PyArg_ParseTuple(args, "L", &size)) {
+    return nullptr;
+  }
+  if (size < 0) {
     return nullptr;
   }
 
@@ -77,7 +79,8 @@ static PyObject* THPStorage_pyNewFilenameStorage(
   return THPStorage_New(c10::make_intrusive<at::StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
       size,
-      THManagedMapAllocator::makeDataPtr("", handle.c_str(), flags, size),
+      THManagedMapAllocator::makeDataPtr(
+          "", handle.c_str(), flags, static_cast<size_t>(size)),
       /*allocator=*/nullptr,
       /*resizable=*/false));
   END_HANDLE_TH_ERRORS
@@ -163,7 +166,7 @@ static PyObject* THPStorage_newSharedFilename(
   }
   const char* manager_handle = PyBytes_AS_STRING(_manager_handle);
   const char* object_handle = PyBytes_AS_STRING(_object_handle);
-  int64_t size = THPUtils_unpackLong(_size);
+  uint64_t size = THPUtils_unpackUInt64(_size);
   int flags = at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
   return THPStorage_New(c10::make_intrusive<at::StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
@@ -177,9 +180,11 @@ static PyObject* THPStorage_newSharedFilename(
 
 static PyObject* THPStorage_pyNewFdStorage(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  long long size;
+  long long size = 0;
   if (!PyArg_ParseTuple(args, "L", &size)) {
+    return nullptr;
+  }
+  if (size < 0) {
     return nullptr;
   }
   return THPStorage_New(at::new_shm_fd_storage(size));

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -120,7 +120,7 @@ THManagedMapAllocator::THManagedMapAllocator(
     const char* manager_handle,
     const char* filename,
     int flags,
-    ptrdiff_t size)
+    size_t size)
     : THManagedMapAllocatorInit(manager_handle, filename),
       at::RefcountedMapAllocator(filename, flags, size) {}
 
@@ -142,7 +142,7 @@ at::DataPtr THManagedMapAllocator::makeDataPtr(
     const char* manager_handle,
     const char* filename,
     int flags,
-    ptrdiff_t size) {
+    size_t size) {
   auto* context =
       new THManagedMapAllocator(manager_handle, filename, flags, size);
   return {

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -23,7 +23,7 @@ class THManagedMapAllocator : private THManagedMapAllocatorInit,
       const char* manager_handle,
       const char* filename,
       int flags,
-      ptrdiff_t size);
+      size_t size);
 
   void close() override;
 
@@ -35,7 +35,7 @@ class THManagedMapAllocator : private THManagedMapAllocatorInit,
       const char* manager_handle,
       const char* filename,
       int flags,
-      ptrdiff_t size);
+      size_t size);
   static THManagedMapAllocator* fromDataPtr(const at::DataPtr&);
 
   const char* manager_handle() const {

--- a/torch/lib/libshm_windows/core.cpp
+++ b/torch/lib/libshm_windows/core.cpp
@@ -14,7 +14,7 @@ at::DataPtr THManagedMapAllocator::makeDataPtr(
     const char* manager_handle,
     const char* filename,
     int flags,
-    ptrdiff_t size) {
+    size_t size) {
   auto* context =
       new THManagedMapAllocator(manager_handle, filename, flags, size);
   return {context->data(), context, &deleteTHManagedMapAllocator, at::kCPU};

--- a/torch/lib/libshm_windows/libshm.h
+++ b/torch/lib/libshm_windows/libshm.h
@@ -18,14 +18,14 @@ class SHM_API THManagedMapAllocator : public at::RefcountedMapAllocator {
       const char* manager_handle,
       const char* filename,
       int flags,
-      ptrdiff_t size)
+      size_t size)
       : at::RefcountedMapAllocator(filename, flags, size) {}
 
   static at::DataPtr makeDataPtr(
       const char* manager_handle,
       const char* filename,
       int flags,
-      ptrdiff_t size);
+      size_t size);
   static THManagedMapAllocator* fromDataPtr(const at::DataPtr&);
 
   const char* manager_handle() const {


### PR DESCRIPTION
When reviewing the source code, I found the ptrdiff_t size in THManagedMapAllocator::THManagedMapAllocator can be changed to size_t size to avoid unnecessary casts.