### PR TITLE
[CUDNN][CUDNN V8 API] LRU Cache for cuDNN frontend `ExecutionPlan`

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -183,7 +183,7 @@ struct CacheKeyFusedWrapper : ParamsWrapper<CacheKeyFused> {
 
 static int getLRUCacheLimit() {
   constexpr int DEFAULT_LIMIT = 10000; // roughly corresponds to 2GiB assuming 200KiB per ExecutionPlan
-  static int limit = [] {
+  static int limit = [&] {
     const char * val = getenv("TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT");
     if (!val) {
        return DEFAULT_LIMIT;

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -201,7 +201,6 @@ static int getLRUCacheLimit() {
   } ();
   return limit;
 }
-}
 
 template <typename T, typename KeyType>
 struct BenchmarkCache {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -181,26 +181,26 @@ struct CacheKeyFusedWrapper : ParamsWrapper<CacheKeyFused> {
   }
 };
 
-static int _parseChosenLRUCacheLimit() {
-  const char * val = getenv("TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT");
-  int limit = 10000; // roughly corresponds to 2GiB assuming 200KiB per ExecutionPlan
-  if (val) {
+static int getLRUCacheLimit() {
+  constexpr int DEFAULT_LIMIT = 10000; // roughly corresponds to 2GiB assuming 200KiB per ExecutionPlan
+  static int limit = [] {
+    const char * val = getenv("TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT");
+    if (!val) {
+       return DEFAULT_LIMIT;
+    }
     try {
-      limit = std::stoi(val);
+      return std::stoi(val);
     } catch(std::invalid_argument const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
-                 " using default LRU cache limit of ", limit, " entries.");
+               " using default LRU cache limit of ", limit, " entries.");
     } catch(std::out_of_range const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
                  " using default LRU cache limit of ", limit, " entries.");
     }
-  }
+    return DEFAULT_LIMIT;
+  } ();
   return limit;
 }
-
-static int getLRUCacheLimit() {
-  static int limit = _parseChosenLRUCacheLimit();
-  return limit;
 }
 
 template <typename T, typename KeyType>

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -235,7 +235,6 @@ cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
     TORCH_INTERNAL_ASSERT(engine_cache_order.size() == engine_cache_order_size, "CUDNN V8 LRU Cache Corrupted (list size unexpectedly changed). Please report a bug to PyTorch.");
     TORCH_INTERNAL_ASSERT(engine_cache.size() == engine_cache.size(), "CUDNN V8 LRU Cache Corrupted (cache size unexpectedly changed). Please report a bug to PyTorch.");
   }
-  std::cout << "map size: " << engine_cache.size() << " list size: " << engine_cache_order.size() << std::endl;
   return &(it->second.first);
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -230,7 +230,8 @@ cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
     engine_cache_order.push_back(key);
     engine_cache.erase(key);
     engine_cache.emplace(key, std::make_pair(plan, --engine_cache_order.end()));
-    TORCH_INTERNAL_ASSERT(engine_cache.find(key)->first == *(engine_cache.find(key)->second.second), "CUDNN V8 LRU Cache Corrupted (refresh list vs. map key mismatch). Please report a bug to PyTorch.");
+    it = engine_cache.find(key);
+    TORCH_INTERNAL_ASSERT(it->first == *(it->second.second), "CUDNN V8 LRU Cache Corrupted (refresh list vs. map key mismatch). Please report a bug to PyTorch.");
     TORCH_INTERNAL_ASSERT((long) engine_cache_order.size() <= lru_cache_limit, "CUDNN V8 LRU Cache Corrupted (refresh size exceeds limit: ", lru_cache_limit, " please report a bug to PyTorch.");
     TORCH_INTERNAL_ASSERT(engine_cache_order.size() == engine_cache_order_size, "CUDNN V8 LRU Cache Corrupted (list size unexpectedly changed). Please report a bug to PyTorch.");
     TORCH_INTERNAL_ASSERT(engine_cache.size() == engine_cache.size(), "CUDNN V8 LRU Cache Corrupted (cache size unexpectedly changed). Please report a bug to PyTorch.");

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -242,8 +242,7 @@ void update(const KeyType& key, T& results) {
   int lru_cache_limit = getLRUCacheLimit();
   if (lru_cache_limit < 0) {
     return;
-  }
-  else if (lru_cache_limit) {
+  } else if (lru_cache_limit) {
     auto it = engine_cache.find(key);
     if (it == engine_cache.end()) {
       auto engine_cache_order_size = engine_cache_order.size();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -206,7 +206,7 @@ static int getLRUCacheLimit() {
 template <typename T, typename KeyType>
 struct BenchmarkCache {
 std::list<KeyType> engine_cache_order;
-std::unordered_map<KeyType, std::pair<cudnn_frontend::ExecutionPlan, typename std::list<KeyType>::iterator >, ParamsWrapperHash<KeyType>> engine_cache;
+std::unordered_map<KeyType, std::pair<cudnn_frontend::ExecutionPlan, typename std::list<KeyType>::iterator>, ParamsWrapperHash<KeyType>> engine_cache;
 
 // no mutexes here as caches are now thread local for v8, can also return a pointer
 // to the Execution Plan if we know it will not be invalidated by another thread

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -192,7 +192,7 @@ static int _parseChosenLRUCacheLimit() {
                  " using default LRU cache limit of ", limit, " entries.");
     } catch(std::out_of_range const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
-                 " using default LRU ache limit of ", limit, " entries.");
+                 " using default LRU cache limit of ", limit, " entries.");
     }
   }
   return limit;

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -211,7 +211,7 @@ std::unordered_map<KeyType, std::pair<cudnn_frontend::ExecutionPlan, typename st
 // no mutexes here as caches are now thread local for v8, can also return a pointer
 // to the Execution Plan if we know it will not be invalidated by another thread
 cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
-  int lru_cache_limit = getLRUCacheLimit();
+  const int lru_cache_limit = getLRUCacheLimit();
   if (lru_cache_limit < 0) {
     return nullptr;
   }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -230,6 +230,7 @@ cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
     engine_cache_order.push_back(key);
     engine_cache.erase(key);
     engine_cache.emplace(key, std::make_pair(plan, --engine_cache_order.end()));
+    // iterator was invalidated by the erase, so we grab it again
     it = engine_cache.find(key);
     TORCH_INTERNAL_ASSERT(it->first == *(it->second.second), "CUDNN V8 LRU Cache Corrupted (refresh list vs. map key mismatch). Please report a bug to PyTorch.");
     TORCH_INTERNAL_ASSERT((long) engine_cache_order.size() <= lru_cache_limit, "CUDNN V8 LRU Cache Corrupted (refresh size exceeds limit: ", lru_cache_limit, " please report a bug to PyTorch.");

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -183,6 +183,8 @@ struct CacheKeyFusedWrapper : ParamsWrapper<CacheKeyFused> {
 
 static int getLRUCacheLimit() {
   constexpr int DEFAULT_LIMIT = 10000; // roughly corresponds to 2GiB assuming 200KiB per ExecutionPlan
+  // 0 is used to indicate no limit
+  // negative values are used to indicate no caching
   static int limit = [&] {
     const char * val = getenv("TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT");
     if (!val) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -195,7 +195,7 @@ static int getLRUCacheLimit() {
                " using default LRU cache limit of ", limit, " entries.");
     } catch(std::out_of_range const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
-                 " using default LRU cache limit of ", limit, " entries.");
+                 " using default LRU cache limit of ", DEFAULT_LIMIT, " entries.");
     }
     return DEFAULT_LIMIT;
   } ();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -192,7 +192,7 @@ static int getLRUCacheLimit() {
       return std::stoi(val);
     } catch(std::invalid_argument const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
-               " using default LRU cache limit of ", limit, " entries.");
+               " using default LRU cache limit of ", DEFAULT_LIMIT, " entries.");
     } catch(std::out_of_range const& e) {
       TORCH_WARN("invalid TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT,",
                  " using default LRU cache limit of ", DEFAULT_LIMIT, " entries.");


### PR DESCRIPTION
Adds LRU functionality to the cuDNN frontend `ExecutionPlan` cache to address high memory usage as observed in #98688, #104122 via the `TORCH_CUDNN_V8_LRU_CACHE_LIMIT` environment variable. By default this limit is set to 10000, which corresponds to about 2GiB of host memory usage as observed empirically. Note that we are still following up with cuDNN to see if the size of an `ExecutionPlan` can be reduced, as it appears to currently be around 200KiB (!!) for a single plan.

This implementation is a bit heavy on the internal asserts for now as it's a bit difficult to directly test the state of the cache without instrumenting it explicitly in tests. Once we are confident that the implementation is stable, we can remove the asserts.

CC @malfet who @ptrblck mentioned may have also been looking into this

CC @colesbury 

cc @csarofeen @ptrblck @xwang233