### PR TITLE
[memory_viz] fix javascript url

### DIFF
--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -378,7 +378,7 @@ html, body {
 </head>
 <body>
 <script type="module">
-import {add_local_files} from "https://cdn.jsdelivr.net/gh/pytorch/pytorch/torch/utils/viz/MemoryViz.js"
+import {add_local_files} from "https://cdn.jsdelivr.net/gh/pytorch/pytorch@main/torch/utils/viz/MemoryViz.js"
 const local_files = $SNAPSHOT
 add_local_files(local_files, $VIZ_KIND)
 </script>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103741
* #103565
* #103497
* #103474

It turns out that jsdelivr, which is used to access the MemoryViz.js
source from generated files, doesn't work unless a version is specified.

This wasn't able to be tested until the PR actually landed.