### PR TITLE
Raise AttributeError in _OpsNamespace if __self__ attribute is requested

### DIFF
--- a/test/jit/test_custom_operators.py
+++ b/test/jit/test_custom_operators.py
@@ -41,6 +41,15 @@ class TestCustomOperators(JitTestCase):
         op2 = torch.ops._test.leaky_relu
         self.assertEqual(op, op2)
 
+    def test_getting_invalid_attr(self):
+        for attr in ["__origin__", "__self__"]:
+            with self.assertRaisesRegexWithHighlight(
+                AttributeError,
+                f"Invalid attribute '{attr}' for '_OpNamespace' '_test'",
+                ""
+            ):
+                getattr(torch.ops._test, attr)
+
     def test_simply_calling_an_operator(self):
         input = torch.randn(100)
         output = torch.ops.aten.relu(input)

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -729,8 +729,10 @@ class _OpNamespace(types.ModuleType):
         # It is not a valid op_name when __file__ is passed in
         if op_name == "__file__":
             return "torch.ops"
-        elif op_name == "__origin__":
-            raise AttributeError()
+        elif op_name in ["__origin__", "__self__"]:
+            raise AttributeError(
+                f"Invalid attribute '{op_name}' for '_OpNamespace' '{self.name}'"
+            )
 
         # Get the op `my_namespace::my_op` if available. This will also check
         # for overloads and raise an exception if there are more than one.


### PR DESCRIPTION
Summary:
Trying to get the `__self__` attribute on any `_OpNamespace` object should be an invalid operation. The `__self__` attribute only exists on instance method object and not on class objects.

In [dynamo](https://github.com/pytorch/pytorch/blob/a152b3e3b8a5f543634fad07f95ef6793c78ae53/torch/_dynamo/variables/torch.py#L164) there is code that tries to access the `__self__` attribute on `TorchVariable`, this currently results in an expensive call to `torch._C._jit_get_operation` [here](https://github.com/pytorch/pytorch/blob/a152b3e3b8a5f543634fad07f95ef6793c78ae53/torch/_ops.py#L740) which ultimately fails and throws an exception. For cases where it fails the operation turns out to be quite expensive on the order of ~0.03s.

For edge use cases when exporting large models with quantized ops this exception is thrown 100's of times resulting in a lot of time wasted. By preventing the call to `torch._C._jit_get_operation` we can quickly return from this function and significantly reduce export times. On a large ASR model for example export currently takes **~405** seconds. With this change we can reduce it to **~340s**.

Overall this should also be a harmless change as no one should mostly ever try to access the `__self__` attribute on any `_OpNamespace` object.

Test Plan: Added test case.

Differential Revision: D46959879

