### PR TITLE
[dynamo] Add `tensorrt` backend for Torch compile

### DIFF
--- a/docs/source/torch.compiler.rst
+++ b/docs/source/torch.compiler.rst
@@ -70,7 +70,7 @@ Some of the most commonly used backends include:
    * - ``torch.compile(m, backend="onnxrt")``
      - Uses ONNXRT for inference on CPU/GPU. `Read more <https://onnxruntime.ai/>`__
    * - ``torch.compile(m, backend="tensorrt")``
-     - Uses ONNXRT to run TensorRT for inference optimizations. `Read more <https://github.com/onnx/onnx-tensorrt>`__
+     - Uses Torch-TensorRT for inference optimizations. `Read more <https://github.com/pytorch/TensorRT>`__
    * - ``torch.compile(m, backend="ipex")``
      - Uses IPEX for inference on CPU. `Read more <https://github.com/intel/intel-extension-for-pytorch>`__
    * - ``torch.compile(m, backend="tvm")``

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -8,6 +8,7 @@ import torch._dynamo
 import torch._dynamo.test_case
 from torch._dynamo.backends.debugging import ExplainWithBackend
 from torch._dynamo.backends.onnxrt import has_onnxruntime
+from torch._dynamo.backends.tensorrt import has_torch_tensorrt
 from torch._dynamo.backends.tvm import has_tvm
 from torch._dynamo.testing import same
 from torch.testing._internal.common_utils import IS_FBCODE, skipIfRocm
@@ -141,6 +142,10 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not has_onnxruntime(), "requires onnxruntime")
     def test_onnxrt(self):
         self._check_backend_works("onnxrt")
+
+    @unittest.skipIf(not has_torch_tensorrt(), "requires Torch-TensorRT")
+    def test_tensorrt(self):
+        self._check_backend_works("tensorrt")
 
     @unittest.skipIf(not has_tvm(), "requires tvm")
     def test_tvm(self):

--- a/torch/_dynamo/backends/tensorrt.py
+++ b/torch/_dynamo/backends/tensorrt.py
@@ -1,12 +1,28 @@
-# import torch  # type: ignore[import]
-# from .common import device_from_inputs, fake_tensor_unsupported  # type: ignore[import]
-# from .registry import register_backend  # type: ignore[import]
+import importlib
+import logging
 
-"""
-Placeholder for TensorRT backend for dynamo via torch-tensorrt
-"""
+from torch._dynamo import register_backend
 
-# @register_backend
-# def tensorrt(gm, example_inputs):
-#    import torch_tensorrt # type: ignore[import]
-#    pass
+logger = logging.getLogger(__name__)
+
+
+@register_backend
+def tensorrt(*args, **kwargs):
+    try:
+        from torch_tensorrt.dynamo.backend import torch_tensorrt_backend
+    except ImportError:
+        logger.exception(
+            "Unable to import Torch-TensorRT. Please install Torch-TensorRT. "
+            "See https://github.com/pytorch/TensorRT for more details."
+        )
+        raise
+
+    return torch_tensorrt_backend(*args, **kwargs)
+
+
+def has_torch_tensorrt():
+    try:
+        importlib.import_module("torch_tensorrt.dynamo.backend")
+        return True
+    except ImportError:
+        return False


### PR DESCRIPTION
#94632 reserved the `tensorrt` namespace in Dynamo compile and this PR adds the corresponding implementation for it, as a reference to [`torch_tensorrt.dynamo.backend.torch_tensorrt_backend`](https://github.com/pytorch/TensorRT/blob/2844630aa8301bc937eb38356026973f74024c0e/py/torch_tensorrt/dynamo/backend/backends.py#L27-L33). This is a placeholder backend which we intend to point to whichever backend implementation is the intended default in Torch-TensorRT. We have a growing suite of tests ([see here](https://github.com/pytorch/TensorRT/tree/2844630aa8301bc937eb38356026973f74024c0e/py/torch_tensorrt/dynamo/backend/test)) which test this backend in multiple different contexts.

- Add backend code to `tensorrt` placeholder file, with imports nested in try/except clauses to fail gracefully
- Add skipped test to CI
- Add documentation to compile docs

cc: @narendasan 

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78