### PR TITLE
Prefixing DeviceType with c10 namespace to avoid name collisions

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -862,6 +862,27 @@ command = [
 ]
 
 [[linter]]
+code = 'DEVICE_TYPE'
+include_patterns = [
+    'c10/**',
+    'aten/**',
+    'torch/csrc/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=DeviceType',
+    '--linter-name=DEVICE_TYPE',
+    '--error-name=invalid DeviceType',
+    '--replace-pattern=s/DeviceType/c10::DeviceType/',
+    """--error-description=\
+        Use of DeviceType is forbidden and should be replaced with c10::DeviceType\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+
+[[linter]]
 code = 'WORKFLOWSYNC'
 include_patterns = [
     '.github/workflows/pull.yml',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -864,14 +864,14 @@ command = [
 [[linter]]
 code = 'DEVICE_TYPE'
 include_patterns = [
-    'c10/**',
-    'aten/**',
-    'torch/csrc/**',
+    'c10/**/*.h',
+    'aten/**/*.h',
+    'torch/csrc/**/*.h',
 ]
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=DeviceType',
+    '--pattern=\(?:\s|^\)\(?!c10::\)\(DeviceType\)',
     '--linter-name=DEVICE_TYPE',
     '--error-name=invalid DeviceType',
     '--replace-pattern=s/DeviceType/c10::DeviceType/',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -862,27 +862,6 @@ command = [
 ]
 
 [[linter]]
-code = 'DEVICE_TYPE'
-include_patterns = [
-    'c10/**/*.h',
-    'aten/**/*.h',
-    'torch/csrc/**/*.h',
-]
-command = [
-    'python3',
-    'tools/linter/adapters/grep_linter.py',
-    '--pattern=\(?:\s|^\)\(?!c10::\)\(DeviceType\)',
-    '--linter-name=DEVICE_TYPE',
-    '--error-name=invalid DeviceType',
-    '--replace-pattern=s/DeviceType/c10::DeviceType/',
-    """--error-description=\
-        Use of DeviceType is forbidden and should be replaced with c10::DeviceType\
-    """,
-    '--',
-    '@{{PATHSFILE}}'
-]
-
-[[linter]]
 code = 'WORKFLOWSYNC'
 include_patterns = [
     '.github/workflows/pull.yml',

--- a/aten/src/ATen/CPUGeneratorImpl.h
+++ b/aten/src/ATen/CPUGeneratorImpl.h
@@ -21,7 +21,7 @@ struct TORCH_API CPUGeneratorImpl : public c10::GeneratorImpl {
   uint64_t seed() override;
   void set_state(const c10::TensorImpl& new_state) override;
   c10::intrusive_ptr<c10::TensorImpl> get_state() const override;
-  static DeviceType device_type();
+  static c10::DeviceType device_type();
   uint32_t random();
   uint64_t random64();
   c10::optional<float> next_float_normal_sample();

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -96,19 +96,19 @@ class TORCH_API Context {
     return detail::getMPSHooks().hasMPS();
   }
   static bool hasIPU() {
-    return c10::impl::hasDeviceGuardImpl(at::DeviceType::IPU);
+    return c10::impl::hasDeviceGuardImpl(c10::DeviceType::IPU);
   }
   static bool hasXLA() {
-    return c10::impl::hasDeviceGuardImpl(at::DeviceType::XLA);
+    return c10::impl::hasDeviceGuardImpl(c10::DeviceType::XLA);
   }
   static bool hasXPU() {
     return detail::getXPUHooks().hasXPU();
   }
   static bool hasLazy() {
-    return c10::impl::hasDeviceGuardImpl(at::DeviceType::Lazy);
+    return c10::impl::hasDeviceGuardImpl(c10::DeviceType::Lazy);
   }
   static bool hasORT() {
-    return c10::impl::hasDeviceGuardImpl(at::DeviceType::ORT);
+    return c10::impl::hasDeviceGuardImpl(c10::DeviceType::ORT);
   }
   // defined in header so that getNonVariableType has ability to inline
   // call_once check. getNonVariableType is called fairly frequently
@@ -450,7 +450,7 @@ static inline void manual_seed(uint64_t seed) {
   }
 
   if (hasMPS()) {
-    auto mps_gen = globalContext().defaultGenerator(DeviceType::MPS);
+    auto mps_gen = globalContext().defaultGenerator(c10::DeviceType::MPS);
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(mps_gen.mutex());
     mps_gen.set_current_seed(seed);

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -34,7 +34,7 @@ class TORCH_API Context {
   Context();
 
   const Generator& defaultGenerator(Device device) {
-    DeviceType device_type = device.type();
+    c10::DeviceType device_type = device.type();
     initCUDAIfNeeded(device_type);
     initHIPIfNeeded(device_type);
     if (device_type == at::kCPU) {
@@ -47,11 +47,11 @@ class TORCH_API Context {
       AT_ERROR(DeviceTypeName(device_type), " device type not enabled.");
     }
   }
-  Device getDeviceFromPtr(void* data, DeviceType device_type) {
+  Device getDeviceFromPtr(void* data, c10::DeviceType device_type) {
     initCUDAIfNeeded(device_type);
     initHIPIfNeeded(device_type);
     if (device_type == at::kCPU) {
-      return DeviceType::CPU;
+      return c10::DeviceType::CPU;
     } else if (device_type == at::kCUDA) {
       return at::detail::getCUDAHooks().getDeviceFromPtr(data);
     } else {
@@ -274,12 +274,12 @@ class TORCH_API Context {
 
  private:
   void initCUDAIfNeeded(DeviceType p) {
-    if (p == DeviceType::CUDA) {
+    if (p == c10::DeviceType::CUDA) {
       lazyInitCUDA();
     }
   }
   void initHIPIfNeeded(DeviceType p) {
-    if (p == DeviceType::HIP) {
+    if (p == c10::DeviceType::HIP) {
       lazyInitHIP();
     }
   }
@@ -428,7 +428,7 @@ static inline bool hasMKLDNN() {
 }
 
 static inline void manual_seed(uint64_t seed) {
-  auto gen = globalContext().defaultGenerator(DeviceType::CPU);
+  auto gen = globalContext().defaultGenerator(c10::DeviceType::CPU);
   {
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(gen.mutex());

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -44,7 +44,7 @@ class TORCH_API Context {
     } else if (device_type == at::kMPS) {
       return at::detail::getMPSHooks().getDefaultMPSGenerator();
     } else {
-      AT_ERROR(DeviceTypeName(device_type), " device type not enabled.");
+      AT_ERROR(c10::DeviceTypeName(device_type), " device type not enabled.");
     }
   }
   Device getDeviceFromPtr(void* data, c10::DeviceType device_type) {
@@ -55,7 +55,7 @@ class TORCH_API Context {
     } else if (device_type == at::kCUDA) {
       return at::detail::getCUDAHooks().getDeviceFromPtr(data);
     } else {
-      AT_ERROR(DeviceTypeName(device_type), " device type not enabled.");
+      AT_ERROR(c10::DeviceTypeName(device_type), " device type not enabled.");
     }
   }
   static bool isPinnedPtr(const void* data) {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -273,12 +273,12 @@ class TORCH_API Context {
   void unsetDefaultMobileCPUAllocator();
 
  private:
-  void initCUDAIfNeeded(DeviceType p) {
+  void initCUDAIfNeeded(c10::DeviceType p) {
     if (p == c10::DeviceType::CUDA) {
       lazyInitCUDA();
     }
   }
-  void initHIPIfNeeded(DeviceType p) {
+  void initHIPIfNeeded(c10::DeviceType p) {
     if (p == c10::DeviceType::HIP) {
       lazyInitHIP();
     }

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -309,7 +309,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   Device device(int arg = 0) const {
     return operands_[arg].device.value();
   }
-  DeviceType device_type(int arg = 0) const {
+  c10::DeviceType device_type(int arg = 0) const {
     return device(arg).type();
   }
   int64_t element_size(int arg) const {

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -33,7 +33,7 @@ static inline std::vector<TensorImpl*> checked_dense_tensor_list_unwrap(
     ArrayRef<Tensor> tensors,
     const char* name,
     int pos,
-    DeviceType device_type,
+    c10::DeviceType device_type,
     ScalarType scalar_type) {
   std::vector<TensorImpl*> unwrapped;
   unwrapped.reserve(tensors.size());

--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -38,7 +38,7 @@ class TORCH_API DeprecatedTypeProperties {
     return layout_from_backend(backend()) == kSparseCsr;
   }
 
-  DeviceType device_type() const {
+  c10::DeviceType device_type() const {
     return backendToDeviceType(backend_);
   }
 

--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -66,7 +66,7 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
    * @brief Gets the const reference of the stored object. The code checks if
    * the stored object is of the desired type.
    */
-  // TODO(jerryzh): add a Get(DeviceType) function?
+  // TODO(jerryzh): add a Get(c10::DeviceType) function?
   template <class T>
   const T& Get() const {
     TORCH_INTERNAL_ASSERT(
@@ -75,7 +75,7 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
         meta_.name(),
         " while caller expects ",
         TypeMeta::TypeName<T>());
-    // TODO: after we add Get<Tensor>(DeviceType)
+    // TODO: after we add Get<Tensor>(c10::DeviceType)
     // and changed all the callsites, we can add
     // a static assert here to enforce T != Tensor
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1268,7 +1268,7 @@ public:
       // representation with Tensor.
       c10::intrusive_ptr_target* as_intrusive_ptr;
       struct {
-        DeviceType type;
+        c10::DeviceType type;
         DeviceIndex index;
       } as_device;
     } u;

--- a/aten/src/ATen/cuda/CUDADevice.h
+++ b/aten/src/ATen/cuda/CUDADevice.h
@@ -18,7 +18,7 @@ inline Device getDeviceFromPtr(void* ptr) {
     "The specified pointer resides on host memory and is not registered with any CUDA device.");
 #endif
 
-  return {DeviceType::CUDA, static_cast<DeviceIndex>(attr.device)};
+  return {c10::DeviceType::CUDA, static_cast<DeviceIndex>(attr.device)};
 }
 
 }} // namespace at::cuda

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.h
@@ -115,7 +115,7 @@ struct TORCH_CUDA_CPP_API CUDAGeneratorImpl : public c10::GeneratorImpl {
   // Allows incremental refactor of call sites to use philox_cuda_state.
   std::pair<uint64_t, uint64_t> philox_engine_inputs(uint64_t increment);
 
-  static DeviceType device_type();
+  static c10::DeviceType device_type();
 
 private:
   CUDAGeneratorImpl* clone_impl() const override;

--- a/aten/src/ATen/hip/impl/HIPAllocatorMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPAllocatorMasqueradingAsCUDA.h
@@ -17,7 +17,7 @@ public:
     : allocator_(allocator) {}
   DataPtr allocate(size_t size) const override {
     DataPtr r = allocator_->allocate(size);
-    r.unsafe_set_device(Device(DeviceType::CUDA, r.device().index()));
+    r.unsafe_set_device(Device(c10::DeviceType::CUDA, r.device().index()));
     return r;
   }
   DeleterFnPtr raw_deleter() const override {

--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -54,13 +54,13 @@ namespace c10 { namespace hip {
 // this HIP implementation.
 
 struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplInterface {
-  static constexpr DeviceType static_type = DeviceType::CUDA;
+  static constexpr c10::DeviceType static_type = c10::DeviceType::CUDA;
   HIPGuardImplMasqueradingAsCUDA() {}
-  HIPGuardImplMasqueradingAsCUDA(DeviceType t) {
-    TORCH_INTERNAL_ASSERT(t == DeviceType::CUDA);
+  HIPGuardImplMasqueradingAsCUDA(c10::DeviceType t) {
+    TORCH_INTERNAL_ASSERT(t == c10::DeviceType::CUDA);
   }
-  DeviceType type() const override {
-    return DeviceType::CUDA;
+  c10::DeviceType type() const override {
+    return c10::DeviceType::CUDA;
   }
   Device exchangeDevice(Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_cuda());
@@ -73,7 +73,7 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
   Device getDevice() const override {
     int device;
     C10_HIP_CHECK(hipGetDevice(&device));
-    return Device(DeviceType::CUDA, device);
+    return Device(c10::DeviceType::CUDA, device);
   }
   void setDevice(Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_cuda());

--- a/aten/src/ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h
@@ -25,7 +25,7 @@ public:
         HIPStream(
           Stream(
             Stream::UNSAFE,
-            Device(DeviceType::HIP, stream.device_index()),
+            Device(c10::DeviceType::HIP, stream.device_index()),
             stream.id())
         )
       ) {}
@@ -51,11 +51,11 @@ public:
   DeviceIndex device_index() const { return stream_.device_index(); }
 
   // Unsafely coerce HIP device into CUDA device
-  DeviceType device_type() const { return DeviceType::CUDA; }
+  c10::DeviceType device_type() const { return c10::DeviceType::CUDA; }
 
   Device device() const {
     // Unsafely coerce HIP device into CUDA device
-    return Device(DeviceType::CUDA, stream_.device_index());
+    return Device(c10::DeviceType::CUDA, stream_.device_index());
   }
 
   StreamId id() const        { return stream_.id(); }
@@ -76,7 +76,7 @@ public:
 
   static HIPStreamMasqueradingAsCUDA unpack3(StreamId stream_id,
                                              DeviceIndex device_index,
-                                             DeviceType device_type) {
+                                             c10::DeviceType device_type) {
     // NB: constructor manages CUDA->HIP translation for us
     return HIPStreamMasqueradingAsCUDA(Stream::unpack3(
         stream_id, device_index, device_type));

--- a/aten/src/ATen/mps/MPSGuardImpl.h
+++ b/aten/src/ATen/mps/MPSGuardImpl.h
@@ -29,29 +29,29 @@ namespace mps {
 // TODO: Move the MPSGuardImpl to inherit from NoOpDeviceGuardImpl
 // https://github.com/pytorch/pytorch/issues/77170
 struct TORCH_API MPSGuardImpl final : public c10::impl::DeviceGuardImplInterface {
-  static constexpr DeviceType static_type = DeviceType::MPS;
+  static constexpr c10::DeviceType static_type = c10::DeviceType::MPS;
 
   // constructor
   MPSGuardImpl() {}
-  explicit MPSGuardImpl(DeviceType t) {
-    TORCH_INTERNAL_ASSERT(t == DeviceType::MPS);
+  explicit MPSGuardImpl(c10::DeviceType t) {
+    TORCH_INTERNAL_ASSERT(t == c10::DeviceType::MPS);
   }
 
   // returns the type
-  DeviceType type() const override {
-    return DeviceType::MPS;
+  c10::DeviceType type() const override {
+    return c10::DeviceType::MPS;
   }
 
   Device exchangeDevice(Device d) const override {
-    return Device(DeviceType::MPS, 0);
+    return Device(c10::DeviceType::MPS, 0);
   }
 
   Device getDevice() const override {
-    return Device(DeviceType::MPS, 0);
+    return Device(c10::DeviceType::MPS, 0);
   }
 
   c10::optional<Device> uncheckedGetDevice() const noexcept {
-    return Device(DeviceType::MPS, 0);
+    return Device(c10::DeviceType::MPS, 0);
   }
 
   void setDevice(Device d) const override {
@@ -63,16 +63,16 @@ struct TORCH_API MPSGuardImpl final : public c10::impl::DeviceGuardImplInterface
   }
 
   Stream getStream(Device d) const noexcept override {
-    return Stream(Stream::DEFAULT, Device(DeviceType::MPS, 0));
+    return Stream(Stream::DEFAULT, Device(c10::DeviceType::MPS, 0));
   }
 
   Stream getDefaultStream(Device d) const override {
-    return Stream(Stream::DEFAULT, Device(DeviceType::MPS, 0));
+    return Stream(Stream::DEFAULT, Device(c10::DeviceType::MPS, 0));
   }
 
   // NB: These do NOT set the current device
   Stream exchangeStream(Stream s) const noexcept override {
-    return Stream(Stream::DEFAULT, Device(DeviceType::MPS, 0));
+    return Stream(Stream::DEFAULT, Device(c10::DeviceType::MPS, 0));
   }
   DeviceIndex deviceCount() const noexcept override {
     if (at::hasMPS()) {

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -68,7 +68,7 @@ struct DispatchStub;
  */
 struct TORCH_API DispatchStubImpl {
   void* get_call_ptr(
-    DeviceType device_type
+    c10::DeviceType device_type
     , void *DEFAULT
 #ifdef HAVE_AVX512_CPU_DEFINITION
       , void *AVX512
@@ -131,7 +131,7 @@ struct DispatchStub<rT (*)(Args...), T> {
   DispatchStub& operator=(const DispatchStub&) = delete;
 
 private:
-  FnPtr get_call_ptr(DeviceType device_type) {
+  FnPtr get_call_ptr(c10::DeviceType device_type) {
     return reinterpret_cast<FnPtr>(
       impl.get_call_ptr(device_type
       , reinterpret_cast<void*>(DEFAULT)
@@ -153,7 +153,7 @@ private:
 
 public:
   template <typename... ArgTypes>
-  rT operator()(DeviceType device_type, ArgTypes&&... args) {
+  rT operator()(c10::DeviceType device_type, ArgTypes&&... args) {
     FnPtr call_ptr = get_call_ptr(device_type);
     return (*call_ptr)(std::forward<ArgTypes>(args)...);
   }

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -329,32 +329,32 @@ class TORCH_API Tensor: public TensorBase {
   Tensor & index_put_(std::initializer_list<at::indexing::TensorIndex> indices, const Scalar& v);
 
   Tensor cpu() const {
-    return to(options().device(DeviceType::CPU), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::CPU), /*non_blocking*/ false, /*copy*/ false);
   }
 
   // TODO: The Python version also accepts arguments
   Tensor cuda() const {
-    return to(options().device(DeviceType::CUDA), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::CUDA), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor hip() const {
-    return to(options().device(DeviceType::HIP), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::HIP), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor ve() const {
-    return to(options().device(DeviceType::VE), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::VE), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor vulkan() const {
-    return to(options().device(DeviceType::Vulkan), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::Vulkan), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor metal() const {
-    return to(options().device(DeviceType::Metal), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::Metal), /*non_blocking*/ false, /*copy*/ false);
   }
 
   Tensor meta() const {
-    return to(options().device(DeviceType::Meta), /*non_blocking*/ false, /*copy*/ false);
+    return to(options().device(c10::DeviceType::Meta), /*non_blocking*/ false, /*copy*/ false);
   }
 
   // ~~~~~ Autograd API ~~~~~

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -629,7 +629,7 @@ inline DispatchKey computeDispatchKey(
       const auto dtype_ = dtype_or_default(dtype);
       switch (device_.type()) {
 #define DO_CASE(device, _)                   \
-  case DeviceType::device: {                 \
+  case c10::DeviceType::device: {            \
     if (isQIntType(dtype_)) {                \
       return DispatchKey::Quantized##device; \
     }                                        \
@@ -637,18 +637,18 @@ inline DispatchKey computeDispatchKey(
   }
         C10_FORALL_BACKEND_DEVICE_TYPES(DO_CASE, unused)
 #undef DO_CASE
-        case DeviceType::FPGA:
+        case c10::DeviceType::FPGA:
           return DispatchKey::FPGA;
-        case DeviceType::ORT:
+        case c10::DeviceType::ORT:
           return DispatchKey::ORT;
-        case DeviceType::Vulkan:
+        case c10::DeviceType::Vulkan:
           return DispatchKey::Vulkan;
-        case DeviceType::Metal:
+        case c10::DeviceType::Metal:
           return DispatchKey::Metal;
-        case DeviceType::MKLDNN:
-        case DeviceType::OPENGL:
-        case DeviceType::OPENCL:
-        case DeviceType::IDEEP:
+        case c10::DeviceType::MKLDNN:
+        case c10::DeviceType::OPENGL:
+        case c10::DeviceType::OPENCL:
+        case c10::DeviceType::IDEEP:
           TORCH_INTERNAL_ASSERT(
               0,
               "This is a grandfathered Caffe2 device type ",
@@ -664,7 +664,7 @@ inline DispatchKey computeDispatchKey(
     case Layout::Sparse:
       switch (device_.type()) {
 #define DO_CASE(device, _)              \
-  case DeviceType::device: {            \
+  case c10::DeviceType::device: {            \
     return DispatchKey::Sparse##device; \
   }
         C10_FORALL_BACKEND_DEVICE_TYPES(DO_CASE, unused)
@@ -677,7 +677,7 @@ inline DispatchKey computeDispatchKey(
       }
     case Layout::Mkldnn:
       switch (device_.type()) {
-        case DeviceType::CPU:
+        case c10::DeviceType::CPU:
           return DispatchKey::MkldnnCPU;
         default:
           TORCH_CHECK_NOT_IMPLEMENTED(
@@ -690,9 +690,9 @@ inline DispatchKey computeDispatchKey(
     case Layout::SparseBsr:
     case Layout::SparseBsc:
       switch (device_.type()) {
-        case DeviceType::CPU:
+        case c10::DeviceType::CPU:
           return DispatchKey::SparseCsrCPU;
-        case DeviceType::CUDA:
+        case c10::DeviceType::CUDA:
           return DispatchKey::SparseCsrCUDA;
         default:
           AT_ERROR(
@@ -726,24 +726,24 @@ inline Layout dispatchKeyToLayout(DispatchKey dispatch_key) {
   }
 }
 
-inline DeviceType dispatchKeyToDeviceType(DispatchKey dispatch_key) {
+inline c10::DeviceType dispatchKeyToDeviceType(DispatchKey dispatch_key) {
   switch (dispatch_key) {
     // stuff that's real
 #define DO_CASE(suffix, prefix)     \
   case DispatchKey::prefix##suffix: \
-    return DeviceType::suffix;
+    return c10::DeviceType::suffix;
 #define DO_CASES(_, prefix) C10_FORALL_BACKEND_DEVICE_TYPES(DO_CASE, prefix)
     C10_FORALL_FUNCTIONALITY_KEYS(DO_CASES)
 #undef DO_CASES
 #undef DO_CASE
 
     case DispatchKey::MkldnnCPU:
-      return DeviceType::CPU;
+      return c10::DeviceType::CPU;
     case DispatchKey::Vulkan:
-      return DeviceType::Vulkan;
+      return c10::DeviceType::Vulkan;
 
     case DispatchKey::ORT:
-      return DeviceType::ORT;
+      return c10::DeviceType::ORT;
     default:
       TORCH_CHECK(
           false,

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -664,7 +664,7 @@ inline DispatchKey computeDispatchKey(
     case Layout::Sparse:
       switch (device_.type()) {
 #define DO_CASE(device, _)              \
-  case c10::DeviceType::device: {            \
+  case c10::DeviceType::device: {       \
     return DispatchKey::Sparse##device; \
   }
         C10_FORALL_BACKEND_DEVICE_TYPES(DO_CASE, unused)

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -790,7 +790,7 @@ inline at::Device toDevice(PyObject* obj) {
   if (THPUtils_checkLong(obj)) {
     const auto device_index = THPUtils_unpackLong(obj);
     TORCH_CHECK(device_index >= 0, "Device index must not be negative");
-    return at::Device(DeviceType::CUDA, device_index);
+    return at::Device(c10::DeviceType::CUDA, device_index);
   }
   const std::string& device_str = THPUtils_unpackString(obj);
   return at::Device(device_str);
@@ -1099,7 +1099,7 @@ inline at::Storage PythonArgs::storage(
 inline c10::Stream PythonArgs::stream(int i) {
   if (!args[i])
     return c10::Stream(
-        c10::Stream::Default::DEFAULT, c10::Device(DeviceType::CPU, -1));
+        c10::Stream::Default::DEFAULT, c10::Device(c10::DeviceType::CPU, -1));
   if (!THPStream_Check(args[i])) {
     throw TypeError(
         "expected Stream object. Got '%s'", Py_TYPE(args[i])->tp_name);
@@ -1107,7 +1107,7 @@ inline c10::Stream PythonArgs::stream(int i) {
   return c10::Stream::unpack3(
       ((THPStream*)args[i])->stream_id,
       ((THPStream*)args[i])->device_index,
-      static_cast<DeviceType>(((THPStream*)args[i])->device_type));
+      static_cast<c10::DeviceType>(((THPStream*)args[i])->device_type));
 }
 
 inline PyObject* PythonArgs::pyobject(int i) {


### PR DESCRIPTION
Fixes #91338

Follow up from https://github.com/pytorch/pytorch/pull/91342

> 🚀 The feature, motivation and pitch
> We have an existing DeviceType class all over the place in our code base, and it conflicts with the one that is used in torch. > Thankfully the pytorch DeciceType enum class is under the c10 namespace.

```
In file included from /xxx/build/_deps/torch-src/../../aten/src/ATen/ops/view.h:5:
/xxx/_deps/torch-src/aten/src/ATen/Context.h:265:14: error: reference to 'DeviceType' is ambiguous
    if (p == DeviceType::HIP) {
             ^
/xxx/include/Common_types.h:178:8: note: candidate found by name lookup is 'DeviceType'
struct DeviceType {
       ^
/xxx/build/_deps/torch-src/c10/../c10/core/DeviceType.h:32:12: note: candidate found by name lookup is 'c10::DeviceType'
enum class DeviceType : int8_t {
```

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5