### PR TITLE
[TP] Async collectives enabled for TP eager

### DIFF
--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -52,7 +52,7 @@ class _ToTorchTensor(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input: "DTensor"):  # type: ignore[override]
         ctx.dtensor_spec = input._spec
-        return input._local_tensor.detach()
+        return input._local_tensor
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
@@ -198,7 +198,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         # detach local tensor from autograd graph as we initialize the
         # distributed tensor and autograd will be working on top of
         # the wrapper tensor directly instead of local torch.Tensor
-        r._local_tensor = local_tensor.detach()
+        r._local_tensor = local_tensor
         return r
 
     # pyre-fixme[14]: `__repr__` overrides method defined in `DTensor` inconsistently.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103399


We want to see if we can loosen some assumptions of DTensor and fully enable async collectives such as ReduceScatter/AllReduce since DTensor is using functional collectives and it comes with async feature by default.


The profiler with this change for a sequence parallel example:

<img width="395" alt="image" src="https://github.com/pytorch/pytorch/assets/6937752/b9590585-6fbd-4ffc-84fc-bf831bdcd022">

