### PR TITLE
[Not for review] [RFC / Discussion PR] Least amount of code to trace into FSDP w/ graph breaks

### DIFF
--- a/fsdp.py
+++ b/fsdp.py
@@ -1,0 +1,62 @@
+"""
+torchrun --standalone --nproc_per_node=2 test_basic.py
+"""
+import os
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch._dynamo
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+def init():
+    torch.manual_seed(0)
+    fsdp_kwargs = {
+        "use_orig_params": True,
+        "auto_wrap_policy": ModuleWrapPolicy({nn.Linear}),
+    }
+    model = nn.Sequential(
+        nn.Linear(3, 3, device="cuda"), nn.ReLU(), nn.Linear(3, 3, device="cuda")
+    )
+    model = FSDP(
+        model,
+        **fsdp_kwargs,
+    )
+    # TODO: Add `model = torch.compile(model)` here if desired
+    optim = torch.optim.SGD(model.parameters(), lr=1e-3)
+    return model, optim
+
+def printing_eager(gm, inputs):
+    gm.graph.print_tabular()
+    return gm.forward
+
+def run(model, optim):
+    losses = []
+    torch.manual_seed(dist.get_rank() + 1)
+    inp = torch.randn((2, 3), device="cuda")
+    # torch._dynamo.optimize(printing_eager)(model)(inp)
+    explain = torch._dynamo.explain(model, inp)
+    print(explain)
+    for g in explain.graphs:
+        g.graph.print_tabular()
+    for i, gb in enumerate(explain.break_reasons):
+        print(f"{i}. {gb}")
+    # for _ in range(3):
+    #     optim.zero_grad(set_to_none=True)
+    #     inp = torch.randn((2, 3), device="cuda")
+    #     out = model(inp)
+    #     loss = out.sum()
+    #     losses.append(loss)
+    #     loss.backward()
+    #     optim.step()
+    return losses
+
+def main():
+    dist.init_process_group(backend="nccl")
+    gpu_id = int(os.environ["LOCAL_RANK"])
+    device = f"cuda:{gpu_id}"
+    torch.cuda.set_device(device)
+    model, optim = init()
+    run(model, optim)
+
+if __name__ == "__main__":
+    main()

--- a/test/dynamo/test_tensor_subclass.py
+++ b/test/dynamo/test_tensor_subclass.py
@@ -1,0 +1,207 @@
+# Owner(s): ["module: dynamo"]
+"""
+PYTEST_DONT_REWRITE (prevents pytest from rewriting assertions, which interferes
+with test_export_persist_assert)
+"""
+
+import torch
+import torch._dynamo
+import torch._dynamo.test_case
+import torch._dynamo.testing
+from torch._dynamo.testing import CompileCounter
+
+
+class TensorSubclassTests(torch._dynamo.test_case.TestCase):
+    def test_tensor_property_on_tensor(self):
+        def fn(x):
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+        y_ = torch.randn([2, 2])
+        x_.y = y_
+
+        eager_result = fn(x_)
+
+        graph = None
+
+        def grab_graph_backend(gm, inps):
+            nonlocal graph
+            graph = gm
+            return gm
+
+        fn = torch._dynamo.optimize(grab_graph_backend, nopython=True)(fn)
+        compile_result = fn(x_)
+        self.assertEqual(eager_result, compile_result)
+
+        placeholder_cnt = 0
+        for node in graph.graph.nodes:
+            if node.op == "placeholder":
+                placeholder_cnt += 1
+
+        # We want to be very sure that this lifts y to inputs!
+        self.assertEqual(placeholder_cnt, 2)
+
+    def test_tensor_property_assigned_on_tensor(self):
+        def fn(x, y):
+            x.y = y
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+        y_ = torch.randn([2, 2])
+
+        eager_result = fn(x_, y_)
+
+        graph = None
+
+        def grab_graph_backend(gm, inps):
+            nonlocal graph
+            graph = gm
+            return gm
+
+        fn = torch._dynamo.optimize(grab_graph_backend, nopython=True)(fn)
+        compile_result = fn(x_, y_)
+        self.assertEqual(eager_result, compile_result)
+
+        placeholder_cnt = 0
+        for node in graph.graph.nodes:
+            if node.op == "placeholder":
+                placeholder_cnt += 1
+
+        # y is already an input
+        self.assertEqual(placeholder_cnt, 2)
+
+    def test_const_property_on_tensor(self):
+        def fn(x):
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+        y_ = 4
+        x_.y = y_
+
+        eager_result = fn(x_)
+
+        graph = None
+
+        def grab_graph_backend(gm, inps):
+            nonlocal graph
+            graph = gm
+            return gm
+
+        fn = torch._dynamo.optimize(grab_graph_backend, nopython=True)(fn)
+        compile_result = fn(x_)
+        self.assertEqual(eager_result, compile_result)
+
+        placeholder_cnt = 0
+        for node in graph.graph.nodes:
+            if node.op == "placeholder":
+                placeholder_cnt += 1
+
+        # We want to be very sure that this does not lifts y to inputs, as its a const
+        self.assertEqual(placeholder_cnt, 1)
+
+    def test_const_property_assigned_on_tensor(self):
+        def fn(x, y):
+            x.y = y
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+        y_ = 4
+
+        eager_result = fn(x_, y_)
+
+        fn = torch._dynamo.optimize("eager", nopython=True)(fn)
+        compile_result = fn(x_, y_)
+        self.assertEqual(eager_result, compile_result)
+
+    def test_guards_correctly_property_assigned_on_tensor_type_change(self):
+        def fn(x, y):
+            x.y = y
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+
+        fn = torch._dynamo.optimize("eager", nopython=True)(fn)
+        compile_result_const = fn(x_, 4)
+        self.assertEqual(compile_result_const, x_ * 4)
+
+        y = torch.randn([2, 2])
+        compile_result_tensor = fn(x_, y)
+        self.assertEqual(compile_result_tensor, x_ * y)
+
+    def test_guards_correctly_property_assigned_on_tensor_type_change_inductor(self):
+        def fn(x, y):
+            x.y = y
+            return x * x.y
+
+        x_ = torch.randn([2, 2])
+
+        fn = torch._dynamo.optimize("inductor", nopython=True)(fn)
+        compile_result_const = fn(x_, 4)
+        self.assertEqual(compile_result_const, x_ * 4)
+
+        y = torch.randn([2, 2])
+        compile_result_tensor = fn(x_, y)
+        self.assertEqual(compile_result_tensor, x_ * y)
+
+    def test_complex_attr_access_with_graph_breaks(self):
+        def fn(x, y, z):
+            for t in x:
+                t.y = y
+                t.z = y * z
+
+            print("Break")
+
+            new_y = 1
+            new_z = 1
+            for t in x:
+                new_y = t.y * new_y
+                new_z = t.z * new_z
+
+            return new_y, new_z
+
+        x_0 = torch.randn([2, 2])
+        x_1 = torch.randn([2, 2])
+        x_2 = torch.randn([2, 2])
+        x = [x_0, x_1, x_2]
+
+        y = torch.randn([2, 2])
+        z = 5
+
+        eager_result = fn(x, y, z)
+
+        counter = CompileCounter()
+        fn = torch._dynamo.optimize(counter)(fn)
+
+        compile_result = fn(x, y, z)
+        self.assertEqual(compile_result, eager_result)
+        self.assertEqual(counter.frame_count, 2)
+        self.assertEqual(counter.op_count, 9)
+        # Graph for reference
+        # <eval_with_key>.1 class GraphModule(torch.nn.Module):
+        # def forward(self, L_x_0_dict_y_ : torch.Tensor, L_x_0_dict_z_ : torch.Tensor, L_x_1_dict_y_ :
+        # torch.Tensor, L_x_1_dict_z_ : torch.Tensor, L_x_2_dict_y_ : torch.Tensor, L_x_2_dict_z_ : torch.Tensor):
+        #     l_x_0_dict_y_ = L_x_0_dict_y_
+        #     l_x_0_dict_z_ = L_x_0_dict_z_
+        #     l_x_1_dict_y_ = L_x_1_dict_y_
+        #     l_x_1_dict_z_ = L_x_1_dict_z_
+        #     l_x_2_dict_y_ = L_x_2_dict_y_
+        #     l_x_2_dict_z_ = L_x_2_dict_z_
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:158, code: new_y = t.y * new_y
+        #     mul = l_x_0_dict_y_ * 1;  l_x_0_dict_y_ = None
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:159, code: new_z = t.z * new_z
+        #     mul_1 = l_x_0_dict_z_ * 1;  l_x_0_dict_z_ = None
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:158, code: new_y = t.y * new_y
+        #     mul_2 = l_x_1_dict_y_ * mul;  l_x_1_dict_y_ = mul = None
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:159, code: new_z = t.z * new_z
+        #     mul_3 = l_x_1_dict_z_ * mul_1;  l_x_1_dict_z_ = mul_1 = None
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:158, code: new_y = t.y * new_y
+        #     mul_4 = l_x_2_dict_y_ * mul_2;  l_x_2_dict_y_ = mul_2 = None
+
+        #     # File: /scratch/voz/work/pytorch/test/dynamo/test_tensor_subclass.py:159, code: new_z = t.z * new_z
+        #     mul_5 = l_x_2_dict_z_ * mul_3;  l_x_2_dict_z_ = mul_3 = None
+        #     return (mul_4, mul_5)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -32,6 +32,8 @@ import weakref
 
 import torch
 import torch._inductor.test_operators
+import torch.distributed.fsdp
+import torch.distributed.utils
 import torch.utils._content_store
 
 from . import comptime, config, external_utils
@@ -110,6 +112,7 @@ FILENAME_ALLOWLIST = {
     torch.set_rng_state.__code__.co_filename,
     torch._inductor.test_operators.__file__,
     torch.utils._content_store.__file__,
+    torch.distributed.fsdp.__file__,
     # These are dynamo files!
     external_utils.__file__,
     comptime.__file__,  # Want to inline these helpers
@@ -123,6 +126,68 @@ FILENAME_ALLOWLIST |= {
 }
 FILENAME_ALLOWLIST |= {torch.optim._functional.__file__}
 FILENAME_ALLOWLIST |= {torch.utils._foreach_utils.__file__}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp.__dict__.values()
+    if inspect.isclass(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp._runtime_utils.__dict__.values()
+    if inspect.isfunction(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp._utils.__dict__.values()
+    if inspect.isclass(obj) or inspect.isfunction(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp._exec_order_utils.__dict__.values()
+    if inspect.isclass(obj)
+}
+
+import torch.nn.parallel.scatter_gather
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.nn.parallel.scatter_gather.__dict__.values()
+    if inspect.isclass(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.utils.__dict__.values()
+    if inspect.isclass(obj) or inspect.isfunction(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed._composable_state.__dict__.values()
+    if inspect.isclass(obj) or inspect.isfunction(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp._fsdp_extensions.__dict__.values()
+    if inspect.isclass(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed.fsdp._traversal_utils.__dict__.values()
+    if inspect.isclass(obj) or inspect.isfunction(obj)
+}
+
+FILENAME_ALLOWLIST |= {
+    inspect.getfile(obj)
+    for obj in torch.distributed._composable.contract.__dict__.values()
+    if inspect.isclass(obj) or inspect.isfunction(obj)
+}
 
 # Do trace through match and replace patterns used in PT2E QAT
 # Note: These patterns are comprised of torch ops and for internal use only.

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1281,7 +1281,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         for k, v in zip(items[::2], items[1::2]):
             assert isinstance(k, (ConstantVariable, EnumVariable, BuiltinVariable)) or (
                 isinstance(k, TensorVariable) and k.specialized_value is not None
-            )
+            ), f"Tried to write key {k}"
 
             result[ConstDictVariable.get_key(k)] = v
         assert len(result) == len(items) / 2

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1673,7 +1673,9 @@ def higher_order_op_converter():
 
 
 def requires_higher_order_op(obj):
-    return obj in higher_order_op_converter()
+    return (
+        isinstance(obj, collections.abc.Hashable) and obj in higher_order_op_converter()
+    )
 
 
 def get_higher_order_op(obj):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1099,6 +1099,8 @@ class BuiltinVariable(VariableTracker):
             )
         elif isinstance(obj, variables.NNModuleVariable):
             obj.convert_to_unspecialized(tx)
+        elif isinstance(obj, variables.TensorVariable):
+            return obj.call_method(tx, "__setattr__", [name_var, val], {})
 
     def call_delattr(self, tx, obj: VariableTracker, name_var: VariableTracker):
         return self.call_setattr(tx, obj, name_var, variables.DeletedVariable())

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -474,7 +474,10 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
         closure_cells = init_cellvars(parent, result, code)
 
         for idx, name in enumerate(code.co_freevars):
-            assert getattr(self.closure.items[idx], name, name) == name
+            if not getattr(self.closure.items[idx], name, name) == name:
+                unimplemented(
+                    f"{getattr(self.closure.items[idx], name, name)} MISMATCH {name}"
+                )
             assert name not in result
             closure_cells[name] = self.closure.items[idx]
 
@@ -569,6 +572,13 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
     def can_rewrite(variable):
         return (
             inspect.isfunction(variable) and variable in _traceable_collective_remaps()
+        )
+
+    @staticmethod
+    def was_rewritten(variable):
+        return (
+            inspect.isfunction(variable)
+            and variable in _traceable_collective_remaps().values()
         )
 
     @staticmethod

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -83,6 +83,8 @@ class TensorVariable(VariableTracker):
         is_sparse=None,
         class_type=torch.Tensor,
         specialized_value=None,
+        tensor_dict=None,
+        _typed_storage=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -99,6 +101,8 @@ class TensorVariable(VariableTracker):
         self.is_sparse = is_sparse
         self.class_type = class_type
         self.specialized_value = specialized_value
+        self.tensor_dict = tensor_dict
+        self._typed_storage = _typed_storage
 
     def as_proxy(self):
         return self.proxy
@@ -130,6 +134,7 @@ class TensorVariable(VariableTracker):
             "is_quantized": value.is_quantized,
             "is_sparse": value.is_sparse,
             "class_type": type(value),
+            "_typed_storage": value._typed_storage,
         }
         if not free_symbols(value):
             # this is a fully static shape, and the keys on props here inform specialization.
@@ -185,6 +190,10 @@ class TensorVariable(VariableTracker):
             result = self.call_method(tx, "detach", [], {})
         if name == "__class__":
             return TorchVariable(self.python_type(), **options)
+        if name == "_typed_storage":
+            return variables.LambdaVariable(
+                lambda *args, **kwargs: TypedStorageVariable(self._typed_storage())
+            ).add_options(self)
 
         # Add a guard for type matching, these guards are checked before tensor guards
         # In some cases, a <tensor>.<attr> guard can be evaluated first, and break if
@@ -234,6 +243,11 @@ class TensorVariable(VariableTracker):
                 )
 
             result = try_generic_attr_handling()
+
+        if self.tensor_dict and name in self.tensor_dict.items:
+            # This is a key from a tensor attribute
+            attr = self.tensor_dict.getitem_const(ConstantVariable(name))
+            return attr
 
         if result is None:
             raise NotImplementedError()
@@ -358,6 +372,8 @@ class TensorVariable(VariableTracker):
         elif name == "get_device" and isinstance(self.device, torch.device):
             index = self.device.index if self.device.type != "cpu" else -1
             constant_result = ConstantVariable(index, **options)
+        elif name == "_typed_storage":
+            return TypedStorageVariable(self._typed_storage)
         else:
             constant_result = None
 
@@ -488,6 +504,8 @@ class TensorVariable(VariableTracker):
             )
             result = TorchVariable(torch.any, **options).call_function(tx, [result], {})
             return result.call_method(tx, "item", [], {})
+        elif name == "__setattr__":
+            unimplemented("Setting on tensors disallowed in compiled graphs.")
         else:
             # Convert x.new(torch.Size) into x.new_empty(torch.Size),
             # as Tensor.new acts differently with a Size input versus a tuple input.
@@ -829,3 +847,68 @@ class FakeItemVariable(TensorVariable):
     @classmethod
     def from_tensor_variable(cls, tensor_variable):
         return FakeItemVariable(**dict(tensor_variable.__dict__))
+
+
+class TypedStorageVariable(VariableTracker):
+    def __init__(self, value, **kwargs):
+        self.value = value
+        super().__init__(**kwargs)
+
+    def reconstruct(self, codegen):
+        return super().reconstruct(codegen)
+
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        if name == "_data_ptr":
+            return ConstantVariable(self.value._data_ptr())
+            # return variables.LambdaVariable(
+            #     lambda *args, **kwargs: ConstantVariable(self.value._data_ptr())
+            # ).add_options(self)
+        if name == "_size":
+            if isinstance(self.value._size(), int):
+                return ConstantVariable(self.value._size())
+            sizes = [ConstantVariable(x) for x in self.value._size()]
+            return SizeVariable(sizes)
+        if name == "device":
+            return ConstantVariable(self.value.device)
+        if name == "_resize_":
+            assert len(args) == 1
+            self.value._resize_(args[0].value)
+            return ConstantVariable(None)
+        print("TypedStorageVariable Call method", name, self.value, args)
+        unimplemented(f"typed_storage method calls WIP {name}")
+
+
+class UnTypedStorageVariable(VariableTracker):
+    def __init__(self, value, **kwargs):
+        self.value = value
+        super().__init__(**kwargs)
+
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        if name == "_data_ptr":
+            return ConstantVariable(self.value._data_ptr())
+            # return variables.LambdaVariable(
+            #     lambda *args, **kwargs: ConstantVariable(self.value._data_ptr())
+            # ).add_options(self)
+        if name == "_size":
+            if isinstance(self.value._size(), int):
+                return ConstantVariable(self.value._size())
+            sizes = [ConstantVariable(x) for x in self.value._size()]
+            return SizeVariable(sizes)
+        if name == "device":
+            return ConstantVariable(self.value.device)
+        if name == "data_ptr":
+            return ConstantVariable(self.value.data_ptr())
+        print("UnTypedStorageVariable Call method", name, self.value, args)
+        unimplemented(f"untyped_storage method calls WIP {name}")

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -369,8 +369,6 @@ def _init_core_state(
     state._is_root = None
     _streams: Dict[str, torch.cuda.Stream] = {}
     state._streams = _streams
-    _stream_to_name: Dict[torch.cuda.Stream, str] = {}
-    state._stream_to_name = _stream_to_name
     state._free_event_queue = _FreeEventQueue()
     state._debug_level = dist.get_debug_level()
     state._exec_order_data = exec_order_utils._ExecOrderData(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -285,8 +285,17 @@ def _share_state_and_init_handle_attrs(
             "set yet or should have been set to `False`",
         )
         fsdp_state._is_root = False
-        fsdp_state._streams = root_state._streams
-        fsdp_state._stream_to_name = root_state._stream_to_name
+        # Stream for unshard logic, including allocating the all-gather destination
+        # tensors and the all-gathers themselves.
+        fsdp_state._streams_unshard = root_state._streams_unshard
+        # Stream for overlapping gradient reduction with the backward pass gradient
+        # computation.
+        fsdp_state._streams_post_backward = root_state._streams_post_backward
+        # Stream for pre-unshard logic, namely allocations and writes for CPU
+        # offloading (H2D copy) and mixed precision (low precision cast).
+        fsdp_state._streams_pre_unshard = root_state._streams_pre_unshard
+        # Default stream for computation
+        fsdp_state._streams_default = root_state._streams_default
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
         fsdp_state._handles_prefetched = root_state._handles_prefetched
@@ -313,21 +322,15 @@ def _init_streams(
     assert state._device_handle.is_available()
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._streams["unshard"] = state._device_handle.Stream()
+    state._streams_unshard = state._device_handle.Stream()
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
-    state._streams["post_backward"] = state._device_handle.Stream()
+    state._streams_post_backward = state._device_handle.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._streams["pre_unshard"] = state._device_handle.Stream()
+    state._streams_pre_unshard = state._device_handle.Stream()
     # Default stream for computation
-    state._streams["default"] = state._device_handle.current_stream()
-    state._stream_to_name = {
-        state._device_handle.current_stream(): "default",
-        state._streams["unshard"]: "unshard",
-        state._streams["pre_unshard"]: "pre_unshard",
-        state._streams["post_backward"]: "post_backward",
-    }
+    state._streams_default = state._device_handle.current_stream()
 
 
 @no_type_check
@@ -474,11 +477,9 @@ def _pre_forward_unshard(
     # If the handles have been prefetched, then there is no need to call
     # `_unshard()` again
     if not state._handles_prefetched.get(handles_key, False):
-        _unshard(
-            state, handles, state._streams["unshard"], state._streams["pre_unshard"]
-        )
+        _unshard(state, handles, state._streams_unshard, state._streams_pre_unshard)
     state._needs_pre_forward_unshard[handles_key] = False
-    state._device_handle.current_stream().wait_stream(state._streams["unshard"])
+    state._device_handle.current_stream().wait_stream(state._streams_unshard)
     _prefetch_handles(state, handles_key, _PrefetchMode.FORWARD)
 
 
@@ -624,8 +625,8 @@ def _root_pre_forward(
                 state._needs_pre_forward_unshard[handles_key] = True
         _wait_for_computation_stream(
             state._device_handle.current_stream(),
-            state._streams["unshard"],
-            state._streams["pre_unshard"],
+            state._streams_unshard,
+            state._streams_pre_unshard,
         )
         _clear_grads_if_needed(state._all_handles)
 
@@ -704,10 +705,10 @@ def _pre_backward_hook(
                 _unshard(
                     state,
                     _handles,
-                    state._streams["unshard"],
-                    state._streams["pre_unshard"],
+                    state._streams_unshard,
+                    state._streams_pre_unshard,
                 )
-            state._device_handle.current_stream().wait_stream(state._streams["unshard"])
+            state._device_handle.current_stream().wait_stream(state._streams_unshard)
 
         # Set this to `False` to ensure that a mistargeted prefetch does not
         # actually unshard these handles
@@ -780,11 +781,9 @@ def _post_backward_hook(
 
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
-        state._streams["post_backward"].wait_stream(
-            state._device_handle.current_stream()
-        )
+        state._streams_post_backward.wait_stream(state._device_handle.current_stream())
 
-        with state._device_handle.stream(state._streams["post_backward"]):
+        with state._device_handle.stream(state._streams_post_backward):
             autograd_computed_grad = flat_param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
@@ -867,14 +866,14 @@ def _post_backward_hook(
                 # post-backward stream, inform the caching allocator
                 _no_dispatch_record_stream(
                     grad_to_offload.data,
-                    state._streams["post_backward"],
+                    state._streams_post_backward,
                 )
 
             # Since the unsharded gradient is produced in the computation
             # stream and consumed in the post-backward stream, inform the
             # caching allocator (before it goes out of scope)
             _no_dispatch_record_stream(
-                autograd_computed_grad, state._streams["post_backward"]
+                autograd_computed_grad, state._streams_post_backward
             )
 
             if handle._use_orig_params:
@@ -1003,7 +1002,7 @@ def _post_backward_final_callback(
 
     if root_state._sync_gradients:
         state._device_handle.current_stream().wait_stream(
-            root_state._streams["post_backward"]
+            root_state._streams_post_backward
         )
         if root_state.cpu_offload.offload_params:
             # Wait for non-blocking GPU -> CPU sharded gradient copies from the
@@ -1123,9 +1122,7 @@ def _prefetch_handles(
                 )
         # Prefetch the next set of handles without synchronizing to allow
         # the sync to happen as late as possible to maximize overlap
-        _unshard(
-            state, handles_key, state._streams["unshard"], state._streams["pre_unshard"]
-        )
+        _unshard(state, handles_key, state._streams_unshard, state._streams_pre_unshard)
         for handle, prev_training_state in zip(handles_key, prev_training_states):
             handle._training_state = prev_training_state
         state._handles_prefetched[handles_key] = True


### PR DESCRIPTION
This shows the changes needed to minimally trace some useful tensor compute out of FSDP.

At large, the changes are:

1) Skipfiles fixes
2) Better handling of rewritten functions (cc @wconstab this doesn't work well, we need to revisit this)
3) Tensor attribute simulation
4) A few small new variable tracker types to help us here

Major features fixed / WIP in other branches that did not make it to the MVP, because while they fix graph breaks, they do not demonstrate minimum viable tracing.

1) Support for partials
2) Module setattr
3) Setattr with custom getattr
4) SetVariable  https://github.com/pytorch/pytorch/pull/103205/files
5) Cudastream support (Reconstruct, class handling, etc)
6) Random fixes for FSDP

The major point of this PR is to drive enablement, by creating a list of graph breaks we can split up and fix.

Important point 1 (cc @jansel, @ezyang, @awgu): Part of the point of tensor subclass simulation is to reject the `__setattr__` calls on tensors, and use this graph break to drive refactor of FlatParameter until we never write to it during trace code (Init is fine, but any written-to properties should either continue to graph break forever, or get refactored onto FlatParameterHandle). Alternatively, we could make __setattr__ work, as long as we very carefully reconstruct values to do the dict association.

We should not have getattr or setattr in the graph. 

Important point 2: (cc @wconstab) The tests introduced in https://github.com/pytorch/pytorch/pull/102222/files PASS but the collectives do not make it into the graph in this PR! I think there is a bug with builder ordering + inlining making some things unexpectedly TorchVariable