### PR TITLE
Fix optimizer grad mode state interaction with dynamo

### DIFF
--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -31,9 +31,9 @@ def make_test(optim_cls, closure=None, **kwargs):
 
         # unwrap step to avoid a deliberate graph break due to
         # a limitation of functionalization/no_grad detection
-        # see the comment in optimizer.py
-        # This unrwaps _use_grad_if_differentiable, and we don't support
-        # differentiable optimizers anyway
+        # see the [Note on graph break] in optimizer.py 
+        # This ignores the outer _use_grad_if_differentiable wrapper, which is fine for now
+        # as dynamo does not support differentiable optimizers anyway
         step_fn = opt.step.__wrapped__
         if closure is not None:
 

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -32,6 +32,8 @@ def make_test(optim_cls, closure=None, **kwargs):
         # unwrap step to avoid a deliberate graph break due to
         # a limitation of functionalization/no_grad detection
         # see the comment in optimizer.py
+        # This unrwaps _use_grad_if_differentiable, and we don't support
+        # differentiable optimizers anyway
         step_fn = opt.step.__wrapped__
         if closure is not None:
 

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -31,7 +31,7 @@ def make_test(optim_cls, closure=None, **kwargs):
 
         # unwrap step to avoid a deliberate graph break due to
         # a limitation of functionalization/no_grad detection
-        # see the [Note on graph break] in optimizer.py 
+        # see the [Note on graph break] in optimizer.py
         # This ignores the outer _use_grad_if_differentiable wrapper, which is fine for now
         # as dynamo does not support differentiable optimizers anyway
         step_fn = opt.step.__wrapped__

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -25,15 +25,26 @@ def make_test(optim_cls, closure=None, **kwargs):
 
     def test_fn(self):
         nonlocal opt
+
+        # run the patcher so that step has the expected structure
+        torch._dynamo.eval_frame.TorchPatcher.patch()
+
+        # unwrap step to avoid a deliberate graph break due to
+        # a limitation of functionalization/no_grad detection
+        # see the comment in optimizer.py
+        step_fn = opt.step.__wrapped__
         if closure is not None:
 
             def fn():
-                opt.step(closure)
+                step_fn(opt, closure)
 
         else:
-            fn = opt.step
 
-        torch.compile(fn, backend="eager", fullgraph=True)()
+            def fn():
+                step_fn(opt)
+
+        with torch.set_grad_enabled(False):
+            torch.compile(fn, backend="eager", fullgraph=True)()
 
     return test_fn
 

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -23,6 +23,11 @@ class GuardInstallException(Exception):
 
 
 class OptimizerVariable(UserDefinedObjectVariable):
+    def __init__(self, value, grad_to_source=None, **kwargs):
+        super().__init__(value, **kwargs)
+        if grad_to_source is None:
+            self.grad_to_source = {}
+
     def call_method(
         self,
         tx,

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -36,6 +36,9 @@ def _use_grad_for_differentiable(func):
             torch.set_grad_enabled(self.defaults['differentiable'])
             ret = func(self, *args, **kwargs)
         finally:
+            # Graph break to ensure AOT correctly runs this
+            # as an inference graph
+            torch._dynamo.graph_break()
             torch.set_grad_enabled(prev_grad)
         return ret
     functools.update_wrapper(_use_grad, func)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -30,7 +30,9 @@ required = _RequiredParameter()
 
 
 def _use_grad_for_differentiable(func):
+
     def _use_grad(self, *args, **kwargs):
+        import torch._dynamo
         prev_grad = torch.is_grad_enabled()
         try:
             # Note on graph break below:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -46,6 +46,7 @@ def _use_grad_for_differentiable(func):
             # In the future, we will either 1) continue to graph break on backward, so this graph break does not matter
             # or 2) have a fully fused forward and backward graph, which will have no_grad by default, and we can remove this
             # graph break to allow the fully fused fwd-bwd-optimizer graph to be compiled.
+            # see https://github.com/pytorch/pytorch/issues/104053
             torch.set_grad_enabled(self.defaults['differentiable'])
             torch._dynamo.graph_break()
             ret = func(self, *args, **kwargs)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -30,7 +30,6 @@ required = _RequiredParameter()
 
 
 def _use_grad_for_differentiable(func):
-
     def _use_grad(self, *args, **kwargs):
         import torch._dynamo
         prev_grad = torch.is_grad_enabled()


### PR DESCRIPTION
Graph break before restoring the grad mode to ensure dynamo respects `no_grad`. This isn't a bug necessarily, but this will allow us to get good perf until aot is updated.

https://github.com/pytorch/pytorch/issues/104053

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78