### PR TITLE
[Pytorch] aten::zeros

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/zero.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/zero.glsl
@@ -15,7 +15,7 @@ layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 /*
- * Returns the input tensor, filled with zeros
+ * Returns a tensor filled with zeros
  */
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);

--- a/aten/src/ATen/native/vulkan/ops/Zero.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Zero.cpp
@@ -23,7 +23,7 @@ Tensor& zero_(at::Tensor& self) {
 
   context->submit_compute_job(
       // shader descriptor
-      VK_KERNEL(zero_),
+      VK_KERNEL(zero),
       // pipeline barrier
       pipeline_barrier,
       // global work group size
@@ -41,10 +41,52 @@ Tensor& zero_(at::Tensor& self) {
   return self;
 }
 
+Tensor zeros(
+    const IntArrayRef size,
+    c10::optional<ScalarType> dtype,
+    c10::optional<c10::Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory) {
+  TORCH_CHECK(size.size() <= 4, "Vulkan zeros supports up to 4d tensors");
+
+  // Get the global Vulkan context
+  api::Context* const context = api::context();
+
+  // Create the output texture
+  vTensor v_output{
+      context,
+      size,
+      ScalarType::Float,
+  };
+
+  // Required to determine how to insert memory barriers in the command buffer
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      VK_KERNEL(zero),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::READ | api::MemoryAccessType::WRITE));
+
+  return convert(v_output);
+}
+
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::zero_"), TORCH_FN(zero_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::zeros"), TORCH_FN(zeros));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3622,9 +3622,10 @@ void test_unsqueeze(const at::IntArrayRef input_shape, int64_t dim) {
   const auto check = almostEqual(out_cpu, out_vulkan.cpu());
   if (!check) {
     showRtol(out_cpu, out_vulkan.cpu());
+    std::cout << "unsqueeze test failed with input shape: "
+              << input_shape << std::endl;
   }
   ASSERT_TRUE(check);
-
 }
 
 TEST_F(VulkanAPITest, unsqueeze_1dto2d_dim0) {
@@ -5059,27 +5060,6 @@ TEST_F(VulkanAPITest, stack_3d) {
   test_stack({221, 193, 11}, -4, 5);
 }
 
-void test_zero_(const at::IntArrayRef input_shape) {
-  auto cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
-  auto vulkan = cpu.vulkan();
-
-  cpu.zero_();
-  vulkan.zero_();
-
-  const auto check = almostEqual(cpu, vulkan.cpu());
-  if (!check) {
-    showRtol(cpu, vulkan.cpu());
-  }
-  ASSERT_TRUE(check);
-}
-
-TEST_F(VulkanAPITest, zero_) {
-  test_zero_({5});
-  test_zero_({5, 7});
-  test_zero_({9, 7, 5});
-  test_zero_({22, 11, 19, 17});
-}
-
 TEST_F(VulkanAPITest, tile_invalid_inputs_exceptions) {
   // Arrange: Vulkan tile only supports input of dims <= 4
   {
@@ -5144,6 +5124,49 @@ void test_tile(
 
 TEST_F(VulkanAPITest, tile) {
   test_tile({13, 5, 13, 7}, {7, 2, 3, 5});
+}
+
+void test_zero_(const at::IntArrayRef input_shape) {
+  auto cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  auto vulkan = cpu.vulkan();
+
+  cpu.zero_();
+  vulkan.zero_();
+
+  const auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+    std::cout << "zero_ test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, zero_) {
+  test_zero_({5});
+  test_zero_({5, 7});
+  test_zero_({9, 7, 5});
+  test_zero_({22, 11, 19, 17});
+}
+
+void test_zeros(const at::IntArrayRef input_shape) {
+  auto cpu = at::zeros(input_shape);
+  auto vulkan = at::zeros(input_shape, at::device(at::kVulkan));
+
+  const auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+    std::cout << "zeros test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, zeros) {
+  test_zeros({5});
+  test_zeros({5, 7});
+  test_zeros({9, 7, 5});
+  test_zeros({22, 11, 19, 17});
 }
 
 TEST_F(VulkanAPITest, clone_success) {


### PR DESCRIPTION
Summary: Implement [aten::zeros](https://pytorch.org/docs/stable/generated/torch.zeros.html?highlight=zeros#torch.zeros)

Test Plan:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*zeros*"
Action graph will be rebuilt because files have been added or removed.
Parsing buck files: finished in 2.3 sec
Downloaded 0/4 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 6.0 sec (100%) 454/454 jobs, 3/454 updated
  Total time: 8.4 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *zeros*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VulkanAPITest
[ RUN      ] VulkanAPITest.zeros
[       OK ] VulkanAPITest.zeros (99 ms)
[----------] 1 test from VulkanAPITest (99 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (99 ms total)
[  PASSED  ] 1 test.
```

Differential Revision: D46777782

