### PR TITLE
Replace torch.has_cuda() call with torch.backends.cuda.built()

### DIFF
--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -13,7 +13,7 @@ from torch.utils.benchmark.utils.valgrind_wrapper import timer_interface as valg
 __all__ = ["Timer", "timer", "Language"]
 
 
-if torch.has_cuda and torch.cuda.is_available():
+if torch.backends.cuda.is_built() and torch.cuda.is_available():
     def timer() -> float:
         torch.cuda.synchronize()
         return timeit.default_timer()


### PR DESCRIPTION
torch.has_cuda() has been deprecated and using torch.backends.cuda.built() instead.
