### PR TITLE
Support Future API for coalescing manager

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -33,6 +33,7 @@ from torch._C._distributed_c10d import (
     Work
 )
 from torch.autograd.profiler import record_function
+from torch.futures import Future, collect_all
 from .constants import default_pg_timeout
 from .c10d_logger import _exception_logger, _time_logger
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
@@ -1622,6 +1623,9 @@ class _CoalescingManager:
     def wait(self):
         for work in self.works:
             work.wait()
+
+    def get_future(self) -> Future:
+        return collect_all([work.get_future() for work in self.works])
 
 
 @contextlib.contextmanager

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1624,7 +1624,7 @@ class _CoalescingManager:
         for work in self.works:
             work.wait()
 
-    def get_future(self) -> Future:
+    def get_future(self) -> Future[List[Future]]:
         return collect_all([work.get_future() for work in self.works])
 
 


### PR DESCRIPTION
I'm not entirely sure why `collect_all` returns a `Future[List[Future]]` instead of a `Future[List]`. I'm guessing it's to keep the granularity and still trigger all the individual hooks ...

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu