### PR TITLE
Inductor cpp wrapper: support Constant in input

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -188,6 +188,7 @@ if RUN_CPU:
         BaseTest("test_sort"),
         BaseTest("test_sum_dtype"),  # float64
         BaseTest("test_sum_int"),  # bool, int64, int8, uint8
+        BaseTest("test_tensor2"),  # constant input
         BaseTest("test_transpose"),  # multiple outputs, buffer clear
         BaseTest("test_view_as_complex"),
     ]:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1010,11 +1010,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
         args_str = "args_tensor = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg) for arg in args]"
         if V.graph.constants:
-            # TODO: further optimize into one line?
             # Append constants to the input args for cpp wrapper.
             # Python wrapper directly gets the value inside the wrapper call
-            # as a global variable passed when calling exec.
-            # For cpp wrapper, we need to pass this python value to the inductor_entry_cpp func
+            # as a global variable passed when calling exec(code, mod.__dict__, mod.__dict__).
+            # For cpp wrapper, we need to pass this python value to the inductor_entry_cpp function explicitly.
             assert all(
                 isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
             ), "Expect all constants to be Tensor"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -288,7 +288,7 @@ class WrapperCodeGen(CodeGen):
         for name, value in V.graph.constants.items():
             # include a hash so our code cache gives different constants different files
             hashed = hashlib.sha256(repr(value).encode("utf-8")).hexdigest()
-            self.header.writeline(f"{name} = None  # {hashed}")
+            self.write_constant(name, hashed)
 
         self.allocated = set()
         self.freed = set()
@@ -306,6 +306,9 @@ class WrapperCodeGen(CodeGen):
 
         self.add_import_once = add_import_once
         self._metas = {}
+
+    def write_constant(self, name, hashed):
+        self.header.writeline(f"{name} = None  # {hashed}")
 
     def write_header(self):
         self.header.splice(
@@ -880,6 +883,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
         self.expr_printer = cexpr
 
+    def write_constant(self, name, hashed):
+        # include a hash so our code cache gives different constants different files
+        self.header.writeline(f"// {name} {hashed}")
+
     def write_header(self):
         if V.graph.aot_mode:
             self.header.splice(
@@ -942,6 +949,15 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     else:
                         self.prefix.writeline(f"at::Tensor {input_key} = args[{idx}];")
 
+            assert all(
+                isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
+            ), "Expect all constants to be Tensor"
+            for idx, constants_key in enumerate(V.graph.constants.keys()):
+                constants_idx = inputs_len + idx
+                self.prefix.writeline(
+                    f"at::Tensor {constants_key} = args[{constants_idx}];"
+                )
+
             self.codegen_inputs(self.prefix, V.graph.graph_inputs)
 
             self.wrapper_call.splice(
@@ -991,12 +1007,29 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     outputs = f(args_tensor)
                     return {outputs_str}
             """
+
+        args_str = "args_tensor = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg) for arg in args]"
+        if V.graph.constants:
+            # TODO: further optimize into one line?
+            # Append constants to the input args for cpp wrapper.
+            # Python wrapper directly gets the value inside the wrapper call
+            # as a global variable passed when calling exec.
+            # For cpp wrapper, we need to pass this python value to the inductor_entry_cpp func
+            assert all(
+                isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
+            ), "Expect all constants to be Tensor"
+            constants_str = f"[{', '.join(V.graph.constants.keys())}]"
+            args_str += f"""
+                    constants_tensor = {constants_str}
+                    args_tensor.extend(constants_tensor)
+            """
+
         # Wrap the func to support setting result._boxed_call = True
         result.splice(
             f"""
             def _wrap_func(f):
                 def g(args):
-                    args_tensor = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg) for arg in args]
+                    {args_str}
                     {return_str}
                 return g
             call = _wrap_func(module.{self.call_func_name})

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -786,15 +786,10 @@ class GraphLowering(torch.fx.Interpreter):
             if not supported_dtype_of_cpp_wrapper(dtype, self.cuda):
                 self.disable_cpp_wrapper("unsupported inputs dtype")
 
-    def check_constant_for_cpp_buffer(self):
-        if self.constants:
-            self.disable_cpp_wrapper("Constants")
-
     def check_cpp_wrapper(self):
         self.check_cpp_codegen_disabled()
         self.check_platform()
         self.check_input_for_cpp_buffer()
-        self.check_constant_for_cpp_buffer()
 
     def init_wrapper_code(self):
         self.cuda = "cuda" in self.device_types


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103496

## Description
Fix cpp wrapper for models which have constants in the graph inputs.

Python wrapper directly gets the value inside the wrapper call as a global variable passed when calling:
https://github.com/pytorch/pytorch/blob/4081e924a8d701d5201db3e4b4ed2da60b072d30/torch/_inductor/codecache.py#L757
The constants value has been saved in `mod.__dict__` in 
https://github.com/pytorch/pytorch/blob/4081e924a8d701d5201db3e4b4ed2da60b072d30/torch/_inductor/graph.py#L874-L875
For cpp wrapper, we need to append constants to the input args, so as to pass this python value to the `inductor_entry_cpp` function explicitly.

### Example
Example of output code for dlrm in TorchBench with this fix:
```py
module = CppWrapperCodeCache.load(cpp_wrapper_src, 'inductor_entry_cpp', 'cfkc6c36t7cggi6mnokrdm5jhesnunjg5xysv3o3x3vaqmzmpe6r', False)

def _wrap_func(f):
    def g(args):
        args_tensor = [arg if isinstance(arg, torch.Tensor) else torch.tensor(arg) for arg in args]
        constants_tensor = [constant0, constant1]
        args_tensor.extend(constants_tensor)

        return f(args_tensor)
    return g
call = _wrap_func(module.inductor_entry_cpp)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @aakhundov