### PR TITLE
Fix tabulate import error

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1295,10 +1295,8 @@ class Graph:
         """
         try:
             from tabulate import tabulate
-        except ImportError:
-            print("`print_tabular` relies on the library `tabulate`, "
-                  "which could not be found on this machine. Run `pip "
-                  "install tabulate` to install the library.")
+        except:
+            raise
         node_specs = [[n.op, n.name, n.target, n.args, n.kwargs]
                       for n in self.nodes]
         print(tabulate(node_specs,

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1295,8 +1295,12 @@ class Graph:
         """
         try:
             from tabulate import tabulate
-        except:
+        except ImportError:
+            print("`print_tabular` relies on the library `tabulate`, "
+                  "which could not be found on this machine. Run `pip "
+                  "install tabulate` to install the library.")
             raise
+
         node_specs = [[n.op, n.name, n.target, n.args, n.kwargs]
                       for n in self.nodes]
         print(tabulate(node_specs,


### PR DESCRIPTION
### Description

This PR fixes issue #104166 by re-raising the exception.

### Context

The `tabulate` package needs to be installed with `pip install tabulate` before calling `tabulate(...)`.