### PR TITLE
[quant][pt2] Fix QAT convert for mobilenetv2

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2039,8 +2039,8 @@ class TestQuantizePT2EModels(PT2EQuantizationTestCase):
             example_inputs = (torch.randn(1, 3, 224, 224),)
             m = torchvision.models.mobilenet_v2()
             self._verify_symmetric_qnnpack_qat_numerics(
-                m, example_inputs, is_per_channel=False, verify_convert=False,
+                m, example_inputs, is_per_channel=False, verify_convert=True,
             )
             self._verify_symmetric_qnnpack_qat_numerics(
-                m, example_inputs, is_per_channel=True, verify_convert=False,
+                m, example_inputs, is_per_channel=True, verify_convert=True,
             )

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -142,6 +142,7 @@ FILENAME_ALLOWLIST |= {
     _module_dir(torch) + "ao/quantization/_pt2e/qat_utils.py",
     _module_dir(torch) + "ao/quantization/_pt2e/quantizer/qnnpack_quantizer.py",
     _module_dir(torch) + "ao/quantization/_pt2e/representation/rewrite.py",
+    _module_dir(torch) + "ao/quantization/_pt2e/utils.py",
 }
 
 # TODO (zhxchen17) Make exportdb importable here.

--- a/torch/ao/quantization/_pt2e/qat_utils.py
+++ b/torch/ao/quantization/_pt2e/qat_utils.py
@@ -14,8 +14,10 @@ from .quantizer import (
     SharedQuantizationSpec,
     QuantizationSpecBase,
 )
-from .utils import _fold_bn_weights_into_conv_node
-from .utils import _get_aten_graph_module
+from .utils import (
+    _fold_bn_weights_into_conv_node,
+    _get_aten_graph_module,
+)
 
 # Example inputs for `_conv2d_bn_pattern`, `_qat_conv2d_bn_pattern`, and `_qat_conv2d_bn_pattern_no_bias`
 _conv2d_bn_pattern_example_inputs = (

--- a/torch/ao/quantization/_quantize_pt2e.py
+++ b/torch/ao/quantization/_quantize_pt2e.py
@@ -10,6 +10,7 @@ from ._pt2e.utils import (
     _get_node_name_to_scope,
     _fuse_conv_bn_,
     _rearrange_weight_observer_for_decomposed_linear,
+    _replace_dropout_for_eval,
 )
 from ._pt2e.representation import reference_representation_rewrite
 from .fx.prepare import prepare as fx_prepare
@@ -86,6 +87,9 @@ def convert_pt2e(
     model: GraphModule,
     use_reference_representation: bool = False,
 ) -> GraphModule:
+    # TODO: Handle this in export itself, outside of quantization
+    # See https://github.com/pytorch/pytorch/issues/103681.
+    _replace_dropout_for_eval(model)
     model = _convert_to_reference_decomposed_fx(model)
     model = _fold_conv_bn_qat(model)
     if use_reference_representation:


### PR DESCRIPTION
Summary:
QAT convert for mobilenetv2 was previously not working
because we incorrectly applied dropout during eval as well as
training. This is because, for exported models, model.eval() does
not change the behavior of dropout, unlike models with torch ops.
This commit simulates the effects of model.eval() for exported
models as well by replacing the aten dropout pattern before eval.
As of this commit, end-to-end QAT numerics now match for
mobilenetv2 between FX and PT2.

Test Plan: python test/test_quantization.py TestQuantizePT2EModels.test_qat_mobilenet_v2

Differential Revision: D46750343



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78