### PR TITLE
Fix argmax and argmin clamp value on MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -901,7 +901,7 @@ void argmax_argmin_out_mps(const Tensor& input_t,
       MPSGraphTensor* outputClampedTensor =
           [mpsGraph clampWithTensor:outputTensor
                      minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
-                     maxValueTensor:[mpsGraph constantWithScalar:LLONG_MAX dataType:MPSDataTypeInt64]
+                     maxValueTensor:[mpsGraph constantWithScalar:0x7FEFFFFFFFFFFFFF dataType:MPSDataTypeInt64]
                                name:nil];
 
       newCachedGraph->inputTensor_ = inputTensor;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4610,6 +4610,23 @@ class TestNLLLoss(TestCaseMPS):
 
         helper((2, 3, 4, 5))
 
+    def test_argmax(self):
+        # https://github.com/pytorch/pytorch/issues/98191
+        cpu_tensor = torch.tensor([[0, 1], [2,1], [1, 0]])
+        res_cpu = torch.argmax(cpu_tensor, dim=1)
+
+        mps_tensor = cpu_tensor.to(torch.device('mps'))
+        res_mps = torch.argmax(mps_tensor, dim=1)
+        self.assertEqual(res_cpu, res_mps)
+
+        # https://github.com/pytorch/pytorch/issues/92311
+        mps_tensor = torch.randn(10,2, device='mps', dtype=torch.float32)
+        cpu_tensor = mps_tensor.detach().clone().cpu()
+
+        res_mps = torch.argmax(mps_tensor, dim=1)
+        res_cpu = torch.argmax(cpu_tensor, dim=1)
+        self.assertEqual(res_cpu, res_mps)
+
     # Test forward argmin argmax
     def test_argmin_argmax(self):
         def helper(n, c, h, w, reduction_type, dtype=torch.float32):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4612,7 +4612,7 @@ class TestNLLLoss(TestCaseMPS):
 
     def test_argmax(self):
         # https://github.com/pytorch/pytorch/issues/98191
-        cpu_tensor = torch.tensor([[0, 1], [2,1], [1, 0]])
+        cpu_tensor = torch.tensor([[0, 1], [2, 1], [1, 0]])
         res_cpu = torch.argmax(cpu_tensor, dim=1)
 
         mps_tensor = cpu_tensor.to(torch.device('mps'))
@@ -4620,7 +4620,7 @@ class TestNLLLoss(TestCaseMPS):
         self.assertEqual(res_cpu, res_mps)
 
         # https://github.com/pytorch/pytorch/issues/92311
-        mps_tensor = torch.randn(10,2, device='mps', dtype=torch.float32)
+        mps_tensor = torch.randn(10, 2, device='mps', dtype=torch.float32)
         cpu_tensor = mps_tensor.detach().clone().cpu()
 
         res_mps = torch.argmax(mps_tensor, dim=1)


### PR DESCRIPTION
Replace clamp `LLONG_MAX` clamp value with the largest integer value that can be stored in a double. `constantWithScalar` takes as input a `double` value, for which `LLONG_MAX` was not fitting in a dobule, resulting in failures on x86. 

Fixes https://github.com/pytorch/pytorch/issues/98191, https://github.com/pytorch/pytorch/issues/92311

