### PR TITLE
Generate `torch._C._nn` functions from yaml

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -47,6 +47,7 @@ read gen_pyi for the gory details.
 def get_py_torch_functions(
     python_funcs: Sequence[PythonSignatureNativeFunctionPair],
     method: bool = False,
+    module_nn: bool = False,
 ) -> Sequence[PythonSignatureGroup]:
     """
     Get declarations (grouped by name) which should be generated
@@ -67,7 +68,20 @@ def get_py_torch_functions(
             and Variant.method in python_func.function.variants
         )
 
-    should_bind = should_bind_method if method else should_bind_function
+    def should_bind_nn_function(python_func: PythonSignatureNativeFunctionPair) -> bool:
+        return (
+            should_generate_py_binding(python_func.function)
+            and python_func.function.python_module == "nn"
+            and Variant.function in python_func.function.variants
+        )
+
+    should_bind = (
+        should_bind_nn_function
+        if module_nn
+        else should_bind_method
+        if method
+        else should_bind_function
+    )
     return group_overloads([f for f in python_funcs if should_bind(f)])
 
 
@@ -286,168 +300,42 @@ def get_max_pool_dispatch(name: str, arg_list: List[str]) -> Dict[str, List[str]
     }
 
 
-def gen_nn_functional(fm: FileManager) -> None:
-    INPUT = "input: Tensor"
-    KERNEL_SIZE = "kernel_size: Union[_int, _size]"
-    STRIDE_PADDING = ", ".join(
-        [
-            "stride: Optional[Union[_int, _size]] = None",
-            "padding: Union[_int, _size] = 0",
-        ]
+def gen_nn_functional(
+    native_yaml_path: str,
+    tags_yaml_path: str,
+    deprecated_yaml_path: str,
+    fm: FileManager,
+) -> None:
+    unsorted_nn_function_hints: Dict[str, List[str]] = collections.defaultdict(list)
+
+    native_functions = parse_native_yaml(
+        native_yaml_path, tags_yaml_path
+    ).native_functions
+    native_functions = list(filter(should_generate_py_binding, native_functions))
+
+    function_signatures = load_signatures(
+        native_functions, deprecated_yaml_path, method=False, pyi=True
     )
+    sig_groups = get_py_torch_functions(function_signatures, module_nn=True)
+    for group in sorted(sig_groups, key=lambda g: g.signature.name):
+        name = group.signature.name
+        unsorted_nn_function_hints[name] += generate_type_hints(group)
 
-    # TODO the list for `torch._C._nn` is nonexhaustive
-    unsorted_c_nn_function_hints: Dict[str, List[str]] = {}
-
-    for d in (2, 3):
-        unsorted_c_nn_function_hints.update(
-            {
-                f"avg_pool{d}d": [
-                    f"def avg_pool{d}d({{}}) -> Tensor: ...".format(
-                        ", ".join(
-                            [
-                                f"{INPUT}",
-                                f"{KERNEL_SIZE}",
-                                f"{STRIDE_PADDING}",
-                                "ceil_mode: bool = False",
-                                "count_include_pad: bool = True",
-                                "divisor_override: Optional[int] = None",
-                            ]
-                        )
-                    )
-                ],
-                f"fractional_max_pool{d}d": [
-                    f"def fractional_max_pool{d}d({{}}) -> {{}}: ...".format(
-                        ", ".join(
-                            [
-                                f"{INPUT}",
-                                f"{KERNEL_SIZE}",
-                                "output_size: Union[_int, _size]",
-                                "_random_samples: Tensor",
-                            ]
-                        ),
-                        "Tuple[Tensor, Tensor]",
-                    )
-                ],
-                f"adaptive_max_pool{d}d": [
-                    f"def adaptive_max_pool{d}d({{}}) -> {{}}: ...".format(
-                        ", ".join([f"{INPUT}", "output_size: Union[_int, _size]"]),
-                        "Tuple[Tensor, Tensor]",
-                    )
-                ],
-            }
+    def replace_special_case(hint: str) -> str:
+        # NB: Keep this in sync with enum in aten/src/ATen/core/Reduction.h
+        hint = hint.replace("at::Reduction::Mean", "1")
+        hint = hint.replace(
+            "out: Union[Tensor, Tuple[Tensor, ...], List[Tensor]] = None",
+            "out: Union[Tensor, Tuple[Tensor, ...], List[Tensor], None] = None",
         )
+        return hint
 
-    unsorted_c_nn_function_hints.update(
-        {
-            "hardtanh": [
-                "def hardtanh({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "input: Tensor",
-                            "min_val: float = ...",
-                            "max_val: float = ...",
-                            "*",
-                            "out: Optional[Tensor] = None",
-                        ]
-                    )
-                )
-            ],
-            "hardtanh_": [
-                "def hardtanh_({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "input: Tensor",
-                            "min_val: float = ...",
-                            "max_val: float = ...",
-                        ]
-                    )
-                )
-            ],
-            "elu_": ["def elu_(input: Tensor, alpha: float = ...) -> Tensor: ..."],
-            "leaky_relu": [
-                "def leaky_relu({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "input: Tensor",
-                            "negative_slope: float = ...",
-                            "*",
-                            "out: Optional[Tensor] = None",
-                        ]
-                    )
-                )
-            ],
-            "leaky_relu_": [
-                "def leaky_relu_({}) -> Tensor: ...".format(
-                    ", ".join(["input: Tensor", "negative_slope: float = ..."])
-                )
-            ],
-            "log_sigmoid": ["def log_sigmoid(input: Tensor) -> Tensor: ..."],
-            "gelu": ["def gelu(input: Tensor, approximate: str = ...) -> Tensor: ..."],
-            "softplus": [
-                "def softplus({}) -> Tensor: ...".format(
-                    ", ".join(
-                        ["input: Tensor", "beta: int = ...", "threshold: int = ..."]
-                    )
-                )
-            ],
-            "softshrink": [
-                "def softshrink(input: Tensor, lambd: float = ...) -> Tensor: ..."
-            ],
-            "hardsigmoid": [
-                "def hardsigmoid({}) -> Tensor: ...".format(
-                    ", ".join(["input: Tensor", "*", "out: Optional[Tensor] = None"])
-                )
-            ],
-            "linear": [
-                "def linear({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "input: Tensor",
-                            "weight: Tensor",
-                            "bias: Optional[Tensor] = None",
-                        ]
-                    )
-                )
-            ],
-            "pad": [
-                "def pad({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "input: Tensor",
-                            "pad: Sequence[int]",
-                            "mode: str = ...",
-                            "value: Optional[float] = None",
-                        ]
-                    )
-                )
-            ],
-            "one_hot": [
-                "def one_hot(tensor: Tensor, num_classes: int = ...) -> Tensor: ..."
-            ],
-            "scaled_dot_product_attention": [
-                "def scaled_dot_product_attention({}) -> Tensor: ...".format(
-                    ", ".join(
-                        [
-                            "query: Tensor",
-                            "key: Tensor",
-                            "value: Tensor",
-                            "attn_mask: Optional[Tensor] = None",
-                            "dropout_p: float = 0.0",
-                            "is_causal: bool = False",
-                            "scale: Optional[float] = None",
-                        ]
-                    )
-                )
-            ],
-        }
-    )
-
-    c_nn_function_hints: List[str] = []
-    for _, hints in sorted(unsorted_c_nn_function_hints.items()):
+    nn_function_hints = []
+    for name, hints in sorted(unsorted_nn_function_hints.items()):
+        hints = [replace_special_case(h) for h in hints]
         if len(hints) > 1:
             hints = ["@overload\n" + h for h in hints]
-        c_nn_function_hints += hints
+        nn_function_hints += hints
 
     # Functions imported into `torch.nn.functional` from `torch`, perhaps being filtered
     # through an `_add_docstr` call
@@ -498,6 +386,15 @@ def gen_nn_functional(fm: FileManager) -> None:
     ]
     # This is from `torch._C._nn` but renamed
     imported_hints.append("from .._C._nn import log_sigmoid\nlogsigmoid = log_sigmoid")
+
+    INPUT = "input: Tensor"
+    KERNEL_SIZE = "kernel_size: Union[_int, _size]"
+    STRIDE_PADDING = ", ".join(
+        [
+            "stride: Optional[Union[_int, _size]] = None",
+            "padding: Union[_int, _size] = 0",
+        ]
+    )
 
     # Functions generated by `torch._jit_internal.boolean_dispatch` in `nn.functional`
     unsorted_dispatched_hints: Dict[str, List[str]] = {}
@@ -553,7 +450,7 @@ def gen_nn_functional(fm: FileManager) -> None:
         "torch/_C/_nn.pyi",
         "torch/_C/_nn.pyi.in",
         lambda: {
-            "c_nn_function_hints": c_nn_function_hints,
+            "nn_function_hints": nn_function_hints,
         },
     )
 
@@ -1385,7 +1282,7 @@ def gen_pyi(
             **env,
         },
     )
-    gen_nn_functional(fm)
+    gen_nn_functional(native_yaml_path, tags_yaml_path, deprecated_yaml_path, fm)
 
 
 def main() -> None:

--- a/torch/_C/_nn.pyi.in
+++ b/torch/_C/_nn.pyi.in
@@ -1,33 +1,22 @@
 from typing import List, Optional, overload, Sequence, Tuple, Union
 
-from torch import memory_format, Tensor
-from torch.types import _bool, _device, _dtype, _int, _size
+from torch import Generator, memory_format, Tensor
+from torch.types import (
+    _bool,
+    _complex,
+    _device,
+    _dtype,
+    _float,
+    _int,
+    _size,
+    Number,
+    SymInt,
+)
 
 # Defined in tools/autograd/templates/python_nn_functions.cpp
+# Definition extracted from aten/src/ATen/native/native_functions.yaml
 
-${c_nn_function_hints}
-
-# Defined in aten/src/ATen/native/mkldnn/Linear.cpp
-def mkldnn_linear(input: Tensor, weight: Tensor, bias: Optional[Tensor]) -> Tensor: ...
-
-# Defined at aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
-def mkldnn_reorder_conv2d_weight(
-    self: Tensor,
-    padding: List,
-    stride: List,
-    dilatation: List,
-    groups: int,
-) -> Tensor: ...
-def mkldnn_reorder_conv3d_weight(
-    self: Tensor,
-    padding: List,
-    stride: List,
-    dilatation: List,
-    groups: int,
-) -> Tensor: ...
-
-# Defined in aten/src/ATen/native/mkldnn/Prelu.cpp
-def mkldnn_prelu(input: Tensor, weight: Tensor) -> Tensor: ...
+${nn_function_hints}
 
 # Defined at tools/autograd/templates/python_nn_functions.cpp
 @overload
@@ -55,12 +44,3 @@ def _parse_to(
     *,
     memory_format: memory_format,
 ) -> Tuple[_device, _dtype, _bool, memory_format]: ...
-
-# Defined in aten/src/ATen/native/PadSequence.cpp
-def pad_sequence(
-    sequences: List[Tensor],
-    batch_first: bool = False,
-    padding_value: float = ...,
-) -> Tensor: ...
-def flatten_dense_tensors(tensors: List[Tensor]) -> Tensor: ...
-def unflatten_dense_tensors(flat: Tensor, tensors: List[Tensor]) -> List[Tensor]: ...


### PR DESCRIPTION
Fixes #103787

- Manually appended annotations in `gen_pyi.py` for `torch._C._nn` are now fully generated.
- Some functions manually added in `torch/_C/_nn.pyi.in` are now generated.
- Runtime check `'mkldnn_prelu' in dir(torch._C._nn)` is `False`, therefore it's removed.