### PR TITLE
[BE] Run lint on local changes first

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,9 @@ jobs:
         RC=0
 
         # Run lintrunner on just the changed files (a fast validation)
-        if ! lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1; then
+        lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1
+        RC=$?
+        if [ $RC -ne 0 ]; then
           echo ""
           echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. (If you don't get the same results, run \`lintrunner init\` to update your local linter)\e[0m"
           echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,13 +76,24 @@ jobs:
           --tags-path aten/src/ATen/native/tags.yaml \
           --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
-        RC=0
-        # Run lintrunner on all files
-        if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then
+        # Run lintrunner on just the changed files (a fast validation)
+        lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1
+        RC=$?
+        if [ $RC -ne 0 ]; then
           echo ""
           echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. (If you don't get the same results, run \'lintrunner init\' to update your local linter)\e[0m"
           echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
           RC=1
+        fi
+
+        if [ $RC -eq 0 ]; then
+          # Run lintrunner on all files
+          if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then
+            echo ""
+            echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner --all-files\`. (If you don't get the same results, run \'lintrunner init\' to update your local linter)\e[0m"
+            echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
+            RC=1
+          fi
         fi
 
         # Use jq to massage the JSON lint output into GitHub Actions workflow commands.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,14 @@ jobs:
         # This has already been cached in the docker image
         lintrunner init 2> /dev/null
 
+        # Do build steps necessary for linter
+        python3 -m tools.linter.clang_tidy.generate_build_files
+        python3 -m tools.generate_torch_version --is_debug=false
+        python3 -m tools.pyi.gen_pyi \
+          --native-functions-path aten/src/ATen/native/native_functions.yaml \
+          --tags-path aten/src/ATen/native/tags.yaml \
+          --deprecated-functions-path "tools/autograd/deprecated.yaml"
+
         RC=0
 
         # Run lintrunner on just the changed files (a fast validation)
@@ -80,14 +88,6 @@ jobs:
 
         # If initial linting passed, run lintrunner on all files
         if [ $RC -eq 0 ]; then
-          # Do build steps necessary for linter
-          python3 -m tools.linter.clang_tidy.generate_build_files
-          python3 -m tools.generate_torch_version --is_debug=false
-          python3 -m tools.pyi.gen_pyi \
-            --native-functions-path aten/src/ATen/native/native_functions.yaml \
-            --tags-path aten/src/ATen/native/tags.yaml \
-            --deprecated-functions-path "tools/autograd/deprecated.yaml"
-
           if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then
             echo ""
             echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner --all-files\`. (If you don't get the same results, run \`lintrunner init\` to update your local linter)\e[0m"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,12 +76,12 @@ jobs:
           --tags-path aten/src/ATen/native/tags.yaml \
           --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
+        $RC = 0
+
         # Run lintrunner on just the changed files (a fast validation)
-        lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1
-        RC=$?
-        if [ $RC -ne 0 ]; then
+        if ! lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1; then
           echo ""
-          echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. (If you don't get the same results, run \'lintrunner init\' to update your local linter)\e[0m"
+          echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. (If you don't get the same results, run \`lintrunner init\` to update your local linter)\e[0m"
           echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
           RC=1
         fi
@@ -90,7 +90,7 @@ jobs:
           # Run lintrunner on all files
           if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then
             echo ""
-            echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner --all-files\`. (If you don't get the same results, run \'lintrunner init\' to update your local linter)\e[0m"
+            echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner --all-files\`. (If you don't get the same results, run \`lintrunner init\` to update your local linter)\e[0m"
             echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
             RC=1
           fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
         # This has already been cached in the docker image
         lintrunner init 2> /dev/null
 
-        RC = 0
+        RC=0
 
         # Run lintrunner on just the changed files (a fast validation)
         if ! lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,15 +68,7 @@ jobs:
         # This has already been cached in the docker image
         lintrunner init 2> /dev/null
 
-        # Do build steps necessary for linters
-        python3 -m tools.linter.clang_tidy.generate_build_files
-        python3 -m tools.generate_torch_version --is_debug=false
-        python3 -m tools.pyi.gen_pyi \
-          --native-functions-path aten/src/ATen/native/native_functions.yaml \
-          --tags-path aten/src/ATen/native/tags.yaml \
-          --deprecated-functions-path "tools/autograd/deprecated.yaml"
-
-        $RC = 0
+        RC = 0
 
         # Run lintrunner on just the changed files (a fast validation)
         if ! lintrunner --force-color --tee-json=lint.json > /dev/null 2>&1; then
@@ -86,8 +78,16 @@ jobs:
           RC=1
         fi
 
+        # If initial linting passed, run lintrunner on all files
         if [ $RC -eq 0 ]; then
-          # Run lintrunner on all files
+          # Do build steps necessary for linter
+          python3 -m tools.linter.clang_tidy.generate_build_files
+          python3 -m tools.generate_torch_version --is_debug=false
+          python3 -m tools.pyi.gen_pyi \
+            --native-functions-path aten/src/ATen/native/native_functions.yaml \
+            --tags-path aten/src/ATen/native/tags.yaml \
+            --deprecated-functions-path "tools/autograd/deprecated.yaml"
+
           if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then
             echo ""
             echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner --all-files\`. (If you don't get the same results, run \`lintrunner init\` to update your local linter)\e[0m"


### PR DESCRIPTION
When linter is run, we would always lint all the files.  This can be unnecessarily time consuming when the most likely source of a linter failure is the dev's own code.

This shrinks the time it takes for devs to be told about lint failures they may have introduced by first running linter just on the recently changed files, and only if that succeeds do we continue to lint all files in the repo.

This speeds up Time to Red Signal by ~10 minutes, cutting time to detect linter failures by ~50%.

Now to have some fun with numbers: 
In the past month, 1/3 of all lintrunner jobs ended in failure (2407 failures total). 10 minutes saved on each of those jobs could be 401 dev hours saved, which is equivalent to about 2.2 dev months of work.