### PR TITLE
`default` should be used as default value in `boolean_dispatch`

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -476,7 +476,7 @@ def boolean_dispatch(
     """
 
     def fn(*args, **kwargs):
-        dispatch_flag = False
+        dispatch_flag = default
         if arg_name in kwargs:
             dispatch_flag = kwargs[arg_name]
         elif arg_index < len(args):


### PR DESCRIPTION
The original code mistakenly uses `False`, but should be `default` as passed in.

NOTE: The behavior is silently changed in an internal package. Be aware if you use it for your own purposes.