### PR TITLE
[ONNX] Alternative design to #104067

### DIFF
--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -24,7 +24,7 @@ pip_install \
   transformers==4.25.1
 
 # TODO: change this when onnx-script is on testPypi
-pip_install "onnxscript@git+https://github.com/microsoft/onnxscript@7e131c578f290ffad1f26bacda11a83daf5476ba"
+pip_install "onnxscript@git+https://github.com/microsoft/onnxscript@e0ae7aa3977b45347f39ed56aac28e762e7b5358"
 
 # Cache the transformers model to be used later by ONNX tests. We need to run the transformers
 # package to download the model. By default, the model is cached at ~/.cache/huggingface/hub/

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -181,11 +181,9 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.linear = torch.nn.Linear(2, 2)
-                self.linear2 = torch.nn.Linear(2, 2)
 
             def forward(self, x):
                 out = self.linear(x)
-                out = self.linear2(out)
                 return out
 
         # User-instantiated FakeTensorMode
@@ -210,6 +208,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         )
 
         assert export_output is not None
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -190,9 +190,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         fake_mode = fake_tensor.FakeTensorMode(
             allow_non_fake_inputs=True,
             shape_env=ShapeEnv(
-                allow_scalar_outputs=False,
-                allow_dynamic_output_shape_ops=False,
-                frame_id=0,
+                allow_scalar_outputs=False, allow_dynamic_output_shape_ops=False
             ),
         )
         # Fakefy input+model before exporting it

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import tempfile
 import unittest
 
@@ -15,11 +16,14 @@ import torch
 import torch.onnx
 import transformers  # type: ignore[import]
 from torch import nn
-from torch._dynamo.output_graph import config
+
 from torch._subclasses import fake_tensor
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.onnx._internal import _beartype
-from torch.onnx._internal.fx import context as fx_context
+from torch.onnx._internal.fx import (
+    context as fx_context,
+    fx_symbolic_graph_extractor,
+    serialization as fx_serialization,
+)
 from torch.testing._internal import common_utils
 
 try:
@@ -668,20 +672,15 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         with tempfile.NamedTemporaryFile(
             prefix=model_name, suffix=".pt"
-        ) as tmp_file, tempfile.TemporaryDirectory(suffix="large_scale_export"):
+        ) as tmp_file, tempfile.TemporaryDirectory(
+            suffix="large_scale_export"
+        ) as tmp_folder:
             # Dump state_dict to a file to simulate how HuggingFace model is initialized.
             # The file will be loaded via .load_state_dict(...)
             torch.save(model.state_dict(), tmp_file.name)
 
-            # User-instantiated FakeTensorMode
-            fake_mode = fake_tensor.FakeTensorMode(
-                allow_non_fake_inputs=False,
-                allow_fallback_kernels=True,
-                shape_env=ShapeEnv(
-                    allow_scalar_outputs=config.capture_scalar_outputs,
-                    allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
-                    frame_id=0,
-                ),
+            ftm = fake_tensor.FakeTensorMode(
+                allow_non_fake_inputs=True, allow_fallback_kernels=False
             )
             ctx = fx_context.FxToOnnxContext()
             # NOTE: FakeTensorMode disallows symbolic shape of fx graph
@@ -689,27 +688,34 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             #  1. Create a model whose parameters and buffers are all FakeTensor's.
             #  2. Convert nn.Module into ONNX model without initializers.
             #  3. Record the file paths to find real initializers.
-
-            with fake_mode, ctx:
+            with ctx, ftm:
                 # Toy model with parameters and buffers as FakeTensor's.
                 fake_model = create_model()
-                # fake_model.load_state_dict(torch.load(tmp_file.name))
+                fake_model.load_state_dict(torch.load(tmp_file.name))
                 # Toy inputs as FakeTensor's.
                 fake_args = create_args()
+                # Export ONNX model without initializers while ctx.paths records
+                # all files that contains real initializers.
 
-            export_options = torch.onnx.ExportOptions(
-                opset_version=self.opset_version,
-                dynamic_shapes=self.dynamic_shapes,
-                op_level_debug=self.op_level_debug,
-                fake_mode=fake_mode,
-            )
-            export_output = torch.onnx.dynamo_export(
-                fake_model,
-                *fake_args,
-                export_options=export_options,
-            )
+                options = torch.onnx.ExportOptions(
+                    opset_version=self.opset_version,
+                    dynamic_shapes=self.dynamic_shapes,
+                    op_level_debug=self.op_level_debug,
+                )
+                export_options = torch.onnx._internal.exporter.ResolvedExportOptions(
+                    options
+                )
+                export_options.fx_tracer = (
+                    fx_symbolic_graph_extractor.FXSymbolicTracer()
+                )
+                export_output = torch.onnx.dynamo_export(
+                    fake_model,
+                    *fake_args,
+                    export_options=export_options,
+                )
 
-            # TODO: Fix export before moving to comparing numbers
+                onnx_model = export_output.model_proto
+
             # Tasks done by the following block.
             #  1. Iterate through all tensors stored in ctx.paths (the file content is loaded torch.load)
             #  2. If a tensor's name matches a "onnx_model"'s input name, an initializer is created and saved to
@@ -717,6 +723,17 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             #  3. A new ONNX model is saved into file with the initializers saved in the previous step.
             #  4. ORT executes the new ONNX model and compares the results with the original GPT model.
 
+            # Model saved to tmp_folder/onnx_model_location
+            # Initializers are saved to tmp_folder/onnx_initializer_location/*.onnx
+            onnx_model_location = model_name + "_external_data.onnx"
+            onnx_initializer_location = model_name + "_initializers"
+            fx_serialization.save_model_with_external_data(
+                tmp_folder,
+                onnx_model_location,
+                onnx_initializer_location,
+                tuple(ctx.paths),
+                onnx_model,
+            )
             # Generate random inputs.
             args = create_args()
             kwargs = create_pytorch_only_kwargs()
@@ -731,7 +748,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             args_not_none = args_not_none[: len(args) - len(kwargs)]
 
             ort_outputs = onnx_test_common.run_ort(
-                export_output,
+                os.path.join(tmp_folder, onnx_model_location),
                 args_not_none,
             )
 
@@ -740,7 +757,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             for ref_output, ort_output in zip(ref_outputs, ort_outputs):
                 torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
-    @unittest.skip("Symbolic tracing not supported yet.")
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )
@@ -779,7 +795,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_pytorch_only_extra_kwargs,
         )
 
-    @unittest.skip("Symbolic tracing not supported yet.")
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -20,8 +20,8 @@ from torch import nn
 from torch._subclasses import fake_tensor
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import (
-    context as fx_context,
     fx_symbolic_graph_extractor,
+    patcher,
     serialization as fx_serialization,
 )
 from torch.testing._internal import common_utils
@@ -682,7 +682,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             ftm = fake_tensor.FakeTensorMode(
                 allow_non_fake_inputs=True, allow_fallback_kernels=False
             )
-            ctx = fx_context.FxToOnnxContext()
+            ctx = patcher.ONNXTorchPatcher()
             # NOTE: FakeTensorMode disallows symbolic shape of fx graph
             # The following coed block does several things.
             #  1. Create a model whose parameters and buffers are all FakeTensor's.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -50,6 +50,7 @@ from ._internal.exporter import (  # usort:skip. needs to be last to avoid circu
     ExportOutput,
     ExportOutputSerializer,
     dynamo_export,
+    enable_fake_mode,
 )
 
 __all__ = [
@@ -93,6 +94,7 @@ __all__ = [
     "ExportOutput",
     "ExportOutputSerializer",
     "dynamo_export",
+    "enable_fake_mode",
 ]
 
 # Set namespace for exposed private names

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -478,7 +478,10 @@ class Exporter:
         )
 
         # Export TorchScript graph to ONNX ModelProto.
-        onnx_model = onnxscript_graph.to_model_proto(self.options.opset_version)
+        onnx_model = onnxscript_graph.to_model_proto(
+            self.options.opset_version,
+            include_initializers=self.options.fake_mode is None,
+        )
         return torch.onnx.ExportOutput(
             onnx_model,
             self.options.fx_tracer.input_adapter,

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -640,8 +640,12 @@ def pre_export_passes(
     # ONNX does not support views and mutations.
     # Functionalize to get a semantically equivalent graph without mutations.
     module = passes.Functionalize(
-        diagnostic_context, module, enable_dynamic_axes=options.dynamic_shapes
+        diagnostic_context,
+        module,
+        enable_dynamic_axes=options.dynamic_shapes,
+        fake_mode=options.fake_mode,
     ).run(*fx_module_args)
+
     # Input mutations are detected and distilled after `Functionalize` pass.
     # Remove them since ONNX inference does not need them.
     module = passes.RemoveInputMutation(diagnostic_context, module).run(*fx_module_args)

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -460,7 +460,6 @@ class Exporter:
             *self.model_args, **self.model_kwargs
         )
 
-        # TODO: Symbolic tracing does not like most of these passes. Why?!
         # TODO: Design the passes API
         graph_module = pre_export_passes(self.options, graph_module, updated_model_args)
 

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -634,6 +634,7 @@ def pre_export_passes(
         fx_module,
         options.decomposition_table,
         enable_dynamic_axes=options.dynamic_shapes,
+        fake_mode=options.fake_mode,
     ).run(*fx_module_args)
 
     # ONNX does not support views and mutations.

--- a/torch/onnx/_internal/fx/__init__.py
+++ b/torch/onnx/_internal/fx/__init__.py
@@ -1,8 +1,8 @@
-from .context import FxToOnnxContext
+from .patcher import ONNXTorchPatcher
 from .serialization import save_model_with_external_data
 
 
 __all__ = [
     "save_model_with_external_data",
-    "FxToOnnxContext",
+    "ONNXTorchPatcher",
 ]

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -178,7 +178,7 @@ class DynamoExport(exporter.FXGraphExtractor):
     ) -> torch.fx.GraphModule:
         # TODO: Discuss whether we want to keep the non-symbolic tracing export
         if options.fake_mode is None:
-            # args will be converted to symbolic tensor. Let's copy to avoid side effects.
+            # args will be converted to fake tensor. Let's copy to avoid side effects.
             args = copy.deepcopy(model_args)
             kwargs = copy.deepcopy(model_kwargs)
         else:

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -177,7 +177,7 @@ class DynamoExport(exporter.FXGraphExtractor):
         model_kwargs: Mapping[str, Any],
     ) -> torch.fx.GraphModule:
         # TODO: Discuss whether we want to keep the non-symbolic tracing export
-        if options.fake_mode is None:
+        if options.fake_context.fake_mode is None:
             # args will be converted to fake tensor. Let's copy to avoid side effects.
             args = copy.deepcopy(model_args)
             kwargs = copy.deepcopy(model_kwargs)
@@ -202,7 +202,7 @@ class DynamoExport(exporter.FXGraphExtractor):
             wrapped_model,
             *args,
             tracing_mode=fx_mode,
-            fake_mode=options.fake_mode,
+            fake_mode=options.fake_context.fake_mode,
             **kwargs,
         )
         del graph_guard  # Unused

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -6,6 +6,7 @@ import torch
 import torch._ops
 import torch.fx
 from torch.fx.experimental import proxy_tensor
+from torch._subclasses import fake_tensor
 
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import _pass, diagnostics
@@ -19,10 +20,12 @@ class Decompose(_pass.Transform):
         module: torch.fx.GraphModule,
         decomposition_table: Mapping[torch._ops.OpOverload, Callable],
         enable_dynamic_axes: bool,
+        fake_mode: fake_tensor.FakeTensorMode,
     ):
         super().__init__(diagnostic_context, module)
         self.decomposition_table = decomposition_table
         self.enable_dynamic_axes = enable_dynamic_axes
+        self.fake_mode = fake_mode
 
     @_beartype.beartype
     def _run(self, *args, **kwargs) -> torch.fx.GraphModule:
@@ -54,6 +57,7 @@ class Decompose(_pass.Transform):
             decomposition_table=self.decomposition_table,
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
+            _allow_fake_constant=self.fake_mode is not None
         )(*args)
         # Rename placeholder targets to match the original module's signature since
         # We don't want to map forward(x, y, z) to forward(arg0, arg1, arg2).

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Optional
 
 import torch
 import torch._ops
@@ -20,7 +20,7 @@ class Decompose(_pass.Transform):
         module: torch.fx.GraphModule,
         decomposition_table: Mapping[torch._ops.OpOverload, Callable],
         enable_dynamic_axes: bool,
-        fake_mode: fake_tensor.FakeTensorMode,
+        fake_mode: Optional[fake_tensor.FakeTensorMode],
     ):
         super().__init__(diagnostic_context, module)
         self.decomposition_table = decomposition_table

--- a/torch/onnx/_internal/fx/passes/decomp.py
+++ b/torch/onnx/_internal/fx/passes/decomp.py
@@ -5,8 +5,8 @@ from typing import Callable, Mapping
 import torch
 import torch._ops
 import torch.fx
-from torch.fx.experimental import proxy_tensor
 from torch._subclasses import fake_tensor
+from torch.fx.experimental import proxy_tensor
 
 from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import _pass, diagnostics
@@ -57,7 +57,7 @@ class Decompose(_pass.Transform):
             decomposition_table=self.decomposition_table,
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
-            _allow_fake_constant=self.fake_mode is not None
+            _allow_fake_constant=self.fake_mode is not None,
         )(*args)
         # Rename placeholder targets to match the original module's signature since
         # We don't want to map forward(x, y, z) to forward(arg0, arg1, arg2).

--- a/torch/onnx/_internal/fx/passes/functionalization.py
+++ b/torch/onnx/_internal/fx/passes/functionalization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 import torch._ops
@@ -65,7 +65,7 @@ class Functionalize(_pass.Transform):
         diagnostic_context: diagnostics.DiagnosticContext,
         module: torch.fx.GraphModule,
         enable_dynamic_axes: bool,
-        fake_mode: proxy_tensor.FakeTensorMode,
+        fake_mode: Optional[proxy_tensor.FakeTensorMode],
     ):
         super().__init__(diagnostic_context, module)
         self.enable_dynamic_axes = enable_dynamic_axes

--- a/torch/onnx/_internal/fx/passes/functionalization.py
+++ b/torch/onnx/_internal/fx/passes/functionalization.py
@@ -65,9 +65,11 @@ class Functionalize(_pass.Transform):
         diagnostic_context: diagnostics.DiagnosticContext,
         module: torch.fx.GraphModule,
         enable_dynamic_axes: bool,
+        fake_mode: proxy_tensor.FakeTensorMode,
     ):
         super().__init__(diagnostic_context, module)
         self.enable_dynamic_axes = enable_dynamic_axes
+        self.fake_mode = fake_mode
 
     def _functionalize(self, function: Callable) -> Callable:
         # Working around a dispatcher issue with `torch.func.functionalize` when used
@@ -107,6 +109,7 @@ class Functionalize(_pass.Transform):
             decomposition_table={},
             tracing_mode=fx_mode,
             _allow_non_fake_inputs=True,
+            _allow_fake_constant=self.fake_mode is not None,
         )(*args)
 
         # Rename placeholder targets to match the original module's signature since

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -4,11 +4,10 @@ from typing import List
 import torch
 
 
-class FxToOnnxContext:
-    """Context manager to make PyTorch friendly to FX-to-ONNX exporter.
-    This class means to collect all "patches" required by FX-to-ONNX
-    exporter. If PyTorch needs to be patched, please use this class to
-    manage the patch.
+class ONNXTorchPatcher:
+    """Context manager to temporarily patch PyTorch during FX-to-ONNX export.
+
+    This class is a collection of "patches" required by FX-to-ONNX exporter.
 
     This context overrides several torch functions to support symbolic
     export of large scale models.
@@ -26,7 +25,7 @@ class FxToOnnxContext:
         This list is extended with (torch.Tensor, "__getitem__") so that
         weight[x, :, y] becomes exportable with torch.fx.symbolic_trace.
 
-    Search for FxToOnnxContext in test_fx_to_onnx_with_onnxruntime.py for
+    Search for ONNXTorchPatcher in test_fx_to_onnx_with_onnxruntime.py for
     example usage.
     """
 
@@ -51,6 +50,7 @@ class FxToOnnxContext:
                 )
                 return t.set_(storage._untyped_storage, storage_offset, size, stride)
 
+            # import pdb; pdb.set_trace()
             mode = _get_current_dispatch_mode()
             if isinstance(mode, FakeTensorMode):
                 # Create a real tensor and then convert it to FakeTensor.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -120,8 +120,8 @@ def save_model_with_external_data(
     onnx_input_names = [input.name for input in onnx_model.graph.input]
 
     for path in torch_load_paths:
-        state_ditc = torch.load(path)
-        for name, tensor in state_ditc.items():
+        state_dict = torch.load(path)
+        for name, tensor in state_dict.items():
             # Basically, "transformer.attention.self.query.weight" is mapped
             # to "transformer_attention_self_query_weight" for mimicking the
             # name-modifying code in FX-to-ONNX exporter.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import io
 import os
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch.onnx import _type_utils as jit_type_utils
@@ -84,7 +85,7 @@ def save_model_with_external_data(
     basepath: str,
     model_location: str,
     initializer_location: str,
-    torch_load_paths: Tuple[str, ...],
+    torch_load_paths: Tuple[Union[str, io.BytesIO], ...],
     onnx_model: onnx.ModelProto,
 ) -> None:
     """Load PyTorch tensors from files and add to "onnx_model" as external initializers.


### PR DESCRIPTION
Usage example is as follows:

```python
        class Model(torch.nn.Module):
            def __init__(self) -> None:
                super().__init__()
                self.linear = torch.nn.Linear(2, 2)

            def forward(self, x):
                out = self.linear(x)
                return out

        with enable_symbolic_mode() as fake_context:
            x = torch.rand(5, 2, 2)
            model = Model()
            fake_context.save_state_dict(model.state_dict())

        # Export the model with fake inputs and parameters
        export_options = ExportOptions(fake_context=fake_context)
        export_output = torch.onnx.dynamo_export(
            model, x, export_options=export_options
        )
```