### PR TITLE
[Pytorch] aten::expand

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Expand.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Expand.cpp
@@ -1,0 +1,87 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/repeat.h>
+#endif
+
+#include <ATen/native/vulkan/ops/Utils.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor expand(
+    const at::Tensor& self,
+    const IntArrayRef output_size,
+    bool implicit = false) {
+  TORCH_CHECK(
+      self.dim() > 0 && self.dim() <= 4,
+      "Vulkan expand supports up to 4d tensors");
+  TORCH_CHECK(
+      self.dim() <= output_size.size(),
+      "Vulkan expand: the number of sizes provided (",
+      output_size.size(),
+      ") must be greater or equal to the number of dimensions in the tensor (",
+      self.dim(),
+      ").");
+
+  std::vector<int64_t> repeat_size = std::vector<int64_t>(output_size.size());
+  std::vector<int64_t> input_size = self.sizes().vec();
+
+  int in_idx = input_size.size() - 1;
+  for (int i = output_size.size() - 1; i >= 0; --i) {
+    if (in_idx >= 0) {
+      TORCH_CHECK(
+          input_size[in_idx] == output_size[i] || input_size[in_idx] == 1 ||
+              output_size[i] == -1,
+          "Vulkan expand: the expanded size of the tensor (",
+          output_size[i],
+          ") must match the existing size (",
+          input_size[in_idx],
+          ") at non-singleton dimension ",
+          i);
+
+      if (input_size[in_idx] == output_size[i] || output_size[i] == -1) {
+        repeat_size[i] = 1;
+      } else if (input_size[in_idx] == 1) {
+        repeat_size[i] = output_size[i];
+      }
+      --in_idx;
+    } else {
+      TORCH_CHECK(
+          output_size[i] != -1,
+          "Vulkan expand: the expanded size of the tensor (-1) is not allowed in a leading, non-existing dimension 0.");
+
+      repeat_size[i] = output_size[i];
+    }
+  }
+
+  return self.repeat(repeat_size);
+}
+
+Tensor expand_as(const at::Tensor& self, const at::Tensor& other) {
+  return expand(self, other.sizes());
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::expand"), TORCH_FN(expand));
+  m.impl(TORCH_SELECTIVE_NAME("aten::expand_as"), TORCH_FN(expand_as));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary:
Expand using `aten::repeat` for all dims

[expand](https://pytorch.org/docs/stable/generated/torch.Tensor.expand.html#torch.Tensor.expand)
[expand_as](
https://pytorch.org/docs/stable/generated/torch.Tensor.expand_as.html)

Test Plan:
clang-format on `Expand.cpp`
expand tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*.expand*"
Action graph will be rebuilt because files have been added or removed.

Parsing buck files: finished in 1.1 sec
Downloaded 5/50 artifacts, 661.18 Kbytes, 37.5% cache miss (for updated rules)
Building: finished in 15.4 sec (100%) 515/515 jobs, 15/515 updated
  Total time: 16.9 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *.expand*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.expand_exceptions
[       OK ] VulkanAPITest.expand_exceptions (66 ms)
[ RUN      ] VulkanAPITest.expand_1d
[       OK ] VulkanAPITest.expand_1d (7 ms)
[ RUN      ] VulkanAPITest.expand_2d
[       OK ] VulkanAPITest.expand_2d (2 ms)
[ RUN      ] VulkanAPITest.expand_3d
[       OK ] VulkanAPITest.expand_3d (2 ms)
[ RUN      ] VulkanAPITest.expand_4d
[       OK ] VulkanAPITest.expand_4d (4 ms)
[ RUN      ] VulkanAPITest.expand_as
[       OK ] VulkanAPITest.expand_as (11 ms)
[----------] 6 tests from VulkanAPITest (95 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (95 ms total)
[  PASSED  ] 6 tests.
lfq@lfq-mbp fbsource %
```

Differential Revision: D46302042

