### PR TITLE
[Easy] Dont truncate cudagraph error msg

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1487,9 +1487,7 @@ def get_block_addrs(pool_id, live_only=True):
 def format_tb(caching_allocator_trace):
     formatted_traceback = []
 
-    MAX_LENGTH = 20
-
-    for entry in caching_allocator_trace["frames"][0:MAX_LENGTH]:
+    for entry in caching_allocator_trace["frames"]:
         formatted_traceback.append(
             traceback.FrameSummary(entry["filename"], entry["line"], entry["name"])
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103693

We're erroring anyway, we don't want to cut off important context.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78