### PR TITLE
Add type hint for retains_grad

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1455,6 +1455,7 @@ class _TensorMeta(type): ...
 # Defined in torch/csrc/autograd/python_variable.cpp
 class _TensorBase(metaclass=_TensorMeta):
     requires_grad: _bool
+    retains_grad: _bool
     shape: Size
     data: Tensor
     names: List[str]


### PR DESCRIPTION
Fixes #103485

Type checkers don't know about the existence of `retains_grad` otherwise:

```python
torch.randn(10, 10).retains_grad  # Cannot access member "retains_grad" for type "Tensor"
```

cc: @albanD @ezyang @janeyx99 

cc @albanD