### PR TITLE
Use the new analytics ID

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -456,7 +456,7 @@ html_theme_options = {
     'collapse_navigation': False,
     'display_version': True,
     'logo_only': True,
-    'analytics_id': 'UA-117752657-2',
+    'analytics_id': 'GTM-T8XT4PS',
 }
 
 html_logo = '_static/img/pytorch-logo-dark-unstable.png'


### PR DESCRIPTION
Re: https://github.com/pytorch/pytorch.github.io/issues/1397
Following the migration to latest google analytics
FYI @malfet 