### PR TITLE
[WIP][nanoGPT][DTensor] enable inplace dropout for nanoGPT benchmark

### DIFF
--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -225,6 +225,7 @@ def _operator_dispatch(
             aten.native_dropout.default,
             aten.normal_.default,
             aten.uniform_.default,
+            aten.bernoulli_.float,
         ]
         # before running local op computation, check if op is random op
         # for random ops, set RNG offset

--- a/torch/distributed/_tensor/ops/pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/pointwise_ops.py
@@ -142,6 +142,7 @@ pointwise_ops = [
     aten.div.Tensor_mode,
     aten.div.out,
     aten.div.out_mode,
+    aten.div_.Scalar,
     aten.div_.Tensor,
     aten.div_.Tensor_mode,
     aten.eq.Tensor,

--- a/torch/distributed/_tensor/ops/random_ops.py
+++ b/torch/distributed/_tensor/ops/random_ops.py
@@ -11,6 +11,7 @@ aten = torch.ops.aten
 random_ops = [
     aten.normal_.default,
     aten.uniform_.default,
+    aten.bernoulli_.float,
 ]
 
 

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -94,6 +94,15 @@ def parallelize_module(  # type: ignore[return]
             return _parallelize_multihead_attn(module, device_mesh)
         elif _is_mlp_for_pairwise_parallel(module):
             return _parallelize_mlp(module, device_mesh, parallelize_plan)
+        elif isinstance(module, torch.nn.Dropout):
+            distribute_module(
+                module,
+                device_mesh,
+                None,
+                input_fn=parallelize_plan._prepare_input,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+                output_fn=parallelize_plan._prepare_output,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+            )
+            return module
         else:
             for n, m in module.named_children():
                 module.register_module(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104200

# WHY
non-inplace dropout seems not working with DTensor. need to further investigate.
