### PR TITLE
[Profiler] Fix flaky test_memory_timeline_no_id

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1591,16 +1591,19 @@ class TestMemoryProfilerE2E(TestCase):
             (_memory_profiler.Action.DESTROY, 1024),
         ]
 
+        actual = [(action, size) for _, action, _, size in memory_profile.timeline]
+
         # See above.
         if not torch.cuda.is_available():
             expected = expected[2:]
-
-        actual = [(action, size) for _, action, _, size in memory_profile.timeline]
-        self.assertEqual(
-            actual,
-            expected,
-            f"expected does not match actual: {actual}",
-        )
+            for event in expected:
+                self.assertTrue(event in actual, f"event: {event} was not found in actual.")
+        else:
+            self.assertEqual(
+                actual,
+                expected,
+                f"expected does not match actual: {actual}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: On CPU only runs, the allocator seems to sometimes report out of context CPU allocations, but sometimes not. Let's just check the expected list is in the actual list for CPU. GPU test stays the same.

Test Plan: CI, ran locally 100 times.

Reviewers: dberard

Resolves: https://github.com/pytorch/pytorch/issues/103286