### PR TITLE
[Dynamo] Support threading.local getattr

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1191,6 +1191,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
     def test_threading_local(self):
         import threading
+
         foo = threading.local()
         foo.x = torch.rand(1)
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1189,6 +1189,23 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         except torch._dynamo.exc.Unsupported:
             pass
 
+    def test_threading_local(self):
+        import threading
+        foo = threading.local()
+        foo.x = torch.rand(1)
+
+        def f(x):
+            return torch.cat([x, foo.x])
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_f = torch._dynamo.optimize(cnt, nopython=True)(f)
+
+        inp = torch.ones(1)
+        out = f(inp)
+        opt_out = opt_f(inp)
+        self.assertEqual(opt_out, out)
+        self.assertEqual(cnt.frame_count, 1)
+
     def test_seq_append_list(self):
         x = torch.randn(4, 10)
         model = SequentialAppendList(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 import itertools
 import random
+import threading
 import types
 from typing import Dict, List
 
@@ -371,6 +372,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if (
             isinstance(self.value, torch.nn.Module)
             or "__slots__" in self.value.__class__.__dict__
+            or type(self.value) == threading.local
         ):
             # getattr_static doesn't work on these
             subobj = getattr(self.value, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #104292

Fixes #104066

threading.local has a custom `__getattribute__` so `_getattr_static`
doesn't work with it. Since we know that threading.local's
`__getattribute__` is well behaved
(e.g. https://github.com/python/cpython/blob/3.11/Lib/_threading_local.py),
we can just special case it.

Test Plan:
- new tests

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78