### PR TITLE
[Inductor][FX passes] Remove config.split_cat_fx_passes & Add config.experimental_patterns

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -7,13 +7,7 @@ from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
-def patch(f):
-    f = torch._inductor.config.patch(split_cat_fx_passes=True)(f)
-    return f
-
-
 class TestSplitCatFxPasses(TestCase):
-    @patch
     def test_split_normalization(self):
         def arg_only(x):
             return [torch.relu(s) for s in torch.split(x, 2, 1)]
@@ -91,7 +85,6 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
-    @patch
     def test_consecutive_split_merge(self):
         def multi_split(x):
             return [torch.split(s, 2, 1) for s in torch.split(x, 2, 1)]
@@ -252,7 +245,6 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
-    @patch
     def test_split_cat_merge(self):
         def simple_split_cat(x):
             return torch.cat(torch.split(x, 4, dim=1), dim=1)
@@ -582,7 +574,7 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
-    @torch._inductor.config.patch(split_cat_fx_passes=False)
+    @torch._inductor.config.patch(pattern_matcher=False)
     def test_config_flag_is_respected(self):
         def split_with_cat(x):
             fs = torch.split(x, [4, 4, 24], dim=-1)
@@ -612,7 +604,6 @@ class TestSplitCatFxPasses(TestCase):
             0,
         )
 
-    @patch
     def test_split_cat_merge_mutation(self):
         args = [
             torch.randn(2, 32, 32, 16),
@@ -631,7 +622,6 @@ class TestSplitCatFxPasses(TestCase):
         self.assertEqual(counters["inductor"]["scmerge_split_removed"], 0)
         self.assertEqual(counters["inductor"]["scmerge_cat_removed"], 0)
 
-    @patch
     def test_split_squeeze(self):
         def split_squeeze_stack(x):
             items = list(torch.split(x, 1, dim=1))
@@ -721,7 +711,6 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
-    @patch
     def test_unbind_stack(self):
         def unbind_stack(x):
             return torch.stack(torch.unbind(x, dim=1), 1)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -45,8 +45,8 @@ epilogue_fusion_first = False
 # enable pattern match+replace optimizations
 pattern_matcher = True
 
-# Optimize away split cat patterns (Experimental)
-split_cat_fx_passes = True
+# enable experimental patterns for match+replace optimizations
+experimental_patterns = False
 
 # enable reordering pass
 reordering = True


### PR DESCRIPTION
Summary:
TLDR:
* Remove config.split_cat_fx_passes, and move split cat passes behind config.pattern_matcher (True by default)
* Add config.experimental_patterns (False by default).
* In the future, general/universal patterns should behind config.pattern_matcher; customized/unmatured patterns should behind config.experimental_patterns.

More details at:
https://docs.google.com/document/d/1P8uJTpOTdQpUbw56UxHol40tt-EPFTq1Qu38072E9aM/edit

Test Plan: Existing unit tests

Reviewed By: jansel, jackiexu1992

Differential Revision: D46752606



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78