### PR TITLE
[BE] Remove unused `dim_plane` from `reflection_pad2d_backward_out_template`

### DIFF
--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -269,12 +269,10 @@ void reflection_pad2d_backward_out_template(
     const Tensor &input, IntArrayRef padding) {
   int dim_w = 2;
   int dim_h = 1;
-  int dim_plane = 0;
 
   if (input.ndimension() == 4) {
     dim_w++;
     dim_h++;
-    dim_plane++;
   }
 
   /* sizes */


### PR DESCRIPTION
Probably introduced by https://github.com/pytorch/pytorch/pull/102254

This fixes `variable 'dim_plane' set but not used ` on my clang-14.0.3 compiler complained about it:
```
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/ReflectionPad.cpp:272:7: error: variable 'dim_plane' set but not used [-Werror,-Wunused-but-set-variable]
  int dim_plane = 0;
      ^
1 error generated.
```

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e254b4b</samp>

> _`dim_plane` is gone_
> _Simpler code, no more warning_
> _Autumn leaves fall fast_
