### PR TITLE
[ROCm] reduce tolerance for triangular solve with well_conditioned set to True

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4040,7 +4040,7 @@ class TestLinalg(TestCase):
 
     # Tolerances dictated by widest acceptable range on CPU before failure
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 1e-3,
+    @precisionOverride({torch.float32: 1e-3 if TEST_WITH_ROCM else 1e-1,
                         torch.float64: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4042,7 +4042,7 @@ class TestLinalg(TestCase):
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3 if TEST_WITH_ROCM else 1e-1,
                         torch.float64: 1e-8,
-                        torch.complex64: 1e-8,
+                        torch.complex64: 1e-1,
                         torch.complex128: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4041,7 +4041,9 @@ class TestLinalg(TestCase):
     # Tolerances dictated by widest acceptable range on CPU before failure
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3 if TEST_WITH_ROCM else 1e-1,
-                        torch.float64: 1e-8})
+                        torch.float64: 1e-8,
+                        torch.complex64: 1e-8,
+                        torch.complex128: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS
         ks = (3, 1, 0)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4039,7 +4039,7 @@ class TestLinalg(TestCase):
         self.assertEqual(X, out)
 
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 1e-4,
+    @precisionOverride({torch.float32: 1e-3,
                         torch.float64: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4039,7 +4039,7 @@ class TestLinalg(TestCase):
         self.assertEqual(X, out)
 
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 2e-1 if TEST_WITH_ROCM else 1e-1, torch.complex64: 1e-1,
+    @precisionOverride({torch.float32: 1e-1, torch.complex64: 1e-1,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS
@@ -4049,7 +4049,7 @@ class TestLinalg(TestCase):
 
         gen_inputs = self._gen_shape_inputs_linalg_triangular_solve
         for b, n, k in product(bs, ns, ks):
-            for A, B, left, upper, uni in gen_inputs((b, n, k), dtype, device):
+            for A, B, left, upper, uni in gen_inputs((b, n, k), dtype, device, well_conditioned=True):
                 self._test_linalg_solve_triangular(A, B, upper, left, uni)
 
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4039,8 +4039,8 @@ class TestLinalg(TestCase):
         self.assertEqual(X, out)
 
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 1e-4, torch.complex64: 1e-8,
-                        torch.float64: 1e-8, torch.complex128: 1e-8})
+    @precisionOverride({torch.float32: 1e-4,
+                        torch.float64: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS
         ks = (3, 1, 0)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4038,6 +4038,7 @@ class TestLinalg(TestCase):
         torch.linalg.solve_triangular(A, B, upper=upper, left=left, unitriangular=uni, out=out)
         self.assertEqual(X, out)
 
+    # Tolerances dictated by widest acceptable range on CPU before failure
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3,
                         torch.float64: 1e-8})

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4039,11 +4039,9 @@ class TestLinalg(TestCase):
         self.assertEqual(X, out)
 
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 1e-1, torch.complex64: 1e-1,
+    @precisionOverride({torch.float32: 2e-1 if TEST_WITH_ROCM else 1e-1, torch.complex64: 1e-1,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
-        if TEST_WITH_ROCM and dtype is torch.float32:
-            raise unittest.SkipTest("Skipping for ROCm for Magma backend; unskip when hipSolver backend is enabled")
         # This exercises the API + BLAS CPU + batched cuBLAS
         ks = (3, 1, 0)
         ns = (5, 0)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4039,7 +4039,7 @@ class TestLinalg(TestCase):
         self.assertEqual(X, out)
 
     @dtypes(*floating_and_complex_types())
-    @precisionOverride({torch.float32: 1e-1, torch.complex64: 1e-1,
+    @precisionOverride({torch.float32: 1e-4, torch.complex64: 1e-8,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_linalg_solve_triangular(self, device, dtype):
         # This exercises the API + BLAS CPU + batched cuBLAS


### PR DESCRIPTION
Current test case causes an edge case tensor input that causes a single generated tensor to fail the tolerance assertion on ROCm only and only for float32. We have reviewed the logic with our libraries team and have discovered the discrepancy is due to a difference in order of operations on AMD GPUs. They came back with "working as intended" and found no perceivable bug. Interestingly, if we change the values in ks, ns, or bs, the test passes on ROCm. These particular sizes in this particular order generates a single problematic input that causes the assertion to fail the tolerance check by ~0.07. Again, this is not a bug, just differences in implementation. This PR loosens the tolerance for ROCm only.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang