### PR TITLE
[c10d] register MTIA device type to c10d ops

### DIFF
--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -76,6 +76,7 @@ namespace ops {
 IMPL_SEND(CPU)
 IMPL_SEND(CUDA)
 IMPL_SEND(PrivateUse1)
+IMPL_SEND(MTIA)
 
 #define IMPL_RECV(DEV)                                                        \
   c10::intrusive_ptr<Work> recv_##DEV(                                        \
@@ -91,6 +92,7 @@ IMPL_SEND(PrivateUse1)
 IMPL_RECV(CPU)
 IMPL_RECV(CUDA)
 IMPL_RECV(PrivateUse1)
+IMPL_RECV(MTIA)
 
 #define IMPL_RECV_ANY_SOURCE(DEV)                            \
   c10::intrusive_ptr<Work> recv_any_source_##DEV(            \
@@ -105,6 +107,7 @@ IMPL_RECV(PrivateUse1)
 IMPL_RECV_ANY_SOURCE(CPU)
 IMPL_RECV_ANY_SOURCE(CUDA)
 IMPL_RECV_ANY_SOURCE(PrivateUse1)
+IMPL_RECV_ANY_SOURCE(MTIA)
 
 #define IMPL_REDUCE(DEV)                                     \
   c10::intrusive_ptr<Work> reduce_##DEV(                     \
@@ -128,6 +131,7 @@ IMPL_RECV_ANY_SOURCE(PrivateUse1)
 IMPL_REDUCE(CPU)
 IMPL_REDUCE(CUDA)
 IMPL_REDUCE(PrivateUse1)
+IMPL_REDUCE(MTIA)
 
 #define IMPL_BROADCAST(DEV)                                               \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>           \
@@ -152,6 +156,7 @@ IMPL_REDUCE(PrivateUse1)
 IMPL_BROADCAST(CPU)
 IMPL_BROADCAST(CUDA)
 IMPL_BROADCAST(PrivateUse1)
+IMPL_BROADCAST(MTIA)
 
 // Return input tensors as output tensors to make inplace allreduce look like
 // a functional API, so that make_fx can correctly build the dependencies in
@@ -177,6 +182,7 @@ IMPL_BROADCAST(PrivateUse1)
 IMPL_ALLREDUCE(CPU)
 IMPL_ALLREDUCE(CUDA)
 IMPL_ALLREDUCE(PrivateUse1)
+IMPL_ALLREDUCE(MTIA)
 
 #define IMPL_ALLREDUCE_COALESCED(DEV)                             \
   c10::intrusive_ptr<Work> allreduce_coalesced_##DEV(             \
@@ -195,6 +201,7 @@ IMPL_ALLREDUCE(PrivateUse1)
 IMPL_ALLREDUCE_COALESCED(CPU)
 IMPL_ALLREDUCE_COALESCED(CUDA)
 IMPL_ALLREDUCE_COALESCED(PrivateUse1)
+IMPL_ALLREDUCE_COALESCED(MTIA)
 
 // Copy output tensors (not storage) so that this can be used in a functional
 // manner
@@ -220,6 +227,7 @@ IMPL_ALLREDUCE_COALESCED(PrivateUse1)
 IMPL_ALLGATHER(CPU)
 IMPL_ALLGATHER(CUDA)
 IMPL_ALLGATHER(PrivateUse1)
+IMPL_ALLGATHER(MTIA)
 
 #define IMPL__ALLGATHER_BASE(DEV)                                         \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV( \
@@ -235,6 +243,7 @@ IMPL_ALLGATHER(PrivateUse1)
 IMPL__ALLGATHER_BASE(CPU)
 IMPL__ALLGATHER_BASE(CUDA)
 IMPL__ALLGATHER_BASE(PrivateUse1)
+IMPL__ALLGATHER_BASE(MTIA)
 
 #define IMPL_ALLGATHER_COALESCED(DEV)                                        \
   c10::intrusive_ptr<Work> allgather_coalesced_##DEV(                        \
@@ -251,6 +260,7 @@ IMPL__ALLGATHER_BASE(PrivateUse1)
 IMPL_ALLGATHER_COALESCED(CPU)
 IMPL_ALLGATHER_COALESCED(CUDA)
 IMPL_ALLGATHER_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_COALESCED(MTIA)
 
 #define IMPL_ALLGATHER_INTO_TENSOR_COALESCED(DEV)                       \
   c10::intrusive_ptr<c10d::Work> allgather_into_tensor_coalesced_##DEV( \
@@ -266,6 +276,7 @@ IMPL_ALLGATHER_COALESCED(PrivateUse1)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CPU)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CUDA)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_INTO_TENSOR_COALESCED(MTIA)
 
 #define IMPL_REDUCE_SCATTER(DEV)                                            \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>             \
@@ -291,6 +302,7 @@ IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
 IMPL_REDUCE_SCATTER(CPU)
 IMPL_REDUCE_SCATTER(CUDA)
 IMPL_REDUCE_SCATTER(PrivateUse1)
+IMPL_REDUCE_SCATTER(MTIA)
 
 #define IMPL__REDUCE_SCATTER_BASE(DEV)                                         \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_##DEV( \
@@ -313,6 +325,7 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
 IMPL__REDUCE_SCATTER_BASE(CPU)
 IMPL__REDUCE_SCATTER_BASE(CUDA)
 IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
+IMPL__REDUCE_SCATTER_BASE(MTIA)
 
 #define IMPL_GATHER(DEV)                                                       \
   c10::intrusive_ptr<Work> gather_##DEV(                                       \
@@ -332,6 +345,7 @@ IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
 IMPL_GATHER(CPU)
 IMPL_GATHER(CUDA)
 IMPL_GATHER(PrivateUse1)
+IMPL_GATHER(MTIA)
 
 #define IMPL_SCATTER(DEV)                                                      \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> scatter_##DEV( \
@@ -355,6 +369,7 @@ IMPL_GATHER(PrivateUse1)
 IMPL_SCATTER(CPU)
 IMPL_SCATTER(CUDA)
 IMPL_SCATTER(PrivateUse1)
+IMPL_SCATTER(MTIA)
 
 #define IMPL_ALLTOALL(DEV)                                                    \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>               \
@@ -377,6 +392,7 @@ IMPL_SCATTER(PrivateUse1)
 IMPL_ALLTOALL(CPU)
 IMPL_ALLTOALL(CUDA)
 IMPL_ALLTOALL(PrivateUse1)
+IMPL_ALLTOALL(MTIA)
 
 #define IMPL_ALLTOALL_BASE(DEV)                                   \
   c10::intrusive_ptr<Work> alltoall_base_##DEV(                   \
@@ -398,6 +414,7 @@ IMPL_ALLTOALL(PrivateUse1)
 IMPL_ALLTOALL_BASE(CPU)
 IMPL_ALLTOALL_BASE(CUDA)
 IMPL_ALLTOALL_BASE(PrivateUse1)
+IMPL_ALLTOALL_BASE(MTIA)
 
 #define IMPL_BARRIER(DEV)                                                    \
   c10::intrusive_ptr<Work> barrier##DEV(                                     \
@@ -413,6 +430,7 @@ IMPL_ALLTOALL_BASE(PrivateUse1)
 IMPL_BARRIER(CPU)
 IMPL_BARRIER(CUDA)
 IMPL_BARRIER(PrivateUse1)
+IMPL_BARRIER(MTIA)
 
 void monitored_barrier_CPU(
     at::Tensor /* unused */,
@@ -438,10 +456,11 @@ namespace {
   }
 
 // 1st level expansion
-#define REGISTER_C10D_OP(FUNC)  \
-  REGISTER_C10D_OP1(FUNC, CPU)  \
-  REGISTER_C10D_OP1(FUNC, CUDA) \
-  REGISTER_C10D_OP1(FUNC, PrivateUse1)
+#define REGISTER_C10D_OP(FUNC)          \
+  REGISTER_C10D_OP1(FUNC, CPU)          \
+  REGISTER_C10D_OP1(FUNC, CUDA)         \
+  REGISTER_C10D_OP1(FUNC, PrivateUse1)  \
+  REGISTER_C10D_OP1(FUNC, MTIA)
 
 // Now we start to register ops with the three device keys
 


### PR DESCRIPTION
Summary: register c10d ops for MTIA device type so c10d dispatch may use them if proper process group is implmenetated

Differential Revision: D46598888

