### PR TITLE
Make `torch._dynamo` lazy-importable

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -6,7 +6,6 @@ import tempfile
 import unittest
 
 import torch
-import torch._dynamo
 from torch._dynamo.testing import CompileCounter
 
 

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from typing import NamedTuple
 
+import torch
 from torch._inductor import config
 from torch.testing._internal.common_utils import (
     IS_MACOS,

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 from typing import NamedTuple
 
-import torch._dynamo
 from torch._inductor import config
 from torch.testing._internal.common_utils import (
     IS_MACOS,

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import numpy as np
 import sympy
 import torch
-import torch._dynamo
 from torch._C import FileCheck
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -4,7 +4,6 @@ import sys
 import unittest
 
 import torch
-import torch._dynamo
 import torch._dynamo.config as dynamo_config
 from torch import nn
 from torch._dynamo.debug_utils import same_two_models

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -9,7 +9,6 @@ import warnings
 
 import torch
 
-import torch._dynamo
 import torch._dynamo.config as dynamo_config
 import torch.nn as nn
 from torch._inductor import config

--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import patch
 
 import torch
-import torch._dynamo
 import torch._dynamo.config as dynamo_config
 import torch._inductor.config as inductor_config
 import torch._inductor.utils

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import functorch
 
-import torch._dynamo
 import torch._inductor.config as config
 from torch._dynamo.backends.registry import register_backend
 from torch._inductor import metrics

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import functorch
 
+import torch
 import torch._inductor.config as config
 from torch._dynamo.backends.registry import register_backend
 from torch._inductor import metrics

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -21,7 +21,6 @@ import numpy as np
 
 import torch
 
-import torch._dynamo
 import torch._dynamo.config as dynamo_config
 import torch.nn as nn
 from torch._dispatch.python import enable_python_dispatcher

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import torch
 
-import torch._dynamo
 from torch._dynamo.test_case import run_tests
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1652,7 +1652,6 @@ def compile(model: Optional[Callable] = None, *,
                            disable=disable)
         return fn
 
-    import torch._dynamo
     if mode is not None and options is not None:
         raise RuntimeError("Either mode or options can be specified, but both can't be specified at the same time.")
     if mode is None and options is None:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1743,12 +1743,26 @@ _deprecated_attrs = {
     "has_cudnn": torch.backends.cudnn.is_available,
     "has_mkldnn": torch.backends.mkldnn.is_available,
 }
+
+_lazy_modules = {
+    "_dynamo",
+    "_inductor",
+}
+
 def __getattr__(name):
+    # Deprecated attrs
     replacement = _deprecated_attrs.get(name)
     if replacement is not None:
         import warnings
         warnings.warn(f"'{name}' is deprecated, please use '{replacement.__module__}.{replacement.__name__}()'", stacklevel=2)
         return replacement()
+
+    # Lazy modules
+    if name in _lazy_modules:
+        import importlib
+        return importlib.import_module(f".{name}", __name__)
+
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 from . import _logging
 _logging._init_logs()


### PR DESCRIPTION
Use [PEP-562](https://peps.python.org/pep-0562) to import `_dynamo` and `_inductor` only when needed.

- Remove redundant imports from tests
- Add `test_lazy_imports_are_lazy` to make sure they will not get imported by accident

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bae8e90</samp>

> _Sing, O Muse, of the daring deeds of PyTorch, the swift and fiery_
> _framework of deep learning, that with skill and cunning wrought_
> _many wonders of dynamic compilation, using the hidden powers_
> _of `_dynamo` and `_inductor`, the secret modules of LLVM and MLIR._


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @anijain2305