### PR TITLE
[AOTAutograd] compare with stride hints

### DIFF
--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -238,6 +238,28 @@ class TestLayoutOptim(TestCase):
 
         self.verify_accuracy_for_infer(Model)
 
+    def test_dyanmic_shape_specialization(self):
+        """
+        Previously in aot_autograd.py we compare strides of FakeTensor
+        with real tensor. That cause dynamic dimensions of the FakeTensor
+        being specialized to static shapes. This test protects against that.
+        """
+
+        def f(a, b):
+            x = a.sin()
+            y = b.cos()
+            z = x + y
+            return z
+
+        for size in [4, 8, 16]:
+            a = torch.randn(2, size, requires_grad=True).cuda()
+            b = torch.randn(2, size).cuda()
+            actual = torch.compile(f, dynamic=True)(a, b)
+            self.assertTrue(torch.allclose(f(a, b), actual))
+
+            # Triger the compiling of the backward graph
+            actual.sum().backward()
+
 
 if __name__ == "__main__":
     if HAS_CUDA and not TEST_WITH_ROCM:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -663,6 +663,13 @@ def from_fun(t):
     torch._sync(t)
     return torch._from_functional_tensor(t)
 
+def _stride_equal(sizes, strides_lhs, strides_rhs):
+    for size, stride_lhs, stride_rhs in zip(sizes, strides_lhs, strides_rhs):
+        if size > 1 and stride_lhs != stride_rhs:
+            return False
+
+    return True
+
 def _get_hints(exprs):
     """
     Get the hints of a list/tuple of int/SymInt.
@@ -3051,7 +3058,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                         # Comparing ph_arg.stride() with real_arg.stride() directly may
                         # cause dynamic dimensions in ph_arg being specialized to static
                         # value. Using the hints to avoid that.
-                        if _get_hints(ph_arg.stride()) != real_arg.stride():
+                        if not _stride_equal(real_arg.size(), _get_hints(ph_arg.stride()), real_arg.stride()):
                             fill_order = _get_fill_order(real_arg.stride())
                             placeholder_list[i] = _apply_fill_order(ph_arg, fill_order)
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -699,7 +699,7 @@ def _apply_fill_order(ft: torch.Tensor, fill_order):
         new_strides[i] = next_stride
         next_stride = next_stride * sizes[i]
 
-    # convert sympy exprssion to SymInt
+    # convert sympy expression to SymInt
     for i, stride in enumerate(new_strides):
         if shape_env:
             new_strides[i] = shape_env.create_symintnode(new_strides[i], hint=None)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -354,6 +354,10 @@ class WrapperCodeGen(CodeGen):
         for name, buf in V.graph.graph_inputs.items():
             if isinstance(buf, sympy.Expr):
                 continue
+
+            # comparing strides for 0 size tensor is tricky. Ignore them for now.
+            if sympy_product(buf.get_size()) == 0:
+                continue
             size = self.codegen_shape_tuple(buf.get_size())
             stride = self.codegen_shape_tuple(buf.get_stride())
             self.prefix.writeline(f"assert_size_stride({name}, {size}, {stride})")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103342

We previously compare FakeTensor's strides with real tensor's strides. This cause dynamic dimension of FakeTensor being specialized to static int. This may cause a graph specialized for one shape being used by another shape which is wrong.

Use stride hints for the comparison instead.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @aakhundov