### PR TITLE
[NCCL][CUDA][CUDA Graphs] Flush enqueued work before starting a graph capture

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -121,7 +121,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   // If the watchdog has remaining work enqueued, an event query on the remaining work will crash
   // the graph capture.
   while (!c10d::ProcessGroupNCCL::watchDogsDone()) {
-    TORCH_WARN("Attempting to start graph capture but NCCL ProcessGroup(s) have remaining enqueued work. Waiting for enqueued work to finish...");
+    TORCH_WARN_ONCE("Attempting to start graph capture but NCCL ProcessGroup(s) have remaining enqueued work. Waiting for enqueued work to finish...");
     // Yield
     std::this_thread::sleep_for(
         std::chrono::milliseconds(_busy_wait_millis));

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -66,11 +66,13 @@ CUDAGraph::CUDAGraph()
 
 void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode) {
 #if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+#ifdef USE_C10D_NCCL
   // If the watchdog has remaining work enqueued, an event query on the remaining work will crash
   // the graph capture.
   while (!c10d::ProcessGroupNCCL::watchDogsDone()) {
     TORCH_WARN("Attempting to start graph capture but NCCL ProcessGroup(s) have remaining enqueued work. Waiting for enqueued work to finish...");
   }
+#endif
   TORCH_CHECK(!has_graph_exec_,
               "This CUDAGraph instance already owns a captured graph. "
               "To capture a new graph, create a new instance.");

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -286,6 +286,7 @@ inline void errorIfCapturingNonCapturableNCCL(c10::cuda::CaptureStatus status) {
 const int64_t ProcessGroupNCCL::kWatchdogThreadSleepMillis = 1000;
 constexpr int64_t kSynchronizeBusyWaitMillis = 10;
 thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
+std::unordered_set<c10d::ProcessGroupNCCL*> ProcessGroupNCCL::all_nccl_process_groups;
 
 std::ostream& operator<<(
     std::ostream& output,
@@ -728,6 +729,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     }
   }
 #endif
+  all_nccl_process_groups.insert(this);
 }
 
 void ProcessGroupNCCL::runHealthCheck() {
@@ -897,6 +899,8 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
   // Abort all NCCL Communicators on Process Group Destruction
   std::string abortReason = c10::str("Process Group destroyed on rank ", rank_);
   abort(abortReason);
+
+  all_nccl_process_groups.erase(this);
 }
 
 void ProcessGroupNCCL::ncclCommWatchdog() {
@@ -1087,6 +1091,16 @@ void ProcessGroupNCCL::runHookLoop() {
     // Lock is still acquired at this point
     done = completedWorkList_.empty();
   }
+}
+
+bool ProcessGroupNCCL::watchDogsDone() {
+  for (auto it = ProcessGroupNCCL::all_nccl_process_groups.begin(); it != ProcessGroupNCCL::all_nccl_process_groups.end(); it++) {
+    std::unique_lock<std::mutex> lock((*it)->workMetaListMutex_);
+    if (!(*it)->workMetaList_.empty()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 std::exception_ptr ProcessGroupNCCL::WorkNCCL::checkForNCCLErrors(
@@ -1632,6 +1646,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   auto& ncclStreams = ncclStreams_[key];
   // TODO(eqy): is this still necessary if avoidRecordStreams_ is set?
   for (const auto i : c10::irange(devices.size())) {
+    cudaStreamCaptureStatus is_capturing;
+    cudaStreamIsCapturing(ncclStreams[i], &is_capturing);
     auto& devEvent = (*work->ncclEndEvents_)[i];
     devEvent.record(ncclStreams[i]);
   }
@@ -1648,6 +1664,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   }
   c10::cuda::CaptureStatus capture_status =
       c10::cuda::currentStreamCaptureStatusMayInitCtx();
+
+  if (capture_status != c10::cuda::CaptureStatus::None) {
+    std::lock_guard<std::mutex> lock(workMetaListMutex_);
+    TORCH_INTERNAL_ASSERT(workMetaList_.empty(), "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
+  }
 
   if ((coalescing_state_ & CoalColl) &&
       capture_status == c10::cuda::CaptureStatus::None) {
@@ -1791,6 +1812,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(devices.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams[i];
+    cudaStreamCaptureStatus is_capturing;
+    cudaStreamIsCapturing(ncclStreams[i], &is_capturing);
     if (!coalescing_state_) {
       (*work->ncclEndEvents_)[i].record(ncclStream);
     }
@@ -1822,6 +1845,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   // multi-device per process is deprecated
   work->numelIn_ = inputs[0].numel();
   work->numelOut_ = outputs[0].numel();
+
+  if (capture_status != c10::cuda::CaptureStatus::None) {
+    std::lock_guard<std::mutex> lock(workMetaListMutex_);
+    TORCH_INTERNAL_ASSERT(workMetaList_.empty(), "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
+  }
 
   if (!coalescing_state_ && capture_status == c10::cuda::CaptureStatus::None) {
     workEnqueue(work);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1646,8 +1646,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   auto& ncclStreams = ncclStreams_[key];
   // TODO(eqy): is this still necessary if avoidRecordStreams_ is set?
   for (const auto i : c10::irange(devices.size())) {
-    cudaStreamCaptureStatus is_capturing;
-    cudaStreamIsCapturing(ncclStreams[i], &is_capturing);
     auto& devEvent = (*work->ncclEndEvents_)[i];
     devEvent.record(ncclStreams[i]);
   }
@@ -1812,8 +1810,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(devices.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams[i];
-    cudaStreamCaptureStatus is_capturing;
-    cudaStreamIsCapturing(ncclStreams[i], &is_capturing);
     if (!coalescing_state_) {
       (*work->ncclEndEvents_)[i].record(ncclStream);
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -286,7 +286,8 @@ inline void errorIfCapturingNonCapturableNCCL(c10::cuda::CaptureStatus status) {
 const int64_t ProcessGroupNCCL::kWatchdogThreadSleepMillis = 1000;
 constexpr int64_t kSynchronizeBusyWaitMillis = 10;
 thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
-std::unordered_set<c10d::ProcessGroupNCCL*> ProcessGroupNCCL::all_nccl_process_groups;
+std::unordered_set<c10d::ProcessGroupNCCL*>
+    ProcessGroupNCCL::all_nccl_process_groups;
 
 std::ostream& operator<<(
     std::ostream& output,
@@ -1094,7 +1095,9 @@ void ProcessGroupNCCL::runHookLoop() {
 }
 
 bool ProcessGroupNCCL::watchDogsDone() {
-  for (auto it = ProcessGroupNCCL::all_nccl_process_groups.begin(); it != ProcessGroupNCCL::all_nccl_process_groups.end(); it++) {
+  for (auto it = ProcessGroupNCCL::all_nccl_process_groups.begin();
+       it != ProcessGroupNCCL::all_nccl_process_groups.end();
+       it++) {
     std::unique_lock<std::mutex> lock((*it)->workMetaListMutex_);
     if (!(*it)->workMetaList_.empty()) {
       return false;
@@ -1665,7 +1668,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
 
   if (capture_status != c10::cuda::CaptureStatus::None) {
     std::lock_guard<std::mutex> lock(workMetaListMutex_);
-    TORCH_INTERNAL_ASSERT(workMetaList_.empty(), "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
+    TORCH_INTERNAL_ASSERT(
+        workMetaList_.empty(),
+        "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
   }
 
   if ((coalescing_state_ & CoalColl) &&
@@ -1844,7 +1849,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
 
   if (capture_status != c10::cuda::CaptureStatus::None) {
     std::lock_guard<std::mutex> lock(workMetaListMutex_);
-    TORCH_INTERNAL_ASSERT(workMetaList_.empty(), "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
+    TORCH_INTERNAL_ASSERT(
+        workMetaList_.empty(),
+        "In the middle of a CUDA Graph capture but the enqueued work is not empty. The watchdog will crash the capture when it polls the work.");
   }
 
   if (!coalescing_state_ && capture_status == c10::cuda::CaptureStatus::None) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1101,17 +1101,13 @@ void ProcessGroupNCCL::runHookLoop() {
   }
 }
 
-bool ProcessGroupNCCL::watchDogsDone() {
+void ProcessGroupNCCL::waitForAllPendingWorks() {
   std::lock_guard<std::mutex> lk(allProcessGroupsMutex_);
   for (auto it = ProcessGroupNCCL::all_nccl_process_groups.begin();
        it != ProcessGroupNCCL::all_nccl_process_groups.end();
        it++) {
-    std::unique_lock<std::mutex> lock((*it)->workMetaListMutex_);
-    if (!(*it)->workMetaList_.empty()) {
-      return false;
-    }
+    (*it)->waitForPendingWorks();
   }
-  return true;
 }
 
 std::exception_ptr ProcessGroupNCCL::WorkNCCL::checkForNCCLErrors(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -794,8 +794,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   static std::shared_ptr<at::DynamicLibrary> uccLib_;
   c10::intrusive_ptr<Backend> uccPG_;
 #endif
-
-
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
@@ -344,6 +345,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       : ProcessGroupNCCL(store, rank, size, options) {}
 
   ~ProcessGroupNCCL() override;
+
+  // Check that all watchdogs are done (no enqueued work).
+  // We use this to avoid uwittingly having watchdogs query work during
+  // CUDA graph captures.
+  static bool watchDogsDone();
 
   c10::intrusive_ptr<Options> getOptions() {
     return options_;
@@ -703,6 +709,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   std::list<ProcessGroupNCCL::WorkNCCL> completedWorkList_;
 
+  // All process groups for checking Watchdog status
+  static std::unordered_set<c10d::ProcessGroupNCCL*> all_nccl_process_groups;
+
   // Add Work Pointer to workVector
   void workEnqueue(c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL>);
 
@@ -785,6 +794,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   static std::shared_ptr<at::DynamicLibrary> uccLib_;
   c10::intrusive_ptr<Backend> uccPG_;
 #endif
+
+
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -695,6 +695,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Mutex to Guard workMetaList_
   std::mutex workMetaListMutex_;
 
+  // Mutex to Guard all_nccl_process_groups
+  static std::mutex allProcessGroupsMutex_;
+
   // Condition Variable for watchdog thread sleep
   std::condition_variable workMetaListCV_;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -346,10 +346,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   ~ProcessGroupNCCL() override;
 
-  // Check that all watchdogs are done (no enqueued work).
+  // Check that all work is done (no enqueued work).
   // We use this to avoid uwittingly having watchdogs query work during
   // CUDA graph captures.
-  static bool watchDogsDone();
+  static void waitForAllPendingWorks();
 
   c10::intrusive_ptr<Options> getOptions() {
     return options_;


### PR DESCRIPTION
#103503 addresses the situation where additional work is enqueued for the NCCL watchdog to poll during a graph capture---something we want to avoid as the subsequent polling will query an event and crash the capture.

However, there is currently no check that there was not work _already_ enqueued for the watchdog to poll. If there was already work that was enqueued and not cleaned up before the start of a graph capture, then we run into a similar problem where the event query will crash the capture. We've observed this causing crashes on several workloads, although it is somewhat flaky (if the watchdog happens to poll just before the graph capture and cleanup, then we dodge the crash).

This is a bit of a tricky issue as it involves making sure that no process group has enqueued work at the start of a capture, and as such the simplest solution is to add a bit of global state to track all process groups. This PR forces the start of the graph capture to wait until all enqueued work is completed and cleaned up or times out.

I did consider the alternative of simply having the watchdog skip cleanup if we detect that we are in the middle of a graph capture, but I think deferring the cleanup until later could result in false positive timeouts (e.g., if we defer cleanup on work that has completed long ago, checking timers after the graph capture could yield a "timeout").

CC @Aidyn-A 
@bottler @kwen2501 @ptrblck 

cc @ptrblck @mcarilli @ezyang