### PR TITLE
Add back in reduce_scatter_tensor_coalesced

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1576,6 +1576,13 @@ Arguments:
               py::arg("opts") = ::c10d::ReduceScatterOptions(),
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "reduce_scatter_tensor_coalesced",
+              &::c10d::ProcessGroup::reduce_scatter_tensor_coalesced,
+              py::arg("outputs"),
+              py::arg("inputs"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
               "alltoall_base",
               &::c10d::ProcessGroup::alltoall_base,
               py::arg("output"),


### PR DESCRIPTION
#104256 erroneously removed the pybind definition for `reduce_scatter_tensor_coalesced` introduced in #103561

This adds it back in and introduces a test for the API.

Test command:
```
pytest test/distributed/test_c10d_nccl.py -vsk test_reduce_scatter_tensor_coalesced
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104424
* __->__ #104345

