### PR TITLE
[fake_pg] remove init barrier env var

### DIFF
--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -80,9 +80,6 @@ class FakeStore(dist.Store):
     pass
 
 def _create_fake_pg(prefix_store, rank, world_size, timeout):
-    # disable barrier after init for fake pg, as it does not
-    # need to sync with other processes/threads
-    os.environ["TORCH_DIST_INIT_BARRIER"] = "0"
     return FakeProcessGroup(rank, world_size)
 
 dist.Backend.register_backend("fake", _create_fake_pg, devices=['cpu', 'cuda'])

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -1,5 +1,3 @@
-import os
-
 import torch.distributed as dist
 
 from torch._C._distributed_c10d import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104428

We can now remove the env var as we by default disable the init barrier