### PR TITLE
Pin pytest linux dependencies in docker

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -139,17 +139,17 @@ psutil
 #Pinned versions:
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
-pytest
+pytest==7.3.2
 #Description: testing framework
 #Pinned versions:
 #test that import: test_typing.py, test_cpp_extensions_aot.py, run_test.py
 
-pytest-xdist
+pytest-xdist==3.3.1
 #Description: plugin for running pytest in parallel
 #Pinned versions:
 #test that import:
 
-pytest-shard
+pytest-shard==0.1.2
 #Description: plugin spliting up tests in pytest
 #Pinned versions:
 #test that import:

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -11,8 +11,8 @@ opt-einsum>=3.3
 psutil==5.9.1
 nvidia-ml-py==11.525.84
 pygments==2.12.0
-pytest==7.2.0
-pytest-xdist==3.0.2
+pytest==7.3.2
+pytest-xdist==3.3.1
 pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 pytest-shard==0.1.2


### PR DESCRIPTION
Pin the pytest dependencies listed in requirements-ci.txt, also change the mac ones to match the linux ones.

The new pytest 7.4.0 causes some weird issues with printing skip messages, so pin to a previous version until I can figure out a fix

