### PR TITLE
Fix broken torch._inductor.config import

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -144,10 +144,11 @@ class _KinetoProfile:
             if (
                 is_cuda11_or_lower
                 and hasattr(torch, '_inductor')
-                and torch._inductor.config.triton.cudagraphs
             ):
-                os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
-                self.add_metadata_json("DISABLE_CUPTI_LAZY_REINIT", "1")
+                import torch._inductor.config as inductor_config
+                if inductor_config.triton.cudagraphs:
+                    os.environ["DISABLE_CUPTI_LAZY_REINIT"] = "1"
+                    self.add_metadata_json("DISABLE_CUPTI_LAZY_REINIT", "1")
 
     def stop_trace(self):
         assert self.profiler is not None


### PR DESCRIPTION
This fixes the bug in profiler code exposed by  https://github.com/pytorch/pytorch/pull/104368 that introduced on the fact that `import torch._dynamo` also imports `torch._inductor.config`:
```
$ python -c "import torch._inductor;print(torch._inductor.config)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'torch._inductor' has no attribute 'config'
(base) $ python -c "import torch._dynamo;print(torch._inductor.config)"
<module 'torch._inductor.config' from '/home/nshulga/git/pytorch/pytorch/torch/_inductor/config.py'>
```

### Testing
D47159397

