### PR TITLE
[Pytorch] aten::stack

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Stack.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Stack.cpp
@@ -1,4 +1,12 @@
 #include <ATen/native/vulkan/ops/Common.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/cat.h>
+#include <ATen/ops/unsqueeze.h>
+#endif
+
 #include <c10/util/irange.h>
 #include <torch/library.h>
 
@@ -10,87 +18,40 @@ namespace {
 
 using namespace api::utils;
 
-Tensor stack_feature(const TensorList tensors, vTensor& v_output) {
-  api::Context* const context = api::context();
-
-  uint32_t num_tensors = tensors.size();
-  for (const auto i : c10::irange(v_output.extents().data[2])) {
-    const vTensor& v_t0 = convert(
-        tensors[4 * i].is_vulkan() ? tensors[4 * i] : tensors[4 * i].vulkan());
-    const vTensor& v_t1 = 4 * i + 1 < num_tensors
-        ? convert(
-              tensors[4 * i + 1].is_vulkan() ? tensors[4 * i + 1]
-                                             : tensors[4 * i + 1].vulkan())
-        : v_t0;
-    const vTensor& v_t2 = 4 * i + 2 < num_tensors
-        ? convert(
-              tensors[4 * i + 2].is_vulkan() ? tensors[4 * i + 2]
-                                             : tensors[4 * i + 2].vulkan())
-        : v_t0;
-    const vTensor& v_t3 = 4 * i + 3 < num_tensors
-        ? convert(
-              tensors[4 * i + 3].is_vulkan() ? tensors[4 * i + 3]
-                                             : tensors[4 * i + 3].vulkan())
-        : v_t0;
-
-    const struct Block final {
-      uvec3 size; // output texture size
-      uint32_t z; // texel along the channel-batch dimension to copy data to
-    } block{v_output.extents(), i};
-
-    api::UniformParamsBuffer params(context, block);
-    api::PipelineBarrier pipeline_barrier{};
-
-    context->submit_compute_job(
-        // shader descriptor
-        VK_KERNEL(stack_feature),
-        // pipeline barrier
-        pipeline_barrier,
-        // global work group size
-        v_t0.extents(),
-        // local work group size
-        adaptive_work_group_size(v_t0.extents()),
-        // fence handle
-        VK_NULL_HANDLE,
-        // shader arguments
-        v_output.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE,
-            api::MemoryAccessType::WRITE),
-        v_t0.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-        v_t1.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-        v_t2.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-        v_t3.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-        // params buffer
-        params.buffer());
-  }
-
-  return convert(v_output);
-}
-
 Tensor stack(const at::TensorList tensors, const int64_t dim) {
   TORCH_CHECK(tensors.size() > 0, "Vulkan stack expects at least one tensor");
-  TORCH_CHECK(dim == 0, "Vulkan stack expects dim = 0");
-
   at::Tensor tensor = tensors[0];
+  TORCH_CHECK(
+      tensor.dim() >= 1 || tensor.dim() <= 3,
+      "Vulkan stack supports 1d, 2d, 3d tensors as input!");
+
+  TORCH_CHECK(
+      dim >= -tensor.dim() - 1 && dim <= tensor.dim(),
+      "Vulkan stack dimension out of range expected to be in range of [",
+      -tensor.dim() - 1,
+      ",",
+      tensor.dim(),
+      "], but got ",
+      dim);
 
   for (const auto& t : tensors) {
-    TORCH_CHECK(t.dim() == 2, "Vulkan stack expects 2 dimensional inputs");
-
     for (const auto d : c10::irange(t.dim())) {
       TORCH_CHECK(
           t.size(d) == tensor.size(d),
-          "Vulkan stack inputs must have matching sizes");
+          "Vulkan stack inputs must have matching sizes, received ",
+          t.size(d),
+          tensor.size(d));
     }
   }
 
-  uint32_t num_tensors = tensors.size();
-  std::vector<int64_t> output_sizes = {
-      num_tensors, tensor.size(0), tensor.size(1)};
-
-  vTensor v_output{api::context(), output_sizes, tensor.scalar_type()};
-
-  return stack_feature(tensors, v_output);
+  // Unsqueeze each tensor in the list
+  std::vector<Tensor> unsqueezed_outputs;
+  for (const auto& t : tensors) {
+    unsqueezed_outputs.push_back(at::unsqueeze(t, dim));
+  }
+  // Cat the tensors
+  const at::TensorList tensorList = unsqueezed_outputs;
+  return at::cat(tensorList, dim);
 }
 
 #ifdef USE_VULKAN_API

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -4903,22 +4903,6 @@ TEST_F(VulkanAPITest, stack_invalid_inputs) {
     at::stack({}, 0);
   }, ::c10::Error);
 
-  // Act: Vulkan stack expects dim = 0
-  EXPECT_THROW({
-    at::stack({
-        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
-        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
-        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()}, 1);
-  }, ::c10::Error);
-
-  // Act: Vulkan stack expects 2 dimensional inputs
-  EXPECT_THROW({
-    at::stack({
-        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
-        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
-        at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()}, 0);
-  }, ::c10::Error);
-
   // Act: Vulkan stack inputs must have matching sizes
   EXPECT_THROW({
     at::stack({
@@ -4928,97 +4912,54 @@ TEST_F(VulkanAPITest, stack_invalid_inputs) {
   }, ::c10::Error);
 }
 
-TEST_F(VulkanAPITest, stack_1_tensor) {
-  // Arrange
-  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-
-  // Act
-  const auto out_cpu = at::stack({in_cpu1}, 0);
-  const auto out_vulkan = at::stack({in_cpu1.vulkan()}, 0);
-
-  // Assert
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, stack_2_tensors) {
-  // Arrange
-  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-
-  // Act
-  const auto out_cpu = at::stack({in_cpu1, in_cpu2}, 0);
-  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan()}, 0);
-
-  // Assert
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, stack_3_tensors) {
-  // Arrange
-  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu3 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-
-  // Act
-  const auto out_cpu = at::stack({in_cpu1, in_cpu2, in_cpu3}, 0);
-  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
-
-  // Assert
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, stack_4_tensors) {
-  // Arrange
-  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu3 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-  const auto in_cpu4 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
-
-  // Act
-  const auto out_cpu = at::stack({in_cpu1, in_cpu2, in_cpu3, in_cpu4}, 0);
-  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan(), in_cpu4.vulkan()}, 0);
-
-  // Assert
-  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-  if (!check) {
-    showRtol(out_cpu, out_vulkan.cpu());
-  }
-
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, stack_from_1_to_20_tensors) {
+void test_stack(const at::IntArrayRef input_shape, int64_t dim, int numTensors) {
   std::vector<at::Tensor> tensors_cpu = {};
   std::vector<at::Tensor> tensors_vulkan = {};
 
-  for (const auto i : c10::irange(20)) {
-    at::Tensor in_cpu = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  for (int i = 0; i < numTensors; i++) {
+    at::Tensor in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
     tensors_cpu.emplace_back(in_cpu);
     tensors_vulkan.emplace_back(in_cpu.vulkan());
-    at::Tensor out_cpu = at::stack(tensors_cpu, 0);
-    at::Tensor out_vulkan = at::stack(tensors_vulkan, 0);
-    const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-    if (!check) {
-      std::cout << "Error when stacking " << i << " tensors" << std::endl;
-      showRtol(out_cpu, out_vulkan.cpu());
-    }
-    ASSERT_TRUE(check);
   }
+
+  at::Tensor out_cpu = at::stack(tensors_cpu, 0);
+  at::Tensor out_vulkan = at::stack(tensors_vulkan, 0);
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    std::cout << "Error when stacking " << numTensors << " tensors" << std::endl;
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, stack_1d) {
+  test_stack({221}, 0, 2);
+  test_stack({193}, 1, 3);
+
+  test_stack({221}, -1, 2);
+  test_stack({193}, -2, 3);
+}
+
+TEST_F(VulkanAPITest, stack_2d) {
+  test_stack({221, 193}, 0, 2);
+  test_stack({221, 193}, 1, 3);
+  test_stack({221, 193}, 2, 4);
+
+  test_stack({221, 193}, -1, 2);
+  test_stack({221, 193}, -2, 3);
+  test_stack({221, 193}, -3, 4);
+}
+
+TEST_F(VulkanAPITest, stack_3d) {
+  test_stack({221, 193, 11}, 0, 2);
+  test_stack({221, 193, 11}, 1, 3);
+  test_stack({221, 193, 11}, 2, 4);
+  test_stack({221, 193, 11}, 3, 5);
+
+  test_stack({221, 193, 11}, -1, 2);
+  test_stack({221, 193, 11}, -2, 3);
+  test_stack({221, 193, 11}, -3, 4);
+  test_stack({221, 193, 11}, -4, 5);
 }
 
 void test_zero_(const at::IntArrayRef input_shape) {


### PR DESCRIPTION
Summary:
Stack: https://pytorch.org/docs/stable/generated/torch.stack.html

This diff uses `at::unsqueeze` and `at::cat` to implement `at::stack` for all dims

Re-organize the tests to 1d, 2d, 3d tensors.

Test Plan:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*stack*"
Restarting Buck daemon because Buck version has changed...
Buck daemon started.
Parsing buck files: finished in 9.1 sec
Creating action graph: finished in 0.7 sec
Downloaded 54/3888 artifacts, 27.68 Mbytes, 97.3% cache miss (for updated rules)
Building: finished in 07:36.5 min (100%) 2487/2487 jobs, 2487/2487 updated
  Total time: 07:46.3 min
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *stack*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.stack_invalid_inputs
[       OK ] VulkanAPITest.stack_invalid_inputs (499 ms)
[ RUN      ] VulkanAPITest.stack_1d
[       OK ] VulkanAPITest.stack_1d (6 ms)
[ RUN      ] VulkanAPITest.stack_2d
[       OK ] VulkanAPITest.stack_2d (12 ms)
[ RUN      ] VulkanAPITest.stack_3d
[       OK ] VulkanAPITest.stack_3d (130 ms)
[----------] 4 tests from VulkanAPITest (649 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (649 ms total)
[  PASSED  ] 4 tests.
lfq@lfq-mbp fbsource %
```

Reviewed By: yipjustin

Differential Revision: D46178424

