### PR TITLE
s390x simd: ensure that vectorized complex constructor behaves same to x86

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -375,6 +375,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
   // because of gcc inconsistency for int64_t we are obliged to use this, not
   // value_type
   using ElementType = ZSimdVectElement<T>;
+  using vinner_data = std::pair<vtype, vtype>;
 
  private:
   vtype _vec0;
@@ -387,6 +388,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
   Vectorized() {}
 
   C10_ALWAYS_INLINE Vectorized(vtype v) : _vec0{v}, _vec1{v} {}
+  C10_ALWAYS_INLINE Vectorized(const vinner_data &v) : _vec0{v.first}, _vec1{v.second} {}
   C10_ALWAYS_INLINE Vectorized(vtype v1, vtype v2) : _vec0{v1}, _vec1{v2} {}
   C10_ALWAYS_INLINE Vectorized(T s)
       : _vec0{vec_splats((ElementType)s)}, _vec1{vec_splats((ElementType)s)} {}
@@ -426,6 +428,14 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
 
   C10_ALWAYS_INLINE const vtype& vec1() const {
     return _vec1;
+  }
+
+  C10_ALWAYS_INLINE vinner_data data() const {
+    return std::make_pair<>(_vec0, _vec1);
+  }
+
+  C10_ALWAYS_INLINE operator vinner_data() const {
+    return data();
   }
 
   C10_ALWAYS_INLINE const vmaskType vecb0() const {
@@ -1956,6 +1966,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
   using vmaskType = ZSimdVectBinary<underline_type>;
   using vinner_type = Vectorized<underline_type>;
   using size_type = int;
+  using vinner_data = typename Vectorized<underline_type>::vinner_data;
 
   static constexpr size_type size() {
     return VECTOR_WIDTH / sizeof(value_type);
@@ -1967,7 +1978,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
  public:
   Vectorized() {}
 
-  C10_ALWAYS_INLINE Vectorized(vinner_type v) : _vec{v} {}
+  C10_ALWAYS_INLINE Vectorized(const vinner_data &v) : _vec{v.first, v.second} {}
 
   template <typename U = T, std::enable_if_t<(sizeof(U) == 16), int> = 0>
   C10_ALWAYS_INLINE Vectorized(T s1, T s2)
@@ -1997,6 +2008,14 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
 
   C10_ALWAYS_INLINE const vinner_type& vec() const {
     return _vec;
+  }
+
+  C10_ALWAYS_INLINE operator vinner_data() const {
+    return _vec.data();
+  }
+
+  C10_ALWAYS_INLINE vinner_data data() const {
+    return _vec.data();
   }
 
   static Vectorized<T> C10_ALWAYS_INLINE
@@ -2192,7 +2211,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
 #if !defined(ZVECTOR_SIMULATE_X86_MULT)
     vinner_type vi = bv.mergeo();
     vinner_type vr = bv.mergee();
-    vinner_type abs_b = b.abs_2_().vec();
+    vinner_type abs_b = b.abs_2_();
     vi = vi ^ isign_mask<underline_type>();
     vinner_type ret = _vec * vr;
     vinner_type vx_swapped = _vec.swapped();
@@ -2204,7 +2223,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
     vinner_type d_c = bv.swapped();
     d_c = d_c ^ rsign_mask<underline_type>();
     vinner_type ad_bc = _vec * d_c;
-    vinner_type abs_b = b.abs_2_().vec();
+    vinner_type abs_b = b.abs_2_();
     vinner_type re_im = vinner_type::horizontal_add_perm(ac_bd, ad_bc);
     vinner_type ret = re_im / abs_b;
 #endif
@@ -2343,19 +2362,19 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
     return Vectorized<T>(_vec ^ vinner_type(isign_mask<underline_type>()));
   }
 
-  Vectorized<T> abs_2_() const {
+  vinner_data abs_2_() const {
     auto a = _vec * _vec;
     a = a + a.swapped();
-    return Vectorized<T>(a.mergee());
+    return a.mergee().data();
   }
 
-  Vectorized<T> abs_() const {
+  vinner_data abs_() const {
     auto ret = abs_2_();
-    return Vectorized<T>(ret.vec().sqrt());
+    return Vectorized<T>{ret}.sqrt().data();
   }
 
   Vectorized<T> abs() const {
-    return abs_().real();
+    return Vectorized<T>{abs_()}.real();
   }
 
   Vectorized<T> exp() const {
@@ -2406,7 +2425,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
     // re = (ac + bd)/abs_2() = c/abs_2()
     // im = (bc - ad)/abs_2() = d/abs_2()
     vinner_type c_d = _vec ^ vinner_type(isign_mask<underline_type>());
-    vinner_type abs = abs_2_().vec();
+    vinner_type abs = abs_2_();
     return Vectorized<T>{c_d / abs};
   }
 

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1088,6 +1088,11 @@ namespace {
         AssertVectorized<vcomplex>(NAME_INFO(complex imag), expected3, actual3).check();
         AssertVectorized<vcomplex>(NAME_INFO(complex conj), expected4, actual4).check();
     }
+    TEST(ComplexTests, TestComplexConstructor) {
+        auto actual1 = vcomplex(1.0);
+        auto expected1 = vcomplex(Complex<float>(1.0));
+        AssertVectorized<vcomplex>(NAME_INFO(complex constructor), expected1, actual1).check();
+    }
     TYPED_TEST(QuantizationTests, Quantize) {
         using vec = TypeParam;
         using underlying = ValueType<vec>;


### PR DESCRIPTION
This change fixes multiple tests,
including test_noncontiguous_samples_lerp_cpu_complex64 from test/test_ops.py

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10