### PR TITLE
Remove CUDA 11.7 Docker image build

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -264,16 +264,6 @@ case "$image" in
     DOCS=yes
     INDUCTOR_BENCHMARKS=yes
     ;;
-  pytorch-linux-jammy-cuda11.7-cudnn8-py3.8-clang12)
-    ANACONDA_PYTHON_VERSION=3.8
-    CUDA_VERSION=11.7
-    CUDNN_VERSION=8
-    CLANG_VERSION=12
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    TRITON=yes
-    ;;
   pytorch-linux-jammy-cuda11.8-cudnn8-py3.8-clang12)
     ANACONDA_PYTHON_VERSION=3.8
     CUDA_VERSION=11.8

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -42,7 +42,6 @@ jobs:
           - docker-image-name: pytorch-linux-bionic-py3.11-clang9
           - docker-image-name: pytorch-linux-focal-rocm-n-1-py3
           - docker-image-name: pytorch-linux-focal-rocm-n-py3
-          - docker-image-name: pytorch-linux-jammy-cuda11.7-cudnn8-py3.8-clang12
           - docker-image-name: pytorch-linux-jammy-cuda11.8-cudnn8-py3.8-clang12
           - docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
           - docker-image-name: pytorch-linux-focal-py3.8-gcc7


### PR DESCRIPTION
This option has been removed by https://github.com/pytorch/builder/pull/1408.  This is currently failing in trunk https://github.com/pytorch/pytorch/actions/runs/5358541073/jobs/9720970056