### PR TITLE
[Core] Drop GIL in THPVariable_item around aten op

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -875,7 +875,11 @@ static PyObject * THPVariable_item(PyObject* self, PyObject* args)
   }
   jit::tracer::warn("Converting a tensor to a Python number", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = THPVariable_Unpack(self);
-  return py::cast(self_.item()).release().ptr();
+  auto dispatch_item_ = [](const Tensor& self) -> at::Scalar {
+    pybind11::gil_scoped_release no_gil;
+    return self.item();
+  };
+  return py::cast(dispatch_item_(self_)).release().ptr();
   END_HANDLE_TH_ERRORS
 }
 


### PR DESCRIPTION
This can cause a deadlock by starving other python threads required for the kernel to make progress.
