### PR TITLE
Meta registration for rshift/lshift op

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -227,17 +227,15 @@ def inferUnsqueezeGeometry(tensor, dim):
     result_strides.insert(dim, new_stride)
     return result_sizes, result_strides
 
+
 @register_meta(aten.__lshift__.Tensor)
 def meta_lshift(self, other, dtype=None, layout=None, device=None):
     # Handle broadcast
     out_shape = _broadcast_shapes(self.shape, other.shape)
     # Handle dtype promotion
     out_dtype = utils.get_higher_dtype(self.dtype, other.dtype)
-    return self.new_empty(
-        out_shape,
-        dtype=out_dtype,
-        layout=layout,
-        device=device)
+    return self.new_empty(out_shape, dtype=out_dtype, layout=layout, device=device)
+
 
 @register_meta(aten.__rshift__.Tensor)
 def meta_rshift(self, other, dtype=None, layout=None, device=None):
@@ -245,11 +243,8 @@ def meta_rshift(self, other, dtype=None, layout=None, device=None):
     out_shape = _broadcast_shapes(self.shape, other.shape)
     # Handle dtype promotion
     out_dtype = utils.get_higher_dtype(self.dtype, other.dtype)
-    return self.new_empty(
-        out_shape,
-        dtype=out_dtype,
-        layout=layout,
-        device=device)
+    return self.new_empty(out_shape, dtype=out_dtype, layout=layout, device=device)
+
 
 @register_meta(aten.unsqueeze_.default)
 def meta_unsqueeze_(self, dim):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -227,6 +227,29 @@ def inferUnsqueezeGeometry(tensor, dim):
     result_strides.insert(dim, new_stride)
     return result_sizes, result_strides
 
+@register_meta(aten.__lshift__.Tensor)
+def meta_lshift(self, other, dtype=None, layout=None, device=None):
+    # Handle broadcast
+    out_shape = _broadcast_shapes(self.shape, other.shape)
+    # Handle dtype promotion
+    out_dtype = utils.get_higher_dtype(self.dtype, other.dtype)
+    return self.new_empty(
+        out_shape,
+        dtype=out_dtype,
+        layout=layout,
+        device=device)
+
+@register_meta(aten.__rshift__.Tensor)
+def meta_rshift(self, other, dtype=None, layout=None, device=None):
+    # Handle broadcast
+    out_shape = _broadcast_shapes(self.shape, other.shape)
+    # Handle dtype promotion
+    out_dtype = utils.get_higher_dtype(self.dtype, other.dtype)
+    return self.new_empty(
+        out_shape,
+        dtype=out_dtype,
+        layout=layout,
+        device=device)
 
 @register_meta(aten.unsqueeze_.default)
 def meta_unsqueeze_(self, dim):


### PR DESCRIPTION
rshift/lshift ops missing fake tensor meta registration. 
When a meta registration is not found it leads to a exception in fake tensor at https://github.com/pytorch/pytorch/blob/main/torch/_subclasses/fake_tensor.py#L1407. 

Callstack:
38712-2023-04-13 12:50:51:449  ERROR    [common_executor.py:142] — exception while executing config: {'operator': '__rshift__', 'framework': 'Torch', 'workload': 'custom_g', 'test_config': '__rshift___4', 'op_data_mode': 1, 'op_data': {'inputs': [256, 256], 'other': [256, 256]}, 'test_name': 'Torch_custom_g___rshift___inplace_fwd_i32_4', 'prec': 'i32', 'variant': 'inplace_fwd', 'seed': 5755}
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/torch/_subclasses/fake_tensor.py", line 1170, in dispatch
    r = func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch/_ops.py", line 287, in __call__
    return self._op(*args, **kwargs or {})
  File "/usr/local/lib/python3.8/dist-packages/torch/_ops.py", line 380, in _get_dispatch
    final_key = resolve_key(self, key)
  File "/usr/local/lib/python3.8/dist-packages/torch/_ops.py", line 109, in resolve_key
    raise NotImplementedError(f"could not find kernel for {op} at dispatch key {k}")
NotImplementedError: could not find kernel for aten.__rshift__.Tensor at dispatch key DispatchKey.Meta

This happens to be the case with different torch compile backend, below is the test scenario.

### Testcase:
import torch
import habana_frameworks.torch.hpu
import numpy as np

COMPILE_BACKEND = {"cpu": "eager", "hpu": "aot_hpu_training_backend"}

class Repro(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, first_tensor, in_out_tensor, gather_indices):
        first_tensor = first_tensor.transpose(1, 0)
        in_out_tensor = torch.gather(in_out_tensor, -2, gather_indices)
        z = getattr(in_out_tensor, "__rshift__")(first_tensor)
        return z

def run_on(device):
    np.random.seed(0)
    torch.manual_seed(0)
    shape = [256, 256]
    in_out_tensor = torch.randn(shape).to(torch.int32).to(device)
    first_tensor = torch.randn(shape).to(torch.int32).to(device)
    gather_indices = torch.tensor(
        np.random.randint(size=shape, low=0, high=shape[-2])
    ).to(device)
    model = Repro()
    torch._dynamo.reset()  # rest dyamo compiler before changing the backened
    model = torch.compile(model, backend=COMPILE_BACKEND[device])
    res = model(first_tensor, in_out_tensor, gather_indices)
    return res.to("cpu")

if __name__ == "__main__":
    print("running on CPU")
    cpu_res = run_on("cpu")
    print(f"cpu_res: {cpu_res}")
    print("running on HPU")
    hpu_res = run_on("hpu")
    print(f"hpu_res: {hpu_res}")
 