### PR TITLE
Update viable/strict script to ignore unstable jobs

### DIFF
--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -49,8 +49,9 @@ def query_commits(commits: List[str]) -> List[Dict[str, Any]]:
     )
     params = [{"name": "shas", "type": "string", "value": ",".join(commits)}]
     res = rs.QueryLambdas.execute_query_lambda(
+        # https://console.rockset.com/lambdas/details/commons.commit_jobs_batch_query
         query_lambda="commit_jobs_batch_query",
-        version="8003fdfd18b64696",
+        version="19c74e10819104f9",
         workspace="commons",
         parameters=params,
     )
@@ -93,6 +94,11 @@ def isGreen(commit: str, results: List[Dict[str, Any]]) -> Tuple[bool, str]:
     }
 
     for check in workflow_checks:
+        jobName = check["jobName"]
+        # Ignore result from unstable job, be it success or failure
+        if "unstable" in jobName:
+            continue
+
         workflowName = check["workflowName"]
         conclusion = check["conclusion"]
         for required_check in regex:


### PR DESCRIPTION
As distributed jobs had been failing in the past few days, viable/strict branch hasn't been updated since June 15th.  The issue was discovered when looking into nightly https://hud.pytorch.org/hud/pytorch/pytorch/nightly which sync with viable/strict.

Despite the fact that the failing job has been marked as unstable by https://github.com/pytorch/pytorch/issues/103612, the script still counted it as a failure https://github.com/pytorch/pytorch/actions/runs/5319411414/jobs/9631875636, and we kind of forget to monitor viable/strict delay to notice this earlier.  An alarm would probably need to be setup for this.

I also update the Rockset query a bit to add a comment on that it's used for.

### Testing

https://github.com/pytorch/pytorch/actions/runs/5326617870