### PR TITLE
[exir] Initial serialization

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -450,7 +450,7 @@ class GraphModuleSerializer:
         node_args = node.args[0]
         if isinstance(node_args, torch.fx.Node):
             node_args = (node_args,)
-        assert isinstance(node_args, tuple)
+        assert isinstance(node_args, (tuple, list))
         self.graph_state.outputs = [self.serialize_input(arg) for arg in node_args]
 
     def handle_call_function(self, node: torch.fx.Node):


### PR DESCRIPTION
Summary:
ETRecord can't use this yet because the other programs need to be migrated to using ExportedProgram (D46729844)

Note: higher order ops like call_delegate/cond are also not supported yet

Test Plan: `buck2 run @//mode/dev-nosan //executorch/exir/tests:serde`

Differential Revision: D46802454

