### PR TITLE
[inductor] Add triton_helpers.any instead of reusing max

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1315,11 +1315,8 @@ class TritonKernel(Kernel):
         reduction_sizes = ["None" for _ in self.range_trees]
         reduction_sizes[-1] = ":"
 
-        if reduction_type == "any":
-            reduction_type = "max"
-
         def final_reduction(value):
-            use_helper = reduction_type in {"max", "min", "prod"}
+            use_helper = reduction_type in {"any", "max", "min", "prod"}
             module = "triton_helpers" if use_helper else "tl"
             if reduction_type in {"max", "min"}:
                 return self.reduction_resize(

--- a/torch/_inductor/triton_helpers.py
+++ b/torch/_inductor/triton_helpers.py
@@ -166,3 +166,20 @@ def randint64(seed, offset, low, high):
     result = result % size.to(tl.uint64)
     result = result.to(tl.int64) + low
     return result
+
+
+if TRITON_HAS_REDUCE:
+
+    @triton.jit
+    def _any_combine(a, b):
+        return a | b
+
+    @triton.jit
+    def any(a, dim):
+        return tl.reduce(a, dim, _any_combine)
+
+else:
+
+    @triton.jit
+    def any(a, dim):
+        return tl.max(a, dim)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103974

I doubt there's much difference in performance, but this improves readability of
the generated code, e.g.

```python
tmp8 = triton_helpers.max2(tmp7, 1)[:, None]
```
becomes
```python
tmp8 = triton_helpers.any(tmp7, 1)[:, None]
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78