### PR TITLE
improve repr for pytrees

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -211,11 +211,12 @@ class TestPytree(TestCase):
         pytree = (0, [0, 0, [0]])
         _, spec = tree_flatten(pytree)
         self.assertEqual(repr(spec), ("TreeSpec(tuple, None, [*,\n"
-                                      "                       TreeSpec(list, None, [*,\n"
-                                      "                                             *,\n"
-                                      "                                             TreeSpec(list, None, [*])])])"))
+                                      "  TreeSpec(list, None, [*,\n"
+                                      "    *,\n"
+                                      "    TreeSpec(list, None, [*])])])"))
 
     def test_broadcast_to_and_flatten(self):
+
         cases = [
             (1, (), []),
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -251,7 +251,7 @@ class TreeSpec:
         repr_prefix: str = f'TreeSpec({self.type.__name__}, {self.context}, ['
         children_specs_str: str = ''
         if len(self.children_specs):
-            indent += len(repr_prefix)
+            indent += 2
             children_specs_str += self.children_specs[0].__repr__(indent)
             children_specs_str += ',' if len(self.children_specs) > 1 else ''
             children_specs_str += ','.join(['\n' + ' ' * indent + child.__repr__(indent) for child in self.children_specs[1:]])


### PR DESCRIPTION
The current thing indents based on the length of the previous line, which is totally unreadable if, e.g. the treespec is a dict with a lot of keys, since all the keys will go on a ginormous line and everything after will be super indented.

Fix the indentation at 2, which is much more compact.

Fixes #ISSUE_NUMBER
