### PR TITLE
[Reland][ET] Select used et_kernel_metadata only

### DIFF
--- a/test/edge/selected_operators.yaml
+++ b/test/edge/selected_operators.yaml
@@ -3,6 +3,10 @@ custom_classes: []
 include_all_non_op_selectives: false
 include_all_operators: false
 kernel_metadata: {}
+et_kernel_metadata:
+  custom::add_3.out:
+    - v1/6;0,1,2,3|6;0,1,2,3|6;0,1,2,3
+    - v1/3;0,1,2,3|3;0,1,2,3|3;0,1,2,3
 operators:
   aten::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams.out:
     debug_info:

--- a/test/edge/selected_operators.yaml
+++ b/test/edge/selected_operators.yaml
@@ -7,6 +7,9 @@ et_kernel_metadata:
   custom::add_3.out:
     - v1/6;0,1,2,3|6;0,1,2,3|6;0,1,2,3
     - v1/3;0,1,2,3|3;0,1,2,3|3;0,1,2,3
+  aten::add.out:
+    - v1/6;0,1,2,3|6;0,1,2,3|6;0,1,2,3
+    - v1/3;0,1,2,3|3;0,1,2,3|3;0,1,2,3
 operators:
   aten::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams.out:
     debug_info:

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -310,34 +310,33 @@ et_kernel_metadata:
    - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
 """
         selector = SelectiveBuilder.from_yaml_str(yaml_config)
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out",
+                [
+                    "v1/6;0,1|6;0,1|6;0,1|6;0,1",
+                    "v1/3;0,1|3;0,1|3;0,1|3;0,1",
+                    "v1/6;1,0|6;0,1|6;0,1|6;0,1",
+                ],
+            ),
         )
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::sub.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::sub.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::mul.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/3;0,1|3;0,1|3;0,1|3;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;1,0|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            [],
+            selector.et_get_selected_kernels(
+                "aten::mul.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )
         # We don't use version for now.
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v2/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v2/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out", ["v2/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -168,8 +168,16 @@ class ComputeCodegenUnboxedKernels:
         kernel_key: Union[ETKernelKey, List[ETKernelKey]] = unbox_kernel_entry[1][0]
         kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
 
-        # TODO: Update to use Kernel Selector
-        if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
+        op_name = f.namespace + "::" + str(f.func.name)
+        if not self.selector.is_root_operator(op_name):
+            return ""
+
+        if not isinstance(kernel_key, list):
+            kernel_key = [kernel_key]
+        used_kernel_keys = self.selector.et_get_selected_kernels(
+            op_name, [k.to_native_string() for k in kernel_key]
+        )
+        if not used_kernel_keys:
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]
         argument_type_gen: Callable[..., NamedCType]
@@ -217,15 +225,12 @@ class ComputeCodegenUnboxedKernels:
                 return_assignment = ""
                 ret_prefix = ""
 
-        if not isinstance(kernel_key, list):
-            kernel_key = [kernel_key]
-
         newline = "\n    "
         return "\n".join(
             [
                 f"""
 Kernel(
-    "{f.namespace}::{f.func.name}",{newline + '"' + (k.to_native_string() + '",') if k.to_native_string() != 'default' else ''}
+    "{f.namespace}::{f.func.name}",{newline + '"' + (k + '",') if k != 'default' else ''}
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
@@ -236,7 +241,7 @@ Kernel(
     }}
 ),
 """
-                for k in kernel_key
+                for k in used_kernel_keys
             ]
         )
 

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -168,7 +168,7 @@ class ComputeCodegenUnboxedKernels:
         kernel_key: Union[ETKernelKey, List[ETKernelKey]] = unbox_kernel_entry[1][0]
         kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
 
-        op_name = f.namespace + "::" + str(f.func.name)
+        op_name = f"{f.namespace}::{f.func.name}"
         if not self.selector.is_root_operator(op_name):
             return ""
 


### PR DESCRIPTION
Currently we rely on root operator, but we also need to check for et_kernel_metadata for used specialized kernels.
