### PR TITLE
Add test to reinitialize pg after abort.

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -640,6 +640,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   std::unordered_map<std::string, std::vector<std::shared_ptr<NCCLComm>>>
       devNCCLCommMap_;
 
+  // The NCCL communicators currently in process of being initialized.
+  std::unordered_map<std::string, std::vector<std::shared_ptr<NCCLComm>>>
+      inInitializationCommMap_;
+
   // Map from ncclUniqueId to appropriate communicator.
   std::unordered_map<std::string, std::vector<std::shared_ptr<NCCLComm>>>
       ncclIdToCommMap_;

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9725,6 +9725,47 @@ class DistributedTest:
                 ddp._check_reducer_finalized()
                 ddp(input)
 
+        @skip_if_lt_x_gpu(2)
+        @skip_but_pass_in_sandcastle_if(
+            BACKEND != "nccl",
+            "TORCH_NCCL_USE_COMM_NONBLOCKING only applies to NCCL"
+        )
+        def test_nccl_init_abort(self):
+            """
+            Tests that we can abort a NCCL communicator during initialization and
+            recover appropriately.
+            """
+            # Reinitialize global process group with TORCH_NCCL_USE_COMM_NONBLOCKING=1
+            os.environ["TORCH_NCCL_USE_COMM_NONBLOCKING"] = "1"
+            dist.destroy_process_group()
+            timeout = timedelta(seconds=1)
+            dist.init_process_group(
+                init_method=INIT_METHOD,
+                backend=BACKEND,
+                world_size=int(os.environ["WORLD_SIZE"]),
+                rank=self.rank,
+                timeout=timeout,
+            )
+
+            # Abort pg in background thread.
+            running = True
+
+            def abort():
+                pg = _get_default_group()
+                while running:
+                    pg._get_backend(torch.device(0))._abort()
+                    time.sleep(1)
+
+            if self.rank != 1:
+                import threading
+                t = threading.Thread(target=abort)
+                t.start()
+                with self.assertRaises(RuntimeError):
+                    # First collective triggers initialization via ncclCommInitRank.
+                    torch.distributed.barrier()
+                running = False
+                t.join()
+
 
 
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
Unit test seems to failing with:

```
[2023-06-20 19:30:18,212] torch.testing._internal.common_distributed: [ERROR] Caught exception: 
Traceback (most recent call last):
  File "torch/testing/_internal/common_distributed.py", line 657, in run_test
    getattr(self, test_name)()
  File "torch/testing/_internal/common_distributed.py", line 543, in wrapper
    fn()
  File "torch/testing/_internal/common_distributed.py", line 174, in wrapper
    return func(*args, **kwargs)
  File "torch/testing/_internal/distributed/distributed_test.py", line 9781, in test_nccl_init_abort
    torch.distributed.barrier(device_ids=[self.rank])
  File "torch/distributed/c10d_logger.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "torch/distributed/distributed_c10d.py", line 3652, in barrier
    work = default_pg.barrier(opts=opts)
torch.distributed.DistBackendError: NCCL error in: torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:1137, invalid usage, NCCL version 2.17.1
ncclInvalidUsage: This usually reflects invalid usage of NCCL library.
Last error:

Exception raised from getNCCLComm at torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:1137 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x1554fd0c1edc in torch/lib/libc10.so)
frame #1: <unknown function> + 0xcadb57 (0x1554fde39b57 in torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0xea0056 (0x1554fe02c056 in torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::allreduce_impl(std::vector<at::Tensor, std::allocator<at::Tensor> >&, c10d::AllreduceOptions const&) + 0x35 (0x1554fe02d8e5 in torch/lib/libtorch_cuda.so)
frame #4: c10d::ProcessGroupNCCL::allreduce(std::vector<at::Tensor, std::allocator<at::Tensor> >&, c10d::AllreduceOptions const&) + 0x3f7 (0x1554fe02fa47 in torch/lib/libtorch_cuda.so)
frame #5: c10d::ProcessGroupNCCL::barrier(c10d::BarrierOptions const&) + 0xb10 (0x1554fe03f3b0 in torch/lib/libtorch_cuda.so)
frame #6: <unknown function> + 0x55336b6 (0x15550d1166b6 in torch/lib/libtorch_cpu.so)
frame #7: <unknown function> + 0x553c68f (0x15550d11f68f in torch/lib/libtorch_cpu.so)
frame #8: <unknown function> + 0x5550251 (0x15550d133251 in torch/lib/libtorch_cpu.so)
frame #9: <unknown function> + 0xc38c56 (0x15551498ac56 in torch/lib/libtorch_python.so)
frame #10: <unknown function> + 0x3f5e2d (0x155514147e2d in torch/lib/libtorch_python.so)
```

Exception seems to be coming from this line: https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1128

Full output with `NCCL_DEBUG=INFO`: https://gist.github.com/pritamdamania87/334e2920202a133e19457b530cbb62b8