### PR TITLE
[cuDNN][cuDNN V8 API] Thread safety fixes for cuDNN V8 API

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -225,8 +225,8 @@ void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const
   // @eqy: temporary workaround for cudnnBackendExecute thread-safety bug
   {
     std::lock_guard<std::mutex> guard(execution_mutex);
+    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
   }
-  AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
 }
 
 void run_conv_plan_fused(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const Tensor& z, const Tensor& b, const cudnn_frontend::ExecutionPlan& plan) {
@@ -240,7 +240,11 @@ void run_conv_plan_fused(cudnnHandle_t handle, const Tensor& x, const Tensor& y,
       .setDataPointers(5, data_ptrs)
       .setUids(5, uids)
       .build();
-  AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
+  // @eqy: temporary workaround for cudnnBackendExecute thread-safety bug
+  {
+    std::lock_guard<std::mutex> guard(execution_mutex);
+    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
+  }
 }
 
 auto build_opgraph(const cudnnHandle_t handle, const cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, const CacheKey& key, const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -158,7 +158,6 @@ struct CacheKeyFused {
 
 template <typename T, typename KeyType>
 struct BenchmarkCache {
-std::mutex mutex;
 std::unordered_map<KeyType, cudnn_frontend::ExecutionPlan, ParamsHash<KeyType>, ParamsEqual<KeyType>> engine_cache;
 
 // no mutexes here as caches are now thread local for v8, can also return a pointer

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -31,8 +31,6 @@ C10_DIAGNOSTIC_POP()
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 
-#include <mutex>
-#include <optional>
 #include <unordered_map>
 
 #ifndef AT_PER_OPERATOR_HEADERS


### PR DESCRIPTION
(this these two fixes are now oudated, see EDIT below)
Fixes for two thread safety issues (one currently unobserved, and one currently observed).
1. `std::erase` can potentially invalidate a pointer to an `ExecutionPlan` in the current implementation. While failures due to this issue have not yet been reported to my knowledge, it is better to return a copy of an `ExecutionPlan` for safety.
2. #103793 surfaced that `cudnnBackendExecute` appears to currently be thread-unsafe. I've verified this with a PyTorch free (pure C++) repro using the cuDNN frontend. This PR addes a mutex that we can hopefully once this issue is resolved.

EDIT:
Feedback from cuDNN is that the V8 backend API has known thread-safety limitations when `ExecutionPlan`s are shared (or even shallow copied) across threads. Given that the common PyTorch use case of eager-mode is singlethreaded (per GPU), this PR now opts to make `ExecutionPlan` caches `thread_local`, as this simplifies the code and eliminates the need for a mutex. The potential tradeoff is some additional warmup cost in multithreaded case, but this would also only be worse than the current case if multiple threads had largely overlapping workloads.

CC @tuero @ptrblck @malfet 

cc @csarofeen @ptrblck @xwang233