### PR TITLE
Rewrite size/stride/numel TensorVariable handling

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1232,7 +1232,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             x = torch.randn(3)
             ref = fn(x)
             res = opt_fn(x)
-            self.assertTrue(same(ref, res))
+            self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 2)
 
     @requires_numpy_pytorch_interop
@@ -1843,8 +1843,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
         x = torch.empty([4, 9, 8])
-        self.assertTrue(opt_fn(x, 1) == 9)
-        self.assertTrue(opt_fn(x, -2) == 9)
+        self.assertEqual(opt_fn(x, 1), 9)
+        self.assertEqual(opt_fn(x, -2), 9)
 
     def test_stride_dim(self):
         cnts = torch._dynamo.testing.CompileCounter()
@@ -1854,8 +1854,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
         x = torch.empty([4, 9, 8])
-        self.assertTrue(opt_fn(x, 0) == 72)
-        self.assertTrue(opt_fn(x, -2) == 8)
+        self.assertEqual(opt_fn(x, 0), 72)
+        self.assertEqual(opt_fn(x, -2), 8)
 
     def test_torch_seed(self):
         cnts = torch._dynamo.testing.CompileCounter()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -982,7 +982,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(cnt.frame_count, 2)
         self.assertEqual(
-            cnt.op_count, ifunspec(37, ifdyn(ifdynstaticdefault(4, 20), 4))
+            cnt.op_count, ifunspec(35, ifdyn(ifdynstaticdefault(4, 20), 4))
         )
 
     def test_hf_t5_forward(self):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -765,7 +765,6 @@ class NumpyNdarrayVariable(TensorVariable):
         # no intrinsic reason ndarray properties are related to Tensor
         # properties.  The inheritance here is for implementation sharing.
 
-        from torch._dynamo.variables import GetAttrVariable, TupleVariable
         from ..utils import numpy_attr_wrapper
         from .builder import wrap_fx_proxy, wrap_fx_proxy_cls
 
@@ -781,10 +780,7 @@ class NumpyNdarrayVariable(TensorVariable):
             return wrap_fx_proxy(
                 tx,
                 tx.output.create_proxy(
-                    "call_function",
-                    numpy_attr_wrapper,
-                    (self.as_proxy(), name),
-                    {}
+                    "call_function", numpy_attr_wrapper, (self.as_proxy(), name), {}
                 ),
                 **options,
             )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -280,14 +280,58 @@ class TensorVariable(VariableTracker):
 
         kwargs = dict(kwargs)
         options = VariableTracker.propagate(self, args, kwargs.values())
-        if name == "stride" and self.stride is not None:
-            constant_result = ConstantVariable(self.stride, **options)
 
-            if "dim" in kwargs:
-                dim = kwargs.pop("dim")
-                constant_result = constant_result.getitem_const(dim)
+        if name in ("stride", "size"):
+            dim_var = None
+            if len(args) == 1:
+                dim_var = args[0]
+            elif "dim" in kwargs:
+                dim_var = kwargs["dim"]
+            else:
+                assert not args and not kwargs, f"Tensor.{name}() unhandled args/kwargs"
 
-        elif name == "size" and self.size is None:
+            dim = None
+            if isinstance(dim_var, SymNodeVariable):
+                # This is because SymNodeVariable intentionally doesn't define
+                # as_python_constant to avoid shunting down some codepaths
+                # that expect consts.   In this case, we know we definitely
+                # want to specialize though.
+                dim = dim_var.evaluate_expr()
+            elif dim_var is not None:
+                dim = dim_var.as_python_constant()
+
+            def make_const_size_variable(x, **options):
+                return SizeVariable(
+                    [ConstantVariable(y, **options) for y in x], **options
+                )
+
+            RetVariable = (
+                make_const_size_variable if name == "size" else ConstantVariable
+            )
+
+            # Technically, this should not be necessary, but I'm including it
+            # for enhanced BC, in case example_value is sometimes not set
+            # (it really should always be set though!)
+            if (r := getattr(self, name)) is not None:
+                if dim is None:
+                    return RetVariable(r, **options)
+                else:
+                    return ConstantVariable(r[dim], **options)
+
+            # It might still be constant!  Consult the fake tensor and see
+            if (fake := self.proxy.node.meta.get("example_value")) is not None:
+                if dim is None:
+                    fake_r = getattr(fake, name)()
+                    if not free_symbols(fake_r):
+                        # int conversion for safety, in case a SymInt refined
+                        # to constant
+                        return RetVariable(tuple(int(r) for r in fake_r), **options)
+                else:
+                    fake_r = getattr(fake, name)(dim)
+                    if not free_symbols(fake_r):
+                        return ConstantVariable(int(fake_r), **options)
+
+            # Oops, it's not constant.  Do the dynamic shapes path.
             return wrap_fx_proxy(
                 tx,
                 tx.output.create_proxy(
@@ -297,16 +341,30 @@ class TensorVariable(VariableTracker):
                 ),
                 **options,
             )
-        elif name == "size" and self.size is not None:
-            sizes = [variables.ConstantVariable(x) for x in self.size]
-            constant_result = SizeVariable(sizes, **options)
 
-            if "dim" in kwargs:
-                dim = kwargs.pop("dim")
-                constant_result = constant_result.getitem_const(dim)
+        elif name in ("numel", "nelement"):
+            if self.size is not None:
+                return ConstantVariable(product(self.size), **options)
 
-        elif name in ("numel", "nelement") and self.size is not None:
-            constant_result = ConstantVariable(product(self.size), **options)
+            # It might still be constant!  Consult the fake tensor and see
+            if (fake := self.proxy.node.meta.get("example_value")) is not None:
+                fake_r = fake.numel()
+                if not free_symbols(fake_r):
+                    return ConstantVariable(int(fake_r), **options)
+
+            assert not kwargs, f"Tensor.{name}() unhandled kwargs"
+
+            # Oops, it's not constant.  Do the dynamic shapes path.
+            return wrap_fx_proxy(
+                tx,
+                tx.output.create_proxy(
+                    "call_method",
+                    "numel",
+                    *proxy_args_kwargs([self] + list(args), kwargs),
+                ),
+                **options,
+            )
+
         elif name in ("ndimension", "dim") and self.ndim is not None:
             constant_result = ConstantVariable(self.ndim, **options)
         elif name == "is_floating_point" and self.dtype is not None:
@@ -363,6 +421,7 @@ class TensorVariable(VariableTracker):
 
         if constant_result:
             assert not kwargs, f"Tensor.{name}() unhandled kwargs"
+            # TODO: I think this branch is dead
             if len(args) == 1:
                 return constant_result.getitem_const(args[0])
             elif args:
@@ -545,7 +604,7 @@ class SymNodeVariable(VariableTracker):
     def as_proxy(self):
         return self.proxy
 
-    def evaluate_expr(self, output_graph):
+    def evaluate_expr(self, output_graph=None):
         return guard_scalar(self.sym_num)
 
     def call_method(
@@ -702,12 +761,34 @@ class NumpyNdarrayVariable(TensorVariable):
         super().__init__(proxy, **kwargs)
 
     def var_getattr(self, tx, name):
+        # NB: This INTENTIONALLY does not call super(), because there is
+        # no intrinsic reason ndarray properties are related to Tensor
+        # properties.  The inheritance here is for implementation sharing.
+
         from torch._dynamo.variables import GetAttrVariable, TupleVariable
         from ..utils import numpy_attr_wrapper
         from .builder import wrap_fx_proxy, wrap_fx_proxy_cls
 
         result = None
         options = VariableTracker.propagate(self)
+
+        import torch_np
+
+        example_value = self.proxy.node.meta["example_value"]
+        example_ndarray = torch_np.ndarray(example_value)
+
+        def insert_into_graph():
+            return wrap_fx_proxy(
+                tx,
+                tx.output.create_proxy(
+                    "call_function",
+                    numpy_attr_wrapper,
+                    (self.as_proxy(), name),
+                    {}
+                ),
+                **options,
+            )
+
         if name in ["T", "real", "imag"]:
             result = wrap_fx_proxy_cls(
                 target_cls=NumpyNdarrayVariable,
@@ -718,56 +799,31 @@ class NumpyNdarrayVariable(TensorVariable):
                     (self.as_proxy(), name),
                     {},
                 ),
-                example_value=None,
                 **options,
             )
-        elif name in ["ndim", "itemsize", "shape"]:
-            result = wrap_fx_proxy_cls(
-                target_cls=ConstantVariable,
-                tx=tx,
-                proxy=GetAttrVariable.create_getattr_proxy(self.as_proxy(), name),
-                example_value=None,
-                **options,
-            )
-        elif name == "shape":
-            # ndarray.shape gives a tuple of ints while tensor.shape returns a torch.Size object.
-            # Here we overrides target_cls to be TupleVariable to match ndarray.shape return type.
-            result = wrap_fx_proxy_cls(
-                target_cls=TupleVariable,
-                tx=tx,
-                proxy=GetAttrVariable.create_getattr_proxy(self.as_proxy(), name),
-                example_value=None,
-                **options,
-            )
+        # These are awkward to implement.  The standard playbook for torch_np
+        # interop is to trace a call into the torch_np wrapper which works for
+        # Tensor operations.  However, we don't want to do this for calls
+        # that don't return Tensors, because in those cases we may not want
+        # to trace the attribute access into the graph at all (it is sort
+        # of harmless to do so, because AOTAutograd will eliminate them,
+        # but it's best not to trace them in to begin with.)  But in any
+        # case, tracing these into the graph is like trying to fit a square
+        # peg into a round hole; best not to do it.  So instead we
+        # painstakingly implement these by hand
+        #
+        # NB: only ALWAYS specialized attributes can go here; notably,
+        # size/shape not allowed!
+        elif name in ("ndim", "itemsize"):
+            return ConstantVariable(getattr(example_ndarray, name), **options)
+        elif name in ("shape", "stride"):
+            if not free_symbols(r := getattr(example_ndarray, name)):
+                return ConstantVariable(tuple(int(r) for r in r), **options)
+            return insert_into_graph()
         elif name == "size":
-            result = wrap_fx_proxy(
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_method",
-                    "numel",
-                    (self.as_proxy(),),
-                    {},
-                ),
-                example_value=None,
-                **options,
-            )
-        elif name == "strides":
-            # ndarray.strides returns a tuple of strides in terms of bytes. E.g., np.ones([2, 3]).strides -> (24, 8).
-            # This result can't be generated from tensor attributes or functions (given we don't have tensor.strides()
-            # and the semantics of tensor.stride() is different), so instead we delegate it to torch_np.ndarray
-            # strides() function call.
-            torch_np_func_name = "strides"
-            result = wrap_fx_proxy(
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_function",
-                    numpy_attr_wrapper,
-                    (self.as_proxy(), torch_np_func_name),
-                    {},
-                ),
-                example_value=None,
-                **options,
-            )
+            if not free_symbols(r := example_ndarray.size):
+                return ConstantVariable(int(r), **options)
+            return insert_into_graph()
         elif name in ["base", "flags", "dtype"]:
             unimplemented(f"TODO: add support for ndarray.{name}")
         if result is None:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -193,12 +193,15 @@ def free_symbols(val: Union[SymInt, torch.Tensor]) -> Set[sympy.Symbol]:
     elif isinstance(val, (int, float, bool)):
         return set()
     elif isinstance(val, torch.Tensor):
+        return (
+            free_symbols(val.size()) |
+            free_symbols(val.stride()) |
+            free_symbols(val.storage_offset())
+        )
+    elif isinstance(val, (tuple, list)):
         r = set()
-        for s in val.size():
+        for s in val:
             r |= free_symbols(s)
-        for s in val.stride():
-            r |= free_symbols(s)
-        r |= free_symbols(val.storage_offset())
         return r
     else:
         raise AssertionError(f"cannot compute free_symbols of {val}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103438
* #103302

The main concept behind this refactor is this: if we know that a size/stride/etc is constant, do NOT trace it into the graph, EXCEPT for any preexisting special cases that applied for static shapes. The refactor unfolds like this:

1. Delete the `dynamic_shapes` branches in torch/_dynamo/variables/builder.py which accept int/float/bool outputs. This is over-aggressive and we don't want to allow this (because if the operator returns a constant, we shouldn't have called wrap_fx_proxy in the first place.) This causes a bunch of failures because we are blindly feeding the result of size() call to wrap_fx_proxy when dynamic shapes is enabled.
2. Modify TensorVariable.call_method in torch/_dynamo/variables/tensor.py to avoid sending constant ints to wrap_fx_proxy. After normal specialization (which should be deleted, see https://github.com/pytorch/pytorch/pull/103434) we consult the fake tensor to see if the values in question have free variables or not. If they don't we short circuit tracing into graph. We only trace into graph if the operation in question is truly symbolic. Note that there is a near miss here: it's OK to trace x.size() call entirely into the graph, even if it doesn't have all dynamic shapes, because operator.getitem with int output is special cased in builder.py. This is a preexisting special case and I don't try to get rid of it.
3. It turns out that the change here also breaks torch_np compatibility layer. So I completely rewrite getattr handling in torch/_dynamo/variables/tensor.py to follow the same pattern (only trace into graph if truly dynamic). 

There's some minor housekeeping in torch/fx/experimental/symbolic_shapes.py and some test files.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy 