### PR TITLE
[BE] Nested namespace in `ATen/native` headers

### DIFF
--- a/aten/src/ATen/native/Activation.h
+++ b/aten/src/ATen/native/Activation.h
@@ -14,10 +14,10 @@ struct TensorIteratorBase;
 class TensorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 // These constants control the approximation behavior of gelu function.
-enum GeluType {
+enum class GeluType {
   None,             // Baseline Gelu
   Tanh,             // Tahn Gelu Approximation
   END
@@ -30,6 +30,14 @@ static GeluType get_gelutype_enum(const c10::string_view approximate) {
     return GeluType::Tanh;
   } else {
     TORCH_CHECK(false, "approximate argument must be either none or tanh.");
+  }
+}
+
+static std::string gelutype_to_string(const GeluType type) {
+  switch(type) {
+    case GeluType::None: return "none";
+    case GeluType::Tanh: return "tanh";
+    default: TORCH_CHECK(false, "unknown GELU type: ", static_cast<int>(type));
   }
 }
 
@@ -87,6 +95,4 @@ DECLARE_DISPATCH(activation_backward_fn, mish_backward_stub);
 DECLARE_DISPATCH(activation_fn, prelu_stub);
 DECLARE_DISPATCH(activation_backward_fn, prelu_backward_stub);
 
-} // namespace native
-
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/AdaptivePooling.h
+++ b/aten/src/ATen/native/AdaptivePooling.h
@@ -6,9 +6,7 @@
 #include <c10/util/irange.h>
 #include <cmath>
 
-namespace at {
-
-namespace native {
+namespace at::native {
 
 using adaptive_avg_pooling_fn = void(*)(Tensor& output, const Tensor& input, IntArrayRef output_size);
 using adaptive_avg_pooling_backward_fn = void(*)(Tensor& grad_input, const Tensor& grad_output);
@@ -38,4 +36,4 @@ static inline void adaptive_pool_empty_output_check(const Tensor& gradOutput_, c
   }
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/BatchLinearAlgebra.h
+++ b/aten/src/ATen/native/BatchLinearAlgebra.h
@@ -15,7 +15,7 @@ enum class TransposeType;
 
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 enum class LapackLstsqDriverType : int64_t { Gels, Gelsd, Gelsy, Gelss};
 
@@ -317,4 +317,4 @@ using ldl_solve_fn = void (*)(
     bool /*upper*/,
     bool /*hermitian*/);
 DECLARE_DISPATCH(ldl_solve_fn, ldl_solve_stub);
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -21,7 +21,7 @@ struct TensorIterator;
 struct TensorIteratorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 inline void alpha_check(const ScalarType dtype, const Scalar& alpha) {
   TORCH_CHECK(! alpha.isBoolean() || dtype == ScalarType::Bool,
@@ -180,4 +180,4 @@ DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_u_stub);
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_v_stub);
 DECLARE_DISPATCH(structured_binary_fn, shifted_chebyshev_polynomial_w_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/BucketizationUtils.h
+++ b/aten/src/ATen/native/BucketizationUtils.h
@@ -10,8 +10,7 @@
 #include <ATen/ops/result_type.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // original values given by raw_*. If an original value is not contiguous, will make a contiguous copy to
 // the corresponding trimmed_* value. Additionally, if the dtypes of the boundary and input tensor do not
@@ -171,4 +170,4 @@ inline void searchsorted_pre_check(
   }
 }
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -7,9 +7,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/Scalar.h>
 
-namespace at {
-namespace native {
-namespace cpublas {
+namespace at::native::cpublas {
 
 namespace internal {
 void normalize_last_dims(
@@ -161,4 +159,4 @@ void copy(int64_t n, const float *x, int64_t incx, float *y, int64_t incy);
 void copy(int64_t n, const c10::complex<double> *x, int64_t incx, c10::complex<double> *y, int64_t incy);
 void copy(int64_t n, const c10::complex<float> *x, int64_t incx, c10::complex<float> *y, int64_t incy);
 
-}}}  // namespace at::native::cpublas
+}  // namespace at::native::cpublas

--- a/aten/src/ATen/native/CPUFallback.h
+++ b/aten/src/ATen/native/CPUFallback.h
@@ -7,7 +7,7 @@
 #include <c10/util/Metaprogramming.h>
 #include <torch/library.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // This function implements a boxed fallback to CPU.
 // External backends can add their own custom logging on top if it to customize their own CPU fallbacks.
@@ -42,5 +42,4 @@ using call_fallback_fn_symint = _call_fallback_fn<fallback_fn, Op, true, typenam
 template<c10::KernelFunction::BoxedKernelFunction* fallback_fn, class Op>
 using call_fallback_fn = _call_fallback_fn<fallback_fn, Op, false, typename Op::schema>;
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/CanUse32BitIndexMath.h
+++ b/aten/src/ATen/native/CanUse32BitIndexMath.h
@@ -6,8 +6,8 @@ namespace at {
 class TensorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 TORCH_API bool canUse32BitIndexMath(const at::TensorBase &t, int64_t max_elem=std::numeric_limits<int32_t>::max());
 
-}}
+}

--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -15,7 +15,7 @@
 // WARNING: this header contains non-inline functions and should be only
 // included from ONE cpp file
 
-namespace at { namespace native {
+namespace at::native {
 
 // View tensor with new dtype, storage offset, sizes and strides
 inline Tensor view_tensor(
@@ -94,4 +94,4 @@ Tensor view_as_complex(const Tensor& self) {
   return view_tensor(self, complex_type, new_storage_offset, new_sizes, new_strides);
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/CompositeRandomAccessor.h
+++ b/aten/src/ATen/native/CompositeRandomAccessor.h
@@ -2,7 +2,7 @@
 
 #include <ATen/native/CompositeRandomAccessorCommon.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 struct TupleInfoCPU {
   template <typename ...Types>
@@ -31,4 +31,4 @@ auto get(references_holder<Values, References> rh) -> decltype(std::get<N>(rh.da
   return std::get<N>(rh.data());
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/CompositeRandomAccessorCommon.h
+++ b/aten/src/ATen/native/CompositeRandomAccessorCommon.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -260,4 +260,4 @@ protected:
   ValueAccessor values;
 };
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -6,7 +6,7 @@
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 using conv_depthwise2d_backward_fn = std::tuple<at::Tensor,at::Tensor>(*)(
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
@@ -407,4 +407,4 @@ static inline bool thnn_conv_use_channels_last(const at::Tensor& input, const at
   return can_use_thnn_channels_last_2d;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ConvolutionMM3d.h
+++ b/aten/src/ATen/native/ConvolutionMM3d.h
@@ -1,7 +1,6 @@
 #include <ATen/core/Tensor.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 std::tuple<Tensor, Tensor, Tensor> slow_conv3d_backward_cpu(
     const Tensor& grad_output,
@@ -12,4 +11,4 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv3d_backward_cpu(
     IntArrayRef padding,
     std::array<bool, 3> output_mask);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/DilatedConvolutionUtils.h
+++ b/aten/src/ATen/native/DilatedConvolutionUtils.h
@@ -19,9 +19,7 @@
       " but got input to be of shape ",              \
       T.sizes())
 
-namespace at {
-namespace native {
-namespace internal {
+namespace at::native::internal {
 namespace {
 inline bool all_positive(IntArrayRef& arr) {
   return std::all_of(
@@ -228,6 +226,4 @@ void slow_conv_dilated_shape_check(
   }
 }
 
-} // namespace internal
-} // namespace native
-} // namespace at
+} // namespace at::native::internal

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -37,12 +37,10 @@
 // the main dispatch mechanism is.
 
 // ignore warnings about DispatchStub::DEFAULT, AVX, AVX2 defined elsewhere
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundefined-var-template"
-#endif
+C10_CLANG_DIAGNOSTIC_PUSH()
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wundefined-var-template")
 
-namespace at { namespace native {
+namespace at::native {
 
 enum class CPUCapability {
   DEFAULT = 0,
@@ -309,9 +307,6 @@ struct RegisterPRIVATEUSE1Dispatch {
 #endif
 
 
-}} // namespace at::native
+} // namespace at::native
 
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+C10_CLANG_DIAGNOSTIC_POP()

--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -22,9 +22,7 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-namespace at {
-namespace native {
-namespace templates {
+namespace at::native::templates {
 
 // ==================================================== Random ========================================================
 
@@ -363,4 +361,4 @@ Tensor& bernoulli_out_impl(Tensor& result, const Tensor& self, c10::optional<Gen
 #undef CHECK_OUT_OF_BOUNDS
 #undef WARN_OUT_OF_BOUNDS
 
-}}}
+} // namespace at::native::templates

--- a/aten/src/ATen/native/EmbeddingBag.h
+++ b/aten/src/ATen/native/EmbeddingBag.h
@@ -6,8 +6,7 @@
 #include <fbgemm/FbgemmEmbedding.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void check_arguments(
     const Tensor& weight,
@@ -137,5 +136,4 @@ void _embedding_bag_cpu_out(
     const c10::optional<int64_t>& padding_idx,
     _EmbeddingBagKernelCache* fbgemm_kernel_cache = nullptr);
 
-} // native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/FractionalMaxPooling.h
+++ b/aten/src/ATen/native/FractionalMaxPooling.h
@@ -3,7 +3,7 @@
 #include <ATen/TensorUtils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename scalar_t>
 static inline std::vector<int> generate_intervals(
@@ -77,4 +77,4 @@ static inline void fractional_max_pool_check_shape(
       "Expect _random_samples.size(2) equals to ", ndim, "; got ", D, ".");
 }
 
-}} // at::native
+} // namespace at::native

--- a/aten/src/ATen/native/GridSampler.h
+++ b/aten/src/ATen/native/GridSampler.h
@@ -7,7 +7,7 @@
 
 #include <ATen/native/GridSamplerUtils.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 using detail::GridSamplerInterpolation;
 using detail::GridSamplerPadding;
@@ -295,4 +295,4 @@ static inline void get_cubic_coefficients_grad(
   coeffs[3] = (3 * A * x - 10 * A) * x + 8 * A;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -6,7 +6,7 @@
 #include <ATen/native/TensorProperties.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace detail {
 
@@ -106,4 +106,4 @@ bool cond_cudnn_grid_sampler(
 
 } // anonymous namespace
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/Histogram.h
+++ b/aten/src/ATen/native/Histogram.h
@@ -3,7 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 using histogramdd_fn = void(*)(const Tensor&, const c10::optional<Tensor>&, bool, Tensor&, const TensorList&);
 using histogramdd_linear_fn = void(*)(const Tensor&, const c10::optional<Tensor>&, bool, Tensor&, const TensorList&, bool);
@@ -11,4 +11,4 @@ using histogramdd_linear_fn = void(*)(const Tensor&, const c10::optional<Tensor>
 DECLARE_DISPATCH(histogramdd_fn, histogramdd_stub);
 DECLARE_DISPATCH(histogramdd_linear_fn, histogramdd_linear_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/IndexKernel.h
+++ b/aten/src/ATen/native/IndexKernel.h
@@ -13,7 +13,7 @@ namespace c10 {
 class Scalar;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using index_fn = void(*)(TensorIteratorBase &, IntArrayRef indexed_sizes, IntArrayRef indexed_strides);
 using index_fill_fn = void(*)(TensorIterator & iter, int64_t dim, int64_t self_dim_size, int64_t self_dim_stride, const Scalar& source);
@@ -38,4 +38,4 @@ DECLARE_DISPATCH(masked_select_fn, masked_select_serial_stub);
 DECLARE_DISPATCH(masked_select_fn, masked_select_stub);
 DECLARE_DISPATCH(masked_scatter_fn, masked_scatter_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -5,7 +5,7 @@
 #include <ATen/core/IListRef.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 [[noreturn]]
 static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, int64_t maskIdx) {
@@ -157,4 +157,4 @@ struct AdvancedIndex {
 };
 
 
-}}
+} //namespace at::native

--- a/aten/src/ATen/native/Lerp.h
+++ b/aten/src/ATen/native/Lerp.h
@@ -5,8 +5,7 @@
 #include <ATen/TensorIterator.h>
 #include <c10/core/Scalar.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t>
 C10_HOST_DEVICE C10_ALWAYS_INLINE bool is_lerp_weight_small(scalar_t weight) {
@@ -44,5 +43,4 @@ using lerp_fn_tensor = void (*)(
 DECLARE_DISPATCH(lerp_fn_scalar, lerp_kernel_scalar_weight);
 DECLARE_DISPATCH(lerp_fn_tensor, lerp_kernel_tensor_weight);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/LinearAlgebra.h
+++ b/aten/src/ATen/native/LinearAlgebra.h
@@ -11,8 +11,8 @@ namespace at {
 struct TensorIterator;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using addr_fn = void (*)(TensorIterator &, const Scalar& beta, const Scalar& alpha);
 DECLARE_DISPATCH(addr_fn, addr_stub);
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -25,7 +25,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 static inline c10::MaybeOwned<Tensor> expect_resolved_conj(const Tensor& tensor) {
   if (tensor.is_conj()) {
@@ -621,4 +621,4 @@ static inline bool is_blas_compatible_row_major_order(const Tensor& input) {
       batch_stride_compatible;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/LossMulti.h
+++ b/aten/src/ATen/native/LossMulti.h
@@ -4,7 +4,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
   static C10_UNUSED void multilabel_margin_loss_shape_check(
     int64_t& nframe,
@@ -69,4 +69,4 @@ namespace {
 
 
 }  // anonymous namespace
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/MathBitsFallback.h
+++ b/aten/src/ATen/native/MathBitsFallback.h
@@ -14,8 +14,7 @@
 #include <utility>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 // This fallback should only be used for operations that are self inverse and have a corresponding tensor
 // bit (internally implemented using DispatchKey) to maintain the state on tensor using tensor bit.
 // Currently there are two tensor bits that trigger this fallback: conjugate bit and negative bit.
@@ -154,5 +153,5 @@ struct MathOpFallback {
   DispatchKey key;
   string op_name;
 };
-}
-}// namespace at
+
+} // namespace at::native

--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -4,8 +4,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // TODO(Heitor) Template by dimension
 struct PoolingParams1D {
@@ -40,5 +39,4 @@ using pooling_fn = void (*)(Tensor&, const Tensor&, const PoolingParams1D&);
 
 DECLARE_DISPATCH(pooling_fn, max_pool1d_stub);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/NonEmptyUtils.h
+++ b/aten/src/ATen/native/NonEmptyUtils.h
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <vector>
 
-namespace at { namespace native {
+namespace at::native {
 
 inline int64_t ensure_nonempty_dim(int64_t dim) {
   return std::max<int64_t>(dim, 1);
@@ -24,4 +24,4 @@ inline IdxVec ensure_nonempty_vec(IdxVec vec) {
   return vec;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/NonSymbolicBC.h
+++ b/aten/src/ATen/native/NonSymbolicBC.h
@@ -3,8 +3,7 @@
 #include <c10/util/irange.h>
 #include <ATen/core/IListRef.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 // This file contains non-symbolic signatures for ops that we have sym-intified the signature of.
 // However, in certain cases (such as static runtime), we call the native versions of the ops directly.
 // In those cases, we will duplicate the signature here with non-symbolic ints, and also duplicate the C++ implementation.
@@ -24,4 +23,4 @@ TORCH_API at::Tensor trace_backward(const at::Tensor & grad, at::IntArrayRef siz
 TORCH_API at::Tensor index_select_backward(const at::Tensor & grad, at::IntArrayRef self_sizes, int64_t dim, const at::Tensor & index);
 TORCH_API at::Tensor select(const at::Tensor& self, int64_t dim, int64_t index);
 TORCH_API std::vector<Tensor> tensor_split(const Tensor& self, IntArrayRef indices, int64_t dim);
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/Normalization.h
+++ b/aten/src/ATen/native/Normalization.h
@@ -3,10 +3,9 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using renorm_scale_factor_fn = void (*) (TensorIteratorBase& iter, double maxnorm);
 DECLARE_DISPATCH(renorm_scale_factor_fn, renorm_scale_factor_stub);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using max_pool2d_fn = void(*)(const Tensor& output, const Tensor& indices, const Tensor& input,
     int kW, int kH, int dW, int dH, int padW, int padH, int dilationW, int dilationH);
@@ -330,7 +329,6 @@ avg_pool3d_backward_shape_check(
   check_dim_size(gradOutput, ndim, ndim-1, owidth);
 }
 
-} // namespace
+} // anonymous namespace
 
-} // at::native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/RNN.h
+++ b/aten/src/ATen/native/RNN.h
@@ -3,7 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 using lstm_fn = void(*)(Tensor&, Tensor&, Tensor&, const Tensor&, TensorList, TensorList, bool, int64_t, double, bool, bool, bool);
 using rnn_fn = void(*)(Tensor&, Tensor&, const Tensor&, const Tensor&, TensorList, bool, int64_t, double, bool, bool, bool);
@@ -50,4 +50,4 @@ inline void check_attributes(const Tensor& input, const TensorList& params, cons
   for (const auto& p : params) check_tensors("parameter", p);
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ReduceAllOps.h
+++ b/aten/src/ATen/native/ReduceAllOps.h
@@ -6,11 +6,11 @@ namespace at {
 class Tensor;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using reduce_all_fn = void (*)(Tensor & result, const Tensor & self);
 using reduce_min_max_fn = void (*)(Tensor & max_result, Tensor & min_result, const Tensor & self);
 DECLARE_DISPATCH(reduce_all_fn, min_all_stub);
 DECLARE_DISPATCH(reduce_all_fn, max_all_stub);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/ReduceOps.h
+++ b/aten/src/ATen/native/ReduceOps.h
@@ -12,7 +12,7 @@ struct TensorIterator;
 class Tensor;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using reduce_fn = void(*)(TensorIterator &);
 
@@ -52,4 +52,4 @@ TORCH_API std::tuple<Tensor&,Tensor&> var_mean_out(
     Tensor &result1, Tensor &result2, const Tensor &self, IntArrayRef dim,
     int64_t correction, bool keepdim);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -16,7 +16,7 @@
 #include <ATen/ops/scalar_tensor.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 // Maximum and minimum possible scalar values, including infinities
 template <typename scalar_t>
@@ -344,9 +344,9 @@ inline ScalarType get_dtype_from_result(Tensor& result, c10::optional<ScalarType
 }
 
 
-} // native
+} // namespace at::native
 
-namespace meta {
+namespace at::meta {
 
 static C10_UNUSED DimVector get_reduction_shape(
     const Tensor& self,
@@ -443,5 +443,4 @@ static C10_UNUSED TensorIterator make_reduction_from_out_ty(
   return make_reduction(self, result, opt_dims, keepdim, in_dtype);
 }
 
-} // namespace meta
-} // namespace at
+} // namespace at::meta

--- a/aten/src/ATen/native/ReductionType.h
+++ b/aten/src/ATen/native/ReductionType.h
@@ -2,9 +2,9 @@
 
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
-enum ReductionType {MAX, MEAN, MIN, SUM, PROD};
+enum class ReductionType {MAX, MEAN, MIN, SUM, PROD};
 
 static inline ReductionType get_reduction_enum(const c10::string_view& reduce) {
   if (reduce == "max" || reduce == "amax") {
@@ -37,4 +37,4 @@ static inline ReductionType get_operator_enum(const c10::string_view reduce, boo
   }
 }
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/Repeat.h
+++ b/aten/src/ATen/native/Repeat.h
@@ -10,8 +10,7 @@
 #include <ATen/ops/empty_like.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <
     typename index_t,
@@ -46,5 +45,4 @@ static inline Tensor repeat_interleave_common(
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -10,7 +10,7 @@
 #include <utility>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 // TODO: make all operations that resize given outputs use this function
 //   for consistency and maintainability.
@@ -166,4 +166,4 @@ inline void setStrided(
   self_->set_sizes_and_strides(size, stride, c10::make_optional(storage_offset));
 }
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/ResizeCommon.h
+++ b/aten/src/ATen/native/ResizeCommon.h
@@ -4,7 +4,7 @@
 #include <ATen/NamedTensorUtils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename T>
 inline T storage_size_for(ArrayRef<T> size, ArrayRef<T> stride) {
@@ -44,4 +44,4 @@ inline const Tensor& resize_named_tensor_(
       optional_memory_format.value());
   return self;
 }
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/ScatterGatherChecks.h
+++ b/aten/src/ATen/native/ScatterGatherChecks.h
@@ -5,7 +5,7 @@
 #include <ATen/native/ReduceOpsUtils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -125,4 +125,4 @@ static C10_UNUSED void scatter_shape_check(
 
 } // anonymous namespace
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/SobolEngineOpsUtils.h
+++ b/aten/src/ATen/native/SobolEngineOpsUtils.h
@@ -10,9 +10,7 @@
 #include <ATen/ops/pow.h>
 #endif
 
-namespace at {
-namespace native {
-namespace sobol_utils {
+namespace at::native::sobol_utils {
 
 /// Function to return the minimum of number of bits to represent the integer `n`
 inline int64_t bit_length(const int64_t n) {
@@ -54,6 +52,4 @@ constexpr float RECIPD = 1.0 / LARGEST_NUMBER;
 extern const int64_t poly[MAXDIM];
 extern const int64_t initsobolstate[MAXDIM][MAXDEG];
 
-} // namespace sobol_utils
-} // namespace native
-} // namespace at
+} // namespace at::native::sobol_utils

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -7,8 +7,7 @@ namespace at {
 class TensorBase;
 }
 
-namespace at {
-namespace native {
+namespace at::native {
 
 enum class QUANTILE_INTERPOLATION_MODE : uint8_t {
   LINEAR,
@@ -26,5 +25,4 @@ DECLARE_DISPATCH(topk_fn, topk_stub);
 
 void _fill_indices(const TensorBase &indices, int64_t dim);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -10,8 +10,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // ensure we get good values and indices for kthvalue, mode
 // this will always be with the reducing dim as 1-d
@@ -86,5 +85,4 @@ inline void _allocate_or_resize_output_with_indices(
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/SparseTensorUtils.h
+++ b/aten/src/ATen/native/SparseTensorUtils.h
@@ -11,8 +11,7 @@
 #include <ATen/ops/tensor.h>
 #endif
 
-namespace at {
-namespace sparse {
+namespace at::sparse {
 
 // Just for documentary purposes
 using SparseTensor = Tensor;
@@ -182,5 +181,4 @@ class TensorGeometryHolder<0> {
   geometry_holder_t t_strides;
 };
 
-} // namespace sparse
-} // namespace at
+} // namespace at::sparse

--- a/aten/src/ATen/native/SpectralOpsUtils.h
+++ b/aten/src/ATen/native/SpectralOpsUtils.h
@@ -5,7 +5,7 @@
 #include <sstream>
 #include <ATen/native/DispatchStub.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // Normalization types used in _fft_with_size
 enum class fft_norm_mode {
@@ -77,4 +77,4 @@ DECLARE_DISPATCH(fft_fill_with_conjugate_symmetry_fn, fft_fill_with_conjugate_sy
 // See NOTE [ Fourier Transform Conjugate Symmetry ]
 TORCH_API void _fft_fill_with_conjugate_symmetry_(const Tensor& self, IntArrayRef dims);
 
-}} // at::native
+} // namespace at::native

--- a/aten/src/ATen/native/StridedRandomAccessor.h
+++ b/aten/src/ATen/native/StridedRandomAccessor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace at { namespace native {
+namespace at::native {
 
 // (Const)StridedRandomAccessor is a
 // (const) random access iterator defined over
@@ -298,4 +298,4 @@ public:
   // }
 };
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorAdvancedIndexing.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.h
@@ -12,7 +12,7 @@ namespace at {
 struct TensorIterator;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using index_put_with_sort_fn = void(*)(Tensor &, const c10::List<c10::optional<Tensor>> &, const Tensor &, bool accumulate, bool unsafe);
 using index_put_with_sort_quantized_fn = void(*)(Tensor& self, const c10::List<c10::optional<Tensor>>& indices, const Tensor& value, double scale, int zero_point, bool unsafe);
@@ -109,4 +109,4 @@ DECLARE_DISPATCH(scatter_add_expanded_index_fn, scatter_add_expanded_index_stub)
 DECLARE_DISPATCH(scatter_reduce_expanded_index_fn, scatter_reduce_expanded_index_stub);
 DECLARE_DISPATCH(gather_expanded_index_fn, gather_expanded_index_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -3,8 +3,7 @@
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/TensorIterator.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 static std::string shapes_as_str(TensorList tensors) {
   std::ostringstream os;
@@ -91,5 +90,4 @@ static AdvancedIndex make_info(Tensor self, IOptTensorListRef orig) {
   return AdvancedIndex(self, indices);
 }
 
-} // at
-} // native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -12,7 +12,7 @@ struct TensorIterator;
 struct TensorIteratorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using reduce_minmax_fn =
     void (*)(Tensor&, Tensor&, const Tensor&, int64_t, bool);
@@ -46,4 +46,4 @@ DECLARE_DISPATCH(void (*)(TensorIteratorBase &, c10::Scalar), clamp_max_scalar_s
 using isin_default_fn = void (*)(const Tensor&, const Tensor&, bool, const Tensor&);
 DECLARE_DISPATCH(isin_default_fn, isin_default_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -2,53 +2,54 @@
 #include <ATen/core/Tensor.h>
 #include <c10/util/irange.h>
 
-namespace at {
-  namespace native {
-    //input tensors are non-zero dim and non-empty
-    template<typename T1, typename T2, typename Function>
-    void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Function func) {
-      int ndims = self.dim();
-      int tensor_dim_apply_has_finished = 0;
-      std::vector<int64_t> counter(ndims, 0);
-      T1* self_data = self.data_ptr<T1>();
-      T1* values_data = values.data_ptr<T1>();
-      T2* indices_data = indices.data_ptr<T2>();
-      int64_t self_stride = self.stride(dim);
-      int64_t values_stride = values.stride(dim);
-      int64_t indices_stride = indices.stride(dim);
-      int self_dim_size = self.size(dim);
+namespace at::native {
+//input tensors are non-zero dim and non-empty
+template<typename T1, typename T2, typename Function>
 
-      while(!tensor_dim_apply_has_finished) {
-        func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
-        if(ndims == 1)
-           break;
-        for (const auto dim_i : c10::irange(ndims)) {
-          if(dim_i == dim) {
-            if(dim_i == (ndims - 1)) {
-              tensor_dim_apply_has_finished = 1;
-              break;
-            }
-            continue;
-          }
-          counter[dim_i]++;
-          self_data += self.stride(dim_i);
-          values_data += values.stride(dim_i);
-          indices_data += indices.stride(dim_i);
+void tensor_dim_apply3(const Tensor& self, Tensor& values, Tensor& indices, int64_t dim, Function func) {
+  int ndims = self.dim();
+  int tensor_dim_apply_has_finished = 0;
+  std::vector<int64_t> counter(ndims, 0);
+  T1* self_data = self.data_ptr<T1>();
+  T1* values_data = values.data_ptr<T1>();
+  T2* indices_data = indices.data_ptr<T2>();
+  int64_t self_stride = self.stride(dim);
+  int64_t values_stride = values.stride(dim);
+  int64_t indices_stride = indices.stride(dim);
+  int self_dim_size = self.size(dim);
 
-          if(counter[dim_i] == self.size(dim_i)) {
-            if(dim_i == ndims-1) {
-              tensor_dim_apply_has_finished = 1;
-              break;
-            } else {
-              self_data -= counter[dim_i]*self.stride(dim_i);
-              values_data -= counter[dim_i]*values.stride(dim_i);
-              indices_data -= counter[dim_i]*indices.stride(dim_i);
-              counter[dim_i] = 0;
-            }
-          } else {
-            break;
-         }
-        }
-      }
+  while (!tensor_dim_apply_has_finished) {
+    func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
+    if (ndims == 1) {
+       break;
     }
-}}
+    for (const auto dim_i : c10::irange(ndims)) {
+      if (dim_i == dim) {
+        if (dim_i == (ndims - 1)) {
+          tensor_dim_apply_has_finished = 1;
+          break;
+        }
+        continue;
+      }
+      counter[dim_i]++;
+      self_data += self.stride(dim_i);
+      values_data += values.stride(dim_i);
+      indices_data += indices.stride(dim_i);
+
+      if (counter[dim_i] == self.size(dim_i)) {
+        if (dim_i == ndims-1) {
+          tensor_dim_apply_has_finished = 1;
+          break;
+        } else {
+          self_data -= counter[dim_i]*self.stride(dim_i);
+          values_data -= counter[dim_i]*values.stride(dim_i);
+          indices_data -= counter[dim_i]*indices.stride(dim_i);
+          counter[dim_i] = 0;
+        }
+      } else {
+        break;
+     }
+    }
+  }
+}
+} // namespace at::native

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -11,7 +11,7 @@
 #include <ATen/ops/scalar_tensor.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 // Different combinations of row, col, and offset can lead to two cases:
 //
 // Case 1 - Trapezoid (Triangle as a special case): row + offset <= col
@@ -118,5 +118,4 @@ using binary_fn = void (*)(TensorIterator&);
 DECLARE_DISPATCH(binary_fn, complex_stub);
 DECLARE_DISPATCH(binary_fn, polar_stub);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -15,7 +15,7 @@
 // On CUDA, the cast is currently pushed down into the kernel (for performance reasons).
 // On CPU, there is currently an internal assert that a dynamic_cast is not needed.
 
-namespace at { namespace native {
+namespace at::native {
 
 // `needs_dynamic_casting` compares the types expected by iterator
 // (i.e. dtypes of the operands) with the actual type of the arguments
@@ -50,4 +50,4 @@ struct needs_dynamic_casting<func_t, 0> {
   }
 };
 
-}} //namespace at::native
+} //namespace at::native

--- a/aten/src/ATen/native/TensorProperties.h
+++ b/aten/src/ATen/native/TensorProperties.h
@@ -5,8 +5,8 @@ namespace at {
 class TensorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 TORCH_API bool cudnn_is_acceptable(const TensorBase& self);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -3,8 +3,7 @@
 #include <c10/util/irange.h>
 #include <ATen/core/IListRef.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 TORCH_API at::Tensor clone_preserve_strides(const at::Tensor& self);
 
@@ -56,4 +55,4 @@ inline int64_t get_num_splits(const Tensor& self, int64_t split_size, int64_t di
   return num_splits;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -8,8 +8,7 @@
 
 #include <c10/util/Exception.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 static inline Tensor roll_common(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   TORCH_CHECK(!shifts.empty(), "`shifts` required");
@@ -28,4 +27,4 @@ static inline Tensor roll_common(const Tensor& self, IntArrayRef shifts, IntArra
   return at::roll(first_dim_rolled, tail_shifts, tail_dims);
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -2,8 +2,7 @@
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/NumericUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 #ifdef CPU_CAPABILITY
 inline namespace CPU_CAPABILITY {
@@ -91,5 +90,4 @@ void topk_impl_loop(
 }
 
 } // namespace CPU_CAPABILITY
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/TransposeType.h
+++ b/aten/src/ATen/native/TransposeType.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <c10/util/Exception.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // Used as an interface between the different BLAS-like libraries
 enum class TransposeType {
@@ -21,4 +20,4 @@ static inline char to_blas(TransposeType trans) {
   TORCH_INTERNAL_ASSERT(false, "Invalid transpose type");
 }
 
-}}  // at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/TriangularOpsUtils.h
+++ b/aten/src/ATen/native/TriangularOpsUtils.h
@@ -1,8 +1,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/LinearAlgebraUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 /*
  * Given batches of matrices with arbitrary batch dim,
@@ -55,5 +54,4 @@ static inline std::tuple<bool, Tensor> checkTrilTriuBatchContiguous(const Tensor
   return std::make_tuple(true, tensor);
 }
 
-}  // namespace native
-}  // namespace at
+}  // namespace at::native

--- a/aten/src/ATen/native/TypeProperties.h
+++ b/aten/src/ATen/native/TypeProperties.h
@@ -3,7 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/IListRef.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 struct ResultTypeState {
   c10::ScalarType dimResult = ScalarType::Undefined;
@@ -17,4 +17,4 @@ TORCH_API ScalarType result_type(const ResultTypeState& state);
 
 TORCH_API ScalarType result_type(ITensorListRef tensors);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -11,7 +11,7 @@ class TensorBase;
 struct TensorIteratorBase;
 }
 
-namespace at { namespace native {
+namespace at::native {
 
 using unary_fn = void(*)(TensorIteratorBase&);
 using unary_fn_with_scalar = void(*)(TensorIteratorBase&, const Scalar& a);
@@ -127,4 +127,4 @@ DECLARE_DISPATCH(void (*)(TensorIteratorBase&, int64_t), round_decimals_stub);
 // clone
 // contiguous
 // zero
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/Unfold2d.h
+++ b/aten/src/ATen/native/Unfold2d.h
@@ -4,7 +4,7 @@
 #include <c10/core/ScalarType.h>
 #include <cstdint>
 
-namespace at { namespace native {
+namespace at::native {
 
 using unfold2d_fn = void (*)(
     ScalarType dtype,
@@ -27,4 +27,4 @@ using unfold2d_fn = void (*)(
 DECLARE_DISPATCH(unfold2d_fn, unfolded2d_copy_stub);
 DECLARE_DISPATCH(unfold2d_fn, unfolded2d_acc_stub);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/Unfold3d.h
+++ b/aten/src/ATen/native/Unfold3d.h
@@ -2,8 +2,7 @@
 
 #include <c10/core/ScalarType.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void Unfold3dCopyCPU(
     ScalarType dtype,
@@ -47,5 +46,4 @@ void Unfold3dAccCPU(
     int64_t pad_w,
     void *dst);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/UnfoldBackward.h
+++ b/aten/src/ATen/native/UnfoldBackward.h
@@ -11,7 +11,7 @@
 #include <ATen/ops/arange.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 using unfold_backward_fn = void (*)(
   Tensor& grad_in,
@@ -109,4 +109,4 @@ static C10_UNUSED TensorIterator _make_unfold_backward_iter_over_grad_out(
 
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -45,8 +45,7 @@
  *     src_idx + 0.5 = scale * (dst_index + 0.5)
  */
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace upsample {
 
@@ -499,5 +498,4 @@ void inline apply_grad_input(float* buffer_ptr, BFloat16* gin, int64_t size) {
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/batch_norm.h
+++ b/aten/src/ATen/native/batch_norm.h
@@ -3,9 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at {
-
-namespace native {
+namespace at::native {
 
 using batch_norm_fn = void (*)(Tensor&, const Tensor&, const Tensor&,
     const Tensor&, const Tensor&, const Tensor&, const Tensor&, const Tensor&, bool, double);
@@ -32,6 +30,4 @@ static scalar_t* conditional_data_ptr(const Tensor& t) {
                      : nullptr;
 }
 
-} // namespace native
-
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceUtils.h
+++ b/aten/src/ATen/native/cpu/ReduceUtils.h
@@ -15,24 +15,24 @@ using namespace vec;
 #define AT_DISPATCH_REDUCTION_TYPES(op, ...)                                   \
   [&] {                                                                        \
     switch (op) {                                                              \
-      case SUM: {                                                              \
-        static constexpr ReductionType reduce = SUM;                           \
+      case ReductionType::SUM: {                                               \
+        static constexpr auto reduce = ReductionType::SUM;                     \
         return __VA_ARGS__();                                                  \
       }                                                                        \
-      case MEAN: {                                                             \
-        static constexpr ReductionType reduce = MEAN;                          \
+      case ReductionType::MEAN: {                                              \
+        static constexpr auto reduce = ReductionType::MEAN;                    \
         return __VA_ARGS__();                                                  \
       }                                                                        \
-      case MIN: {                                                              \
-        static constexpr ReductionType reduce = MIN;                           \
+      case ReductionType::MIN: {                                               \
+        static constexpr auto reduce = ReductionType::MIN;                     \
         return __VA_ARGS__();                                                  \
       }                                                                        \
-      case MAX: {                                                              \
-        static constexpr ReductionType reduce = MAX;                           \
+      case ReductionType::MAX: {                                               \
+        static constexpr auto reduce = ReductionType::MAX;                     \
         return __VA_ARGS__();                                                  \
       }                                                                        \
-      case PROD: {                                                             \
-        static constexpr ReductionType reduce = PROD;                          \
+      case ReductionType::PROD: {                                              \
+        static constexpr auto reduce = ReductionType::PROD;                    \
         return __VA_ARGS__();                                                  \
       }                                                                        \
     }                                                                          \

--- a/aten/src/ATen/native/im2col.h
+++ b/aten/src/ATen/native/im2col.h
@@ -9,8 +9,7 @@
 
 #include <algorithm>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename T>
 static void im2col(
@@ -147,5 +146,4 @@ static void col2im(
   }
 }
 
-} // native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/im2col_shape_check.h
+++ b/aten/src/ATen/native/im2col_shape_check.h
@@ -3,8 +3,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/div_rtn.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 static inline void col2im_shape_check(
     const Tensor& input,
@@ -230,5 +229,4 @@ static inline void im2col_shape_check(
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -4,8 +4,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <c10/util/accumulate.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -98,5 +97,4 @@ using backward_fn = void (*)(
 DECLARE_DISPATCH(forward_fn, LayerNormKernel);
 DECLARE_DISPATCH(backward_fn, LayerNormBackwardKernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -717,7 +717,7 @@ TORCH_IMPL_FUNC(gelu_out_mps)(const Tensor& self, c10::string_view approximate, 
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "gelu_out_mps" + getTensorsStringKey({self}) + ":" + std::to_string(approximate_type);
+    const auto key = "gelu_out_mps" + getTensorsStringKey({self}) + ":" + gelutype_to_string(approximate_type);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
 
@@ -758,7 +758,7 @@ TORCH_IMPL_FUNC(gelu_backward_out_mps)
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + std::to_string(approximate_type);
+    const auto key = "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + gelutype_to_string(approximate_type);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto dataType = getMPSDataType(self);
 

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -758,7 +758,8 @@ TORCH_IMPL_FUNC(gelu_backward_out_mps)
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    const auto key = "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + gelutype_to_string(approximate_type);
+    const auto key =
+        "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + gelutype_to_string(approximate_type);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto dataType = getMPSDataType(self);
 

--- a/aten/src/ATen/native/verbose_wrapper.h
+++ b/aten/src/ATen/native/verbose_wrapper.h
@@ -1,12 +1,8 @@
-#ifndef VERBOSE_WRAPPER_H
-#define VERBOSE_WRAPPER_H
+#pragma once
+
 #include <c10/macros/Export.h>
 
-namespace torch {
-namespace verbose {
+namespace torch::verbose {
 TORCH_API int _mkl_set_verbose(int enable);
 TORCH_API int _mkldnn_set_verbose(int level);
-} // namespace verbose
-} // namespace torch
-
-#endif // VERBOSE_WRAPPER_H
+} // namespace torch::verbose

--- a/aten/src/ATen/native/vol2col.h
+++ b/aten/src/ATen/native/vol2col.h
@@ -2,8 +2,7 @@
 
 #include <cstring>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename T>
 static void vol2col(
@@ -79,22 +78,21 @@ static void col2vol(
     const int64_t dilationH,
     const int64_t dilationW,
     T* data_vol) {
-  int64_t c, t, h, w;
   memset(data_vol, 0, sizeof(T) * depth * height * width * channels);
   int64_t depth_col = out_depth;
   int64_t height_col = out_height;
   int64_t width_col = out_width;
   int64_t channels_col = channels * kT * kernel_height * kernel_width;
-  for (c = 0; c < channels_col; ++c) {
+  for (int64_t c = 0; c < channels_col; ++c) {
     int64_t w_offset = c % kernel_width;
     int64_t h_offset = (c / kernel_width) % kernel_height;
     int64_t t_offset = (c / kernel_width / kernel_height) % kT;
     int64_t c_vol = c / kT / kernel_height / kernel_width;
-    for (t = 0; t < depth_col; ++t) {
+    for (int64_t t = 0; t < depth_col; ++t) {
       int64_t t_pad = t * dT - pT + t_offset * dilationT;
-      for (h = 0; h < height_col; ++h) {
+      for (int64_t h = 0; h < height_col; ++h) {
         int64_t h_pad = h * dH - pH + h_offset * dilationH;
-        for (w = 0; w < width_col; ++w) {
+        for (int64_t w = 0; w < width_col; ++w) {
           int64_t w_pad = w * dW - pW + w_offset * dilationW;
           if (t_pad >= 0 && t_pad < depth && h_pad >= 0 && h_pad < height &&
               w_pad >= 0 && w_pad < width)
@@ -108,5 +106,4 @@ static void col2vol(
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native


### PR DESCRIPTION
Use nested namespace and `enum class` in `ATen/native` headers.
In particular, it helps avoid polluting global namespace with `MAX`,`MIN` enum values.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10