### PR TITLE
[CI] Add DALLE2_pytorch to FORCE_AMP_FOR_FP16_BF16_MODELS

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -211,6 +211,7 @@ MAX_BATCH_SIZE_FOR_ACCURACY_CHECK = {
 }
 
 FORCE_AMP_FOR_FP16_BF16_MODELS = {
+    "DALLE2_pytorch",
     "doctr_det_predictor",
     "doctr_reco_predictor",
     "Super_SloMo",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104283

Summary: DALLE2_pytorch inference does not support bfloat16, fallback to use AMP.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78