### PR TITLE
[2D parallel] workaround for FSDP init issue

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -482,20 +482,44 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
             )
 
     @skip_if_lt_x_gpu(2)
-    def test_multi_device_not_supported(self):
-        """Tests that wrapping a multi-device module (i.e. with submodules on
-        both GPU and CPU) with FSDP raises an error."""
+    def test_cpu_gpu_module(self):
+        """Tests a CPU + GPU module supported if device_id is passed
+        in, errors if device_id is not.
+        """
+        torch.cuda.set_device(self.rank)
 
-        class MultiDeviceModule(nn.Module):
+        class CPUGPUModule(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.a = nn.Linear(1, 1).cuda()
                 self.b = nn.Linear(1, 1)
 
+        cpu_gpu = CPUGPUModule()
+        fsdp = FSDP(cpu_gpu, device_id=torch.cuda.current_device())
+        for param in fsdp.parameters():
+            self.assertEqual(param.device, torch.device(torch.cuda.current_device()))
+
+        # without device_id, we hit an error
+        with self.assertRaisesRegex(RuntimeError, "please pass in device_id"):
+            FSDP(CPUGPUModule())
+
+    @skip_if_lt_x_gpu(2)
+    def test_multigpu_module(self):
+        """
+        Module on multiple GPUs wrapped in FSDP should raise an error.
+        """
+
+        class MultiGPUModule(nn.Module):
+            def __init__(self, rank):
+                super().__init__()
+                self.rank = rank
+                self.a = nn.Linear(1, 1).cuda(self.rank)
+                self.b = nn.Linear(1, 1).cuda((self.rank + 1) % dist.get_world_size())
+
         with self.assertRaisesRegex(
             RuntimeError, "FSDP only supports single device modules"
         ):
-            FSDP(MultiDeviceModule())
+            FSDP(MultiGPUModule(self.rank))
 
     @skip_if_lt_x_gpu(2)
     def test_no_params(self):

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -453,7 +453,7 @@ def _init_param_handle_from_module(
     Initializes a ``FlatParamHandle`` from a module ``fully_sharded_module``.
     This is the module wrapper code path.
     """
-    _check_single_device_module(fully_sharded_module, state._ignored_params)
+    _check_single_device_module(fully_sharded_module, state._ignored_params, device_id)
     device_from_device_id = _get_device_from_device_id(device_id, state.rank)
     is_meta_module, is_torchdistX_deferred_init = _need_to_materialize_module(
         fully_sharded_module, state._ignored_params
@@ -508,7 +508,7 @@ def _init_param_handles_from_module(
         state._ignored_modules,
         state._ignored_params,
     )
-    _check_single_device_module(root_module, state._ignored_params)
+    _check_single_device_module(root_module, state._ignored_params, device_id)
     device_from_device_id = _get_device_from_device_id(device_id, state.rank)
     # Initialize and shard `FlatParamHandle`s one by one following reverse
     # depth-first order (i.e. reverse `.modules()` order), which represents a
@@ -742,6 +742,7 @@ def _get_buffer_names(root_module: nn.Module) -> Set[str]:
 def _check_single_device_module(
     module: nn.Module,
     ignored_params: Set[nn.Parameter],
+    device_id: Optional[Union[int, torch.device]],
 ) -> None:
     """
     Raises an error if ``module`` has original parameters on multiple devices,
@@ -749,7 +750,19 @@ def _check_single_device_module(
     module must be either fully on the CPU or fully on a non-CPU device.
     """
     devices = {param.device for param in _get_orig_params(module, ignored_params)}
-    if len(devices) > 1:
+    # We allow module to be partially on CPU and partially on GPU if device_id is not
+    # None, since the device_id arg will result in the CPU portion being moved to
+    # GPU. This is useful in cases where part of the module may be parallelized
+    # by another algorithm and may already be on GPU. We'd like to enforce device_id
+    # to not be None, otherwise we'd flatten parameters in a mixed module which is
+    # not supported.
+    if len(devices) == 2 and torch.device("cpu") in devices:
+        if device_id is None:
+            raise RuntimeError(
+                "To support a module with both CPU and GPU params, "
+                "please pass in device_id argument."
+            )
+    elif len(devices) > 1:
         raise RuntimeError(
             f"FSDP only supports single device modules but got params on {devices}"
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104398

Closes https://github.com/pytorch/pytorch/issues/96491 and does so by relaxing FSDP's assumption that the entire input module must be on the same device. Now, FSDP can accept a module partially on CPU and GPU and just emits a warning.

Differential Revision: [D47117256](https://our.internmc.facebook.com/intern/diff/D47117256/)