### PR TITLE
Disable cudagraphs by default when dynamic shape is enabled.

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -172,9 +172,17 @@ class TestInductorConfig(TestCase):
         self.assertEqual(reduce_overhead_opts["triton.cudagraphs"], True)
         self.assertEqual(reduce_overhead_opts.get("max_autotune", False), False)
 
+        reduce_overhead_opts = torch._inductor.list_mode_options("reduce-overhead", dynamic=True)
+        self.assertEqual(reduce_overhead_opts["triton.cudagraphs"], False)
+        self.assertEqual(reduce_overhead_opts.get("max_autotune", False), False)
+
         max_autotune_opts = torch._inductor.list_mode_options("max-autotune")
         self.assertEqual(max_autotune_opts["max_autotune"], True)
         self.assertEqual(max_autotune_opts["triton.cudagraphs"], True)
+
+        max_autotune_opts = torch._inductor.list_mode_options("max-autotune", dynamic=True)
+        self.assertEqual(max_autotune_opts["max_autotune"], True)
+        self.assertEqual(max_autotune_opts["triton.cudagraphs"], False)
 
         max_autotune_no_cudagraphs_opts = torch._inductor.list_mode_options(
             "max-autotune-no-cudagraphs"

--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -172,10 +172,6 @@ class TestInductorConfig(TestCase):
         self.assertEqual(reduce_overhead_opts["triton.cudagraphs"], True)
         self.assertEqual(reduce_overhead_opts.get("max_autotune", False), False)
 
-        reduce_overhead_opts = torch._inductor.list_mode_options("reduce-overhead", dynamic=True)
-        self.assertEqual(reduce_overhead_opts["triton.cudagraphs"], False)
-        self.assertEqual(reduce_overhead_opts.get("max_autotune", False), False)
-
         max_autotune_opts = torch._inductor.list_mode_options("max-autotune")
         self.assertEqual(max_autotune_opts["max_autotune"], True)
         self.assertEqual(max_autotune_opts["triton.cudagraphs"], True)

--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -176,7 +176,9 @@ class TestInductorConfig(TestCase):
         self.assertEqual(max_autotune_opts["max_autotune"], True)
         self.assertEqual(max_autotune_opts["triton.cudagraphs"], True)
 
-        max_autotune_opts = torch._inductor.list_mode_options("max-autotune", dynamic=True)
+        max_autotune_opts = torch._inductor.list_mode_options(
+            "max-autotune", dynamic=True
+        )
         self.assertEqual(max_autotune_opts["max_autotune"], True)
         self.assertEqual(max_autotune_opts["triton.cudagraphs"], False)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1511,7 +1511,7 @@ class _TorchCompileInductorWrapper:
             pass
         elif mode in ("reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"):
             from torch._inductor import list_mode_options
-            self.apply_options(list_mode_options(mode))
+            self.apply_options(list_mode_options(mode, self.dynamic))
         else:
             raise RuntimeError(
                 f"Unrecognized mode={mode}, should be one of: default, reduce-overhead, max-autotune, max-autotune-no-cudagraphs"

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1513,10 +1513,10 @@ class _TorchCompileInductorWrapper:
             from torch._inductor import list_mode_options
             if mode == "reduce-overhead" and self.dynamic:
                 raise RuntimeError(
-                        "mode=reduce-overhead cannot be used together with dynamic=True! "
-                        "reduce-overhead enables cudagraph. dynamic=True forces recompiliation "
-                        "for each new shape, which defeats the purpose of cudagraph. "
-                        "Please only enable one of them."
+                    "mode=reduce-overhead cannot be used together with dynamic=True! "
+                    "reduce-overhead enables cudagraph. dynamic=True forces recompiliation "
+                    "for each new shape, which defeats the purpose of cudagraph. "
+                    "Please only enable one of them."
                 )
             self.apply_options(list_mode_options(mode, self.dynamic))
         else:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1511,6 +1511,13 @@ class _TorchCompileInductorWrapper:
             pass
         elif mode in ("reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"):
             from torch._inductor import list_mode_options
+            if mode == "reduce-overhead" and self.dynamic:
+                raise RuntimeError(
+                        "mode=reduce-overhead cannot be used together with dynamic=True! "
+                        "reduce-overhead enables cudagraph. dynamic=True forces recompiliation "
+                        "for each new shape, which defeats the purpose of cudagraph. "
+                        "Please only enable one of them."
+                )
             self.apply_options(list_mode_options(mode, self.dynamic))
         else:
             raise RuntimeError(

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -54,13 +54,15 @@ def aot_compile(
     return lib_path
 
 
-def list_mode_options(mode: str = None) -> Dict[str, Any]:
+def list_mode_options(mode: str = None, dynamic: bool = None) -> Dict[str, Any]:
     r"""Returns a dictionary describing the optimizations that each of the available
     modes passed to `torch.compile()` performs.
 
     Args:
         mode (str, optional): The mode to return the optimizations for.
         If None, returns optimizations for all modes
+        dynamic (bool, optional): Whether dynamic shape is enabled.
+        When dynamic_shape is enabled, cuda graph will be disabled.
 
     Example::
         >>> torch._inductor.list_mode_options()
@@ -68,18 +70,23 @@ def list_mode_options(mode: str = None) -> Dict[str, Any]:
 
     mode_options = {
         "default": {},
-        # enable cudagraphs
+        # enable cudagraphs when dynamic is not set
+        # otherwise, if both cudagraphs and dynamic are enabled, Inductor
+        # recompiles for each new shape
         "reduce-overhead": {
-            "triton.cudagraphs": True,
+            "triton.cudagraphs": (dynamic is not True),
         },
         # enable max-autotune
         "max-autotune-no-cudagraphs": {
             "max_autotune": True,
         },
-        # enable both cuda-graphs and max-autotune
+        # enable max-autotune
+        # enable cudagraphs when dynamic is not set
+        # otherwise, if both cudagraphs and dynamic are enabled, Inductor
+        # recompiles for each new shape
         "max-autotune": {
             "max_autotune": True,
-            "triton.cudagraphs": True,
+            "triton.cudagraphs": (dynamic is not True),
         },
     }
     return mode_options[mode] if mode else mode_options

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -70,11 +70,9 @@ def list_mode_options(mode: str = None, dynamic: bool = None) -> Dict[str, Any]:
 
     mode_options = {
         "default": {},
-        # enable cudagraphs when dynamic is not set
-        # otherwise, if both cudagraphs and dynamic are enabled, Inductor
-        # recompiles for each new shape
+        # enable cudagraphs
         "reduce-overhead": {
-            "triton.cudagraphs": (dynamic is not True),
+            "triton.cudagraphs": True,
         },
         # enable max-autotune
         "max-autotune-no-cudagraphs": {


### PR DESCRIPTION
Disable cudagraphs when dynamic shape is enabled (via torch.compile(dynamic=True)).
Otherwise, Inductor recompiles for each new shape, which doesn't seem to be very reasonable.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ngimel @yf225 @chenyang78 @kadeng @muchulee8