### PR TITLE
[codemod][third-party][gtest] Migrate all fbcode gtest from tp2 to fbsource/third-party

### DIFF
--- a/c10/cuda/test/build.bzl
+++ b/c10/cuda/test/build.bzl
@@ -17,6 +17,7 @@ def define_targets(rules):
         target_compatible_with = rules.requires_cuda_enabled(),
         deps = [
             "//c10/cuda",
+            "@com_google_googletest//:gmock",
             "@com_google_googletest//:gtest_main",
         ],
     )
@@ -31,6 +32,7 @@ def define_targets(rules):
             target_compatible_with = rules.requires_cuda_enabled(),
             deps = [
                 "//c10/cuda",
+                "@com_google_googletest//:gmock",
                 "@com_google_googletest//:gtest_main",
             ],
         )


### PR DESCRIPTION
Summary:
## What is this?
This is a giant codemod to migrate all of fbcode from the tp2 version of gtest to the `fbsource/third-party` version.

## Why?
Various parts of the monorepo use different versions of gtest which are incompatible with each other and make maintenance of C++ testing more difficult than it should be. There also doesn't seem to be much reason for this fragmentation. Shifting all `gtest` dependencies towards `fbsource/third-party` is a big step in the right direction towards cleaning this up.

Also -- tp2 is deprecated, so we want to stop using that anyway. If we're going to make improvements to `gtest`, we should get away from tp2 as a first step.

## How?

I used bash script to perform the majority of the codemod: P777150295

I followed up with `rg` to find additional dependencies, then simply iterated a ton until CI was (mostly) happy.

This diff also includes an update to autodeps to use the `third-party/fbsource` version of gtest rather than the `tp2` version.

#forcetdhashing

Test Plan: CI

Differential Revision: D46961576

