### PR TITLE
[AOTAutograd] make _unsafe_view() logic happen during the runtime epilogue

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -474,6 +474,9 @@ class ViewAndMutationMeta:
             for i, m in enumerate(self.output_info)
             if m.output_type not in [OutputType.non_alias, OutputType.unsafe_view_alias]
         ]
+        unsafe_view_out_indices = [
+            i for i, m in enumerate(self.output_info) if m.output_type is OutputType.unsafe_view_alias
+        ]
 
         self.mutated_inp_indices = mutated_inp_indices
         # This is pre-computed in post_init for perf.
@@ -484,6 +487,7 @@ class ViewAndMutationMeta:
         # It contains the index of every element
         # of output_info that corresponds to an alias (either of an input or intermediate)
         self.aliased_out_indices = aliased_out_indices
+        self.unsafe_view_out_indices = unsafe_view_out_indices
         self.num_outputs = len(self.output_info)
         self.num_outputs_non_aliased = len(
             [x for x in self.output_info if x.output_type in [OutputType.non_alias, OutputType.unsafe_view_alias]]
@@ -498,6 +502,7 @@ class ViewAndMutationMeta:
                 ]
             ]
         )
+        self.num_unsafe_view_outputs = len(self.unsafe_view_out_indices)
         self.num_outputs_aliased_to_intermediates = len(
             [
                 x
@@ -1158,9 +1163,6 @@ def fn_prepped_for_autograd(
         for i, (o, info) in enumerate(zip(outs, meta.output_info)):
             if info.output_type == OutputType.alias_of_intermediate_save_as_output:
                 intermediate_bases.append(o._base)
-            elif info.output_type == OutputType.unsafe_view_alias:
-                # See Note [Intermediate Bases Optimization]
-                outs[i] = torch.ops.aten._unsafe_view.default(o, o.shape)
 
         assert meta.num_intermediate_bases == len(intermediate_bases)
 
@@ -2876,6 +2878,12 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                     ]
                     assert len(user_mutated_inputs_raw) == len(mut_inp_infos)
 
+            if CompiledFunction.metadata.num_unsafe_view_outputs > 0:
+                for idx in CompiledFunction.metadata.unsafe_view_out_indices:
+                    raw_return_idx = num_mutated_inputs + idx
+                    o = raw_returns[raw_return_idx]
+                    raw_returns[raw_return_idx] = torch.ops.aten._unsafe_view(o, o.shape)
+
             if num_outputs_aliased > 0:
                 for idx in CompiledFunction.metadata.aliased_out_indices:
                     raw_return_idx = num_mutated_inputs + idx
@@ -3037,6 +3045,8 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                 )
 
                 out = functionalized_rng_runtime_epilogue(CompiledFunction.metadata, out)
+                print("BACKWARD")
+                print(torch.cuda.memory_allocated())
                 return tuple(out)
 
             if torch.is_grad_enabled() and any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -3045,8 +3045,6 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                 )
 
                 out = functionalized_rng_runtime_epilogue(CompiledFunction.metadata, out)
-                print("BACKWARD")
-                print(torch.cuda.memory_allocated())
                 return tuple(out)
 
             if torch.is_grad_enabled() and any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/103153

AOTAutograd has some logic for handling the case when we have:
* a graph output that is a view of an intermediate
* None of the other aliases of that output escape the graph, so from the perspective of the user + the autograd engine, we can pretend that the output is not a view

However, that logic would inject an `_unsafe_view()` call into the graph at trace time. This isn't wrong, but inductor will just immediately decompose `_unsafe_view()` into `view()`, and so the output tensor will continue to show up as having view metadata w.r.t. autograd.

This PR changes the `unsafe_view()` call to be in the runtime epilogue, instead of being part of the graph (where the compiler might do bad things to it - the compiler also shouldn't have to concern itself with autograd metadata).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103919

