### PR TITLE
Add typing on `Tensor` dunder methods for binary arithmetic ops

### DIFF
--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -70,7 +70,7 @@ def philox_rand_offset(
     device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
     blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
     grid_size = (numel + block_size - 1) // block_size
-    grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)
+    grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)  # type: ignore[call-overload]
     offset = (
         (numel - 1) // (block_size * grid_size * unroll) + 1
     ) * curand4_engine_calls


### PR DESCRIPTION
Fixes #103393

### Example
```python
import torch
a = torch.Tensor()
reveal_type(1 - a)
reveal_type(a ** 2)
```
Previously:
```
a.py:3:13: note: Revealed type is "Any"
a.py:4:13: note: Revealed type is "Any"
```
Now:
```
a.py:3:13: note: Revealed type is "torch._tensor.Tensor"
a.py:4:13: note: Revealed type is "torch._tensor.Tensor"
```
