### PR TITLE
[BE]Fix @parametrize not working when using @with_comms in DTensorTestBase

### DIFF
--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -171,7 +171,7 @@ def with_comms(func: TestFunc) -> TestFunc:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         self.init_pg(backend=pg_backend)
-        func(self)  # type: ignore[misc]
+        func(self, *args, **kwargs)  # type: ignore[misc]
         self.destroy_pg()
 
     return wrapper


### PR DESCRIPTION
1) Fix @parametrize not working when using @with_comms in DTensorTestBase, this is because args and kwargs are currently not being passed when using @with_comms wrapper. 
2) Use @parametrize in test_fsdp_dtensor_state_dict.py to make sure it is working correctly. 