### PR TITLE
[pytorch] Update docstring for FSDP.set_state_dict_type

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -664,6 +664,9 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             state_dict_type (StateDictType): the desired ``state_dict_type`` to set.
             state_dict_config (Optional[StateDictConfig]): the configuration for the
                 target ``state_dict_type``.
+            optim_state_dict_config (Optional[OptimStateDictConfig]): the configuration
+                for the optimizer state dict.
+
         Returns:
             A StateDictSettings that include the previous state_dict type and
             configuration for the module.


### PR DESCRIPTION
Summary: I noticed optim_state_dict_config was missing from the Args section

Test Plan: N/A

Reviewed By: rohan-varma

Differential Revision: D46670165

