### PR TITLE
propagate pred guards in TorchHigherOrderOperatorVariable call_function for cond

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -901,7 +901,8 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
 
         opt_test = torch.compile(test, backend="eager")
         inp = torch.ones(3, 3)
-        self.assertFalse(torch.allclose(opt_test(True, inp), opt_test(False, inp)))
+        self.assertTrue(torch.allclose(test(True, inp), opt_test(True, inp)))
+        self.assertTrue(torch.allclose(test(False, inp), opt_test(False, inp)))
 
     def test_map_graph_break(self):
         backend = EagerAndRecordGraphs()

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -889,6 +889,20 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         self.assertEqual(len(backend.graphs), 0)
         self.assertEqual(res, mod_for_eager(torch.tensor(True), torch.tensor(5)))
 
+    def test_cond_with_constant_pred(self):
+        def test(pred, x):
+            def true_fn(x):
+                return x
+
+            def false_fn(x):
+                return -x
+
+            return control_flow.cond(pred, true_fn, false_fn, [x])
+
+        opt_test = torch.compile(test, backend="eager")
+        inp = torch.ones(3, 3)
+        self.assertFalse(torch.allclose(opt_test(True, inp), opt_test(False, inp)))
+
     def test_map_graph_break(self):
         backend = EagerAndRecordGraphs()
         cnt = CompileCounterWithBackend(backend)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -983,6 +983,7 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
                     f"item but got {str(type(args[0]))} "
                     f"with original python type {str(args[0].python_type())}.",
                 )
+            tx.output.guards.update(args[0].guards)
 
             # operands
             if type(args[3]) is not ListVariable:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104379

Fixes https://github.com/pytorch/pytorch/issues/104372

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78