### PR TITLE
[RFC] Create functional aten assertion ops

### DIFF
--- a/aten/src/ATen/native/Constraints.cpp
+++ b/aten/src/ATen/native/Constraints.cpp
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/Scalar.h>
 #include <c10/util/Optional.h>
 
@@ -10,6 +11,14 @@ void sym_constrain_range_cpu(
     const Scalar& size,
     c10::optional<int64_t> min = c10::nullopt,
     c10::optional<int64_t> max = c10::nullopt) {}
+
+Tensor functional_sym_constrain_range_cpu(
+    const Scalar& size,
+    c10::optional<int64_t> min = c10::nullopt,
+    c10::optional<int64_t> max = c10::nullopt,
+    const c10::optional<Tensor>& dep_token = c10::nullopt) {
+  return c10::value_or_else(dep_token, []{return Tensor();});
+}
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -409,6 +409,19 @@ void _assert_async_msg_cpu(const Tensor& self, c10::string_view assert_msg) {
   TORCH_CHECK(native::is_nonzero(self), assert_msg != "" ? assert_msg : "Assertion is failed");
 }
 
+Tensor _functional_assert_async_cpu(const Tensor& self, const Tensor& dep_token) {
+  _assert_async_cpu(self);
+  return dep_token;
+}
+Tensor _functional_assert_async_msg_cpu(
+  const Tensor& self,
+  c10::string_view assert_msg,
+  const Tensor& dep_token) {
+  _assert_async_msg_cpu(self, assert_msg);
+  return dep_token;
+}
+
+
 // Sorting-based algorithm for isin(); used when the number of test elements is large.
 static void isin_sorting(
     const Tensor& elements,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -170,10 +170,18 @@
     CPU: _assert_async_cpu
     CUDA: _assert_async_cuda
 
+- func: _functional_assert_async(Tensor self, Tensor dep_token) -> Tensor
+  dispatch:
+    CPU: _functional_assert_async_cpu
+
 - func: _assert_async.msg(Tensor self, str assert_msg) -> ()
   dispatch:
     CPU: _assert_async_msg_cpu
     CUDA: _assert_async_msg_cuda
+
+- func: _functional_assert_async.msg(Tensor self, str assert_msg, Tensor dep_token) -> Tensor
+  dispatch:
+    CPU: _functional_assert_async_msg_cpu
 
 - func: _assert_tensor_metadata(Tensor a, SymInt[]? size=None, SymInt[]? stride=None, ScalarType? dtype=None) -> ()
 
@@ -181,6 +189,10 @@
   dispatch:
     CPU: sym_constrain_range_cpu
     CUDA: sym_constrain_range_cuda
+
+- func: functional_sym_constrain_range(Scalar size, int? min=None, int? max=None, Tensor? dep_token=None) -> Tensor
+  dispatch:
+    CPU: functional_sym_constrain_range_cpu
 #
 - func: refine_names(Tensor(a) self, Dimname[] names) -> Tensor(a)
   variants: method

--- a/test/export/test_assertions.py
+++ b/test/export/test_assertions.py
@@ -1,0 +1,42 @@
+# Owner(s): ["module: dynamo"]
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestAssertions(TestCase):
+    def test_functional_assert_async(self) -> None:
+        dep_token = torch.empty((1, 2))
+        self.assertEqual(
+            torch.ops.aten._functional_assert_async(torch.tensor(1), dep_token),
+            dep_token,
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "Expected Tensor with single nonzero value, but got zero"
+        ) as cm:
+            torch._functional_assert_async(torch.tensor(0), dep_token)
+
+    def test_functional_assert_async_msg(self) -> None:
+        dep_token = torch.empty((2, 3))
+        self.assertEqual(
+            torch.ops.aten._functional_assert_async.msg(
+                torch.tensor(1), "test msg", dep_token
+            ),
+            dep_token,
+        )
+        with self.assertRaisesRegex(RuntimeError, "test msg"):
+            torch.ops.aten._functional_assert_async.msg(
+                torch.tensor(0), "test msg", dep_token
+            ),
+
+    def test_functional_sym_constrain_range(self) -> None:
+        dep_token = torch.empty((1,))
+        self.assertEqual(
+            torch.ops.aten.functional_sym_constrain_range(
+                3, min=2, max=5, dep_token=dep_token
+            ),
+            dep_token,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103699
* #103346

This is a simple PR to creates the functional version of ATen assertion ops and later it will be used to replace the current no functional ops during export to keep the exported graph functional.

**NOTE:** GPU version is skipped for now and will be added later in separate PRs

