### PR TITLE
allow cpu scalar to be moved to xpu in masked_fill

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4966,8 +4966,8 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             value_ndim == 0,
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
-        # `masked_fill` allows cpu scalar to be moved to cuda but not otherwise.
-        is_cpu_scalar = a.device.type == "cuda" and value.device.type == "cpu"
+        # `masked_fill` allows cpu scalar to be moved to cuda and xpu but not otherwise.
+        is_cpu_scalar = a.device.type in ["cuda", "xpu"] and value.device.type == "cpu"
         check(
             is_cpu_scalar or value.device == a.device,
             lambda: "Expected `value` to be on same device as `a`",


### PR DESCRIPTION
# Motivation
Align to CUDA scenario, allow cpu scalar to be moved to xpu device in masked_fill.

# Solution
Add "xpu" support in condition control.

# Additional
no need for more UT. 