### PR TITLE
lazy init device mesh in fsdp

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -228,7 +228,6 @@ def _init_device_mesh(
         return None
     from torch.distributed.distributed_c10d import _get_group_tag
 
-
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))
     device_mesh = DeviceMesh(device_type, mesh_tensor, _init_process_groups=False)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -231,7 +231,10 @@ def _init_device_mesh(
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))
     device_mesh = DeviceMesh(device_type, mesh_tensor, _init_process_groups=False)
-    device_mesh._dim_group_infos = (_get_group_tag(root_state.process_group), mesh_tensor.tolist())
+    device_mesh._dim_group_infos = (
+        _get_group_tag(root_state.process_group),
+        mesh_tensor.tolist(),
+    )
     return device_mesh
 
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -226,9 +226,13 @@ def _init_device_mesh(
         return None
     if get_backend() == "fake" or not root_state.compute_device:
         return None
+    from torch.distributed.distributed_c10d import _get_group_tag
+
+
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))
-    device_mesh = DeviceMesh(device_type, mesh_tensor)
+    device_mesh = DeviceMesh(device_type, mesh_tensor, _init_process_groups=False)
+    device_mesh._dim_group_infos = (_get_group_tag(root_state.process_group), mesh_tensor.tolist())
     return device_mesh
 
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -24,6 +24,7 @@ from torch.autograd.graph import register_multi_grad_hook
 from torch.distributed import get_backend, get_world_size
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
+from torch.distributed.distributed_c10d import _get_group_tag
 from torch.distributed.fsdp._common_utils import (
     _assert_in_training_states,
     _FSDPState,
@@ -226,7 +227,6 @@ def _init_device_mesh(
         return None
     if get_backend() == "fake" or not root_state.compute_device:
         return None
-    from torch.distributed.distributed_c10d import _get_group_tag
 
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -38,12 +38,31 @@ class FakeProcessGroup(dist.ProcessGroup):
         return ret_work(tensor_list)
 
     def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+        # NOTE: in general it's not good form to try to make FakePG work with 'real data',
+        # but the reasoning here is that we want FakePG to work with DeviceMesh's init
+        # code that have the data validation, which makes it worth the tradeoff.
+        # In general user should use MTPG or normal PG for cases where they may care about
+        # real data from collectives
+        for chunk in output_tensors[0]:
+            chunk.copy_(input_tensor[0])
         return ret_work(output_tensors)
 
     def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
         return ret_work(output_tensor)
 
     def _allgather_base(self, output_tensor, input_tensor, opts=AllgatherOptions()):
+        # assume each rank have the same input tensor so we just copy to the results
+        # since it's not a real allgather, we simply make this copying logic to let
+        # some simple validation works (i.e. calling allgather to see if each rank have
+        # the same tensor or not)
+        # NOTE: in general it's not good form to try to make FakePG work with 'real data',
+        # but the reasoning here is that we want FakePG to work with DeviceMesh's init
+        # code that have the data validation, which makes it worth the tradeoff.
+        # In general user should use MTPG or normal PG for cases where they may care about
+        # real data from collectives
+        chunks = output_tensor.chunk(self._world_size)
+        for chunk in chunks:
+            chunk.copy_(input_tensor)
         return ret_work(output_tensor)
 
     def _reduce_scatter_base(self, output_tensor, input_tensor, opts=ReduceScatterOptions()):

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -44,18 +44,6 @@ class FakeProcessGroup(dist.ProcessGroup):
         return ret_work(output_tensor)
 
     def _allgather_base(self, output_tensor, input_tensor, opts=AllgatherOptions()):
-        # assume each rank have the same input tensor so we just copy to the results
-        # since it's not a real allgather, we simply make this copying logic to let
-        # some simple validation works (i.e. calling allgather to see if each rank have
-        # the same tensor or not)
-        # NOTE: in general it's not good form to try to make FakePG work with 'real data',
-        # but the reasoning here is that we want FakePG to work with DeviceMesh's init
-        # code that have the data validation, which makes it worth the tradeoff.
-        # In general user should use MTPG or normal PG for cases where they may care about
-        # real data from collectives
-        chunks = output_tensor.chunk(self._world_size)
-        for chunk in chunks:
-            chunk.copy_(input_tensor)
         return ret_work(output_tensor)
 
     def _reduce_scatter_base(self, output_tensor, input_tensor, opts=ReduceScatterOptions()):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104056
* __->__ #104447

since fsdp state is lazy init, we also need to lazy init device mesh
otherwise devicemesh allgather check would trigger some mismatch in
allgather counts in fsdp tests