### PR TITLE
indexing_dtype_strength_reduction more aggressive free_symbols tests

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -14,7 +14,6 @@ import torch
 
 import torch._logging
 from torch._prims_common import is_integer_dtype
-from ..._dynamo import config as dynamo_config
 from ..._dynamo.utils import counters
 from .. import config, ir, scheduler
 from ..codecache import get_code_path
@@ -2132,16 +2131,8 @@ class TritonScheduling:
                     stack.close()
                     kernel.set_last_usage(current_reduction_nodes(node_schedule[i:]))
                 else:
-                    # TODO - mostly works but needs a couple fixes
-                    # Problem looks like free variables NYI: s0
-                    # We need to detect if the proposed ranges would have
-                    # symbols and bail out on this optimization if so
-                    if (
-                        not dynamo_config.dynamic_shapes
-                        and dynamo_config.assume_static_by_default
-                    ):
-                        # TODO - use split ranges ?
-                        indexing_dtype_strength_reduction(node._body)
+                    # TODO - use split ranges ?
+                    indexing_dtype_strength_reduction(node._body)
                     index_vars = kernel.split_and_set_ranges(node.get_ranges())
                     node.codegen(index_vars)
 

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -65,8 +65,8 @@ def range_expressable_in_32_bits(range):
 
 
 def get_expr_range(expr, vars_ranges: dict):
-    free_symbols = list(expr.free_symbols)
-    if len(free_symbols) == 0:
+    fs = list(expr.free_symbols)
+    if len(fs) == 0:
         return ValueRanges(expr, expr)
 
     def replace_symbols_for_deriv(expr):

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -105,6 +105,7 @@ def get_expr_range(expr, vars_ranges: dict):
             if (
                 len(diff_free_symbols) == 1
                 and symbol in diff_free_symbols
+                and symbol in vars_ranges
                 and vars_ranges[symbol].lower == vars_ranges[symbol].upper
             ):
                 monotonic_increasing.append(symbol)
@@ -129,7 +130,7 @@ def get_expr_range(expr, vars_ranges: dict):
         if free_symbols(min_val):
             min_val = -math.inf
         if free_symbols(max_val):
-            max_val = -math.inf
+            max_val = math.inf
         return ValueRanges(min_val, max_val)
     else:
         # bail on optimizing, have not run into this yet

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -190,6 +190,8 @@ def tensor_has_hints(t):
 def free_symbols(val: Union[SymInt, torch.Tensor]) -> Set[sympy.Symbol]:
     if isinstance(val, (SymInt, SymFloat)):
         return val.node.expr.free_symbols
+    elif isinstance(val, sympy.Expr):
+        return val.free_symbols
     elif isinstance(val, (int, float, bool)):
         return set()
     elif isinstance(val, torch.Tensor):
@@ -204,7 +206,7 @@ def free_symbols(val: Union[SymInt, torch.Tensor]) -> Set[sympy.Symbol]:
             r |= free_symbols(s)
         return r
     else:
-        raise AssertionError(f"cannot compute free_symbols of {val}")
+        raise AssertionError(f"cannot compute free_symbols of {val} {type(val)}")
 
 # WARNING: Don't use this on Dynamo produced graphs, they don't have meta
 # setup!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103377
* __->__ #103470

ValueRanges can't handle symbolic bounds. Be a bit more careful about detecting if you try to pass in expressions with free symbols, and fall back to "don't know" range if this occurs.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @aakhundov @chenyang78