### PR TITLE
Fix typing on internal functions for `nn.functional`

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -301,7 +301,7 @@ class TensorVariable(VariableTracker):
             elif dim_var is not None:
                 dim = dim_var.as_python_constant()
 
-            def make_const_size_variable(x, **options):
+            def make_const_size_variable(x, **options) -> SizeVariable:
                 return SizeVariable(
                     [ConstantVariable(y, **options) for y in x], **options
                 )

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -7,6 +7,7 @@ circular dependency problems
 import ast
 import builtins
 import collections
+import collections.abc
 import contextlib
 import enum
 import inspect
@@ -27,6 +28,7 @@ from typing import (  # noqa: F401
     Generic,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -1004,6 +1006,19 @@ def is_list(ann) -> bool:
     if IS_PY39_PLUS and ann.__module__ == "builtins" and ann_origin is list:
         return True
     return ann.__module__ == "typing" and (ann_origin is List or ann_origin is list)
+
+
+def is_sequence(ann) -> bool:
+    if ann is Sequence:
+        raise_error_container_parameter_missing("Sequence")
+
+    if not hasattr(ann, "__module__"):
+        return False
+
+    ann_origin = getattr(ann, "__origin__", None)
+    if IS_PY39_PLUS and ann.__module__ == "collections.abc" and ann_origin is collections.abc.Sequence:
+        return True
+    return ann.__module__ == "typing" and (ann_origin is Sequence or ann_origin is collections.abc.Sequence)
 
 
 def is_dict(ann) -> bool:

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -7,7 +7,8 @@ import builtins
 import torch
 import warnings
 from .._jit_internal import List, Tuple, is_tuple, is_list, Dict, is_dict, Optional, \
-    is_optional, _qualified_name, Any, Future, is_future, _Await, is_await, is_ignored_fn, Union, is_union
+    is_optional, _qualified_name, Any, Future, is_future, _Await, is_await, is_ignored_fn, \
+    Union, is_union, Sequence, is_sequence
 from .._jit_internal import BroadcastingList1, BroadcastingList2, BroadcastingList3  # type: ignore[attr-defined]
 from ._state import _get_script_class
 
@@ -45,6 +46,7 @@ class EvalEnv:
         'typing': Module('typing', {'Tuple': Tuple}),
         'Tuple': Tuple,
         'List': List,
+        'Sequence': Sequence,
         'Dict': Dict,
         'Optional': Optional,
         'Union': Union,
@@ -331,7 +333,7 @@ def try_ann_to_type(ann, loc, rcb=None):
         if len(ann.__args__) == 1 and ann.__args__[0] == ():
             return TupleType([])
         return TupleType([try_ann_to_type(a, loc) for a in ann.__args__])
-    if is_list(ann):
+    if is_list(ann) or is_sequence(ann):
         elem_type = try_ann_to_type(ann.__args__[0], loc)
         if elem_type:
             return ListType(elem_type)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -9,6 +9,7 @@ from torch import _VF
 from torch import sym_int as _sym_int
 from torch._C import _infer_size, _add_docstr
 from torch._torch_docs import reproducibility_notes, tf32_notes, sparse_support_notes
+from torch.types import _size
 # A workaround to support both TorchScript and MyPy:
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -2432,7 +2433,7 @@ if embedding_bag.__doc__:
     embedding_bag.__doc__ = embedding_bag.__doc__.format(**reproducibility_notes)
 
 
-def _verify_batch_size(size: List[int]) -> None:
+def _verify_batch_size(size: _size) -> None:
     # XXX: JIT script does not support the reduce from functools, and mul op is a
     # builtin, which cannot be used as a value to a func yet, so rewrite this size
     # check to a simple equivalent for loop
@@ -2485,7 +2486,7 @@ def batch_norm(
     )
 
 
-def _verify_spatial_size(size: List[int]) -> None:
+def _verify_spatial_size(size: _size) -> None:
     # Verify that there is > 1 spatial element for instance norm calculation.
     size_prods = 1
     for i in range(2, len(size)):
@@ -4781,7 +4782,7 @@ def _in_projection_packed(
     v: Tensor,
     w: Tensor,
     b: Optional[Tensor] = None,
-) -> List[Tensor]:
+) -> Tuple[Tensor, Tensor, Tensor]:
     r"""
     Performs the in-projection step of the attention operation, using packed weights.
     Output is a triple containing projection tensors for query, key and value.
@@ -4806,7 +4807,7 @@ def _in_projection_packed(
         - b: :math:`E * 3` where E is the embedding dimension
 
         Output:
-        - in output list :math:`[q', k', v']`, each output tensor will have the
+        - in output tuple :math:`(q', k', v')`, each output tensor will have the
             same shape as the corresponding input tensor.
     """
     E = q.size(-1)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,5 +1,5 @@
 """Functional interface"""
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union, Sequence
 import math
 import warnings
 import importlib
@@ -9,7 +9,7 @@ from torch import _VF
 from torch import sym_int as _sym_int
 from torch._C import _infer_size, _add_docstr
 from torch._torch_docs import reproducibility_notes, tf32_notes, sparse_support_notes
-from torch.types import _size
+_size = Sequence[int]
 # A workaround to support both TorchScript and MyPy:
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -1,6 +1,8 @@
 from itertools import repeat
 from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar, Union
 
+from torch.types import _size
+
 __all__ = ['consume_prefix_in_state_dict_if_present']
 
 T = TypeVar("T")
@@ -31,7 +33,7 @@ def _reverse_repeat_tuple(t, n):
     return tuple(x for x in reversed(t) for _ in range(n))
 
 
-def _list_with_default(out_size: List[int], defaults: List[int]) -> List[int]:
+def _list_with_default(out_size: Union[int, _size], defaults: _size) -> Union[int, List[int]]:
     if isinstance(out_size, int):
         return out_size
     if len(defaults) <= len(out_size):

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -1,7 +1,7 @@
 from itertools import repeat
-from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar, Union, Sequence
 
-from torch.types import _size
+_size = Sequence[int]
 
 __all__ = ['consume_prefix_in_state_dict_if_present']
 

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -1,13 +1,14 @@
-import collections
 from itertools import repeat
-from typing import List, Dict, Any
+from typing import Any, Callable, Dict, Iterable, List, Tuple, TypeVar, Union
 
 __all__ = ['consume_prefix_in_state_dict_if_present']
 
+T = TypeVar("T")
 
-def _ntuple(n, name="parse"):
-    def parse(x):
-        if isinstance(x, collections.abc.Iterable):
+
+def _ntuple(n, name="parse") -> Callable[[Union[T, Iterable[T]]], Tuple[T, ...]]:
+    def parse(x: Union[T, Iterable[T]]) -> Tuple[T, ...]:
+        if isinstance(x, Iterable):
             return tuple(x)
         return tuple(repeat(x, n))
 


### PR DESCRIPTION
Fixes #103798

- Eliminates the errors in the above issue
- Adds return annotation here because the local run of mypy could break:
https://github.com/pytorch/pytorch/blob/918fe519a0f9bdb2dd213eaaffbcd420b7391280/torch/_dynamo/variables/tensor.py#L304
- Some mypy errors are not captured because they do not directly affect `nn.functional`, see errors in https://github.com/pytorch/pytorch/actions/runs/5297825524/jobs/9589927958, https://github.com/pytorch/pytorch/actions/runs/5298444191/jobs/9590880132

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov