### PR TITLE
sparse.sampled_addmm: skip tests when TEST_WITH_TORCHINDUCTOR

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -3521,7 +3521,7 @@ class TestSparseCompressedTritonKernels(TestCase):
     @onlyCUDA
     @skipIfRocm
     @dtypes(torch.half)
-    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU or torch._running_with_deploy(),
+    @unittest.skipIf((not TEST_WITH_TORCHINDUCTOR) or (IS_FBCODE and IS_REMOTE_GPU) or torch._running_with_deploy(),
                      "Skipped for deploy and internal with remote GPUs")
     def test_triton_bsr_dense_bmm_error_messages(self, device, dtype):
         from torch.sparse._triton_ops import bsr_dense_mm
@@ -3569,7 +3569,8 @@ class TestSparseCompressedTritonKernels(TestCase):
     @skipIfRocm
     @dtypes(torch.half, torch.bfloat16, torch.float)
     @dtypesIfCUDA(torch.half, *[torch.bfloat16] if SM80OrLater else [], torch.float)
-    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
+    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU or torch._running_with_deploy(),
+                     "Skipped for deploy and internal with remote GPUs")
     def test_triton_sampled_addmm(self, device, dtype, block_size):
         from functools import partial
         from torch.sparse._triton_ops import sampled_addmm, broadcast_batch_dims_bsr


### PR DESCRIPTION
As per title, otherwise issues with illegal memory access on H100. Fixes https://github.com/pytorch/pytorch/issues/104322.
Copy-pasted from https://github.com/pytorch/pytorch/pull/102660.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104422



cc @alexsamardzic @pearu @cpuhrsch @amjames @bhosmer @ptrblck