### PR TITLE
[pt2][inductor] include `allow_tf32` in system information

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -119,6 +119,9 @@ class CacheBase:
                 "cuda": torch.version.cuda,
                 "triton": triton_version,
             },
+            "other": {
+                "allow_tf32": torch.backends.cuda.matmul.allow_tf32,
+            },
         }
 
         system["hash"] = hashlib.sha256(


### PR DESCRIPTION
Summary: include `allow_tf32` in system information; previously aten results did not specify whether `allow_tf32` was true or not

Test Plan: sandcastle + CI

Differential Revision: D46568468



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8