### PR TITLE
[Reland][ET] Select used et_kernel_metadata only

### DIFF
--- a/test/edge/selected_operators.yaml
+++ b/test/edge/selected_operators.yaml
@@ -3,6 +3,13 @@ custom_classes: []
 include_all_non_op_selectives: false
 include_all_operators: false
 kernel_metadata: {}
+et_kernel_metadata:
+  custom::add_3.out:
+    - v1/6;0,1,2,3|6;0,1,2,3|6;0,1,2,3
+    - v1/3;0,1,2,3|3;0,1,2,3|3;0,1,2,3
+  aten::add.out:
+    - v1/6;0,1,2,3|6;0,1,2,3|6;0,1,2,3
+    - v1/3;0,1,2,3|3;0,1,2,3|3;0,1,2,3
 operators:
   aten::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams.out:
     debug_info:

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -442,7 +442,14 @@ class TestComputeCodegenUnboxedKernels(unittest.TestCase):
             {"T0": ["Double"]},
             {"D0": [0, 1, 2, 3]},
         )
-        selector = SelectiveBuilder.get_nop_selector()
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
         use_aten_lib = False
         entry = (
             self.native_function_no_kern,
@@ -471,8 +478,101 @@ Kernel(
 
         self.assertEqual(expected_str, result)
 
+    def test_codegen_unboxed_specialized_not_matching(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml(
+            {"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")},
+            {"T0": ["Double"]},
+            {"D0": [0, 1, 2, 3]},
+        )
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/8;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
+        use_aten_lib = False
+        entry = (
+            self.native_function_no_kern,
+            (specialized_kernel_key, self.default_backend_metadata),
+        )
+
+        self.assertRaises(
+            Exception, ComputeCodegenUnboxedKernels(selector, use_aten_lib), entry
+        )
+
+    def test_codegen_unboxed_specialized_missing_root_op(self) -> None:
+        specialized_kernel_key = ETKernelKey.gen_from_yaml(
+            {"self": ("T0", "D0"), "other": ("T0", "D0"), "out": ("T0", "D0")},
+            {"T0": ["Double"]},
+            {"D0": [0, 1, 2, 3]},
+        )
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                }
+            }
+        )
+        use_aten_lib = False
+        entry = (
+            self.native_function_no_kern,
+            (specialized_kernel_key, self.default_backend_metadata),
+        )
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = """"""
+
+        self.assertEqual(expected_str, result)
+
     def test_codegen_unboxed_default(self) -> None:
-        selector = SelectiveBuilder.get_nop_selector()
+        """
+        This test checks that if there is no specialized kernel, the default kernel is used.
+        """
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {
+                    "custom_1::op_1": ["v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3"]
+                },
+            }
+        )
+        use_aten_lib = False
+        entry = (self.native_function_no_kern, self.default_kernel_entry)
+
+        result = ComputeCodegenUnboxedKernels(selector, use_aten_lib)(entry)
+        # Concat used to prevent whitespace stripping
+        expected_str = (
+            """
+Kernel(
+    "custom_1::op_1",
+    [](torch::executor::RuntimeContext & context, EValue** stack) {
+        """
+            + """
+
+        EXECUTORCH_SCOPE_PROF("native_call_op_1");
+        bool result_ = at::native::default_kernel(context, );
+
+        *stack[0] = EValue(result_);
+    }
+),
+"""
+        )
+
+        self.assertEqual(expected_str, result)
+
+    def test_codegen_unboxed_default_kernel_key_selected(self) -> None:
+        """
+        This test checks that if there is no specialized kernel, the default kernel is used, when the selector only has default key.
+        """
+        selector = SelectiveBuilder.from_yaml_dict(
+            {
+                "include_all_operators": True,
+                "et_kernel_metadata": {"custom_1::op_1": ["default"]},
+            }
+        )
         use_aten_lib = False
         entry = (self.native_function_no_kern, self.default_kernel_entry)
 

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -310,34 +310,33 @@ et_kernel_metadata:
    - "v1/6;0,1|6;0,1|6;0,1|6;0,1"
 """
         selector = SelectiveBuilder.from_yaml_str(yaml_config)
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out",
+                [
+                    "v1/6;0,1|6;0,1|6;0,1|6;0,1",
+                    "v1/3;0,1|3;0,1|3;0,1|3;0,1",
+                    "v1/6;1,0|6;0,1|6;0,1|6;0,1",
+                ],
+            ),
         )
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::sub.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v1/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::sub.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::mul.out", "v1/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/3;0,1|3;0,1|3;0,1|3;0,1"
-            )
-        )
-        self.assertFalse(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v1/6;1,0|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            [],
+            selector.et_get_selected_kernels(
+                "aten::mul.out", ["v1/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )
         # We don't use version for now.
-        self.assertTrue(
-            selector.is_et_kernel_selected(
-                "aten::add.out", "v2/6;0,1|6;0,1|6;0,1|6;0,1"
-            )
+        self.assertListEqual(
+            ["v2/6;0,1|6;0,1|6;0,1|6;0,1"],
+            selector.et_get_selected_kernels(
+                "aten::add.out", ["v2/6;0,1|6;0,1|6;0,1|6;0,1"]
+            ),
         )

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -168,8 +168,16 @@ class ComputeCodegenUnboxedKernels:
         kernel_key: Union[ETKernelKey, List[ETKernelKey]] = unbox_kernel_entry[1][0]
         kernel_meta: BackendMetadata = unbox_kernel_entry[1][1]
 
-        # TODO: Update to use Kernel Selector
-        if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
+        op_name = f"{f.namespace}::{f.func.name}"
+        if not self.selector.is_root_operator(op_name):
+            return ""
+
+        if not isinstance(kernel_key, list):
+            kernel_key = [kernel_key]
+        used_kernel_keys = self.selector.et_get_selected_kernels(
+            op_name, [k.to_native_string() for k in kernel_key]
+        )
+        if not used_kernel_keys:
             return ""
         sig: Union[CppSignature, ExecutorchCppSignature]
         argument_type_gen: Callable[..., NamedCType]
@@ -217,15 +225,12 @@ class ComputeCodegenUnboxedKernels:
                 return_assignment = ""
                 ret_prefix = ""
 
-        if not isinstance(kernel_key, list):
-            kernel_key = [kernel_key]
-
         newline = "\n    "
         return "\n".join(
             [
                 f"""
 Kernel(
-    "{f.namespace}::{f.func.name}",{newline + '"' + (k.to_native_string() + '",') if k.to_native_string() != 'default' else ''}
+    "{f.namespace}::{f.func.name}",{newline + '"' + (k + '",') if k != 'default' else ''}
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
@@ -236,7 +241,7 @@ Kernel(
     }}
 ),
 """
-                for k in kernel_key
+                for k in used_kernel_keys
             ]
         )
 

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple
@@ -230,17 +231,35 @@ class SelectiveBuilder:
             and dtype in self.kernel_metadata[kernel_tag]
         )
 
-    def is_et_kernel_selected(self, op_name: str, kernel_key: str) -> bool:
+    def et_get_selected_kernels(self, op_name: str, kernel_key: List[str]) -> List[str]:
+        """
+        Return a list of kernel keys that cover the used ops
+        """
+        # If no kernel metadata, either it's implied by include_all_operators=True or the op is not used.
         if op_name not in self.et_kernel_metadata:
-            return False
-        # Don't compare the version for now
-        tensor_metadata = kernel_key.split("/")[1]
+            return kernel_key if self.include_all_operators else []
+        # Otherwise, only return the specific kernel keys.
+
+        result_set = set()
 
         for model_kernel_keys in self.et_kernel_metadata[op_name]:
-            if tensor_metadata == model_kernel_keys.split("/")[1]:
-                return True
+            key_found = False
+            for key in kernel_key:
+                # Don't compare the version for now
+                if (
+                    key != "default"
+                    and key.split("/")[1] == model_kernel_keys.split("/")[1]
+                ):
+                    result_set.add(key)
+                    key_found = True
+                    break
+            if not key_found:
+                if "default" not in kernel_key:
+                    raise Exception("Missing kernel for the model")
+                else:
+                    result_set.add("default")
 
-        return False
+        return list(result_set)
 
     def to_dict(self) -> Dict[str, object]:
         ret: Dict[str, object] = {
@@ -258,6 +277,8 @@ class SelectiveBuilder:
         ret["kernel_metadata"] = {
             k: sorted(v) for (k, v) in self.kernel_metadata.items()
         }
+
+        ret["et_kernel_metadata"] = self.et_kernel_metadata
 
         ret["custom_classes"] = sorted(self.custom_classes)
 
@@ -281,6 +302,18 @@ def merge_kernel_metadata(
     return kernel_metadata
 
 
+def merge_et_kernel_metadata(
+    lhs: Dict[str, List[str]],
+    rhs: Dict[str, List[str]],
+) -> Dict[str, List[str]]:
+    merge_et_kernel_metadata: Dict[str, Set[str]] = defaultdict(set)
+    for op in list(lhs.keys()) + list(rhs.keys()):
+        merge_et_kernel_metadata[op].update(lhs.get(op, []))
+        merge_et_kernel_metadata[op].update(rhs.get(op, []))
+
+    return {op: sorted(val) for op, val in merge_et_kernel_metadata.items()}
+
+
 def combine_selective_builders(
     lhs: SelectiveBuilder, rhs: SelectiveBuilder
 ) -> SelectiveBuilder:
@@ -288,8 +321,9 @@ def combine_selective_builders(
     debug_info = merge_debug_info(lhs._debug_info, rhs._debug_info)
     operators = merge_operator_dicts(lhs.operators, rhs.operators)
     kernel_metadata = merge_kernel_metadata(lhs.kernel_metadata, rhs.kernel_metadata)
-    # TODO(T149265497): Need to parse the et kernel metadata
-    et_kernel_metadata: Dict[str, List[str]] = {}
+    et_kernel_metadata = merge_et_kernel_metadata(
+        lhs.et_kernel_metadata, rhs.et_kernel_metadata
+    )
     include_all_non_op_selectives = (
         lhs.include_all_non_op_selectives or rhs.include_all_non_op_selectives
     )


### PR DESCRIPTION
Summary: Currently we rely on root operator, but we also need to check for et_kernel_metadata for used specialized kernels.

Test Plan: contbuild & OSS CI

Reviewed By: Jack-Khuu

Differential Revision: D46882119

