### PR TITLE
[FSDP] Check module.training for _root_cast_forward_inputs

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -757,6 +757,35 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         model(inp).sum().backward()
 
     @skip_if_lt_x_gpu(2)
+    def test_eval_root_cast_inputs(self):
+        """
+        In a case where root module does not manage FSDP parameters,
+        ensure that we don't cast forward inputs which could potentially
+        cause a dtype mismatch.
+        """
+
+        class MyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Linear(5, 5)
+
+            def forward(self, x):
+                assert x.dtype == torch.float32, f"Expected fp32, got {x.dtype}"
+                return self.a(x)
+
+        mp_config = MixedPrecision(
+            param_dtype=torch.float16,
+            reduce_dtype=torch.float16,
+            buffer_dtype=torch.float16,
+        )
+        m = MyModel().cuda()
+        m.a = FSDP(m.a, mixed_precision=mp_config)
+        model = FSDP(m, mixed_precision=mp_config)
+        model.eval()
+        inp = torch.randn(5, 5)
+        model(inp).sum().backward()
+
+    @skip_if_lt_x_gpu(2)
     def test_full_precision_in_eval(self):
         for use_composable, cast_forward_inputs in itertools.product(
             [True, False], [True, False]

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -573,7 +573,7 @@ def _root_pre_forward(
             # increase some overhead, so not turned on for model wrapper path right now where
             # manual wrapping is more broadly used.
             if _is_composable(state):
-                return _root_cast_forward_input(state, args, kwargs)
+                return _root_cast_forward_input(state, module, args, kwargs)
             return args, kwargs
 
         # We cast buffers back to full precision if we're forcing full precision. Disjointly, we check if buffers
@@ -640,13 +640,13 @@ def _root_pre_forward(
         args = args_tuple[0]
         kwargs = kwargs_tuple[0]
 
-        return _root_cast_forward_input(state, args, kwargs)
+        return _root_cast_forward_input(state, module, args, kwargs)
 
 
 @no_type_check
-def _root_cast_forward_input(state: _FSDPState, args, kwargs) -> Tuple[Any, Any]:
+def _root_cast_forward_input(state: _FSDPState, module: torch.nn.Module, args, kwargs) -> Tuple[Any, Any]:
     should_cast_forward_inputs = (
-        all(not handle._force_full_precision for handle in state._handles)
+        (module.training and all(not handle._force_full_precision for handle in state._handles))
         and state.mixed_precision.cast_root_forward_inputs
     )
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -644,11 +644,13 @@ def _root_pre_forward(
 
 
 @no_type_check
-def _root_cast_forward_input(state: _FSDPState, module: torch.nn.Module, args, kwargs) -> Tuple[Any, Any]:
+def _root_cast_forward_input(
+    state: _FSDPState, module: torch.nn.Module, args, kwargs
+) -> Tuple[Any, Any]:
     should_cast_forward_inputs = (
-        (module.training and all(not handle._force_full_precision for handle in state._handles))
-        and state.mixed_precision.cast_root_forward_inputs
-    )
+        module.training
+        and all(not handle._force_full_precision for handle in state._handles)
+    ) and state.mixed_precision.cast_root_forward_inputs
 
     if should_cast_forward_inputs:
         input_dtype: Optional[torch.dtype] = state.mixed_precision.param_dtype


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104223

We might erroneously cast forward inputs for the root if it doesn't
manage any handles (FSDP parameters). As a fix, pass in the module and check
its training attribute to ensure we don't cast inputs in eval mode.

Differential Revision: [D47041673](https://our.internmc.facebook.com/intern/diff/D47041673/)