### PR TITLE
Re-enable `test_typing`

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -185,7 +185,6 @@ TESTS = discover_tests(
         "test_segment_reductions",
         "test_static_runtime",
         "test_throughput_benchmark",
-        "test_typing",
         "distributed/bin/test_script",
         "distributed/elastic/multiprocessing/bin/test_script",
         "distributed/launcher/bin/test_script",

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -5,6 +5,7 @@ import itertools
 import os
 import re
 import shutil
+import sys
 from collections import defaultdict
 from typing import IO, Dict, List, Optional
 
@@ -19,6 +20,9 @@ except ImportError:
 else:
     NO_MYPY = False
 
+# NB Tests can be skipped because mypy==0.960 cannnot work with python>=3.10
+# due to positional-only args. Ref https://github.com/python/mypy/issues/13627
+INCOMPATIBLE_PY = sys.version_info >= (3, 10)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "typing")
 REVEAL_DIR = os.path.join(DATA_DIR, "reveal")
@@ -47,6 +51,7 @@ def _strip_filename(msg: str) -> str:
     return tail.split(":", 1)[-1]
 
 
+@pytest.mark.skipif(INCOMPATIBLE_PY, reason="Python 3.10+ is not yet supported")
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.fixture(scope="module", autouse=True)
 def run_mypy() -> None:
@@ -99,6 +104,7 @@ def get_test_cases(directory):
                 )
 
 
+@pytest.mark.skipif(INCOMPATIBLE_PY, reason="Python 3.10+ is not yet supported")
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
@@ -110,6 +116,7 @@ def test_success(path):
         raise AssertionError(msg)
 
 
+@pytest.mark.skipif(INCOMPATIBLE_PY, reason="Python 3.10+ is not yet supported")
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
 def test_fail(path):
@@ -204,6 +211,7 @@ def _parse_reveals(file: IO[str]) -> List[str]:
     return fmt_str.split("/n")
 
 
+@pytest.mark.skipif(INCOMPATIBLE_PY, reason="Python 3.10+ is not yet supported")
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(REVEAL_DIR))
 def test_reveal(path):

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -76,7 +76,7 @@ def run_mypy() -> None:
                 directory,
             ]
         )
-        assert not stderr, directory
+        assert not stderr, f"In {directory}, mypy raised error: {stderr}"
         stdout = stdout.replace("*", "")
 
         # Parse the output
@@ -121,7 +121,7 @@ def test_fail(path):
     errors = defaultdict(lambda: "")
 
     output_mypy = OUTPUT_MYPY
-    assert path in output_mypy
+    assert path in output_mypy, f"{path} not in {output_mypy}"
     for error_line in output_mypy[path]:
         error_line = _strip_filename(error_line)
         match = re.match(
@@ -213,7 +213,7 @@ def test_reveal(path):
         lines = _parse_reveals(fin)
 
     output_mypy = OUTPUT_MYPY
-    assert path in output_mypy
+    assert path in output_mypy, f"{path} not in {output_mypy}"
     for error_line in output_mypy[path]:
         match = re.match(
             r"^.+\.py:(?P<lineno>\d+):\d+: note: .+$",

--- a/test/typing/fail/bitwise_ops.py
+++ b/test/typing/fail/bitwise_ops.py
@@ -1,9 +1,0 @@
-# flake8: noqa
-import torch
-
-# binary ops: <<, >>, |, &, ~, ^
-
-a = torch.ones(3, dtype=torch.float64)
-i = int()
-
-i | a  # E: Unsupported operand types

--- a/test/typing/reveal/namedtuple.py
+++ b/test/typing/reveal/namedtuple.py
@@ -9,7 +9,8 @@ t_sort.indices[0, 0] == 1   # noqa: B015
 t_sort.values[0, 0] == 1.5  # noqa: B015
 reveal_type(t_sort)  # E: Tuple[{Tensor}, {Tensor}, fallback=torch.return_types.sort]
 
-t_qr = torch.linalg.qr(t)
-t_qr[0].shape == [2, 2]     # noqa: B015
-t_qr.Q.shape == [2, 2]      # noqa: B015
-reveal_type(t_qr)  # E: Tuple[{Tensor}, {Tensor}, fallback=torch.return_types.qr]
+# TODO: activate when linalg has typing
+# t_qr = torch.linalg.qr(t)
+# t_qr[0].shape == [2, 2]     # noqa: B015
+# t_qr.Q.shape == [2, 2]      # noqa: B015
+# reveal_type(t_qr)  # E: Tuple[{Tensor}, {Tensor}, fallback=torch.return_types.qr]

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -352,7 +352,7 @@ class TensorVariable(VariableTracker):
             elif dim_var is not None:
                 dim = dim_var.as_python_constant()
 
-            def make_const_size_variable(x, **options):
+            def make_const_size_variable(x, **options) -> SizeVariable:
                 return SizeVariable(
                     [ConstantVariable(y, **options) for y in x], **options
                 )


### PR DESCRIPTION
Fixes #104119

- Adds an env var to control whether to clear mypy cache, because rebuilding cache is slow.
- Adjusts result parsing to follow the format specified in [`mypy.ini`](https://github.com/pytorch/pytorch/blob/main/mypy.ini) (column is shown)
- Removes the failure test on bitwise ops because they are indeed supported on float tensors (at least from the view of mypy)
- Deactivates the reveal test on `linalg` because it's not typed at all.

For more details see conversations in the code.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @ipiszy