### PR TITLE
[inductor] Fix an expression printer issue during generate_return

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -83,9 +83,6 @@ test_failures_cpp_wrapper = {
 
 # see https://github.com/pytorch/pytorch/issues/103194
 test_failures_cuda_wrapper = {
-    "test_batch_norm_2d_2_cuda_dynamic_shapes": test_torchinductor.TestFailure(
-        ("cuda_wrapper",)
-    ),
     "test_fft_real_input_cuda_dynamic_shapes": test_torchinductor.TestFailure(
         ("cuda_wrapper",)
     ),

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2197,9 +2197,7 @@ class ShapeAsConstantBuffer(IRNode):
         self.shape = shape
 
     def codegen_reference(self):
-        from torch._inductor.codegen.wrapper import pexpr
-
-        expr = pexpr(V.graph.sizevars.simplify(self.shape))
+        expr = V.graph.wrapper_code.expr_printer(V.graph.sizevars.simplify(self.shape))
         if V.graph.cpp_wrapper:
             # wrap scalar to 0-d tensor for cpp wrapper
             return f"torch::tensor({expr})"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103557
* #103409

Summary: This fixes a symbolic expression printing issue when cpp_wrapper
is on.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @aakhundov @chenyang78