### PR TITLE
[DONT REVIEW][dynamo] Refactor disable impl to cleanup TorchPatcher

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -20,6 +20,7 @@ from .exc import unimplemented
 from .source import AttrSource, GeneratorStateSource, Source
 from .utils import is_safe_constant, rot_n_helper
 from .variables.base import VariableTracker
+from .variables.functions import DisabledFunctionVariable, DisabledMethodVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import (
     NumpyNdarrayVariable,
@@ -98,6 +99,9 @@ class PyCodegen:
             value.source is not None
             and allow_cache
             and not isinstance(value.source, GeneratorStateSource)
+            and not isinstance(
+                value, (DisabledFunctionVariable, DisabledMethodVariable)
+            )
         ):
             output.extend(value.source.reconstruct(self))
         elif value.is_python_constant() and is_safe_constant(

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -15,6 +15,7 @@ from .bytecode_transformation import (
     create_load_global,
     create_rot_n,
     Instruction,
+    unique_id,
 )
 from .exc import unimplemented
 from .source import AttrSource, GeneratorStateSource, Source
@@ -354,3 +355,11 @@ class PyCodegen:
             self.create_load_const(kw_names),
             create_instruction("CALL_FUNCTION_KW", arg=nargs),
         ]
+
+    def create_and_load_disabled_fn(self, fn, name):
+        from .eval_frame import disable
+
+        disabled_fn = disable(fn)
+        name = unique_id(name)
+        self.tx.output.install_global(name, disabled_fn)
+        return self.load_function_name(name, True)

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -29,6 +29,7 @@ from .variables.tensor import (
     TensorWithTFOverrideVariable,
     UnspecializedPythonVariable,
 )
+from .variables.torch import HigherOrderCheckpointVariable
 
 
 @dataclasses.dataclass
@@ -100,7 +101,12 @@ class PyCodegen:
             and allow_cache
             and not isinstance(value.source, GeneratorStateSource)
             and not isinstance(
-                value, (DisabledFunctionVariable, DisabledMethodVariable)
+                value,
+                (
+                    DisabledFunctionVariable,
+                    DisabledMethodVariable,
+                    HigherOrderCheckpointVariable,
+                ),
             )
         ):
             output.extend(value.source.reconstruct(self))

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1311,18 +1311,6 @@ class TorchPatcher:
             # disable future hooking
             opt.step.hooked = True
 
-        # TorchDynamo does not step inside utils.checkpoint function.  The flow
-        # looks likes this
-        #  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
-        #     speculatively checking if the forward function is safe to trace.
-        #  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
-        #     order op. As a result, TorchDynamo does not look inside utils.checkpoint.
-        #  3) If not, then TorchDynamo falls back to eager by performing a graph
-        #     break. And here, the following disable wrapper ensures that
-        #     TorchDynamo does not trigger again on the frames created by
-        #     utils.checkpoint innards.
-        # torch.utils.checkpoint.checkpoint = disable(torch.utils.checkpoint.checkpoint)
-
         torch._dynamo.variables.lists._register_dynamo_list_to_tree_spec()
         torch._dynamo.variables.lists._register_dynamo_tuple_to_tree_spec()
         torch._dynamo.variables.dicts._register_dynamo_dict_to_tree_spec()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1221,7 +1221,8 @@ class TorchPatcher:
     def patch():
         # torch.jit.trace still has to be disabled because it is skipped by
         # TorchDynamo, and therefore remains unchanged, and the child frames get
-        # intercepted by TorchDynamo.
+        # intercepted by TorchDynamo. This is a limitation.
+        disable_torch_fn(torch.jit.trace)
         torch.jit.trace = disable(torch.jit.trace)
         disable_torch_fn(torch.jit._get_trace_graph)
         disable_torch_fn(torch.jit.trace_module)
@@ -1233,6 +1234,7 @@ class TorchPatcher:
         torch.distributions.Distribution.set_default_validate_args(False)
 
         disable_torch_fn(proxy_tensor.dispatch_trace)
+        proxy_tensor.dispatch_trace = disable(proxy_tensor.dispatch_trace)
 
         optimizers = [
             opt

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1219,10 +1219,12 @@ class TorchPatcher:
     @staticmethod
     @functools.lru_cache(None)
     def patch():
-        # Disable TorchDynamo on some torch.* compilers generated frames
-        disable_torch_fn(torch.jit.trace)
-        disable_torch_fn(torch.jit.trace_module)
+        # torch.jit.trace still has to be disabled because it is skipped by
+        # TorchDynamo, and therefore remains unchanged, and the child frames get
+        # intercepted by TorchDynamo.
+        torch.jit.trace = disable(torch.jit.trace)
         disable_torch_fn(torch.jit._get_trace_graph)
+        disable_torch_fn(torch.jit.trace_module)
 
         # symbolic_trace creates new frames. We disable Dynamo on such frames
         disable_torch_fn(torch.fx._symbolic_trace.Tracer.trace)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1207,12 +1207,12 @@ def skip(fn=None):
     return fn
 
 
-disabled_torch_fns = set()
+disabled_torch_fns = dict()
 
 
 def disable_torch_fn(fn):
     assert callable(fn)
-    disabled_torch_fns.add(fn)
+    disabled_torch_fns[id(fn)] = fn
 
 
 class TorchPatcher:
@@ -1321,7 +1321,7 @@ class TorchPatcher:
         #     break. And here, the following disable wrapper ensures that
         #     TorchDynamo does not trigger again on the frames created by
         #     utils.checkpoint innards.
-        torch.utils.checkpoint.checkpoint = disable(torch.utils.checkpoint.checkpoint)
+        # torch.utils.checkpoint.checkpoint = disable(torch.utils.checkpoint.checkpoint)
 
         torch._dynamo.variables.lists._register_dynamo_list_to_tree_spec()
         torch._dynamo.variables.lists._register_dynamo_tuple_to_tree_spec()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1684,7 +1684,7 @@ def is_utils_checkpoint(obj):
     return obj is torch.utils.checkpoint.checkpoint
 
 
-def build_checkpoint_variable(guards):
+def build_checkpoint_variable(**options):
     import torch._higher_order_ops.wrap as higher_order_ops
     from .variables.torch import HigherOrderCheckpointVariable
 
@@ -1695,7 +1695,5 @@ def build_checkpoint_variable(guards):
     return HigherOrderCheckpointVariable(
         activation_checkpoint_op,
         source_fn=torch.utils.checkpoint.checkpoint,
-        disable_on_reconstruction=True,
-        guards=guards,
+        **options,
     )
-

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1680,15 +1680,6 @@ def defake(x):
     return y
 
 
-# NB: The dictionary has to be created lazily after TorchPatcher is called so
-# that we pick up the disabled torch.utils.checkpoint wrapper. Therefore, it is
-# sitting in a separate function.
-# We also need the original untouched/ not disabled torch utils checkpoint
-# becuase distributed checkpointed wrappers import these utils before
-# TorchDynamo TorchPatcher runs.
-# untouched_torch_utils_checkpoint = torch.utils.checkpoint.checkpoint
-
-
 def is_utils_checkpoint(obj):
     return obj is torch.utils.checkpoint.checkpoint
 
@@ -1705,21 +1696,6 @@ def build_checkpoint_variable(guards):
         activation_checkpoint_op,
         source_fn=torch.utils.checkpoint.checkpoint,
         disable_on_reconstruction=True,
-        guards=self.make_guards(GuardBuilder.TYPE_MATCH, GuardBuilder.NAME_MATCH),
+        guards=guards,
     )
 
-
-# def requires_higher_order_op(obj):
-#     import torch._higher_order_ops.wrap as higher_order_ops
-
-#     activation_checkpoint_op = higher_order_ops.tag_activation_checkpoint
-#     if torch._functorch.config.functionalize_rng_ops:
-#         activation_checkpoint_op = higher_order_ops.wrap_activation_checkpoint
-
-#     d = {
-#         torch.utils.checkpoint.checkpoint: activation_checkpoint_op,
-#         # untouched_torch_utils_checkpoint: activation_checkpoint_op,
-#     }
-#     if obj not in d:
-#         return None
-#     return d[obj]

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -48,7 +48,11 @@ from .tensor import (
     TensorVariable,
     UnspecializedPythonVariable,
 )
-from .torch import TorchHigherOrderOperatorVariable, TorchVariable
+from .torch import (
+    HigherOrderCheckpointVariable,
+    TorchHigherOrderOperatorVariable,
+    TorchVariable,
+)
 from .user_defined import UserDefinedClassVariable, UserDefinedObjectVariable
 
 __all__ = [

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -11,6 +11,7 @@ from .ctx_manager import (
 )
 from .dicts import ConstDictVariable, DataClassVariable, DefaultDictVariable
 from .functions import (
+    DisabledFunctionVariable,
     NestedUserFunctionVariable,
     UserFunctionVariable,
     UserMethodVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -467,7 +467,7 @@ class VariableBuilder:
             )
         elif is_utils_checkpoint(value):
             guards = self.make_guards(GuardBuilder.TYPE_MATCH, GuardBuilder.NAME_MATCH)
-            return build_checkpoint_variable(guards)
+            return build_checkpoint_variable(source=self.source, guards=guards)
         elif id(value) in disabled_torch_fns:
             return DisabledFunctionVariable(value)
         elif is_allowed(value):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -73,6 +73,7 @@ from .dicts import (
 )
 from .functions import (
     CollectiveFunctionRewriteVariable,
+    DisabledFunctionVariable,
     UserFunctionVariable,
     UserMethodVariable,
 )
@@ -363,6 +364,8 @@ class VariableBuilder:
         return result
 
     def _wrap(self, value):
+        from ..eval_frame import disabled_torch_fns
+
         make_guards = self.make_guards
 
         # Handle exact type() match
@@ -382,6 +385,8 @@ class VariableBuilder:
         # Everything else (NB: order matters!)
         if istype(value, config.traceable_tensor_subclasses):
             return self.wrap_tensor(value)
+        elif value in disabled_torch_fns:
+            return DisabledFunctionVariable(value)
         elif is_namedtuple(value):
             return self.wrap_listlike(value)
         elif istype(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -42,6 +42,7 @@ from ..source import (
     TupleIteratorGetItemSource,
 )
 from ..utils import (
+    build_checkpoint_variable,
     clone_input,
     get_fake_value,
     getfile,
@@ -49,11 +50,11 @@ from ..utils import (
     HAS_NUMPY,
     is_namedtuple,
     is_typing,
+    is_utils_checkpoint,
     istype,
     np,
     odict_values,
     preserve_rng_state,
-    requires_higher_order_op,
     tensor_always_has_static_shape,
     tuple_iterator,
     tuple_iterator_getitem,
@@ -464,7 +465,10 @@ class VariableBuilder:
                 source=self.source,
                 guards=make_guards(GuardBuilder.BUILTIN_MATCH),
             )
-        elif callable(value) and value in disabled_torch_fns:
+        elif is_utils_checkpoint(value):
+            guards = self.make_guards(GuardBuilder.TYPE_MATCH, GuardBuilder.NAME_MATCH)
+            return build_checkpoint_variable(guards)
+        elif id(value) in disabled_torch_fns:
             return DisabledFunctionVariable(value)
         elif is_allowed(value):
             return TorchVariable(
@@ -493,7 +497,6 @@ class VariableBuilder:
             istype(value, (type, types.FunctionType))
             and skipfiles.check(getfile(value), allow_torch=True)
             and not inspect.getattr_static(value, "_torchdynamo_inline", False)
-            and not requires_higher_order_op(value)
         ):
             return SkipFilesVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -385,8 +385,6 @@ class VariableBuilder:
         # Everything else (NB: order matters!)
         if istype(value, config.traceable_tensor_subclasses):
             return self.wrap_tensor(value)
-        elif value in disabled_torch_fns:
-            return DisabledFunctionVariable(value)
         elif is_namedtuple(value):
             return self.wrap_listlike(value)
         elif istype(
@@ -466,6 +464,8 @@ class VariableBuilder:
                 source=self.source,
                 guards=make_guards(GuardBuilder.BUILTIN_MATCH),
             )
+        elif callable(value) and value in disabled_torch_fns:
+            return DisabledFunctionVariable(value)
         elif is_allowed(value):
             return TorchVariable(
                 value,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -12,6 +12,7 @@ from torch import sym_float, sym_int
 
 from .. import config, variables
 from ..allowed_functions import is_allowed
+from ..eval_frame import disabled_torch_fns
 from ..exc import (
     AttributeMutationError,
     unimplemented,
@@ -997,6 +998,7 @@ class BuiltinVariable(VariableTracker):
     ):
         from . import (
             ConstantVariable,
+            DisabledFunctionVariable,
             GetAttrVariable,
             PythonModuleVariable,
             TorchHigherOrderOperatorVariable,
@@ -1071,6 +1073,8 @@ class BuiltinVariable(VariableTracker):
                 return TorchHigherOrderOperatorVariable(
                     get_higher_order_op(member), **options
                 )
+            elif member in disabled_torch_fns:
+                return DisabledFunctionVariable(member, **options)
             elif is_allowed(member):
                 return TorchVariable(member, **options)
             elif ConstantVariable.is_literal(member):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -24,13 +24,13 @@ from ..guards import GuardBuilder
 from ..replay_record import DummyModule
 from ..source import AttrSource, is_constant_source, SuperSource, TypeSource
 from ..utils import (
+    build_checkpoint_variable,
     check_constant_args,
     check_numpy_ndarray_args,
     check_unspec_python_args,
-    get_higher_order_op,
+    is_utils_checkpoint,
     istype,
     proxy_args_kwargs,
-    requires_higher_order_op,
     specialize_args_kwargs,
 )
 from .base import MutableLocal, typestr, VariableTracker
@@ -1001,7 +1001,6 @@ class BuiltinVariable(VariableTracker):
             DisabledFunctionVariable,
             GetAttrVariable,
             PythonModuleVariable,
-            TorchHigherOrderOperatorVariable,
             TorchVariable,
             UserFunctionVariable,
         )
@@ -1069,11 +1068,9 @@ class BuiltinVariable(VariableTracker):
                 return GetAttrVariable(obj, name, **options)
         elif isinstance(obj, TorchVariable):
             member = getattr(obj.value, name)
-            if requires_higher_order_op(member):
-                return TorchHigherOrderOperatorVariable(
-                    get_higher_order_op(member), **options
-                )
-            elif member in disabled_torch_fns:
+            if is_utils_checkpoint(member):
+                return build_checkpoint_variable(options["guards"])
+            elif id(member) in disabled_torch_fns:
                 return DisabledFunctionVariable(member, **options)
             elif is_allowed(member):
                 return TorchVariable(member, **options)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1069,7 +1069,8 @@ class BuiltinVariable(VariableTracker):
         elif isinstance(obj, TorchVariable):
             member = getattr(obj.value, name)
             if is_utils_checkpoint(member):
-                return build_checkpoint_variable(options["guards"])
+                options["source"] = source
+                return build_checkpoint_variable(**options)
             elif id(member) in disabled_torch_fns:
                 return DisabledFunctionVariable(member, **options)
             elif is_allowed(member):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -637,7 +637,7 @@ class DisabledMethodVariable(VariableTracker):
         # here we have to create a wrapper that prepends self (i.e. self.obj in
         # this case) to the call.
         def method_wrapper(*args, **kwargs):
-            return disabled_fn(self.obj, *args, **kwargs)
+            return disabled_fn(self.obj.value, *args, **kwargs)
 
         name = unique_id("__disabled_fn")
         codegen.tx.output.install_global(name, method_wrapper)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1452,3 +1452,28 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
             ),
             example_value=example_value,
         )
+
+
+class HigherOrderCheckpointVariable(TorchHigherOrderOperatorVariable):
+    def __init__(
+        self,
+        value,
+        source: Optional[Source] = None,
+        source_fn=None,
+        disable_on_reconstruction=False,
+        **kwargs,
+    ):
+        super().__init__(value, source, **kwargs)
+        self.source_fn = source_fn
+        self.disable_on_reconstruction = disable_on_reconstruction
+
+    def reconstruct(self, codegen):
+        if self.disable_on_reconstruction:
+            from ..bytecode_transformation import unique_id
+            from ..eval_frame import disable
+
+            disabled_fn = disable(self.source_fn)
+            name = unique_id("__disabled_fn")
+            codegen.tx.output.install_global(name, disabled_fn)
+            return codegen.load_function_name(name, True)
+        return super().reconstruct(codegen)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1455,6 +1455,20 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
 
 
 class HigherOrderCheckpointVariable(TorchHigherOrderOperatorVariable):
+    # The only difference between this and the TorchHigherOrderOperatorVariable
+    # is the reconstruction. We want to disable TorchDynamo on
+    # torch.utils.checkpoint whenever there is a graph break inside the
+    # subgraph.
+    #
+    # This class prevents TorchDynamo from steppint inside utils.checkpoint
+    # function.  The flow looks likes this
+    #  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
+    #     speculatively checking if the forward function is safe to trace.
+    #  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
+    #     order op. As a result, TorchDynamo does not look inside utils.checkpoint.
+    #  3) If not, then TorchDynamo falls back to eager by performing a graph
+    #     break. And here, the following reconstruction variable wraps the
+    #     utils.checkpoint in a disable wrapper.
     def __init__(
         self,
         value,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -348,7 +348,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             }
             partial_kwargs.update(kwargs)
             if is_utils_checkpoint(self.value.func):
-                return build_checkpoint_variable(options["guards"])
+                options["source"] = self.source
+                return build_checkpoint_variable(**options).call_function(
+                    tx, partial_args, partial_kwargs
+                )
             return variables.TorchVariable(self.value.func, **options).call_function(
                 tx, partial_args, partial_kwargs
             )
@@ -443,7 +446,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                     return variables.functions.DisabledFunctionVariable(func, **options)
 
                 if is_utils_checkpoint(func):
-                    return build_checkpoint_variable(options["guards"])
+                    options["source"] = source
+                    return build_checkpoint_variable(**options)
                 return variables.UserFunctionVariable(func, source=source, **options)
 
         if (

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -17,14 +17,14 @@ from ..guards import GuardBuilder
 from ..source import AttrSource, ODictGetItemSource, RandomValueSource
 from ..utils import (
     all_hook_names,
+    build_checkpoint_variable,
     check_constant_args,
     get_custom_getattr,
-    get_higher_order_op,
     is_namedtuple_cls,
+    is_utils_checkpoint,
     istype,
     namedtuple_fields,
     object_has_getattribute,
-    requires_higher_order_op,
 )
 from .base import MutableLocal, VariableTracker
 from .ctx_manager import GenericContextWrappingVariable, NullContextVariable
@@ -347,10 +347,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 k: variables.ConstantVariable(v) for k, v in self.value.keywords.items()
             }
             partial_kwargs.update(kwargs)
-            if requires_higher_order_op(self.value.func):
-                return variables.TorchHigherOrderOperatorVariable(
-                    get_higher_order_op(self.value.func), source=self.source, **options
-                ).call_function(tx, partial_args, partial_kwargs)
+            if is_utils_checkpoint(self.value.func):
+                return build_checkpoint_variable(options["guards"])
             return variables.TorchVariable(self.value.func, **options).call_function(
                 tx, partial_args, partial_kwargs
             )
@@ -433,7 +431,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             from ..eval_frame import disabled_torch_fns
 
             if inspect.ismethod(dynamic_subobj):
-                if func in disabled_torch_fns:
+                if id(func) in disabled_torch_fns:
                     return variables.functions.DisabledMethodVariable(
                         func, self, **options
                     )
@@ -441,12 +439,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                     func, self, source=source, **options
                 )
             elif inspect.isfunction(dynamic_subobj):
-                if func in disabled_torch_fns:
+                if id(func) in disabled_torch_fns:
                     return variables.functions.DisabledFunctionVariable(func, **options)
-                if requires_higher_order_op(func):
-                    return variables.TorchHigherOrderOperatorVariable(
-                        get_higher_order_op(func), **options
-                    )
+
+                if is_utils_checkpoint(func):
+                    return build_checkpoint_variable(options["guards"])
                 return variables.UserFunctionVariable(func, source=source, **options)
 
         if (

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -430,11 +430,19 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             # Static lookup can't tell us it's a method or function correctly,
             # so we trigger dynamic lookup here to get the correct type.
             dynamic_subobj = getattr(self.value, name)
+            from ..eval_frame import disabled_torch_fns
+
             if inspect.ismethod(dynamic_subobj):
+                if func in disabled_torch_fns:
+                    return variables.functions.DisabledMethodVariable(
+                        func, self, **options
+                    )
                 return variables.UserMethodVariable(
                     func, self, source=source, **options
                 )
             elif inspect.isfunction(dynamic_subobj):
+                if func in disabled_torch_fns:
+                    return variables.functions.DisabledFunctionVariable(func, **options)
                 if requires_higher_order_op(func):
                     return variables.TorchHigherOrderOperatorVariable(
                         get_higher_order_op(func), **options


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104210


This PR does 2 things
* Instead of monkeypatching the functions to be disabled, they are now disabled via bytecode tracing using reconstruction. The reconstruction is delayed all the way to CALL_FUNCTION_* bytecode.
* Similarly handle the activation checkpointed fallback.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78