### PR TITLE
add named tensor support for custom device

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -277,8 +277,8 @@ Tensor empty_names(
   }
   TORCH_CHECK(options.layout() == Layout::Strided,
       "NYI: named tensors only support strided layout");
-  TORCH_CHECK(options.device().is_cpu() || options.device().is_cuda(),
-      "NYI: named tensors only support CPU and CUDA tensors");
+  TORCH_CHECK(options.device().is_cpu() || options.device().is_cuda() || options.device().is_privateuseone(),
+      "NYI: named tensors only support CPU, CUDA or ", c10::get_privateuse1_backend(), " tensors.");
   auto result = at::empty(size, options, optional_memory_format);
   internal_set_names_inplace(result, names);
   return result;

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -401,12 +401,14 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         def test_open_device_faketensor():
             torch.utils.rename_privateuse1_backend('foo')
-            # register foo module, torch.foo
-            torch._register_device_module('foo', DummyModule)
             with torch._subclasses.fake_tensor.FakeTensorMode.push():
                 a = torch.empty(1, device="foo")
                 b = torch.empty(1, device="foo:0")
                 result = a + b
+
+        def test_open_device_named_tensor():
+            torch.utils.rename_privateuse1_backend('foo')
+            a = torch.empty([2, 3, 4, 5], device="foo", names=["N", "C", "H", "W"])
 
         test_base_device_registration()
         test_before_common_registration()
@@ -422,6 +424,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_open_device_storage_resize()
         test_open_device_storage_type()
         test_open_device_faketensor()
+        test_open_device_named_tensor()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1. for custom device(privateuse1 backend), we also want to support named tensors, so I optimize the check and add test.