### PR TITLE
consider `CALL_FINALLY` non-jumping in `stacksize_analysis`

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3375,6 +3375,21 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = torch._dynamo.optimize("eager", nopython=True)(mod)(**inputs)
         self.assertEqual(ref, res)
 
+    def test_call_finally_python_3_8(self):
+        # Issue - https://github.com/pytorch/pytorch/issues/97811
+        def make_fn(g):
+            def fn():
+                while True:
+                    try:
+                        print(g)
+                        break
+                    except Exception as _:
+                        break
+
+            return torch.compile(fn, backend="eager")
+
+        make_fn(None)()
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -12,8 +12,6 @@ TERMINAL_OPCODES = {
 }
 if sys.version_info >= (3, 9):
     TERMINAL_OPCODES.add(dis.opmap["RERAISE"])
-else:
-    TERMINAL_OPCODES.add(dis.opmap["END_FINALLY"])
 if sys.version_info >= (3, 11):
     TERMINAL_OPCODES.add(dis.opmap["JUMP_BACKWARD"])
     TERMINAL_OPCODES.add(dis.opmap["JUMP_FORWARD"])
@@ -215,7 +213,9 @@ def stacksize_analysis(instructions):
 
         for inst, next_inst in zip(instructions, instructions[1:] + [None]):
             stack_size = stack_sizes[inst]
-            if inst.opcode not in TERMINAL_OPCODES:
+            if inst.opcode not in TERMINAL_OPCODES and (
+                sys.version_info >= (3, 9) or inst.opcode != dis.opmap["END_FINALLY"]
+            ):
                 assert next_inst is not None, f"missing next inst: {inst}"
                 stack_sizes[next_inst].offset_of(
                     stack_size, stack_effect(inst.opcode, inst.arg, jump=False)

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -12,6 +12,8 @@ TERMINAL_OPCODES = {
 }
 if sys.version_info >= (3, 9):
     TERMINAL_OPCODES.add(dis.opmap["RERAISE"])
+else:
+    TERMINAL_OPCODES.add(dis.opmap["END_FINALLY"])
 if sys.version_info >= (3, 11):
     TERMINAL_OPCODES.add(dis.opmap["JUMP_BACKWARD"])
     TERMINAL_OPCODES.add(dis.opmap["JUMP_FORWARD"])

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -213,14 +213,14 @@ def stacksize_analysis(instructions):
 
         for inst, next_inst in zip(instructions, instructions[1:] + [None]):
             stack_size = stack_sizes[inst]
-            if inst.opcode not in TERMINAL_OPCODES and (
-                sys.version_info >= (3, 9) or inst.opcode != dis.opmap["END_FINALLY"]
-            ):
+            if inst.opcode not in TERMINAL_OPCODES:
                 assert next_inst is not None, f"missing next inst: {inst}"
                 stack_sizes[next_inst].offset_of(
                     stack_size, stack_effect(inst.opcode, inst.arg, jump=False)
                 )
-            if inst.opcode in JUMP_OPCODES:
+            if inst.opcode in JUMP_OPCODES and (
+                sys.version_info >= (3, 9) or inst.opcode != dis.opmap["CALL_FINALLY"]
+            ):
                 stack_sizes[inst.target].offset_of(
                     stack_size, stack_effect(inst.opcode, inst.arg, jump=True)
                 )

--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -213,6 +213,11 @@ def stacksize_analysis(instructions):
 
         for inst, next_inst in zip(instructions, instructions[1:] + [None]):
             stack_size = stack_sizes[inst]
+            # CALL_FINALLY in Python 3.8 is handled differently when determining stack depth.
+            # See https://github.com/python/cpython/blob/3.8/Python/compile.c#L5450.
+            # Essentially, the stack effect of CALL_FINALLY is computed with jump=True,
+            # but the resulting stack depth is propagated to the next instruction, not the
+            # jump target.
             is_call_finally = (
                 sys.version_info < (3, 9) and inst.opcode == dis.opmap["CALL_FINALLY"]
             )


### PR DESCRIPTION
Fixes #97811.

This PR fixes a bug in `stacksize_analysis`. The pre-`python3.9` opcode `END_FINALLY` should be considered terminal. (edit: this is no longer what this PR does)

With this change, [this](https://github.com/pytorch/pytorch/issues/97811#issuecomment-1591888590) previously failing example  now passes.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @msaroufim