### PR TITLE
Add vfdev-5 as reviewer for CPU Aten backend

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -296,6 +296,7 @@
   - mingfeima
   - XiaobingSuper
   - jgong5
+  - vfdef-5
   mandatory_checks_name:
   - EasyCLA
   - Lint

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -296,7 +296,7 @@
   - mingfeima
   - XiaobingSuper
   - jgong5
-  - vfdef-5
+  - vfdev-5
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
As suggested by @malfet. @vfdev-5 is the primary owner of the `interpolate()` op  and this will avoid having to ask for stamps like in https://github.com/pytorch/pytorch/pull/103252.