### PR TITLE
Link new PyTorch Contributing Guidelines from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,24 +57,13 @@
 
 ## Contributing to PyTorch
 
-Thank you for your interest in contributing to PyTorch! Before you begin writing code, it is important
-that you share your intention to contribute with the team, based on the type of contribution:
+Thank you for your interest in contributing to PyTorch!
+If you're a new contributor, please first take a read through our
+[Contributing Guidelines](https://docs.google.com/document/d/1oNhUeGE-8ajsYaMpoV6ZQANQZVeKrdFanI9VMbFzOzc/edit)
+that walks through the process of contributing a change to PyTorch.
 
-1. You want to propose a new feature and implement it.
-    - Post about your intended feature in an [issue](https://github.com/pytorch/pytorch/issues),
-    and we shall discuss the design and implementation. Once we agree that the plan looks good,
-    go ahead and implement it.
-2. You want to implement a feature or bug-fix for an outstanding issue.
-    - Search for your issue in the [PyTorch issue list](https://github.com/pytorch/pytorch/issues).
-    - Pick an issue and comment that you'd like to work on the feature or bug-fix.
-    - If you need more context on a particular issue, please ask and we shall provide.
-
-Once you implement and test your feature or bug-fix, please submit a Pull Request to
-https://github.com/pytorch/pytorch.
-
-This document covers some of the more technical aspects of contributing
-to PyTorch.  For more non-technical guidance about how to contribute to
-PyTorch, see the [Contributing Guide](docs/source/community/contribution_guide.rst).
+The rest of this document (CONTRIBUTING.md) covers some of the more technical
+aspects of contributing to PyTorch.
 
 ## Developing PyTorch
 Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source). If you get stuck when developing PyTorch on your machine, check out the [tips and debugging](#tips-and-debugging) section below for common solutions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+Thank you for your interest in contributing to PyTorch!
+If you're a new contributor, please first take a read through our
+[Contributing Guidelines](https://docs.google.com/document/d/1oNhUeGE-8ajsYaMpoV6ZQANQZVeKrdFanI9VMbFzOzc/edit)
+
 # Table of Contents
 
 <!-- toc -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,15 @@
 Thank you for your interest in contributing to PyTorch!
 If you're a new contributor, please first take a read through our
 [Contributing Guidelines](https://docs.google.com/document/d/1oNhUeGE-8ajsYaMpoV6ZQANQZVeKrdFanI9VMbFzOzc/edit)
+that walks through the process of contributing a change to PyTorch.
+
+The rest of this document (CONTRIBUTING.md) covers some of the more technical
+aspects of contributing to PyTorch.
 
 # Table of Contents
 
 <!-- toc -->
 
-- [Contributing to PyTorch](#contributing-to-pytorch)
 - [Developing PyTorch](#developing-pytorch)
   - [Tips and Debugging](#tips-and-debugging)
 - [Nightly Checkout & Pull](#nightly-checkout--pull)
@@ -58,16 +61,6 @@ If you're a new contributor, please first take a read through our
 - [Dev Infra Office Hours](#dev-infra-office-hours)
 
 <!-- tocstop -->
-
-## Contributing to PyTorch
-
-Thank you for your interest in contributing to PyTorch!
-If you're a new contributor, please first take a read through our
-[Contributing Guidelines](https://docs.google.com/document/d/1oNhUeGE-8ajsYaMpoV6ZQANQZVeKrdFanI9VMbFzOzc/edit)
-that walks through the process of contributing a change to PyTorch.
-
-The rest of this document (CONTRIBUTING.md) covers some of the more technical
-aspects of contributing to PyTorch.
 
 ## Developing PyTorch
 Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source). If you get stuck when developing PyTorch on your machine, check out the [tips and debugging](#tips-and-debugging) section below for common solutions.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #103986

We wrote some new Contributing Guidelines that guide a contributor
through the lifecycle of a Pull Request to PyTorch.

We've gotten some positive feedback from early adopters so we are now
adding it as the go-to link in CONTRIBUTING.md and the PyTorch Wiki.

Note that there are older contributing guidelines over at
https://github.com/pytorch/pytorch/blob/main/docs/source/community/contribution_guide.rst
The new Contributing Guidelines doc is targeted towards guiding a user
through submitting and merging a Pull Request to pytorch; the existing
guidelines are more of a high-level overview. We should rationalize these
at some point, but I left the resources for now.