### PR TITLE
Update pointwise Triton kernel config heuristics

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3079,11 +3079,7 @@ def max_pool2d_with_indices_backward(
             x_stride = x.get_stride()
         except AttributeError:
             x_stride = None
-    if (
-        (x_stride is not None and x_stride[1] == 1)
-        or (gO_stride is not None and gO_stride[1] == 1)
-        or any(d != 1 for d in dilation)
-    ):
+    if any(d != 1 for d in dilation):
         # don't codegen channels-last, it's very slow
         return fallback_max_pool2d_with_indices_backward(
             grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -610,7 +610,7 @@ def triton_config(size_hints, x, y=None, z=None, num_stages=1) -> Config:
         cfg["YBLOCK"] = y
     if z:
         cfg["ZBLOCK"] = z
-    num_warps = next_power_of_2(min(max(conditional_product(x, y, z) // 256, 1), 8))
+    num_warps = next_power_of_2(min(max(conditional_product(x, y, z) // 64, 1), 8))
     # we are going to arrive at 2 warps only if bs was too small due to
     # numel being too small. However to workaround some ptx bugs we still
     # want at least 4 warps if there's enough elements per thread
@@ -690,12 +690,23 @@ def pointwise(size_hints, meta, tile_hint=None, filename=None):
     bs = max(256, min(numel // 128, 1024))
 
     if len(size_hints) == 1:
-        return cached_autotune(
-            [triton_config(size_hints, bs)],
-            meta=meta,
-            heuristic_type=HeuristicType.POINTWISE,
-            filename=filename,
-        )
+        if disable_pointwise_autotuning():
+            return cached_autotune(
+                [triton_config(size_hints, bs)],
+                meta=meta,
+                heuristic_type=HeuristicType.POINTWISE,
+                filename=filename,
+            )
+        else:
+            return cached_autotune(
+                [
+                    triton_config(size_hints, bs),
+                    triton_config(size_hints, bs // 2),
+                ],
+                meta=meta,
+                heuristic_type=HeuristicType.POINTWISE,
+                filename=filename,
+            )
     if len(size_hints) == 2:
         if (disable_pointwise_autotuning() or tile_hint == TileHint.SQUARE) and not (
             config.max_autotune or config.max_autotune_pointwise


### PR DESCRIPTION
# Summary
1. Increased num_warps by 4 times. It improves performance of `max_pool2d_with_indices_backward` kernel, but needs to be verified on other kernels as well. TODO: Figure out perf tests to run.
2. Added an entry for Pointwise autotune when len(size_hints)==1. This is from the results of `CoordescTuner` for the `max_pool2d_with_indices_backward` kernel. Maybe this is not necessary due to the change above - we could use perf test results to validate.
3. Made `max_pool2d_with_indices_backward` channel-first consider torch inductor lowering by default.

# Performance test results
```
python3.9 benchmarks/dynamo/microbenchmarks/operatorbench.py --suite=timm --op=aten.max_pool2d_with_indices_backward.default --max-samples=5 --dtype=float16 --channels-last

Before this change:

Fallback
Inductor Speedups : [0.9997202597876758, 1.0001309108307304, 1.0002654421310901]

Default lowering:
Inductor Speedups : [0.9945062166479167, 1.0632119741391315, 1.3002933288577507]

TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=0
Inductor Speedups : [0.9941159121217165, 1.0648002410311495, 1.2999986086755966]

TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=1 
Inductor Speedups : [0.9950528253874693, 1.0651245316963014, 1.3013674401534756]

TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=1
Inductor Speedups : [1.4020247605755827, 1.5504232138088152, 1.8226088905229931]


After this change:

Default lowering:
Inductor Speedups : [1.4027474195572964, 1.5484107304178663, 1.8226782956041285]

TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=1
Inductor Speedups : [1.403303265792746, 1.548831582475635, 1.822278780085024]

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ngimel @yf225 @chenyang78