### PR TITLE
Enable more tests

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -190,7 +190,6 @@ TESTS = discover_tests(
         "test_jit_string",
         "test_kernel_launch_checks",
         "test_nnapi",
-        "test_segment_reductions",
         "test_static_runtime",
         "test_throughput_benchmark",
         "test_typing",

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     gradcheck,
     parametrize,
-
+    skipIfRocm,
 )
 
 
@@ -231,6 +231,7 @@ class TestSegmentReductions(TestCase):
                             length_type,
                         )
 
+    @skipIfRocm
     @dtypes(
         *product(
             (torch.half, torch.bfloat16, torch.float, torch.double),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -326,7 +326,6 @@ class TestTorchDeviceType(TestCase):
         s = t.storage()
         self._check_storage_meta(s, s_check)
 
-    @onlyCPU
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_storage_meta_errors(self, device, dtype):
         s0 = torch.TypedStorage([1, 2, 3, 4], device='meta', dtype=dtype)


### PR DESCRIPTION
Remove `test_segment_reductions` from list of blocklisted tests Remove `@onlyCPU` qualifier from test_segment_reductions as it has CUDA specific parts

Fixes https://github.com/pytorch/pytorch/issues/104410

