### PR TITLE
Back out "[Inductor][FX passes] Remove config.split_cat_fx_passes & A…

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -45,8 +45,8 @@ epilogue_fusion_first = False
 # enable pattern match+replace optimizations
 pattern_matcher = True
 
-# enable experimental patterns for match+replace optimizations
-experimental_patterns = False
+# Optimize away split cat patterns (Experimental)
+split_cat_fx_passes = True
 
 # enable reordering pass
 reordering = True

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -12,6 +12,7 @@ from ..pattern_matcher import (
     CallFunction,
     CallFunctionVarArgs,
     CallMethodVarArgs,
+    config_flag,
     FailedMatch,
     get_arg_value,
     Ignored,
@@ -85,10 +86,12 @@ def normalize_split_base(match: Match, _get_split_args: Callable):
 @register_graph_pattern(
     CallFunctionVarArgs(torch.split, users=MULTIPLE),
     pass_dict=normalization_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     CallMethodVarArgs("split", users=MULTIPLE),
     pass_dict=normalization_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def normalize_split_default(match: Match, *args, **kwargs):
     return normalize_split_base(match, _get_split_args_default)
@@ -97,6 +100,7 @@ def normalize_split_default(match: Match, *args, **kwargs):
 @register_graph_pattern(
     CallFunctionVarArgs(torch.cat, users=MULTIPLE),
     pass_dict=normalization_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def normalize_cat_default(match: Match, *args, **kwargs):
     cat_node = match.nodes[0]
@@ -147,6 +151,7 @@ def find_next_users(split_node):
 @register_graph_pattern(
     CallMethodVarArgs("squeeze", users=MULTIPLE),
     pass_dict=normalization_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def normalize_squeeze_default(match: Match, *args, **kwargs):
     squeeze_node = match.nodes[0]
@@ -214,6 +219,7 @@ class TorchSplit(CallFunction):
         KeywordArg("next_split_sections"),
     ),
     pass_dict=merge_splits_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def merge_splits(
     match: Match,
@@ -808,6 +814,7 @@ class GetItem(CallFunction):
         ),
     ),
     pass_dict=split_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     RepeatedExpr(
@@ -825,6 +832,7 @@ class GetItem(CallFunction):
         )
     ),
     pass_dict=split_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def merge_split_squeeze(
     match: Match, split_input: torch.fx.Node, split_sizes: List[int], dim: int
@@ -876,18 +884,21 @@ getitem_unbind = ListOf(
 @register_graph_pattern(
     CallFunction([torch.stack, torch.cat], getitem_unbind, Ignored(), _users=MULTIPLE),
     pass_dict=unbind_stack_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     CallFunction(
         [torch.stack, torch.cat], getitem_unbind, dim=Ignored(), _users=MULTIPLE
     ),
     pass_dict=unbind_stack_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     CallFunction(
         [torch.stack, torch.cat], tensors=getitem_unbind, dim=Ignored(), _users=MULTIPLE
     ),
     pass_dict=unbind_stack_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def merge_unbind_stack(match: Match, unbind_input: torch.fx.Node, dim: int):
     unbind_node = next(node for node in match.nodes if node.target == torch.unbind)
@@ -916,6 +927,7 @@ getitem_split = ListOf(
         _users=MULTIPLE,
     ),
     pass_dict=split_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     CallFunction(
@@ -925,6 +937,7 @@ getitem_split = ListOf(
         _users=MULTIPLE,
     ),
     pass_dict=split_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 @register_graph_pattern(
     CallFunction(
@@ -934,6 +947,7 @@ getitem_split = ListOf(
         _users=MULTIPLE,
     ),
     pass_dict=split_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
 )
 def simplify_split_cat(match: Match, split_sections: List[int], dim: int):
     if not isinstance(split_sections, (list, tuple)):  # Unnormalized split


### PR DESCRIPTION
…dd config.experimental_patterns" (#104362)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/104362

revert D46752606 to unblock pyper release. This diff introduced a package incompatibility between ads_dper3 and training_platform.

Test Plan: tests pass

Reviewed By: yanboliang

Differential Revision: D47100297

fbshipit-source-id: 24a0bc149f0f9165b5ffcca80e669e917d6dd4c2

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78