### PR TITLE
Remove ExportGraphModuleMixin.

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -7,7 +7,7 @@ from torch._functorch.aot_autograd import FQN, GraphInputName, GraphOutputName
 
 
 import torch
-from torch.fx.passes.pass_manager import PassManager
+from torch.fx.passes.infra.pass_manager import PassManager
 import torch.fx._pytree as fx_pytree
 import torch.utils._pytree as pytree
 from torch.fx.experimental.symbolic_shapes import SymInt
@@ -162,6 +162,8 @@ class ExportedProgram:
             copy.deepcopy(self.range_constraints),
             copy.deepcopy(self.equality_constraints),
         )
+        transformed_ep.graph_module.meta.update(self.graph_module.meta)
+        transformed_ep.graph_module.meta.update(res.graph_module.meta)
         return transformed_ep
 
     def _add_runtime_assertions(self) -> "ExportedProgram":


### PR DESCRIPTION
Summary:
We remove the ExportGraphModuleMixin. There are several implications of this change:
1. The graph_module of ExportedProgram, EdgeDialectProgram and ExecutorchProgram won't have the same signature as original user function. Instead, we should directly call the *Program, which has the same calling convention. e.g:

2. All passes need to go through prog.transform(*passes). We need to make all passes return PassResult as a result.

3. We also need to make sure the graph_module.meta is preserved after transform.

Test Plan: Test with CI.

Differential Revision: D46729844

