### PR TITLE
Deprecated the device usage without device_type

### DIFF
--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -792,7 +792,7 @@ inline at::Device toDevice(PyObject* obj) {
     TORCH_CHECK(device_index >= 0, "Device index must not be negative");
     TORCH_WARN_ONCE(
         "For the `device` argument, `device=index will be deprecated as of "
-        "PyTorch 2.1, you should use `device=device_type:index` instead.");
+        "PyTorch 2.2, you should use `device=device_type:index` instead.");
     return at::Device(DeviceType::CUDA, device_index);
   }
   const std::string& device_str = THPUtils_unpackString(obj);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -790,7 +790,10 @@ inline at::Device toDevice(PyObject* obj) {
   if (THPUtils_checkLong(obj)) {
     const auto device_index = THPUtils_unpackLong(obj);
     TORCH_CHECK(device_index >= 0, "Device index must not be negative");
-    return at::Device(c10::DeviceType::CUDA, device_index);
+    TORCH_WARN_ONCE(
+        "For the `device` argument, `device=index will be deprecated as of "
+        "PyTorch 2.1, you should use `device=device_type:index` instead.");
+    return at::Device(DeviceType::CUDA, device_index);
   }
   const std::string& device_str = THPUtils_unpackString(obj);
   return at::Device(device_str);


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
1. Now for the operators or APIs, we can call it by `device=index` without `device_type`, for example, `torch.device(0)` will get `cuda:0`, and `torch.rand(2, device=0)` also will get `cuda:0`, but it is not friendly for other device type, so I add the deprecated warning info to suggest to use `device="cuda:0"`. 