### PR TITLE
enable performance-noexcept-move-constructor in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,7 +42,6 @@ modernize-*,
 -modernize-use-trailing-return-type,
 -modernize-use-nodiscard,
 performance-*,
--performance-noexcept-move-constructor,
 -performance-unnecessary-value-param,
 readability-container-size-empty,
 '


### PR DESCRIPTION
Use noexcept as much as possible can improve code performance significantly.