### PR TITLE
[Xcode 15][caffe2] Avoid redundant redeclaration of 'constexpr' static data member

### DIFF
--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -375,7 +375,7 @@ DynamicTypePtr ivalue::TupleTypeFactory<c10::DynamicType>::fallback(
 }
 
 TORCH_API TupleTypePtr
-ivalue::TupleTypeFactory<TupleType>::fallback(const Type& type) {
+ivalue::TupleTypeFactory<TupleType>::fallback(C10_UNUSED const Type& type) {
 #ifdef C10_MOBILE
   return nullptr;
 #else
@@ -396,10 +396,5 @@ ivalue::TupleTypeFactory<TupleType>::fallback(const Type& type) {
 #endif
 }
 
-#define DYNAMIC_TYPE_TAG_VALUE(NAME, _, __) \
-  constexpr bool DynamicTypeTrait<NAME##Type>::isBaseType;
-FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_TAG_VALUE)
-FORALL_DYNAMIC_TYPES_FAKE(DYNAMIC_TYPE_TAG_VALUE)
-#undef DYNAMIC_TYPE_TAG_VALUE
 
 } // namespace c10


### PR DESCRIPTION
Summary: Handling the `out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Werror,-Wdeprecated]` warning on Xcode 15.

Test Plan: Build

Reviewed By: n0shake

Differential Revision: D46875270

