### PR TITLE
Revert "NCCL process group: avoid workEnqueue when capturing cuda graph (#102542)"

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -410,28 +410,6 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
             work.wait()
         torch.cuda.synchronize(local_device)
 
-    @requires_nccl()
-    @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")
-    def test_allreduce_in_cudagraph(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        pg = self._create_process_group_nccl(store, self.opts())
-        local_device_idx = self.rank_to_GPU[self.rank][0]
-
-        xs = [torch.FloatTensor([1]).cuda(local_device_idx)]
-        ys = [torch.FloatTensor([8]).cuda(local_device_idx)]
-
-        # single warmup
-        pg.allreduce(xs).wait()
-        self.assertEqual(2, xs[0].item())
-
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            pg.allreduce(xs).wait()
-        self.assertEqual(2, xs[0].item())
-
-        graph.replay()
-        graph.replay()
-        self.assertEqual(xs, ys)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")


### PR DESCRIPTION

This reverts commit 74a5d62d7ca9204b3b24137065c73fc7c66cc02d from PR https://github.com/pytorch/pytorch/pull/102542

That PR introduces a land race (see failure [here](https://hud.pytorch.org/pytorch/pytorch/commit/5aefa61d2ff198d2e4bef301bf2ee42ca4ff66d1)), and since it was exported from phabricator it cannot be reverted normally