### PR TITLE
[ET] Select used et_kernel_metadata only

### DIFF
--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -442,7 +442,14 @@ class TestComputeCodegenUnboxedKernels(unittest.TestCase):
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
@@ -477,14 +484,23 @@ Kernel(
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/8;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/8;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
             (specialized_kernel_key, self.default_backend_metadata),
         )
 
-        self.assertRaises(Exception, ComputeCodegenUnboxedKernels(selector, use_aten_lib), entry)
+        self.assertRaises(
+            Exception, ComputeCodegenUnboxedKernels(selector, use_aten_lib), entry
+        )
 
     def test_codegen_unboxed_specialized_missing_root_op(self) -> None:
         specialized_kernel_key = ETKernelKey.gen_from_yaml(
@@ -492,7 +508,13 @@ Kernel(
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.from_yaml_dict({"et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                }
+            }
+        )
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
@@ -501,18 +523,22 @@ Kernel(
 
         result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
         # Concat used to prevent whitespace stripping
-        expected_str = (
-            """"""
-        )
+        expected_str = """"""
 
         self.assertEqual(expected_str, result)
-
 
     def test_codegen_unboxed_default(self) -> None:
         """
         This test checks that if there is no specialized kernel, the default kernel is used.
         """
-        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
         use_aten_lib = False
         entry = (self.native_function_no_kern, self.default_kernel_entry)
 

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -442,7 +442,7 @@ class TestComputeCodegenUnboxedKernels(unittest.TestCase):
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.get_nop_selector()
+        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
@@ -471,8 +471,48 @@ Kernel(
 
         self.assertEqual(expected_str, result)
 
+    def test_codegen_unboxed_specialized_not_matching(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml(
+            {"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")},
+            {"T0": ["Double"]},
+            {"D0": [0, 1, 2, 3]},
+        )
+        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/8;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        use_aten_lib = False
+        entry = (
+            self.native_function_no_kern,
+            (specialized_kernel_key, self.default_backend_metadata),
+        )
+
+        self.assertRaises(Exception, ComputeCodegenUnboxedKernels(selector, use_aten_lib), entry)
+
+    def test_codegen_unboxed_specialized_missing_root_op(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml(
+            {"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")},
+            {"T0": ["Double"]},
+            {"D0": [0, 1, 2, 3]},
+        )
+        selector = SelectiveBuilder.from_yaml_dict({"et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
+        use_aten_lib = False
+        entry = (
+            self.native_function_no_kern,
+            (specialized_kernel_key, self.default_backend_metadata),
+        )
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = (
+            """"""
+        )
+
+        self.assertEqual(expected_str, result)
+
+
     def test_codegen_unboxed_default(self) -> None:
-        selector = SelectiveBuilder.get_nop_selector()
+        """
+        This test checks that if there is no specialized kernel, the default kernel is used.
+        """
+        selector = SelectiveBuilder.from_yaml_dict({"include_all_operators": True, "et_kernel_metadata": {"custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]}})
         use_aten_lib = False
         entry = (self.native_function_no_kern, self.default_kernel_entry)
 

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -310,24 +310,33 @@ et_kernel_metadata:
    - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
 """
         selector = SelectiveBuilder.from_yaml_str(yaml_config)
-        self.assertListEqual(["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
             selector.et_get_selected_kernels(
-                "aten::add.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1", "v1/3;0,1|3;0,1|3;0,1|3;0,1", "v1/6;1,0|6;0,1|6;0,1|6;0,1"]
-            )
+                "aten::add.out",
+                [
+                    "v1/6;0,1|6;0,1|6;0,1|6;0,1",
+                    "v1/3;0,1|3;0,1|3;0,1|3;0,1",
+                    "v1/6;1,0|6;0,1|6;0,1|6;0,1",
+                ],
+            ),
         )
-        self.assertListEqual(["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
             selector.et_get_selected_kernels(
                 "aten::sub.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
-            )
+            ),
         )
-        self.assertListEqual([],
+        self.assertListEqual(
+            [],
             selector.et_get_selected_kernels(
                 "aten::mul.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
-            )
+            ),
         )
         # We don't use version for now.
-        self.assertListEqual(["v2/6;0,1|6;0,1|6;0,1|6;0,1"],
+        self.assertListEqual(
+            ["v2/6;0,1|6;0,1|6;0,1|6;0,1"],
             selector.et_get_selected_kernels(
                 "aten::add.out", ["v2/6;0,1|6;0,1|6;0,1|6;0,1"]
-            )
+            ),
         )

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -310,34 +310,24 @@ et_kernel_metadata:
    - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
 """
         selector = SelectiveBuilder.from_yaml_str(yaml_config)
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
+        self.assertListEqual(["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1", "v1/3;0,1|3;0,1|3;0,1|3;0,1", "v1/6;1,0|6;0,1|6;0,1|6;0,1"]
             )
         )
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::sub.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
+        self.assertListEqual(["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::sub.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
             )
         )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::mul.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/3;0,1|3;0,1|3;0,1|3;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;1,0|6;0,1|6;0,1|6;0,1"
+        self.assertListEqual([],
+            selector.et_get_selected_kernels(
+                "aten::mul.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
             )
         )
         # We don't use version for now.
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v2/6;0,1|6;0,1|6;0,1|6;0,1"
+        self.assertListEqual(["v2/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out", ["v2/6;0,1|6;0,1|6;0,1|6;0,1"]
             )
         )

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -168,8 +168,11 @@ class ComputeCodegenUnboxedKernels:
         kernel_key: Union[ETKernelKey, List[ETKernelKey]] = unbox_kernel_entry[1][0]
         kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
 
-        # TODO: Update to use Kernel Selector
-        if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
+        op_name = f.namespace + "::" + str(f.func.name)
+        if not isinstance(kernel_key, list):
+            kernel_key = [kernel_key]
+        used_kernel_keys = self.selector.et_get_selected_kernels(op_name, [k.to_native_string() for k in kernel_key])
+        if not used_kernel_keys or not self.selector.is_root_operator(op_name):
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]
         argument_type_gen: Callable[..., NamedCType]
@@ -217,15 +220,12 @@ class ComputeCodegenUnboxedKernels:
                 return_assignment = ""
                 ret_prefix = ""
 
-        if not isinstance(kernel_key, list):
-            kernel_key = [kernel_key]
-
         newline = "\n    "
         return "\n".join(
             [
                 f"""
 Kernel(
-    "{f.namespace}::{f.func.name}",{newline + '"' + (k.to_native_string() + '",') if k.to_native_string() != 'default' else ''}
+    "{f.namespace}::{f.func.name}",{newline + '"' + (k + '",') if k != 'default' else ''}
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
@@ -236,7 +236,7 @@ Kernel(
     }}
 ),
 """
-                for k in kernel_key
+                for k in used_kernel_keys
             ]
         )
 

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -169,12 +169,15 @@ class ComputeCodegenUnboxedKernels:
         kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
 
         op_name = f.namespace + "::" + str(f.func.name)
+        if not self.selector.is_root_operator(op_name):
+            return ""
+
         if not isinstance(kernel_key, list):
             kernel_key = [kernel_key]
         used_kernel_keys = self.selector.et_get_selected_kernels(
             op_name, [k.to_native_string() for k in kernel_key]
         )
-        if not used_kernel_keys or not self.selector.is_root_operator(op_name):
+        if not used_kernel_keys:
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]
         argument_type_gen: Callable[..., NamedCType]

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -171,7 +171,9 @@ class ComputeCodegenUnboxedKernels:
         op_name = f.namespace + "::" + str(f.func.name)
         if not isinstance(kernel_key, list):
             kernel_key = [kernel_key]
-        used_kernel_keys = self.selector.et_get_selected_kernels(op_name, [k.to_native_string() for k in kernel_key])
+        used_kernel_keys = self.selector.et_get_selected_kernels(
+            op_name, [k.to_native_string() for k in kernel_key]
+        )
         if not used_kernel_keys or not self.selector.is_root_operator(op_name):
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -244,7 +244,10 @@ class SelectiveBuilder:
             key_found = False
             for key in kernel_key:
                 # Don't compare the version for now
-                if key != "default" and key.split("/")[1] == model_kernel_keys.split("/")[1]:
+                if (
+                    key != "default"
+                    and key.split("/")[1] == model_kernel_keys.split("/")[1]
+                ):
                     result_set.add(key)
                     key_found = True
                     break
@@ -255,8 +258,6 @@ class SelectiveBuilder:
                     return ["default"]
 
         return list(result_set)
-
-
 
     def to_dict(self) -> Dict[str, object]:
         ret: Dict[str, object] = {

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -255,7 +255,7 @@ class SelectiveBuilder:
                 if "default" not in kernel_key:
                     raise Exception("Missing kernel for the model")
                 else:
-                    return ["default"]
+                    result_set.add("default")
 
         return list(result_set)
 

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -230,17 +230,33 @@ class SelectiveBuilder:
             and dtype in self.kernel_metadata[kernel_tag]
         )
 
-    def is_et_kernel_selected(self, op_name: str, kernel_key: str) -> bool:
+    def et_get_selected_kernels(self, op_name: str, kernel_key: List[str]) -> List[str]:
+        """
+        Return a list of kernel keys that cover the used ops
+        """
         if op_name not in self.et_kernel_metadata:
-            return False
-        # Don't compare the version for now
-        tensor_metadata = kernel_key.split("/")[1]
+            # Operator is unused at all
+            return []
+
+        result_set = set()
 
         for model_kernel_keys in self.et_kernel_metadata[op_name]:
-            if tensor_metadata == model_kernel_keys.split("/")[1]:
-                return True
+            key_found = False
+            for key in kernel_key:
+                # Don't compare the version for now
+                if key != "default" and key.split("/")[1] == model_kernel_keys.split("/")[1]:
+                    result_set.add(key)
+                    key_found = True
+                    break
+            if not key_found:
+                if "default" not in kernel_key:
+                    raise Exception("Missing kernel for the model")
+                else:
+                    return ["default"]
 
-        return False
+        return list(result_set)
+
+
 
     def to_dict(self) -> Dict[str, object]:
         ret: Dict[str, object] = {


### PR DESCRIPTION
Currently we rely on root operator, but we also need to check for et_kernel_metadata for used specialized kernels.

