### PR TITLE
[dynamo] Show guard failures if report_guard_failures=True, even if logging is not set to debug/info

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -240,7 +240,9 @@ def convert_frame_assert(
         code = frame.f_code
 
         if code in input_codes and (
-            recompiles_log.isEnabledFor(logging.DEBUG) or config.error_on_recompile
+            recompiles_log.isEnabledFor(logging.DEBUG)
+            or config.error_on_recompile
+            or config.report_guard_failures
         ):
             if config.report_guard_failures:
                 message = (
@@ -253,8 +255,11 @@ def convert_frame_assert(
                     "set env var TORCHDYNAMO_REPORT_GUARD_FAILURES=1 to debug further",
                 )
 
-            if recompiles_log.isEnabledFor(logging.DEBUG):
-                recompiles_log.debug(message)
+            if (
+                recompiles_log.isEnabledFor(logging.DEBUG)
+                or config.report_guard_failures
+            ):
+                recompiles_log.warning(message)
 
             if config.error_on_recompile:
                 raise exc.RecompileError(message)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #104394

If the user sets TORCHDYNAMO_REPORT_GUARD_FAILURES=True, they probably want these logs even if dynamo debug logging isn't turned on.

Before: you could turn on `report_guard_failures=True` (and guard_fail_hooks would be registered) but you wouldn't get any logs unless you also set TORCH_LOGS=+dynamo.

After this PR you would get those logs with just `report_guard_failures=True`

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @ipiszy

Differential Revision: [D47115718](https://our.internmc.facebook.com/intern/diff/D47115718)