### PR TITLE
Fix group norm mixed type error

### DIFF
--- a/aten/src/ATen/native/cpu/mixed_data_type.h
+++ b/aten/src/ATen/native/cpu/mixed_data_type.h
@@ -24,7 +24,7 @@ inline bool is_mixed_type(const Tensor& input, const Args&... parameters) {
 // when input is 'BFloat16' and parameters are 'Float'
 inline void check_mixed_data_type(const Tensor& input) {
   TORCH_CHECK(input.scalar_type() == ScalarType::BFloat16,
-      "mixed dtype (CPU): expect input to have scalar type of BFloat16");
+      "mixed dtype (CPU): all inputs must share same datatype.");
 }
 
 template <typename... Args>


### PR DESCRIPTION
Fixes #102922, adding a more descriptive error message when dealing with inputs that contain mixed types.

Would be happy to add a test (I believe in test_nn.py?), just want to confirm that this is the correct place to put it!

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @albanD 