### PR TITLE
[onnx] Convert aten::flatten with 0d input to onnx Reshape and 1d to Identity

### DIFF
--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -516,6 +516,23 @@ class TestONNXOpset(pytorch_test_common.ExportTestCase):
                 training=torch.onnx.TrainingMode.EVAL,
             )
 
+    def test_flatten(self):
+        class MyModule(Module):
+            def forward(self, x):
+                return torch.flatten(x)
+
+        module = MyModule()
+
+        ops_0d = [{"op_name": "Constant"}, {"op_name": "Reshape"}]
+        ops_1d = [{"op_name": "Identity"}]
+        for shape in ([], [3]):
+            x = torch.randn(shape)
+            for opset_version in [9, 10]:
+                ops = {opset_version: (ops_0d if len(shape) == 0 else ops_1d)}
+                check_onnx_opsets_operator(
+                    module, x, ops, opset_versions=[opset_version]
+                )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5505,11 +5505,19 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def forward(self, input):
                 return torch.flatten(input)
 
-        x = torch.randint(10, (1, 2, 3, 4))
-        self.run_test(FlattenModel(), x)
+        model = FlattenModel()
 
+        # flatten with 4d input
+        x = torch.randint(10, (1, 2, 3, 4))
+        self.run_test(model, x)
+
+        # flatten with 0d input
+        x = torch.randn([])
+        self.run_test(model, x)
+
+        # flatten with 1d input
         x = torch.randn(4)
-        self.run_test(FlattenModel(), x)
+        self.run_test(model, x)
 
     def test_flatten2d(self):
         class FlattenModel(torch.nn.Module):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5292,6 +5292,10 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
             input,
         )
 
+    if dim == 0:
+        return symbolic_helper._reshape_helper(g, input, [1])
+    if dim == 1:
+        return g.op("Identity", input)
     # TODO: remove this as onnx opset 11 spec allows negative axes
     if end_dim < 0:
         end_dim = dim + end_dim


### PR DESCRIPTION
Avoid empty tensor generated by Slice op if using _flatten_helper for aten::flatten with 0d/1d input.

