### PR TITLE
Update C++ frontend docs

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -33,7 +33,7 @@ this:
 
 .. code-block:: cmake
 
-  cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
   project(example-app)
 
   find_package(Torch REQUIRED)
@@ -41,7 +41,7 @@ this:
 
   add_executable(example-app example-app.cpp)
   target_link_libraries(example-app "${TORCH_LIBRARIES}")
-  set_property(TARGET example-app PROPERTY CXX_STANDARD 14)
+  set_property(TARGET example-app PROPERTY CXX_STANDARD 17)
 
   # The following code block is suggested to be used on Windows.
   # According to https://github.com/pytorch/pytorch/issues/25457,


### PR DESCRIPTION
Specify that C++ standard is not C++17 and minimum supported CMake version is 3.18

Fixes https://github.com/pytorch/pytorch/issues/103371
