### PR TITLE
s390x simd: switch clamp min and max order

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -1312,7 +1312,7 @@ inline Vectorized<uint8_t> operator~(const Vectorized<uint8_t>& a) {
       const Vectorized<typex>& a,                                 \
       const Vectorized<typex>& min,                               \
       const Vectorized<typex>& max) {                             \
-    return clamp_min(clamp_max(a, max), min);                     \
+    return clamp_max(clamp_min(a, min), max);                     \
   }
 
 DEFINE_CLAMP_MAXMIN_FUNCS(int8_t)


### PR DESCRIPTION
This change makes s390x behave closer to non-simd. It also fixes multiple tests in test/test_ops.py


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10