### PR TITLE
[inductor] fix a bug in coordinate descent tuner

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -31,6 +31,21 @@ class TestCoordinateDescentTuner(TestCase):
         best_config = tuner.autotune(func, baseline_config)
         self.assertTrue(best_config.kwargs.get("XBLOCK") == 16, str(best_config))
 
+    def test_no_neighbors(self):
+        """
+        Test the case that there is no available neighbor values for a field.
+        """
+
+        # size hint for x being 1 limits the max XBLOCK we try to be 1
+        tuner = CoordescTuner(size_hints=[1])
+        baseline_config = triton.Config({"XBLOCK": 1}, num_warps=8, num_stages=1)
+
+        def func(config):
+            return abs(config.kwargs["XBLOCK"] - 15)
+
+        best_config = tuner.autotune(func, baseline_config)
+        self.assertTrue(best_config.kwargs.get("XBLOCK") == 1, str(best_config))
+
     def test_get_neighbour_values(self):
         tuner = CoordescTuner()
 

--- a/torch/_inductor/coordinate_descent_tuner.py
+++ b/torch/_inductor/coordinate_descent_tuner.py
@@ -264,8 +264,10 @@ class CoordescTuner:
                 if cur_val is None:
                     continue
 
+                # It's possible that candidate_values is empty.
+                # E.g., if XBLOCK is 1 initially and size_hint for x is also 1.
+                # We would not try either larger or smaller XBLOCK in this case.
                 candidate_values = self.get_neighbour_values(name, cur_val)
-                assert len(candidate_values) > 0
 
                 for next_val in candidate_values:
                     candidate_config = copy.deepcopy(best_config)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104293

The neighbor values we try for a field can be empty in some corner cases.
```
                # E.g., if XBLOCK is 1 initially and size_hint for x is also 1.
                # We would not try either larger or smaller XBLOCK in this case.
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78