### PR TITLE
aten: Ensure dim is size_t

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Expand.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Expand.cpp
@@ -26,7 +26,7 @@ Tensor expand(
       self.dim() > 0 && self.dim() <= 4,
       "Vulkan expand supports up to 4d tensors");
   TORCH_CHECK(
-      self.dim() <= output_size.size(),
+      static_cast<size_t>(self.dim()) <= output_size.size(),
       "Vulkan expand: the number of sizes provided (",
       output_size.size(),
       ") must be greater or equal to the number of dimensions in the tensor (",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104201

Attempts to fix failures introduced in https://github.com/pytorch/pytorch/pull/103930 (example failures: https://github.com/pytorch/pytorch/actions/runs/5363450214/jobs/9731034104)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 67d5076</samp>

### Summary
🔧🚨🚦

<!--
1.  🔧 (wrench) - This emoji can be used to indicate a bug fix or a minor improvement to the code quality or performance.
2.  🚨 (rotating light) - This emoji can be used to indicate a change that affects the error handling or validation logic of the code, or that adds or modifies a test case.
3.  🚦 (vertical traffic light) - This emoji can be used to indicate a change that affects the control flow or branching logic of the code, or that adds or modifies a condition or assertion.
-->
Fix a compiler warning in `Expand.cpp` by casting a tensor dimension to `size_t`. This improves the code quality and correctness of the `expand` function for the Vulkan backend.

> _`expand` tensor_
> _cast `dim()` to `size_t`_
> _autumn leaves warning_

### Walkthrough
*  Cast `self.dim()` to `size_t` to avoid signed-unsigned comparison warning in `expand` function ([link](https://github.com/pytorch/pytorch/pull/104201/files?diff=unified&w=0#diff-c175e908cbcb8595b22696e672b526202ed3a4a11341603c1522397e499b5c2bL29-R29))

<details>
<summary> Fix done using chatgpt </summary>


![Screenshot 2023-06-26 at 11 52 14 AM](https://github.com/pytorch/pytorch/assets/1700823/95c141e5-36b6-4916-85ca-85415bcc507f)

</details>
Signed-off-by: Eli Uriegas <eliuriegas@meta.com>