### PR TITLE
Add partial derivative unit tests

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -474,11 +474,11 @@ class TestModule(TestCase):
             self.assertTrue(check(fn_to_gradcheck, flat_input, nondet_tol=gradcheck_nondet_tol))
 
             # check partial derivatives
-            old_params_requires_grad = [ p.requires_grad for p in params ]
+            old_params_requires_grad = [p.requires_grad for p in params]
             for p in params:
                 p.requires_grad = False
 
-            old_kwargs_requires_grad = [ obj.requires_grad for (_, obj) in kwarg_tensors ]
+            old_kwargs_requires_grad = [obj.requires_grad for (_, obj) in kwarg_tensors]
             for (_, obj) in kwarg_tensors:
                 obj.requires_grad = False
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -456,10 +456,6 @@ class TestModule(TestCase):
                 else:
                     other_kwargs[name] = obj
 
-            grad_input = input_args + params + tuple(obj for (_, obj) in kwarg_tensors)
-
-            flat_input, flat_spec = torch.utils._pytree.tree_flatten(grad_input)
-
             def fn_to_gradcheck(*flat_input_and_params):
                 input_and_params = torch.utils._pytree.tree_unflatten(flat_input_and_params, flat_spec)
                 new_input_args = input_and_params[:len(input_args)]
@@ -471,7 +467,34 @@ class TestModule(TestCase):
                     output_flattened, _ = torch.utils._pytree.tree_flatten(output)
                     return output_flattened
 
+            # check total derivative
+            grad_input = input_args + params + tuple(obj for (_, obj) in kwarg_tensors)
+            flat_input, flat_spec = torch.utils._pytree.tree_flatten(grad_input)
+
             self.assertTrue(check(fn_to_gradcheck, flat_input, nondet_tol=gradcheck_nondet_tol))
+
+            # check partial derivatives
+            old_params_requires_grad = [ p.requires_grad for p in params ]
+            for p in params:
+                p.requires_grad = False
+
+            old_kwargs_requires_grad = [ obj.requires_grad for (_, obj) in kwarg_tensors ]
+            for (_, obj) in kwarg_tensors:
+                obj.requires_grad = False
+
+            for p, old in zip(params, old_params_requires_grad):
+                p.requires_grad = old
+                grad_input = input_args + params + tuple(obj for (_, obj) in kwarg_tensors)
+                flat_input, flat_spec = torch.utils._pytree.tree_flatten(grad_input)
+                self.assertTrue(check(fn_to_gradcheck, flat_input, nondet_tol=gradcheck_nondet_tol))
+                p.requires_grad = False
+
+            for (_, obj), old in zip(kwarg_tensors, old_kwargs_requires_grad):
+                obj.requires_grad = old
+                grad_input = input_args + params + tuple(obj for (_, obj) in kwarg_tensors)
+                flat_input, flat_spec = torch.utils._pytree.tree_flatten(grad_input)
+                self.assertTrue(check(fn_to_gradcheck, flat_input, nondet_tol=gradcheck_nondet_tol))
+                obj.requires_grad = False
 
     @modules(module_db, allowed_dtypes=[torch.double])
     def test_grad(self, device, dtype, module_info, training):

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1368,6 +1368,10 @@ def module_inputs_torch_nn_LayerNorm(module_info, device, dtype, requires_grad, 
             forward_input=FunctionInput(make_input(((4, 5, 5)))),
             desc='1d_elementwise_affine'),
         ModuleInput(
+            constructor_input=FunctionInput([5], 1e-3),
+            forward_input=FunctionInput(make_input(((128, 5, 5)))),
+            desc='1d_elementwise_affine_large_batch'),
+        ModuleInput(
             constructor_input=FunctionInput([5], 1e-3, False),
             forward_input=FunctionInput(make_input(((4, 5, 5)))),
             desc='1d_no_elementwise_affine'),


### PR DESCRIPTION
Adds the unit tests requested in #95810 

This PR also addresses a gap in unit testing of gradients, as `gradcheck` always performs total derivatives w.r.t. all arguments and module parameters. Some modules have different code paths for partial derivatives, e.g. `LayerNorm`, and those should be tested separately.

The PR has the following limitations:
- it does not test partial derivatives w.r.t. every combination of arguments, which would exponentially increase CI time.
- it does not implement the same logic for Hessians, where the increase in CI time would be quadratic in the number of arguments.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo