### PR TITLE
Use hipsolver for default svd case on ROCm

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2210,19 +2210,6 @@ void svd_kernel(const Tensor& A,
 #if defined(USE_LINALG_SOLVER)
   // We always use cuSOLVER unless the user has specified they want to use MAGMA
   bool use_magma = at::globalContext().linalgPreferredBackend() == at::LinalgBackend::Magma;
-#ifdef USE_ROCM
-  // However for current hipSOLVER, MAGMA is preferred for larger matrices due to
-  // performance. Here are a few performance numbers on MI200, ROCM 5.3.22000:
-  //    Size       MAGMA     hipSOLVER
-  //  100x100      0.127s      0.428s
-  //  200x200      0.113s      3.35s
-  //  300x300      0.111s      10.9s
-  //  400x400      0.126s      25.9s
-  //  500x500      0.146s      > 10 minutes, have to kill with SIGTERM
-  //
-  // TODO: Fix this when hipSOLVER has better performance numbers
-  use_magma = use_magma || (A.size(-1) >= 50 && A.size(-2) >= 50);
-#endif
   if (use_magma) {
     svd_magma(A, full_matrices, compute_uv, U, S, Vh, info);
   } else {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2353,7 +2353,6 @@ class TestLinalg(TestCase):
         self.assertRaisesRegex(IndexError, "Dimension out of range", torch.norm, x, "nuc", (0, 2))
 
     @skipCUDAIfNoCusolver
-    @skipCUDAIfRocm
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_svd_lowrank(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7213,7 +7213,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         run_test((1, 1), (1, 1, 1025))
 
     @skipCUDAIfNoCusolver
-    @skipCUDAIfRocm
     @skipCPUIfNoLapack
     def test_pca_lowrank(self, device):
         from torch.testing._internal.common_utils import random_lowrank_matrix, random_sparse_matrix


### PR DESCRIPTION
Fixes #102678 
Fixes #102629
Fixes #102558
HipSOLVER performance on ROCm5.4.2 and later no longer serves as massive bottleneck. Additionally, using magma on rocm in this case caused test_compare_cpu_lialg_pinv_singular_cuda_float32 to fail. Using hipSOLVER, the test now passes.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang