### PR TITLE
[inductor] Fix squeeze normalization pattern

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1574,6 +1574,13 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(1, 2, 1, 2, 2, 2, 1),))
 
+    def test_squeeze_varargs(self):
+        def fn(x):
+            return x.squeeze(1, 2).clone()
+
+        a = torch.randn(1024, 1, 1)
+        self.common(fn, (a,))
+
     def test_simplify_loops(self):
         def fn(a, b):
             return a + b

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1,6 +1,6 @@
 import logging
 import operator
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Sequence, Tuple, Union
 
 import numpy
 
@@ -151,7 +151,24 @@ def find_next_users(split_node):
 def normalize_squeeze_default(match: Match, *args, **kwargs):
     squeeze_node = match.nodes[0]
     squeeze_input = get_arg_value(squeeze_node, 0)
-    dim = get_arg_value(squeeze_node, 1, "dim")
+
+    if "dim" in squeeze_node.kwargs:
+        assert len(squeeze_node.args) == 1
+        dim = squeeze_node.kwargs["dim"]
+    elif len(squeeze_node.args) == 1:
+        # squeeze(Tensor)
+        dim = None
+    elif len(squeeze_node.args) == 2:
+        # squeeze(Tensor self, int dim)
+        # squeeze(Tensor self, int[] dim)
+        dim = squeeze_node.args[1]
+    else:
+        # squeeze(Tensor self, int[] dim) (called with varargs)
+        dim = squeeze_node.args[1:]
+
+    if isinstance(dim, Sequence) and len(dim) == 1:
+        dim = dim[0]
+
     with match.graph.inserting_after(squeeze_node):
         if dim is None:
             new_squeeze_node = match.graph.call_function(
@@ -832,6 +849,8 @@ def merge_split_squeeze(
     graph = match.graph
     split = next(node for node in match.nodes if node.target == torch.split)
     if not all(s == 1 for s in split_sizes):
+        return
+    if isinstance(dim, Sequence):
         return
     next_users = find_next_users(split)
     if not all(node.target == torch.squeeze for node in next_users):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104434

Fixes #103875

In the test sample, this pass would turn:
```
%squeeze : [num_users=1] = call_method[target=squeeze](args = (%l_x_, 1, 2), kwargs = {})
```
into
```
%squeeze_1 : [num_users=1] = call_function[target=torch.squeeze](args = (%l_x_, 1), kwargs = {})
```
which is clearly wrong as we've dropped the second squeeze dim.

Instead, this PR now normalizes to
```
%squeeze_1 : [num_users=1] = call_function[target=torch.squeeze](args = (%l_x_, (1, 2)), kwargs = {})
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78