### PR TITLE
[DDP] multiple forward support for static graph

### DIFF
--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -34,6 +34,8 @@ if BACKEND == "gloo" or BACKEND == "nccl" or BACKEND == "ucc":
             super().setUp()
             self._spawn_processes()
             torch.backends.cudnn.flags(enabled=True, allow_tf32=False).__enter__()
+else:
+    print(f"Invalid backend {BACKEND}. Tests will not be run!")
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -109,6 +109,8 @@ Reducer::Reducer(
       gradient_as_bucket_view_(gradient_as_bucket_view),
       local_used_map_reduced_(false),
       num_iterations_(0),
+      num_bwd_calls_(0),
+      first_autograd_hook_called_(false),
       num_buckets_ready_(0),
       has_rebuilt_bucket_(false),
       bucket_bytes_cap_(bucket_bytes_cap),
@@ -267,11 +269,11 @@ bool Reducer::dynamic_graph_find_unused() {
 }
 
 bool Reducer::static_graph_first_iteration() {
-  return static_graph_ && num_iterations_ == 1;
+  return static_graph_ && num_bwd_calls_ == 1;
 }
 
 bool Reducer::static_graph_after_first_iteration() {
-  return static_graph_ && num_iterations_ > 1;
+  return static_graph_ && num_bwd_calls_ > 1;
 }
 
 bool Reducer::ddp_graph_static() {
@@ -613,6 +615,10 @@ void Reducer::set_logger(std::weak_ptr<c10d::Logger> logger) {
 // This function is only to be called from the autograd thread.
 void Reducer::autograd_hook(size_t index) {
   std::lock_guard<std::mutex> lock(this->mutex_);
+  if (!first_autograd_hook_called_) {
+    first_autograd_hook_called_ = true;
+    num_bwd_calls_++;
+  }
   // Ignore if we don't expect to be called.
   // This may be the case if the user wants to accumulate gradients
   // for number of iterations before reducing them.
@@ -1520,6 +1526,8 @@ void Reducer::finalize_backward() {
   // No longer expect autograd hooks to fire after this function returns.
   TORCH_INTERNAL_ASSERT(expect_autograd_hooks_);
   expect_autograd_hooks_ = false;
+  // reset for the next iteration
+  first_autograd_hook_called_ = false;
 
   // No longer require call to finalize after this function returns.
   TORCH_INTERNAL_ASSERT(require_finalize_);

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -404,6 +404,11 @@ class TORCH_API Reducer {
 
   // track the number of iterations to synchronize grads in training so far.
   long num_iterations_;
+  // track distinct iteration of backward call. This is distinct from num_iterations_,
+  // for example in the case of multiple forward before backward.
+  long num_bwd_calls_;
+  // whether the first autograd hook for a distinct backward pass has been called.
+  bool first_autograd_hook_called_;
   // track the number of buckets that have been ready for
   // communication calls like allReduce or communication hooks.
   int num_buckets_ready_;

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -256,7 +256,9 @@ class _DDPSink(Function):
         ddp_weakref = ctx.ddp_weakref()
         reducer = ddp_weakref.reducer
         static_graph = ddp_weakref.static_graph
-        delay_ar_enqueued = ddp_weakref.static_graph_delay_allreduce_enqueued
+        delay_ar_enqueued = (
+            static_graph and ddp_weakref.static_graph_delay_allreduce_enqueued
+        )
         if static_graph and not delay_ar_enqueued:
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -256,11 +256,13 @@ class _DDPSink(Function):
         ddp_weakref = ctx.ddp_weakref()
         reducer = ddp_weakref.reducer
         static_graph = ddp_weakref.static_graph
-        num_forward_calls = ddp_weakref.num_forward_calls
-        if static_graph and num_forward_calls == 1:
+        delay_ar_enqueued = ddp_weakref.static_graph_delay_allreduce_enqueued
+        if static_graph and not delay_ar_enqueued:
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce
             )
+            print(f"Enqueud delay allreduce")
+            ddp_weakref.static_graph_delay_allreduce_enqueued = True
 
         return (None, *grad_outputs)
 
@@ -1050,7 +1052,6 @@ class DistributedDataParallel(Module, Joinable):
         (4) Logging construction-time DDP logging data
         (5) passing a handle of DDP to SyncBatchNorm Layer
         """
-        self.num_forward_calls = 0
         # Notice, the parameters order is not in the order in which they are used,
         # especially in models with control flow.
         #
@@ -1384,7 +1385,6 @@ class DistributedDataParallel(Module, Joinable):
         if torch.is_grad_enabled() and self.require_backward_grad_sync:
             assert self.logger is not None
             self.logger.set_runtime_stats_and_log()
-            self.num_forward_calls += 1
             self.reducer.prepare_for_forward()
 
         # Notify the join context that this process has not joined, if
@@ -1469,7 +1469,7 @@ class DistributedDataParallel(Module, Joinable):
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
         if (self.find_unused_parameters and not self.static_graph) or (
-            self.static_graph and self.num_forward_calls == 1
+            self.static_graph and not self.static_graph_delay_allreduce_enqueued
         ):
             (
                 output_tensor_list,
@@ -2201,6 +2201,7 @@ class DistributedDataParallel(Module, Joinable):
             )
             return
         self.static_graph = True
+        self.static_graph_delay_allreduce_enqueued = False
         self.reducer._set_static_graph()
         assert self.logger is not None
         self.logger._set_static_graph()

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -257,13 +257,13 @@ class _DDPSink(Function):
         reducer = ddp_weakref.reducer
         static_graph = ddp_weakref.static_graph
         delay_ar_enqueued = (
-            static_graph and ddp_weakref.static_graph_delay_allreduce_enqueued
+            static_graph and ddp_weakref._static_graph_delay_allreduce_enqueued
         )
         if static_graph and not delay_ar_enqueued:
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce
             )
-            ddp_weakref.static_graph_delay_allreduce_enqueued = True
+            ddp_weakref._static_graph_delay_allreduce_enqueued = True
 
         return (None, *grad_outputs)
 
@@ -1470,7 +1470,7 @@ class DistributedDataParallel(Module, Joinable):
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
         if (self.find_unused_parameters and not self.static_graph) or (
-            self.static_graph and not self.static_graph_delay_allreduce_enqueued
+            self.static_graph and not self._static_graph_delay_allreduce_enqueued
         ):
             (
                 output_tensor_list,
@@ -2202,7 +2202,7 @@ class DistributedDataParallel(Module, Joinable):
             )
             return
         self.static_graph = True
-        self.static_graph_delay_allreduce_enqueued = False
+        self._static_graph_delay_allreduce_enqueued = False
         self.reducer._set_static_graph()
         assert self.logger is not None
         self.logger._set_static_graph()

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -263,7 +263,6 @@ class _DDPSink(Function):
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce
             )
-            print(f"Enqueud delay allreduce")
             ddp_weakref.static_graph_delay_allreduce_enqueued = True
 
         return (None, *grad_outputs)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9810,7 +9810,7 @@ class DistributedTest:
 
                     ws = dist.get_world_size()
                     for p in local_model.parameters():
-                        p.grad.data = p.grad / 2
+                        p.grad.data = p.grad / dist.get_world_size()
 
                     for p_ddp, p_local in zip(
                         model.parameters(),

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9774,6 +9774,60 @@ class DistributedTest:
             BACKEND != "nccl" and BACKEND != "gloo",
             "Only Nccl & Gloo backend support DistributedDataParallel",
         )
+        def test_static_graph_multi_forward(self):
+            class Net(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.lin = nn.Linear(10, 10)
+                    self.relu = nn.ReLU()
+                def forward(self, x):
+                    return self.relu(self.lin(x))
+
+            torch.cuda.set_device(self.rank)
+            torch.manual_seed(42 << 1337 % (self.rank +1))
+            model = Net().cuda(self.rank)
+            from copy import deepcopy
+            local_model = deepcopy(model)
+            model = torch.nn.parallel.DistributedDataParallel(
+                model, device_ids=[self.rank], static_graph=True
+            )
+            inp = torch.ones(2, 10, device="cuda")
+            for _ in range(3):
+                model.zero_grad()
+                local_model.zero_grad()
+                a = model(inp)
+                b = model(inp)
+                loss = a.sum() + b.sum()
+                loss.backward()
+                # Grads should be equal to a local model that ran through inp twice and averaged grads
+                if self.rank == 0:
+                    inp_clone = inp.clone()
+                    for _ in range(2):
+                        a = local_model(inp_clone)
+                        b = local_model(inp_clone)
+                        loss = a.sum() + b.sum()
+                        loss.backward()
+                    for p in local_model.parameters():
+                        p.grad.data = p.grad / 2
+
+                    for p_ddp, p_local in zip(
+                        model.parameters(),
+                        local_model.parameters()
+                    ):
+                        self.assertTrue(
+                            torch.allclose(
+                                p_ddp.grad, p_local.grad
+                            ),
+                            f"{p_ddp.grad} vs {p_local.grad}"
+                        )
+
+            dist.barrier()
+
+        @skip_if_lt_x_gpu(2)
+        @skip_but_pass_in_sandcastle_if(
+            BACKEND != "nccl" and BACKEND != "gloo",
+            "Only Nccl & Gloo backend support DistributedDataParallel",
+        )
         def test_sync_bn_logged(self):
             model = BN_NET
             rank = self.rank

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9787,8 +9787,7 @@ class DistributedTest:
             torch.cuda.set_device(self.rank)
             torch.manual_seed(42 << 1337 % (self.rank + 1))
             model = Net().cuda(self.rank)
-            from copy import deepcopy
-            local_model = deepcopy(model)
+            local_model = copy.deepcopy(model)
             model = torch.nn.parallel.DistributedDataParallel(
                 model, device_ids=[self.rank], static_graph=True
             )
@@ -9808,6 +9807,8 @@ class DistributedTest:
                         b = local_model(inp_clone)
                         loss = a.sum() + b.sum()
                         loss.backward()
+
+                    ws = dist.get_world_size()
                     for p in local_model.parameters():
                         p.grad.data = p.grad / 2
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9780,11 +9780,12 @@ class DistributedTest:
                     super().__init__()
                     self.lin = nn.Linear(10, 10)
                     self.relu = nn.ReLU()
+
                 def forward(self, x):
                     return self.relu(self.lin(x))
 
             torch.cuda.set_device(self.rank)
-            torch.manual_seed(42 << 1337 % (self.rank +1))
+            torch.manual_seed(42 << 1337 % (self.rank + 1))
             model = Net().cuda(self.rank)
             from copy import deepcopy
             local_model = deepcopy(model)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103487
* #103304
* #103283
* #103282

Adds support for multiple forward before bwd call for
static_graph=True.

There are 2 changes:
1) Change tracking of accounting of when to populate static grap related maps
from relying on forward iteration to backward calls
2) In DDP python, don't rely on num_forward iterations == 1 to enqueue the
delay allreduce. Instead use a flag.

Differential Revision: [D46673736](https://our.internmc.facebook.com/intern/diff/D46673736/)