### PR TITLE
Revert "[DDP] multiple forward support for static graph (#103487)"

### DIFF
--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -34,8 +34,6 @@ if BACKEND == "gloo" or BACKEND == "nccl" or BACKEND == "ucc":
             super().setUp()
             self._spawn_processes()
             torch.backends.cudnn.flags(enabled=True, allow_tf32=False).__enter__()
-else:
-    print(f"Invalid backend {BACKEND}. Tests will not be run!")
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -404,11 +404,6 @@ class TORCH_API Reducer {
 
   // track the number of iterations to synchronize grads in training so far.
   long num_iterations_;
-  // track distinct iteration of backward call. This is distinct from num_iterations_,
-  // for example in the case of multiple forward before backward.
-  long num_bwd_calls_;
-  // whether the first autograd hook for a distinct backward pass has been called.
-  bool first_autograd_hook_called_;
   // track the number of buckets that have been ready for
   // communication calls like allReduce or communication hooks.
   int num_buckets_ready_;

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -254,7 +254,7 @@ class _DDPSink(Function):
     def backward(ctx, *grad_outputs):
         # Enqueue delay allreduce for static graph training on the first
         # iteration.
-        if ctx.ddp_state["static_graph"] and ctx.ddp_state["num_forward_calls"] == 1:
+        if ctx.ddp_state["static_graph"] and ctx.ddp_state["num_iterations"] == 1:
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 ctx.reducer._delay_all_reduce
             )
@@ -1047,7 +1047,7 @@ class DistributedDataParallel(Module, Joinable):
         (4) Logging construction-time DDP logging data
         (5) passing a handle of DDP to SyncBatchNorm Layer
         """
-        self.num_forward_calls = 0
+        self.num_iterations = 0
         # Notice, the parameters order is not in the order in which they are used,
         # especially in models with control flow.
         #
@@ -1381,7 +1381,7 @@ class DistributedDataParallel(Module, Joinable):
         if torch.is_grad_enabled() and self.require_backward_grad_sync:
             assert self.logger is not None
             self.logger.set_runtime_stats_and_log()
-            self.num_forward_calls += 1
+            self.num_iterations += 1
             self.reducer.prepare_for_forward()
 
         # Notify the join context that this process has not joined, if
@@ -1466,11 +1466,11 @@ class DistributedDataParallel(Module, Joinable):
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
         if (self.find_unused_parameters and not self.static_graph) or (
-            self.static_graph and self.num_forward_calls == 1
+            self.static_graph and self.num_iterations == 1
         ):
             ddp_state = {
                 "static_graph": self.static_graph,
-                "num_forward_calls": self.num_forward_calls,
+                "num_iterations": self.num_iterations,
             }
 
             (

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -256,14 +256,11 @@ class _DDPSink(Function):
         ddp_weakref = ctx.ddp_weakref()
         reducer = ddp_weakref.reducer
         static_graph = ddp_weakref.static_graph
-        delay_ar_enqueued = (
-            static_graph and ddp_weakref._static_graph_delay_allreduce_enqueued
-        )
-        if static_graph and not delay_ar_enqueued:
+        num_forward_calls = ddp_weakref.num_forward_calls
+        if static_graph and num_forward_calls == 1:
             Variable._execution_engine.queue_callback(  # type: ignore[call-arg,misc]
                 reducer._delay_all_reduce
             )
-            ddp_weakref._static_graph_delay_allreduce_enqueued = True
 
         return (None, *grad_outputs)
 
@@ -1053,6 +1050,7 @@ class DistributedDataParallel(Module, Joinable):
         (4) Logging construction-time DDP logging data
         (5) passing a handle of DDP to SyncBatchNorm Layer
         """
+        self.num_forward_calls = 0
         # Notice, the parameters order is not in the order in which they are used,
         # especially in models with control flow.
         #
@@ -1386,6 +1384,7 @@ class DistributedDataParallel(Module, Joinable):
         if torch.is_grad_enabled() and self.require_backward_grad_sync:
             assert self.logger is not None
             self.logger.set_runtime_stats_and_log()
+            self.num_forward_calls += 1
             self.reducer.prepare_for_forward()
 
         # Notify the join context that this process has not joined, if
@@ -1470,7 +1469,7 @@ class DistributedDataParallel(Module, Joinable):
         # TODO: DDPSink is currently enabled for unused parameter detection and
         # static graph training for first iteration.
         if (self.find_unused_parameters and not self.static_graph) or (
-            self.static_graph and not self._static_graph_delay_allreduce_enqueued
+            self.static_graph and self.num_forward_calls == 1
         ):
             (
                 output_tensor_list,
@@ -2202,7 +2201,6 @@ class DistributedDataParallel(Module, Joinable):
             )
             return
         self.static_graph = True
-        self._static_graph_delay_allreduce_enqueued = False
         self.reducer._set_static_graph()
         assert self.logger is not None
         self.logger._set_static_graph()


### PR DESCRIPTION
Per the discussion in https://github.com/pytorch/pytorch/pull/103629#issuecomment-1598001313, I preemptively create this revert PR to revert all commits in the stack.  This seems like a safer option than using the bot as the commit has already been in trunk since last week.