### PR TITLE
[CI] Update inference accuracy test

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -426,8 +426,8 @@ test_dynamo_benchmark() {
   elif [[ "${TEST_CONFIG}" == *perf* ]]; then
     test_single_dynamo_benchmark "dashboard" "$suite" "$shard_id" "$@"
   else
-    # Check inference with --float32
-    test_single_dynamo_benchmark "inference" "$suite" "$shard_id" --inference --float32 "$@"
+    # Check inference with --amp
+    test_single_dynamo_benchmark "inference" "$suite" "$shard_id" --inference --amp "$@"
     if [[ "${TEST_CONFIG}" != *cpu_accuracy* ]]; then
       # Check training with --amp
       test_single_dynamo_benchmark "training" "$suite" "$shard_id" --training --amp "$@"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -426,10 +426,10 @@ test_dynamo_benchmark() {
   elif [[ "${TEST_CONFIG}" == *perf* ]]; then
     test_single_dynamo_benchmark "dashboard" "$suite" "$shard_id" "$@"
   else
-    # Check inference with --amp
-    test_single_dynamo_benchmark "inference" "$suite" "$shard_id" --inference --amp "$@"
-    if [[ "${TEST_CONFIG}" != *cpu_accuracy* ]]; then
-      # Check training with --amp
+    if [[ "${TEST_CONFIG}" == *cpu_accuracy* ]]; then
+      test_single_dynamo_benchmark "inference" "$suite" "$shard_id" --inference --float32 "$@"
+    else
+      test_single_dynamo_benchmark "inference" "$suite" "$shard_id" --inference --amp "$@"
       test_single_dynamo_benchmark "training" "$suite" "$shard_id" --training --amp "$@"
     fi
   fi

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_dynamic_inference.csv
@@ -5,7 +5,6 @@ AllenaiLongformerBase,pass,4
 BartForCausalLM,pass,0
 BertForMaskedLM,pass,0
 BertForQuestionAnswering,pass,0
-BlenderbotForCausalLM,pass_due_to_skip,0
 BlenderbotSmallForCausalLM,pass,0
 BlenderbotSmallForConditionalGeneration,pass,0
 CamemBert,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_dynamic_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_dynamic_training.csv
@@ -16,6 +16,7 @@ DistillGPT2,pass,6
 ElectraForCausalLM,pass,6
 ElectraForQuestionAnswering,pass,6
 GPT2ForSequenceClassification,pass,8
+GoogleFnet,pass,6
 LayoutLMForMaskedLM,pass,6
 LayoutLMForSequenceClassification,pass,8
 M2M100ForConditionalGeneration,pass,6

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_inference.csv
@@ -6,7 +6,6 @@ BartForCausalLM,pass,0
 BartForConditionalGeneration,pass,0
 BertForMaskedLM,pass,0
 BertForQuestionAnswering,pass,0
-BlenderbotForCausalLM,pass_due_to_skip,0
 BlenderbotSmallForCausalLM,pass,0
 BlenderbotSmallForConditionalGeneration,pass,0
 CamemBert,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
@@ -18,6 +18,7 @@ DistillGPT2,pass,6
 ElectraForCausalLM,pass,6
 ElectraForQuestionAnswering,pass,6
 GPT2ForSequenceClassification,pass,8
+GoogleFnet,pass,6
 LayoutLMForMaskedLM,pass,6
 LayoutLMForSequenceClassification,pass,8
 M2M100ForConditionalGeneration,fail_accuracy,6

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -13,7 +13,7 @@ cm3leon_generate,pass,6
 dcgan,pass,0
 dlrm,pass,0
 doctr_det_predictor,pass,4
-doctr_reco_predictor,pass,4
+doctr_reco_predictor,fail_accuracy,4
 drq,pass,0
 fastNLP_Bert,pass,5
 functorch_dp_cifar10,pass,0
@@ -25,7 +25,7 @@ hf_Bert_large,pass,0
 hf_DistilBert,pass,0
 hf_GPT2,pass,0
 hf_Reformer,pass,27
-hf_T5_generate,pass,49
+hf_T5_generate,pass,57
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,0
 llama,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -13,7 +13,7 @@ cm3leon_generate,pass,67
 dcgan,pass,0
 dlrm,pass,0
 doctr_det_predictor,pass,4
-doctr_reco_predictor,pass,4
+doctr_reco_predictor,fail_accuracy,4
 drq,pass,0
 fastNLP_Bert,pass,5
 functorch_dp_cifar10,pass,0
@@ -25,7 +25,7 @@ hf_Bert_large,pass,0
 hf_DistilBert,pass,0
 hf_GPT2,pass,0
 hf_Reformer,pass,27
-hf_T5_generate,pass,49
+hf_T5_generate,pass,179
 hf_T5_large,pass_due_to_skip,0
 lennard_jones,pass,0
 llama,pass,0
@@ -59,5 +59,5 @@ timm_vision_transformer_large,pass_due_to_skip,0
 timm_vovnet,pass,0
 tts_angular,pass,2
 vgg16,pass,0
-vision_maskrcnn,pass,124
+vision_maskrcnn,fail_accuracy,124
 yolov3,pass,2

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1150,6 +1150,9 @@ class BenchmarkRunner:
         self._args = None
 
     def setup_amp(self):
+        if self.args.only in self.fp32_only_models:
+            return
+
         if self.args.amp and self.args.devices == ["cuda"]:
             # AMP training can lead to small loss values which can undeflow
             # gradient values returning in zero gradients. To solve this
@@ -1215,11 +1218,11 @@ class BenchmarkRunner:
         return set()
 
     @property
-    def skip_not_suitable_for_training_models(self):
+    def fp32_only_models(self):
         return set()
 
     @property
-    def failing_torchinductor_models(self):
+    def skip_not_suitable_for_training_models(self):
         return set()
 
     @property
@@ -2457,25 +2460,6 @@ def run(runner, args, original_dir=None):
         runner.skip_models.update(runner.skip_models_for_cpu)
     elif args.devices == ["cuda"]:
         runner.skip_models.update(runner.skip_models_for_cuda)
-
-    if args.inductor or args.inductor_settings:
-        runner.skip_models.update(runner.failing_torchinductor_models)
-        if args.float16:
-            # TODO(jansel): check if correctness issue is real
-            runner.skip_models.add("yolov3")
-
-    if args.float16:
-        # these give `INCORRECT - Variation in Eager runs itself` sometimes
-        runner.non_deterministic_models.update(
-            {
-                "demucs",
-                "pyhpc_equation_of_state",
-                "timm_efficientdet",
-                "pyhpc_isoneutral_mixing",
-                "pyhpc_turbulent_kinetic_energy",
-                "shufflenet_v2_x1_0",
-            }
-        )
 
     if args.no_skip:
         runner.skip_models.clear()

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1226,6 +1226,10 @@ class BenchmarkRunner:
         return set()
 
     @property
+    def failing_torchinductor_models(self):
+        return set()
+
+    @property
     def failing_fx2trt_models(self):
         return set()
 

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -179,6 +179,10 @@ ONLY_EVAL_MODE = {
     "M2M100ForConditionalGeneration",  # Fails with dynamo for train mode
 }
 
+FP32_ONLY_MODELS = {
+    "GoogleFnet",
+}
+
 
 def get_module_cls_by_model_name(model_cls_name):
     _module_by_model_name = {
@@ -402,6 +406,10 @@ class HuggingfaceRunner(BenchmarkRunner):
     @property
     def skip_models_for_cpu(self):
         return SKIP_FOR_CPU
+
+    @property
+    def fp32_only_models(self):
+        return FP32_ONLY_MODELS
 
     def _get_model_cls_and_config(self, model_name):
         if model_name not in EXTRA_MODELS:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103361

Summary:
1) Switch inference accuracy test from fp32 to amp (consistent with dashboard run, https://github.com/pytorch/pytorch/pull/103220)
2) GoogleFnet fails in eager with amp or fp16, so fallback to always using fp32.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @aakhundov