### PR TITLE
[PyTorch Vulkan] add Vulkan support for `aten::tile`

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Tile.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tile.cpp
@@ -1,0 +1,48 @@
+#include <ATen/native/vulkan/ops/Common.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/repeat.h>
+#endif
+
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor tile(const Tensor& self, const IntArrayRef repeats) {
+  // If self.size() > len(reps), reps is promoted to self.size() by pre-pending
+  // 1’s to it to keep the same behaviour as `numpy.tile`.
+  // Thus for a tensor of shape (2, 3, 4, 5), a dims of (2, 2) is treated
+  // as (1, 1, 2, 2).
+  const int64_t size_diff = self.dim() - static_cast<int64_t>(repeats.size());
+  if (size_diff > 0) {
+    std::vector<int64_t> new_repeats(size_diff, 1);
+    for (const auto i : c10::irange(repeats.size())) {
+      new_repeats.emplace_back(repeats[i]);
+    }
+    return self.repeat(IntArrayRef(new_repeats));
+  }
+  return self.repeat(repeats);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::tile"), TORCH_FN(tile));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary: We implement `aten::tile` on Vulkan backend through `aten::repeat`. The behavior of `aten::tile` is demonstrated here https://pytorch.org/docs/stable/generated/torch.tile.html

Test Plan:
Run tests for combinations of input dim between 1 and 4 and repeats of size  between 1 and 4. When a test case fails, the shape info is printed, e.g. `Tile test failed when input is of shape [13, 5] and repeat of [7, 2, 3]`.

```
(base) luwei@luwei-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*tile*"
Building: finished in 0.1 sec (100%) 263/2812 jobs, 0/2812 updated
  Total time: 0.1 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *tile*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.tile_invalid_inputs_exceptions
[       OK ] VulkanAPITest.tile_invalid_inputs_exceptions (34 ms)
[ RUN      ] VulkanAPITest.tile_invalid_outpus_exceptions
[       OK ] VulkanAPITest.tile_invalid_outpus_exceptions (2 ms)
[ RUN      ] VulkanAPITest.tile
[       OK ] VulkanAPITest.tile (63 ms)
[----------] 3 tests from VulkanAPITest (100 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (100 ms total)
[  PASSED  ] 3 tests.
```

Reviewed By: yipjustin

Differential Revision: D46367170

