### PR TITLE
[ONNX] Export dynamic step size for aten::slice()

### DIFF
--- a/test/onnx/expect/TestOperators.test_narrow.expect
+++ b/test/onnx/expect/TestOperators.test_narrow.expect
@@ -25,7 +25,7 @@ graph {
       t {
         dims: 1
         data_type: 7
-        raw_data: "\002\000\000\000\000\000\000\000"
+        raw_data: "\000\000\000\000\000\000\000\000"
       }
       type: TENSOR
     }
@@ -39,16 +39,16 @@ graph {
       t {
         dims: 1
         data_type: 7
-        raw_data: "\000\000\000\000\000\000\000\000"
+        raw_data: "\002\000\000\000\000\000\000\000"
       }
       type: TENSOR
     }
   }
   node {
     input: "onnx::Slice_0"
-    input: "onnx::Slice_13"
     input: "onnx::Slice_14"
     input: "onnx::Slice_15"
+    input: "onnx::Slice_13"
     output: "11"
     name: "Slice_3"
     op_type: "Slice"

--- a/test/onnx/expect/TestOperators.test_slice.expect
+++ b/test/onnx/expect/TestOperators.test_slice.expect
@@ -3,7 +3,7 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    output: "onnx::Slice_1"
+    output: "onnx::Slice_12"
     name: "Constant_0"
     op_type: "Constant"
     attribute {
@@ -17,7 +17,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_2"
+    output: "onnx::Slice_13"
     name: "Constant_1"
     op_type: "Constant"
     attribute {
@@ -31,7 +31,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_3"
+    output: "onnx::Slice_14"
     name: "Constant_2"
     op_type: "Constant"
     attribute {
@@ -45,7 +45,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_4"
+    output: "onnx::Slice_15"
     name: "Constant_3"
     op_type: "Constant"
     attribute {
@@ -60,11 +60,11 @@ graph {
   }
   node {
     input: "onnx::Slice_0"
-    input: "onnx::Slice_2"
-    input: "onnx::Slice_3"
-    input: "onnx::Slice_1"
-    input: "onnx::Slice_4"
-    output: "5"
+    input: "onnx::Slice_13"
+    input: "onnx::Slice_14"
+    input: "onnx::Slice_12"
+    input: "onnx::Slice_15"
+    output: "11"
     name: "Slice_4"
     op_type: "Slice"
   }
@@ -86,7 +86,7 @@ graph {
     }
   }
   output {
-    name: "5"
+    name: "11"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_slice_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_slice_dynamic.expect
@@ -3,7 +3,7 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    output: "onnx::Slice_1"
+    output: "onnx::Slice_12"
     name: "Constant_0"
     op_type: "Constant"
     attribute {
@@ -17,7 +17,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_2"
+    output: "onnx::Slice_13"
     name: "Constant_1"
     op_type: "Constant"
     attribute {
@@ -31,7 +31,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_3"
+    output: "onnx::Slice_14"
     name: "Constant_2"
     op_type: "Constant"
     attribute {
@@ -45,7 +45,7 @@ graph {
     }
   }
   node {
-    output: "onnx::Slice_4"
+    output: "onnx::Slice_15"
     name: "Constant_3"
     op_type: "Constant"
     attribute {
@@ -60,16 +60,16 @@ graph {
   }
   node {
     input: "onnx::Slice_0"
-    input: "onnx::Slice_2"
-    input: "onnx::Slice_3"
-    input: "onnx::Slice_1"
-    input: "onnx::Slice_4"
-    output: "onnx::Gather_5"
+    input: "onnx::Slice_13"
+    input: "onnx::Slice_14"
+    input: "onnx::Slice_12"
+    input: "onnx::Slice_15"
+    output: "onnx::Gather_9"
     name: "Slice_4"
     op_type: "Slice"
   }
   node {
-    output: "onnx::Gather_6"
+    output: "onnx::Gather_10"
     name: "Constant_5"
     op_type: "Constant"
     attribute {
@@ -82,9 +82,9 @@ graph {
     }
   }
   node {
-    input: "onnx::Gather_5"
-    input: "onnx::Gather_6"
-    output: "7"
+    input: "onnx::Gather_9"
+    input: "onnx::Gather_10"
+    output: "11"
     name: "Gather_6"
     op_type: "Gather"
     attribute {
@@ -111,7 +111,7 @@ graph {
     }
   }
   output {
-    name: "7"
+    name: "11"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -250,11 +250,11 @@ class TestONNXOpset(pytorch_test_common.ExportTestCase):
             {"op_name": "Constant"},
             {"op_name": "Gather", "attributes": [{"name": "axis", "i": 0, "type": 2}]},
             {"op_name": "Constant"},
+            {"op_name": "Constant"},
             {
                 "op_name": "Unsqueeze",
                 "attributes": [{"name": "axes", "i": 0, "type": 7}],
             },
-            {"op_name": "Constant"},
             {"op_name": "Constant"},
             {"op_name": "Slice", "attributes": []},
         ]

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1923,6 +1923,30 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         y = torch.rand((22, 256))
         self.run_test(InputIndexSlice(), (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    @skipScriptTest()  # Torchscript doesn't support 1d index.
+    def test_slice_with_1d_input_index(self):
+        class InputIndexSlice(torch.nn.Module):
+            def forward(self, x, y):
+                x[:y, 0, :] = y
+                return x
+
+        x = torch.zeros((56, 6, 256))
+        y = torch.tensor([5], dtype=torch.int64)
+        self.run_test(InputIndexSlice(), (x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_slice_with_input_step_size(self):
+        class InputIndexSlice(torch.nn.Module):
+            def forward(self, x, y, z):
+                x[:y:z, 0::z, :] = 1
+                return x
+
+        x = torch.zeros((56, 6, 256))
+        y = torch.tensor(5, dtype=torch.int64)
+        z = torch.tensor(2, dtype=torch.int64)
+        self.run_test(InputIndexSlice(), (x, y, z))
+
     @skipIfUnsupportedMinOpsetVersion(10)
     @skipScriptTest()  # scripting tuple/list append
     def test_slice_dynamic(self):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -717,7 +717,6 @@ def _slice_helper(
     starts,
     ends,
     steps=None,
-    dynamic_slice=False,
 ):
     if g.opset <= 9:
         from torch.onnx.symbolic_opset9 import _slice as _slice9
@@ -726,7 +725,7 @@ def _slice_helper(
     else:
         from torch.onnx.symbolic_opset10 import _slice as _slice10
 
-        return _slice10(g, input, axes, starts, ends, steps, dynamic_slice)
+        return _slice10(g, input, axes, starts, ends, steps)
 
 
 @_beartype.beartype

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -1,7 +1,7 @@
 import functools
 import sys
 import warnings
-from typing import Callable
+from typing import Callable, List, Optional, Union
 
 import torch
 import torch._C._onnx as _C_onnx
@@ -231,8 +231,8 @@ def _max_pool(name: str, tuple_fn: Callable, ndims: int, return_indices: bool):
                 g,
                 flattened_indices,
                 axes=[2 + i for i in range(ndims)],
-                starts=tuple_fn(0),
-                ends=tuple_fn(1),
+                starts=list(tuple_fn(0)),
+                ends=list(tuple_fn(1)),
             )
             indices = opset9.sub(g, indices, s)
             return r, indices
@@ -331,38 +331,59 @@ def __interpolate(
 @_beartype.beartype
 def _slice(
     g: jit_utils.GraphContext,
-    input,
-    axes,
-    starts,
-    ends,
-    steps=None,
-    dynamic_slice=False,
+    input: torch._C.Value,
+    axes: Union[List, torch.Tensor, torch._C.Value],
+    starts: Union[List, torch.Tensor, torch._C.Value],
+    ends: Union[List, torch.Tensor, torch._C.Value],
+    steps: Optional[Union[List, torch.Tensor, torch._C.Value]] = None,
 ):
-    if dynamic_slice:
-        starts = symbolic_helper._unsqueeze_helper(g, starts, [0])
-        ends = symbolic_helper._unsqueeze_helper(g, ends, [0])
-        if isinstance(axes, int):
-            axes = g.op("Constant", value_t=torch.tensor(axes))
-        axes = symbolic_helper._unsqueeze_helper(g, axes, [0])
-    else:
-        assert len(starts) == len(ends)
-        assert len(starts) == len(axes)
-        assert steps is None or len(starts) == len(steps)
-        if (
-            len(starts) == 1
-            and starts[0] == 0
-            and ends[0] == _constants.INT64_MAX
-            and (steps is None or (len(steps) == 1 and steps[0] == 1))
-        ):
-            return input
-        if ends[0] > _constants.INT64_MAX:
-            ends[0] = _constants.INT64_MAX
-        axes = g.op("Constant", value_t=torch.tensor(axes))
-        starts = g.op("Constant", value_t=torch.tensor(starts))
-        ends = g.op("Constant", value_t=torch.tensor(ends))
+    def is_none_value(value):
+        if value is None:
+            return True
+        return (
+            isinstance(value, torch._C.Value)
+            and value.node().kind() == "prim::Constant"
+            and isinstance(value.type(), _C.NoneType)
+        )
+
+    def to_slice_input(list_or_value, default_value=None):
+        # Convert input param into a 1D torch.Value.
+        if is_none_value(list_or_value) and default_value is not None:
+            list_or_value = [default_value]
+
+        if isinstance(list_or_value, (list, torch.Tensor)):
+            return g.op("Constant", value_t=torch.tensor(list_or_value))
+
+        rank = symbolic_helper._get_tensor_rank(list_or_value)
+        if rank == 0:
+            return symbolic_helper._unsqueeze_helper(g, list_or_value, [0])
+        if rank == 1:
+            return list_or_value
+        raise errors.SymbolicValueError(
+            f"Rank must be 0 or 1, not {rank}", list_or_value
+        )
+
+    def get_const_value(list_or_value):
+        if isinstance(list_or_value, (list, torch.Tensor)):
+            if len(list_or_value) == 1:
+                return list_or_value[0]
+            return None
+        return symbolic_helper._maybe_get_const(list_or_value, "i")
+
+    # Check if slice is a no-op
+    if (
+        get_const_value(starts) == 0
+        and get_const_value(ends) == _constants.INT64_MAX
+        and (steps is None or get_const_value(steps) == 1)
+    ):
+        return input
+
+    axes = to_slice_input(axes)
+    starts = to_slice_input(starts, default_value=0)
+    ends = to_slice_input(ends, default_value=_constants.INT64_MAX)
     if steps is None:
         return g.op("Slice", input, starts, ends, axes)
-    steps = g.op("Constant", value_t=torch.tensor(steps))
+    steps = to_slice_input(steps, default_value=1)
     return g.op("Slice", input, starts, ends, axes, steps)
 
 
@@ -371,49 +392,21 @@ def _slice(
 def slice(g: jit_utils.GraphContext, self, *args):
     if len(args) == 4:
         # aten::slice(Tensor self, int dim, int? start=None, int? end=None, int step=1) -> Tensor
-        dim, start, end, step = args
+        dims, start, end, step = args
     elif len(args) == 3:
         # aten::slice(t[] l, int? start=None, int? end=None, int step=1) -> t[]
         start, end, step = args
-        dim = 0
+        dims = [0]
     else:
         raise errors.SymbolicValueError("Unknown aten::slice signature", self)
-    is_start_none = start.node().kind() == "prim::Constant" and isinstance(
-        start.type(), _C.NoneType
-    )
-    is_end_none = end.node().kind() == "prim::Constant" and isinstance(
-        end.type(), _C.NoneType
-    )
-    is_start_onnx_const = start.node().kind() == "onnx::Constant"
-    is_end_onnx_const = end.node().kind() == "onnx::Constant"
-    step = symbolic_helper._parse_arg(step, "i")
-    if (
-        (not is_start_none and not is_start_onnx_const)
-        or (not isinstance(end, int) and not is_end_none and not is_end_onnx_const)
-        or (not isinstance(dim, int) and dim.node().kind() != "onnx::Constant")
-    ):
-        dynamic_slice = True
-        if is_start_none:
-            start = g.op("Constant", value_t=torch.tensor(0))
-        if is_end_none:
-            end = g.op("Constant", value_t=torch.tensor(_constants.INT64_MAX))
-    else:
-        start = [0 if is_start_none else symbolic_helper._parse_arg(start, "i")]
-        end = [
-            _constants.INT64_MAX
-            if is_end_none
-            else symbolic_helper._parse_arg(end, "i")
-        ]
-        dim = [symbolic_helper._parse_arg(dim, "i")]
-        dynamic_slice = False
+
     return symbolic_helper._slice_helper(
         g,
         self,
-        axes=dim,
+        axes=dims,
         starts=start,
         ends=end,
-        steps=[step],
-        dynamic_slice=dynamic_slice,
+        steps=step,
     )
 
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -469,7 +469,6 @@ def masked_scatter(g: jit_utils.GraphContext, self, mask, source):
         axes=torch.LongTensor([0]),
         starts=torch.LongTensor([0]),
         ends=opset9.size(g, index, torch.LongTensor([0])),
-        dynamic_slice=True,
     )
     return g.op("ScatterND", self, index, source)
 
@@ -1298,9 +1297,7 @@ def im2col(g: jit_utils.GraphContext, input, kernel_size, dilation, padding, str
 @_beartype.beartype
 def narrow(g: jit_utils.GraphContext, input, dim, start, length):
     end = g.op("Add", start, length)
-    return symbolic_helper._slice_helper(
-        g, input, axes=dim, starts=start, ends=end, dynamic_slice=True
-    )
+    return symbolic_helper._slice_helper(g, input, axes=dim, starts=start, ends=end)
 
 
 @_onnx_symbolic("aten::flatten")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1672,8 +1672,8 @@ def _max_pool(name, tuple_fn, ndims, return_indices):
                 g,
                 flattened_indices,
                 axes=[2 + i for i in range(ndims)],
-                starts=tuple_fn(0),
-                ends=tuple_fn(1),
+                starts=list(tuple_fn(0)),
+                ends=list(tuple_fn(1)),
             )
             indices = sub(g, indices, s)
             return r, indices


### PR DESCRIPTION
This commit improves the export of aten::slice() to ONNX in the following ways:

1. The step size can be an input tensor rather than a constant.
2. Fixes a bug where using a 1-D, 1-element torch tensor as an index created a broken ONNX model.

This commit also adds tests for the new functionality.

Fixes #104314
