### PR TITLE
[Easy][FSDP] Remove misleading asserts

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -109,15 +109,6 @@ def _init_process_group_state(
             )
         else:
             state = _init_process_group_state_for_hybrid_shard(state, process_group)
-            assert (
-                state.process_group is not None
-            ), "Expected to populate state.process_group for hybrid shard"
-            assert (
-                state._inter_node_pg is not None
-            ), "Expected to populate state._inter_node_pg for hybrid shard"
-            assert (
-                state._inter_node_state is not None
-            ), "Expected to populate state._inter_node_state for hybrid shad."
     else:
         state.process_group = (
             process_group if process_group is not None else _get_default_group()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104275
* __->__ #104274
* #104273
* #104253

Since we do not call `_FSDPState.__init__()` and only use it for typing, it is not possible for these attributes to be `None`. The purpose of these `assert`s is to make sure that these attributes are set by `_init_process_group_state_for_hybrid_shard()`. If we care to make that explicit, I would posit that we should be using `hasattr` checks, not `is not None` checks, because if indeed `_init_process_group_state_for_hybrid_shard()` did not set these attributes, then even checking that it is not `None` would lead to an `AttributeError`. I do not include these `hasattr` checks for now since `_init_process_group_state_for_hybrid_shard()` is short enough that we can quickly tell by inspection that it sets the desired attributes.