### PR TITLE
Fix device of lengths in pack_padded_sequence when the default device is GPU

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -248,7 +248,7 @@ def pack_padded_sequence(
                           'values, and it will treat them as constants, likely rendering '
                           'the trace incorrect for any other combination of lengths.',
                           stacklevel=2)
-        lengths = torch.as_tensor(lengths, dtype=torch.int64)
+        lengths = torch.as_tensor(lengths, dtype=torch.int64, device='cpu')
     else:
         lengths = lengths.to(dtype=torch.int64)
 


### PR DESCRIPTION
Fixes #103964

Always create the `lengths` tensor on cpu