### PR TITLE
The static checks of the TransformerEncoder should consider ...

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -196,27 +196,28 @@ class TransformerEncoder(Module):
         self.use_nested_tensor = enable_nested_tensor
         self.mask_check = mask_check
 
-        first_layer = self.layers[0]
-        str_first_layer = "self.layers[0]"
-        why_not_sparsity_fast_path = ''
-        if not isinstance(first_layer, torch.nn.TransformerEncoderLayer):
-            why_not_sparsity_fast_path = f"{str_first_layer} was not TransformerEncoderLayer"
-        elif first_layer.norm_first :
-            why_not_sparsity_fast_path = f"{str_first_layer}.norm_first was True"
-        elif not first_layer.self_attn.batch_first:
-            why_not_sparsity_fast_path = f" {str_first_layer}.self_attn.batch_first was not True"
-        elif not first_layer.self_attn._qkv_same_embed_dim:
-            why_not_sparsity_fast_path = f"{str_first_layer}.self_attn._qkv_same_embed_dim was not True"
-        elif not first_layer.activation_relu_or_gelu:
-            why_not_sparsity_fast_path = f" {str_first_layer}.activation_relu_or_gelu was not True"
-        elif not (first_layer.norm1.eps == first_layer.norm2.eps) :
-            why_not_sparsity_fast_path = f"{str_first_layer}.norm1.eps was not equal to {str_first_layer}.norm2.eps"
-        elif first_layer.self_attn.num_heads % 2 == 1:
-            why_not_sparsity_fast_path = "num_head is odd"
+        if self.num_layers > 0:
+            first_layer = self.layers[0]
+            str_first_layer = "self.layers[0]"
+            why_not_sparsity_fast_path = ''
+            if not isinstance(first_layer, torch.nn.TransformerEncoderLayer):
+                why_not_sparsity_fast_path = f"{str_first_layer} was not TransformerEncoderLayer"
+            elif first_layer.norm_first :
+                why_not_sparsity_fast_path = f"{str_first_layer}.norm_first was True"
+            elif not first_layer.self_attn.batch_first:
+                why_not_sparsity_fast_path = f" {str_first_layer}.self_attn.batch_first was not True"
+            elif not first_layer.self_attn._qkv_same_embed_dim:
+                why_not_sparsity_fast_path = f"{str_first_layer}.self_attn._qkv_same_embed_dim was not True"
+            elif not first_layer.activation_relu_or_gelu:
+                why_not_sparsity_fast_path = f" {str_first_layer}.activation_relu_or_gelu was not True"
+            elif not (first_layer.norm1.eps == first_layer.norm2.eps) :
+                why_not_sparsity_fast_path = f"{str_first_layer}.norm1.eps was not equal to {str_first_layer}.norm2.eps"
+            elif first_layer.self_attn.num_heads % 2 == 1:
+                why_not_sparsity_fast_path = "num_head is odd"
 
-        if enable_nested_tensor and why_not_sparsity_fast_path:
-            warnings.warn(f"enable_nested_tensor is True, but self.use_nested_tensor is False because {why_not_sparsity_fast_path}")
-            self.use_nested_tensor = False
+            if enable_nested_tensor and why_not_sparsity_fast_path:
+                warnings.warn(f"enable_nested_tensor is True, but self.use_nested_tensor is False because {why_not_sparsity_fast_path}")
+                self.use_nested_tensor = False
 
 
     def forward(
@@ -261,59 +262,60 @@ class TransformerEncoder(Module):
 
         output = src
         convert_to_nested = False
-        first_layer = self.layers[0]
-        src_key_padding_mask_for_layers = src_key_padding_mask
-        why_not_sparsity_fast_path = ''
-        str_first_layer = "self.layers[0]"
-        if not hasattr(self, "use_nested_tensor"):
-            why_not_sparsity_fast_path = "use_nested_tensor attribute not present"
-        elif not self.use_nested_tensor:
-            why_not_sparsity_fast_path = "self.use_nested_tensor (set in init) was not True"
-        elif first_layer.training:
-            why_not_sparsity_fast_path = f"{str_first_layer} was in training mode"
-        elif not src.dim() == 3:
-            why_not_sparsity_fast_path = f"input not batched; expected src.dim() of 3 but got {src.dim()}"
-        elif src_key_padding_mask is None:
-            why_not_sparsity_fast_path = "src_key_padding_mask was None"
-        elif (((not hasattr(self, "mask_check")) or self.mask_check)
-                and not torch._nested_tensor_from_mask_left_aligned(src, src_key_padding_mask.logical_not())):
-            why_not_sparsity_fast_path = "mask_check enabled, and src and src_key_padding_mask was not left aligned"
-        elif output.is_nested:
-            why_not_sparsity_fast_path = "NestedTensor input is not supported"
-        elif mask is not None:
-            why_not_sparsity_fast_path = "src_key_padding_mask and mask were both supplied"
-        elif torch.is_autocast_enabled():
-            why_not_sparsity_fast_path = "autocast is enabled"
+        if self.num_layers > 0:
+            first_layer = self.layers[0]
+            src_key_padding_mask_for_layers = src_key_padding_mask
+            why_not_sparsity_fast_path = ''
+            str_first_layer = "self.layers[0]"
+            if not hasattr(self, "use_nested_tensor"):
+                why_not_sparsity_fast_path = "use_nested_tensor attribute not present"
+            elif not self.use_nested_tensor:
+                why_not_sparsity_fast_path = "self.use_nested_tensor (set in init) was not True"
+            elif first_layer.training:
+                why_not_sparsity_fast_path = f"{str_first_layer} was in training mode"
+            elif not src.dim() == 3:
+                why_not_sparsity_fast_path = f"input not batched; expected src.dim() of 3 but got {src.dim()}"
+            elif src_key_padding_mask is None:
+                why_not_sparsity_fast_path = "src_key_padding_mask was None"
+            elif (((not hasattr(self, "mask_check")) or self.mask_check)
+                    and not torch._nested_tensor_from_mask_left_aligned(src, src_key_padding_mask.logical_not())):
+                why_not_sparsity_fast_path = "mask_check enabled, and src and src_key_padding_mask was not left aligned"
+            elif output.is_nested:
+                why_not_sparsity_fast_path = "NestedTensor input is not supported"
+            elif mask is not None:
+                why_not_sparsity_fast_path = "src_key_padding_mask and mask were both supplied"
+            elif torch.is_autocast_enabled():
+                why_not_sparsity_fast_path = "autocast is enabled"
 
-        if not why_not_sparsity_fast_path:
-            tensor_args = (
-                src,
-                first_layer.self_attn.in_proj_weight,
-                first_layer.self_attn.in_proj_bias,
-                first_layer.self_attn.out_proj.weight,
-                first_layer.self_attn.out_proj.bias,
-                first_layer.norm1.weight,
-                first_layer.norm1.bias,
-                first_layer.norm2.weight,
-                first_layer.norm2.bias,
-                first_layer.linear1.weight,
-                first_layer.linear1.bias,
-                first_layer.linear2.weight,
-                first_layer.linear2.bias,
-            )
+            if not why_not_sparsity_fast_path:
+                tensor_args = (
+                    src,
+                    first_layer.self_attn.in_proj_weight,
+                    first_layer.self_attn.in_proj_bias,
+                    first_layer.self_attn.out_proj.weight,
+                    first_layer.self_attn.out_proj.bias,
+                    first_layer.norm1.weight,
+                    first_layer.norm1.bias,
+                    first_layer.norm2.weight,
+                    first_layer.norm2.bias,
+                    first_layer.linear1.weight,
+                    first_layer.linear1.bias,
+                    first_layer.linear2.weight,
+                    first_layer.linear2.bias,
+                )
 
-            if torch.overrides.has_torch_function(tensor_args):
-                why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not (src.is_cuda or 'cpu' in str(src.device)):
-                why_not_sparsity_fast_path = "src is neither CUDA nor CPU"
-            elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
-                why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
-                                              "input/output projection weights or biases requires_grad")
+                if torch.overrides.has_torch_function(tensor_args):
+                    why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
+                elif not (src.is_cuda or 'cpu' in str(src.device)):
+                    why_not_sparsity_fast_path = "src is neither CUDA nor CPU"
+                elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
+                    why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
+                                                "input/output projection weights or biases requires_grad")
 
-            if (not why_not_sparsity_fast_path) and (src_key_padding_mask is not None):
-                convert_to_nested = True
-                output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not(), mask_check=False)
-                src_key_padding_mask_for_layers = None
+                if (not why_not_sparsity_fast_path) and (src_key_padding_mask is not None):
+                    convert_to_nested = True
+                    output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not(), mask_check=False)
+                    src_key_padding_mask_for_layers = None
 
         # Prevent type refinement
         make_causal = (is_causal is True)

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -262,9 +262,9 @@ class TransformerEncoder(Module):
 
         output = src
         convert_to_nested = False
+        src_key_padding_mask_for_layers = src_key_padding_mask
         if self.num_layers > 0:
             first_layer = self.layers[0]
-            src_key_padding_mask_for_layers = src_key_padding_mask
             why_not_sparsity_fast_path = ''
             str_first_layer = "self.layers[0]"
             if not hasattr(self, "use_nested_tensor"):


### PR DESCRIPTION
**Transformer support num_encoder_layers=0 as PyTorch 1.6**

The static checks of the TransformerEncoder should consider num_layers to avoid IndexError.


The `Transformer` can be used to implement all the capabilities of the `TransformerEncoder` and `TransformerDecoder`. Therefore it is also possible to set the `Transformer` initialization parameter `num_encoder_layers` to `0`. In this case the current static check (`first_layer = self.layers[0]`) will throw an exception `IndexError: index 0 is out of range`. This pr is to fix this bug of out-of-bounds array access.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @bhosmer @cpuhrsch @erichan1 @drisspg