### PR TITLE
Fix CUDA Bazel build to optionally include gmock after #104255

### DIFF
--- a/c10/cuda/test/BUILD.bazel
+++ b/c10/cuda/test/BUILD.bazel
@@ -1,4 +1,11 @@
 load("//:tools/bazel.bzl", "rules")
 load(":build.bzl", "define_targets")
 
-define_targets(rules = rules)
+define_targets(
+    rules = rules,
+    # gmock has already been included as part of gtest_main, thus there is no
+    # gmock target https://github.com/google/googletest/blob/main/BUILD.bazel
+    gtest_deps = [
+        "@com_google_googletest//:gtest_main",
+    ]
+)

--- a/c10/cuda/test/build.bzl
+++ b/c10/cuda/test/build.bzl
@@ -8,7 +8,7 @@ dsa_tests = [
     "impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu",
 ]
 
-def define_targets(rules):
+def define_targets(rules, gtest_deps):
     rules.cc_test(
         name = "test",
         srcs = [
@@ -17,9 +17,7 @@ def define_targets(rules):
         target_compatible_with = rules.requires_cuda_enabled(),
         deps = [
             "//c10/cuda",
-            "@com_google_googletest//:gmock",
-            "@com_google_googletest//:gtest_main",
-        ],
+        ] + gtest_deps,
     )
 
     for src in dsa_tests:
@@ -32,9 +30,7 @@ def define_targets(rules):
             target_compatible_with = rules.requires_cuda_enabled(),
             deps = [
                 "//c10/cuda",
-                "@com_google_googletest//:gmock",
-                "@com_google_googletest//:gtest_main",
-            ],
+            ] + gtest_deps,
         )
         rules.cc_test(
             name = "test_" + name,


### PR DESCRIPTION
This reverts commit 39868b0578c18ddc194deac697d0675760de5f11.  Fixes https://github.com/pytorch/pytorch/issues/104279.

The change came from an internal codemod diff that we don't want to revert.  AFAIK, this addition is not needed as gmock has already been included https://github.com/google/googletest/blob/main/BUILD.bazel

### Testing

* OSS CUDA Bazel build should be back after this revert
* Import as D47077813 to make sure that nothing breaks internally
