### PR TITLE
[FAILING] Tighten FakeTensorProp assert to require only fake tensor returns.

### DIFF
--- a/torch/fx/passes/fake_tensor_prop.py
+++ b/torch/fx/passes/fake_tensor_prop.py
@@ -36,7 +36,7 @@ class FakeTensorProp(torch.fx.Interpreter):
             if isinstance(obj, FakeTensor):
                 return snapshot_fake(obj)
             elif isinstance(obj, torch.Tensor):
-                return snapshot_fake(self._mode.from_tensor(obj))
+                assert False, "should be run under fake tensor mode"
             elif isinstance(obj, py_sym_types):
                 return obj
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103395

Signed-off-by: Edward Z. Yang <ezyang@meta.com>