### PR TITLE
Fixes test/run_test.py for standalone runs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
+
 import argparse
 import copy
 import glob

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
 import argparse
 import copy
 import glob
@@ -38,7 +39,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 try:
     # using tools/ to optimize test run.
-    sys.path.append(str(REPO_ROOT))
+    sys.path.insert(0, str(REPO_ROOT))
     from tools.stats.export_test_times import TEST_TIMES_FILE
     from tools.testing.test_selections import (
         calculate_shards,


### PR DESCRIPTION
When running[1] this script locally, outside the context of CI scripts, two errors may arise:

1) `from tools.stats.export_test_times import TEST_TIMES_FILE` is not
   found when the runtime environment also has PyTorch Text installed.
   That happens because PytorchText also has a `tools` namespace,
   confusing the search path
   (aka https://github.com/pytorch/text/tree/main/tools/__init__.py)

2) `NameError: name 'ShardedTest' is not defined` happens because
   `ShardedTest` is only available if the import from previous bullet
    succeeds.

This PR fixes 1) by prepending (instead of appending) `REPO_ROOT` to the system PATH variable. It fixes 2) by including `from __future__ import annotations` to the import list.

[1] `python test/run_test.py --dynamo --exclude-jit-executor --exclude-distributed-tests --exclude test_autograd test_jit test_proxy_tensor test_quantization test_public_bindings test_dataloader test_reductions test_namedtensor test_namedtuple_return_api profiler/test_profiler profiler/test_profiler_tree test_overrides test_python_dispatch test_fx test_package test_legacy_vmap export/test_db functorch/test_dims functorch/test_aotdispatch --verbose --include export/test_pass_infra` is an example on how to run this script locally and repro the issue.