### PR TITLE
[Inductor][FX passes] Pre grad pass modified graph should be topological sorted

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -687,6 +687,13 @@ class TestSplitCatFxPasses(TestCase):
             split_items = [torch.squeeze(s, 1) for s in items[1:]]
             return torch.stack(split_items), torch.relu(items[0])
 
+        def graph_should_be_topological_sorted(x):
+            output = []
+            for t in x.split(1):
+                output.append(torch.sin(t.squeeze(dim=0)))
+            output = torch.stack(output)
+            return output
+
         args = [
             torch.randn(2, 32),
         ]
@@ -702,6 +709,7 @@ class TestSplitCatFxPasses(TestCase):
             (dim_mismatch, 0),
             (other_users, 0),
             (other_users_2, 0),
+            (graph_should_be_topological_sorted, 1),
         ]:
             expected = fn(*args)
             actual = torch.compile(fn)(*args)

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -17,7 +17,11 @@ from .. import config
 
 from ..fx_utils import matches_module_function_pattern
 from ..mkldnn import mkldnn_fuse_fx
-from ..pattern_matcher import init_once_fakemode, PatternMatcherPass
+from ..pattern_matcher import (
+    init_once_fakemode,
+    PatternMatcherPass,
+    stable_topological_sort,
+)
 from ..utils import is_cpu_device
 
 log = logging.getLogger(__name__)
@@ -62,6 +66,7 @@ def pre_grad_passes(gm, example_inputs):
         for pattern_matcher_pass in pattern_matcher_passes:
             pattern_matcher_pass.apply(gm.graph)
 
+    stable_topological_sort(gm.graph)
     gm.graph.lint()
     gm.recompile()
 


### PR DESCRIPTION
Error from 14k github models.
Minimized repro: please check the unit test I added
Error:
```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: Argument 'getitem_2' of Node 'sin' was used before it has been defined! Please check that Nodes in the graph are topologically ordered
graph():
    %l_x_ : torch.Tensor [#users=1] = placeholder[target=L_x_]
    %sin : [#users=1] = call_function[target=torch.sin](args = (%getitem_2,), kwargs = {})
    %unbind : [#users=2] = call_function[target=torch.unbind](args = (%l_x_,), kwargs = {dim: 0})
    %getitem_2 : [#users=1] = call_function[target=operator.getitem](args = (%unbind, 0), kwargs = {})
    %getitem_3 : [#users=1] = call_function[target=operator.getitem](args = (%unbind, 1), kwargs = {})
    %sin_1 : [#users=1] = call_function[target=torch.sin](args = (%getitem_3,), kwargs = {})
    %stack : [#users=1] = call_function[target=torch.stack](args = ([%sin, %sin_1],), kwargs = {})
    return (stack,)
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78