### PR TITLE
[GHF] Auth when trying to fetch labels

### DIFF
--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -4,7 +4,6 @@ import json
 
 from functools import lru_cache
 from typing import Any, List, Tuple, TYPE_CHECKING, Union
-from urllib.request import Request, urlopen
 
 from github_utils import gh_fetch_url_and_headers, GitHubComment
 

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from typing import Any, List, Tuple, TYPE_CHECKING, Union
 from urllib.request import Request, urlopen
 
-from github_utils import gh_fetch_url, GitHubComment
+from github_utils import gh_fetch_url_and_headers, GitHubComment
 
 # TODO: this is a temp workaround to avoid circular dependencies,
 #       and should be removed once GitHubPR is refactored out of trymerge script.
@@ -29,15 +29,11 @@ https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for
 """
 
 
-# Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
-def _read_url(url: Request) -> Tuple[Any, Any]:
-    with urlopen(url) as r:
-        return r.headers, r.read().decode(r.headers.get_content_charset("utf-8"))
-
-
 def request_for_labels(url: str) -> Tuple[Any, Any]:
     headers = {"Accept": "application/vnd.github.v3+json"}
-    return _read_url(Request(url, headers=headers))
+    return gh_fetch_url_and_headers(
+        url, headers=headers, reader=lambda x: x.read().decode("utf-8")
+    )
 
 
 def update_labels(labels: List[str], info: str) -> None:
@@ -77,14 +73,14 @@ def gh_get_labels(org: str, repo: str) -> List[str]:
 def gh_add_labels(
     org: str, repo: str, pr_num: int, labels: Union[str, List[str]]
 ) -> None:
-    gh_fetch_url(
+    gh_fetch_url_and_headers(
         url=f"https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/labels",
         data={"labels": labels},
     )
 
 
 def gh_remove_label(org: str, repo: str, pr_num: int, label: str) -> None:
-    gh_fetch_url(
+    gh_fetch_url_and_headers(
         url=f"https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/labels/{label}",
         method="DELETE",
     )


### PR DESCRIPTION
There were few merge bot failures reported recently due to HTTP/403 error:
- https://github.com/pytorch/pytorch/actions/runs/5269083146/jobs/9526693976#step:6:80
- https://github.com/pytorch/pytorch/actions/runs/5272750075/jobs/9535376256#step:6:93

Which likely stems from the fact that `_fetch_url` method did not try to pass the auth token even when it was available and as result was rate-limited to 60 requests per hour, according to [Resources in the REST API](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limit-headers)

Refactor `gh_fetch_url` into `gh_fetch_url_and_headers` and use it from `request_for_labels` to utilize auth token, if available, which bumps rate limit to 1000 per hour as well as print more actionable message when rate limit is exceeded.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 499b805</samp>

> _`gh_fetch_url` splits_
> _returns headers and body_
> _wrapper function_

