### PR TITLE
Propagate Specialized Kernel Support through ComputeCodegenUnboxedKernels

### DIFF
--- a/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
+++ b/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
@@ -1,25 +1,25 @@
 #include <operator_registry.h>
-#include "Functions.h"
+#include "${fn_header}" // Generated Function import headers
 
 namespace torch {
 namespace executor {
 
 namespace {
-using OpArrayRef = ::at::ArrayRef<::torch::executor::Operator>;
+using KernelArrayRef = ::at::ArrayRef<::torch::executor::Kernel>;
 
-static Operator operators_to_register[] = {
-    ${unboxed_ops} // Generated operators
+static Kernel operators_to_register[] = {
+    ${unboxed_kernels} // Generated operators
 };
 
 // Explicitly convert to ArrayRef, so that the API can take an empty C array of
-// Operators.
-static OpArrayRef op_array_ref(
-    operators_to_register,
-    operators_to_register + sizeof(operators_to_register) / sizeof(Operator));
+// Kernels.
+static KernelArrayRef kernel_array_ref(
+    kernels_to_register,
+    kernels_to_register + sizeof(kernels_to_register) / sizeof(Kernel));
 
 // Return value not used. Keep the static variable assignment to register
 // operators in static initialization time.
-static auto success_with_op_reg = register_operators(op_array_ref);
+static auto success_with_kernel_reg = register_kernels(kernel_array_ref);
 } // namespace
 } // namespace executor
 } // namespace torch

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -5,10 +5,11 @@ from typing import Dict
 
 import yaml
 
-from torchgen.executorch.model import ETKernelIndex
+from torchgen.executorch.model import ETKernelIndex, ETKernelKey
 from torchgen.gen import LineLoader
 
 from torchgen.gen_executorch import (
+    ComputeCodegenUnboxedKernels,
     gen_functions_declarations,
     parse_yaml_files,
     translate_native_yaml,
@@ -360,6 +361,7 @@ class TestGenFunctionsDeclarations(unittest.TestCase):
             selector=SelectiveBuilder.get_nop_selector(),
             use_aten_lib=False,
         )
+        print(declarations)
         self.assertTrue(
             """
 namespace custom_1 {
@@ -411,3 +413,81 @@ TORCH_API inline bool op_1(torch::executor::RuntimeContext & context) {
         """
             in declarations
         )
+
+
+class TestComputeCodegenUnboxedKernels(unittest.TestCase):
+    def setUp(self) -> None:
+        (
+            self.native_function_no_kern,
+            _,
+        ) = NativeFunction.from_yaml(
+            {
+                "func": "custom_1::op_1() -> bool",
+                "dispatch": {"CPU": "unused_kernel_1"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        self.default_kernel_key = ETKernelKey(default=True)
+        self.default_backend_metadata = BackendMetadata(
+            "default_kernel", False, "at::native"
+        )
+        self.default_kernel_entry = (
+            [self.default_kernel_key],
+            self.default_backend_metadata,
+        )
+
+    def test_codegen_unboxed_specialized(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml({"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")}, {"T0": ["Double"]}, {"D0": [0, 1, 2, 3]})
+        selector = SelectiveBuilder.get_nop_selector()
+        use_aten_lib = False
+        entry = (self.native_function_no_kern, (specialized_kernel_key, self.default_backend_metadata))
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = (
+            """
+Kernel(
+    "custom_1::op_1",
+    "v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3",
+    [](torch::executor::RuntimeContext & context, EValue** stack) {
+        """
+            + """
+
+        EXECUTORCH_SCOPE_PROF("native_call_op_1");
+        bool result_ = at::native::default_kernel(context, );
+
+        *stack[0] = EValue(result_);
+    }
+),
+"""
+        )
+
+        self.assertEqual(expected_str, result)
+
+    def test_codegen_unboxed_default(self) -> None:
+        selector = SelectiveBuilder.get_nop_selector()
+        use_aten_lib = False
+        entry = (self.native_function_no_kern, self.default_kernel_entry)
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = (
+            """
+Kernel(
+    "custom_1::op_1",
+    [](torch::executor::RuntimeContext & context, EValue** stack) {
+        """
+            + """
+
+        EXECUTORCH_SCOPE_PROF("native_call_op_1");
+        bool result_ = at::native::default_kernel(context, );
+
+        *stack[0] = EValue(result_);
+    }
+),
+"""
+        )
+
+        self.assertEqual(expected_str, result)

--- a/torchgen/context.py
+++ b/torchgen/context.py
@@ -1,7 +1,7 @@
 import contextlib
 
 import functools
-from typing import Callable, Dict, Iterator, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, Union
 
 import torchgen.local as local
 from torchgen.model import (
@@ -32,6 +32,8 @@ F2 = TypeVar(
     bool,
     str,
 )
+
+F3 = TypeVar("F3", Tuple[NativeFunction, Any], List[NativeFunction])
 
 
 @contextlib.contextmanager
@@ -85,6 +87,17 @@ def method_with_native_function(func: Callable[[S, F], T]) -> Callable[[S, F], T
     @functools.wraps(func)
     def wrapper(slf: S, f: F) -> T:
         with native_function_manager(f):
+            return func(slf, f)
+
+    return wrapper
+
+
+def method_with_nested_native_function(
+    func: Callable[[S, F3], T]
+) -> Callable[[S, F3], T]:
+    @functools.wraps(func)
+    def wrapper(slf: S, f: F3) -> T:
+        with native_function_manager(f[0]):
             return func(slf, f)
 
     return wrapper

--- a/torchgen/executorch/model.py
+++ b/torchgen/executorch/model.py
@@ -62,7 +62,7 @@ class ETKernelKey:
     def gen_from_yaml(
         args: Dict[str, Tuple[str, str]],
         type_alias_map: Dict[str, List[str]],  # TODO: Support unwrapped str val
-        dim_order_alias_map: Dict[str, List[str]],
+        dim_order_alias_map: Dict[str, List[int]],
     ) -> List["ETKernelKey"]:
         """Generate ETKernelKeys from arg kernel specs
         Multiple ETKernelKeys are returned due to dtype permutations from utilizing
@@ -194,7 +194,8 @@ class ETKernelIndex:
             assert (
                 len(kernel_dict.values()) == 1
             ), f"Can't convert ETKernelIndex to BackendIndex because {op} has more than one kernels. Got {kernel_dict}"
-            index[op] = kernel_dict[ETKernelKey(default=True)]
+            # Default key should always exist, the default is for testing only
+            index[op] = kernel_dict.get(ETKernelKey(default=True), BackendMetadata(kernel="", structured=False, cpp_namespace=""))
         return BackendIndex(
             dispatch_key=DispatchKey.CPU,
             use_out_as_primary=False,

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -11,7 +11,11 @@ import yaml
 from torchgen import dest
 from torchgen.api import cpp as aten_cpp
 from torchgen.api.types import CppSignature, CppSignatureGroup, CType, NamedCType
-from torchgen.context import method_with_native_function, with_native_function_and_index
+from torchgen.context import (
+    method_with_native_function,
+    method_with_nested_native_function,
+    with_native_function_and_index,
+)
 from torchgen.executorch.api import et_cpp
 from torchgen.executorch.api.custom_ops import (
     ComputeNativeFunctionStub,
@@ -19,7 +23,7 @@ from torchgen.executorch.api.custom_ops import (
 )
 from torchgen.executorch.api.types import contextArg, ExecutorchCppSignature
 from torchgen.executorch.api.unboxing import Unboxing
-from torchgen.executorch.model import ETKernelIndex, ETParsedYaml
+from torchgen.executorch.model import ETKernelIndex, ETKernelKey, ETParsedYaml
 from torchgen.executorch.parse import ET_FIELDS, parse_et_yaml, parse_et_yaml_struct
 from torchgen.gen import (
     get_custom_build_selector,
@@ -155,8 +159,16 @@ class ComputeCodegenUnboxedKernels:
 
     use_aten_lib: bool
 
-    @method_with_native_function
-    def __call__(self, f: NativeFunction) -> str:
+    @method_with_nested_native_function
+    def __call__(
+        self,
+        unbox_kernel_entry: Tuple[NativeFunction, Tuple[ETKernelKey, BackendMetadata]],
+    ) -> str:
+        f: NativeFunction = unbox_kernel_entry[0]
+        kernel_key: ETKernelKey | List[ETKernelKey] = unbox_kernel_entry[1][0]
+        kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
+
+        # TODO: Update to use Kernel Selector
         if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]
@@ -169,11 +181,13 @@ class ComputeCodegenUnboxedKernels:
             argument_type_gen = aten_cpp.argumenttype_type
             return_type_gen = aten_cpp.returns_type
             arguments = sig.arguments()
+            kernel_call = f"torch::executor::{f.namespace}::{sig.name()}"
         else:
             sig = ExecutorchCppSignature.from_native_function(f)
             argument_type_gen = et_cpp.argumenttype_type
             return_type_gen = et_cpp.returns_type
             arguments = sig.arguments(include_context=False)
+            kernel_call = f"{kernel_meta.cpp_namespace}::{kernel_meta.kernel}"
         # parse arguments into C++ code
         binding_list, code_list = Unboxing(
             argument_type_gen=argument_type_gen
@@ -203,19 +217,23 @@ class ComputeCodegenUnboxedKernels:
                 return_assignment = ""
                 ret_prefix = ""
 
-        return f"""
-Operator(
-    "{f.namespace}::{f.func.name}",
+        if type(kernel_key) != list:
+            kernel_key = [kernel_key]
+
+        newline = '\n    '
+        return "\n".join([f"""
+Kernel(
+    "{f.namespace}::{f.func.name}",{newline + '"' + (k.to_native_string() + '",') if k.to_native_string() != 'default' else ''}
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
         EXECUTORCH_SCOPE_PROF("native_call_{f.func.name}");
-        {ret_prefix}torch::executor::{f.namespace}::{sig.name()}({"context, "}{args_str});
+        {ret_prefix}{kernel_call}(context, {args_str});
 
         {return_assignment}
     }}
 ),
-"""
+""" for k in kernel_key])
 
 
 def gen_unboxing(
@@ -224,19 +242,36 @@ def gen_unboxing(
     cpu_fm: FileManager,
     selector: SelectiveBuilder,
     use_aten_lib: bool,
+    kernel_index: ETKernelIndex,
 ) -> None:
-    def key_func(fn: Union[NativeFunction, NativeFunctionsGroup]) -> str:
-        return fn.root_name
+    # Iterable type for write_sharded is a Tuple of (native_function, (kernel_key, metadata))
+    def key_func(
+        item: Tuple[NativeFunction, Tuple[ETKernelKey, BackendMetadata]]
+    ) -> str:
+        return item[0].root_name + ":" + item[1][0].to_native_string()
+
+    items: List[Tuple[NativeFunction, Tuple[ETKernelKey, BackendMetadata]]] = [
+        (native_function, (kernel_key, metadata))
+        for native_function in native_functions
+        for kernel_key, metadata in kernel_index.get_kernels(native_function).items()
+    ]
+
+    header = ["Functions.h" if use_aten_lib else "NativeFunctions.h"]
 
     cpu_fm.write_sharded(
         "RegisterCodegenUnboxedKernels.cpp",
-        native_functions,
+        items,
         key_fn=key_func,
-        env_callable=lambda fn: {
-            "unboxed_ops": [ComputeCodegenUnboxedKernels(selector, use_aten_lib)(fn)],
+        env_callable=lambda unbox_kernel_entry: {
+            "unboxed_kernels": [
+                ComputeCodegenUnboxedKernels(selector, use_aten_lib)(unbox_kernel_entry)
+            ],
+            "fn_header": header
+            if unbox_kernel_entry == items[0]
+            else [],  # Only write header once
         },
         num_shards=1,
-        sharded_keys={"unboxed_ops"},
+        sharded_keys={"unboxed_kernels", "fn_header"},
     )
 
 
@@ -853,6 +888,7 @@ def main() -> None:
             cpu_fm=cpu_fm,
             selector=selector,
             use_aten_lib=options.use_aten_lib,
+            kernel_index=kernel_index,
         )
         if custom_ops_native_functions:
             gen_custom_ops(


### PR DESCRIPTION
Summary: Also sync the template to OSS

Test Plan:
```
buck test xplat/caffe2/tools/...
buck test xplat/executorch/core/test:operator_double_registration_test
```

Differential Revision: D46612784

