### PR TITLE
Make PyTorch compilable without XNNPACK

### DIFF
--- a/aten/src/ATen/native/xnnpack/Activation.cpp
+++ b/aten/src/ATen/native/xnnpack/Activation.cpp
@@ -4,9 +4,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #include <ATen/native/utils/Factory.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 
 bool use_hardswish(
@@ -91,8 +89,6 @@ Tensor& hardswish_(Tensor& input) {
   }
 }
 
-}
-}
-}
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/AveragePooling.cpp
+++ b/aten/src/ATen/native/xnnpack/AveragePooling.cpp
@@ -5,9 +5,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #include <ATen/native/xnnpack/Pooling.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 bool use_global_average_pool(
   const Tensor& input) {
@@ -79,8 +77,7 @@ Tensor global_average_pool(
 
   return output.to(input.suggest_memory_format());
 }
-}
-}
-}
+
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/ChannelShuffle.cpp
+++ b/aten/src/ATen/native/xnnpack/ChannelShuffle.cpp
@@ -4,9 +4,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #include <ATen/native/utils/Factory.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 bool use_channel_shuffle(
     const Tensor& input,
@@ -103,8 +101,6 @@ Tensor channel_shuffle(
   return output_padded_contig_nhwc.contiguous(input.suggest_memory_format());
 }
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Common.h
+++ b/aten/src/ATen/native/xnnpack/Common.h
@@ -8,9 +8,7 @@
 #include <limits>
 #include <memory>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 struct Deleter final {
   void operator()(const xnn_operator_t op) const {
@@ -65,8 +63,6 @@ struct ContextConv2D final {
   static constexpr float kMax = std::numeric_limits<float>::infinity();
 };
 
-
-bool available();
 
 namespace internal {
 
@@ -123,8 +119,6 @@ struct Layout final {
   };
 };
 } // namespace internal
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Common.h
+++ b/aten/src/ATen/native/xnnpack/Common.h
@@ -122,3 +122,7 @@ struct Layout final {
 } // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */
+
+namespace at::native::xnnpack {
+bool available();
+} // namespace at::native::xnnpack

--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -10,9 +10,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #include <c10/util/irange.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 namespace internal {
 namespace convolution2d {
 
@@ -496,9 +494,6 @@ Tensor convolution2d(
       ContextConv2D::kMax);
 }
 
-} // namespace xnnpack
-
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Convolution.h
+++ b/aten/src/ATen/native/xnnpack/Convolution.h
@@ -6,11 +6,8 @@
 #include <ATen/native/xnnpack/Common.h>
 #include <ATen/native/xnnpack/OpContext.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
-namespace internal {
-namespace convolution2d {
+namespace at::native::xnnpack {
+namespace internal::convolution2d {
 
 c10::intrusive_ptr<xnnpack::Conv2dOpContext>
     createConv2dClampPrePackOpContext(
@@ -60,8 +57,7 @@ ContextConv2D create(
 
 Tensor run(ContextConv2D& context, const Tensor& input);
 
-} // namespace convolution2d
-} // namespace internal
+} // namespace internal::convolution2d
 
 Tensor convolution2d(
     const Tensor& input,
@@ -71,8 +67,6 @@ Tensor convolution2d(
     const IntArrayRef stride,
     const IntArrayRef dilation,
     const int64_t groups);
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Engine.h
+++ b/aten/src/ATen/native/xnnpack/Engine.h
@@ -3,9 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <limits>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 //
 // Convolution
@@ -94,6 +92,6 @@ bool use_hardswish(const Tensor& input);
 Tensor hardswish(const Tensor& input);
 Tensor& hardswish_(Tensor& input);
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+bool available();
+
+} // namespace at::native::xnnpack

--- a/aten/src/ATen/native/xnnpack/Engine.h
+++ b/aten/src/ATen/native/xnnpack/Engine.h
@@ -92,6 +92,4 @@ bool use_hardswish(const Tensor& input);
 Tensor hardswish(const Tensor& input);
 Tensor& hardswish_(Tensor& input);
 
-bool available();
-
 } // namespace at::native::xnnpack

--- a/aten/src/ATen/native/xnnpack/Init.cpp
+++ b/aten/src/ATen/native/xnnpack/Init.cpp
@@ -3,9 +3,7 @@
 #include <ATen/native/xnnpack/Common.h>
 #include <c10/util/Exception.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 namespace internal {
 namespace {
 
@@ -57,8 +55,6 @@ bool available() {
   return internal::initialize();
 }
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Linear.cpp
+++ b/aten/src/ATen/native/xnnpack/Linear.cpp
@@ -4,11 +4,8 @@
 #include <ATen/native/utils/Factory.h>
 #include <ATen/native/xnnpack/Linear.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
-namespace internal {
-namespace linear {
+namespace at::native::xnpack {
+namespace internal::linear {
 
 namespace {
 
@@ -64,7 +61,7 @@ Tensor create_and_run(
       input);
 }
 
-} // namespace
+} // anonymous namespace
 
 ContextLinear create(
     const Tensor& weight,
@@ -191,8 +188,7 @@ unpack_prepacked_sizes_linear(const IValue& ivalue) {
       (bias && bias->defined()) ? at::OptionalIntArrayRef(bias->sizes()) : c10::nullopt));
 }
 
-} // namespace linear
-} // namespace internal
+} // namespace internal::linear
 
 bool use_linear(
     const Tensor& input,
@@ -219,9 +215,6 @@ Tensor linear(
       ContextLinear::kMax);
 }
 
-} // namespace xnnpack
-
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Linear.cpp
+++ b/aten/src/ATen/native/xnnpack/Linear.cpp
@@ -4,7 +4,7 @@
 #include <ATen/native/utils/Factory.h>
 #include <ATen/native/xnnpack/Linear.h>
 
-namespace at::native::xnpack {
+namespace at::native::xnnpack {
 namespace internal::linear {
 
 namespace {

--- a/aten/src/ATen/native/xnnpack/Linear.h
+++ b/aten/src/ATen/native/xnnpack/Linear.h
@@ -6,11 +6,8 @@
 #include <ATen/native/xnnpack/Common.h>
 #include <ATen/native/xnnpack/OpContext.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
-namespace internal {
-namespace linear {
+namespace at::native::xnnpack {
+namespace internal::linear {
 
 c10::intrusive_ptr<xnnpack::LinearOpContext> createLinearClampPrePackOpContext(
     Tensor weight,
@@ -30,8 +27,7 @@ ContextLinear create(
     const float output_max);
 
 Tensor run(const ContextLinear& context, const Tensor& input);
-} // namespace linear
-} // namespace internal
+} // namespace internal::linear
 
 bool use_linear(
     const Tensor& input,
@@ -42,8 +38,7 @@ Tensor linear(
     const Tensor& input,
     const Tensor& weight,
     const Tensor& bias);
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/MaxPooling.cpp
+++ b/aten/src/ATen/native/xnnpack/MaxPooling.cpp
@@ -6,9 +6,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #include <ATen/native/xnnpack/Pooling.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 // Supports NHWC and NCHW FP32 max pooling with any
 //  - kernel size
@@ -240,8 +238,6 @@ Tensor max_pool2d(
   return output_padded_contig_nhwc.contiguous(input.suggest_memory_format());
 }
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/OpContext.cpp
+++ b/aten/src/ATen/native/xnnpack/OpContext.cpp
@@ -5,9 +5,7 @@
 
 #include <ATen/Context.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 c10::intrusive_ptr<LinearOpContext>
 XNNPackLinearOpContext::create_context(
@@ -156,8 +154,6 @@ void XNNPackTransposeConv2dOpContext::free_orig_weight_and_bias() {
   orig_bias_.reset();
 }
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/OpContext.h
+++ b/aten/src/ATen/native/xnnpack/OpContext.h
@@ -6,9 +6,7 @@
 #include <ATen/native/xnnpack/Common.h>
 #include <ATen/Tensor.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 using SerializationTypeLinearPrePack = std::tuple<
     Tensor,
@@ -245,9 +243,6 @@ class XNNPackTransposeConv2dOpContext final : public TransposeConv2dOpContext {
       const c10::optional<Scalar>& output_max);
 };
 
-} // namespace xnnpack
-
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Pooling.h
+++ b/aten/src/ATen/native/xnnpack/Pooling.h
@@ -4,11 +4,7 @@
 
 #include <ATen/Tensor.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
-namespace internal {
-namespace pooling {
+namespace at::native::xnnpack::internal::pooling {
 
 struct Parameters final {
 
@@ -41,10 +37,6 @@ private:
   }
 };
 
-} // namespace pooling
-} // namespace internal
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack::internal::pooling
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
+++ b/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
@@ -7,9 +7,7 @@
 #include <ATen/Tensor.h>
 #include <torch/custom_class.h>
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 
 using internal::linear::createLinearClampPrePackOpContext;
 using internal::convolution2d::createConv2dClampPrePackOpContext;
@@ -93,8 +91,6 @@ TORCH_LIBRARY_IMPL(prepacked, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("prepacked::conv2d_transpose_clamp_run"), TORCH_FN(internal::convolution2d::conv2d_transpose_clamp_run));
 }
 
-} // namespace xnnpack
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Shim.cpp
+++ b/aten/src/ATen/native/xnnpack/Shim.cpp
@@ -1,6 +1,7 @@
 #ifndef USE_XNNPACK
 
 #include <ATen/native/xnnpack/Common.h>
+#include <ATen/native/xnnpack/Engine.h>
 #include <ATen/core/Tensor.h>
 
 //
@@ -13,9 +14,7 @@
 // trigger an error.
 //
 
-namespace at {
-namespace native {
-namespace xnnpack {
+namespace at::native::xnnpack {
 namespace internal {
 namespace {
 
@@ -90,9 +89,6 @@ Tensor max_pool2d(
   TORCH_CHECK(false, internal::kError);
 }
 
-} // namespace xnnpack
-
-} // namespace native
-} // namespace at
+} // namespace at::native::xnnpack
 
 #endif /* USE_XNNPACK */


### PR DESCRIPTION
By including `Engine.h` in `Shim.cpp` and defining `bool available()` outside of `#ifdef` guard in `Common.h`.

Modernize code a bit by using nested namespaces.

Fixes following compilation error if `USE_XNNPACK` is false:
```
Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:26:6: error: no previous prototype for function 'available' [-Werror,-Wmissing-prototypes]
bool available() {
     ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:30:6: error: no previous prototype for function 'use_convolution2d' [-Werror,-Wmissing-prototypes]
bool use_convolution2d(
     ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:42:8: error: no previous prototype for function 'convolution2d' [-Werror,-Wmissing-prototypes]
Tensor convolution2d(
       ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:53:6: error: no previous prototype for function 'use_linear' [-Werror,-Wmissing-prototypes]
bool use_linear(
     ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:60:8: error: no previous prototype for function 'linear' [-Werror,-Wmissing-prototypes]
Tensor linear(
       ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:67:6: error: no previous prototype for function 'use_max_pool2d' [-Werror,-Wmissing-prototypes]
bool use_max_pool2d(
     ^
/Users/nshulga/git/pytorch/pytorch/aten/src/ATen/native/xnnpack/Shim.cpp:79:8: error: no previous prototype for function 'max_pool2d' [-Werror,-Wmissing-prototypes]
Tensor max_pool2d(
       ^
```

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f8ac185</samp>

> _The code for xnnpack activations_
> _Was scattered in different locations_
> _But now it's all neat_
> _In `Activation.cpp`_
> _With nested namespaces and simplifications_
