### PR TITLE
Fix bug for buffer reuse

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -27,10 +27,10 @@ size_asserts = os.environ.get("TORCHINDUCTOR_SIZE_ASSERTS", "1") == "1"
 # enable loop reordering based on input orders
 pick_loop_orders = True
 
-# generate inplace computations
+# reuse a kernel input as the output
 inplace_buffers = True
 
-# allow reusing buffers for more efficient memory use
+# reuse a buffer for an unrelated purpose
 allow_buffer_reuse = True
 
 # codegen benchmark harness

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -267,7 +267,7 @@ class BaseSchedulerNode:
                 input_node: BaseSchedulerNode = self.scheduler.name_to_node.get(
                     read.name
                 )
-                if input_node and V.graph.wrapper_code.can_reuse(input_node):
+                if input_node and config.allow_buffer_reuse and V.graph.wrapper_code.can_reuse(input_node):
                     remaining_uses = [
                         x
                         for x in input_node.users

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -267,7 +267,11 @@ class BaseSchedulerNode:
                 input_node: BaseSchedulerNode = self.scheduler.name_to_node.get(
                     read.name
                 )
-                if input_node and config.allow_buffer_reuse and V.graph.wrapper_code.can_reuse(input_node):
+                if (
+                    input_node
+                    and config.allow_buffer_reuse
+                    and V.graph.wrapper_code.can_reuse(input_node)
+                ):
                     remaining_uses = [
                         x
                         for x in input_node.users

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -267,11 +267,7 @@ class BaseSchedulerNode:
                 input_node: BaseSchedulerNode = self.scheduler.name_to_node.get(
                     read.name
                 )
-                if (
-                    input_node
-                    and config.inplace_buffers
-                    and V.graph.wrapper_code.can_reuse(input_node)
-                ):
+                if input_node and V.graph.wrapper_code.can_reuse(input_node):
                     remaining_uses = [
                         x
                         for x in input_node.users

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -269,7 +269,7 @@ class BaseSchedulerNode:
                 )
                 if (
                     input_node
-                    and config.allow_buffer_reuse
+                    and config.inplace_buffers
                     and V.graph.wrapper_code.can_reuse(input_node)
                 ):
                     remaining_uses = [
@@ -1237,7 +1237,11 @@ class Scheduler:
 
     def free_buffers(self):
         """Free any buffers that are no longer needed"""
-        for name in sorted(self.buffer_names_to_free - V.graph.removed_buffers):
+        for name in sorted(
+            self.buffer_names_to_free
+            - V.graph.removed_buffers
+            - V.graph.wrapper_code.freed
+        ):
             if name in self.name_to_node:
                 node = self.name_to_node[name]
                 if node.can_free():


### PR DESCRIPTION
When disable `allow_buffer_reuse` in `torch/_inductor/config.py`, the buffer reuse still happens. This PR fixes the missing check. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78