### PR TITLE
Use plain power operator in Adam/Adamw when capturing

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -364,10 +364,8 @@ def _single_tensor_adam(params: List[Tensor],
         if capturable or differentiable:
             step = step_t
 
-            # 1 - beta1 ** step can't be captured in a CUDA graph, even if step is a CUDA tensor
-            # (incurs "RuntimeError: CUDA error: operation not permitted when stream is capturing")
-            bias_correction1 = 1 - torch.pow(beta1, step)
-            bias_correction2 = 1 - torch.pow(beta2, step)
+            bias_correction1 = 1 - beta1 ** step
+            bias_correction2 = 1 - beta2 ** step
 
             step_size = lr / bias_correction1
             step_size_neg = step_size.neg()

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -407,10 +407,8 @@ def _single_tensor_adamw(
         if capturable or differentiable:
             step = step_t
 
-            # 1 - beta1 ** step can't be captured in a CUDA graph, even if step is a CUDA tensor
-            # (incurs "RuntimeError: CUDA error: operation not permitted when stream is capturing")
-            bias_correction1 = 1 - torch.pow(beta1, step)
-            bias_correction2 = 1 - torch.pow(beta2, step)
+            bias_correction1 = 1 - beta1 ** step
+            bias_correction2 = 1 - beta2 ** step
 
             step_size = lr / bias_correction1
             step_size_neg = step_size.neg()

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14475,8 +14475,6 @@ op_db: List[OpInfo] = [
                     supports_fwgrad_bwgrad=True,
                     supports_one_python_scalar=True,
                     skips=(
-                        DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
-                        DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',),
                         # TODO: FIXME tolerance is too high
                         DecorateInfo(unittest.skip('Skipped!'), 'TestFwdGradients'),
                         DecorateInfo(unittest.skip('Skipped!'), 'TestBwdGradients'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14475,6 +14475,7 @@ op_db: List[OpInfo] = [
                     supports_fwgrad_bwgrad=True,
                     supports_one_python_scalar=True,
                     skips=(
+                        DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
                         DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',),
                         # TODO: FIXME tolerance is too high
                         DecorateInfo(unittest.skip('Skipped!'), 'TestFwdGradients'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14475,6 +14475,7 @@ op_db: List[OpInfo] = [
                     supports_fwgrad_bwgrad=True,
                     supports_one_python_scalar=True,
                     skips=(
+                        DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',),
                         # TODO: FIXME tolerance is too high
                         DecorateInfo(unittest.skip('Skipped!'), 'TestFwdGradients'),
                         DecorateInfo(unittest.skip('Skipped!'), 'TestBwdGradients'),


### PR DESCRIPTION
The goal is to fix the problem from https://github.com/pytorch/pytorch/pull/102858 

The full error this used to raise was :
```
2023-06-27T15:12:15.0663239Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/optim/adamw.py", line 409, in _single_tensor_adamw
2023-06-27T15:12:15.0663699Z     bias_correction1 = 1 - beta1 ** step
2023-06-27T15:12:15.0664200Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_tensor.py", line 40, in wrapped
2023-06-27T15:12:15.0664547Z     return f(*args, **kwargs)
2023-06-27T15:12:15.0665031Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_tensor.py", line 882, in __rpow__
2023-06-27T15:12:15.0665483Z     return torch.tensor(other, dtype=dtype, device=self.device) ** self
2023-06-27T15:12:15.0665899Z RuntimeError: CUDA error: operation not permitted when stream is capturing
2023-06-27T15:12:15.0666401Z CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
```

This pow issue was fixed in https://github.com/pytorch/pytorch/pull/104264 and so this problem should be solvable now.