### PR TITLE
[ROCm] Enable tl.reduce usage on ROCm

### DIFF
--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -283,8 +283,6 @@ test_failures = {
 if TEST_WITH_ROCM:
     # aten.miopen_batch_norm is not registered for lowering
     test_failures["test_batch_norm_2d_dynamic_shapes"] = TestFailure(("cuda"))
-    # Failed to find triton kernel after ROCm aten.prod fallback
-    test_failures["test_prod_dynamic_shapes"] = TestFailure(("cpu", "cuda"))
 
 DynamicShapesCodegenCommonTemplate = make_dynamic_cls(
     CommonTemplate, xfail_prop="_expected_failure_codegen_dynamic"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -734,9 +734,7 @@ class TritonKernel(Kernel):
         self.last_usage = set()
 
         self.persistent_reduction = self.should_use_persistent_reduction()
-        is_rocm = torch.version.hip is not None and torch.cuda.is_available()
         self.no_x_dim = (
-            not is_rocm
             and self.reduction_hint == ReductionHint.INNER
             and self.persistent_reduction
             and len(self.numels) == 2

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -735,7 +735,7 @@ class TritonKernel(Kernel):
 
         self.persistent_reduction = self.should_use_persistent_reduction()
         self.no_x_dim = (
-            and self.reduction_hint == ReductionHint.INNER
+            self.reduction_hint == ReductionHint.INNER
             and self.persistent_reduction
             and len(self.numels) == 2
             and self.numels[-1] >= 256

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1755,10 +1755,6 @@ make_fallback(aten.exponential.default, warn=False)
 # ROCm specific fallback, perf issues are observed when registered
 make_fallback(aten.miopen_batch_norm, warn=False)
 
-if torch.version.hip is not None and torch.cuda.is_available():
-    # tl.reduce not available yet in ROCm's version of triton
-    make_fallback(aten.prod, warn=False)
-
 
 @register_lowering(aten.clone)
 def clone(x, *, memory_format=0):

--- a/torch/_inductor/triton_helpers.py
+++ b/torch/_inductor/triton_helpers.py
@@ -1,8 +1,6 @@
 import triton
 import triton.language as tl
 
-TRITON_HAS_REDUCE = hasattr(tl, "reduce")
-
 
 @triton.jit
 def promote_to_tensor(x):
@@ -41,35 +39,14 @@ def maximum(a, b):
     return tl.where(mask, a, b)
 
 
-if TRITON_HAS_REDUCE:
+@triton.jit
+def min2(a, dim):
+    return tl.reduce(a, dim, minimum)
 
-    @triton.jit
-    def min2(a, dim):
-        return tl.reduce(a, dim, minimum)
 
-    @triton.jit
-    def max2(a, dim):
-        return tl.reduce(a, dim, maximum)
-
-else:
-
-    @triton.jit
-    def min2(a, dim):
-        min_values = tl.min(a, dim)
-        if is_floating(a):
-            has_nan = tl.sum(a != a, dim)
-            nan = tl.full([1], float("nan"), tl.float32).to(a.dtype)
-            min_values = tl.where(has_nan, nan, min_values)
-        return min_values
-
-    @triton.jit
-    def max2(a, dim):
-        max_values = tl.max(a, dim)
-        if is_floating(a):
-            has_nan = tl.sum(a != a, dim)
-            nan = tl.full([1], float("nan"), tl.float32).to(a.dtype)
-            max_values = tl.where(has_nan, nan, max_values)
-        return max_values
+@triton.jit
+def max2(a, dim):
+    return tl.reduce(a, dim, maximum)
 
 
 @triton.jit
@@ -104,50 +81,14 @@ def maximum_with_index(a_value, a_index, b_value, b_index):
     return tl.where(mask, a_value, b_value), tl.where(mask, a_index, b_index)
 
 
-if TRITON_HAS_REDUCE:
+@triton.jit
+def min_with_index(value, index, dim):
+    return tl.reduce((value, index), dim, minimum_with_index)
 
-    @triton.jit
-    def min_with_index(value, index, dim):
-        return tl.reduce((value, index), dim, minimum_with_index)
 
-    @triton.jit
-    def max_with_index(value, index, dim):
-        return tl.reduce((value, index), dim, maximum_with_index)
-
-else:
-
-    @triton.jit
-    def _argreduce_index(reduction_result, value, index, dim):
-        reduction_result_keepdim = reduction_result[None, :]
-        if dim == 0:
-            pass
-        elif dim == 1:
-            reduction_result_keepdim = reduction_result[:, None]
-        else:
-            tl.device_assert(False)
-
-        equal = value == reduction_result_keepdim
-        if is_floating(value):
-            # Treat nan as equal
-            result_is_nan = reduction_result_keepdim != reduction_result_keepdim
-            equal |= (value != value) and result_is_nan
-
-        invalid_index = 2**62
-        indices = tl.where(equal, index, invalid_index)
-        index = tl.min(indices, dim)
-        return index
-
-    @triton.jit
-    def min_with_index(value, index, dim):
-        min_values = min2(value, dim)
-        min_index = _argreduce_index(min_values, value, index, dim)
-        return min_values, min_index
-
-    @triton.jit
-    def max_with_index(value, index, dim):
-        max_values = max2(value, dim)
-        max_index = _argreduce_index(max_values, value, index, dim)
-        return max_values, max_index
+@triton.jit
+def max_with_index(value, index, dim):
+    return tl.reduce((value, index), dim, maximum_with_index)
 
 
 @triton.jit
@@ -168,18 +109,11 @@ def randint64(seed, offset, low, high):
     return result
 
 
-if TRITON_HAS_REDUCE:
+@triton.jit
+def _any_combine(a, b):
+    return a | b
 
-    @triton.jit
-    def _any_combine(a, b):
-        return a | b
 
-    @triton.jit
-    def any(a, dim):
-        return tl.reduce(a, dim, _any_combine)
-
-else:
-
-    @triton.jit
-    def any(a, dim):
-        return tl.max(a, dim)
+@triton.jit
+def any(a, dim):
+    return tl.reduce(a, dim, _any_combine)


### PR DESCRIPTION
Revert aten.prod explicit fallback on ROCm and enabling the use of tl.reduce in triton codegen. This PR also enables an optimisation that was previously conditionalised out for ROCm https://github.com/pytorch/pytorch/pull/102444

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78