### PR TITLE
Add check for malformed tensor in load.

### DIFF
--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -43,6 +43,7 @@ bool InputArchive::try_read(
     return false;
   }
   auto read_tensor = iv.toTensor();
+  TORCH_CHECK(read_tensor.data_ptr() != 0, "Malfomed input tensor")
   // clang-format on
   if (tensor.defined()) {
     torch::NoGradGuard guard;


### PR DESCRIPTION
Hi! We've been fuzzing torchvision project with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz).
We've found the input for the `torch::load` function, which makes `data_ptr` field of input Tensor `NULL` after loading from file. This can lead to the null pointer dereference later, the example with reproducing is shown below.
To prevent the error we suggest to add the check for the `data_ptr` field.

torchvision version: 9d0a93eee90bf7c401b74ebf9c8be80346254f15

pytorch version: 0f1621df1a0a73956c7ce4e2f72f069e610e0137

OS: Ubuntu 20.04

How to reproduce

1. Build docker from [here](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/torchvision) and run the container:

        sudo docker build -t oss-sydr-fuzz-torchvision .
        sudo docker run --privileged --rm -v `pwd`:/fuzz -it oss-sydr-fuzz-torchvision /bin/bash

2. Run the target on this input: [null-ptr-deref-vec.txt](https://github.com/pytorch/pytorch/files/11835087/null-ptr-deref-vec.txt)


        /encode_png_fuzz null-ptr-deref-vec.txt

3. You will see the following output:

        =================================================================
        AddressSanitizer:DEADLYSIGNAL
        ==936==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000011582f19 bp 0x7ffc439944b0 sp 0x7ffc439943c0 T0)
        ==936==The signal is caused by a READ memory access.
        ==936==Hint: address points to the zero page.
            #0 0x11582f19 in at::vec::AVX2::Vectorized8<unsigned char>::loadu(void const*) /pytorch/aten/src/ATen/cpu/vec/vec256/vec256_int.h:681:12
            #1 0x11582f19 in function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>::ArgsTuple at::native::AVX2::dereference_vec_impl<function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>, 0ul>(char* restrict*, function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>::result_type const&, unsigned long, long, std::integer_sequence<unsigned long, 0ul>) /pytorch/aten/src/ATen/native/cpu/Loops.h:73:7
            #2 0x11581524 in function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>::ArgsTuple at::native::AVX2::dereference_vec<function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&> >(char* restrict*, function_traits<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>::result_type const&, unsigned long, long) /pytorch/aten/src/ATen/native/cpu/Loops.h:80:10
            #3 0x11581524 in void at::native::AVX2::vectorized_loop<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char)&, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&>(char**, long, long, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char)&, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&) /pytorch/aten/src/ATen/native/cpu/Loops.h:213:18
            #4 0x11580a03 in at::native::AVX2::VectorizedLoop2d<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char), at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)>::operator()(char**, long const*, long, long) /pytorch/aten/src/ATen/native/cpu/Loops.h:275:9
            #5 0x11580a03 in void c10::function_ref<void (char**, long const*, long, long)>::callback_fn<at::native::AVX2::VectorizedLoop2d<at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char), at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)> >(long, char**, long const*, long, long) /pytorch/c10/util/FunctionRef.h:43:12
            #6 0x8c1eb6 in at::internal::serial_for_each(c10::ArrayRef<long>, c10::ArrayRef<long>, char**, unsigned long, c10::function_ref<void (char**, long const*, long, long)>, at::Range) /pytorch/aten/src/ATen/TensorIteratorInternal.h:65:7
            #7 0x8bff21 in at::TensorIteratorBase::serial_for_each(c10::function_ref<void (char**, long const*, long, long)>, at::Range) const /pytorch/aten/src/ATen/TensorIterator.cpp:777:3
            #8 0x83d498 in std::function<void (long, long)>::operator()(long, long) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_function.h:622:14
            #9 0x83ce7a in at::internal::invoke_parallel(long, long, long, std::function<void (long, long)> const&)::$_0::operator()(int, unsigned long) const /pytorch/aten/src/ATen/ParallelNative.cpp:168:9
            #10 0x83ce7a in void std::__invoke_impl<void, at::internal::invoke_parallel(long, long, long, std::function<void (long, long)> const&)::$_0&, int, unsigned long>(std::__invoke_other, at::internal::invoke_parallel(long, long, long, std::function<void (long, long)> const&)::$_0&, int&&, unsigned long&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14
            #11 0x8246f2 in std::function<void (int, unsigned long)>::operator()(int, unsigned long) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_function.h:622:14
            #12 0x822039 in at::(anonymous namespace)::_run_with_pool(std::function<void (int, unsigned long)> const&, unsigned long) /pytorch/aten/src/ATen/ParallelNative.cpp:96:3
            #13 0x820e00 in at::internal::invoke_parallel(long, long, long, std::function<void (long, long)> const&) /pytorch/aten/src/ATen/ParallelNative.cpp:183:3
            #14 0x8c0703 in void at::parallel_for<at::TensorIteratorBase::for_each(c10::function_ref<void (char**, long const*, long, long)>, long)::$_5>(long, long, long, at::TensorIteratorBase::for_each(c10::function_ref<void (char**, long const*, long, long)>, long)::$_5 const&) /pytorch/aten/src/ATen/Parallel-inl.h:31:3
            #15 0x8bf680 in at::TensorIteratorBase::for_each(c10::function_ref<void (char**, long const*, long, long)>, long) /pytorch/aten/src/ATen/TensorIterator.cpp:751:5
            #16 0x115802cc in void at::native::AVX2::cpu_kernel_vec<true, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char), at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)>(at::TensorIteratorBase&, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(unsigned char)&&, at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const::'lambda'(at::vec::AVX2::Vectorized<unsigned char>)&&, long) /pytorch/aten/src/ATen/native/cpu/Loops.h:352:8
            #17 0x1156ff6f in at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const::'lambda'()::operator()() const /pytorch/aten/src/ATen/native/cpu/CopyKernel.cpp:186:5
            #18 0x1156ff6f in at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)::$_7::operator()() const /pytorch/aten/src/ATen/native/cpu/CopyKernel.cpp:186:5
            #19 0x1156ff6f in at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&) /pytorch/aten/src/ATen/native/cpu/CopyKernel.cpp:186:5
            #20 0x11571742 in at::native::AVX2::copy_kernel(at::TensorIterator&, bool) /pytorch/aten/src/ATen/native/cpu/CopyKernel.cpp:233:5
            #21 0x133613e in at::native::copy_impl(at::Tensor&, at::Tensor const&, bool) /pytorch/aten/src/ATen/native/Copy.cpp:278:3
            #22 0x133509e in at::native::copy_(at::Tensor&, at::Tensor const&, bool) /pytorch/aten/src/ATen/native/Copy.cpp:301:5
            #23 0x3a6f2f5 in at::Tensor& c10::KernelFunction::call<at::Tensor&, at::Tensor&, at::Tensor const&, bool>(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor&, at::Tensor const&, bool) const /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:102:16
            #24 0x3a6f2f5 in at::Tensor& c10::Dispatcher::call<at::Tensor&, at::Tensor&, at::Tensor const&, bool>(c10::TypedOperatorHandle<at::Tensor& (at::Tensor&, at::Tensor const&, bool)> const&, at::Tensor&, at::Tensor const&, bool) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:644:26
            #25 0x3a6f2f5 in c10::TypedOperatorHandle<at::Tensor& (at::Tensor&, at::Tensor const&, bool)>::call(at::Tensor&, at::Tensor const&, bool) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492:41
            #26 0x3a6f2f5 in at::_ops::copy_::call(at::Tensor&, at::Tensor const&, bool) /pytorch/build/aten/src/ATen/Operators_3.cpp:2152:15
            #27 0x1ea317d in at::Tensor::copy_(at::Tensor const&, bool) const /pytorch/build/aten/src/ATen/core/TensorBody.h:2103:12
            #28 0x1ea317d in at::native::clone(at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/aten/src/ATen/native/TensorFactories.cpp:1611:10
            #29 0x4add399 in at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeExplicitAutograd__clone(at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/build/aten/src/ATen/RegisterCompositeExplicitAutograd.cpp:4160:10
            #30 0x4add399 in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>), &(at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeExplicitAutograd__clone(at::Tensor const&, c10::optional<c10::MemoryFormat>))>, at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, c10::optional<c10::MemoryFormat> > >::operator()(at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13:16
            #31 0x4add399 in c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>), &(at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeExplicitAutograd__clone(at::Tensor const&, c10::optional<c10::MemoryFormat>))>, at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, c10::optional<c10::MemoryFormat> > >, at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:463:14
            #32 0x33bb614 in at::Tensor c10::callUnboxedKernelFunction<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(void*, c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>&&) /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50:12
            #33 0x33bb614 in at::Tensor c10::KernelFunction::call<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:102:16
            #34 0x33bb614 in at::Tensor c10::Dispatcher::redispatch<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>)> const&, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:661:26
            #35 0x3170e8e in c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>)>::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:497:41
            #36 0x3170e8e in at::_ops::clone::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/build/aten/src/ATen/Operators_1.cpp:5921:15
            #37 0xaa5285f in at::redispatch::clone(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/build/aten/src/ATen/RedispatchFunctions.h:7947:16
            #38 0xaa5285f in torch::autograd::VariableType::(anonymous namespace)::clone(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>)::$_55::operator()() const /pytorch/torch/csrc/autograd/generated/VariableType_1.cpp:5240:12
            #39 0xaa5285f in torch::autograd::VariableType::(anonymous namespace)::clone(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/torch/csrc/autograd/generated/VariableType_1.cpp:5238:15
            #40 0xaa548ae in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>), &(torch::autograd::VariableType::(anonymous namespace)::clone(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>))>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat> > >::operator()(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13:16
            #41 0xaa548ae in c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>), &(torch::autograd::VariableType::(anonymous namespace)::clone(c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>))>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat> > >, at::Tensor (c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:480:14
            #42 0x3170723 in at::Tensor c10::callUnboxedKernelFunction<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(void*, c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>&&) /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50:12
            #43 0x3170723 in at::Tensor c10::KernelFunction::call<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:102:16
            #44 0x3170723 in at::Tensor c10::Dispatcher::call<at::Tensor, at::Tensor const&, c10::optional<c10::MemoryFormat> >(c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>)> const&, at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:644:26
            #45 0x3170723 in c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::optional<c10::MemoryFormat>)>::call(at::Tensor const&, c10::optional<c10::MemoryFormat>) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492:41
            #46 0x3170723 in at::_ops::clone::call(at::Tensor const&, c10::optional<c10::MemoryFormat>) /pytorch/build/aten/src/ATen/Operators_1.cpp:5914:15
            #47 0x1ec7c66 in at::Tensor::clone(c10::optional<c10::MemoryFormat>) const /pytorch/build/aten/src/ATen/core/TensorBody.h:3873:12
            #48 0x1ec7c66 in at::native::contiguous(at::Tensor const&, c10::MemoryFormat) /pytorch/aten/src/ATen/native/TensorProperties.cpp:101:15
            #49 0x50965da in at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeImplicitAutograd__contiguous(at::Tensor const&, c10::MemoryFormat) /pytorch/build/aten/src/ATen/RegisterCompositeImplicitAutograd.cpp:1889:10
            #50 0x50965da in c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (at::Tensor const&, c10::MemoryFormat), &(at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeImplicitAutograd__contiguous(at::Tensor const&, c10::MemoryFormat))>, at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, c10::MemoryFormat> >::operator()(at::Tensor const&, c10::MemoryFormat) /pytorch/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h:13:16
            #51 0x50965da in c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (at::Tensor const&, c10::MemoryFormat), &(at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeImplicitAutograd__contiguous(at::Tensor const&, c10::MemoryFormat))>, at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, c10::MemoryFormat> >, at::Tensor (at::Tensor const&, c10::MemoryFormat)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::MemoryFormat) /pytorch/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:463:14
            #52 0x3fc4b45 in at::Tensor c10::callUnboxedKernelFunction<at::Tensor, at::Tensor const&, c10::MemoryFormat>(void*, c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::MemoryFormat&&) /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:50:12
            #53 0x3df7b26 in at::Tensor c10::KernelFunction::call<at::Tensor, at::Tensor const&, c10::MemoryFormat>(c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, c10::MemoryFormat) const /pytorch/aten/src/ATen/core/boxing/KernelFunction_impl.h:102:16
            #54 0x3df7b26 in at::Tensor c10::Dispatcher::call<at::Tensor, at::Tensor const&, c10::MemoryFormat>(c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::MemoryFormat)> const&, at::Tensor const&, c10::MemoryFormat) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:644:26
            #55 0x3df7b26 in c10::TypedOperatorHandle<at::Tensor (at::Tensor const&, c10::MemoryFormat)>::call(at::Tensor const&, c10::MemoryFormat) const /pytorch/aten/src/ATen/core/dispatch/Dispatcher.h:492:41
            #56 0x3df7b26 in at::_ops::contiguous::call(at::Tensor const&, c10::MemoryFormat) /pytorch/build/aten/src/ATen/Operators_4.cpp:1663:15
            #57 0xe0a185 in at::TensorBase::__dispatch_contiguous(c10::MemoryFormat) const /pytorch/aten/src/ATen/core/Tensor.cpp:26:10
            #58 0x628ce6 in at::TensorBase::contiguous(c10::MemoryFormat) const /pytorch/torch/include/ATen/core/TensorBase.h:128:14
            #59 0x622567 in at::Tensor::contiguous(c10::MemoryFormat) const /pytorch/torch/include/ATen/core/TensorBody.h:122:24
            #60 0x61f106 in vision::image::encode_png(at::Tensor const&, long) /vision/torchvision/csrc/io/image/cpu/encode_png.cpp:115:40
            #61 0x604619 in LLVMFuzzerTestOneInput /vision/encode_png.cc:64:32
            #62 0x66b041 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /llvm-project-llvmorg-14.0.6/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
            #63 0x6544cc in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /llvm-project-llvmorg-14.0.6/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
            #64 0x65a61b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /llvm-project-llvmorg-14.0.6/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
            #65 0x654222 in main /llvm-project-llvmorg-14.0.6/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
            #66 0x7fdbe688e082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
            #67 0x542cdd in _start (/encode_png_fuzz+0x542cdd)
        
        AddressSanitizer can not provide additional info.
        SUMMARY: AddressSanitizer: SEGV /pytorch/aten/src/ATen/cpu/vec/vec256/vec256_int.h:681:12 in at::vec::AVX2::Vectorized8<unsigned char>::loadu(void const*)
        ==936==ABORTING