### PR TITLE
[5/n][FSDP] Update _sharded_post_state_dict_hook to use DTensor when use_dtensor=True in state_dict_config

### DIFF
--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -142,10 +142,14 @@ def _create_chunk_dtensor(
     corresponding chunk as the local tensor to create a DTensor.
     """
     shard_placement = DShard(0)
-    tensor_padded_list, _ = shard_placement._split_tensor(
+    tensor_list, _ = shard_placement._split_tensor(
         tensor,
         device_mesh.size(dim=0),
         with_padding=False,
         contiguous=True,
     )
-    return DTensor.from_local(tensor_padded_list[rank], device_mesh, [shard_placement])
+    # We need to explicitly call .clone() here as tensor.chunks() splits a tensor into the specified number of chunks.
+    # Each chunk is a view of the input tensor. If the original tensor change, the view will also be changed.
+    # We need to explicitly call .detach() to return a new tensor detached from the current graph.
+    local_tensor = tensor_list[rank].clone().detach()
+    return DTensor.from_local(local_tensor, device_mesh, [shard_placement])

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -49,7 +49,11 @@ from torch.distributed.fsdp.api import (
 )
 from torch.distributed.utils import _replace_by_prefix
 
-from ._fsdp_extensions import _ext_chunk_tensor, _ext_pre_load_state_dict_transform
+from ._fsdp_extensions import (
+    _ext_chunk_dtensor,
+    _ext_chunk_tensor,
+    _ext_pre_load_state_dict_transform,
+)
 from ._unshard_param_utils import _unshard_fsdp_state_params, FLAT_PARAM
 
 
@@ -436,6 +440,7 @@ def _local_post_state_dict_hook(
     sharded_tensor = init_from_local_shards(
         local_shards, full_numel, process_group=fsdp_state.process_group
     )  # type: ignore[assignment]
+    # TODO: Add DTensor state_dict support for LOCAL_STATE_DICT.
     if fsdp_state._state_dict_config.offload_to_cpu:
         sharded_tensor = sharded_tensor.cpu()
     state_dict[f"{prefix}{FLAT_PARAM}"] = sharded_tensor
@@ -492,6 +497,7 @@ def _local_pre_load_state_dict_hook(
             load_tensor = F.pad(load_tensor, [0, flat_param._shard_numel_padded])
     else:
         load_tensor = flat_param
+    # TODO: Add DTensor state_dict support for LOCAL_STATE_DICT.
     state_dict[fqn] = load_tensor
 
 
@@ -538,13 +544,20 @@ def _sharded_post_state_dict_hook(
 
     def param_hook(state_dict: Dict[str, Any], prefix: str, fqn: str):
         param = state_dict[fqn]
-        sharded_tensor = _ext_chunk_tensor(
-            tensor=param,
-            rank=fsdp_state.rank,
-            world_size=fsdp_state.world_size,
-            num_devices_per_node=fsdp_state._device_handle.device_count(),
-            pg=fsdp_state.process_group,
-        )
+        if not fsdp_state._state_dict_config.use_dtensor:
+            sharded_tensor = _ext_chunk_tensor(
+                tensor=param,
+                rank=fsdp_state.rank,
+                world_size=fsdp_state.world_size,
+                num_devices_per_node=fsdp_state._device_handle.device_count(),
+                pg=fsdp_state.process_group,
+            )
+        else:
+            sharded_tensor = _ext_chunk_dtensor(
+                tensor=param,
+                rank=fsdp_state.rank,
+                device_mesh=fsdp_state._device_mesh,
+            )
         if fsdp_state._state_dict_config.offload_to_cpu:
             sharded_tensor = sharded_tensor.cpu()
         state_dict[fqn] = sharded_tensor


### PR DESCRIPTION
This allows us use use_dtensor=True for ShardedStateDictConfig() before calling model.state_dict().

load_state_dict hooks updates will be in next PR. 

cc @zhaojuanmao @mrshenli @rohan-varma @awgu