### PR TITLE
Revert D46729844: Multisect successfully blamed D46729844 for test or build failures

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -7,7 +7,7 @@ from torch._functorch.aot_autograd import FQN, GraphInputName, GraphOutputName
 
 
 import torch
-from torch.fx.passes.infra.pass_manager import PassManager
+from torch.fx.passes.pass_manager import PassManager
 import torch.fx._pytree as fx_pytree
 import torch.utils._pytree as pytree
 from torch.fx.experimental.symbolic_shapes import SymInt
@@ -162,8 +162,6 @@ class ExportedProgram:
             copy.deepcopy(self.range_constraints),
             copy.deepcopy(self.equality_constraints),
         )
-        transformed_ep.graph_module.meta.update(self.graph_module.meta)
-        transformed_ep.graph_module.meta.update(res.graph_module.meta)
         return transformed_ep
 
     def _add_runtime_assertions(self) -> "ExportedProgram":

--- a/torch/_export/passes/replace_sym_size_ops_pass.py
+++ b/torch/_export/passes/replace_sym_size_ops_pass.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 import torch
-from torch.fx.passes.infra.pass_base import PassBase, PassResult
+from torch.fx.passes.infra.pass_base import PassBase
 
 replacements: Dict[torch._ops.OpOverloadPacket, torch._ops.OpOverload] = {
     torch.ops.aten.sym_size: torch.ops.aten.sym_size.int,
@@ -16,13 +16,10 @@ class _ReplaceSymSizeOpPass(PassBase):
     and torch.ops.aten.sym_stride with torch.ops.aten.sym_stride.int
     """
 
-    def call(self, graph_module) -> PassResult:
-        modified = False
+    def call(self, graph_module):
         for module in graph_module.modules():
             if not isinstance(module, torch.fx.GraphModule):
                 continue
             for node in module.graph.nodes:
                 if node.target in replacements:
                     node.target = replacements[node.target]
-                    modified = True
-        return PassResult(graph_module, modified)


### PR DESCRIPTION
Summary:
This diff is reverting D46729844
D46729844: Remove ExportGraphModuleMixin. by ydwu4 has been identified to be causing the following test or build failures:

Tests affected:
- [pye/model_inventory/occlusion_detection_model:occlusion_detection_export_test - test_export_xnnpack_fp32 (pye.model_inventory.occlusion_detection_model.OcclusionDetectionModelExportTest.OcclusionDetectionModelExportTest)](https://www.internalfb.com/intern/test/562950050433172/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2336443
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: JacobSzwejbka

Differential Revision: D46964068

