### PR TITLE
[6/n][FSDP] Update _sharded_pre_load_state_dict_hook to use DTensor when use_dtensor=True in ShardedStateDictConfig 

### DIFF
--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -1,5 +1,8 @@
 # Owner(s): ["oncall: distributed"]
 
+import io
+from copy import deepcopy
+
 import torch
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
@@ -85,9 +88,7 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
                     # check whether local_tensor are the same
                     self.assertEqual(v1.to_local(), v2.local_tensor())
                     # check whether device are the same
-                    self.assertEqual(
-                        v1.to_local().device, v2.local_tensor().device
-                    )
+                    self.assertEqual(v1.to_local().device, v2.local_tensor().device)
 
 
 # TODO: consolidate test cases once we test all DTensor usage
@@ -133,8 +134,10 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_dtensor_sharded_model_load_state_dict(self):
+    @parametrize("map_location", ["cpu", "cuda"])
+    def test_dtensor_sharded_model_load_state_dict(self, map_location):
         model = FSDP(TestDummyModel().cuda())
+        optim = torch.optim.Adam(model.parameters(), lr=0.1)
 
         FSDP.set_state_dict_type(
             model,
@@ -144,24 +147,30 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
                 offload_to_cpu=False,
             ),
         )
-        ref_dtensor_sd = model.state_dict()
 
+        checkpoint = io.BytesIO()
+        torch.save(model.state_dict(), checkpoint)
+        # Deepcopy to save current state_dict to compare with the loaded state dict below.
+        ref_state_dict = deepcopy(model.state_dict())
+        # Hmmm...Why does ```torch.save(ref_state_dict, checkpoint)``` not work while torch.save(model.state_dict()) work?
+
+        # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
         model(model.get_input()).sum().backward()
+        optim.step()
 
-        model.load_state_dict(ref_dtensor_sd)
+        # Load ref_state_dict back.
+        checkpoint.seek(0)
+        # Test both parameters in state_dict are loaded to CPU and GPU.
+        load_ref_state_dict = torch.load(checkpoint, map_location=map_location)
+        model.load_state_dict(load_ref_state_dict)
         new_state_dict = model.state_dict()
 
-        for ref_dtensor_sd, new_state_dict in zip(
-            ref_dtensor_sd.items(), new_state_dict.items()
-        ):
-            k1, v1 = ref_dtensor_sd
-            k2, v2 = new_state_dict
-            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-                self.assertEqual(k1, k2)
-                # check whether local_tensor are the same
-                self.assertEqual(v1.to_local(), v2.local_tensor())
-                # check whether device are the same
-                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+        # Check whether new_state_dict is the same as ref_state_dict.
+        for (k1, v1), (k2, v2) in zip(ref_state_dict.items(), new_state_dict.items()):
+            # check whether fqn are the same
+            self.assertEqual(k1, k2)
+            # check whether DTensor are the same
+            self.assertEqual(v1, v2)
 
 
 instantiate_parametrized_tests(TestDtensorShardedModelStateDict)

--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -152,7 +152,6 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
         torch.save(model.state_dict(), checkpoint)
         # Deepcopy to save current state_dict to compare with the loaded state dict below.
         ref_state_dict = deepcopy(model.state_dict())
-        # Hmmm...Why does ```torch.save(ref_state_dict, checkpoint)``` not work while torch.save(model.state_dict()) work?
 
         # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
         model(model.get_input()).sum().backward()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -231,10 +231,12 @@ def _init_device_mesh(
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))
     device_mesh = DeviceMesh(device_type, mesh_tensor, _init_process_groups=False)
-    device_mesh._dim_group_infos = (
-        _get_group_tag(root_state.process_group),
-        mesh_tensor.tolist(),
-    )
+    device_mesh._dim_group_infos = [
+        (
+            _get_group_tag(root_state.process_group),
+            mesh_tensor.tolist(),
+        )
+    ]
     return device_mesh
 
 

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -2,20 +2,11 @@ import contextlib
 import logging
 import math
 import warnings
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    no_type_check,
-    Tuple,
-)
+from typing import Any, Callable, cast, Dict, Generator, Iterator, no_type_check, Tuple
 
 import torch
 import torch.distributed as dist
+
 import torch.distributed.algorithms._checkpoint.checkpoint_wrapper as checkpoint_wrapper
 
 import torch.nn as nn
@@ -25,7 +16,7 @@ from torch.distributed._shard.sharded_tensor import (
     Shard,
     ShardedTensor,
 )
-from torch.distributed._tensor import DTensor
+from torch.distributed._tensor import DTensor, Replicate, Shard as DShard
 
 from torch.distributed.distributed_c10d import _get_pg_default_device
 from torch.distributed.fsdp._common_utils import (
@@ -606,10 +597,11 @@ def _sharded_pre_load_state_dict_hook(
         else:
             fqn_from_global_root = f"{prefix}{fqn}"
         param = state_dict.pop(fqn_from_global_root)
-        # All-gather the param (ShardedTensor)
 
         if not fsdp_state._state_dict_config.use_dtensor:
+            # All-gather the param (ShardedTensor)
             param, shards = _ext_pre_load_state_dict_transform(param)
+
             assert len(shards) < 2, (
                 "Expects 0 or 1 shard per rank "
                 f"but got {len(shards)} shards on rank {fsdp_state.rank}."
@@ -617,7 +609,9 @@ def _sharded_pre_load_state_dict_hook(
             param_numel = param.size().numel()
             dim_0_size = param.size()[0]
             chunk_size = (
-                math.ceil(dim_0_size / fsdp_state.world_size) * param_numel // dim_0_size
+                math.ceil(dim_0_size / fsdp_state.world_size)
+                * param_numel
+                // dim_0_size
             )
             if len(shards) == 1:
                 local_tensor = shards[0].tensor.flatten()
@@ -630,32 +624,37 @@ def _sharded_pre_load_state_dict_hook(
             else:
                 local_tensor = torch.zeros(chunk_size, dtype=param.dtype, device=device)
             tensor = torch.empty(
-                chunk_size * fsdp_state.world_size, dtype=local_tensor.dtype, device=device
+                chunk_size * fsdp_state.world_size,
+                dtype=local_tensor.dtype,
+                device=device,
             )
-        else: 
-            param_numel = param.numel()
-            dim_0_size = param.size()[0]
-            chunk_size = (
-                math.ceil(dim_0_size / fsdp_state.world_size) * param_numel // dim_0_size
-            )
-            local_tensor = param.to_local()
-            num_padding = chunk_size - local_tensor.numel()
-            if num_padding > 0:
-                local_tensor = F.pad(local_tensor, [0, num_padding])
-            else: 
-                local_tensor = torch.zeros(chunk_size, dtype=local_tensor.dtype, device=local_tensor.device)
-
-        if local_tensor.is_cpu:
-            tensor_list = list(
-                torch.chunk(tensor, dist.get_world_size(fsdp_state.process_group))
-            )
-            dist.all_gather(tensor_list, local_tensor, group=fsdp_state.process_group)
+            if local_tensor.is_cpu:
+                tensor_list = list(
+                    torch.chunk(tensor, dist.get_world_size(fsdp_state.process_group))
+                )
+                dist.all_gather(
+                    tensor_list, local_tensor, group=fsdp_state.process_group
+                )
+            else:
+                dist.all_gather_into_tensor(
+                    tensor, local_tensor, group=fsdp_state.process_group
+                )
+            tensor = tensor.narrow(0, 0, param_numel).reshape(param.size())
+            state_dict[fqn_from_global_root] = tensor
         else:
-            dist.all_gather_into_tensor(
-                tensor, local_tensor, group=fsdp_state.process_group
+            # TODO: make use_dtensor=True work with offload_to_cpu=True.
+            local_tensor = param.to_local()
+            if param.device != local_tensor.device:
+                # construct from a cpu local tensor with cuda device mesh
+                # will automatically convert the dist tensor to cuda
+                param = DTensor.from_local(
+                    local_tensor, fsdp_state._device_mesh, [DShard(0)]
+                )
+
+            param = param.redistribute(
+                device_mesh=param.device_mesh, placements=[Replicate()]
             )
-        tensor = tensor.narrow(0, 0, param_numel).reshape(param.size())
-        state_dict[fqn_from_global_root] = tensor
+            state_dict[fqn_from_global_root] = param.to_local()
 
     _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
 


### PR DESCRIPTION
This allows us use use_dtensor=True for ShardedStateDictConfig() before calling model.load_state_dict(). It only works for offload_to_cpu=False now. 

Next PR will make use_dtensor=True work with offload_to_cpu=True for load_state_dict().

 


cc @zhaojuanmao @mrshenli @rohan-varma @awgu