### PR TITLE
[ET][XNNPACK] Add support for quantized Multiply

### DIFF
--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -311,7 +311,7 @@ def _get_binary_ops_configs() -> List[BackendPatternConfig]:
         2: ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
     }
     binary_op_configs: List[BackendPatternConfig] = []
-    for op in [operator.add, torch.add, operator.sub, torch.sub]:
+    for op in [operator.add, torch.add, operator.sub, torch.sub, operator.mul, torch.mul]:
         bop_patterns = [
             (op, torch.nn.ReLU),
             (op, torch.nn.functional.relu),


### PR DESCRIPTION
Summary:
Also adds support for backend_config with relu fusion since XNNPACK allows it.

We should revisit the relu fusion once we gain more clarity on quantSrcPartition or some other way to do these fusion and not having to add all combinations.

We should really rename the backend config to et_xnnpack.py or something TODO

Test Plan: `buck test fbcode//mode/dev-nosan fbcode//executorch/backends/xnnpack/test:`

Differential Revision: D46985169

