### PR TITLE
enable ASAN on some tests

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -169,7 +169,7 @@ if [[ "$BUILD_ENVIRONMENT" == *-clang*-asan* ]]; then
   export USE_CUDA=0
   export USE_ASAN=1
   export USE_MKLDNN=0
-  export UBSAN_FLAGS="-fno-sanitize-recover=all"
+  export UBSAN_FLAGS="-fno-sanitize-recover=all;-fno-sanitize=bool;-fno-sanitize=float-cast-overflow;-fno-sanitize=float-divide-by-zero"
   unset USE_LLVM
 fi
 

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -169,7 +169,7 @@ if [[ "$BUILD_ENVIRONMENT" == *-clang*-asan* ]]; then
   export USE_CUDA=0
   export USE_ASAN=1
   export USE_MKLDNN=0
-  export UBSAN_FLAGS="-fno-sanitize-recover=all;-fno-sanitize=bool;-fno-sanitize=float-cast-overflow;-fno-sanitize=float-divide-by-zero"
+  export UBSAN_FLAGS="-fno-sanitize-recover=all;-fno-sanitize=float-divide-by-zero;-fno-sanitize=float-cast-overflow"
   unset USE_LLVM
 fi
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -187,7 +187,7 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     (cd test && python -c "import torch; print(torch.__version__, torch.version.git_version)")
     echo "The next four invocations are expected to crash; if they don't that means ASAN/UBSAN is misconfigured"
     (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")
-    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
+    #(cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
     (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_vptr_ubsan()")
     (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_aten_asan(3)")
 fi

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -186,10 +186,10 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
 
     (cd test && python -c "import torch; print(torch.__version__, torch.version.git_version)")
     echo "The next four invocations are expected to crash; if they don't that means ASAN/UBSAN is misconfigured"
-    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")
-    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
-    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_vptr_ubsan()")
-    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_aten_asan(3)")
+    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")
+    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
+    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_vptr_ubsan()")
+    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_aten_asan(3)")
 fi
 
 # The torch._C._crash_if_debug_asserts_fail() function should only fail if both of the following are true:

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -186,10 +186,10 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
 
     (cd test && python -c "import torch; print(torch.__version__, torch.version.git_version)")
     echo "The next four invocations are expected to crash; if they don't that means ASAN/UBSAN is misconfigured"
-    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")
-    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
-    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_vptr_ubsan()")
-    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_aten_asan(3)")
+    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")
+    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_ubsan(0)")
+    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_vptr_ubsan()")
+    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_aten_asan(3)")
 fi
 
 # The torch._C._crash_if_debug_asserts_fail() function should only fail if both of the following are true:

--- a/test/ao/sparsity/test_data_sparsifier.py
+++ b/test/ao/sparsity/test_data_sparsifier.py
@@ -4,8 +4,7 @@
 import logging
 import torch
 from torch.nn.utils.parametrize import is_parametrized
-import unittest
-from torch.testing._internal.common_utils import TestCase, TEST_WITH_ASAN
+from torch.testing._internal.common_utils import TestCase
 
 from typing import Tuple
 from torch import nn
@@ -511,7 +510,6 @@ class Model(nn.Module):
 
 
 class TestQuantizationUtils(TestCase):
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN due to address sanitization")
     def test_ptq_sparsify_first(self):
         """The expectation is post_training_sparse_quantize function
         1. Takes in a model
@@ -551,7 +549,6 @@ class TestQuantizationUtils(TestCase):
         assert abs(sl_emb1 - 0.80) <= 0.05  # +- 5% leeway
         assert abs(sl_embbag1 - 0.80) <= 0.05  # +- 5% leeway
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN due to address sanitization")
     def test_ptq_quantize_first(self):
         """The expectation is post_training_sparse_quantize function
         1. Takes in a model

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -10,7 +10,7 @@ from functorch.dim import Tensor, Dim, dims, dimlists, stack, DimensionBindError
 from attn_ft import BertSelfAttention as BertSelfAttentionA, Linear
 from attn_positional import BertSelfAttention as BertSelfAttentionB
 
-from torch.testing._internal.common_utils import TestCase, run_tests, TEST_CUDA, TEST_WITH_ASAN
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_CUDA
 
 from unittest import skip, skipIf
 import torch
@@ -105,7 +105,6 @@ class TestMin(TestCase):
             f'extra torch.Tensor, Dim, or Tensor left allocated: {len(interesting)} objects of types:' \
             f' { [type(t) for t in interesting] }'
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_manual_stuff(self):
 
         A_ = torch.rand(3, 4)
@@ -178,11 +177,9 @@ class TestMin(TestCase):
             gpu_time(lambda: B(hidden_state), "positional", r=3)
             gpu_time(lambda: A(hidden_state), "first_class", r=3)
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_attn(self):
         self.attn()
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_inplace(self):
         # some embeddings table
         embeddings = torch.zeros(10, 3)
@@ -244,7 +241,6 @@ class TestMin(TestCase):
         x = r.order(i, [j, k])
         self.assertTrue(torch.allclose(a, x))
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_hello(self):
         A = torch.rand(3, 4)
         B = torch.rand(4, 5)
@@ -340,7 +336,6 @@ class TestMin(TestCase):
         r = [id(x) for x in torch.nn.functional.dropout(A[i, k]).dims]
         assert id(i) in r and id(k) in r
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_simple(self):
         i, j, k = dims()
         x = torch.rand(3, 4)
@@ -392,7 +387,6 @@ class TestMin(TestCase):
 
         assert torch.allclose(r1.order(i, j), r0)
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_compare_dims(self):
         i, j = dims()
         i.size = 3
@@ -402,7 +396,6 @@ class TestMin(TestCase):
     def test_c(self):
         _test_c()
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_seg(self):
         A = torch.rand(3, 4)
         i, k = dims()
@@ -416,7 +409,6 @@ class TestMin(TestCase):
         assert list(A[i].expand(2, 4).order(i).size()) == [3, 2, 4]
 
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, maybe real issue")
     def test_parse(self):
         self.assertEqual(("x", None, None, None), _parse_test(1, 0, "x"))
         self.assertEqual(("x", None, "y", None), _parse_test(1, 0, "x", c="y"))
@@ -467,13 +459,11 @@ class TestMin(TestCase):
         assert b[0].size == 4
         assert b[1].size == 5
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_diag(self):
         i = dims()
         A = torch.rand(4, 4)
         (A[i, i])
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_softmax_split(self):
         a = torch.rand(16)
         g, i = dims(sizes=[2, None])
@@ -525,7 +515,6 @@ class TestMin(TestCase):
         x.new(a)
         # self.assertEqual(x.new([z[2], z[0] + 3]).tolist(), [3, 4])
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_index_placement(self):
         A = torch.rand(1, 2, 3, 4)
 
@@ -541,13 +530,11 @@ class TestMin(TestCase):
         A = torch.rand(3, 4, 5)
         assert torch.allclose(A[i].order(1, i), A.permute(2, 0, 1))
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_mask(self):
         a = torch.rand(5)
         i, j = dims(sizes=[a.size(0), a.size(0)])
         ((i >= j) * a[i]).sum(j).order(i)
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_eq(self):
         i, j = dims(sizes=[3, 3])
         assert (i == j).sum((i, j)) == 3
@@ -564,7 +551,6 @@ class TestMin(TestCase):
         assert str(y.x) == "d1"
         assert str(q) == "d2"
 
-    @skipIf(TEST_WITH_ASAN, "tests gets asan error, put up issue since seems real")
     def test_dir(self):
         i, j = dims(sizes=[3, 3])
         dir(i <= j)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3603,8 +3603,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         decorate('bitwise_right_shift', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         # UBSAN: runtime error: -1e+20 is outside the range of representable values of type 'long'
         decorate('special.hermite_polynomial_h', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
-        # UBSAN: runtime error: 1.27043e+262 is outside the range of representable values of type 'float'
-        decorate('special.zeta', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error"))
     }))
     def test_vmap_exhaustive(self, device, dtype, op):
         # needs to be fixed
@@ -3748,8 +3746,6 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         # One or more of the overload doesn't have a Batch rule.
         xfail('bincount'),
-        # UBSAN: runtime error: 1.27043e+262 is outside the range of representable values of type 'float'
-        decorate('special.zeta', decorator=unittest.skipIf(TEST_WITH_UBSAN, "Fails with above error")),
         # RuntimeError: Expected all tensors to be on the same device,
         # but found at least two devices, cuda:0 and cpu!
         xfail('ge', device_type='cuda'),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5716,8 +5716,7 @@ class CommonTemplate:
         self.common(forward, inps, atol=1e-05, rtol=2e-05)
 
     @unittest.skipIf(
-        TEST_WITH_ASAN
-        or os.environ.get("BUILD_ENVIRONMENT", "").startswith("parallelnative"),
+        os.environ.get("BUILD_ENVIRONMENT", "").startswith("parallelnative"),
         "TODO: debug this with asan",
     )
     def test_tmp_not_defined_issue2(self):

--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -8,7 +8,6 @@ import torch
 import torch._C
 from pathlib import Path
 from test_nnapi import TestNNAPI
-from torch.testing._internal.common_utils import TEST_WITH_ASAN
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -27,13 +26,10 @@ Inherits most tests from TestNNAPI, which loads Android NNAPI models
 without the delegate API.
 """
 # First skip is needed for IS_WINDOWS or IS_MACOS to skip the tests.
-# Second skip is because ASAN is currently causing an error.
-# It is still unclear how to resolve this. T95764916
 torch_root = Path(__file__).resolve().parent.parent.parent
 lib_path = torch_root / 'build' / 'lib' / 'libnnapi_backend.so'
 @unittest.skipIf(not os.path.exists(lib_path),
                  "Skipping the test as libnnapi_backend.so was not found")
-@unittest.skipIf(TEST_WITH_ASAN, "Unresolved bug with ASAN")
 class TestNnapiBackend(TestNNAPI):
     def setUp(self):
         super().setUp()

--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -20,7 +20,6 @@ from torch.optim.lr_scheduler import (
 )
 from torch.testing._internal.common_utils import (
     TestCase,
-    TEST_WITH_UBSAN,
     load_tests,
     gradcheck,
     skipIfRocm,
@@ -1527,7 +1526,6 @@ class TestOptim(TestCase):
             ignore_multidevice=True,
         )
 
-    @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
     def test_lbfgs_returns_consistent_type(self):
         params = [torch.randn(10, 5), torch.randn(10)]
         opt1 = optim.LBFGS(params, 0.01, tolerance_grad=math.inf)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -208,8 +208,6 @@ class TestBinaryUfuncs(TestCase):
         )
         self._test_reference_numerics(dtype, op, gen, equal_nan=True)
 
-    # TODO: review if this skip is necessary
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @ops(
         binary_ufuncs_with_references,
         allowed_dtypes=(
@@ -230,8 +228,6 @@ class TestBinaryUfuncs(TestCase):
         )
         self._test_reference_numerics(dtype, op, gen, equal_nan=True)
 
-    # TODO: review if this skip is necessary
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @ops(
         binary_ufuncs_with_references,
         allowed_dtypes=(

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -9,7 +9,6 @@ from itertools import product
 import math
 import random
 from numbers import Number
-import unittest
 import warnings
 import operator
 from functools import partial
@@ -20,7 +19,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     slowTest,
     iter_indices,
-    TEST_WITH_ASAN,
     run_tests,
     gradcheck,
     torch_to_numpy_dtype_dict,
@@ -196,8 +194,6 @@ class TestBinaryUfuncs(TestCase):
         gen = generate_elementwise_binary_tensors(op, device=device, dtype=dtype)
         self._test_reference_numerics(dtype, op, gen, equal_nan=True)
 
-    # runtime error: 128 is outside the range of representable values of type 'signed char'
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @ops(binary_ufuncs_with_references)
     def test_reference_numerics_small_values(self, device, dtype, op):
         if dtype is torch.bool:
@@ -3013,7 +3009,6 @@ class TestBinaryUfuncs(TestCase):
             with self.assertWarnsOnceRegex(UserWarning, "floor_divide"):
                 a // b
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Integer overflows are not allowed under ASAN")
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_muldiv_scalar(self, device, dtype):
         x = make_tensor((10, 3), dtype=dtype, device=device, low=None, high=None)

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -402,7 +402,6 @@ class TestDecomp(TestCase):
     # NB: This actually overlaps with test_comprehensive, but it only
     # runs on things that are definitely decomposed so it's a lot faster
     # to run
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     @suppress_warnings
@@ -410,7 +409,6 @@ class TestDecomp(TestCase):
     def test_quick(self, device, dtype, op):
         self.do_cross_ref(device, dtype, op, run_all=False)
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     @suppress_warnings
@@ -432,7 +430,6 @@ class TestDecomp(TestCase):
         self.assertEqual(ref, res)
 
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @tf32_off()
     # only tests RNNs since we have py dispsatcher decomps for them
@@ -646,7 +643,6 @@ instantiate_device_type_tests(TestDecomp, globals())
 
 
 class DecompOneOffTests(TestCase):
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_softmax(self, device):
@@ -661,7 +657,6 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_log_softmax(self, device):
@@ -676,7 +671,6 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._log_softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfCrossRef
     @onlyCUDA
     def test_amp_batch_norm_backward(self):
@@ -715,7 +709,6 @@ class DecompOneOffTests(TestCase):
             self.assertEqual(a.dtype, b.dtype)
 
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_elu_backward(self, device):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -14,7 +14,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     skipIfCrossRef,
     suppress_warnings,
-    TEST_WITH_ASAN,
     run_tests,
     skipIfTorchDynamo,
 )
@@ -32,7 +31,6 @@ from torch._ops import DispatchKey
 import itertools
 import functools
 from functools import partial
-import unittest
 
 aten = torch.ops.aten
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     skipIfCrossRef,
     suppress_warnings,
+    TEST_WITH_ASAN,
     run_tests,
     skipIfTorchDynamo,
 )
@@ -31,6 +32,7 @@ from torch._ops import DispatchKey
 import itertools
 import functools
 from functools import partial
+import unittest
 
 aten = torch.ops.aten
 
@@ -400,6 +402,7 @@ class TestDecomp(TestCase):
     # NB: This actually overlaps with test_comprehensive, but it only
     # runs on things that are definitely decomposed so it's a lot faster
     # to run
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     @suppress_warnings
@@ -407,6 +410,7 @@ class TestDecomp(TestCase):
     def test_quick(self, device, dtype, op):
         self.do_cross_ref(device, dtype, op, run_all=False)
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     @suppress_warnings
@@ -428,6 +432,7 @@ class TestDecomp(TestCase):
         self.assertEqual(ref, res)
 
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @tf32_off()
     # only tests RNNs since we have py dispsatcher decomps for them
@@ -641,6 +646,7 @@ instantiate_device_type_tests(TestDecomp, globals())
 
 
 class DecompOneOffTests(TestCase):
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_softmax(self, device):
@@ -655,6 +661,7 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_log_softmax(self, device):
@@ -669,6 +676,7 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._log_softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfCrossRef
     @onlyCUDA
     def test_amp_batch_norm_backward(self):
@@ -707,6 +715,7 @@ class DecompOneOffTests(TestCase):
             self.assertEqual(a.dtype, b.dtype)
 
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_elu_backward(self, device):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -16,7 +16,7 @@ from functools import reduce, partial
 
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
-     TEST_WITH_ASAN, TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
+     TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
      setLinalgBackendsToDefaultFinally)
@@ -1685,7 +1685,6 @@ class TestLinalg(TestCase):
     # Test degenerate shape results match numpy for linalg.norm vector norms
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped on ASAN since it checks for undefined behavior.")
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_norm_vector_degenerate_shapes(self, device, dtype):
         def run_test_case(input, ord, dim, keepdim):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -23,7 +23,7 @@ from torch.nn import Parameter
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, run_tests, TestCase, download_file, IS_CI, NoTest,
-     TEST_WITH_UBSAN, skipIfSlowGradcheckEnv, TEST_WITH_ASAN, suppress_warnings)
+     TEST_WITH_UBSAN, skipIfSlowGradcheckEnv, suppress_warnings)
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes, integral_types
 import torch.backends.mps
@@ -10647,7 +10647,6 @@ class TestCommon(TestCase):
     # MPS still requires some fairly heavy special casing in the test framework.
     # When MPS becomes more consistent, this can probably be merged with that test using
     # `@dtypesIfMPS(torch.float32)`, but for now, the assertions themselves need to be loosened
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     # MPS only supports float32
     @ops(_ref_test_ops, allowed_dtypes=(torch.float32,))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -37,7 +37,7 @@ from torch.testing._internal.common_dtype import integral_types, get_all_math_dt
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMps,\
-    TEST_WITH_UBSAN, IS_PPC, \
+    IS_PPC, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
     skipIfTorchDynamo, IS_WINDOWS, gcIfJetson
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
@@ -11580,7 +11580,6 @@ class TestNNDeviceType(NNTestCase):
         self._nll_loss_helper([2, 3, 5, 0], "none", torch.empty([2, 5, 0], device=device), device)
         self._nll_loss_helper([2, 3, 5, 7, 0], "none", torch.empty([2, 5, 7, 0], device=device), device)
 
-    @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
     def test_nll_loss_empty_tensor_reduction_mean(self, device):
         nan = torch.tensor(float('nan'), device=device)
         self._nll_loss_helper([0, 3], "mean", nan, device)
@@ -11597,7 +11596,6 @@ class TestNNDeviceType(NNTestCase):
         self._nll_loss_helper([2, 3, 5, 0], "sum", zero, device)
         self._nll_loss_helper([2, 3, 5, 7, 0], "sum", zero, device)
 
-    @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
     def test_nll_loss_total_weight_is_zero(self, device):
 
         def helper(input_size):
@@ -11614,7 +11612,6 @@ class TestNNDeviceType(NNTestCase):
         helper([2, 3, 5, 7])
         helper([2, 3, 5, 7, 9])
 
-    @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
     def test_nll_loss_all_ignored(self, device):
 
         def helper(input_size):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -254,7 +254,6 @@ class TestCommon(TestCase):
     # This test runs in double and complex double precision because
     # NumPy does computation internally using double precision for many functions
     # resulting in possible equality check failures.
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @suppress_warnings
     @ops(_ref_test_ops, allowed_dtypes=(torch.float64, torch.long, torch.complex128))
@@ -300,7 +299,6 @@ class TestCommon(TestCase):
     # Tests that experimental Python References can propagate shape, dtype,
     # and device metadata properly.
     # See https://github.com/pytorch/pytorch/issues/78050 for a discussion of stride propagation.
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
@@ -463,7 +461,6 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namesapce are remapped to the refs namespace (torch.foo becomes refs.foo).
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
@@ -476,7 +473,6 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namespace are preserved (torch.foo remains torch.foo).
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
@@ -587,7 +583,6 @@ class TestCommon(TestCase):
     # TODO: get working with Windows by addressing failing operators
     # TODO: get working with ASAN by addressing failing operators
     @unittest.skipIf(IS_WINDOWS, "Skipped under Windows")
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1265,7 +1265,6 @@ class TestCommon(TestCase):
 
     # Validates that each OpInfo specifies its forward and backward dtypes
     #   correctly for CPU and CUDA devices
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipMeta
     @onlyNativeDeviceTypes
     @ops(ops_and_refs, dtypes=OpDTypes.none)

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_utils import (
     skipIfNoSciPy,
     IS_WINDOWS,
     gradcheck,
-    TEST_WITH_ASAN,
 )
 from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs,
@@ -269,7 +268,6 @@ class TestUnaryUfuncs(TestCase):
     #   values on a range of tensors, including empty tensors, scalar tensors,
     #   1D tensors and a large 2D tensor with interesting and extremal values
     #   and noncontiguities.
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @ops(reference_filtered_ops)
     def test_reference_numerics_normal(self, device, dtype, op):
@@ -278,7 +276,6 @@ class TestUnaryUfuncs(TestCase):
         )
         self._test_reference_numerics(dtype, op, tensors)
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @ops(reference_filtered_ops)
     def test_reference_numerics_small(self, device, dtype, op):
@@ -290,7 +287,6 @@ class TestUnaryUfuncs(TestCase):
         )
         self._test_reference_numerics(dtype, op, tensors)
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @ops(reference_filtered_ops)
     def test_reference_numerics_large(self, device, dtype, op):
@@ -302,7 +298,6 @@ class TestUnaryUfuncs(TestCase):
         )
         self._test_reference_numerics(dtype, op, tensors)
 
-    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @suppress_warnings
     @ops(
         reference_filtered_ops,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10719,8 +10719,6 @@ op_db: List[OpInfo] = [
                        # 76047
                        DecorateInfo(unittest.expectedFailure, 'TestNNCOpInfo', 'test_nnc_correctness',
                                     dtypes=(torch.bfloat16, torch.float32, torch.float64)),
-                       DecorateInfo(unittest.skip("unexpected success on ASAN"), 'TestNNCOpInfo',
-                                    'test_nnc_correctness', dtypes=(torch.bfloat16,), active_if=TEST_WITH_ASAN),
                    )),
     OpInfo('stft',
            decorators=[
@@ -12895,10 +12893,7 @@ op_db: List[OpInfo] = [
            dtypes=floating_types_and(torch.bfloat16),
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            error_inputs_func=error_inputs_max_pool2d,
-           sample_inputs_func=sample_inputs_max_pool,
-           decorators=(
-               DecorateInfo(slowTest, 'TestJit', 'test_variant_consistency_jit', active_if=TEST_WITH_ASAN),
-           )),
+           sample_inputs_func=sample_inputs_max_pool),
     OpInfo('max_pool2d_with_indices_backward',
            op=max_pool2d_backward,
            # We've defined a custom op, so there's no corresponding aten op
@@ -14991,8 +14986,7 @@ op_db: List[OpInfo] = [
            decorators=[skipCUDAIfNoCusolver, skipCPUIfNoLapack, with_tf32_off,
                        DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-03, rtol=1e-03)}),
                                     'TestCommon', 'test_noncontiguous_samples',
-                                    device_type='cuda'),
-                       DecorateInfo(slowTest, 'TestCompositeCompliance', 'test_backward', active_if=TEST_WITH_ASAN)],
+                                    device_type='cuda')],
            skips=(
                # test does not work with passing lambda for op
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),


### PR DESCRIPTION
Enabling more tests on ASAN, meanwhile we disable float-divide-by-zero and float-cast-overflow, both are disabled because they are also disabled by default in latest clang.
The following cited doc explains the reasons.
```
-fsanitize=float-cast-overflow: Conversion to, from, or between floating-point types 
which would overflow the destination. Because the range of representable values 
for all floating-point types supported by Clang is [-inf, +inf], the only cases detected are 
conversions from floating point to integer types.
-fsanitize=float-divide-by-zero: Floating point division by zero. 
This is undefined per the C and C++ standards,
 but is defined by Clang (and by ISO/IEC/IEEE 60559 / IEEE 754) as producing 
either an infinity or NaN value, 
so is not included in -fsanitize=undefined.
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78