### PR TITLE
Silence CUDA graph tree cuda warning

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -82,7 +82,7 @@ StorageWeakRefPointer = int
 StorageDataPtr = int
 NBytes = int
 
-if torch.has_cuda:
+if torch.backends.cuda.is_built():
     from torch._C import (
         _cuda_CUDAAllocator_AllocatorState as AllocatorState,
         _set_cached_tensors_enabled as _set_cached_tensors_enabled,


### PR DESCRIPTION
Fixes

```
/data/home/marksaroufim/miniconda/envs/saf/lib/python3.8/site-packages/torch/_inductor/cudagraph_trees.py:85: UserWarning: 'has_cuda' is deprecated, please use 'torch.backends.cuda.is_built()'
  if torch.has_cuda:
Traceback (most recent call last):
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78