### PR TITLE
[c10d] Add xpu to the default device supported by user specified backend

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -299,6 +299,7 @@ class BackendConfig:
             self.device_backend_map = {
                 "cpu" : backend_val,
                 "cuda" : backend_val,
+                "xpu" : backend_val,
             }
 
         logger.info(


### PR DESCRIPTION
**Motivation:** 
For collective dispatching, we want to provide a more user friendly usage for xpu device and CCL backend (user specified backend) mapping. 

**Solution:**
We add xpu to the default device list, and it can construct the mapping between xpu and the user specified backend directly. 
Usage:
When using xpu device, user can specify backend name only:
`dist.init_process_group(backend='ccl')`




