### PR TITLE
Tidy __all__ under torch._refs

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1739,6 +1739,7 @@ class TestRefsOpsInfo(TestCase):
 
     # TODO: References that do not have an entry in python_ref_db
     skip_ref_ops = {
+        '_refs.alias',
         '_refs.bitwise_right_shift',
         '_refs.copy_to',
         '_refs.empty_permuted',
@@ -1747,6 +1748,7 @@ class TestRefsOpsInfo(TestCase):
         '_refs.full',
         '_refs.full_like',
         '_refs.to',
+        '_refs.mvlgamma',
         '_refs.ones',
         '_refs.ones_like',
         '_refs.special.expit',
@@ -1755,6 +1757,7 @@ class TestRefsOpsInfo(TestCase):
         '_refs.uniform',
         '_refs.scalar_tensor',
         '_refs.trunc_divide',
+        '_refs.zero',
         '_refs.zeros',
         '_refs.zeros_like',
         '_refs.rfloordiv',
@@ -1793,6 +1796,8 @@ class TestRefsOpsInfo(TestCase):
         '_refs._conversions.cdouble',
         '_refs.broadcast_shapes',
         '_refs.broadcast_tensors',
+        '_refs.mvlgamma',
+        '_refs.nn.functional.layer_norm',
         '_refs.nn.functional.tanhshrink',
         '_refs.nn.functional.triplet_margin_loss',
         '_refs.rfloordiv',
@@ -1810,6 +1815,7 @@ class TestRefsOpsInfo(TestCase):
         '_refs.dsplit',
         '_refs.dstack',
         '_refs.fill',
+        '_refs.fill_',
         '_refs.flatten',
         '_refs.fliplr',
         '_refs.flipud',
@@ -1863,6 +1869,8 @@ class TestRefsOpsInfo(TestCase):
         '_refs.conj',  # Calls _prims.conj
         '_refs.real',
         '_refs.imag',
+        '_refs.reshape_as',
+        '_refs.view_as',
     }
 
     @parametrize("op", ref_ops_names)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -65,16 +65,21 @@ __all__ = [
     "conj_physical",
     "cos",
     "cosh",
+    "count_nonzero",
+    "deg2rad",
     "digamma",
     "erf",
     "erfinv",
     "erfc",
     "exp",
     "expm1",
+    "exponential",
     "exp2",
     "fill",
+    "fill_",
     "floor",
     "frac",
+    "geometric",
     "index_add",
     "index_copy",
     "index_copy_",
@@ -94,10 +99,15 @@ __all__ = [
     "log1p",
     "log2",
     "log10",
+    "log_normal",
     "log_softmax",
+    "mvlgamma",
+    "norm",
+    "normal",
     "nan_to_num",
     "neg",
     "positive",
+    "rad2deg",
     "reciprocal",
     "round",  # TODO: model kwargs
     "sigmoid",
@@ -144,6 +154,8 @@ __all__ = [
     "imag",
     "isclose",
     "lcm",
+    "logaddexp",
+    "logsumexp",
     # 'ldexp',
     "le",
     "logical_and",
@@ -180,6 +192,7 @@ __all__ = [
     # Conditional references
     #
     "masked_fill",
+    "masked_fill_",
     "where",
     #
     # Data conversion and movement references
@@ -212,10 +225,12 @@ __all__ = [
     #
     # View & Shape Ops
     #
+    "alias",
     "atleast_1d",
     "atleast_2d",
     "atleast_3d",
     "as_strided",
+    "as_strided_scatter",
     "broadcast_shapes",
     "broadcast_tensors",
     "broadcast_to",
@@ -250,6 +265,7 @@ __all__ = [
     "ravel",
     "repeat",
     "reshape",
+    "reshape_as",
     "roll",
     "rot90",
     "rsqrt",
@@ -264,6 +280,7 @@ __all__ = [
     "unfold_copy",
     "unsqueeze",
     "view",
+    "view_as",
     "vsplit",
     "vstack",
     "unflatten",
@@ -276,6 +293,7 @@ __all__ = [
     # Tensor Creation
     #
     "arange",
+    "cauchy",
     "empty",
     "empty_like",
     "empty_permuted",
@@ -285,10 +303,16 @@ __all__ = [
     "full_like",
     "linspace",
     "logspace",
+    "new_empty",
+    "new_empty_strided",
+    "new_full",
+    "new_ones",
+    "new_zeros",
     "ones",
     "ones_like",
     "randn",
     "scalar_tensor",
+    "zero",
     "zeros",
     "zeros_like",
     #
@@ -415,16 +439,19 @@ def _make_elementwise_unary_reference(
     return inner
 
 
-def _make_alias(fn, name):
+def _make_alias(fn, name, module_name):
     """
-    This function defines an alias of another function and sets its __name__argument
-    Note that when naïvely doing `alias = fn`, we have that `alias.__name__ == "fn"`.
+    This function defines an alias of another function and sets its __name__ and __module__
+    argument.
+    Note that when naïvely doing `alias = fn`, we have that `alias.__name__ == "fn"`, and
+    `alias.__module__ == fn.__module__`.
     """
 
     def _fn(*args, **kwargs):
         return fn(*args, **kwargs)
 
     _fn.__name__ = name
+    _fn.__module__ = module_name
     return _fn
 
 
@@ -652,7 +679,7 @@ def isnan(a: TensorLikeType) -> TensorLikeType:
 
 
 # alias
-mvlgamma = _make_alias(torch.special.multigammaln, "mvlgamma")  # type: ignore[has-type]
+mvlgamma = _make_alias(torch.special.multigammaln, "mvlgamma", __name__)  # type: ignore[has-type]
 
 
 @_make_elementwise_unary_reference(
@@ -1972,7 +1999,7 @@ def _to_other(
 
 
 # remove to_kwargs that is already present in `a`
-def canonicalize_to_arguments(a: Tensor, to_kwargs: dict):
+def _canonicalize_to_arguments(a: Tensor, to_kwargs: dict):
     options_to_check = ["dtype", "device", "layout", "memory_format"]
     # "device" option could be passed a str instead torch.device
     if "device" in to_kwargs and isinstance(to_kwargs["device"], str):
@@ -2004,7 +2031,7 @@ def to(a: TensorLikeType, *args, **kwargs) -> TensorLikeType:
     # TODO: is_pinned is not currently supported in refs or fake_tensor
     # https://github.com/pytorch/pytorch/issues/84925
     assert "pin_memory" not in kwargs
-    canonicalize_to_arguments(a, kwargs)
+    _canonicalize_to_arguments(a, kwargs)
 
     if _to_will_alias(a, **kwargs):
         return a

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1,5 +1,6 @@
 import builtins
 import collections
+import inspect
 import math
 import operator
 import warnings
@@ -439,10 +440,10 @@ def _make_elementwise_unary_reference(
     return inner
 
 
-def _make_alias(fn, name, module_name):
+def _make_alias(fn, name):
     """
-    This function defines an alias of another function and sets its __name__ and __module__
-    argument.
+    This function defines an alias of another function and sets its __name__ argument.
+    It also sets its __module__ argument to the module of the caller.
     Note that when naïvely doing `alias = fn`, we have that `alias.__name__ == "fn"`, and
     `alias.__module__ == fn.__module__`.
     """
@@ -451,7 +452,7 @@ def _make_alias(fn, name, module_name):
         return fn(*args, **kwargs)
 
     _fn.__name__ = name
-    _fn.__module__ = module_name
+    _fn.__module__ = inspect.currentframe().f_back.f_globals["__name__"]
     return _fn
 
 
@@ -679,7 +680,7 @@ def isnan(a: TensorLikeType) -> TensorLikeType:
 
 
 # alias
-mvlgamma = _make_alias(torch.special.multigammaln, "mvlgamma", __name__)  # type: ignore[has-type]
+mvlgamma = _make_alias(torch.special.multigammaln, "mvlgamma")  # type: ignore[has-type]
 
 
 @_make_elementwise_unary_reference(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -452,7 +452,7 @@ def _make_alias(fn, name):
         return fn(*args, **kwargs)
 
     _fn.__name__ = name
-    _fn.__module__ = inspect.currentframe().f_back.f_globals["__name__"]
+    _fn.__module__ = inspect.currentframe().f_back.f_globals["__name__"]  # type: ignore[union-attr]
     return _fn
 
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -25,34 +25,43 @@ from torch._refs import _make_inplace
 __all__ = [
     "alpha_dropout",
     "celu",
+    "celu_",
     "dropout",
     "elu",
+    "elu_",
+    "gelu",
+    "glu",
+    "group_norm",
     "hardshrink",
     "hardtanh",
     "hinge_embedding_loss",
     "huber_loss",
     "l1_loss",
-    "smooth_l1_loss",
+    "layer_norm",
+    "leaky_relu",
     "log_softmax",
     "margin_ranking_loss",
     "mish",
-    "nll_loss",
+    "mish_",
     "mse_loss",
+    "nll_loss",
+    "pairwise_distance",
+    "pdist",
     "poisson_nll_loss",
     "prelu",
     "relu",
     "relu6",
     "selu",
+    "selu_",
+    "smooth_l1_loss",
     "softmax",
     "softmin",
     "softplus",
     "softshrink",
     "tanhshrink",
     "threshold",
+    "threshold_",
     "triplet_margin_loss",
-    "glu",
-    "pairwise_distance",
-    "pdist",
 ]
 
 Tensor = torch.Tensor
@@ -116,7 +125,7 @@ def alpha_dropout(
     return self * dropout_mask + b
 
 
-def inplace_wrapper(fn):
+def _inplace_wrapper(fn):
     """
     Given a nn.functional non-linearity, implements its `inplace: bool` argument
     """
@@ -139,7 +148,7 @@ def inplace_wrapper(fn):
 # celu is implemented specially because it has an alpha argument
 # celu is very similar to elu
 @register_decomposition(aten.celu)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -173,7 +182,7 @@ def celu(
 
 
 @register_decomposition(aten.dropout)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 def dropout(
     a: TensorLikeType, p: float = 0.5, training: bool = True, inplace: bool = False
@@ -202,7 +211,7 @@ def dropout(
 
 
 @register_decomposition(aten.elu)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -240,7 +249,7 @@ def elu(
 
 
 @register_decomposition(aten.relu)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -311,7 +320,7 @@ def layer_norm(
 
 
 @register_decomposition(aten.leaky_relu)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -335,7 +344,7 @@ def leaky_relu(
 
 
 @register_decomposition(aten.mish)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -352,7 +361,7 @@ def mish(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
 
 
 @register_decomposition(aten.selu)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -406,7 +415,7 @@ def softmin(
 
 # softplus is implemented specially because it has beta and threshold arguments
 @register_decomposition(aten.softplus)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -855,7 +864,7 @@ def tanhshrink(a: TensorLikeType) -> TensorLikeType:
 
 
 @register_decomposition(aten.threshold)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
@@ -956,7 +965,7 @@ def _triplet_margin_with_distance_loss(
 
 
 @register_decomposition(aten.hardtanh)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 @elementwise_unary_scalar_wrapper
 @elementwise_type_promotion_wrapper(
@@ -1100,7 +1109,7 @@ def prelu(a: TensorLikeType, weight: TensorLikeType) -> TensorLikeType:
 
 
 @register_decomposition(aten.relu6)
-@inplace_wrapper
+@_inplace_wrapper
 @out_wrapper()
 def relu6(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
     """

--- a/torch/_refs/special/__init__.py
+++ b/torch/_refs/special/__init__.py
@@ -85,7 +85,7 @@ def erfcx(a: TensorLikeType) -> TensorLikeType:
 
 
 # alias for sigmoid
-expit = _make_alias(torch.sigmoid, "expit", __name__)
+expit = _make_alias(torch.sigmoid, "expit")
 
 
 @_make_elementwise_unary_reference(

--- a/torch/_refs/special/__init__.py
+++ b/torch/_refs/special/__init__.py
@@ -17,6 +17,7 @@ from torch._prims_common import (
 )
 from torch._prims_common.wrappers import elementwise_type_promotion_wrapper, out_wrapper
 from torch._refs import (
+    _make_alias,
     _make_elementwise_binary_reference,
     _make_elementwise_unary_reference,
 )
@@ -84,7 +85,7 @@ def erfcx(a: TensorLikeType) -> TensorLikeType:
 
 
 # alias for sigmoid
-expit = torch.sigmoid
+expit = _make_alias(torch.sigmoid, "expit", __name__)
 
 
 @_make_elementwise_unary_reference(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103712

- Added ops that were missing under `__all__`.
- Some misc changes to helper functions to make them private.
- Set correct `fn.__module__` for `fn` created by `_make_alias`, when called in another module.

All modification largely references results from a hacked version of `test_public_bindings::test_correct_module_names`.
By default `torch._refs` is not included in the test because it is technically a private package.

cc @ezyang @mruberry @Lezcano @peterbell10