### PR TITLE
Make all CI commit pin changes trigger ciflow/inductor

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,6 +21,7 @@
 - functorch/_src/partitioners.py
 - functorch/_src/aot_autograd.py
 - .ci/docker/ci_commit_pins/**
+- .github/ci_commit_pins/**
 
 "module: cpu":
 - aten/src/ATen/cpu/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,7 +20,7 @@
 - test/distributed/test_inductor_collectives.py
 - functorch/_src/partitioners.py
 - functorch/_src/aot_autograd.py
-- .ci/docker/ci_commit_pins/triton.txt
+- .ci/docker/ci_commit_pins/**
 
 "module: cpu":
 - aten/src/ATen/cpu/**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103443

Signed-off-by: Edward Z. Yang <ezyang@meta.com>