### PR TITLE
[BE][Test] Remove `--pytest` option from `run_test.py`

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1086,14 +1086,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "-pt",
-        "--pytest",
-        action="store_true",
-        help="If true, use `pytest` to execute the tests. E.g., this runs "
-        "TestTorch with pytest in verbose and coverage mode: "
-        "python run_test.py -vci torch -pt",
-    )
-    parser.add_argument(
         "-k",
         "--pytest-k-expr",
         default="",


### PR DESCRIPTION
Because we always run tests with pytest now.

Marking it as `bc-breaking` as there could technically be some scripts depending on it somewhere...

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1760568</samp>

> _`pytest` option gone_
> _simpler test runner script_
> _autumn leaves fall fast_