### PR TITLE
Optimize scatter_add/scatter_reduce in BFloat16/Half data type in CPU backend

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceUtils.h
+++ b/aten/src/ATen/native/cpu/ReduceUtils.h
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/native/ReductionType.h>
 #include <c10/util/irange.h>
+#include <ATen/OpMathType.h>
 
 namespace at::native {
 inline namespace CPU_CAPABILITY {
@@ -93,6 +94,15 @@ inline void init(scalar_t* out, int64_t size, bool include_self = false) {
   }
 }
 
+template <typename scalar_t, ReductionType reduce>
+inline void _init(scalar_t* self_ptr, at::opmath_type<scalar_t>* buffer_ptr, int64_t size, bool include_self) {
+  if (!include_self) {
+    init<at::opmath_type<scalar_t>, reduce>(buffer_ptr, size, include_self);
+  } else {
+    vec::convert(self_ptr, buffer_ptr, size);
+  }
+}
+
 template <typename scalar_t>
 inline scalar_t _max(const scalar_t& x, const scalar_t& y) {
   return at::_isnan(y) ? y : std::max(x, y);
@@ -140,6 +150,37 @@ inline void update(scalar_t* out, scalar_t* data, int64_t K) {
       out,
       data,
       K);
+}
+
+template <typename scalar_t, ReductionType reduce,
+          typename std::enable_if_t<!is_reduced_floating_point_v<scalar_t>, int> = 0>
+inline void _update(scalar_t* src_data, at::opmath_type<scalar_t>* buffer_ptr, int64_t col, int64_t K) {
+  update<scalar_t, reduce>(buffer_ptr, src_data + col * K, K);
+}
+
+template <typename scalar_t, ReductionType reduce,
+          typename std::enable_if_t<is_reduced_floating_point_v<scalar_t>, int> = 0>
+inline void _update(scalar_t* src_data, at::opmath_type<scalar_t>* buffer_ptr, int64_t col, int64_t K) {
+  using opmath_t = at::opmath_type<scalar_t>;
+  using Vec = vec::Vectorized<scalar_t>;
+  using fVec = vec::Vectorized<opmath_t>;
+  int64_t k = 0;
+  constexpr int64_t kVecSize = Vec::size();
+  constexpr int64_t kfVecSize = fVec::size();
+  for (k = 0; k < K - (K % kVecSize); k += kVecSize) {
+    Vec src_vec = Vec::loadu(src_data + col * K + k);
+    fVec src_vec0, src_vec1;
+    std::tie(src_vec0, src_vec1) = convert_to_float<scalar_t>(src_vec);
+    fVec buf_vec0, buf_vec1;
+    buf_vec0 = update<fVec, reduce>(fVec::loadu(buffer_ptr + k), src_vec0);
+    buf_vec1 = update<fVec, reduce>(fVec::loadu(buffer_ptr + k + kfVecSize), src_vec1);
+    buf_vec0.store(buffer_ptr + k);
+    buf_vec1.store(buffer_ptr + k + fVec::size());
+  }
+  for (; k < K; k++) {
+    opmath_t src_val = opmath_t(src_data[col * K + k]);
+    buffer_ptr[k] = update<opmath_t, reduce>(buffer_ptr[k], src_val);
+  }
 }
 
 template <typename scalar_t, ReductionType reduce>

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -15,6 +15,7 @@
 #ifdef USE_FBGEMM
 #include <fbgemm/Utils.h>
 #endif
+#include <ATen/ops/zeros.h>
 
 namespace at::native {
 
@@ -720,6 +721,135 @@ void cpu_scatter_reduce_expanded_index(const Tensor& self, const Tensor& index, 
   });
 }
 
+template <typename scalar_t, ReductionType reduce>
+void cpu_scatter_reduce_expanded_index_reduction(const Tensor& self, const Tensor& index, const Tensor& src, bool include_self) {
+  int64_t* index_data = index.data_ptr<int64_t>();
+  scalar_t* self_data = self.data_ptr<scalar_t>();
+  scalar_t* src_data = src.data_ptr<scalar_t>();
+
+  const int64_t M = ensure_nonempty_size(self, 0);
+  const int64_t nnz = ensure_nonempty_size(index, 0);
+  const int64_t K = index.numel() / nnz;
+
+  const int64_t index_upper_bound = M;
+
+  auto keys = std::make_unique<int64_t[]>(nnz);
+  auto values = std::make_unique<int64_t[]>(nnz);
+  auto keys_tmp = std::make_unique<int64_t[]>(nnz);
+  auto values_tmp = std::make_unique<int64_t[]>(nnz);
+  at::parallel_for(0, nnz, 1, [&](int64_t begin, int64_t end) {
+    for (const auto i : c10::irange(begin, end)) {
+      int64_t index = index_data[i];
+      TORCH_CHECK(index >= 0 && index < index_upper_bound,
+                  "index ", index,
+                  " is out of bounds for dimension ", 0,
+                  " with size ", index_upper_bound);
+      keys[i] = index;
+      values[i] = i;
+    }
+  });
+
+  int64_t* sorted_col_index_keys = nullptr;
+  int64_t* sorted_col_index_values = nullptr;
+  std::tie(sorted_col_index_keys, sorted_col_index_values) = radix_sort_parallel(
+      keys.get(),
+      values.get(),
+      keys_tmp.get(),
+      values_tmp.get(),
+      nnz,
+      M);
+
+  int num_threads = at::get_num_threads();
+  std::vector<int64_t> num_uniq(num_threads, 0);
+  at::parallel_for(1, nnz, 1, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    for(const auto i : c10::irange(begin, end)) {
+      if (sorted_col_index_keys[i] != sorted_col_index_keys[i - 1]) {
+        num_uniq[tid]++;
+      }
+    }
+  });
+  num_uniq[0]++;
+  for (const auto n : c10::irange(1, num_threads)) {
+    num_uniq[n] += num_uniq[n - 1];
+  }
+
+  // in case some rows are not written into, num_nonzero_rows will be smaller than M
+  int64_t num_nonzero_rows = num_uniq[num_threads - 1];
+  auto row_index_tmp = std::make_unique<int64_t[]>(num_nonzero_rows);
+  auto row_index_offset_tmp = std::make_unique<int64_t[]>(num_nonzero_rows + 1);
+  int64_t* row_index = row_index_tmp.get();
+  int64_t* row_index_offset = row_index_offset_tmp.get();
+  row_index[0] = sorted_col_index_keys[0];
+  row_index_offset[0] = 0;
+  row_index_offset[num_nonzero_rows] = nnz;
+
+  at::parallel_for(1, nnz, 1, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    int64_t* t_index = row_index + ((tid == 0) ? 1 : num_uniq[tid - 1]);
+    int64_t* t_index_offset = row_index_offset + ((tid == 0) ? 1 : num_uniq[tid - 1]);
+    for (const auto i : c10::irange(begin, end)) {
+      if (sorted_col_index_keys[i] != sorted_col_index_keys[i - 1]) {
+        *t_index = sorted_col_index_keys[i];
+        *t_index_offset = i;
+        t_index++;
+        t_index_offset++;
+      }
+    }
+  });
+
+  Tensor buffer = at::zeros({num_threads, K}, self.options().dtype(kFloat));
+  float* buffer_data = buffer.data_ptr<float>();
+  using Vec = vec::Vectorized<scalar_t>;
+
+  // TODO: do blocking on col dimension to reduce WR bandwidth
+  at::parallel_for(0, num_nonzero_rows, 1, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    TORCH_CHECK(tid < num_threads,
+                "expect thread id smaller than ", num_threads, ", got thread id ", tid);
+    float* buffer_ptr = buffer_data + tid * K;
+    for (const auto m : c10::irange(begin, end)) {
+      int64_t row = row_index[m];
+      int64_t off_start = row_index_offset[m];
+      int64_t off_end = row_index_offset[m + 1];
+      scalar_t* self_ptr = self_data + row * K;
+
+      // step 1: reinit rows in `self` if needed
+      if (!include_self) {
+        init<float, reduce>(buffer_ptr, K, false);
+      } else {
+        vec::convert(self_ptr, buffer_ptr, K);
+      }
+
+      // step 2: reduce
+      uint64_t k = 0;
+      for (const auto n : c10::irange(off_start, off_end)) {
+        int64_t col = sorted_col_index_values[n];
+        for (k = 0; k < K - (K % Vec::size()); k += Vec::size()) {
+          Vec src_vec = Vec::loadu(src_data + col * K + k);
+          Vectorized<float> src_vec0, src_vec1;
+          std::tie(src_vec0, src_vec1) = convert_to_float<scalar_t>(src_vec);
+          Vectorized<float> buf_vec0, buf_vec1;
+          buf_vec0 = update<Vectorized<float>, reduce>(Vectorized<float>::loadu(buffer_ptr + k), src_vec0);
+          buf_vec1 = update<Vectorized<float>, reduce>(Vectorized<float>::loadu(buffer_ptr + k + Vectorized<float>::size()), src_vec1);
+          buf_vec0.store(buffer_ptr + k);
+          buf_vec1.store(buffer_ptr + k + Vectorized<float>::size());
+        }
+        for (; k < K; k++) {
+          float src_val = float(src_data[col * K + k]);
+          buffer_ptr[k] = update<float, reduce>(buffer_ptr[k], src_val);
+        }
+      }
+      vec::convert(buffer_ptr, self_ptr, K);
+
+      // step 3: finalize
+      int64_t count = include_self ? 1 : 0;
+      count += off_end - off_start;
+      write<scalar_t, reduce>(self_ptr, count, K);
+    }
+  });
+}
+
 template <typename scalar_t>
 void cpu_gather_expanded_index_kernel(const Tensor& result, const Tensor& index, const Tensor& self) {
   int64_t* index_data = index.data_ptr<int64_t>();
@@ -759,21 +889,37 @@ void cpu_gather_expanded_index_kernel(const Tensor& result, const Tensor& index,
 }
 
 void scatter_add_expanded_index_kernel(const Tensor& self, const Tensor& index, const Tensor& src) {
-  AT_DISPATCH_FLOATING_TYPES_AND(
-    ScalarType::BFloat16, self.scalar_type(), "scatter_add_expanded_index", [&] {
-      cpu_scatter_reduce_expanded_index<scalar_t, ReductionType::SUM>(self, index, src, /*include_self*/true);
-  });
+  if (at::isReducedFloatingType(self.scalar_type())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      self.scalar_type(), "scatter_add_expanded_index", [&] () {
+        cpu_scatter_reduce_expanded_index_reduction<scalar_t, ReductionType::SUM>(self, index, src, /*include_self*/true);
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES(
+      self.scalar_type(), "scatter_add_expanded_index", [&] () {
+        cpu_scatter_reduce_expanded_index<scalar_t, ReductionType::SUM>(self, index, src, /*include_self*/true);
+    });
+  }
 }
 
 void scatter_reduce_expanded_index_kernel(
     const Tensor& self, const Tensor& index, const Tensor& src,
     const ReductionType& reduction, bool include_self) {
-  AT_DISPATCH_FLOATING_TYPES_AND(
-    ScalarType::BFloat16, self.scalar_type(), "scatter_reduce_expanded_index", [&] {
-    AT_DISPATCH_REDUCTION_TYPES(reduction, [&]() {
-      cpu_scatter_reduce_expanded_index<scalar_t, reduce>(self, index, src, include_self);
+  if (at::isReducedFloatingType(self.scalar_type())) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      self.scalar_type(), "scatter_reduce_expanded_index", [&] {
+      AT_DISPATCH_REDUCTION_TYPES(reduction, [&]() {
+        cpu_scatter_reduce_expanded_index_reduction<scalar_t, reduce>(self, index, src, include_self);
+      });
     });
-  });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES(
+      self.scalar_type(), "scatter_reduce_expanded_index", [&] {
+      AT_DISPATCH_REDUCTION_TYPES(reduction, [&]() {
+        cpu_scatter_reduce_expanded_index<scalar_t, reduce>(self, index, src, include_self);
+      });
+    });
+  }
 }
 
 void gather_expanded_index_kernel(const Tensor& result, const Tensor& self, const Tensor& index) {

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -18,6 +18,12 @@
 #include <ATen/ops/zeros.h>
 #include <ATen/OpMathType.h>
 
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/zeros.h>
+#endif
 namespace at::native {
 
 namespace {

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -817,8 +817,8 @@ void cpu_gather_expanded_index_kernel(const Tensor& result, const Tensor& index,
 }
 
 void scatter_add_expanded_index_kernel(const Tensor& self, const Tensor& index, const Tensor& src) {
-  AT_DISPATCH_FLOATING_TYPES_AND(
-    ScalarType::BFloat16, self.scalar_type(), "scatter_add_expanded_index", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    ScalarType::BFloat16, ScalarType::Half, self.scalar_type(), "scatter_add_expanded_index", [&] {
       cpu_scatter_reduce_expanded_index<scalar_t, ReductionType::SUM>(self, index, src, /*include_self*/true);
   });
 }
@@ -826,8 +826,8 @@ void scatter_add_expanded_index_kernel(const Tensor& self, const Tensor& index, 
 void scatter_reduce_expanded_index_kernel(
     const Tensor& self, const Tensor& index, const Tensor& src,
     const ReductionType& reduction, bool include_self) {
-  AT_DISPATCH_FLOATING_TYPES_AND(
-    ScalarType::BFloat16, self.scalar_type(), "scatter_reduce_expanded_index", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    ScalarType::BFloat16, ScalarType::Half, self.scalar_type(), "scatter_reduce_expanded_index", [&] {
     AT_DISPATCH_REDUCTION_TYPES(reduction, [&]() {
       cpu_scatter_reduce_expanded_index<scalar_t, reduce>(self, index, src, include_self);
     });

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -279,14 +279,9 @@ class TestScatterGather(TestCase):
     @onlyCPU
     @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.float16)
     def test_scatter_expanded_index(self, device, dtype):
-        def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
-            is_reduced_type = dtype in [torch.bfloat16, torch.float16]
-            if is_reduced_type:
-                atol = 1e-2
-                rtol = 1e-2
+        def helper(input_size, idx_size):
             input = torch.randn(input_size, device=device).to(dtype=dtype)
-            input2 = input.clone().to(torch.float32) if is_reduced_type else input.clone()
-            input3 = input.clone()
+            input2 = input.clone()
 
             shape = [1] * len(input_size)
             shape[0] = idx_size
@@ -305,27 +300,16 @@ class TestScatterGather(TestCase):
             idx = idx.expand(expanded_shape)
             idx2 = idx.contiguous()
             src = torch.randn(expanded_shape, device=device).to(dtype=dtype)
-            src2 = src.clone().to(torch.float32) if is_reduced_type else src.clone()
 
             out = input.scatter_add(0, idx, src)
-            out2 = input2.scatter_add(0, idx2, src2)
-
-            if torch.has_openmp:
-                self.assertEqual(out, out2.to(dtype) if is_reduced_type else out2, atol=atol, rtol=rtol)
-            else:
-                out3 = input3.scatter_add(0, idx2, src)
-                self.assertEqual(out, out3)
+            out2 = input2.scatter_add(0, idx2, src)
+            self.assertEqual(out, out2)
 
             for reduce in ["sum", "prod", "mean", "amax", "amin"]:
                 for include_self in [True, False]:
                     out = input.scatter_reduce(0, idx, src, reduce=reduce, include_self=include_self)
-                    out2 = input2.scatter_reduce(0, idx2, src2, reduce=reduce, include_self=include_self)
-                    if torch.has_openmp:
-                        self.assertEqual(out, out2.to(dtype) if is_reduced_type else out2,
-                                         atol=atol, rtol=rtol)
-                    else:
-                        out3 = input3.scatter_reduce(0, idx2, src, reduce=reduce, include_self=include_self)
-                        self.assertEqual(out, out3)
+                    out2 = input2.scatter_reduce(0, idx2, src, reduce=reduce, include_self=include_self)
+                    self.assertEqual(out, out2)
 
         helper([50, 17], 100)
         helper([50, 1], 100)

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -279,9 +279,9 @@ class TestScatterGather(TestCase):
     @onlyCPU
     @dtypes(torch.float32, torch.float64, torch.bfloat16)
     def test_scatter_expanded_index(self, device, dtype):
-        def helper(input_size, idx_size):
+        def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
             input = torch.randn(input_size, device=device).to(dtype=dtype)
-            input2 = input.clone()
+            input2 = input.clone().to(torch.float32) if dtype in [torch.bfloat16, torch.float16] else input.clone()
 
             shape = [1] * len(input_size)
             shape[0] = idx_size
@@ -300,20 +300,21 @@ class TestScatterGather(TestCase):
             idx = idx.expand(expanded_shape)
             idx2 = idx.contiguous()
             src = torch.randn(expanded_shape, device=device).to(dtype=dtype)
+            src2 = src.clone().to(torch.float32) if dtype in [torch.bfloat16, torch.float16] else src.clone()
 
             out = input.scatter_add(0, idx, src)
-            out2 = input2.scatter_add(0, idx2, src)
+            out2 = input2.scatter_add(0, idx2, src2)
 
-            self.assertEqual(out, out2)
+            self.assertEqual(out, out2.to(dtype) if dtype in [torch.bfloat16, torch.float16] else out2, atol=atol, rtol=rtol)
 
             for reduce in ["sum", "prod", "mean", "amax", "amin"]:
                 for include_self in [True, False]:
                     out = input.scatter_reduce(0, idx, src, reduce=reduce, include_self=include_self)
-                    out2 = input2.scatter_reduce(0, idx2, src, reduce=reduce, include_self=include_self)
-                    self.assertEqual(out, out2)
+                    out2 = input2.scatter_reduce(0, idx2, src2, reduce=reduce, include_self=include_self)
+                    self.assertEqual(out, out2.to(dtype) if dtype in [torch.bfloat16, torch.float16] else out2, atol=atol, rtol=rtol)
 
         helper([50, 17], 100)
-        helper([50, 1], 100)
+        helper([50, 1], 100, atol=1e-3, rtol=0.016) # SLow path has accuracy gap between float32 and low precision
         helper([50, 8, 7], 100)
         helper([50, 3, 4, 5], 100)
 

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -311,10 +311,11 @@ class TestScatterGather(TestCase):
                 for include_self in [True, False]:
                     out = input.scatter_reduce(0, idx, src, reduce=reduce, include_self=include_self)
                     out2 = input2.scatter_reduce(0, idx2, src2, reduce=reduce, include_self=include_self)
-                    self.assertEqual(out, out2.to(dtype) if dtype in [torch.bfloat16, torch.float16] else out2, atol=atol, rtol=rtol)
+                    self.assertEqual(out, out2.to(dtype) if dtype in [torch.bfloat16, torch.float16] else out2,
+                                     atol=atol, rtol=rtol)
 
         helper([50, 17], 100)
-        helper([50, 1], 100, atol=1e-3, rtol=0.016) # SLow path has accuracy gap between float32 and low precision
+        helper([50, 1], 100, atol=1e-3, rtol=0.016)  # SLow path has accuracy gap between float32 and low precision
         helper([50, 8, 7], 100)
         helper([50, 3, 4, 5], 100)
 

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -280,6 +280,7 @@ class TestScatterGather(TestCase):
     @dtypes(torch.float32, torch.float64, torch.bfloat16)
     def test_scatter_expanded_index(self, device, dtype):
         def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
+            torch.manual_seed(1234)
             is_reduced_type = dtype in [torch.bfloat16, torch.float16]
             if is_reduced_type:
                 atol = 1e-2

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -277,7 +277,7 @@ class TestScatterGather(TestCase):
                 self.assertEqual(input, expected_result)
 
     @onlyCPU
-    @dtypes(torch.float32, torch.float64, torch.bfloat16)
+    @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.float16)
     def test_scatter_expanded_index(self, device, dtype):
         def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
             is_reduced_type = dtype in [torch.bfloat16, torch.float16]

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -280,7 +280,6 @@ class TestScatterGather(TestCase):
     @dtypes(torch.float32, torch.float64, torch.bfloat16)
     def test_scatter_expanded_index(self, device, dtype):
         def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
-            torch.manual_seed(1234)
             is_reduced_type = dtype in [torch.bfloat16, torch.float16]
             if is_reduced_type:
                 atol = 1e-2

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -282,8 +282,8 @@ class TestScatterGather(TestCase):
         def helper(input_size, idx_size, atol=1e-5, rtol=0.016):
             is_reduced_type = dtype in [torch.bfloat16, torch.float16]
             if is_reduced_type:
-                atol = 1e-3
-                rtol = 0.016
+                atol = 1e-2
+                rtol = 1e-2
             input = torch.randn(input_size, device=device).to(dtype=dtype)
             input2 = input.clone().to(torch.float32) if is_reduced_type else input.clone()
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2517,6 +2517,7 @@ class TestSparseCSR(TestCase):
 
     @onlyCPU
     @dtypes(torch.float32, torch.float64, torch.bfloat16)
+    @precisionOverride({torch.bfloat16: 0.01})
     def test_sparse_mm_reduce(self, device, dtype):
         def run_test(m, n, k, nnz, reduce_type, index_dtype, train):
             csr = self.genSparseCSRTensor((m, n), nnz, dtype=dtype, device=device, index_dtype=index_dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6017,7 +6017,8 @@ class TestTorch(TestCase):
             if device == 'cuda':
                 self.assertEqual(out, ref_out, atol=1e-2, rtol=1e-2)
             else:
-                self.assertEqual(out, ref_out.to(dtype=dtype))
+                # scatter_add uses fp32 as accumulate type, while index_add doesn't.
+                self.assertEqual(out, ref_out.to(dtype=dtype), atol=1e-2, rtol=1e-2)
 
         for dim in [-1, -2, -3]:
             for dtype in all_types_and_complex_and(torch.half, torch.bfloat16):


### PR DESCRIPTION
### Description

This PR is to optimize scatter_add/scatter_reduce of BFloat16/Half data type in CPU backend, which is one task in https://github.com/pyg-team/pytorch_geometric/issues/7057. Main point is creating a buffer among threads to accumulate intermediate data as fp32 data type.

Next step:

 - [x] Add benchmarks
 - [x] Extend to Half
 - [x] Simplify code

### Performance test (Updated)

Test BFloat16 in Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz
With jemalloc and iomp

Single socket (40C)
![image](https://github.com/pytorch/pytorch/assets/61222868/4b4342f1-8cc3-46f7-81f5-651becd9b1e3)

Single core
![image](https://github.com/pytorch/pytorch/assets/61222868/09e5f700-2c2e-4208-979e-74b85474dea6)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10