### PR TITLE
[Pytorch Edge][BE] Delete Sparse Qnnpack test failing since 2022 jul

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gemm_sparse.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gemm_sparse.cc
@@ -1474,32 +1474,6 @@ TEST(Q8GEMM_8x4c1x4__SSE2, packedA_k_gt_8_nozp) {
   }
 }
 
-TEST(Q8GEMM_8x4c1x4__SSE2, packedA_k_gt_8_subtile) {
-  TEST_REQUIRES_X86_SSE2;
-  for (size_t k = 9; k < 16; k++) {
-    for (uint32_t m = 1; m <= 8; m++) {
-      for (uint32_t n = 1; n <= 4; n++) {
-        GemmBlockSparseMicrokernelTester tester = GemmBlockSparseMicrokernelTester()
-            .mr(8)
-            .nr(4)
-            .m(m)
-            .n(n)
-            .k(k)
-            .iterations(3);
-        tester.test_packed<uint32_t>(
-            pytorch_q8gemm_sparse_packA_ukernel_8x4__sse2,
-            pytorch_q8gemm_dq_sparse_1x4_ukernel_8x4_packedA_w32__sse2);
-        tester.test_packed<uint16_t>(
-            pytorch_q8gemm_sparse_packA_ukernel_8x4__sse2,
-            pytorch_q8gemm_dq_sparse_1x4_ukernel_8x4_packedA_w16__sse2);
-        tester.test_packed<uint8_t>(
-            pytorch_q8gemm_sparse_packA_ukernel_8x4__sse2,
-            pytorch_q8gemm_dq_sparse_1x4_ukernel_8x4_packedA_w8__sse2);
-      }
-    }
-  }
-}
-
 TEST(Q8GEMM_8x4c1x4__SSE2, packedA_k_div_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t k = 16; k < 128; k += 8) {


### PR DESCRIPTION
Summary:
According to https://www.internalfb.com/omh/view/ai_infra_mobile_platform/tests these have been failing since jul 2022.

Just going to delete unless someone thinks they actually do matter and should be made green

https://www.internalfb.com/intern/test/562949996115570/ <- failing test

I ran locally and got errors like

  xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h:483: Failure
  Expected equality of these values:
  c[mIndex * cStride() + nIndex]
    Which is: -872.50446
  acc[mIndex * n() + nIndex]
    Which is: -872.50488
  at 0, 0: reference = -872.5048828125, optimized = -872.50445556640625, Mr x Nr = 8 x 4, M x N x K = 7 x 1 x 13
  xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h:483: Failure
  Expected equality of these values:
  c[mIndex * cStride() + nIndex]
    Which is: -67.246628
  acc[mIndex * n() + nIndex]
    Which is: -67.24707
  at 3, 0: reference = -67.2470703125, optimized = -67.246627807617188, Mr x Nr = 8 x 4, M x N x K = 4 x 1 x 15
  [  FAILED  ] Q8GEMM_8x4c1x4__SSE2.packedA_k_gt_8_subtile (148 ms)

Test Plan: ci

Reviewed By: kimishpatel

Differential Revision: D46950966



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10