### PR TITLE
Fix wrong ifdef for xnnpack shim

### DIFF
--- a/aten/src/ATen/native/xnnpack/Shim.cpp
+++ b/aten/src/ATen/native/xnnpack/Shim.cpp
@@ -16,7 +16,6 @@
 namespace at {
 namespace native {
 namespace xnnpack {
-
 namespace internal {
 namespace {
 
@@ -26,54 +25,11 @@ constexpr const char * const kError =
 } // namespace
 } // namespace internal
 
-bool available();
-bool use_convolution2d(
-    const Tensor&,
-    const Tensor&,
-    const at::OptionalIntArrayRef,
-    const IntArrayRef,
-    const IntArrayRef,
-    const IntArrayRef,
-    const int64_t,
-    bool);
-Tensor convolution2d(
-    const Tensor&,
-    const Tensor&,
-    const Tensor&,
-    const IntArrayRef,
-    const IntArrayRef,
-    const IntArrayRef,
-    const int64_t);
-
-bool use_linear(const Tensor&, const Tensor&, const Tensor&);
-
-Tensor linear(const Tensor&, const Tensor&, const Tensor&);
-
-bool use_max_pool2d(
-    const Tensor&,
-    const IntArrayRef,
-    const IntArrayRef,
-    IntArrayRef,
-    const IntArrayRef,
-    const bool,
-    const float,
-    const float);
-
-Tensor max_pool2d(
-    const Tensor&,
-    const IntArrayRef,
-    const IntArrayRef,
-    IntArrayRef,
-    const IntArrayRef,
-    const bool,
-    const float,
-    const float);
-
-bool available() {
+static bool available() {
     return false;
 }
 
-bool use_convolution2d(
+static bool use_convolution2d(
     const Tensor&,
     const Tensor&,
     const at::OptionalIntArrayRef,
@@ -85,7 +41,7 @@ bool use_convolution2d(
   return false;
 }
 
-Tensor convolution2d(
+static Tensor convolution2d(
     const Tensor&,
     const Tensor&,
     const Tensor&,
@@ -96,21 +52,21 @@ Tensor convolution2d(
   TORCH_CHECK(false, internal::kError);
 }
 
-bool use_linear(
+static bool use_linear(
     const Tensor&,
     const Tensor&,
     const Tensor&) {
   return false;
 }
 
-Tensor linear(
+static Tensor linear(
     const Tensor&,
     const Tensor&,
     const Tensor&) {
   TORCH_CHECK(false, internal::kError);
 }
 
-bool use_max_pool2d(
+static bool use_max_pool2d(
     const Tensor&,
     const IntArrayRef,
     const IntArrayRef,
@@ -122,7 +78,7 @@ bool use_max_pool2d(
   return false;
 }
 
-Tensor max_pool2d(
+static Tensor max_pool2d(
     const Tensor&,
     const IntArrayRef,
     const IntArrayRef,

--- a/aten/src/ATen/native/xnnpack/Shim.cpp
+++ b/aten/src/ATen/native/xnnpack/Shim.cpp
@@ -17,6 +17,15 @@ namespace at {
 namespace native {
 namespace xnnpack {
 
+namespace internal {
+namespace {
+
+constexpr const char * const kError =
+    "Not Implemented! Reason: PyTorch not built with XNNPACK support.";
+
+} // namespace
+} // namespace internal
+
 bool available();
 bool use_convolution2d(
     const Tensor&,
@@ -59,15 +68,6 @@ Tensor max_pool2d(
     const bool,
     const float,
     const float);
-
-namespace internal {
-namespace {
-
-constexpr const char * const kError =
-    "Not Implemented! Reason: PyTorch not built with XNNPACK support.";
-
-} // namespace
-} // namespace internal
 
 bool available() {
     return false;

--- a/aten/src/ATen/native/xnnpack/Shim.cpp
+++ b/aten/src/ATen/native/xnnpack/Shim.cpp
@@ -1,4 +1,4 @@
-#ifndef USE_XNNPACK
+#ifdef USE_XNNPACK
 
 #include <ATen/native/xnnpack/Common.h>
 #include <ATen/core/Tensor.h>

--- a/aten/src/ATen/native/xnnpack/Shim.cpp
+++ b/aten/src/ATen/native/xnnpack/Shim.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_XNNPACK
+#ifndef USE_XNNPACK
 
 #include <ATen/native/xnnpack/Common.h>
 #include <ATen/core/Tensor.h>
@@ -16,6 +16,50 @@
 namespace at {
 namespace native {
 namespace xnnpack {
+
+bool available();
+bool use_convolution2d(
+    const Tensor&,
+    const Tensor&,
+    const at::OptionalIntArrayRef,
+    const IntArrayRef,
+    const IntArrayRef,
+    const IntArrayRef,
+    const int64_t,
+    bool);
+Tensor convolution2d(
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const IntArrayRef,
+    const IntArrayRef,
+    const IntArrayRef,
+    const int64_t);
+
+bool use_linear(const Tensor&, const Tensor&, const Tensor&);
+
+Tensor linear(const Tensor&, const Tensor&, const Tensor&);
+
+bool use_max_pool2d(
+    const Tensor&,
+    const IntArrayRef,
+    const IntArrayRef,
+    IntArrayRef,
+    const IntArrayRef,
+    const bool,
+    const float,
+    const float);
+
+Tensor max_pool2d(
+    const Tensor&,
+    const IntArrayRef,
+    const IntArrayRef,
+    IntArrayRef,
+    const IntArrayRef,
+    const bool,
+    const float,
+    const float);
+
 namespace internal {
 namespace {
 


### PR DESCRIPTION
Fixes a missing prototype warning when these sources are trying to be build with XNN_PACK turned off.
