### PR TITLE
Add overloads to ModuleList getitem

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -111,7 +111,15 @@ class Sequential(Module):
             raise IndexError('index {} is out of range'.format(idx))
         idx %= size
         return next(islice(iterator, idx, None))
+        
+    @overload
+    def __getitem__(self, idx: int) -> Module:
+        ...
 
+    @overload
+    def __getitem__(self, idx: slice) -> 'ModuleList': 
+        ...
+        
     @_copy_to_script_wrapper
     def __getitem__(self, idx: Union[slice, int]) -> Union['Sequential', T]:
         if isinstance(idx, slice):


### PR DESCRIPTION
Currently, calling ModuleList's `__getitem__` yields a return type that pyright can't unify as either a `Module` or `ModuleList`. The following code works fine, but yields a type error:
```python
class Network(nn.Module):
    def __init__(self):
        self.layers : nn.ModuleList = nn.ModuleList()

    def foo(self):
        for _ in self.layers[:-1]:
            pass
```
Error: `"Module" is not iterable  "__iter__" method not defined`. 

This problem is removed by adding overload annotations. 