### PR TITLE
Skip Tensor-Tensor ops which have a Scalar input

### DIFF
--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -45,6 +45,13 @@ def remove_no_ops(
 
     def replace_no_op(node, replace_input_index):
         replacement = node.args[replace_input_index]
+
+        # https://github.com/pytorch/pytorch/issues/86128 causes
+        # non-Tensor inputs even for ops with only Tensor inputs.
+        # TODO - decompose/type promote to avoid this
+        if not all(isinstance(arg, torch.fx.Node) for arg in node.args):
+            return
+
         if not fake_tensors_eq(node.meta["val"], replacement.meta["val"]):
             if fake_tensors_eq(
                 node.meta["val"],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103928

The pass was assuming aten.mul.Tensor would have two Tensor inputs, as per its schema, but because of https://github.com/pytorch/pytorch/issues/86128 a Scalar may show up.

Fix for https://github.com/pytorch/pytorch/issues/103924

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78