### PR TITLE
add custom device support for special nn.modules

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from .linear import NonDynamicallyQuantizableLinear
 from torch.nn.init import constant_, xavier_normal_, xavier_uniform_
 from torch.nn.parameter import Parameter
-from .module import Module, _get_special_module_supported_device_types
+from .module import Module
 from .. import functional as F
 
 __all__ = ['Threshold', 'ReLU', 'RReLU', 'Hardtanh', 'ReLU6', 'Sigmoid', 'Hardsigmoid', 'Tanh',
@@ -891,7 +891,7 @@ def _check_arg_device(x: Optional[torch.Tensor]) -> bool:
     if x is None:
         return True
     else:
-        return x.device.type in _get_special_module_supported_device_types()
+        return x.device.type in ["cpu", "cuda", torch.utils.backend_registration._privateuse1_backend_name]
 
     return False
 
@@ -1176,7 +1176,7 @@ class MultiheadAttention(Module):
                 why_not_fast_path = "some Tensor argument has_torch_function"
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = ("some Tensor argument's device is neither one of "
-                                     f"{_get_special_module_supported_device_types()}")
+                                     f"cpu, cuda or {torch.utils.backend_registration._privateuse1_backend_name}")
             elif torch.is_grad_enabled() and any(_arg_requires_grad(x) for x in tensor_args):
                 why_not_fast_path = ("grad is enabled and at least one of query or the "
                                      "input/output projection weights or biases requires_grad")

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from .linear import NonDynamicallyQuantizableLinear
 from torch.nn.init import constant_, xavier_normal_, xavier_uniform_
 from torch.nn.parameter import Parameter
-from .module import Module, _get_speacial_module_supported_device
+from .module import Module, _get_special_module_supported_device_types
 from .. import functional as F
 
 __all__ = ['Threshold', 'ReLU', 'RReLU', 'Hardtanh', 'ReLU6', 'Sigmoid', 'Hardsigmoid', 'Tanh',
@@ -891,7 +891,7 @@ def _check_arg_device(x: Optional[torch.Tensor]) -> bool:
     if x is None:
         return True
     else:
-        return x.device.type in _get_speacial_module_supported_device()
+        return x.device.type in _get_special_module_supported_device_types()
 
     return False
 
@@ -1175,8 +1175,8 @@ class MultiheadAttention(Module):
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_fast_path = "some Tensor argument has_torch_function"
             elif not all(_check_arg_device(x) for x in tensor_args):
-                why_not_fast_path = f"some Tensor argument's device is neither one of "
-                                     "{_get_speacial_module_supported_device()}"
+                why_not_fast_path = ("some Tensor argument's device is neither one of "
+                                     f"{_get_special_module_supported_device_types()}")
             elif torch.is_grad_enabled() and any(_arg_requires_grad(x) for x in tensor_args):
                 why_not_fast_path = ("grad is enabled and at least one of query or the "
                                      "input/output projection weights or biases requires_grad")

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -732,7 +732,7 @@ class SyncBatchNorm(_BatchNorm):
             # currently only GPU/PrivateUse1 input is supported
             if input.device.type not in ["cuda", torch._C._get_privateuse1_backend_name()]:
                 raise ValueError("SyncBatchNorm expected input tensor to be on GPU or "
-                                 "{torch._C._get_privateuse1_backend_name()}")
+                                 f"{torch._C._get_privateuse1_backend_name()}")
 
             process_group = torch.distributed.group.WORLD
             if self.process_group:

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -729,9 +729,10 @@ class SyncBatchNorm(_BatchNorm):
         need_sync = (bn_training and self.training and
                      torch.distributed.is_available() and torch.distributed.is_initialized())
         if need_sync:
-            # currently only GPU input is supported
-            if not input.is_cuda:
-                raise ValueError("SyncBatchNorm expected input tensor to be on GPU")
+            # currently only GPU/PrivateUse1 input is supported
+            if input.device.type not in ["cuda", torch._C._get_privateuse1_backend_name()]:
+                raise ValueError("SyncBatchNorm expected input tensor to be on GPU or "
+                                 "{torch._C._get_privateuse1_backend_name()}")
 
             process_group = torch.distributed.group.WORLD
             if self.process_group:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -666,7 +666,10 @@ class ParameterList(Module):
         for k, p in enumerate(self):
             if isinstance(p, torch.Tensor):
                 size_str = 'x'.join(str(size) for size in p.size())
-                device_str = '' if p.device.type == "cpu" else ' ({})'.format(p.device())
+                if p.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
+                    device_str = ' ({})'.format(p.device)
+                else:
+                    device_str = ''
                 parastr = '{} containing: [{} of size {}{}]'.format(
                     "Parameter" if isinstance(p, Parameter) else "Tensor",
                     p.dtype, size_str, device_str)
@@ -890,7 +893,10 @@ class ParameterDict(Module):
         for k, p in self.items():
             if isinstance(p, torch.Tensor):
                 size_str = 'x'.join(str(size) for size in p.size())
-                device_str = '' if p.device.type == "cpu" else ' ({})'.format(p.device())
+                if p.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
+                    device_str = ' ({})'.format(p.device)
+                else:
+                    device_str = ''
                 parastr = '{} containing: [{} of size {}{}]'.format(
                     "Parameter" if isinstance(p, Parameter) else "Tensor",
                     torch.typename(p), size_str, device_str)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -666,7 +666,7 @@ class ParameterList(Module):
         for k, p in enumerate(self):
             if isinstance(p, torch.Tensor):
                 size_str = 'x'.join(str(size) for size in p.size())
-                device_str = '' if not p.is_cuda else ' (GPU {})'.format(p.get_device())
+                device_str = '' if p.device.type == "cpu" else ' ({})'.format(p.device())
                 parastr = '{} containing: [{} of size {}{}]'.format(
                     "Parameter" if isinstance(p, Parameter) else "Tensor",
                     p.dtype, size_str, device_str)
@@ -890,7 +890,7 @@ class ParameterDict(Module):
         for k, p in self.items():
             if isinstance(p, torch.Tensor):
                 size_str = 'x'.join(str(size) for size in p.size())
-                device_str = '' if not p.is_cuda else ' (GPU {})'.format(p.get_device())
+                device_str = '' if p.device.type == "cpu" else ' ({})'.format(p.device())
                 parastr = '{} containing: [{} of size {}{}]'.format(
                     "Parameter" if isinstance(p, Parameter) else "Tensor",
                     torch.typename(p), size_str, device_str)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -24,6 +24,12 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 T = TypeVar('T', bound='Module')
 
 
+def _get_speacial_module_supported_device():
+    r"""get the list of device which support the speacial Modules,
+    including Transformer(TransformerEncoder, TransformerEncoderLayer), MultiheadAttention.
+    """
+    return ["cpu", "cuda", torch._C._get_privateuse1_backend_name()]
+
 class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpected_keys'])):
     def __repr__(self):
         if not self.missing_keys and not self.unexpected_keys:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -24,11 +24,11 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 T = TypeVar('T', bound='Module')
 
 
-def _get_speacial_module_supported_device():
+def _get_special_module_supported_device_types():
     r"""get the list of device which support the speacial Modules,
     including Transformer(TransformerEncoder, TransformerEncoderLayer), MultiheadAttention.
     """
-    return ["cpu", "cuda", torch._C._get_privateuse1_backend_name()]
+    return ["cpu", "cuda", torch.utils.backend_registration._privateuse1_backend_name]
 
 class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpected_keys'])):
     def __repr__(self):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -24,12 +24,6 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 T = TypeVar('T', bound='Module')
 
 
-def _get_special_module_supported_device_types():
-    r"""get the list of device which support the speacial Modules,
-    including Transformer(TransformerEncoder, TransformerEncoderLayer), MultiheadAttention.
-    """
-    return ["cpu", "cuda", torch.utils.backend_registration._privateuse1_backend_name]
-
 class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpected_keys'])):
     def __repr__(self):
         if not self.missing_keys and not self.unexpected_keys:

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -5,7 +5,7 @@ import torch
 import warnings
 from torch import Tensor
 from .. import functional as F
-from .module import Module
+from .module import Module, _get_speacial_module_supported_device
 from .activation import MultiheadAttention
 from .container import ModuleList
 from ..init import xavier_uniform_
@@ -304,8 +304,8 @@ class TransformerEncoder(Module):
 
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not (src.is_cuda or 'cpu' in str(src.device)):
-                why_not_sparsity_fast_path = "src is neither CUDA nor CPU"
+            elif not (src.device.type in _get_speacial_module_supported_device()):
+                why_not_sparsity_fast_path = "src device is neither one of {_get_speacial_module_supported_device()}"
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")
@@ -606,8 +606,9 @@ class TransformerEncoderLayer(Module):
             # generator expressions.
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not all((x.is_cuda or 'cpu' in str(x.device)) for x in tensor_args):
-                why_not_sparsity_fast_path = "some Tensor argument is neither CUDA nor CPU"
+            elif not all((x.device.type in _get_speacial_module_supported_device() for x in tensor_args):
+                why_not_sparsity_fast_path = f"some Tensor argument's device is neither one of "
+                                              "{_get_speacial_module_supported_device()}"
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -5,7 +5,7 @@ import torch
 import warnings
 from torch import Tensor
 from .. import functional as F
-from .module import Module, _get_special_module_supported_device_types
+from .module import Module
 from .activation import MultiheadAttention
 from .container import ModuleList
 from ..init import xavier_uniform_
@@ -301,11 +301,11 @@ class TransformerEncoder(Module):
                 first_layer.linear2.weight,
                 first_layer.linear2.bias,
             )
-
+            _supported_device_type = ["cpu", "cuda", torch.utils.backend_registration._privateuse1_backend_name]
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif src.device.type not in _get_special_module_supported_device_types():
-                why_not_sparsity_fast_path = "src device is neither one of {_get_special_module_supported_device_types()}"
+            elif src.device.type not in _supported_device_type:
+                why_not_sparsity_fast_path = f"src device is neither one of {_supported_device_type}"
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")
@@ -604,11 +604,12 @@ class TransformerEncoderLayer(Module):
 
             # We have to use list comprehensions below because TorchScript does not support
             # generator expressions.
+            _supported_device_type = ["cpu", "cuda", torch.utils.backend_registration._privateuse1_backend_name]
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not all((x.device.type in _get_special_module_supported_device_types()) for x in tensor_args):
+            elif not all((x.device.type in _supported_device_type) for x in tensor_args):
                 why_not_sparsity_fast_path = ("some Tensor argument's device is neither one of "
-                                              f"{_get_special_module_supported_device_types()}")
+                                              f"{_supported_device_type}")
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -5,7 +5,7 @@ import torch
 import warnings
 from torch import Tensor
 from .. import functional as F
-from .module import Module, _get_speacial_module_supported_device
+from .module import Module, _get_special_module_supported_device_types
 from .activation import MultiheadAttention
 from .container import ModuleList
 from ..init import xavier_uniform_
@@ -304,8 +304,8 @@ class TransformerEncoder(Module):
 
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not (src.device.type in _get_speacial_module_supported_device()):
-                why_not_sparsity_fast_path = "src device is neither one of {_get_speacial_module_supported_device()}"
+            elif src.device.type not in _get_special_module_supported_device_types():
+                why_not_sparsity_fast_path = "src device is neither one of {_get_special_module_supported_device_types()}"
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")
@@ -606,9 +606,9 @@ class TransformerEncoderLayer(Module):
             # generator expressions.
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif not all((x.device.type in _get_speacial_module_supported_device() for x in tensor_args):
-                why_not_sparsity_fast_path = f"some Tensor argument's device is neither one of "
-                                              "{_get_speacial_module_supported_device()}"
+            elif not all((x.device.type in _get_special_module_supported_device_types()) for x in tensor_args):
+                why_not_sparsity_fast_path = ("some Tensor argument's device is neither one of "
+                                              f"{_get_special_module_supported_device_types()}")
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = ("grad is enabled and at least one of query or the "
                                               "input/output projection weights or biases requires_grad")

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -58,7 +58,7 @@ def _check_param_device(param: torch.Tensor, old_param_device: Optional[int]) ->
     r"""This helper function is to check if the parameters are located
     in the same device. Currently, the conversion between model parameters
     and single vector form is not supported for multiple allocations,
-    e.g. parameters in different GPUs, or mixture of CPU/GPU.
+    e.g. parameters in different GPUs/PrivateUse1s, or mixture of CPU/GPU/PrivateUse1.
 
     Args:
         param ([Tensor]): a Tensor of a parameter of a model
@@ -70,11 +70,12 @@ def _check_param_device(param: torch.Tensor, old_param_device: Optional[int]) ->
     """
 
     # Meet the first parameter
+    support_device_types = ["cuda", torch._C._get_privateuse1_backend_name()]
     if old_param_device is None:
-        old_param_device = param.get_device() if param.is_cuda else -1
+        old_param_device = param.get_device() if param.device.type in support_device_types else -1
     else:
         warn = False
-        if param.is_cuda:  # Check if in same GPU
+        if param.device.type in support_device_types:  # Check if in same GPU/PrivateUse1
             warn = (param.get_device() != old_param_device)
         else:  # Check if in CPU
             warn = (old_param_device != -1)

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -4,6 +4,12 @@ from typing import List, Optional, Union
 
 __all__ = ["rename_privateuse1_backend", "generate_methods_for_privateuse1_backend"]
 
+# TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
+# renamed-backend name for `privateuse1`, but the func will cause an
+# with torch._jit_script_compile, so we use the global variable named
+# `_privateuse1_backend_name`.
+_privateuse1_backend_name = "privateuseone"
+
 def rename_privateuse1_backend(backend_name: str) -> None:
     r"""
     rename_privateuse1_backend(backend_name) -> None
@@ -77,7 +83,9 @@ def rename_privateuse1_backend(backend_name: str) -> None:
         # to implement torch.ones.
         >>> a = torch.ones(2, device="foo")
         """
-    return _rename_privateuse1_backend(backend_name)
+    _rename_privateuse1_backend(backend_name)
+    global _privateuse1_backend_name
+    _privateuse1_backend_name = backend_name
 
 
 def _check_register_once(module, attr):


### PR DESCRIPTION
Fixes #103818
1. for some special nn.Modules, there are checks which only support cuda, so I add `privateuse1` check.
2. when get the device type for `privateuse1` by `torch._C._get_privateuse1_backend_name()`, it will get error in `torch.jit.script`, so I add a global variable to avoid this.