### PR TITLE
Normal and Uniform return earlier without entering kernel<RNG>

### DIFF
--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -72,6 +72,8 @@ int64_t update_to(int64_t to) {
   return to;
 }
 
+// Return earlier for not invoking kernel.
+// See https://github.com/pytorch/pytorch/issues/103418 for more details
 #define CHECK_EMPTY_AND_RETURN(tensor) \
   if (tensor.numel() == 0) {  \
     return tensor;  \
@@ -189,9 +191,6 @@ at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, c10::optional<in
 template<template<typename> class normal_kernel, typename RNG>
 Tensor& normal_impl_(Tensor& self, double mean, double std, c10::optional<Generator> gen) {
   CHECK_NORMAL_STD(std);
-
-  // return earlier for not invoking normal_kernel
-  // see https://github.com/pytorch/pytorch/issues/103418 for more details
   CHECK_EMPTY_AND_RETURN(self);
 
   if (self.is_complex()) {

--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -124,7 +124,6 @@ static void check_from_to_in_range(int64_t from, int64_t to_inc, caffe2::TypeMet
 
 template<template<typename> class random_from_to_kernel, typename RNG>
 at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, c10::optional<int64_t> to_opt, c10::optional<Generator> generator) {
-  CHECK_EMPTY_AND_RETURN(self);
   uint64_t range = 0;
   auto iter = at::TensorIterator::borrowing_nullary_op(self);
   if (to_opt.has_value()) {
@@ -139,6 +138,7 @@ at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, c10::optional<in
       });
     }
     check_from_to_in_range(from, to - 1, self.dtype());
+    CHECK_EMPTY_AND_RETURN(self);
     range = static_cast<uint64_t>(to) - static_cast<uint64_t>(from);
     random_from_to_kernel<RNG>()(iter, range, from, generator);
   } else if (from != std::numeric_limits<int64_t>::lowest()) {
@@ -163,11 +163,13 @@ at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, c10::optional<in
       TORCH_CHECK(false, "random_from_to_impl handles only integral, floating-point and boolean types");
     }
     check_from_to_in_range(from, to_inc, self.dtype());
+    CHECK_EMPTY_AND_RETURN(self);
     range = static_cast<uint64_t>(to_inc) - static_cast<uint64_t>(from) + 1;
     random_from_to_kernel<RNG>()(iter, range, from, generator);
   } else {
     // [std::numeric_limits<int64_t>::lowest(), std::numeric_limits<int64_t>::max()]
     // range = 2^64
+    CHECK_EMPTY_AND_RETURN(self);
     random_from_to_kernel<RNG>()(iter, generator);
   }
   return self;
@@ -273,8 +275,8 @@ Tensor normal_impl(const Tensor& mean, const Tensor& std, c10::optional<Generato
 
 template<template<typename> class uniform_kernel, typename RNG>
 at::Tensor& uniform_impl_(at::Tensor& self, double from, double to, c10::optional<Generator> generator) {
-  CHECK_EMPTY_AND_RETURN(self);
   if (self.is_complex()) {
+    CHECK_EMPTY_AND_RETURN(self);
     auto float_tensor = at::view_as_real(self);
     uniform_impl_<uniform_kernel, RNG>(float_tensor, from, to, generator);
   } else {
@@ -292,6 +294,7 @@ at::Tensor& uniform_impl_(at::Tensor& self, double from, double to, c10::optiona
       from = std::min(std::max(from, min), max);
       to = std::max(std::min(to, max), min);
     });
+    CHECK_EMPTY_AND_RETURN(self);
     auto iter = at::TensorIterator::borrowing_nullary_op(self);
     uniform_kernel<RNG>()(iter, from, to, generator);
   }
@@ -302,8 +305,8 @@ at::Tensor& uniform_impl_(at::Tensor& self, double from, double to, c10::optiona
 
 template<template<typename> class log_normal_kernel, typename RNG>
 at::Tensor& log_normal_impl_(at::Tensor& self, double mean, double std, c10::optional<Generator> gen) {
-  CHECK_EMPTY_AND_RETURN(self);
   TORCH_CHECK(std > 0.0, "log_normal_ expects std > 0.0, but found std=", std);
+  CHECK_EMPTY_AND_RETURN(self);
   auto iter = TensorIterator::borrowing_nullary_op(self);
   log_normal_kernel<RNG>()(iter, mean, std, gen);
   return self;
@@ -313,8 +316,8 @@ at::Tensor& log_normal_impl_(at::Tensor& self, double mean, double std, c10::opt
 
 template<template<typename> class geometric_kernel, typename RNG>
 Tensor& geometric_impl_(Tensor& self, double p, c10::optional<Generator> gen) {
-  CHECK_EMPTY_AND_RETURN(self);
   TORCH_CHECK(0 < p && p < 1, "geometric_ expects p to be in (0, 1), but got p=", p);
+  CHECK_EMPTY_AND_RETURN(self);
   auto iter = TensorIterator::borrowing_nullary_op(self);
   geometric_kernel<RNG>()(iter, p, gen);
   return self;
@@ -324,8 +327,8 @@ Tensor& geometric_impl_(Tensor& self, double p, c10::optional<Generator> gen) {
 
 template<template<typename> class exponential_kernel, typename RNG>
 Tensor& exponential_impl_(Tensor& self, double lambda, c10::optional<Generator> gen) {
-  CHECK_EMPTY_AND_RETURN(self);
   TORCH_CHECK(lambda > 0.0, "exponential_ expects lambda > 0.0, but found lambda=", lambda);
+  CHECK_EMPTY_AND_RETURN(self);
   auto iter = TensorIterator::borrowing_nullary_op(self);
   exponential_kernel<RNG>()(iter, lambda, gen);
   return self;
@@ -335,11 +338,11 @@ Tensor& exponential_impl_(Tensor& self, double lambda, c10::optional<Generator> 
 
 template<template<typename> class cauchy_kernel, typename RNG>
 Tensor& cauchy_impl_(Tensor& self, double median, double sigma, c10::optional<Generator> gen) {
-  CHECK_EMPTY_AND_RETURN(self);
   // TODO: instead of variable name 'sigma', use 'gamma' or 'scale'
   // the variance, squared sigma, is undefined for cauchy distribution
   TORCH_CHECK(sigma > 0.0, "cauchy_ expects sigma > 0.0, but found sigma=", sigma);
   TORCH_CHECK(at::isFloatingType(self.scalar_type()), "Cauchy distribution is a continuous probability distribution. dtype must be a floating point but you specified ", self.dtype());
+  CHECK_EMPTY_AND_RETURN(self);
   auto iter = TensorIterator::borrowing_nullary_op(self);
   cauchy_kernel<RNG>()(iter, median, sigma, gen);
   return self;
@@ -358,8 +361,8 @@ Tensor& bernoulli_impl_(Tensor& self, const Tensor& p_, c10::optional<Generator>
 
 template<template<typename> class bernoulli_scalar_kernel, typename RNG>
 Tensor& bernoulli_impl_(Tensor& self, double p, c10::optional<Generator> gen) {
-  CHECK_EMPTY_AND_RETURN(self);
   TORCH_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
+  CHECK_EMPTY_AND_RETURN(self);
   at::assert_no_internal_overlap(self);
   bernoulli_scalar_kernel<RNG>()(self, p, gen);
   return self;


### PR DESCRIPTION
Fixes [#103418](https://github.com/pytorch/pytorch/issues/103418)

By the way, I'm wondering should we update other distribution funcs in `aten\src\ATen\native\DistributionTemplates.h`?
