### PR TITLE
[gloo] Make it possible for gloo TCPStore to take over an existing socket fd

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -183,6 +183,7 @@ class TCPStore(Store):
         timeout: timedelta = ...,
         wait_for_workers: bool = ...,
         multi_tenant: bool = ...,
+        master_listen_fd: Optional[int] = ...,
     ): ...
     @property
     def host(self) -> str: ...

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -850,7 +850,9 @@ std::mutex TCPServer::cache_mutex_{};
 
 std::shared_ptr<TCPServer> TCPServer::start(const TCPStoreOptions& opts) {
   auto startCore = [&opts]() {
-    Socket socket = Socket::listen(opts.port);
+    Socket socket = opts.masterListenFd.has_value()
+        ? Socket::listenFromFd(*opts.masterListenFd, opts.port)
+        : Socket::listen(opts.port);
 
     std::uint16_t port = socket.port();
 

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -34,6 +34,11 @@ struct TCPStoreOptions {
   // A boolean value indicating whether multiple store instances can be
   // initialized with the same host:port pair.
   bool multiTenant = false;
+
+  // If specified, and if isServer is true, the underlying TCPServer will take
+  // over the bound socket associated to this fd. This option is useful to avoid
+  // port assignment races in certain scenarios.
+  c10::optional<int> masterListenFd = c10::nullopt;
 };
 
 class TORCH_API TCPStore : public Store {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1276,7 +1276,8 @@ Arguments:
     is_master (bool, optional): True when initializing the server store and False for client stores. Default is False.
     timeout (timedelta, optional): Timeout used by the store during initialization and for methods such as :meth:`~torch.distributed.store.get` and :meth:`~torch.distributed.store.wait`. Default is timedelta(seconds=300)
     wait_for_worker (bool, optional): Whether to wait for all the workers to connect with the server store. This is only applicable when world_size is a fixed value. Default is True.
-
+    multi_tenant (bool, optional): If True, all ``TCPStore`` instances in the current process with the same host/port will use the same underlying ``TCPServer``. Default is False.
+    master_listen_fd (int, optional): If specified, the underlying ``TCPServer`` will listen on this file descriptor, which must be a socket already bound to ``port``. Useful to avoid port assignment races in some scenarios. Default is None (meaning the server creates a new socket and attempts to bind it to ``port``).
 Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
@@ -1295,14 +1296,21 @@ Example::
                       bool isServer,
                       std::chrono::milliseconds timeout,
                       bool waitWorkers,
-                      bool multiTenant) {
+                      bool multiTenant,
+                      c10::optional<int> masterListenFd) {
             c10::optional<std::size_t> numWorkers = c10::nullopt;
             if (worldSize.has_value() && worldSize.value() > -1) {
               numWorkers = static_cast<std::size_t>(worldSize.value());
             }
 
             ::c10d::TCPStoreOptions opts{
-                port, isServer, numWorkers, waitWorkers, timeout, multiTenant};
+                port,
+                isServer,
+                numWorkers,
+                waitWorkers,
+                timeout,
+                multiTenant,
+                masterListenFd};
 
             return c10::make_intrusive<::c10d::TCPStore>(host, opts);
           }),
@@ -1316,6 +1324,7 @@ Example::
               std::chrono::milliseconds(::c10d::Store::kDefaultTimeout),
           py::arg("wait_for_workers") = true,
           py::arg("multi_tenant") = false,
+          py::arg("master_listen_fd") = py::none(),
           py::call_guard<py::gil_scoped_release>())
       .def_property_readonly(
           "host",

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -568,6 +568,58 @@ bool SocketListenOp::tryListen(const ::addrinfo& addr) {
   return true;
 }
 
+class SocketListenFromFdOp {
+ public:
+  SocketListenFromFdOp(int fd, std::uint16_t expected_port);
+
+  std::unique_ptr<SocketImpl> run() const;
+
+ private:
+  const int fd_;
+  const std::uint16_t expected_port_;
+};
+
+SocketListenFromFdOp::SocketListenFromFdOp(int fd, std::uint16_t expected_port)
+    : fd_(fd), expected_port_(expected_port) {}
+
+std::unique_ptr<SocketImpl> SocketListenFromFdOp::run() const {
+  C10D_DEBUG("listenFromFd: fd {}, expected port {}", fd_, expected_port_);
+
+  ::sockaddr_storage addr_storage;
+  ::socklen_t addr_len = sizeof(addr_storage);
+  if (::getsockname(
+          fd_, reinterpret_cast<::sockaddr*>(&addr_storage), &addr_len) < 0) {
+    throw SocketError{
+        fmt::format("getsockname failed for fd {}: {}", fd_, getSocketError())};
+  }
+
+  auto socket = std::make_unique<SocketImpl>(fd_);
+  const auto port = socket->getPort();
+
+  if (port != expected_port_) {
+    throw SocketError{fmt::format(
+        "listen fd {} is bound to port {}, expected to be bound to port {}",
+        fd_,
+        port,
+        expected_port_)};
+  }
+
+  if (::listen(socket->handle(), 2048 /* backlog */) != 0) {
+    throw SocketError{fmt::format(
+        "Failed to listen on socket initialized from fd {}: {}.",
+        socket->handle(),
+        getSocketError())};
+  }
+
+  socket->closeOnExec();
+
+  C10D_INFO(
+      "The server has taken over the listening socket with fd {}, address {}",
+      fd_,
+      *socket);
+  return socket;
+}
+
 class SocketConnectOp {
   using Clock = std::chrono::steady_clock;
   using Duration = std::chrono::steady_clock::duration;
@@ -881,6 +933,12 @@ void Socket::initialize() {
 
 Socket Socket::listen(std::uint16_t port, const SocketOptions& opts) {
   SocketListenOp op{port, opts};
+
+  return Socket{op.run()};
+}
+
+Socket Socket::listenFromFd(int fd, std::uint16_t expected_port) {
+  SocketListenFromFdOp op{fd, expected_port};
 
   return Socket{op.run()};
 }

--- a/torch/csrc/distributed/c10d/socket.h
+++ b/torch/csrc/distributed/c10d/socket.h
@@ -54,6 +54,8 @@ class Socket {
 
   static Socket listen(std::uint16_t port, const SocketOptions& opts = {});
 
+  static Socket listenFromFd(int fd, std::uint16_t expected_port);
+
   static Socket connect(
       const std::string& host,
       std::uint16_t port,


### PR DESCRIPTION
Summary:
This diff allows the `TCPStore` server associated with a gloo process group to listen on an existing socket already bound to a port.

Without the functionality in this diff, canonical initialization of a gloo `ProcessGroup` is fundamentally racy: 1) ask the OS for a free port by creating a socket bound to port 0, 2) close the socket, 3) attempt to initialize a `TCPStore` server that listens on the previously free port. Of course, the problem is that in between steps 2 and 3, another process on the host may have claimed the port, causing `TCPStore` and overall process group initialization to fail. With this diff, it is now possible for users to completely avoid this race (see unit test for how this can be achieved).

Test Plan:
Added new unit test:
  buck2 test caffe2/test/distributed:store

Differential Revision: D46622317

