### PR TITLE
Add detailed requirement of compiler in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ They require JetPack 4.2 and above, and [@dusty-nv](https://github.com/dusty-nv)
 #### Prerequisites
 If you are installing from source, you will need:
 - Python 3.8 or later (for Linux, Python 3.8.1+ is needed)
-- A C++17 compatible compiler, such as clang
+- A compiler that fully supports C++17, such as clang or gcc (especially for aarch64, gcc 9.4.0 or newer is required)
 
 We highly recommend installing an [Anaconda](https://www.anaconda.com/distribution/#download-section) environment. You will get a high-quality BLAS library (MKL) and you get controlled dependency versions regardless of your Linux distro.
 


### PR DESCRIPTION
Refer to this [issue](https://github.com/pytorch/pytorch/issues/102258), a compiler that fully supports C++17 is required, otherwise the precision of some operators will have problems for aarch64. Therefore, It will be more user-friendly to specify the gcc version especially for aarch64.

Fixes #102258
