### PR TITLE
add dist hooks support for custom device

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -850,3 +850,12 @@ def classproperty(func):
 # Whether we are compiling with torch.compile or not
 def is_compiling():
     return False
+
+
+def _get_device_module(device_type: str):
+    device_module = getattr(torch, device_type, None)
+    if device_module is None:
+        raise RuntimeError(
+            f"invalid device type {device_type}, no module named torch.{device_type}."
+        )
+    return device_module

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -4,7 +4,7 @@ from torch.autograd import Variable
 
 from dataclasses import dataclass
 from typing import Any, no_type_check
-from torch.distributed.utils import _free_storage
+from torch.distributed.utils import _free_storage, _DeviceModule
 
 @dataclass
 class _AllreduceUpcastHookState:
@@ -16,7 +16,7 @@ class _AllreduceUpcastHookState:
     ddp_weakref: Any
     upcast_stream: torch.Stream
     wait_for_stream_enqueued: bool = False
-    device_module: Any = torch.cuda
+    device_module: _DeviceModule = torch.cuda  # type: ignore[assignment]
 
 @no_type_check
 def _reducer_allreduce_and_upcast_hook(

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -14,7 +14,7 @@ class _AllreduceUpcastHookState:
     group, and a stream to run parameter and gradient upcasts.
     """
     ddp_weakref: Any
-    upcast_stream: torch.cuda.Stream
+    upcast_stream: torch.Stream
     wait_for_stream_enqueued: bool = False
 
 @no_type_check
@@ -38,7 +38,10 @@ def _reducer_allreduce_and_upcast_hook(
     fut = reducer._run_allreduce_hook(bucket)
     ret_fut = torch.futures.Future()
     stream = hook_state.upcast_stream
-    with torch.cuda.stream(stream):
+    device_type = stream.device.type
+    assert device_type in ["cuda", torch._C._get_privateuse1_backend_name()]
+    device_module = getattr(torch, device_type)
+    with device_module.stream(stream):
         fut.wait()
         bucket.buffer().div_(process_group.size())
         ret_fut.set_result(bucket.buffer())
@@ -54,7 +57,7 @@ def _reducer_allreduce_and_upcast_hook(
 
     # enqueue a callback to wait for this stream at end of backward
     def wait_for_stream_cb():
-        torch.cuda.current_stream().wait_stream(stream)
+        device_module.current_stream().wait_stream(stream)
         # Remove post-backward hooks since they are re-installed in next
         # iteration, similar to FSDP.
         # Parameters that don't require grad still needed to be casted since

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, List, no_type_check
 import torch
 import torch.distributed as dist
 from torch.autograd import Variable
+from torch.distributed.utils import _DeviceModule
 from torch._utils import _get_device_module
 from functools import partial
 from dataclasses import dataclass
@@ -40,7 +41,7 @@ class _OptimizerHookState:
 class _OptimInBackwardHookState:
     optim_stream: torch.Stream
     wait_for_optim_stream_enqueued: bool
-    device_module: Any = torch.cuda
+    device_module: _DeviceModule = torch.cuda  # type: ignore[assignment]
 
 @no_type_check
 def _apply_optim_in_backward_hook(

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, List, no_type_check
 import torch
 import torch.distributed as dist
 from torch.autograd import Variable
+from torch._utils import _get_device_module
 from functools import partial
 from dataclasses import dataclass
 
@@ -50,9 +51,7 @@ def _apply_optim_in_backward_hook(
     optimizer with backward pass, DDP will run the below hook to run optimizer
     step for parameters after gradient communication has taken place.
     """
-    device_module = getattr(torch, device_type, None)
-    if device_module is None:
-        raise RuntimeError(f"invalid device type {device_type}, no module named torch.{device_type}.")
+    device_module = _get_device_module(device_type)
     optim_in_bwd_state = _OptimInBackwardHookState(
         optim_stream=device_module.Stream(),
         wait_for_optim_stream_enqueued=False,

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -5,9 +5,10 @@ from typing import Dict
 
 import torch
 import torch.distributed as dist
+from torch.distributed import distributed_c10d
+from torch._utils import _get_device_module
 
 from . import default_hooks as default
-from torch.distributed import distributed_c10d
 
 __all__ = [
     "PowerSGDState", "powerSGD_hook", "batched_powerSGD_hook"
@@ -397,9 +398,7 @@ def powerSGD_hook(
 
     # Apply PowerSGD after `start_powerSGD_iter` iterations.
     device = input_tensor.device
-    device_module = getattr(torch, device.type, None)
-    if device_module is None:
-        raise RuntimeError(f"invalid device type {device.type}, no module named torch.{device.type}.")
+    device_module = _get_device_module(device.type)
     dtype = input_tensor.dtype
 
     # Incorporate the error from the previous state into the gradients.
@@ -706,9 +705,7 @@ def batched_powerSGD_hook(
 
     # Apply PowerSGD after `start_powerSGD_iter` iterations.
     device = input_tensor.device
-    device_module = getattr(torch, device.type, None)
-    if device_module is None:
-        raise RuntimeError(f"invalid device type {device.type}, no module named torch.{device.type}.")
+    device_module = _get_device_module(device.type)
     total_length = input_tensor.shape[0]
     state.total_numel_before_compression += total_length
 

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,10 +1,11 @@
 import dataclasses
 import traceback
-from typing import Any, Callable, Container, Dict, List, Optional, OrderedDict, Tuple, TypeVar, overload
+from contextlib import AbstractContextManager
+from typing import Any, Callable, Container, Dict, List, Optional, OrderedDict, Tuple, TypeVar, overload, Protocol
 
 import torch
 import torch.distributed as dist
-from torch import nn
+from torch import nn, Stream
 from torch.nn.parallel._functions import _get_stream
 from torch.nn.parallel.scatter_gather import _is_namedtuple
 from torch.nn.utils.rnn import PackedSequence
@@ -330,3 +331,11 @@ def _replace_by_prefix(
         new_key = new_prefix + key[len(old_prefix) :]
         state_dict[new_key] = state_dict[key]
         del state_dict[key]
+
+
+class _DeviceModule(Protocol):
+    def stream(self, Stream) -> AbstractContextManager:
+        ...
+
+    def current_stream(self) -> Stream:
+        ...

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -850,6 +850,7 @@ class DistributedDataParallel(Module, Joinable):
             upcast_hook_state = _AllreduceUpcastHookState(
                 ddp_weakref=weakref.ref(self),
                 upcast_stream=_get_device_module(self._device_module_type).Stream(),
+                device_module=_get_device_module(self._device_module_type),
             )
             self.register_comm_hook(
                 upcast_hook_state,

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -35,7 +35,7 @@ if torch.distributed.rpc.is_available():
     RPC_AVAILABLE = True
     from torch.distributed.rpc import RRef
 
-from torch._utils import _get_device_index
+from torch._utils import _get_device_index, _get_device_module
 
 from ..modules import Module
 from .scatter_gather import gather, scatter_kwargs  # noqa: F401
@@ -703,9 +703,11 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         self.device_type = list(distinct_device_types)[0]
-        self.device_module = getattr(torch, self.device_type, None)
-        if self.device_module is None:
-            raise RuntimeError(f"invalid device type {self.device_type}, no module named torch.{self.device_type}.")
+        # use `torch.cuda` module to solve `xla` device
+        self._device_module_type = (
+            self.device_type if self.device_type != "xla" else "cuda"
+        )
+        _get_device_module(self._device_module_type)
 
         if (
             device_ids is None
@@ -821,7 +823,7 @@ class DistributedDataParallel(Module, Joinable):
             _setup_mixed_precision_params(self.mixed_precision, self.module)
             _cast_buffers(self.mixed_precision, self.module)
             # Stream used for async low precision copies.
-            self._mp_stream = self.device_module.Stream()
+            self._mp_stream = _get_device_module(self._device_module_type).Stream()
             self._submodule_to_event = defaultdict(deque)  # type: ignore[var-annotated]
             # Add forward pre-hook to root module to kick off copies to lower
             # precision.
@@ -847,7 +849,7 @@ class DistributedDataParallel(Module, Joinable):
 
             upcast_hook_state = _AllreduceUpcastHookState(
                 ddp_weakref=weakref.ref(self),
-                upcast_stream=self.device_module.Stream(),
+                upcast_stream=_get_device_module(self._device_module_type).Stream(),
             )
             self.register_comm_hook(
                 upcast_hook_state,
@@ -952,7 +954,7 @@ class DistributedDataParallel(Module, Joinable):
                 ddp_weakref,
                 _apply_optim_in_backward_hook(
                     gradient_is_bucket_view=self.gradient_as_bucket_view,
-                    device_type=self.device_type,
+                    device_type=self._device_module_type,
                 ),
             )
 
@@ -977,7 +979,7 @@ class DistributedDataParallel(Module, Joinable):
         # may have populated some events for modules that didn't end up being
         # used.
         self._submodule_to_event = defaultdict(deque)  # type: ignore[var-annotated]
-        with self.device_module.stream(self._mp_stream):
+        with _get_device_module(self._device_module_type).stream(self._mp_stream):
             for submodule in self.module.modules():
                 for param in submodule.parameters(recurse=False):
                     # Do not cast DDP ignored parameters.
@@ -1001,7 +1003,7 @@ class DistributedDataParallel(Module, Joinable):
                                 self.mixed_precision.param_dtype  # type: ignore[union-attr]
                             )
                     param.data = param._mp_param
-                copy_event = self.device_module.Event()
+                copy_event = _get_device_module(self._device_module_type).Event()
                 copy_event.record()
                 self._submodule_to_event[submodule].append(copy_event)
 
@@ -1021,7 +1023,7 @@ class DistributedDataParallel(Module, Joinable):
             # copy event has already been waited on
             return
 
-        event.wait(stream=self.device_module.current_stream())
+        event.wait(stream=_get_device_module(self._device_module_type).current_stream())
         for p in module.parameters(recurse=False):
             # Don't register hooks if param does not require grad
             if not p.requires_grad or (hasattr(p, "_ddp_ignored") and p._ddp_ignored):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/104389
1. Now for distributed hooks, there are some hard-code like `cuda`, we want to support these hooks for custom device( privateuse1 backend), so we use the abstract device-module to run some funcs.
2. In `torch/nn/parallel/distributed.py`, I want to define a variable `self.device_module = getattr(torch, self.device_type, None)` so that we can reuse it, but it will cause an error in serialization, `TypeError: cannot pickle 'module' object`. So we call the func by `getattr` when needs.