### PR TITLE
Upgrade Pybind submodule to 2.10.4

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -140,7 +140,7 @@ fi
 # ASAN test is not working
 if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     export ASAN_OPTIONS=detect_leaks=0:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true
-    export UBSAN_OPTIONS=print_stacktrace=1
+    export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/ubsan.supp
     export PYTORCH_TEST_WITH_ASAN=1
     export PYTORCH_TEST_WITH_UBSAN=1
     # TODO: Figure out how to avoid hard-coding these paths

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -141,6 +141,7 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
 
 PyRRef::~PyRRef() {
   if (type_.has_value()) {
+    pybind11::gil_scoped_acquire ag;
     (*type_).dec_ref();
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
     // decref on the PyObject again.

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,1 +1,1 @@
-vptr:warn_mod.so
+vptr:pybind11::detail::translate_exception

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,0 +1,1 @@
+vptr:warn_mod.so


### PR DESCRIPTION
EDIT: since the final failing function is in libtorch_python.so, we would need to skip that whole lib (not ok). So now we're skipping based on the function name which should be restrictive enough to not hide any real bug.

The decref was tracked down and fixed here.

Old comment:
This is not ready for review, this is to make sure asan is fixed.
Not sure what is the most effective way to track down the bad dec_ref within deploy yet.

The asan silencing is done to match this comment:
https://github.com/pytorch/pytorch/blob/1c79003b3c13c7bc47e5796e4451d6565121f3a0/test/test_cpp_extensions_jit.py#L749-L752
cc @Skylion007 