### PR TITLE
Preserve all submodules/parameters/buffers when unpickle graph module

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -153,6 +153,10 @@ class Foo:  # noqa: B209
         self.a = a
         self.b = b
 
+class Add(torch.nn.Module):
+    def forward(self, x):
+        return x + x
+
 @torch.fx.has_side_effect
 @torch.fx.wrap
 def side_effect_func(x: torch.Tensor):
@@ -4068,6 +4072,18 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
                 found = True
         self.assertTrue(found)
 
+    def test_preserve_unused_attr_after_unpickle(self):
+        gm = torch.fx.symbolic_trace(Add())
+        gm.add_submodule("foo", Add())
+        gm.register_buffer("dummy_buffer", torch.empty(1))
+        gm.register_parameter("dummy_parameter", torch.nn.Parameter(torch.empty(1)))
+        b = io.BytesIO()
+        torch.save(gm, b)
+        b.seek(0)
+        reload_gm = torch.load(b)
+        self.assertTrue(hasattr(reload_gm, "foo"))
+        self.assertTrue(hasattr(reload_gm, "dummy_buffer"))
+        self.assertTrue(hasattr(reload_gm, "dummy_parameter"))
 
 class TestFunctionalTracing(JitTestCase):
     def setUp(self):

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -127,6 +127,13 @@ def reduce_deploy_graph_module(
     forward = _forward_from_src(import_block + fn_src, ns)
     return _deserialize_graph_module(forward, body)
 
+# We create a dummy class here because symbolic_trace pulls the forward()
+# function off of the class, rather than the instance. This class is used
+# in _deserialize_graph_module() below.
+class _CodeOnlyModule(torch.nn.Module):
+    def __init__(self, body):
+        super().__init__()
+        self.__dict__ = body
 
 def _deserialize_graph_module(forward, body: Dict[Any, Any]) -> torch.nn.Module:
     """
@@ -135,15 +142,9 @@ def _deserialize_graph_module(forward, body: Dict[Any, Any]) -> torch.nn.Module:
     saving the dictionary so that changes to the in-memory graph format do not
     get serialized.
     """
-    # We create a dummy class here because symbolic_trace pulls the forward()
-    # function off of the class, rather than the instance
-    class CodeOnlyModule(torch.nn.Module):
-        def __init__(self, body):
-            super().__init__()
-            self.__dict__ = body
 
     # Try to retrieve the forward source in a backward-compatible way
-    CodeOnlyModule.forward = forward
+    _CodeOnlyModule.forward = forward
 
     tracer_cls = body.get('_tracer_cls')
     if tracer_cls is None:
@@ -162,7 +163,7 @@ def _deserialize_graph_module(forward, body: Dict[Any, Any]) -> torch.nn.Module:
         def is_leaf_module(self, _: torch.nn.Module, __: str) -> bool:
             return True
 
-    com = CodeOnlyModule(body)
+    com = _CodeOnlyModule(body)
 
     tracer_extras = body.get('_tracer_extras', {})
     graph = KeepModules().trace(com, **tracer_extras)
@@ -342,6 +343,18 @@ class GraphModule(torch.nn.Module):
         if isinstance(root, torch.nn.Module):
             if hasattr(root, 'training'):
                 self.training = root.training
+
+            # When we pickle/unpickle graph module, we don't want to drop any module or attributes.
+            if isinstance(root, _CodeOnlyModule):
+                for k, _ in root.named_children():
+                    _copy_attr(root, self, k)
+
+                for k, _ in root.named_buffers():
+                    _copy_attr(root, self, k)
+
+                for k, _ in root.named_parameters():
+                    _copy_attr(root, self, k)
+
             for node in graph.nodes:
                 if node.op in ['get_attr', 'call_module']:
                     assert isinstance(node.target, str)


### PR DESCRIPTION
Summary:
When we pickle/unpickle graph module in multipy, we would lost modules/attributes that are not referred in the graph. This is because when unpickle fx graph module, we use the stored `__dict__` and the fx graph to create a new graph module. In GraphModule init, we drop any attribute that is not referred in the graph.

This behavior is not ideal because we actually expect a graph module that's exactly the same after unpickling.

Test Plan:
```
buck test mode/opt caffe2/test:fx -- test_preserve_unused_attr_after_unpickle

Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D46976230

