### PR TITLE
Fix IndexKernel.cu build

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -54,8 +54,8 @@ static void launch_kernel(const int64_t N, const func_t& f) {
 template <typename func_t>
 void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, const IntArrayRef index_stride, const func_t& f) {
   const auto num_indices = index_size.size();
-  AT_ASSERT(static_cast<size_t>(num_indices) == index_stride.size());
-  AT_ASSERT(num_indices == iter.ntensors() - 2);
+  AT_ASSERT(num_indices == index_stride.size());
+  AT_ASSERT(static_cast<int64_t>(num_indices) == iter.ntensors() - 2);
 
   if (iter.numel() == 0) {
     return;
@@ -71,7 +71,7 @@ void gpu_index_kernel(TensorIteratorBase& iter, const IntArrayRef index_size, co
   auto sizes = at::detail::Array<int64_t, MAX_DIMS>(0);
   auto strides = at::detail::Array<int64_t, MAX_DIMS>(0);
   auto index_ptrs = at::detail::Array<char*, MAX_DIMS>(nullptr);
-  for (int i = 0; i < num_indices; i++) {
+  for (unsigned i = 0; i < num_indices; i++) {
     sizes[i] = index_size[i];
     strides[i] = index_stride[i];
     index_ptrs[i] = (char*)iter.data_ptr(i + 2);


### PR DESCRIPTION
Fixes `signed-unsigned comparison` warnings introduced by https://github.com/pytorch/pytorch/pull/106809 (previously by  <s> https://github.com/pytorch/pytorch/pull/104054 </s> ) that changed type of `num_indices` to unsigned.


Before the change warnings looks as follows:
```
/tmp/tmpxft_00194ca7_00000000-6_IndexKernel.cudafe1.stub.c:31:580:   required from here
/home/nshulga/git/pytorch/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:58:63: warning: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘int’ [-Wsign-compare]
   58 |   AT_ASSERT(num_indices == iter.ntensors() - 2);
      |                                                               ^                        
/home/nshulga/git/pytorch/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:74:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const long unsigned int’ [-Wsign-compare]
   74 |   for (int i = 0; i < num_indices; i++) {
      |                 ~~^~~~~~~~~~~~~
```
TODO: Turn those warning into errors

