### PR TITLE
Dynamically assign number of threads in innerdim scan

### DIFF
--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -16,6 +16,30 @@ constexpr inline integer ceil_div(integer n, integer m) {
   return (n + m - 1) / m;
 }
 
+template <typename integer>
+constexpr inline integer get_log_num_threads_x_inner_scan(integer num_rows, integer row_size) {
+  integer log_num_threads_x = 0;
+  integer log_num_threads_y = 0;
+  while (((integer)1 << log_num_threads_x) < row_size) {
+    ++log_num_threads_x;
+  }
+  while (((integer)1 << log_num_threads_y) < num_rows) {
+    ++log_num_threads_y;
+  }
+  // we want to keep the ratio between the x-threads and y-threads about the same as
+  // the ratio between the row_size and num_rows, but the total number of threads in
+  // a block should be about 512
+  integer diff = log_num_threads_x - log_num_threads_y;
+  // 9 is from log2(512)
+  log_num_threads_x = ((integer)9 + diff) / (integer)2;
+  // I found that in having larger log_num_threads_x can give significant speed up in some cases,
+  // but detrimental in another case, so just keep the lower bound to be log2(16) == 4 to make it
+  // similar to the previous implementation
+  // Keeping the upper bound to be log2(512) == 9 as the maximum number of threads in a block.
+  log_num_threads_x = std::min(std::max((integer)4, log_num_threads_x), (integer)9);
+  return log_num_threads_x;
+}
+
 template<typename scalar_t, typename idx_t, typename BinaryOperation>
 __device__ void binary_op_update(const scalar_t lhs, scalar_t& rhs, const idx_t lhs_idx, idx_t& rhs_idx, BinaryOperation binary_op) {
   if(!at::_isnan(rhs) && (at::_isnan(lhs) || !binary_op(rhs, lhs))) {
@@ -265,10 +289,12 @@ __global__ void tensor_kernel_scan_outer_dim(scalar_t *tgt_, const scalar_t *src
  * Each thread block processes one or more sets of contiguous rows (processing multiple rows
  * per thread block is quicker than processing a single row, especially for short rows).
  */
-template<typename T, int num_threads_x, int num_threads_y, class BinaryFunction>
+template<typename T, int num_threads, class BinaryFunction>
 __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const T *src_,
                                       const uint32_t num_rows, const uint32_t row_size,
+                                      const uint32_t log_num_threads_x,
                                       T init, BinaryFunction binary_op){
+  const uint32_t num_threads_x = 1 << log_num_threads_x;
   for (uint32_t block_row = blockIdx.x * blockDim.y;
        block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
@@ -307,9 +333,10 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
 
       // Parallel reduction with Sklansky method. The diagram can be seen on this paper:
       // https://research.nvidia.com/publication/single-pass-parallel-prefix-scan-decoupled-look-back
-      for (uint32_t s = 1; s <= num_threads_x; s <<= 1) {
+      for (uint32_t m = 0; m <= log_num_threads_x; ++m) {
         if (row_exists) {
-          uint32_t a = (threadIdx.x / s) * (2 * s) + s;
+          uint32_t s = 1 << m; // s = 2 ^ m
+          uint32_t a = ((threadIdx.x >> m) << (m + 1)) | s; // a = (threadIdx.x / s) * (2 * s) + s
           uint32_t ti = a + (threadIdx.x % s);
           uint32_t si = a - 1;
           row_buf[ti] = binary_op(row_buf[ti], row_buf[si]);
@@ -330,8 +357,7 @@ __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const
 
 template <
     typename T,
-    int num_threads_x,
-    int num_threads_y,
+    int num_threads,
     class BinaryFunction>
 __global__ typename std::enable_if<!c10::is_complex<T>::value, void>::type
 tensor_kernel_scan_innermost_dim(
@@ -339,19 +365,20 @@ tensor_kernel_scan_innermost_dim(
     const T* src_,
     const uint32_t num_rows,
     const uint32_t row_size,
+    const uint32_t log_num_threads_x,
     T init,
     BinaryFunction binary_op) {
-  __shared__ T sbuf[num_threads_y][2 * num_threads_x];
-  T* row_buf = sbuf[threadIdx.y];
+  __shared__ T sbuf[num_threads * 2];
+  const uint32_t num_threads_x = 1 << log_num_threads_x;
+  T* row_buf = sbuf + num_threads_x * 2 * threadIdx.y;
 
-  tensor_kernel_scan_innermost_dim_impl<T, num_threads_x, num_threads_y>(
-      row_buf, tgt_, src_, num_rows, row_size, init, binary_op);
+  tensor_kernel_scan_innermost_dim_impl<T, num_threads>(
+      row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
 }
 
 template <
     typename T,
-    int num_threads_x,
-    int num_threads_y,
+    int num_threads,
     class BinaryFunction>
 __global__ typename std::enable_if<c10::is_complex<T>::value, void>::type
 tensor_kernel_scan_innermost_dim(
@@ -359,6 +386,7 @@ tensor_kernel_scan_innermost_dim(
     const T* src_,
     const uint32_t num_rows,
     const uint32_t row_size,
+    const uint32_t log_num_threads_x,
     T init,
     BinaryFunction binary_op) {
   // As we cannot directly initialize shared array for complex types
@@ -367,12 +395,13 @@ tensor_kernel_scan_innermost_dim(
   // We instead get the base scalar type and allocate twice number of
   // elements required of base type and reinterpret them as complex.
   using base_t = typename scalar_value_type<T>::type;
-  __shared__ base_t sbuf[num_threads_y][4 * num_threads_x];
+  const uint32_t num_threads_x = 1 << log_num_threads_x;
+  __shared__ base_t sbuf[4 * num_threads];
 
-  T* row_buf = reinterpret_cast<T*>(sbuf[threadIdx.y]);
+  T* row_buf = reinterpret_cast<T*>(sbuf + num_threads_x * 4 * threadIdx.y);
 
-  tensor_kernel_scan_innermost_dim_impl<T, num_threads_x, num_threads_y>(
-      row_buf, tgt_, src_, num_rows, row_size, init, binary_op);
+  tensor_kernel_scan_innermost_dim_impl<T, num_threads>(
+      row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
 }
 
 
@@ -410,16 +439,20 @@ void scan_innermost_dim(const TensorBase& self, const TensorBase& result,
   int64_t row_size = self.size(ndim - 1);
   int64_t num_rows = self.numel() / row_size;
 
-  dim3 threads(16, 32);
+  // assuming max_num_threads per block is 512
+  const uint32_t log_num_threads_x = get_log_num_threads_x_inner_scan<uint32_t>(num_rows, row_size);
+  const uint32_t num_threads_x = (1 << log_num_threads_x);
+  const uint32_t num_threads_y = 512 / num_threads_x;
+  dim3 threads(num_threads_x, num_threads_y);
   int64_t maxGridDim = at::cuda::getCurrentDeviceProperties()->maxGridSize[0];
   dim3 grid(std::min(maxGridDim, ceil_div(num_rows, int64_t{threads.y})));
 
   check_fits_in_unsigned(num_rows, "Number of rows (self.numel()/self.size(self.dim()-1))");
   check_fits_in_unsigned(row_size, "row_size");
 
-  tensor_kernel_scan_innermost_dim<scalar_t, 16, 32><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  tensor_kernel_scan_innermost_dim<scalar_t, 512><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
     result.mutable_data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(),
-    num_rows, row_size, init, binary_op);
+    num_rows, row_size, log_num_threads_x, init, binary_op);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 

--- a/aten/src/ATen/native/cuda/ScanUtils.cuh
+++ b/aten/src/ATen/native/cuda/ScanUtils.cuh
@@ -289,7 +289,7 @@ __global__ void tensor_kernel_scan_outer_dim(scalar_t *tgt_, const scalar_t *src
  * Each thread block processes one or more sets of contiguous rows (processing multiple rows
  * per thread block is quicker than processing a single row, especially for short rows).
  */
-template<typename T, int num_threads, class BinaryFunction>
+template<typename T, class BinaryFunction>
 __device__ void tensor_kernel_scan_innermost_dim_impl(T* row_buf, T *tgt_, const T *src_,
                                       const uint32_t num_rows, const uint32_t row_size,
                                       const uint32_t log_num_threads_x,
@@ -372,7 +372,7 @@ tensor_kernel_scan_innermost_dim(
   const uint32_t num_threads_x = 1 << log_num_threads_x;
   T* row_buf = sbuf + num_threads_x * 2 * threadIdx.y;
 
-  tensor_kernel_scan_innermost_dim_impl<T, num_threads>(
+  tensor_kernel_scan_innermost_dim_impl<T>(
       row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
 }
 
@@ -400,7 +400,7 @@ tensor_kernel_scan_innermost_dim(
 
   T* row_buf = reinterpret_cast<T*>(sbuf + num_threads_x * 4 * threadIdx.y);
 
-  tensor_kernel_scan_innermost_dim_impl<T, num_threads>(
+  tensor_kernel_scan_innermost_dim_impl<T>(
       row_buf, tgt_, src_, num_rows, row_size, log_num_threads_x, init, binary_op);
 }
 


### PR DESCRIPTION
This is the continuation of optimizing inner-dimension scan operations (`torch.cumsum`, `torch.cumprod`, `torch.logcumsumexp`) by dynamically setting the number of threads based on the input shape from #103314.
What I found that just setting the number of x-threads and y-threads following the ratio of the tensor's shape works quite well (with some clamping).
Here is the speed-up of this PR, compared to `2.0.0+cu118` (not compared to #103314) using A100 with 40GB memory (up to 23x faster):
```
                2        8       32      128      512     1024     2048     4096     8096    16348    65536   262144  1048576 
       2:  1.07(4)  1.02(5)  1.01(6)  1.07(7)  2.16(8)  4.94(9)  8.71(9) 11.00(9) 12.99(9) 14.77(9) 16.41(9) 16.81(9) 16.97(9) 
       8:  1.20(4)  1.00(4)  1.01(5)  1.08(6)  2.85(7)  4.90(8)  6.34(8) 11.76(9) 13.86(9) 15.26(9) 16.96(9) 17.45(9) 19.75(9) 
      32:  1.08(4)  1.00(4)  1.00(4)  1.23(5)  2.48(6)  4.23(7)  5.04(7)  9.16(8) 10.11(8) 18.72(9) 20.64(9) 23.13(9) 23.50(9) 
     128:  1.09(4)  1.02(4)  1.03(4)  1.02(4)  1.64(5)  2.84(6)  3.08(6)  5.61(7)  5.86(7) 10.72(8) 19.22(9) 19.75(9) 19.97(9) 
     512:  1.06(4)  1.14(4)  1.01(4)  1.10(4)  1.02(4)  1.78(5)  1.85(5)  3.26(6)  3.34(6)  5.56(7)  8.56(8)  9.55(9)  9.62(9) 
    1024:  1.21(4)  1.22(4)  1.20(4)  1.06(4)  1.03(4)  1.05(4)  1.81(5)  1.86(5)  3.06(6)  3.12(6)  4.76(7)  5.20(8)  5.56(9) 
    2048:  1.04(4)  0.88(4)  1.00(4)  1.01(4)  1.02(4)  1.03(4)  1.02(4)  1.72(5)  1.73(5)  2.62(6)  2.86(7)  3.06(8) -------- 
    4096:  1.02(4)  1.12(4)  0.98(4)  1.60(4)  1.16(4)  1.09(4)  1.10(4)  1.10(4)  1.74(5)  1.75(5)  1.86(6)  2.00(7) -------- 
    8096:  1.03(4)  1.00(4)  1.00(4)  1.16(4)  1.17(4)  1.17(4)  1.18(4)  1.18(4)  1.18(4)  1.27(5)  1.43(6) -------- -------- 
   16348:  1.02(4)  1.15(4)  1.11(4)  1.17(4)  1.12(4)  1.11(4)  1.13(4)  1.12(4)  1.11(4)  1.08(4)  1.32(5) -------- -------- 
   65536:  1.17(4)  1.17(4)  1.16(4)  1.15(4)  1.12(4)  1.12(4)  1.12(4)  1.10(4)  1.10(4)  1.07(4) -------- -------- -------- 
  262144:  1.20(4)  1.20(4)  1.08(4)  1.13(4)  1.10(4)  1.09(4)  1.10(4)  1.08(4) -------- -------- -------- -------- -------- 
 1048576:  1.21(4)  1.14(4)  1.10(4)  1.13(4)  1.09(4)  1.08(4) -------- -------- -------- -------- -------- -------- --------
```
The first row is the innermost dimension, the first column is the outermost dimension (i.e. the batch size).
The float numbers are the speed up while the integers within the brackets are the log2 of number of x-threads.
The blank cells (the ones with dashes) are not compared because of my GPU's memory limitation.

There are some slowdowns that I observed (like `(2048, 8)` and `(4096, 32)`). The slowdown is because in this PR, the scan loop (the one I use with Sklansky) is not optimized by the compiler due to dynamic number of iterations (it is `log2(num_threads_x)`), while in the previous version, the scan loop can be unrolled and optimized by the compiler due to fixed number of iterations.
That's why I slightly modified the operations within the scan loop to use bit operations in order to compensate for this slowdown.

The most significant acceleration comes from the tensors with relatively small batch size (<= 4096) and with very long sequence.
As the batch size increases, the speed up is not that significant because the previous implementation is most likely to be optimized.
NOTE: I haven't optimized scan dim with indices, it could come in another PR.

As for the build time, I tried not to write more templated functions than necessary.
I will report the build time when I already have the numbers.
UPDATE: I compared the build time when I changed ScanUtils.cuh only. In `main` branch, it took 4m2s, while in this PR, it took 3m39s.

What do you think, @ngimel?