### PR TITLE
[inductor] let coordinate descent tuning respect max block size

### DIFF
--- a/torch/_inductor/coordinate_descent_tuner.py
+++ b/torch/_inductor/coordinate_descent_tuner.py
@@ -73,7 +73,7 @@ class CoordescTuner:
             return self.size_hints[-1]  # the last one is for reduction
         else:
             # large enough. We should not pick this large RBLOCK anyway
-            return 2 ** 30
+            return 2**30
 
     def cache_benchmark_result(self, config, timing):
         self.cached_benchmark_results[triton_config_to_hashable(config)] = timing
@@ -120,7 +120,7 @@ class CoordescTuner:
             return val > self.get_zmax()
         if name == "RBLOCK":
             return val > self.get_rmax()
-    
+
         return False
 
     def get_neighbour_values(self, name, orig_val, radius=1, include_self=False):

--- a/torch/_inductor/coordinate_descent_tuner.py
+++ b/torch/_inductor/coordinate_descent_tuner.py
@@ -44,10 +44,36 @@ class CoordescTuner:
           i.e., there are multiple local optima..
     """
 
-    def __init__(self, is_mm=False, name="unknown"):
+    def __init__(self, is_mm=False, name="unknown", size_hints=None):
         self.is_mm = is_mm  # we will tune num_stages for mm
         self.cached_benchmark_results = {}
         self.name = name
+        self.size_hints = size_hints
+
+    def get_xmax(self):
+        xmax = inductor_config.triton.max_block["X"]
+        if self.size_hints and len(self.size_hints) > 0:
+            xmax = min(xmax, self.size_hints[0])
+        return xmax
+
+    def get_ymax(self):
+        ymax = inductor_config.triton.max_block["Y"]
+        if self.size_hints and len(self.size_hints) > 1:
+            ymax = min(ymax, self.size_hints[1])
+        return ymax
+
+    def get_zmax(self):
+        zmax = inductor_config.triton.max_block["Z"]
+        if self.size_hints and len(self.size_hints) > 2:
+            zmax = min(zmax, self.size_hints[2])
+        return zmax
+
+    def get_rmax(self):
+        if self.size_hints and len(self.size_hints) > 0:
+            return self.size_hints[-1]  # the last one is for reduction
+        else:
+            # large enough. We should not pick this large RBLOCK anyway
+            return 2 ** 30
 
     def cache_benchmark_result(self, config, timing):
         self.cached_benchmark_results[triton_config_to_hashable(config)] = timing
@@ -85,8 +111,19 @@ class CoordescTuner:
 
         return out
 
-    @staticmethod
-    def get_neighbour_values(name, orig_val, radius=1, include_self=False):
+    def value_too_large(self, name, val):
+        if name == "XBLOCK":
+            return val > self.get_xmax()
+        if name == "YBLOCK":
+            return val > self.get_ymax()
+        if name == "ZBLOCK":
+            return val > self.get_zmax()
+        if name == "RBLOCK":
+            return val > self.get_rmax()
+    
+        return False
+
+    def get_neighbour_values(self, name, orig_val, radius=1, include_self=False):
         """
         Get neighbour values in 'radius' steps. The original value is not
         returned as it's own neighbour.
@@ -110,6 +147,8 @@ class CoordescTuner:
         cur_val = orig_val
         for _ in range(radius):
             cur_val = update(cur_val, True)
+            if self.value_too_large(name, cur_val):
+                break
             out.append(cur_val)
 
         # decrement loop

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -70,7 +70,7 @@ class CachingAutotuner(KernelInterface):
     """
 
     def __init__(
-        self, fn, meta, configs, save_cache_hook, mutated_arg_names, heuristic_type
+        self, fn, meta, configs, save_cache_hook, mutated_arg_names, heuristic_type, size_hints,
     ):
         super().__init__()
         self.fn = fn
@@ -94,7 +94,7 @@ class CachingAutotuner(KernelInterface):
                 str(self.meta.get("device", 0)),
             )
 
-        self.coordesc_tuner = CoordescTuner(is_mm=False, name=self.fn.__name__)
+        self.coordesc_tuner = CoordescTuner(is_mm=False, name=self.fn.__name__, size_hints=size_hints)
 
     def precompile(self, warm_cache_only_with_cc=None):
         with self.lock:
@@ -467,6 +467,7 @@ def load_cached_autotuning(
 
 
 def cached_autotune(
+    size_hints: List[int],
     configs: List[Config],
     meta,
     heuristic_type,
@@ -519,6 +520,7 @@ def cached_autotune(
                 save_cache_hook=save_cache_hook,
                 mutated_arg_names=mutated_arg_names,
                 heuristic_type=heuristic_type,
+                size_hints=size_hints,
             )
         return CachingAutotuner(
             fn,
@@ -527,6 +529,7 @@ def cached_autotune(
             save_cache_hook=save_cache_hook,
             mutated_arg_names=mutated_arg_names,
             heuristic_type=heuristic_type,
+            size_hints=size_hints,
         )
 
     return decorator
@@ -692,6 +695,7 @@ def pointwise(size_hints, meta, tile_hint=None, filename=None):
 
     if len(size_hints) == 1:
         return cached_autotune(
+            size_hints,
             [triton_config(size_hints, bs)],
             meta=meta,
             heuristic_type=HeuristicType.POINTWISE,
@@ -702,12 +706,14 @@ def pointwise(size_hints, meta, tile_hint=None, filename=None):
             config.max_autotune or config.max_autotune_pointwise
         ):
             return cached_autotune(
+                size_hints,
                 [triton_config(size_hints, 32, 32)],
                 meta=meta,
                 heuristic_type=HeuristicType.POINTWISE,
                 filename=filename,
             )
         return cached_autotune(
+            size_hints,
             [
                 triton_config(size_hints, 32, 32),
                 triton_config(size_hints, 64, 64),  # ~8% better for fp16
@@ -723,12 +729,14 @@ def pointwise(size_hints, meta, tile_hint=None, filename=None):
     if len(size_hints) == 3:
         if disable_pointwise_autotuning():
             return cached_autotune(
+                size_hints,
                 [triton_config(size_hints, 16, 16, 16)],
                 meta=meta,
                 heuristic_type=HeuristicType.POINTWISE,
                 filename=filename,
             )
         return cached_autotune(
+            size_hints,
             [
                 triton_config(size_hints, 16, 16, 16),
                 triton_config(size_hints, 64, 8, 8),
@@ -761,6 +769,7 @@ def reduction(size_hints, reduction_hint=False, meta=None, filename=None):
             pass  # skip all these cases
         elif reduction_hint == ReductionHint.INNER:
             return cached_autotune(
+                size_hints,
                 [contiguous_config],
                 meta=meta,
                 heuristic_type=HeuristicType.REDUCTION,
@@ -768,6 +777,7 @@ def reduction(size_hints, reduction_hint=False, meta=None, filename=None):
             )
         elif reduction_hint == ReductionHint.OUTER:
             return cached_autotune(
+                size_hints,
                 [outer_config],
                 meta=meta,
                 heuristic_type=HeuristicType.REDUCTION,
@@ -775,6 +785,7 @@ def reduction(size_hints, reduction_hint=False, meta=None, filename=None):
             )
         elif reduction_hint == ReductionHint.OUTER_TINY:
             return cached_autotune(
+                size_hints,
                 [tiny_config],
                 meta=meta,
                 heuristic_type=HeuristicType.REDUCTION,
@@ -782,12 +793,14 @@ def reduction(size_hints, reduction_hint=False, meta=None, filename=None):
             )
         if disable_pointwise_autotuning():
             return cached_autotune(
+                size_hints,
                 [triton_config_reduction(size_hints, 32, 128)],
                 meta=meta,
                 heuristic_type=HeuristicType.REDUCTION,
                 filename=filename,
             )
         return cached_autotune(
+            size_hints,
             [
                 contiguous_config,
                 outer_config,
@@ -830,6 +843,7 @@ def persistent_reduction(size_hints, reduction_hint=False, meta=None, filename=N
         configs = configs[:1]
 
     return cached_autotune(
+        size_hints,
         configs,
         meta=meta,
         filename=filename,
@@ -842,6 +856,7 @@ def template(num_stages, num_warps, meta, filename=None):
     Compile a triton template
     """
     return cached_autotune(
+        None,
         [triton.Config({}, num_stages=num_stages, num_warps=num_warps)],
         meta=meta,
         heuristic_type=HeuristicType.TEMPLATE,
@@ -854,6 +869,7 @@ def foreach(meta, num_warps, filename=None):
     Compile a triton foreach kernel
     """
     return cached_autotune(
+        None,
         [triton.Config({}, num_stages=1, num_warps=num_warps)],
         meta=meta,
         heuristic_type=HeuristicType.TEMPLATE,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -70,7 +70,14 @@ class CachingAutotuner(KernelInterface):
     """
 
     def __init__(
-        self, fn, meta, configs, save_cache_hook, mutated_arg_names, heuristic_type, size_hints,
+        self,
+        fn,
+        meta,
+        configs,
+        save_cache_hook,
+        mutated_arg_names,
+        heuristic_type,
+        size_hints=None,
     ):
         super().__init__()
         self.fn = fn
@@ -94,7 +101,9 @@ class CachingAutotuner(KernelInterface):
                 str(self.meta.get("device", 0)),
             )
 
-        self.coordesc_tuner = CoordescTuner(is_mm=False, name=self.fn.__name__, size_hints=size_hints)
+        self.coordesc_tuner = CoordescTuner(
+            is_mm=False, name=self.fn.__name__, size_hints=size_hints
+        )
 
     def precompile(self, warm_cache_only_with_cc=None):
         with self.lock:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103660

It turns out that we need fix https://github.com/pytorch/pytorch/issues/103656 in coordinate descent tuner.

Inductor generate triton code with assumption of max-block-size. If inductor is sure that numel is a multiple of the max-block-size, inductor will safely skip the check of the corresponding mask for perf reason.

Coordinate descent tuner previous does not respect this assumption and may pick triton config with even larger block size. That will cause IMA.


BTW, I was wondering how we pick those max block size. Not enforcing a max block size may allow coordinate descent tuner find an even better config. But it may slow down other cases a bit because of extra mask check.


Test:

```
TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=1 TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=1 TORCHINDUCTOR_BENCHMARK_KERNEL=1 python benchmarks/dynamo/torchbench.py --amp --performance --inference --inductor --only alexnet
```
Fail before and works after.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78