### PR TITLE
Pass in .so name via lower setting

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -656,7 +656,10 @@ class AotCodeCache:
             lock_dir = get_lock_dir()
             lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
             with lock:
-                output_so = f"{input_path[:-4]}.so"
+                output_so_dir = input_path[:-4]
+                if not os.path.exists(output_so_dir):
+                    os.makedirs(output_so_dir, exist_ok=True)
+                output_so = f"{output_so_dir}/{config.dll_name}.so"
                 if not os.path.exists(output_so):
                     cmd = cpp_compile_command(
                         input=input_path,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -51,6 +51,9 @@ split_cat_fx_passes = True
 # enable reordering pass
 reordering = True
 
+# inductor engine name
+dll_name = "inductor_engine.so"
+
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 


### PR DESCRIPTION
Summary:
After change the .so is under
/tmp/torchinductor_shirong/inductor_engine.so

Test Plan:
CUDA_VISIBLE_DEVICES=5 ../buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file.par  --action=generate --input_file=/tmp/403237826.tp --output_file=/tmp/403237826_999.predictor.disagg.gpu.merge   --lower_backend inductor

result
```
[shirong@devgpu001.nao2 ~/fbsource/fbcode (21e7abb15)]$ ls /tmp/torchinductor_shirong/62/c62valbeuhijck4v6jzjot44ydjjv5bwhwrycdmm67vs5t66dddx
test_name_1.so
```

generated command:
```
g++ /tmp/torchinductor_shirong/62/c62valbeuhijck4v6jzjot44ydjjv5bwhwrycdmm67vs5t66dddx.cpp -shared -fPIC -Wall -std=c++17 -Wno-unused-variable -I/data/users/shirong/fbsource/buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file#link-tree/torch/include -I/data/users/shirong/fbsource/buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file#link-tree/torch/include/torch/csrc/api/include -I/data/users/shirong/fbsource/buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file#link-tree/torch/include/TH -I/data/users/shirong/fbsource/buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file#link-tree/torch/include/THC -I/usr/local/cuda/include -I/usr/local/fbcode/platform010/include/python3.8 -L/data/users/shirong/fbsource/buck-out/v2/gen/fbcode/806bf3d25d2aa9ce/caffe2/torch/fb/model_transform/fx2trt/packaging/__generate_merge_net_file__/generate_merge_net_file#link-tree/torch/lib -L/usr/local/cuda/lib64 -L/usr/local/fbcode/platform010/lib -lgomp -lcuda -O3 -ffast-math -fno-finite-math-only -march=native -fopenmp -D C10_USING_CUSTOM_GENERATED_MACROS -D C10_USE_GLOG -D C10_USE_MINIMAL_GLOG -D C10_MOBILE -o /tmp/torchinductor_shirong/62/c62valbeuhijck4v6jzjot44ydjjv5bwhwrycdmm67vs5t66dddx/test_name_1.so
```

Reviewed By: desertfire

Differential Revision: D46816183



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78