### PR TITLE
Exception is hard to catch in a long job. Better to raise the excepti…

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1295,14 +1295,16 @@ class Graph:
         """
         try:
             from tabulate import tabulate
+            
+            node_specs = [[n.op, n.name, n.target, n.args, n.kwargs]
+                        for n in self.nodes]
+            print(tabulate(node_specs,
+                headers=['opcode', 'name', 'target', 'args', 'kwargs']))
+
         except ImportError:
-            print("`print_tabular` relies on the library `tabulate`, "
+            raise ImportError("`print_tabular` relies on the library `tabulate`, "
                   "which could not be found on this machine. Run `pip "
                   "install tabulate` to install the library.")
-        node_specs = [[n.op, n.name, n.target, n.args, n.kwargs]
-                      for n in self.nodes]
-        print(tabulate(node_specs,
-              headers=['opcode', 'name', 'target', 'args', 'kwargs']))
 
     @compatibility(is_backward_compatible=True)
     def lint(self):


### PR DESCRIPTION
This is a simple fix/code change that will make it easier to catch the fact that the `tabulate` package is missing. Currently, we try to import, catch the error, use the package, and fail. The current fix changes this by importing the package, using it, and if not installed raising the error via:

```python
raise ImportError("`print_tabular` relies on the library `tabulate`, "
                  "which could not be found on this machine. Run `pip "
                  "install tabulate` to install the library.")
```

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv