### PR TITLE
[Dynamo] Fix lineinfo generation on PY3.11+

### DIFF
--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -12,7 +12,7 @@ import torch._dynamo.testing
 
 
 class RecompileUxTests(torch._dynamo.test_case.TestCase):
-    # TODO(whc) dynamo actualy recompiles one more time than the cache limit
+    # TODO(whc) dynamo actually recompiles one more time than the cache limit
     cache_limit = 1
 
     @classmethod

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -700,7 +700,6 @@ class TestIndexing(TestCase):
         boolIndices = torch.tensor([True, False, False], dtype=torch.bool, device=device)
         uint8Indices = torch.tensor([1, 0, 0], dtype=torch.uint8, device=device)
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")  # TODO: Remove me once #103355 is closed
             self.assertEqual(v[boolIndices].shape, v[uint8Indices].shape)
             self.assertEqual(v[boolIndices], v[uint8Indices])
             self.assertEqual(v[boolIndices], tensor([True], dtype=torch.bool, device=device))

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -1,4 +1,3 @@
-import bisect
 import copy
 import dataclasses
 import sys

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -383,7 +383,7 @@ class ContinueExecutionCache:
             code_options["co_flags"] = code_options["co_flags"] & ~(
                 CO_VARARGS | CO_VARKEYWORDS
             )
-            (target,) = [i for i in instructions if i.offset == offset]
+            target = next(i for i in instructions if i.offset == offset)
 
             prefix = []
             if is_py311_plus:
@@ -435,7 +435,7 @@ class ContinueExecutionCache:
             # remove starts_line for any instructions before the graph break instruction
             # this will ensure the instructions after the break have the correct line numbers
             for inst in instructions:
-                if inst.offset and inst.offset >= target.offset:
+                if inst.offset == target.offset:
                     break
                 inst.starts_line = None
 

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -436,8 +436,10 @@ class ContinueExecutionCache:
             # this will ensure the instructions after the break have the correct line numbers
             if is_py311_plus:
                 # In 3.11+ bytecode instruction size vary, so do bisect to find the index
-                target_ind = bisect.bisect_left(
-                    instructions, target.offset, key=lambda i: i.offset
+                target_ind = next(
+                    idx
+                    for (idx, inst) in enumerate(instructions)
+                    if inst.offset is not None and inst.offset >= target.offset
                 )
             else:
                 target_ind = target.offset // 2

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -436,7 +436,9 @@ class ContinueExecutionCache:
             # this will ensure the instructions after the break have the correct line numbers
             if is_py311_plus:
                 # In 3.11+ bytecode instruction size vary, so do bisect to find the index
-                target_ind = bisect.bisect_left(instructions, target.offset, key=lambda i:i.offset)
+                target_ind = bisect.bisect_left(
+                    instructions, target.offset, key=lambda i: i.offset
+                )
             else:
                 target_ind = target.offset // 2
 


### PR DESCRIPTION
- Replace `for inst in instructions[0:targe.offset//2]: inst.starts_line = None`, with the one that that iterates over all instructions until `inst.offset == target.offset` condition is met, this way making it uniform across Python bytecode dialects (Python-3.11+ bytecode size is variable, while bytecode size is fixed for older Pythons)
- Speedup target_index search by replacing `[i for i in instructions if i.offset == offset][0]` with `next(i for i in instructions if i.offset == offset)`, which aborts the evaluation after condition met for the first time, according to:
  ```python
   In [1]: lst=list(range(10000))

   In [2]: %time [i for i in lst if i == 10]
   CPU times: user 144 µs, sys: 23 µs, total: 167 µs
   Wall time: 168 µs
   Out[2]: [10]

   In [3]: %time next(i for i in lst if i == 10)
   CPU times: user 6 µs, sys: 0 ns, total: 6 µs
   Wall time: 9.06 µs
   Out[3]: 10
   ```
- Fix small typo
- use `is_py311_plus` variable rather than checking `sys.version_info`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6cd7f27</samp>

> _We fix the typos in our code of doom_
> _We remove the warnings that obscure our vision_
> _We refactor the `generate` function for the dynamo_
> _We resume the execution with precision_ 

Fixes https://github.com/pytorch/pytorch/issues/103355

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @msaroufim