### PR TITLE
Cast computation_node_input_size to int

### DIFF
--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -295,8 +295,8 @@ def pack_module(gm: torch.fx.GraphModule):
                     ):
                         continue
                 else:
-                    computation_node_input_size = (
-                        node.args[0].meta.get("tensor_meta").shape
+                    computation_node_input_size = tuple(
+                        int(x) for x in node.args[0].meta.get("tensor_meta").shape
                     )
                     if any(size == 0 for size in computation_node_input_size):
                         continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103677

This bandaid fixes yolov3 with automatic_dynamic_shapes.
A more proper fix probably is to figure out why when we
have

```
TypeError: mkldnn_reorder_conv2d_weight(): argument 'input_size' (position 6) must be tuple of ints, but found element of type SymInt at pos 1
```

where the SymInt is known to be constant, we aren't willing to
coerce it to int.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78