### PR TITLE
[operator_compile_check] Add FakeTensor testing

### DIFF
--- a/test/test_custom_op_testing.py
+++ b/test/test_custom_op_testing.py
@@ -181,7 +181,7 @@ class TestCustomOpTesting(TestCase):
         x = torch.tensor([0, 1.], requires_grad=True)
         with self.assertRaisesRegex(
                 RuntimeError,
-                'FooBackward returned an invalid gradient at index 0'):
+                'Shapes .* are not equal'):
             operator_compile_check(f, (x,), {})
 
     def test_missing_functionalization(self, device):
@@ -246,7 +246,7 @@ class TestCustomOpTesting(TestCase):
 
         x = torch.randn([], requires_grad=True)
 
-        with self.assertRaisesRegex(AssertionError, 'incorrect gradients'):
+        with self.assertRaisesRegex(AssertionError, 'mismatched requires_grad-ness'):
             operator_compile_check(f, (x,), {})
 
         # I'm not sure why this is necessary

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -28,6 +28,7 @@ import contextlib
 import weakref
 import copy
 import torch._functorch.config
+import torch.testing._internal.optests as optests
 from unittest.mock import patch
 
 from torch import distributed as dist
@@ -764,12 +765,7 @@ class FakeTensorOpInfoTest(TestCase):
         for sample_input in sample_inputs_itr:
             args = (sample_input.input,) + sample_input.args
             kwargs = sample_input.kwargs
-        with torch._subclasses.CrossRefFakeMode():
-            try:
-                op(*args, **kwargs)
-            except DynamicOutputShapeException:
-                if op.name not in data_dependent_outputs:
-                    raise
+            optests.fake_check(op, args, kwargs, op.name in data_dependnet_outputs)
 
 
 class FakeTensorConverterTest(TestCase):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -765,7 +765,7 @@ class FakeTensorOpInfoTest(TestCase):
         for sample_input in sample_inputs_itr:
             args = (sample_input.input,) + sample_input.args
             kwargs = sample_input.kwargs
-            optests.fake_check(op, args, kwargs, op.name in data_dependnet_outputs)
+            optests.fake_check(op, args, kwargs, op.name in data_dependent_outputs)
 
 
 class FakeTensorConverterTest(TestCase):

--- a/torch/testing/_internal/optests/__init__.py
+++ b/torch/testing/_internal/optests/__init__.py
@@ -1,3 +1,4 @@
 from .make_fx import make_fx_check
 from .aot_autograd import aot_autograd_check, _test_aot_autograd_forwards_backwards_helper
 from .compile_check import operator_compile_check
+from .fake_tensor import fake_check

--- a/torch/testing/_internal/optests/compile_check.py
+++ b/torch/testing/_internal/optests/compile_check.py
@@ -1,6 +1,7 @@
 import torch
 from .make_fx import make_fx_check
 from .aot_autograd import aot_autograd_check
+from .fake_tensor import fake_check
 from torch._subclasses.schema_check_mode import SchemaCheckMode
 
 
@@ -47,6 +48,7 @@ def operator_compile_check(
         check_compile(func, args, kwargs, fullgraph=fullgraph, backend='inductor', dynamic=dynamic)
 
     schema_check(func, args, kwargs)
+    fake_check(func, args, kwargs, dynamic_only)
     if not dynamic_only:
         run_static_or_dynamic_tests(dynamic=False)
     run_static_or_dynamic_tests(dynamic=True)

--- a/torch/testing/_internal/optests/fake_tensor.py
+++ b/torch/testing/_internal/optests/fake_tensor.py
@@ -1,0 +1,23 @@
+import torch._subclasses
+from torch._subclasses.fake_tensor import DynamicOutputShapeException
+
+
+def is_builtin(op):
+    return op.namespace in ('aten', 'prims', 'prim')
+
+
+def fake_check(op, args, kwargs, dynamic_only):
+    with torch._subclasses.CrossRefFakeMode(ignore_op_fn=is_builtin):
+        try:
+            op(*args, **kwargs)
+        except DynamicOutputShapeException:
+            if not dynamic_only:
+                raise
+            return
+        if dynamic_only:
+            raise AssertionError(
+                f"fake_check({op}, ..., dynamic_only={dynamic_only}): "
+                f"dynamic_only means that the operator is expected to have "
+                f"data-dependent output shape. We have not detected that this is "
+                f"the case. Please check that your operator's FakeTensor "
+                f"implementation is actually data dependent")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #103595
* #103198
* #103197
* #103196

This PR adds dedicated FakeTensor testing to operator_compile_check. We
reuse CrossRefFakeMode to do this and improve the error messages on it.

Note that this only really runs detailed tests for operators that do not
have data-dependent output shape. In the future we should add something
like a dynamic CrossRefFakeMode.

Test Plan:
- existing tests (these now have improved error messages).