### PR TITLE
[ONNX] Add fake tensor support to torch.onnx.dynamo_export

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -729,6 +729,7 @@ Preview: torch.onnx TorchDynamo Exporter
   subject to rapid change.
 
 .. autofunction:: torch.onnx.dynamo_export
+.. autofunction:: torch.onnx.enable_fake_mode
 
 .. autosummary::
     :toctree: generated
@@ -738,3 +739,4 @@ Preview: torch.onnx TorchDynamo Exporter
     torch.onnx.ExportOptions
     torch.onnx.ExportOutput
     torch.onnx.ExportOutputSerializer
+    torch.onnx.OnnxExporterError

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: onnx"]
 from __future__ import annotations
 
+import tempfile
+
 import onnx
 import pytorch_test_common
 import torch
@@ -258,9 +260,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         )
 
     def test_symbolic_tracing_simple(self):
-        from torch._subclasses import fake_tensor
-        from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -270,22 +269,25 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 out = self.linear(x)
                 return out
 
-        # User-instantiated FakeTensorMode
-        fake_mode = fake_tensor.FakeTensorMode(
-            allow_non_fake_inputs=True,
-            shape_env=ShapeEnv(
-                allow_scalar_outputs=False, allow_dynamic_output_shape_ops=False
-            ),
-        )
-        # Fakefy input+model before exporting it
-        with fake_mode:
+        model_state_dict = Model().state_dict()  # optional
+
+        with torch.onnx.enable_fake_mode(
+            model_state_dict=model_state_dict
+        ) as fake_context:
             x = torch.rand(5, 2, 2)
             model = Model()
+
         # Export the model with fake inputs and parameters
-        export_options = ExportOptions(fake_mode=fake_mode)
+        export_options = ExportOptions(fake_context=fake_context)
         export_output = torch.onnx.dynamo_export(
             model, x, export_options=export_options
         )
+
+        assert export_output.model_proto is not None
+        assert len(export_output.model_proto.graph.initializer) == 0
+        with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_file:
+            export_output.save(tmp_file.name)
+            assert len(onnx.load(tmp_file.name).graph.initializer) > 0
 
         assert export_output is not None
         onnx.checker.check_model(export_output.model_proto, full_check=True)

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -269,11 +269,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 out = self.linear(x)
                 return out
 
-        model_state_dict = Model().state_dict()  # optional
-
-        with torch.onnx.enable_fake_mode(
-            model_state_dict=model_state_dict
-        ) as fake_context:
+        with torch.onnx.enable_fake_mode() as fake_context:
             x = torch.rand(5, 2, 2)
             model = Model()
 
@@ -285,9 +281,24 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
 
         assert export_output.model_proto is not None
         assert len(export_output.model_proto.graph.initializer) == 0
-        with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_file:
-            export_output.save(tmp_file.name)
-            assert len(onnx.load(tmp_file.name).graph.initializer) > 0
+
+        # Save ONNX proto using Model's state_dict()
+        with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
+            model_state_dict = Model().state_dict()  # optional
+            export_output.save(tmp_onnx_file.name, model_state_dict=model_state_dict)
+            assert len(onnx.load(tmp_onnx_file.name).graph.initializer) > 0
+
+        # Save ONNX proto using Model checkpoint file
+        with tempfile.NamedTemporaryFile(
+            suffix=".onnx"
+        ) as tmp_onnx_file, tempfile.NamedTemporaryFile(
+            suffix=".pt"
+        ) as tmp_checkpoint_file:
+            torch.save(Model().state_dict(), tmp_checkpoint_file.name)  # optional
+            export_output.save(
+                tmp_onnx_file.name, model_state_dict=tmp_checkpoint_file.name
+            )
+            assert len(onnx.load(tmp_onnx_file.name).graph.initializer) > 0
 
         assert export_output is not None
         onnx.checker.check_model(export_output.model_proto, full_check=True)

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -274,9 +274,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         fake_mode = fake_tensor.FakeTensorMode(
             allow_non_fake_inputs=True,
             shape_env=ShapeEnv(
-                allow_scalar_outputs=False,
-                allow_dynamic_output_shape_ops=False,
-                frame_id=0,
+                allow_scalar_outputs=False, allow_dynamic_output_shape_ops=False
             ),
         )
         # Fakefy input+model before exporting it

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: onnx"]
 from __future__ import annotations
 
+import onnx
 import pytorch_test_common
 import torch
 from torch import nn
@@ -257,7 +258,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         )
 
     def test_symbolic_tracing_simple(self):
-        from torch._dynamo.output_graph import config
         from torch._subclasses import fake_tensor
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
@@ -272,11 +272,10 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
 
         # User-instantiated FakeTensorMode
         fake_mode = fake_tensor.FakeTensorMode(
-            allow_non_fake_inputs=False,
-            allow_fallback_kernels=True,
+            allow_non_fake_inputs=True,
             shape_env=ShapeEnv(
-                allow_scalar_outputs=config.capture_scalar_outputs,
-                allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
+                allow_scalar_outputs=False,
+                allow_dynamic_output_shape_ops=False,
                 frame_id=0,
             ),
         )
@@ -284,7 +283,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         with fake_mode:
             x = torch.rand(5, 2, 2)
             model = Model()
-
         # Export the model with fake inputs and parameters
         export_options = ExportOptions(fake_mode=fake_mode)
         export_output = torch.onnx.dynamo_export(
@@ -292,6 +290,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         )
 
         assert export_output is not None
+        onnx.checker.check_model(export_output.model_proto, full_check=True)
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -256,6 +256,44 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             {*model.state_dict().keys()},
         )
 
+    def test_symbolic_tracing_simple(self):
+        from torch._dynamo.output_graph import config
+        from torch._subclasses import fake_tensor
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2)
+                self.linear2 = torch.nn.Linear(2, 2)
+
+            def forward(self, x):
+                out = self.linear(x)
+                out = self.linear2(out)
+                return out
+
+        # User-instantiated FakeTensorMode
+        fake_mode = fake_tensor.FakeTensorMode(
+            allow_non_fake_inputs=False,
+            allow_fallback_kernels=True,
+            shape_env=ShapeEnv(
+                allow_scalar_outputs=config.capture_scalar_outputs,
+                allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
+                frame_id=0,
+            ),
+        )
+        # Fakefy input+model before exporting it
+        with fake_mode:
+            x = torch.rand(5, 2, 2)
+            model = Model()
+
+        # Export the model with fake inputs and parameters
+        export_options = ExportOptions(fake_mode=fake_mode)
+        export_output = torch.onnx.dynamo_export(
+            model, x, export_options=export_options
+        )
+
+        assert export_output is not None
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -265,11 +265,9 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.linear = torch.nn.Linear(2, 2)
-                self.linear2 = torch.nn.Linear(2, 2)
 
             def forward(self, x):
                 out = self.linear(x)
-                out = self.linear2(out)
                 return out
 
         # User-instantiated FakeTensorMode
@@ -294,6 +292,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         )
 
         assert export_output is not None
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import tempfile
 import unittest
 
@@ -15,11 +16,14 @@ import torch
 import torch.onnx
 import transformers  # type: ignore[import]
 from torch import nn
-from torch._dynamo.output_graph import config
+
 from torch._subclasses import fake_tensor
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.onnx._internal import _beartype
-from torch.onnx._internal.fx import context as fx_context
+from torch.onnx._internal.fx import (
+    context as fx_context,
+    fx_symbolic_graph_extractor,
+    serialization as fx_serialization,
+)
 from torch.testing._internal import common_utils
 
 try:
@@ -668,20 +672,15 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         with tempfile.NamedTemporaryFile(
             prefix=model_name, suffix=".pt"
-        ) as tmp_file, tempfile.TemporaryDirectory(suffix="large_scale_export"):
+        ) as tmp_file, tempfile.TemporaryDirectory(
+            suffix="large_scale_export"
+        ) as tmp_folder:
             # Dump state_dict to a file to simulate how HuggingFace model is initialized.
             # The file will be loaded via .load_state_dict(...)
             torch.save(model.state_dict(), tmp_file.name)
 
-            # User-instantiated FakeTensorMode
-            fake_mode = fake_tensor.FakeTensorMode(
-                allow_non_fake_inputs=False,
-                allow_fallback_kernels=True,
-                shape_env=ShapeEnv(
-                    allow_scalar_outputs=config.capture_scalar_outputs,
-                    allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
-                    frame_id=0,
-                ),
+            ftm = fake_tensor.FakeTensorMode(
+                allow_non_fake_inputs=True, allow_fallback_kernels=False
             )
             ctx = fx_context.FxToOnnxContext()
             # NOTE: FakeTensorMode disallows symbolic shape of fx graph
@@ -689,27 +688,34 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             #  1. Create a model whose parameters and buffers are all FakeTensor's.
             #  2. Convert nn.Module into ONNX model without initializers.
             #  3. Record the file paths to find real initializers.
-
-            with fake_mode, ctx:
+            with ctx, ftm:
                 # Toy model with parameters and buffers as FakeTensor's.
                 fake_model = create_model()
-                # fake_model.load_state_dict(torch.load(tmp_file.name))
+                fake_model.load_state_dict(torch.load(tmp_file.name))
                 # Toy inputs as FakeTensor's.
                 fake_args = create_args()
+                # Export ONNX model without initializers while ctx.paths records
+                # all files that contains real initializers.
 
-            export_options = torch.onnx.ExportOptions(
-                opset_version=self.opset_version,
-                dynamic_shapes=self.dynamic_shapes,
-                op_level_debug=self.op_level_debug,
-                fake_mode=fake_mode,
-            )
-            export_output = torch.onnx.dynamo_export(
-                fake_model,
-                *fake_args,
-                export_options=export_options,
-            )
+                options = torch.onnx.ExportOptions(
+                    opset_version=self.opset_version,
+                    dynamic_shapes=self.dynamic_shapes,
+                    op_level_debug=self.op_level_debug,
+                )
+                export_options = torch.onnx._internal.exporter.ResolvedExportOptions(
+                    options
+                )
+                export_options.fx_tracer = (
+                    fx_symbolic_graph_extractor.FXSymbolicTracer()
+                )
+                export_output = torch.onnx.dynamo_export(
+                    fake_model,
+                    *fake_args,
+                    export_options=export_options,
+                )
 
-            # TODO: Fix export before moving to comparing numbers
+                onnx_model = export_output.model_proto
+
             # Tasks done by the following block.
             #  1. Iterate through all tensors stored in ctx.paths (the file content is loaded torch.load)
             #  2. If a tensor's name matches a "onnx_model"'s input name, an initializer is created and saved to
@@ -717,6 +723,17 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             #  3. A new ONNX model is saved into file with the initializers saved in the previous step.
             #  4. ORT executes the new ONNX model and compares the results with the original GPT model.
 
+            # Model saved to tmp_folder/onnx_model_location
+            # Initializers are saved to tmp_folder/onnx_initializer_location/*.onnx
+            onnx_model_location = model_name + "_external_data.onnx"
+            onnx_initializer_location = model_name + "_initializers"
+            fx_serialization.save_model_with_external_data(
+                tmp_folder,
+                onnx_model_location,
+                onnx_initializer_location,
+                tuple(ctx.paths),
+                onnx_model,
+            )
             # Generate random inputs.
             args = create_args()
             kwargs = create_pytorch_only_kwargs()
@@ -731,7 +748,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             args_not_none = args_not_none[: len(args) - len(kwargs)]
 
             ort_outputs = onnx_test_common.run_ort(
-                export_output,
+                os.path.join(tmp_folder, onnx_model_location),
                 args_not_none,
             )
 
@@ -740,7 +757,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             for ref_output, ort_output in zip(ref_outputs, ort_outputs):
                 torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
-    @unittest.skip("Symbolic tracing not supported yet.")
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )
@@ -779,7 +795,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_pytorch_only_extra_kwargs,
         )
 
-    @unittest.skip("Symbolic tracing not supported yet.")
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -20,8 +20,8 @@ from torch import nn
 from torch._subclasses import fake_tensor
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import (
-    context as fx_context,
     fx_symbolic_graph_extractor,
+    patcher,
     serialization as fx_serialization,
 )
 from torch.testing._internal import common_utils
@@ -682,7 +682,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             ftm = fake_tensor.FakeTensorMode(
                 allow_non_fake_inputs=True, allow_fallback_kernels=False
             )
-            ctx = fx_context.FxToOnnxContext()
+            ctx = patcher.ONNXTorchPatcher()
             # NOTE: FakeTensorMode disallows symbolic shape of fx graph
             # The following coed block does several things.
             #  1. Create a model whose parameters and buffers are all FakeTensor's.

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -639,7 +639,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @_beartype.beartype
-    def _test_large_scale_exporter(
+    def _test_fx_symbolic_tracer_large_scale_exporter(
         self,
         model_name: str,
         create_model: Callable,
@@ -760,7 +760,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )
-    def test_large_scale_exporter_with_toy_mlp(self):
+    def test_fx_symbolic_tracer_large_scale_exporter_with_toy_mlp(self):
         class MLPModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -788,7 +788,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         def create_pytorch_only_extra_kwargs():
             return {}
 
-        self._test_large_scale_exporter(
+        self._test_fx_symbolic_tracer_large_scale_exporter(
             "toy_mlp1",
             create_model,
             create_args,

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -814,7 +814,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         def create_pytorch_only_extra_kwargs():
             return {"return_dict": False}
 
-        self._test_large_scale_exporter(
+        self._test_fx_symbolic_tracer_large_scale_exporter(
             "tiny_gpt2",
             create_model,
             create_args,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -50,6 +50,7 @@ from ._internal.exporter import (  # usort:skip. needs to be last to avoid circu
     ExportOutput,
     ExportOutputSerializer,
     dynamo_export,
+    enable_fake_mode,
 )
 
 __all__ = [
@@ -93,6 +94,7 @@ __all__ = [
     "ExportOutput",
     "ExportOutputSerializer",
     "dynamo_export",
+    "enable_fake_mode",
 ]
 
 # Set namespace for exposed private names

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -106,6 +106,8 @@ ExportOptions.__module__ = "torch.onnx"
 ExportOutput.__module__ = "torch.onnx"
 ExportOutputSerializer.__module__ = "torch.onnx"
 dynamo_export.__module__ = "torch.onnx"
+OnnxExporterError.__module__ = "torch.onnx"
+enable_fake_mode.__module__ = "torch.onnx"
 
 producer_name = "pytorch"
 producer_version = _C_onnx.PRODUCER_VERSION

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -50,6 +50,7 @@ from ._internal.exporter import (  # usort:skip. needs to be last to avoid circu
     ExportOutput,
     ExportOutputSerializer,
     dynamo_export,
+    OnnxExporterError,
     enable_fake_mode,
 )
 
@@ -94,6 +95,7 @@ __all__ = [
     "ExportOutput",
     "ExportOutputSerializer",
     "dynamo_export",
+    "OnnxExporterError",
     "enable_fake_mode",
 ]
 

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -478,7 +478,10 @@ class Exporter:
         )
 
         # Export TorchScript graph to ONNX ModelProto.
-        onnx_model = onnxscript_graph.to_model_proto(self.options.opset_version)
+        onnx_model = onnxscript_graph.to_model_proto(
+            self.options.opset_version,
+            include_initializers=self.options.fake_mode is None,
+        )
         return torch.onnx.ExportOutput(
             onnx_model,
             self.options.fx_tracer.input_adapter,

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -2,13 +2,17 @@
 from __future__ import annotations
 
 import abc
+
+import contextlib
 import io
 import logging
+import os
 from typing import (
     Any,
     Callable,
     Dict,
     Final,
+    List,
     Mapping,
     Optional,
     Protocol,
@@ -26,7 +30,12 @@ from torch._subclasses import fake_tensor
 from torch.onnx._internal import _beartype, io_adapter
 from torch.onnx._internal.diagnostics import infra
 
-from torch.onnx._internal.fx import decomposition_table, registration
+from torch.onnx._internal.fx import (
+    decomposition_table,
+    patcher as patcher,
+    registration,
+    serialization as fx_serialization,
+)
 
 # We can only import onnx from this module in a type-checking context to ensure that
 # 'import torch.onnx' continues to work without having 'onnx' installed. We fully
@@ -45,6 +54,46 @@ _PYTORCH_GITHUB_ISSUES_URL = "https://github.com/pytorch/pytorch/issues"
 
 _DEFAULT_FAILED_EXPORT_SARIF_LOG_PATH = "report_dynamo_export.sarif"
 """The default path to write the SARIF log to if the export fails."""
+
+
+class ONNXFakeContext:
+    """A context used for exporting model using FakeTensor.
+
+    By using this context, it will convert real tensors and model parameters into
+    fake tensors during tracing of a torch.nn.Module into a FX Graph
+    """
+
+    model_state_dict: Any
+    """The model's state_dict with real tensors."""
+
+    fake_mode: fake_tensor.FakeTensorMode
+    """The fake tensor mode to use for symbolic tracing."""
+
+    model_state_dict_files: Optional[List[Any]] = None
+    """List of file-like objects that contain the model's state_dict with real tensors."""
+
+    @_beartype.beartype
+    def __init__(
+        self,
+        *,
+        fake_mode: fake_tensor.FakeTensorMode,
+        model_state_dict: Optional[Any] = None,
+    ):
+        self.fake_mode = fake_mode
+        self.model_state_dict = model_state_dict
+
+        # Add initializers when symbolic tracing is enabled
+        if model_state_dict is not None:
+            buffer = io.BytesIO()
+            torch.save(model_state_dict, buffer)
+            ctx = patcher.ONNXTorchPatcher()
+            with ctx:
+                buffer.seek(0)
+                _ = torch.load(buffer)
+            self._model_state_dict_files = ctx.paths
+            # Reset the buffer to the beginning before reading it again
+            for file_obj in ctx.paths:
+                file_obj.seek(0)
 
 
 class ExportOptions:
@@ -71,8 +120,8 @@ class ExportOptions:
     logger named "torch.onnx" under the current logger (as returned by
     :py:meth:`logging.getLogger`)."""
 
-    fake_mode: Optional[fake_tensor.FakeTensorMode] = None
-    """The fake tensor mode to use for symbolic tracing."""
+    fake_context: Optional[ONNXFakeContext] = None
+    """The fake context used for symbolic tracing."""
 
     @_beartype.beartype
     def __init__(
@@ -82,13 +131,13 @@ class ExportOptions:
         dynamic_shapes: Optional[bool] = None,
         op_level_debug: Optional[bool] = None,
         logger: Optional[logging.Logger] = None,
-        fake_mode: Optional[fake_tensor.FakeTensorMode] = None,
+        fake_context: Optional[ONNXFakeContext] = None,
     ):
         self.opset_version = opset_version
         self.dynamic_shapes = dynamic_shapes
         self.op_level_debug = op_level_debug
         self.logger = logger
-        self.fake_mode = fake_mode
+        self.fake_context = fake_context
 
 
 class ResolvedExportOptions(ExportOptions):
@@ -102,7 +151,7 @@ class ResolvedExportOptions(ExportOptions):
     dynamic_shapes: bool
     op_level_debug: bool
     logger: logging.Logger
-    fake_mode: fake_tensor.FakeTensorMode
+    fake_context: ONNXFakeContext
 
     # Private only attributes
     decomposition_table: Dict[torch._ops.OpOverload, Callable]
@@ -137,7 +186,7 @@ class ResolvedExportOptions(ExportOptions):
             self.onnxfunction_dispatcher = options.onnxfunction_dispatcher
             self.decomposition_table = options.decomposition_table
             self.diagnostic_context = options.diagnostic_context
-            self.fake_mode = options.fake_mode
+            self.fake_context = options.fake_context
         else:
             T = TypeVar("T")
 
@@ -158,7 +207,7 @@ class ResolvedExportOptions(ExportOptions):
             self.logger = resolve(
                 options.logger, lambda: logging.getLogger().getChild("torch.onnx")
             )
-            self.fake_mode = resolve(options.fake_mode, None)
+            self.fake_context = resolve(options.fake_context, None)
             # TODO(bowbao): This introduces onnxscript dependency once diagnostics is moved.
             # Options:
             #   - Add a shim and make it noop if onnxscript is not available.
@@ -191,6 +240,32 @@ class ResolvedExportOptions(ExportOptions):
             for key in dir(options):
                 if not key.startswith("_"):  # skip private attributes
                     assert hasattr(self, key), f"Unresolved option '{key}'"
+
+
+@contextlib.contextmanager
+def enable_fake_mode(model_state_dict: Optional[Any] = None):
+    """Enable fake mode for the duration of the context.
+
+    User input and model are converted to fake tensors, which means they
+    do not carry actual data, but only shape information.
+
+    It must be used when exporting models that are too large to fit into memory.
+    """
+    from torch._subclasses import fake_tensor
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    fake_mode = fake_tensor.FakeTensorMode(
+        allow_non_fake_inputs=False,
+        shape_env=ShapeEnv(
+            allow_scalar_outputs=False, allow_dynamic_output_shape_ops=False
+        ),
+    )
+    fake_context = ONNXFakeContext(
+        fake_mode=fake_mode, model_state_dict=model_state_dict
+    )
+    torch_patcher = patcher.ONNXTorchPatcher()
+    with fake_mode:
+        yield fake_context
 
 
 @runtime_checkable
@@ -250,6 +325,7 @@ class ExportOutput:
     _input_adapter: Final[io_adapter.InputAdapter]
     _output_adapter: Final[io_adapter.OutputAdapter]
     _diagnostic_context: Final[infra.DiagnosticContext]
+    _model_state_dict_files: Final[List[io.BytesIO]]
 
     @_beartype.beartype
     def __init__(
@@ -258,11 +334,13 @@ class ExportOutput:
         input_adapter: io_adapter.InputAdapter,
         output_adapter: io_adapter.OutputAdapter,
         diagnostic_context: infra.DiagnosticContext,
+        model_state_dict_files: List[io.BytesIO],
     ):
         self._model_proto = model_proto
         self._input_adapter = input_adapter
         self._output_adapter = output_adapter
         self._diagnostic_context = diagnostic_context
+        self._model_state_dict_files = model_state_dict_files
 
     @property
     def model_proto(self) -> onnx.ModelProto:
@@ -396,11 +474,27 @@ class ExportOutput:
 
         if serializer is None:
             serializer = ProtobufExportOutputSerializer()
-        if isinstance(destination, str):
-            with open(destination, "wb") as f:
-                serializer.serialize(self, f)
+        if self._model_state_dict_files is not None:
+            if not isinstance(destination, str):
+                raise RuntimeError("Cannot save to file when model has state_dict")
+            destination_path, destination_filename = os.path.split(destination)
+            onnx_model_location = destination_filename
+            onnx_initializer_location = (
+                destination_filename.split(".")[0] + "_initializers"
+            )
+            fx_serialization.save_model_with_external_data(
+                destination_path,
+                onnx_model_location,
+                onnx_initializer_location,
+                tuple(self._model_state_dict_files),
+                self.model_proto,
+            )
         else:
-            serializer.serialize(self, destination)
+            if isinstance(destination, str):
+                with open(destination, "wb") as f:
+                    serializer.serialize(self, f)
+            else:
+                serializer.serialize(self, destination)
 
 
 class FXGraphExtractor(abc.ABC):
@@ -479,13 +573,15 @@ class Exporter:
         # Export TorchScript graph to ONNX ModelProto.
         onnx_model = onnxscript_graph.to_model_proto(
             self.options.opset_version,
-            include_initializers=self.options.fake_mode is None,
+            include_initializers=self.options.fake_context is None,
         )
+
         return torch.onnx.ExportOutput(
             onnx_model,
             self.options.fx_tracer.input_adapter,
             self.options.fx_tracer.output_adapter,
             self.options.diagnostic_context,
+            self.options.fake_context._model_state_dict_files,
         )
 
     @property
@@ -637,7 +733,7 @@ def pre_export_passes(
         fx_module,
         options.decomposition_table,
         enable_dynamic_axes=options.dynamic_shapes,
-        fake_mode=options.fake_mode,
+        fake_mode=options.fake_context.fake_mode,
     ).run(*fx_module_args)
 
     # ONNX does not support views and mutations.
@@ -646,7 +742,7 @@ def pre_export_passes(
         diagnostic_context,
         module,
         enable_dynamic_axes=options.dynamic_shapes,
-        fake_mode=options.fake_mode,
+        fake_mode=options.fake_context.fake_mode,
     ).run(*fx_module_args)
 
     # Input mutations are detected and distilled after `Functionalize` pass.

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -12,7 +12,6 @@ from typing import (
     Callable,
     Dict,
     Final,
-    List,
     Mapping,
     Optional,
     Protocol,
@@ -63,37 +62,16 @@ class ONNXFakeContext:
     fake tensors during tracing of a torch.nn.Module into a FX Graph
     """
 
-    model_state_dict: Any
-    """The model's state_dict with real tensors."""
-
     fake_mode: fake_tensor.FakeTensorMode
     """The fake tensor mode to use for symbolic tracing."""
-
-    model_state_dict_files: Optional[List[Any]] = None
-    """List of file-like objects that contain the model's state_dict with real tensors."""
 
     @_beartype.beartype
     def __init__(
         self,
         *,
         fake_mode: fake_tensor.FakeTensorMode,
-        model_state_dict: Optional[Any] = None,
     ):
         self.fake_mode = fake_mode
-        self.model_state_dict = model_state_dict
-
-        # Add initializers when symbolic tracing is enabled
-        if model_state_dict is not None:
-            buffer = io.BytesIO()
-            torch.save(model_state_dict, buffer)
-            ctx = patcher.ONNXTorchPatcher()
-            with ctx:
-                buffer.seek(0)
-                _ = torch.load(buffer)
-            self._model_state_dict_files = ctx.paths
-            # Reset the buffer to the beginning before reading it again
-            for file_obj in ctx.paths:
-                file_obj.seek(0)
 
 
 class ExportOptions:
@@ -243,7 +221,7 @@ class ResolvedExportOptions(ExportOptions):
 
 
 @contextlib.contextmanager
-def enable_fake_mode(model_state_dict: Optional[Any] = None):
+def enable_fake_mode():
     """Enable fake mode for the duration of the context.
 
     User input and model are converted to fake tensors, which means they
@@ -260,11 +238,9 @@ def enable_fake_mode(model_state_dict: Optional[Any] = None):
             allow_scalar_outputs=False, allow_dynamic_output_shape_ops=False
         ),
     )
-    fake_context = ONNXFakeContext(
-        fake_mode=fake_mode, model_state_dict=model_state_dict
-    )
+    fake_context = ONNXFakeContext(fake_mode=fake_mode)
     torch_patcher = patcher.ONNXTorchPatcher()
-    with fake_mode:
+    with fake_mode, torch_patcher:
         yield fake_context
 
 
@@ -325,7 +301,6 @@ class ExportOutput:
     _input_adapter: Final[io_adapter.InputAdapter]
     _output_adapter: Final[io_adapter.OutputAdapter]
     _diagnostic_context: Final[infra.DiagnosticContext]
-    _model_state_dict_files: Final[List[io.BytesIO]]
 
     @_beartype.beartype
     def __init__(
@@ -334,13 +309,11 @@ class ExportOutput:
         input_adapter: io_adapter.InputAdapter,
         output_adapter: io_adapter.OutputAdapter,
         diagnostic_context: infra.DiagnosticContext,
-        model_state_dict_files: List[io.BytesIO],
     ):
         self._model_proto = model_proto
         self._input_adapter = input_adapter
         self._output_adapter = output_adapter
         self._diagnostic_context = diagnostic_context
-        self._model_state_dict_files = model_state_dict_files
 
     @property
     def model_proto(self) -> onnx.ModelProto:
@@ -467,13 +440,45 @@ class ExportOutput:
         self,
         destination: Union[str, io.BufferedIOBase],
         *,
+        model_state_dict: Optional[Any] = None,
         serializer: Optional[ExportOutputSerializer] = None,
     ) -> None:
         """Saves the in-memory ONNX model to ``destination`` using specified ``serializer``.
-        If no ``serializer`` is specified, the model will be serialized as Protobuf."""
+
+        Args:
+            destination: The destination to save the ONNX model. It can be either a string or a file-like object.
+                When used with ``model_state_dict``, it must be a string with a full path to the destination.
+                In that case, besides saving the ONNX model, a folder with "_initializers" suffix (without extension)
+                will be created to store the each initializer of the ONNX model in a separate file. For example, if the
+                destination is "/path/model.onnx", the initializers will be saved in "/path/model_initializers/" folder.
+            model_state_dict: The state_dict of the PyTorch model with all weights on it.
+                Required when ``enable_fake_mode`` is used but real initializers are needed on the ONNX graph.
+                It can be either a string with the path to a checkpoint or a dictionary with the actual model state.
+            serializer: The serializer to use. If not specified, the model will be serialized as Protobuf.
+        """
 
         if serializer is None:
             serializer = ProtobufExportOutputSerializer()
+
+        # Add initializers when symbolic tracing is enabled
+        if model_state_dict is not None:
+            if isinstance(model_state_dict, dict):
+                model_state_dict_file = io.BytesIO()
+                torch.save(model_state_dict, model_state_dict_file)
+                model_state_dict_file.seek(0)
+            else:
+                model_state_dict_file = model_state_dict
+
+            ctx = patcher.ONNXTorchPatcher()
+            with ctx:
+                _ = torch.load(model_state_dict_file)
+            self._model_state_dict_files = ctx.paths
+
+            # Reset the buffer to the beginning before reading it again
+            if isinstance(model_state_dict, dict):
+                for file_obj in ctx.paths:
+                    file_obj.seek(0)
+
         if self._model_state_dict_files is not None:
             if not isinstance(destination, str):
                 raise RuntimeError("Cannot save to file when model has state_dict")
@@ -581,7 +586,6 @@ class Exporter:
             self.options.fx_tracer.input_adapter,
             self.options.fx_tracer.output_adapter,
             self.options.diagnostic_context,
-            self.options.fake_context._model_state_dict_files,
         )
 
     @property
@@ -733,7 +737,7 @@ def pre_export_passes(
         fx_module,
         options.decomposition_table,
         enable_dynamic_axes=options.dynamic_shapes,
-        fake_mode=options.fake_context.fake_mode,
+        allow_fake_constant=options.fake_context.fake_mode is not None,
     ).run(*fx_module_args)
 
     # ONNX does not support views and mutations.
@@ -742,7 +746,7 @@ def pre_export_passes(
         diagnostic_context,
         module,
         enable_dynamic_axes=options.dynamic_shapes,
-        fake_mode=options.fake_context.fake_mode,
+        allow_fake_constant=options.fake_context.fake_mode is not None,
     ).run(*fx_module_args)
 
     # Input mutations are detected and distilled after `Functionalize` pass.

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -635,6 +635,7 @@ def pre_export_passes(
         fx_module,
         options.decomposition_table,
         enable_dynamic_axes=options.dynamic_shapes,
+        fake_mode=options.fake_mode,
     ).run(*fx_module_args)
 
     # ONNX does not support views and mutations.

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -641,8 +641,12 @@ def pre_export_passes(
     # ONNX does not support views and mutations.
     # Functionalize to get a semantically equivalent graph without mutations.
     module = passes.Functionalize(
-        diagnostic_context, module, enable_dynamic_axes=options.dynamic_shapes
+        diagnostic_context,
+        module,
+        enable_dynamic_axes=options.dynamic_shapes,
+        fake_mode=options.fake_mode,
     ).run(*fx_module_args)
+
     # Input mutations are detected and distilled after `Functionalize` pass.
     # Remove them since ONNX inference does not need them.
     module = passes.RemoveInputMutation(diagnostic_context, module).run(*fx_module_args)

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -458,7 +458,6 @@ class Exporter:
             *self.model_args, **self.model_kwargs
         )
 
-        # TODO: Symbolic tracing does not like most of these passes. Why?!
         # TODO: Design the passes API
         graph_module = pre_export_passes(
             self.options, self.model, graph_module, updated_model_args

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -21,6 +21,7 @@ from typing import (
 
 import torch
 import torch._ops
+from torch._subclasses import fake_tensor
 
 from torch.onnx._internal import _beartype, io_adapter
 from torch.onnx._internal.diagnostics import infra
@@ -70,6 +71,9 @@ class ExportOptions:
     logger named "torch.onnx" under the current logger (as returned by
     :py:meth:`logging.getLogger`)."""
 
+    fake_mode: Optional[fake_tensor.FakeTensorMode] = None
+    """The fake tensor mode to use for symbolic tracing."""
+
     @_beartype.beartype
     def __init__(
         self,
@@ -78,11 +82,13 @@ class ExportOptions:
         dynamic_shapes: Optional[bool] = None,
         op_level_debug: Optional[bool] = None,
         logger: Optional[logging.Logger] = None,
+        fake_mode: Optional[fake_tensor.FakeTensorMode] = None,
     ):
         self.opset_version = opset_version
         self.dynamic_shapes = dynamic_shapes
         self.op_level_debug = op_level_debug
         self.logger = logger
+        self.fake_mode = fake_mode
 
 
 class ResolvedExportOptions(ExportOptions):
@@ -96,6 +102,7 @@ class ResolvedExportOptions(ExportOptions):
     dynamic_shapes: bool
     op_level_debug: bool
     logger: logging.Logger
+    fake_mode: fake_tensor.FakeTensorMode
 
     # Private only attributes
     decomposition_table: Dict[torch._ops.OpOverload, Callable]
@@ -130,6 +137,7 @@ class ResolvedExportOptions(ExportOptions):
             self.onnxfunction_dispatcher = options.onnxfunction_dispatcher
             self.decomposition_table = options.decomposition_table
             self.diagnostic_context = options.diagnostic_context
+            self.fake_mode = options.fake_mode
         else:
             T = TypeVar("T")
 
@@ -150,6 +158,7 @@ class ResolvedExportOptions(ExportOptions):
             self.logger = resolve(
                 options.logger, lambda: logging.getLogger().getChild("torch.onnx")
             )
+            self.fake_mode = resolve(options.fake_mode, None)
             # TODO(bowbao): This introduces onnxscript dependency once diagnostics is moved.
             # Options:
             #   - Add a shim and make it noop if onnxscript is not available.
@@ -449,6 +458,7 @@ class Exporter:
             *self.model_args, **self.model_kwargs
         )
 
+        # TODO: Symbolic tracing does not like most of these passes. Why?!
         # TODO: Design the passes API
         graph_module = pre_export_passes(
             self.options, self.model, graph_module, updated_model_args

--- a/torch/onnx/_internal/fx/__init__.py
+++ b/torch/onnx/_internal/fx/__init__.py
@@ -1,8 +1,8 @@
-from .context import FxToOnnxContext
+from .patcher import ONNXTorchPatcher
 from .serialization import save_model_with_external_data
 
 
 __all__ = [
     "save_model_with_external_data",
-    "FxToOnnxContext",
+    "ONNXTorchPatcher",
 ]

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -189,7 +189,11 @@ class DynamoExport(exporter.FXGraphExtractor):
         #
         fx_mode = "symbolic" if options.dynamic_shapes else "fake"
         graph_module, graph_guard = torch._dynamo.export(
-            wrapped_model, *model_args, tracing_mode=fx_mode, **model_kwargs
+            wrapped_model,
+            *model_args,
+            tracing_mode=fx_mode,
+            fake_mode=options.fake_mode,
+            **model_kwargs,
         )
         del graph_guard  # Unused
         torch._dynamo.reset()

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -187,13 +187,14 @@ class DynamoExport(exporter.FXGraphExtractor):
 
         # Translate callable to FX graph.
         #
+        fake_mode = options.fake_context.fake_mode if options.fake_context else None
         fx_mode = "symbolic" if options.dynamic_shapes else "fake"
         graph_module, graph_guard = torch._dynamo.export(
             wrapped_model,
             *model_args,
             tracing_mode=fx_mode,
-            fake_mode=options.fake_context.fake_mode,
-            **model_kwargs,
+            fake_mode=fake_mode,
+            **kwargs,
         )
         del graph_guard  # Unused
         torch._dynamo.reset()

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -192,7 +192,7 @@ class DynamoExport(exporter.FXGraphExtractor):
             wrapped_model,
             *model_args,
             tracing_mode=fx_mode,
-            fake_mode=options.fake_mode,
+            fake_mode=options.fake_context.fake_mode,
             **model_kwargs,
         )
         del graph_guard  # Unused

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -194,7 +194,7 @@ class DynamoExport(exporter.FXGraphExtractor):
             *model_args,
             tracing_mode=fx_mode,
             fake_mode=fake_mode,
-            **kwargs,
+            **model_kwargs,
         )
         del graph_guard  # Unused
         torch._dynamo.reset()

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -6,6 +6,7 @@ import torch
 import torch._ops
 import torch.fx
 from torch.fx.experimental import proxy_tensor
+from torch._subclasses import fake_tensor
 
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import _pass, diagnostics
@@ -19,10 +20,12 @@ class Decompose(_pass.Transform):
         module: torch.fx.GraphModule,
         decomposition_table: Mapping[torch._ops.OpOverload, Callable],
         enable_dynamic_axes: bool,
+        fake_mode: fake_tensor.FakeTensorMode,
     ):
         super().__init__(diagnostic_context, module)
         self.decomposition_table = decomposition_table
         self.enable_dynamic_axes = enable_dynamic_axes
+        self.fake_mode = fake_mode
 
     @_beartype.beartype
     def _run(self, *args, **kwargs) -> torch.fx.GraphModule:
@@ -54,6 +57,7 @@ class Decompose(_pass.Transform):
             decomposition_table=self.decomposition_table,
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
+            _allow_fake_constant=self.fake_mode is not None
         )(*args)
         # Rename placeholder targets to match the original module's signature since
         # We don't want to map forward(x, y, z) to forward(arg0, arg1, arg2).

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Optional
 
 import torch
 import torch._ops
@@ -20,7 +20,7 @@ class Decompose(_pass.Transform):
         module: torch.fx.GraphModule,
         decomposition_table: Mapping[torch._ops.OpOverload, Callable],
         enable_dynamic_axes: bool,
-        fake_mode: fake_tensor.FakeTensorMode,
+        fake_mode: Optional[fake_tensor.FakeTensorMode],
     ):
         super().__init__(diagnostic_context, module)
         self.decomposition_table = decomposition_table

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -5,8 +5,8 @@ from typing import Callable, Mapping
 import torch
 import torch._ops
 import torch.fx
-from torch.fx.experimental import proxy_tensor
 from torch._subclasses import fake_tensor
+from torch.fx.experimental import proxy_tensor
 
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import _pass, diagnostics
@@ -57,7 +57,7 @@ class Decompose(_pass.Transform):
             decomposition_table=self.decomposition_table,
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
-            _allow_fake_constant=self.fake_mode is not None
+            _allow_fake_constant=self.fake_mode is not None,
         )(*args)
         # Rename placeholder targets to match the original module's signature since
         # We don't want to map forward(x, y, z) to forward(arg0, arg1, arg2).

--- a/torch/onnx/_internal/fx/passes/functionalization.py
+++ b/torch/onnx/_internal/fx/passes/functionalization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 import torch._ops
@@ -65,7 +65,7 @@ class Functionalize(_pass.Transform):
         diagnostic_context: diagnostics.DiagnosticContext,
         module: torch.fx.GraphModule,
         enable_dynamic_axes: bool,
-        fake_mode: proxy_tensor.FakeTensorMode,
+        fake_mode: Optional[proxy_tensor.FakeTensorMode],
     ):
         super().__init__(diagnostic_context, module)
         self.enable_dynamic_axes = enable_dynamic_axes

--- a/torch/onnx/_internal/fx/passes/functionalization.py
+++ b/torch/onnx/_internal/fx/passes/functionalization.py
@@ -65,9 +65,11 @@ class Functionalize(_pass.Transform):
         diagnostic_context: diagnostics.DiagnosticContext,
         module: torch.fx.GraphModule,
         enable_dynamic_axes: bool,
+        fake_mode: proxy_tensor.FakeTensorMode,
     ):
         super().__init__(diagnostic_context, module)
         self.enable_dynamic_axes = enable_dynamic_axes
+        self.fake_mode = fake_mode
 
     def _functionalize(self, function: Callable) -> Callable:
         # Working around a dispatcher issue with `torch.func.functionalize` when used
@@ -107,6 +109,7 @@ class Functionalize(_pass.Transform):
             decomposition_table={},
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
+            _allow_fake_constant=self.fake_mode is not None,
         )(*args)
 
         # Rename placeholder targets to match the original module's signature since

--- a/torch/onnx/_internal/fx/passes/functionalization.py
+++ b/torch/onnx/_internal/fx/passes/functionalization.py
@@ -65,11 +65,11 @@ class Functionalize(_pass.Transform):
         diagnostic_context: diagnostics.DiagnosticContext,
         module: torch.fx.GraphModule,
         enable_dynamic_axes: bool,
-        fake_mode: Optional[proxy_tensor.FakeTensorMode],
+        allow_fake_constant: Optional[bool] = False,
     ):
         super().__init__(diagnostic_context, module)
         self.enable_dynamic_axes = enable_dynamic_axes
-        self.fake_mode = fake_mode
+        self.allow_fake_constant = allow_fake_constant
 
     def _functionalize(self, function: Callable) -> Callable:
         # Working around a dispatcher issue with `torch.func.functionalize` when used
@@ -109,7 +109,7 @@ class Functionalize(_pass.Transform):
             decomposition_table={},
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
-            _allow_fake_constant=self.fake_mode is not None,
+            _allow_fake_constant=self.allow_fake_constant,
         )(*args)
 
         # Rename placeholder targets to match the original module's signature since

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -4,11 +4,10 @@ from typing import List
 import torch
 
 
-class FxToOnnxContext:
-    """Context manager to make PyTorch friendly to FX-to-ONNX exporter.
-    This class means to collect all "patches" required by FX-to-ONNX
-    exporter. If PyTorch needs to be patched, please use this class to
-    manage the patch.
+class ONNXTorchPatcher:
+    """Context manager to temporarily patch PyTorch during FX-to-ONNX export.
+
+    This class is a collection of "patches" required by FX-to-ONNX exporter.
 
     This context overrides several torch functions to support symbolic
     export of large scale models.
@@ -26,7 +25,7 @@ class FxToOnnxContext:
         This list is extended with (torch.Tensor, "__getitem__") so that
         weight[x, :, y] becomes exportable with torch.fx.symbolic_trace.
 
-    Search for FxToOnnxContext in test_fx_to_onnx_with_onnxruntime.py for
+    Search for ONNXTorchPatcher in test_fx_to_onnx_with_onnxruntime.py for
     example usage.
     """
 
@@ -51,6 +50,7 @@ class FxToOnnxContext:
                 )
                 return t.set_(storage._untyped_storage, storage_offset, size, stride)
 
+            # import pdb; pdb.set_trace()
             mode = _get_current_dispatch_mode()
             if isinstance(mode, FakeTensorMode):
                 # Create a real tensor and then convert it to FakeTensor.

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -28,6 +28,12 @@ class ONNXTorchPatcher:
 
     Search for ONNXTorchPatcher in test_fx_to_onnx_with_onnxruntime.py for
     example usage.
+
+    TODO: Should this really be a global patcher? Can we make it a local patcher?
+        A reason for splitting this into several patchers is to patch one part of the code
+        as a collateral damage of patching another part of the code. For example, we
+        for tracing model with torch._dynamo.export, we don't need to patch
+        `torch.fx._symbolic_trace._wrapped_methods_to_patch`
     """
 
     def __init__(self):

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -1,5 +1,6 @@
 import copy
-from typing import List
+import io
+from typing import List, Union
 
 import torch
 
@@ -31,7 +32,7 @@ class ONNXTorchPatcher:
 
     def __init__(self):
         # List of file paths processed by torch.load.
-        self.paths: List[str] = []
+        self.paths: List[Union[str, io.BufferedIOBase]] = []
 
         def torch_load_wrapper(f, *args, **kwargs):
             # Record path.

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -50,7 +50,6 @@ class ONNXTorchPatcher:
                 )
                 return t.set_(storage._untyped_storage, storage_offset, size, stride)
 
-            # import pdb; pdb.set_trace()
             mode = _get_current_dispatch_mode()
             if isinstance(mode, FakeTensorMode):
                 # Create a real tensor and then convert it to FakeTensor.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -120,8 +120,8 @@ def save_model_with_external_data(
     onnx_input_names = [input.name for input in onnx_model.graph.input]
 
     for path in torch_load_paths:
-        state_ditc = torch.load(path)
-        for name, tensor in state_ditc.items():
+        state_dict = torch.load(path)
+        for name, tensor in state_dict.items():
             # Basically, "transformer.attention.self.query.weight" is mapped
             # to "transformer_attention_self_query_weight" for mimicking the
             # name-modifying code in FX-to-ONNX exporter.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import io
 import os
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch.onnx import _type_utils as jit_type_utils
@@ -84,7 +85,7 @@ def save_model_with_external_data(
     basepath: str,
     model_location: str,
     initializer_location: str,
-    torch_load_paths: Tuple[str, ...],
+    torch_load_paths: Tuple[Union[str, io.BytesIO], ...],
     onnx_model: onnx.ModelProto,
 ) -> None:
     """Load PyTorch tensors from files and add to "onnx_model" as external initializers.


### PR DESCRIPTION
## Context prior to this PR

https://github.com/pytorch/pytorch/pull/100017/ was merged onto PyTorch `main` branch with the goal of enabling `torch._dynamo.export` to perform symbolic tracing. 
In that context, symbolic tracing is defined as tracing of a model using fake inputs and weights. An input is Fake when `torch.nn.Tensor` is replaced by `torch._subclasses.FakeTensor`, whereas a weight is fake when a `torch.nn.Parameter` is replaced by `torch._subclasses.FakeTensor`.

For additional context, several strategies were discussed with Meta to enable this feature, including 1) calling `torch._dynamo.export` within a `torch._subclass.FakeTensorMode` context and 2) **fake**fying input and model as separate step and then call `torch._dynamo.export` without an active `torch._subclass.FakeTensorMode` context. At the end, 2) was preferred and implemented by #100017 to minimize the number of side-effects the fake tensor mode has on the code base.

As a consequence, `torch._dynamo.export` API introduced a new argument called `fake_mode`. When symbolic tracing is used, the user must pass in the `fake_mode` used to fakefy both the input and the model. Internally, `torch._dynamo.export` will adopt this `fake_mode` instead of creating its own instance. This is needed because each instance of `FakeTensorMode` has metadata on the tensor/parameter it fakefied. Thus, using real tensor/model and specify a `fake_mode` to `torch._dynamo.export` is an error. Also, specify a `fake_mode` instance to `torch._dynamo.export` different than the one used to fakefy the model and input is also an error.

## Changes introduced from this PR

This PR is intended to integrate `torch._dynamo.export(fake_mode=...)` through `torch.onnx.dynamo_export`. In essence, it 
* Introduces a new public API `ONNXFakeContext` which wraps a `FakeTensorMode` under the hood. This removes complexity from the user side while still allow the exporter to leverage the fake mode.
* Adds a new public API `enable_fake_mode` *context manager* that instantiates and return a `ONNXFakeContext`. 
* Adds a new `ExportOptions.fake_context` that will be used to persist the `ONNXFakeContext` created by `enable_fake_mode` and plumb through until it reaches the call to `torch._dynamo.export`.
* Adds a `model_state_dict` argument to `ExportOutput.save` API.
  * When model is exported with fake tensors, no actual data exist in the FX module and, therefore, in the ONNX graph. 
    * In fact, `torch.fx.make_fx` lifts initializers as model input when fake tensors are used
      * https://github.com/pytorch/pytorch/pull/104493 is needed to enforce name matching between Parameters and inputs
    *  A model checkpoint file or state_dict is needed to populate the ONNX graph with real initializers through `export_output.save(model_state_dict=...)` API

Symbolic tracing, or onnx fake mode, is only enabled when the user instantiates the input and model within the `enable_fake_mode` context. Otherwise, real tracing is done, which preserves the current behavior.

## Usability

Because symbolic tracing depends a lot on having changes made on Dynamo side before it can be consumed on ONNX exporter, this feature may have its API and assumptions changed as symbolic tracing matures upstream. Nonetheless, it is still important to have this feature merged ASAP on the ONNX exporter side to "lock" changes on Dynamo that would otherwise break ONNX exporter without warning.

Example:

```python
class Model(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.linear = torch.nn.Linear(2, 2)

    def forward(self, x):
        out = self.linear(x)
        return out

with torch.onnx.enable_fake_mode() as fake_context:
    x = torch.rand(5, 2, 2)
    model = Model()

# Export the model with fake inputs and parameters
export_options = ExportOptions(fake_context=fake_context)
export_output = torch.onnx.dynamo_export(
    model, x, export_options=export_options
)

model_state_dict = Model().state_dict()  # optional
export_output.save("/path/to/model.onnx", model_state_dict=model_state_dict)
```

## Next steps

* Add unit tests running the exported model with ORT
Today this is not possible yet because `make_fx` used by our Decomposition pass lifts initializers as model inputs. However, the initializer names are not preserved by FX tracing, causing a mismatch between the initializer and input name.
https://github.com/pytorch/pytorch/pull/104493 and https://github.com/pytorch/pytorch/pull/104741 should fix the initializer mismatch, enabling model execution

* Revisit `ONNXTorchPatcher` and how the ONNX initializers are saved in the graph as external data
We can try to get rid of the PyTorch patcher. If we can't, we might prefer to create specific patchers, say `FXSymbolicTracePatcher` used specifically during an export using `torch.fx.symbolic_trace` and maybe a `ExportOutputSavePacther` used specifically for `ExportOutput.save` to prevent "patching too many pytorch API that we don't need

## References

* [FakeTensor implementation](https://github.com/pytorch/pytorch/blob/main/torch/_subclasses/fake_tensor.py)
* [PR that adds fake tensor support to torch._dynamo.export](https://github.com/pytorch/pytorch/pull/100017)
* [Short fake tensor documentation](https://pytorch.org/torchdistx/latest/fake_tensor.html)