### PR TITLE
make funcs argument type from torch.cuda.stream as torch.Stream

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -337,8 +337,8 @@ def _init_streams(
 def _unshard(
     state: _FSDPState,
     handles: List[FlatParamHandle],
-    unshard_stream: torch.cuda.Stream,
-    pre_unshard_stream: torch.cuda.Stream,
+    unshard_stream: torch.Stream,
+    pre_unshard_stream: torch.Stream,
 ) -> None:
     """
     Unshards the handles in ``handles``. If the handles are in
@@ -1426,9 +1426,9 @@ def _register_post_backward_final_callback(
 
 
 def _wait_for_computation_stream(
-    computation_stream: torch.cuda.Stream,
-    unshard_stream: torch.cuda.Stream,
-    pre_unshard_stream: torch.cuda.Stream,
+    computation_stream: torch.Stream,
+    unshard_stream: torch.Stream,
+    pre_unshard_stream: torch.Stream,
 ):
     """
     Has the unshard and pre-unshard streams wait for the computation stream.

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -54,9 +54,9 @@ def _same_storage_as_data_ptr(x: torch.Tensor, data_ptr: int) -> bool:
     return x._typed_storage()._data_ptr() == data_ptr
 
 
-def _no_dispatch_record_stream(tensor: torch.Tensor, stream: torch.cuda.Stream) -> None:
+def _no_dispatch_record_stream(tensor: torch.Tensor, stream: torch.Stream) -> None:
     # FIXME record_stream doesn't work with non-cuda tensors
     if not tensor.is_cuda:
         return
     with no_dispatch():
-        tensor.record_stream(cast(torch._C.Stream, stream))
+        tensor.record_stream(cast(torch._C.Stream, stream))  # type: ignore[redundant-cast]

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, cast, Dict, Type
+from typing import Any, Dict, Type
 
 import torch
 
@@ -56,7 +56,7 @@ def _same_storage_as_data_ptr(x: torch.Tensor, data_ptr: int) -> bool:
 
 def _no_dispatch_record_stream(tensor: torch.Tensor, stream: torch.Stream) -> None:
     # FIXME record_stream doesn't work with non-cuda tensors
-    if not tensor.is_cuda:
+    if tensor.device.type not in ["cuda", torch._C._get_privateuse1_backend_name()]:
         return
     with no_dispatch():
-        tensor.record_stream(cast(torch._C.Stream, stream))  # type: ignore[redundant-cast]
+        tensor.record_stream(stream)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1. we want to support fsdp for custom device, so we make funcs argument type from torch.cuda.stream as torch.Stream