### PR TITLE
[Inductor/cpp] Fix reduction on pre clang-10

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -177,19 +177,23 @@ def argmax_argmin_prefix(reduction_type, src_dtype, tmpvar):
     if reduction_type == "argmax":
         prefix.extend(
             [
-                f"#pragma omp declare reduction(argmax : struct {struct_name} :\\",
+                "#if !defined(__clang_major__) || __clang_major__ > 9",
+                f"#pragma omp declare reduction(argmax : {struct_name} :\\",
                 "    omp_out.value = omp_in.value < omp_out.value ? omp_out.value : omp_in.value,\\",
                 "    omp_out.index = omp_in.value < omp_out.value ? omp_out.index : omp_in.index)\\",
                 f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, src_dtype)}}})",
+                "#endif",
             ]
         )
     elif reduction_type == "argmin":
         prefix.extend(
             [
-                f"#pragma omp declare reduction(argmin : struct {struct_name} :\\",
+                "#if !defined(__clang_major__) || __clang_major__ > 9",
+                f"#pragma omp declare reduction(argmin : {struct_name} :\\",
                 "    omp_out.value = omp_in.value > omp_out.value ? omp_out.value : omp_in.value,\\",
                 "    omp_out.index = omp_in.value > omp_out.value ? omp_out.index : omp_in.index)\\",
                 f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, src_dtype)}}})",
+                "#endif",
             ]
         )
     return prefix


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103350
* #103349
* #103348
* __->__ #103347

`#pragma omp declare reduction` is not supported before clang-10 and results in a misleading compiler error in the following example:
```c++

template<typename T>
T max_propagate_nan(T, T);

extern "C" void cpp_fused_argmax_max_sum_0(const float* in_ptr0,
                       float* out_ptr0,
                       float* out_ptr1,
                       long* out_ptr2)
{
    float tmp_acc0 = 0;
    float tmp_acc1 = -std::numeric_limits<float>::infinity();
    float tmp_acc2 = std::numeric_limits<float>::infinity();
    struct IndexValue_7 {size_t index; float value;};
    IndexValue_7 tmp_acc3{0, -std::numeric_limits<float>::infinity()};
    #pragma omp declare reduction(argmax : IndexValue_7 :                omp_out.value = omp_in.value < omp_out.value ? omp_out.value : omp_in.value,                omp_out.index = omp_in.value < omp_out.value ? omp_out.index : omp_in.index)               initializer(omp_priv = {0, -std::numeric_limits<float>::infinity()})
    for(long i0=static_cast<long>(0L); i0<static_cast<long>(3L); i0+=static_cast<long>(1L))
    {
        auto tmp0 = in_ptr0[static_cast<long>(i0)];
        tmp_acc0 = tmp_acc0 + tmp0;
        tmp_acc1 = max_propagate_nan(tmp_acc1, tmp0);
        if (tmp_acc3.value < tmp0) {
            tmp_acc3.index = i0; tmp_acc3.value = tmp0;
        }
    }
    out_ptr0[static_cast<long>(0L)] = tmp_acc0;
    out_ptr1[static_cast<long>(0L)] = tmp_acc1;
    out_ptr2[static_cast<long>(0L)] = tmp_acc3.index;
}
```

```
% clang++-10 -std=c++17 -fopenmp bar.cpp  -c -O3
% clang++-9 -std=c++17 -fopenmp bar.cpp  -c -O3
bar.cpp:17:149: error: expected ')'
    #pragma omp declare reduction(argmax : IndexValue_7 :                omp_out.value = omp_in.value < omp_out.value ? omp_out.value : omp_in.value,                omp_out.index = omp_in.value < omp_out.value ? omp_out.index : omp_in.index)               initializer(omp_priv = {0, -std::numeric_limits<float>::infinity()})
                                                                                                                                                    ^
bar.cpp:17:34: note: to match this '('
    #pragma omp declare reduction(argmax : IndexValue_7 :                omp_out.value = omp_in.value < omp_out.value ? omp_out.value : omp_in.value,                omp_out.index = omp_in.value < omp_out.value ? omp_out.index : omp_in.index)               initializer(omp_priv = {0, -std::numeric_limits<float>::infinity()})
                                 ^
1 error generated.
```

Also, remove unnecessary `struct` keyword in front of type, as C++ compiler already assumes that (and again, it causes problem with clang++-10 implementation)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @aakhundov