### PR TITLE
Correct output_padding for quantized tconv (torch->onnx)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12491,7 +12491,9 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
 
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_conv_transpose1d(self):
-        model = torch.ao.nn.quantized.ConvTranspose1d(16, 33, 3, stride=2)
+        model = torch.ao.nn.quantized.ConvTranspose1d(
+            16, 33, 3, output_padding=1, stride=2
+        )
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
         q_weight = torch.quantize_per_tensor(
@@ -12505,7 +12507,9 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
 
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_conv_transpose2d(self):
-        model = torch.ao.nn.quantized.ConvTranspose2d(16, 33, 3, stride=2)
+        model = torch.ao.nn.quantized.ConvTranspose2d(
+            16, 33, 3, output_padding=(0, 1), stride=2
+        )
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
         q_weight = torch.quantize_per_tensor(
@@ -12521,7 +12525,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfQuantizationBackendQNNPack
     def test_quantized_conv_transpose3d(self):
         model = torch.ao.nn.quantized.ConvTranspose3d(
-            16, 33, [2, 3, 4], stride=[3, 1, 2]
+            16, 33, [2, 3, 4], output_padding=(0, 1, 2), stride=[3, 1, 2]
         )
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -313,7 +313,8 @@ void unpackQuantizedWeightsHelper(
     const std::string& pattern,
     const std::string& unpack_fn,
     QuantizedParamsType params_type,
-    bool caffe2 = true) {
+    bool caffe2 = true,
+    bool expect_output_padding = false) {
   Graph pattern_graph;
   std::unordered_map<std::string, Value*> vmap;
   parseIR(pattern, &pattern_graph, vmap);
@@ -334,8 +335,17 @@ void unpackQuantizedWeightsHelper(
     c10::optional<at::Tensor> bias;
     constexpr int64_t stride_idx = 2;
     constexpr int64_t padding_idx = 3;
-    constexpr int64_t dilation_idx = 4;
-    constexpr int64_t groups_idx = 5;
+    int64_t output_padding_idx;
+    int64_t dilation_idx;
+    int64_t groups_idx;
+    if (expect_output_padding) {
+      output_padding_idx = 4;
+      dilation_idx = 5;
+      groups_idx = 6;
+    } else {
+      dilation_idx = 4;
+      groups_idx = 5;
+    }
     c10::optional<torch::List<int64_t>> stride, padding, dilation,
         output_padding;
     c10::optional<int64_t> groups;
@@ -413,6 +423,9 @@ void unpackQuantizedWeightsHelper(
         dilation = dilation_int;
         groups = groups_int;
         transpose = transpose_int;
+        if (expect_output_padding) {
+          output_padding = output_padding_int;
+        }
       } else if (
           (params_type == QuantizedParamsType::CONV ||
            params_type == QuantizedParamsType::CONV1D) &&
@@ -478,6 +491,9 @@ void unpackQuantizedWeightsHelper(
         dilation = dilation_int;
         groups = groups_int;
         transpose = transpose_int;
+        if (expect_output_padding) {
+          output_padding = output_padding_int;
+        }
       } else { // Legacy
         unpacked_weight = ser_tup->elements()[0].toTensor();
         bias = ser_tup->elements()[1].toOptional<at::Tensor>();
@@ -502,6 +518,15 @@ void unpackQuantizedWeightsHelper(
           padding = padding_int;
           dilation = dilation_int;
           groups = groups_int;
+
+          if (expect_output_padding) {
+            auto output_padding_ivalue =
+                ser_tup->elements()[output_padding_idx].toListRef();
+            for (const auto& d : output_padding_ivalue) {
+              output_padding_int.emplace_back(d.toTensor()[0].item<int64_t>());
+            }
+            output_padding = output_padding_int;
+          }
         }
       }
     } else {
@@ -571,10 +596,14 @@ void unpackQuantizedWeightsHelper(
 
     // add conv arguments: stride, padding, dilation, groups
     if (stride.has_value() && padding.has_value() && dilation.has_value() &&
-        groups.has_value()) {
+        groups.has_value() &&
+        (!expect_output_padding || output_padding.has_value())) {
       std::vector<c10::optional<torch::List<int64_t>>> conv_ints_args;
       conv_ints_args.push_back(stride);
       conv_ints_args.push_back(padding);
+      if (expect_output_padding) {
+        conv_ints_args.push_back(output_padding);
+      }
       conv_ints_args.push_back(dilation);
       // skip (input, weight, bias)
       const size_t arg_offset = 3;
@@ -741,21 +770,24 @@ void UnpackQuantizedWeights(
       qconv_transpose1d,
       "quantized::conv_transpose1d_unpack",
       QuantizedParamsType::CONV1D,
-      caffe2);
+      caffe2,
+      true);
   unpackQuantizedWeightsHelper(
       graph,
       paramsDict,
       qconv_transpose2d,
       "quantized::conv_transpose2d_unpack",
       QuantizedParamsType::CONV,
-      caffe2);
+      caffe2,
+      true);
   unpackQuantizedWeightsHelper(
       graph,
       paramsDict,
       qconv_transpose3d,
       "quantized::conv_transpose3d_unpack",
       QuantizedParamsType::CONV,
-      caffe2);
+      caffe2,
+      true);
   if (!caffe2) {
     UnpackQuantizedTensorInputs(graph);
   }

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -594,7 +594,7 @@ void unpackQuantizedWeightsHelper(
       qlinear_node->insertInput(2, bias->output());
     }
 
-    // add conv arguments: stride, padding, dilation, groups
+    // add conv arguments: stride, padding, dilation, groups, output_padding
     if (stride.has_value() && padding.has_value() && dilation.has_value() &&
         groups.has_value() &&
         (!expect_output_padding || output_padding.has_value())) {

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -958,6 +958,7 @@ def quantized_conv_transpose1d(
     bias,
     stride,
     padding,
+    output_padding,
     dilation,
     groups,
     op_scale,
@@ -968,7 +969,6 @@ def quantized_conv_transpose1d(
     q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
-    output_padding = [0]
     output = opset9.conv_transpose2d(
         g, input, weight, bias, stride, padding, output_padding, groups, dilation
     )
@@ -985,6 +985,7 @@ def quantized_conv_transpose2d(
     bias,
     stride,
     padding,
+    output_padding,
     dilation,
     groups,
     op_scale,
@@ -995,7 +996,6 @@ def quantized_conv_transpose2d(
     q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
-    output_padding = [0, 0]
     output = opset9.conv_transpose2d(
         g, input, weight, bias, stride, padding, output_padding, groups, dilation
     )
@@ -1012,6 +1012,7 @@ def quantized_conv_transpose3d(
     bias,
     stride,
     padding,
+    output_padding,
     dilation,
     groups,
     op_scale,
@@ -1022,7 +1023,6 @@ def quantized_conv_transpose3d(
     q_bias = symbolic_helper.requantize_bias_helper(g, bias, input_scale, weight_scale)
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
-    output_padding = [0, 0, 0]
     output = opset9.conv_transpose3d(
         g, input, weight, bias, stride, padding, output_padding, groups, dilation
     )

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -888,9 +888,9 @@ def quantized_linear(
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
 
-@_onnx_symbolic("quantized::conv2d")
+@_onnx_symbolic("quantized::conv1d_relu")
 @_beartype.beartype
-def quantized_conv2d(
+def quantized_conv1d_relu(
     g: jit_utils.GraphContext,
     q_input,
     q_weight,
@@ -909,7 +909,8 @@ def quantized_conv2d(
     )
     bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
 
-    output = opset9.conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+    output = opset9.conv1d(g, input, weight, bias, stride, padding, dilation, groups)
+    output = opset9.relu(g, output)
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
@@ -937,5 +938,197 @@ def quantized_conv2d_relu(
 
     output = opset9.conv2d(g, input, weight, bias, stride, padding, dilation, groups)
     output = opset9.relu(g, output)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv3d_relu")
+@_beartype.beartype
+def quantized_conv3d_relu(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv3d(g, input, weight, bias, stride, padding, dilation, groups)
+    output = opset9.relu(g, output)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv1d")
+@_beartype.beartype
+def quantized_conv1d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv1d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv2d")
+@_beartype.beartype
+def quantized_conv2d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv3d")
+@_beartype.beartype
+def quantized_conv3d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv3d(g, input, weight, bias, stride, padding, dilation, groups)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose1d")
+@_beartype.beartype
+def quantized_conv_transpose1d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    output_padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv_transpose2d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose2d")
+@_beartype.beartype
+def quantized_conv_transpose2d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    output_padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv_transpose2d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
+@_onnx_symbolic("quantized::conv_transpose3d")
+@_beartype.beartype
+def quantized_conv_transpose3d(
+    g: jit_utils.GraphContext,
+    q_input,
+    q_weight,
+    bias,
+    stride,
+    padding,
+    output_padding,
+    dilation,
+    groups,
+    op_scale,
+    op_zero_point,
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.conv_transpose3d(
+        g, input, weight, bias, stride, padding, output_padding, groups, dilation
+    )
 
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)


### PR DESCRIPTION
- In #102759, the support for `quantized::conv_transposeNd` was introduced. This incorrectly set `output_padding` to all zeros. Turns out, you can specify output_padding in PyTorch, but this parameter was not being unpacked correctly and thus did not show up in the python torch->onnx code.
- This adds unpacking of output_padding in `unpack_quantized_weights.cpp` when needed. It also adds this as a parameter in the python functions and uses that (and removes the all-zero defaults)
- Another issue with #102759 is that it only added these new ops to opset10 without adding the ability to specify axis in opset13. This PR also fixes this.

Fixes #104206
