### PR TITLE
Make sure that little endian is default case when __BYTE_ORDER__ is not defined

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -552,9 +552,11 @@ void Pickler::pushDouble(double value) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   // Python pickle format is big endian, swap.
   push<double>(swapDouble(value));
-#else /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   push<double>(value);
-#endif /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
 }
 void Pickler::pushComplexDouble(const IValue& value) {
   c10::complex<double> d = value.toComplexDouble();

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -230,9 +230,11 @@ double Unpickler::readFloat() {
       reinterpret_cast<char*>(&little_endian));
 
   return little_endian;
-#else /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   return big_endian;
-#endif /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
 }
 
 void Unpickler::run() {

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -836,7 +836,7 @@ void initTensorExprBindings(PyObject* module) {
                 value_ptrs.emplace_back(value.cast<at::Tensor>().data_ptr());
               }
             }
-#else /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
             if (py::len(values) != self.buffer_args().size()) {
               throw malformed_input("bad args in CodeGen.call function");
             }
@@ -862,7 +862,9 @@ void initTensorExprBindings(PyObject* module) {
                 value_ptrs.emplace_back(value.cast<at::Tensor>().data_ptr());
               }
             }
-#endif /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
             self.call(value_ptrs);
           })
       .def(

--- a/torch/csrc/utils/byte_order.h
+++ b/torch/csrc/utils/byte_order.h
@@ -41,7 +41,7 @@
 #define from_le32(x) (x)
 #define to_le64(x) (x)
 #define from_le64(x) (x)
-#else
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define to_be16(x) (x)
 #define from_be16(x) (x)
 #define to_be32(x) (x)
@@ -54,6 +54,8 @@
 #define from_le32(x) thp_bswap32(x)
 #define to_le64(x) thp_bswap64(x)
 #define from_le64(x) thp_bswap64(x)
+#else
+#error Unexpected or undefined __BYTE_ORDER__
 #endif
 
 namespace torch {


### PR DESCRIPTION
This is a follow up to discussion
in https://github.com/pytorch/pytorch/pull/96422

cc @EikanWang @jgong5