### PR TITLE
[fake_pg] allow fake_pg allgather to do some simple validation

### DIFF
--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -44,6 +44,13 @@ class FakeProcessGroup(dist.ProcessGroup):
         return ret_work(output_tensor)
 
     def _allgather_base(self, output_tensor, input_tensor, opts=AllgatherOptions()):
+        # assume each rank have the same input tensor so we just copy to the results
+        # since it's not a real allgather, we simply make this copying logic to let
+        # some simple validation works (i.e. calling allgather to see if each rank have
+        # the same tensor or not)
+        chunks = output_tensor.chunk(self._world_size)
+        for chunk in chunks:
+            chunk.copy_(input_tensor)
         return ret_work(output_tensor)
 
     def _reduce_scatter_base(self, output_tensor, input_tensor, opts=ReduceScatterOptions()):

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -48,6 +48,11 @@ class FakeProcessGroup(dist.ProcessGroup):
         # since it's not a real allgather, we simply make this copying logic to let
         # some simple validation works (i.e. calling allgather to see if each rank have
         # the same tensor or not)
+        # NOTE: in general it's not good form to try to make FakePG work with 'real data',
+        # but the reasoning here is that we want FakePG to work with DeviceMesh's init
+        # code that have the data validation, which makes it worth the tradeoff.
+        # In general user should use MTPG or normal PG for cases where they may care about
+        # real data from collectives
         chunks = output_tensor.chunk(self._world_size)
         for chunk in chunks:
             chunk.copy_(input_tensor)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104213

Note that in general it's not good form to try to make FakePG work with 'real data',
but the reasoning here is that we want FakePG to work with DeviceMesh's init code
that have the data validation, which makes it worth the tradeoff.

In general user should use MTPG or normal PG for cases where they may care about
real data from collectives