### PR TITLE
[FSDP] Fix `device_id` when buffer-only module

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -595,7 +595,6 @@ def _init_param_handle_from_params(
         state.process_group,
         state._use_orig_params,
     )
-    # TODO: Can simplify call `shard()` in the `FlatParamHandle` ctor
     handle.shard()
     assert handle not in state._handles
     state.params.append(handle.flat_param)
@@ -854,32 +853,35 @@ def _move_module_to_device(
 
     Precondition: ``_check_single_device_module()``.
     """
-    param = next(_get_orig_params(module, ignored_params), None)
-    if param is None:
-        return  # no original parameters to manage
-    cpu_device = torch.device("cpu")
-    # TODO: This only checks the parameter's device, not any buffers. Thus, a
-    # buffer-only module will not get offloaded to CPU.
     if device_from_device_id is not None:
-        if param.device == cpu_device:
-            # BFS from `module` without traversing any nested FSDP instances to
-            # collect the parameters/buffers that have not yet been managed
-            queue: Deque[nn.Module] = collections.deque()
-            queue.append(module)
-            params: List[nn.Parameter] = []
-            buffers: List[torch.Tensor] = []
-            while queue:
-                curr_module = queue.popleft()
-                params.extend(curr_module.parameters(recurse=False))
-                buffers.extend(curr_module.buffers(recurse=False))
-                for submodule in curr_module.children():
-                    if not isinstance(submodule, fsdp_file.FullyShardedDataParallel):
-                        queue.append(submodule)
-            # NOTE: This includes moving ignored modules' parameters. If we
-            # decide to change the semantics in the future, simply filter based
-            # on the ignored parameters (and buffers).
-            _move_states_to_device(params, buffers, device_from_device_id)
-    elif param.device == cpu_device:
+        # BFS from `module` without traversing any nested FSDP instances to
+        # collect the parameters/buffers that have not yet been managed
+        queue: Deque[nn.Module] = collections.deque()
+        queue.append(module)
+        params: List[nn.Parameter] = []
+        buffers: List[torch.Tensor] = []
+        while queue:
+            curr_module = queue.popleft()
+            params.extend(
+                param
+                for param in curr_module.parameters(recurse=False)
+                if param.device != device_from_device_id
+            )
+            buffers.extend(
+                buffer
+                for buffer in curr_module.buffers(recurse=False)
+                if buffer.device != device_from_device_id
+            )
+            for submodule in curr_module.children():
+                if not isinstance(submodule, fsdp_file.FullyShardedDataParallel):
+                    queue.append(submodule)
+        # NOTE: This includes moving ignored modules' parameters. If we
+        # decide to change the semantics in the future, simply filter based
+        # on the ignored parameters (and buffers).
+        _move_states_to_device(params, buffers, device_from_device_id)
+        return
+    param = next(_get_orig_params(module, ignored_params), None)
+    if param.device == torch.device("cpu"):
         _warn_cpu_init()
 
 
@@ -973,7 +975,6 @@ def _sync_module_params_and_buffers(
     Precondition: ``sync_module_states == True`` and ``self.process_group`` has
     been set.
     """
-    _check_params_for_sync_module_states(params)
     module_states: List[torch.Tensor] = []
     for buffer in module.buffers():
         # Avoid re-synchronizing buffers in case of nested wrapping
@@ -981,6 +982,7 @@ def _sync_module_params_and_buffers(
             setattr(buffer, FSDP_SYNCED, True)
             module_states.append(buffer.detach())
     module_states.extend(param.detach() for param in params)
+    _check_module_states_for_sync_module_states(module_states)
     _sync_params_and_buffers(
         process_group,
         module_states,
@@ -994,12 +996,12 @@ def _sync_module_states(
     buffers: List[torch.Tensor],
     process_group: dist.ProcessGroup,
 ) -> None:
-    _check_params_for_sync_module_states(params)
     # Assumes that each call to this method passes in disjoint `params` and
     # and `buffers` across calls, so there is no chance of re-synchronizing
     params_and_buffers = [param.detach() for param in params] + [
         buffer.detach() for buffer in buffers
     ]
+    _check_module_states_for_sync_module_states(params_and_buffers)
     _sync_params_and_buffers(
         process_group,
         params_and_buffers,
@@ -1008,15 +1010,16 @@ def _sync_module_states(
     )
 
 
-def _check_params_for_sync_module_states(
-    params: List[nn.Parameter],
+def _check_module_states_for_sync_module_states(
+    module_states: List[torch.Tensor],
 ) -> None:
-    if params and any(param.device == torch.device("cpu") for param in params):
+    if module_states and any(
+        tensor.device == torch.device("cpu") for tensor in module_states
+    ):
         raise ValueError(
-            "The module has CPU parameters when `sync_module_states=True`, "
-            "which only works when all parameters are on GPU. Please specify "
-            "the `device_id` argument or move the module to GPU before passing "
-            "into FSDP."
+            "The module has CPU parameters or buffers when `sync_module_states=True`, "
+            "which requires them to be on GPU. Please specify the `device_id` argument "
+            "or move the module to GPU before passing it to FSDP."
         )
 
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -881,7 +881,7 @@ def _move_module_to_device(
         _move_states_to_device(params, buffers, device_from_device_id)
         return
     param = next(_get_orig_params(module, ignored_params), None)
-    if param.device == torch.device("cpu"):
+    if param is not None and param.device == torch.device("cpu"):
         _warn_cpu_init()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103504

There was an issue reported internally that with `sync_module_states=True`, if the model had buffers on CPU, even with `device_id` specified, FSDP would try to broadcast CPU buffers, leading to an error like:
```
RuntimeError: No backend type associated with device type cpu
```

After some investigation, I determined that we should _not_ fix this by moving the buffers to GPU just for the broadcast and then back to CPU. Instead, we should fix our `device_id` logic.

The issue is that we always used the _parameters_ as the proxy to tell whether we should move module states to the device specified by `device_id`. However, a module (often the root) may not have any parameters but have some buffers! In that case, the buffers are left on CPU even if `device_id` is specified. This PR fixes this by considering both parameters and buffers for movement to `device_id`.

Note that this PR preserves the logic that `ignored_modules` / `ignored_parameters` are not considered for this movement, meaning that ignored parameters are moved to `device_id`.

Note also that I had to move the unit test back from using MTPG to the normal PG since otherwise, I could not repro the original error. (It seems like MTPG does not complain if we try to use `dist._broadcast_coalesced()` with CPU tensors.)
