### PR TITLE
[quant][pt2] Fix QAT convert for resnet18

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1766,10 +1766,9 @@ class TestQuantizePT2EModels(PT2EQuantizationTestCase):
         with override_quantized_engine("qnnpack"):
             example_inputs = (torch.randn(1, 3, 224, 224),)
             m = torchvision.models.resnet18()
-            # TODO: verify convert numerics in a future PR
             self._verify_symmetric_qnnpack_qat_numerics(
-                m, example_inputs, is_per_channel=False,
+                m, example_inputs, is_per_channel=False, verify_convert=True,
             )
             self._verify_symmetric_qnnpack_qat_numerics(
-                m, example_inputs, is_per_channel=True,
+                m, example_inputs, is_per_channel=True, verify_convert=True,
             )

--- a/torch/ao/quantization/_pt2e/qat_utils.py
+++ b/torch/ao/quantization/_pt2e/qat_utils.py
@@ -171,7 +171,12 @@ def _get_input_output_quantized_filter():
     return _input_output_quantized_filter
 
 
-def _get_quantized_qat_conv2d_bn_pattern(is_per_channel: bool, has_relu: bool, has_bias: bool):
+def _get_quantized_qat_conv2d_bn_pattern(
+    is_per_channel: bool,
+    has_relu: bool,
+    has_bias: bool,
+    relu_is_inplace: bool,
+) -> Callable:
     """
     Return the quantized version of QAT conv + BN pattern.
     This is based on `nniqat.ConvBn2d._forward_approximate`,
@@ -227,11 +232,19 @@ def _get_quantized_qat_conv2d_bn_pattern(is_per_channel: bool, has_relu: bool, h
             x = x + kwargs["conv_bias"].reshape(bias_shape)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
         if has_relu:
-            x = F.relu(x)
+            if relu_is_inplace:
+                x = F.relu_(x)
+            else:
+                x = F.relu(x)
         return x
     return _quantized_qat_conv2d_bn_pattern
 
-def _get_folded_quantized_qat_conv2d_bn_pattern(is_per_channel: bool, has_relu: bool, has_bias: bool):
+def _get_folded_quantized_qat_conv2d_bn_pattern(
+    is_per_channel: bool,
+    has_relu: bool,
+    has_bias: bool,
+    relu_is_inplace: bool,
+) -> Callable:
     """
     Quantized QAT conv - bn pattern with bn weights being folded into conv.
     """
@@ -272,7 +285,10 @@ def _get_folded_quantized_qat_conv2d_bn_pattern(is_per_channel: bool, has_relu: 
             x = F.conv2d(x, conv_weight, None)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
         if has_relu:
-            x = F.relu(x)
+            if relu_is_inplace:
+                x = F.relu_(x)
+            else:
+                x = F.relu(x)
         return x
     return _folded_quantized_qat_conv2d_bn_pattern
 
@@ -509,12 +525,62 @@ def _fuse_conv_bn_qat(m: GraphModule) -> GraphModule:
                 replacement_getitem_node.meta = original_node.meta
     return m
 
+def _duplicate_dequantize_node(m: GraphModule):
+    """
+    Helper function to duplicate all dequantize nodes in the graph if the
+    node has more than one user. For example:
+
+    Before:
+      quantize -> dequantize -> a
+                          \\--> b
+                          \\--> c
+
+    After:
+      quantize -> dequantize_1 -> a
+            \\--> dequantize_2 -> b
+            \\--> dequantize_3 -> c
+
+    This is useful for subgraph rewriting. E.g. if we wish to match the
+    pattern [dequantize - a] above, subgraph matching would fail because
+    the dequantize node has users outside the matched portion of the graph.
+    Instead, we match [dequantize_1 - a], which is safe.
+    """
+    dq_op = torch.ops.quantized_decomposed.dequantize_per_tensor
+    for n in m.graph.nodes:
+        if n.op != "call_function" or n.target != dq_op or len(n.users) == 1:
+            continue
+        for user in list(n.users):
+            with m.graph.inserting_before(n):
+                new_node = m.graph.create_node("call_function", dq_op, n.args, n.kwargs)
+            user.replace_input_with(n, new_node)
+        m.graph.erase_node(n)
+    m.recompile()
+
+def _remove_extra_dequantize(m: GraphModule):
+    """
+    Removes duplicate dequant nodes in the graph, for an operator that has
+    multiple dequant nodes as a user, replace them with a single dequant node
+    that can be shared across all the uses. This should be seen as the "reverse"
+    of `_duplicate_dequantize_node`.
+    """
+    dq_op = torch.ops.quantized_decomposed.dequantize_per_tensor
+    for n in m.graph.nodes:
+        dq_users = [user for user in n.users if user.op == "call_function" and user.target == dq_op]
+        if len(dq_users) > 1:
+            with m.graph.inserting_after(dq_users[0]):
+                new_node = m.graph.create_node("call_function", dq_op, dq_users[0].args, {})
+            for dq_user in dq_users:
+                dq_user.replace_all_uses_with(new_node)
+                m.graph.erase_node(dq_user)
+    m.recompile()
+
 def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
     """
     Replace the quantized (conv + bn) pattern with conv with bn weights folded into the weights of conv.
     """
     m.graph.eliminate_dead_code()
     m.recompile()
+    _duplicate_dequantize_node(m)
 
     # Step (1): Replace QAT pattern with simple [conv - bn] pattern
     replacements = []
@@ -522,13 +588,22 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
         [True, False],  # is_per_channel
         [True, False],  # has_relu
         [True, False],  # has_bias
+        [True, False],  # relu_is_inplace
     )
-    for is_per_channel, has_relu, has_bias in replacement_options:
+    for is_per_channel, has_relu, has_bias, relu_is_inplace in replacement_options:
+        # For the cases without relu, `relu_is_inplace` is irrelevant, so here we arbitrarily
+        # filter out one of the values for this flag to avoid having duplicate patterns
+        if not has_relu and relu_is_inplace:
+            continue
         example_inputs = _quantized_conv2d_bn_pattern_example_inputs
         kwargs = _get_quantized_conv2d_bn_pattern_example_inputs_kwargs(is_per_channel, has_bias)
-        match_pattern = _get_quantized_qat_conv2d_bn_pattern(is_per_channel, has_relu, has_bias)
+        match_pattern = _get_quantized_qat_conv2d_bn_pattern(
+            is_per_channel, has_relu, has_bias, relu_is_inplace,
+        )
         match_pattern = _get_aten_graph_module(match_pattern, example_inputs, **kwargs)
-        replacement_pattern = _get_folded_quantized_qat_conv2d_bn_pattern(is_per_channel, has_relu, has_bias)
+        replacement_pattern = _get_folded_quantized_qat_conv2d_bn_pattern(
+            is_per_channel, has_relu, has_bias, relu_is_inplace,
+        )
         replacement_pattern = _get_aten_graph_module(replacement_pattern, example_inputs, **kwargs)
         replacements.extend(
             replace_pattern_with_filters(
@@ -540,6 +615,7 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
             )
         )
     m.recompile()
+    _remove_extra_dequantize(m)
 
     # Step (2): Fold BN weights into conv
     for r in replacements:


### PR DESCRIPTION
Summary:
Before this commit, only prepare QAT numerics matched
between PT2 and FX for resnet18. Convert numerics diverged,
however, for two reasons:

(1) Existing patterns did not handle inplace ReLUs. This commit
fixes this by adding extra patterns that use these ReLUs instead
of the normal ones.

(2) Subgraph rewriter could not handle skip connections in
quantized models, because the dequantize node is used in both
the conv node within the match pattern, and an inplace add node
outside of the match pattern. This led the subgraph matcher to
filter out the match, complaining that it was not self contained.
This commit fixes this problem by duplicating the dequantize
nodes, one for each user, such that subsequent matches will
be self contained.

Test Plan: python test/test_quantization.py TestQuantizePT2EModels.test_qat_resnet18

Reviewed By: jerryzh168

Differential Revision: D46564114

