### PR TITLE
Fix typing on `Tensor` inplace ops

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1028,7 +1028,7 @@ def gen_pyi(
         ) or (
             not name.startswith("_") and not name.endswith("__") and name.endswith("_")
         ):
-            # _TensorBase.__iadd__() etc and _TensorBase.idd_() etc should return self
+            # _TensorBase.__iadd__() etc and _TensorBase.add_() etc should return self
             # TODO `self: Self` is not needed when PEP-673 Self is supported
             hints = [
                 h.replace("self", "self: Self", 1).replace("-> Tensor", "-> Self")

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -54,6 +54,7 @@ from . import _functorch, _lazy, _lazy_ts_backend, _nn, _onnx, _VariableFunction
 
 T = TypeVar("T")
 S = TypeVar("S", bound="torch.Tensor")
+Self = TypeVar("Self", bound="_TensorBase")  # replacement of PEP-673 Self
 
 # Defined in torch/csrc/Device.cpp
 class device:


### PR DESCRIPTION
Fixes #103375

Changes:
- Make `__iop__` return `Self` (the current mypy version does not support PEP 673 `Self`, so it's implemented by a `TypeVar`)
- Make `op_` return `Self` (e.g. `add_`)
- Sort `__iop__` and `__rop__` with cleanup
  - Sort them to have the same order as `__op__` (looks more clear)
  - Some ops actually not in `dir(torch._C._TensorBase)` and therefore removed (defined in `Tensor` instead)

### Example
```python
import torch
a = torch.nn.Parameter()
a *= 2
reveal_type(a.mul_(2))
print(a.mul_(2).__class__)  # torch.nn.parameter.Parameter
```
Previously:
```
a.py:3:1: error: Result type of * incompatible in assignment  [misc]
a.py:4:13: note: Revealed type is "torch._tensor.Tensor"
```
Now:
```
a.py:4:13: note: Revealed type is "torch.nn.parameter.Parameter"
```