### PR TITLE
Handle long Docker image name when building Docker image

### DIFF
--- a/.ci/docker/build_docker.sh
+++ b/.ci/docker/build_docker.sh
@@ -11,9 +11,9 @@ registry="308535385114.dkr.ecr.us-east-1.amazonaws.com"
 
 # NB: The image name could now be both the short form, like pytorch-linux-bionic-py3.11-clang9, or the
 # full name, like 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.11-clang9
-if [[ "${IMAGE_NAME}" == *"${registry}/pytorch"* ]]; then
+if [[ "${IMAGE_NAME}" == *"${registry}/pytorch/"* ]]; then
   # Extract the image name from the long name
-  EXTRACTED_IMAGE_NAME=$(echo ${IMAGE_NAME#"${registry}/pytorch"} | awk -F '[:,]' '{print $1}')
+  EXTRACTED_IMAGE_NAME=$(echo ${IMAGE_NAME#"${registry}/pytorch/"} | awk -F '[:,]' '{print $1}')
   IMAGE_NAME="${EXTRACTED_IMAGE_NAME}"
 fi
 

--- a/.ci/docker/build_docker.sh
+++ b/.ci/docker/build_docker.sh
@@ -6,17 +6,17 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*)
 }
 
-# If UPSTREAM_BUILD_ID is set (see trigger job), then we can
-# use it to tag this build with the same ID used to tag all other
-# base image builds. Also, we can try and pull the previous
-# image first, to avoid rebuilding layers that haven't changed.
-
-#until we find a way to reliably reuse previous build, this last_tag is not in use
-# last_tag="$(( CIRCLE_BUILD_NUM - 1 ))"
 tag="${DOCKER_TAG}"
-
-
 registry="308535385114.dkr.ecr.us-east-1.amazonaws.com"
+
+# NB: The image name could now be both the short form, like pytorch-linux-bionic-py3.11-clang9, or the
+# full name, like 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.11-clang9
+if [[ "${IMAGE_NAME}" == *"${registry}/pytorch"* ]]; then
+  # Extract the image name from the long name
+  EXTRACTED_IMAGE_NAME=$(echo ${IMAGE_NAME#"${registry}/pytorch"} | awk -F '[:,]' '{print $1}')
+  IMAGE_NAME="${EXTRACTED_IMAGE_NAME}"
+fi
+
 image="${registry}/pytorch/${IMAGE_NAME}"
 
 login() {
@@ -34,11 +34,6 @@ if [[ -z "${GITHUB_ACTIONS}" ]]; then
   # Logout on exit
   trap "docker logout ${registry}" EXIT
 fi
-
-# Try to pull the previous image (perhaps we can reuse some layers)
-# if [ -n "${last_tag}" ]; then
-#   docker pull "${image}:${last_tag}" || true
-# fi
 
 # Build new image
 ./build.sh ${IMAGE_NAME} -t "${image}:${tag}"

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -50,6 +50,9 @@ runs:
           DOCKER_TAG=$(echo "${DOCKER_IMAGE_NAME}" | awk -F '[:,]' '{print $2}')
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+
+          EXTRACTED_DOCKER_IMAGE_NAME=$(echo ${DOCKER_IMAGE_NAME#"${DOCKER_IMAGE_ECR_PREFIX}/"} | awk -F '[:,]' '{print $1}')
+          echo "docker-image-name=${EXTRACTED_DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         else
           DOCKER_IMAGE_BASE="${DOCKER_IMAGE_ECR_PREFIX}/${DOCKER_IMAGE_NAME}"
 
@@ -63,6 +66,7 @@ runs:
             echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
             echo "docker-image=${DOCKER_IMAGE_BASE}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           fi
+          echo "docker-image-name=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Check if image should be built
@@ -111,7 +115,7 @@ runs:
     - name: Build and push docker image
       if: inputs.always-rebuild || steps.check.outputs.rebuild
       env:
-        IMAGE_NAME: ${{inputs.docker-image-name}}
+        IMAGE_NAME: ${{ steps.calculate-tag.outputs.docker-image-name }}
         DOCKER_SKIP_S3_UPLOAD: "1"
         # Skip push if we don't need it, or if specified in the inputs
         DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || inputs.skip_push }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -50,9 +50,6 @@ runs:
           DOCKER_TAG=$(echo "${DOCKER_IMAGE_NAME}" | awk -F '[:,]' '{print $2}')
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
-
-          EXTRACTED_DOCKER_IMAGE_NAME=$(echo ${DOCKER_IMAGE_NAME#"${DOCKER_IMAGE_ECR_PREFIX}/"} | awk -F '[:,]' '{print $1}')
-          echo "docker-image-name=${EXTRACTED_DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         else
           DOCKER_IMAGE_BASE="${DOCKER_IMAGE_ECR_PREFIX}/${DOCKER_IMAGE_NAME}"
 
@@ -66,7 +63,6 @@ runs:
             echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
             echo "docker-image=${DOCKER_IMAGE_BASE}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           fi
-          echo "docker-image-name=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Check if image should be built
@@ -115,7 +111,7 @@ runs:
     - name: Build and push docker image
       if: inputs.always-rebuild || steps.check.outputs.rebuild
       env:
-        IMAGE_NAME: ${{ steps.calculate-tag.outputs.docker-image-name }}
+        IMAGE_NAME: ${{ inputs.docker-image-name }}
         DOCKER_SKIP_S3_UPLOAD: "1"
         # Skip push if we don't need it, or if specified in the inputs
         DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || inputs.skip_push }}


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/102562, the `IMAGE_NAME` input to `.ci/docker/build_docker.sh` now accepts the name in the following two formats:

* Short form, like `pytorch-linux-bionic-py3.11-clang9`
* Or long form, like `308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.11-clang9`

This PR updates the build script to handle both cases.

This bug was discovered when I saw the wrong image name in https://github.com/pytorch/pytorch/actions/runs/5261424181/jobs/9509633110.

### Testing

Verify that the long form is handled correctly

```
export IMAGE_NAME=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-focal-py3.8-gcc7:06fdf1facf0eef5e5f303dd9cfac8639fb5f9201
export DOCKER_TAG=06fdf1facf0eef5e5f303dd9cfac8639fb5f9201

./build_docker.sh
+ tag=06fdf1facf0eef5e5f303dd9cfac8639fb5f9201
+ registry=308535385114.dkr.ecr.us-east-1.amazonaws.com
+ [[ 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-focal-py3.8-gcc7:06fdf1facf0eef5e5f303dd9cfac8639fb5f9201 == *\3\0\8\5\3\5\3\8\5\1\1\4\.\d\k\r\.\e\c\r\.\u\s\-\e\a\s\t\-\1\.\a\m\a\z\o\n\a\w\s\.\c\o\m\/\p\y\t\o\r\c\h\/* ]]
++ echo pytorch-linux-focal-py3.8-gcc7:06fdf1facf0eef5e5f303dd9cfac8639fb5f9201
++ awk -F '[:,]' '{print $1}'
+ EXTRACTED_IMAGE_NAME=pytorch-linux-focal-py3.8-gcc7
+ IMAGE_NAME=pytorch-linux-focal-py3.8-gcc7
+ image=308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-focal-py3.8-gcc7
+ [[ -z '' ]]
+ retry login 308535385114.dkr.ecr.us-east-1.amazonaws.com
+ login 308535385114.dkr.ecr.us-east-1.amazonaws.com
+ aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken'
+ base64 -d
+ cut -d: -f2
+ docker login -u AWS --password-stdin 308535385114.dkr.ecr.us-east-1.amazonaws.com
```