### PR TITLE
[benchmarks] get skip tests based on device in runner.py and add some skip models

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -359,7 +359,7 @@ def get_mode(args):
     return "training"
 
 
-def get_skip_tests(suite):
+def get_skip_tests(suite,device):
     """
     Generate -x seperated string to skip the unusual setup training tests
     """
@@ -372,6 +372,10 @@ def get_skip_tests(suite):
         skip_tests.update(module.SKIP)
     if hasattr(module, "SKIP_TRAIN"):
         skip_tests.update(module.SKIP_TRAIN)
+    if hasattr(module, "SKIP_FOR_CPU") and device == 'cpu':
+        skip_tests.update(module.SKIP_FOR_CPU)
+    if hasattr(module, "SKIP_FOR_CUDA") and device == 'cuda':
+        skip_tests.update(module.SKIP_FOR_CUDA)    
 
     skip_tests = (f"-x {name}" for name in skip_tests)
     skip_str = " ".join(skip_tests)
@@ -419,7 +423,7 @@ def generate_commands(args, dtypes, suites, devices, compilers, output_dir):
                         launcher_cmd = f"python -m torch.backends.xeon.run_cpu {args.cpu_launcher_args}"
                     cmd = f"{launcher_cmd} benchmarks/dynamo/{suite}.py --{testing} --{dtype} -d{device} --output={output_filename}"
                     cmd = f"{cmd} {base_cmd} {args.extra_args} --no-skip --dashboard"
-                    skip_tests_str = get_skip_tests(suite)
+                    skip_tests_str = get_skip_tests(suite,device)
                     cmd = f"{cmd} {skip_tests_str}"
 
                     if args.log_operator_inputs:

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -76,6 +76,7 @@ SKIP = {
     "fambench_xlmr",
     # TIMEOUT, https://github.com/pytorch/pytorch/issues/98467
     "tacotron2",
+
 }
 
 SKIP_FOR_CPU = {
@@ -83,6 +84,7 @@ SKIP_FOR_CPU = {
     "cm3leon_generate",  # model is CUDA only
     "nanogpt_generate",  # timeout
     "sam",  # timeout
+    "torchrec_dlrm", # model is CUDA only
 }
 
 SKIP_FOR_CUDA = {
@@ -99,6 +101,9 @@ SKIP_TRAIN = {
     "pyhpc_turbulent_kinetic_energy",
     "maml",
     "llama",
+    "doctr_det_predictor",
+    "doctr_reco_predictor",
+    "cm3leon_generate",
 }
 SKIP_TRAIN.update(DETECTRON2_MODELS)
 


### PR DESCRIPTION
skip some models which not suitable for benchmarks. @chuanqi129 


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @ipiszy @msaroufim