### PR TITLE
[export][serde] Allow dynamo to trace through sym_size.int

### DIFF
--- a/test/export/test_upgrade.py
+++ b/test/export/test_upgrade.py
@@ -108,7 +108,7 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
             return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
 
         inputs = (torch.ones([2, 3]) * 4, 2.)
-        ep = export(fn, inputs, [], _add_runtime_assertions=False)
+        ep = export(fn, inputs, [])
         compiler_opset_version = {"aten": 4}
         model_opset_version = {"aten": 3}
         upgrader = GraphModuleOpUpgrader(compiler_opset_version, model_opset_version, TEST_UPGRADERS)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1226,6 +1226,7 @@ def wrap_fx_proxy_cls(
         # This always wants to be in the graph, even if the constraint
         # results in a constant int
         torch._export.constraints.constrain_as_value,
+        torch.ops.aten.sym_size.int,
     ):
         return ConstantVariable(example_value, **options)
     elif istype(example_value, torch.Size) and all(

--- a/torch/fx/passes/infra/pass_manager.py
+++ b/torch/fx/passes/infra/pass_manager.py
@@ -277,7 +277,7 @@ class PassManager:
                             + "Please wrap it with pass_result_wrapper()"
                         )
                     module = res.graph_module
-                    modified = modified or res.modified
+                    modified = modified or (hasattr(res, "modified") and res.modified)
 
                     if isinstance(module, GraphModule):
                         logger.debug("Graph after pass '%s': %s", fn_name, module.graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #104235
* #104227

Add `sym_size.int` in `builder.py` to allow dynamo to trace through sym_size.int.
Also fix a small issue in `exported_program.py`.

This enables retrace for `ExportedProgram`.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78