### PR TITLE
[ET] Select used et_kernel_metadata only

### DIFF
--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -442,7 +442,13 @@ class TestComputeCodegenUnboxedKernels(unittest.TestCase):
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.get_nop_selector()
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                }
+            }
+        )
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
@@ -468,6 +474,31 @@ Kernel(
 ),
 """
         )
+
+        self.assertEqual(expected_str, result)
+
+    def test_codegen_unboxed_specialized_not_matching(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml(
+            {"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")},
+            {"T0": ["Double"]},
+            {"D0": [0, 1, 2, 3]},
+        )
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/8;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                }
+            }
+        )
+        use_aten_lib = False
+        entry = (
+            self.native_function_no_kern,
+            (specialized_kernel_key, self.default_backend_metadata),
+        )
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = """"""
 
         self.assertEqual(expected_str, result)
 

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -233,6 +233,11 @@ class SelectiveBuilder:
     def is_et_kernel_selected(self, op_name: str, kernel_key: str) -> bool:
         if op_name not in self.et_kernel_metadata:
             return False
+
+        # Always select default key for now
+        if kernel_key == "default":
+            return True
+
         # Don't compare the version for now
         tensor_metadata = kernel_key.split("/")[1]
 


### PR DESCRIPTION
Currently we rely on root operator, but we also need to check for et_kernel_metadata for used specialized kernels.

The default kernel is still always used, and will be fixed in a followup patch.

