### PR TITLE
Fix bug in SplitCatSimplifier when next_user is an output node

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -413,6 +413,26 @@ class TestSplitCatFxPasses(TestCase):
 
             return cat1, stack1, relu1
 
+        def input_shuffling_direct_output(x):
+            split_output = list(torch.split(x, 4, dim=1))
+            cat1 = torch.cat(
+                [torch.ones(2, 4, 32, 16)]
+                + [split_output[1], split_output[2], split_output[3]]
+                + [torch.ones(2, 4, 32, 16)],
+                dim=2,
+            )
+            stack1 = torch.stack(
+                [
+                    torch.ones(2, 4, 32, 16),
+                    split_output[4],
+                    split_output[5],
+                    torch.ones(2, 4, 32, 16),
+                ],
+                dim=1,
+            )
+
+            return cat1, stack1, split_output[6]
+
         def input_shuffling_multiple_output_same_ranges(x):
             split_output = list(torch.split(x, 4, dim=1))
             cat1 = torch.cat(
@@ -533,6 +553,7 @@ class TestSplitCatFxPasses(TestCase):
             (input_shuffling_dim_mismatch, 1, 1, 1, 1, 4, default_args),
             (input_shuffling_dim_mismatch_stack, 1, 1, 1, 1, 4, default_args),
             (input_shuffling_multiple_output, 1, 1, 2, 2, 3, default_args),
+            (input_shuffling_direct_output, 1, 1, 2, 2, 3, default_args),
             (unequal_split_multiple_output, 1, 1, 2, 2, 3, default_args),
             (multi_split_cat, 2, 2, 4, 4, 3, multi_args),
         ]:

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -378,7 +378,7 @@ class SplitCatSimplifier:
         """
         node_input = []
         split_users = set(split_node.users.keys())
-        for node_arg in (*node.args, *node.kwargs.values()):
+        for node_arg in node.all_input_nodes:
             if node_arg in split_users:
                 getitem_num = get_arg_value(node_arg, 1)
                 node_input.append((getitem_num, getitem_num))
@@ -591,17 +591,11 @@ class SplitCatSimplifier:
                 # Change the args and kwargs of non-cat/stack nodes. Replace old getitems (belonging to
                 # the original split node) with the newer getitems
                 next_cat_input = 0
-                new_args = []
-                for arg_num, arg in enumerate(user_node.args):
-                    if arg in split_users:
-                        new_args.append(user_inputs_new[next_cat_input])
-                        next_cat_input += 1
-                    else:
-                        new_args.append(arg)
-                user_node.args = tuple(new_args)
-                for key, arg in user_node.kwargs.items():
-                    if arg in split_users:
-                        user_node.kwargs[key] = user_inputs_new[next_cat_input]
+                for input_node in user_node.all_input_nodes:
+                    if input_node in split_users:
+                        user_node.replace_input_with(
+                            input_node, user_inputs_new[next_cat_input]
+                        )
                         next_cat_input += 1
                 continue
 


### PR DESCRIPTION
Summary:
When simplifying split cat patterns, if next user of a split node was an output node, there was a bug leading to an issue like: P765993221

Basically, the bug was in how args and kwargs of the user were getting replaced, and the code didn't handle nested arg/kwargs.

Using torch.fx.Node functions such as `all_input_nodes` and `replace_input_with` fixes this issue

Differential Revision: D46603618



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @aakhundov @chenyang78