### PR TITLE
add default argument device type api

### DIFF
--- a/aten/src/ATen/templates/RegisterBackendSelect.cpp
+++ b/aten/src/ATen/templates/RegisterBackendSelect.cpp
@@ -29,13 +29,15 @@ bool is_pinned(const Tensor& self, c10::optional<at::Device> device) {
     return false;
   }
   // TODO: fetch scalar type from Tensor? But it doesn't really matter...
-  DispatchKeySet _dk = c10::DispatchKeySet(c10::computeDispatchKey(c10::nullopt, self.layout(), device.value_or(at::kCUDA)));
+  DispatchKeySet _dk = c10::DispatchKeySet(c10::computeDispatchKey(c10::nullopt, self.layout(),
+      device.value_or(c10::get_default_argument_device_type())));
   return at::_ops::is_pinned::redispatch(_dk, self, device);
 }
 
 at::Tensor _pin_memory(const Tensor& self, c10::optional<at::Device> device) {
   TORCH_CHECK(self.device().is_cpu(), "cannot pin '", self.toString(), "' only dense CPU tensors can be pinned");
-  DispatchKeySet _dk = c10::DispatchKeySet(c10::computeDispatchKey(c10::nullopt, self.layout(), device.value_or(at::kCUDA)));
+  DispatchKeySet _dk = c10::DispatchKeySet(c10::computeDispatchKey(c10::nullopt, self.layout(),
+      device.value_or(c10::get_default_argument_device_type())));
   return at::_ops::_pin_memory::redispatch(_dk, self, device);
 }
 

--- a/c10/core/DefaultDevice.cpp
+++ b/c10/core/DefaultDevice.cpp
@@ -1,0 +1,22 @@
+#include <c10/core/DefaultDevice.h>
+
+namespace c10 {
+
+// For many operators(such as pin_memory), the device argument is `cuda` if
+// not given; but for other device, we must have to give extra argument
+// `device_type` comparing to `cuda`, so we add an API to set the default
+// argument device just once at the begining to keep usage consistent with
+// `cuda`.
+static c10::DeviceType default_argument_device_type = c10::DeviceType::CUDA;
+
+void set_default_argument_device_type(c10::DeviceType device_type) {
+  TORCH_CHECK(
+      device_type != c10::DeviceType::CPU,
+      "only device type except cpu is supported as default argument device.");
+  default_argument_device_type = device_type;
+}
+
+c10::DeviceType get_default_argument_device_type() {
+  return default_argument_device_type;
+}
+} // namespace c10

--- a/c10/core/DefaultDevice.h
+++ b/c10/core/DefaultDevice.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <c10/core/Device.h>
+#include <c10/macros/Export.h>
+
+namespace c10 {
+C10_API void set_default_argument_device_type(c10::DeviceType device_type);
+C10_API c10::DeviceType get_default_argument_device_type();
+} // namespace c10

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/Backend.h>
+#include <c10/core/DefaultDevice.h>
 #include <c10/core/DefaultDtype.h>
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -385,6 +385,15 @@ class TestCppExtensionOpenRgistration(common.TestCase):
                 b = torch.empty(1, device="foo:0")
                 result = a + b
 
+        def test_open_device_default_argument_device():
+            torch.utils.rename_privateuse1_backend('foo')
+            try:
+                self.assertEqual(torch._C._get_default_argument_device(), "cuda")
+                torch._C._set_default_argument_device_type("foo")
+                self.assertEqual(torch._C._get_default_argument_device(), "foo")
+            finally:
+                torch._C._set_default_argument_device_type("cuda")
+
         test_base_device_registration()
         test_before_common_registration()
         test_common_registration()
@@ -399,6 +408,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_open_device_storage_resize()
         test_open_device_storage_type()
         test_open_device_faketensor()
+        test_open_device_default_argument_device()
 
 
 if __name__ == "__main__":

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -975,6 +975,8 @@ def _add_docstr(obj: T, doc_obj: str) -> T: ...  # THPModule_addDocStr
 def _init_names(arg: Sequence[Type]) -> None: ...  # THPModule_initNames
 def _has_distributed() -> _bool: ...  # THPModule_hasDistributed
 def _set_default_tensor_type(type) -> None: ...  # THPModule_setDefaultTensorType
+def _set_default_argument_device_type(type: str) -> None: ...  # THPModule_setDefaultArgumentDeviceType
+def _get_default_argument_device() -> str: ...  # THPModule_getDefaultArgumentDevice
 def _set_default_dtype(d: _dtype) -> None: ...  # THPModule_setDefaultDtype
 def _infer_size(arg1: Size, arg2: Size) -> Size: ...  # THPModule_inferSize
 def _crash_if_csrc_asan() -> _int: ...  # THPModule_crashIfCsrcASAN

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -285,6 +285,24 @@ PyObject* THPModule_setDefaultDtype(PyObject* _unused, PyObject* dtype) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPModule_setDefaultArgumentDeviceType(
+    PyObject* _unused,
+    PyObject* device_type) {
+  HANDLE_TH_ERRORS
+  torch::tensors::py_set_default_argument_device_type(device_type);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THPModule_getDefaultArgumentDevice(
+    PyObject* _unused,
+    PyObject* device_type) {
+  HANDLE_TH_ERRORS
+  return THPUtils_packString(c10::DeviceTypeName(
+      torch::tensors::py_get_default_argument_device_type(), true));
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
   // adds a __doc__ string to a function, similar to numpy's arr_add_docstring
   static std::vector<std::string> all_docs;
@@ -1037,6 +1055,14 @@ static PyMethodDef TorchMethods[] = {
      METH_O,
      nullptr},
     {"_set_default_dtype", THPModule_setDefaultDtype, METH_O, nullptr},
+    {"_set_default_argument_device_type",
+     THPModule_setDefaultArgumentDeviceType,
+     METH_O,
+     nullptr},
+    {"_get_default_argument_device",
+     THPModule_getDefaultArgumentDevice,
+     METH_NOARGS,
+     nullptr},
     {"_infer_size", THPModule_inferSize, METH_VARARGS, nullptr},
     {"_crash_if_csrc_asan", THPModule_crashIfCsrcASAN, METH_O, nullptr},
     {"_crash_if_csrc_ubsan", THPModule_crashIfCsrcUBSAN, METH_O, nullptr},

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -469,6 +469,21 @@ void py_set_default_dtype(PyObject* obj) {
   set_default_tensor_type(/*backend=*/c10::nullopt, scalar_type);
 }
 
+void py_set_default_argument_device_type(PyObject* obj) {
+  TORCH_CHECK_TYPE(
+      THPUtils_checkString(obj),
+      "invalid device string, only device type except cpu is supported as default argument device.");
+  auto device_type = at::Device(THPUtils_unpackString((obj))).type();
+  TORCH_CHECK(
+      device_type != c10::DeviceType::CPU,
+      "only device type except cpu is supported as default argument device.");
+  at::set_default_argument_device_type(device_type);
+}
+
+c10::DeviceType py_get_default_argument_device_type() {
+  return at::get_default_argument_device_type();
+}
+
 c10::DispatchKey get_default_dispatch_key() {
   return backendToDispatchKey(default_backend);
 }

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/core/DefaultDevice.h>
 #include <c10/core/Device.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/core/ScalarType.h>
@@ -21,6 +22,13 @@ void py_set_default_tensor_type(PyObject* type_obj);
 
 // Same as py_set_default_tensor_type, but only changes the dtype (ScalarType).
 void py_set_default_dtype(PyObject* dtype_obj);
+
+// set default backend argument for operators if not given device argument,
+// cannot be `cpu`.
+void py_set_default_argument_device_type(PyObject* device_obj);
+
+// get default backend argument for operators if not given device argument.
+c10::DeviceType py_get_default_argument_device_type();
 
 // Gets the DispatchKey for the default tensor type.
 //

--- a/torch/random.py
+++ b/torch/random.py
@@ -101,7 +101,7 @@ _fork_rng_warned_already = False
 
 
 @contextlib.contextmanager
-def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices", device_type="cuda") -> Generator:
+def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices", device_type=None) -> Generator:
     """
     Forks the RNG, so that when you return, the RNG is reset
     to the state that it was previously in.
@@ -118,7 +118,8 @@ def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="device
         deivce(str): device type str, default is `cuda`. As for custom device,
             see details in [Note: support the custom device with privateuse1]
     """
-
+    if device_type is None:
+        device_type = torch._C._get_default_argument_device()
     device_type = torch.device(device_type).type
     device_mod = getattr(torch, device_type, None)
     if device_mod is None:


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1、For many operators(such as pin_memory), the device argument is `cuda` if not given; but for other device, we must have to give extra argument `device_type` comparing to `cuda`, so we add an API to set the default argument device just once at the begining to keep usage consistent with `cuda`.
2、And there are some API defined in Python, we add a argument named `device_type` and the default value is `cuda`, so that  we could support more device (privateuse1 device). So we use the this api to get the default device  to keep usage consistent with `cuda` if not gived `device_type`.