### PR TITLE
Add inverse gamma distribution and fix `sign` bug in `PowerTransform`.

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -167,6 +167,15 @@ Probability distributions - torch.distributions
     :undoc-members:
     :show-inheritance:
 
+:hidden:`InverseGamma`
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.inverse_gamma
+.. autoclass:: InverseGamma
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :hidden:`Kumaraswamy`
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -424,6 +424,7 @@ Probability distributions - torch.distributions
 .. py:module:: torch.distributions.half_cauchy
 .. py:module:: torch.distributions.half_normal
 .. py:module:: torch.distributions.independent
+.. py:module:: torch.distributions.inverse_gamma
 .. py:module:: torch.distributions.kumaraswamy
 .. py:module:: torch.distributions.laplace
 .. py:module:: torch.distributions.lkj_cholesky

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -50,7 +50,7 @@ from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, ContinuousBernoulli, Dirichlet,
                                  Distribution, Exponential, ExponentialFamily,
                                  FisherSnedecor, Gamma, Geometric, Gumbel,
-                                 HalfCauchy, HalfNormal, Independent, Kumaraswamy,
+                                 HalfCauchy, HalfNormal, Independent, InverseGamma, Kumaraswamy,
                                  LKJCholesky, Laplace, LogisticNormal,
                                  LogNormal, LowRankMultivariateNormal,
                                  MixtureSameFamily, Multinomial, MultivariateNormal,
@@ -530,7 +530,17 @@ def _get_examples():
             {'probs': torch.tensor([0.3], requires_grad=True)},
             {'probs': 0.3},
             {'logits': torch.tensor([0.], requires_grad=True)},
-        ])
+        ]),
+        Example(InverseGamma, [
+            {
+                'concentration': torch.randn(2, 3).exp().requires_grad_(),
+                'rate': torch.randn(2, 3).exp().requires_grad_(),
+            },
+            {
+                'concentration': torch.randn(1).exp().requires_grad_(),
+                'rate': torch.randn(1).exp().requires_grad_(),
+            },
+        ]),
     ]
 
 def _get_bad_examples():
@@ -788,7 +798,17 @@ def _get_bad_examples():
             {'probs': torch.tensor([1.1, 0.2, 0.4], requires_grad=True)},
             {'probs': torch.tensor([-0.5], requires_grad=True)},
             {'probs': 1.00001},
-        ])
+        ]),
+        Example(InverseGamma, [
+            {
+                'concentration': torch.tensor([0., 0.], requires_grad=True),
+                'rate': torch.tensor([-1., -100.], requires_grad=True),
+            },
+            {
+                'concentration': torch.tensor([1., 1.], requires_grad=True),
+                'rate': torch.tensor([0., 0.], requires_grad=True),
+            }
+        ]),
     ]
 
 
@@ -1717,6 +1737,33 @@ class TestDistributions(DistributionsTestCase):
             self._check_sampler_sampler(HalfNormal(std),
                                         scipy.stats.halfnorm(scale=std),
                                         f'HalfNormal(scale={std})')
+
+    @set_default_dtype(torch.double)
+    def test_inversegamma(self):
+        alpha = torch.randn(2, 3).exp().requires_grad_()
+        beta = torch.randn(2, 3).exp().requires_grad_()
+        alpha_1d = torch.randn(1).exp().requires_grad_()
+        beta_1d = torch.randn(1).exp().requires_grad_()
+        self.assertEqual(InverseGamma(alpha, beta).sample().size(), (2, 3))
+        self.assertEqual(InverseGamma(alpha, beta).sample((5,)).size(), (5, 2, 3))
+        self.assertEqual(InverseGamma(alpha_1d, beta_1d).sample((1,)).size(), (1, 1))
+        self.assertEqual(InverseGamma(alpha_1d, beta_1d).sample().size(), (1,))
+        self.assertEqual(InverseGamma(0.5, 0.5).sample().size(), ())
+        self.assertEqual(InverseGamma(0.5, 0.5).sample((1,)).size(), (1,))
+
+        self._gradcheck_log_prob(InverseGamma, (alpha, beta))
+
+        dist = InverseGamma(torch.ones(4), torch.ones(2, 1, 1))
+        log_prob = dist.log_prob(torch.ones(3, 1))
+        self.assertEqual(log_prob.shape, (2, 3, 4))
+
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_inversegamma_sample(self):
+        set_rng_seed(0)  # see Note [Randomized statistical tests]
+        for concentration, rate in product([0.5, 1, 2], [0.1, 1.0, 10.0]):
+            self._check_sampler_sampler(InverseGamma(concentration, rate),
+                                        scipy.stats.invgamma(concentration, 1 / rate),
+                                        'InverseGamma()')
 
     @set_default_dtype(torch.double)
     def test_lognormal(self):
@@ -4026,6 +4073,7 @@ class TestKL(DistributionsTestCase):
         gamma = pairwise(Gamma, [1.0, 2.5, 1.0, 2.5], [1.5, 1.5, 3.5, 3.5])
         gumbel = pairwise(Gumbel, [-2.0, 4.0, -3.0, 6.0], [1.0, 2.5, 1.0, 2.5])
         halfnormal = pairwise(HalfNormal, [1.0, 2.0, 1.0, 2.0])
+        inversegamma = pairwise(InverseGamma, [1.0, 2.5, 1.0, 2.5], [1.5, 1.5, 3.5, 3.5])
         laplace = pairwise(Laplace, [-2.0, 4.0, -3.0, 6.0], [1.0, 2.5, 1.0, 2.5])
         lognormal = pairwise(LogNormal, [-2.0, 2.0, -3.0, 3.0], [1.0, 2.0, 1.0, 2.0])
         normal = pairwise(Normal, [-2.0, 2.0, -3.0, 3.0], [1.0, 2.0, 1.0, 2.0])
@@ -4085,6 +4133,7 @@ class TestKL(DistributionsTestCase):
             (gumbel, normal),
             (halfnormal, halfnormal),
             (independent, independent),
+            (inversegamma, inversegamma),
             (laplace, laplace),
             (lognormal, lognormal),
             (laplace, normal),
@@ -4764,6 +4813,10 @@ class TestAgainstScipy(DistributionsTestCase):
             (
                 HalfNormal(positive_var2),
                 scipy.stats.halfnorm(scale=positive_var2)
+            ),
+            (
+                InverseGamma(positive_var, positive_var2),
+                scipy.stats.invgamma(positive_var, scale=positive_var2.reciprocal())
             ),
             (
                 Laplace(random_var, positive_var2),

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1760,9 +1760,9 @@ class TestDistributions(DistributionsTestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_inversegamma_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
-        for concentration, rate in product([0.5, 1, 2], [0.1, 1.0, 10.0]):
+        for concentration, rate in product([2, 5], [0.1, 1.0, 10.0]):
             self._check_sampler_sampler(InverseGamma(concentration, rate),
-                                        scipy.stats.invgamma(concentration, 1 / rate),
+                                        scipy.stats.invgamma(concentration, scale=rate),
                                         'InverseGamma()')
 
     @set_default_dtype(torch.double)
@@ -4816,7 +4816,7 @@ class TestAgainstScipy(DistributionsTestCase):
             ),
             (
                 InverseGamma(positive_var, positive_var2),
-                scipy.stats.invgamma(positive_var, scale=positive_var2.reciprocal())
+                scipy.stats.invgamma(positive_var, scale=positive_var2)
             ),
             (
                 Laplace(random_var, positive_var2),

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -90,8 +90,8 @@ from .gumbel import Gumbel
 from .half_cauchy import HalfCauchy
 from .half_normal import HalfNormal
 from .independent import Independent
-from .kl import _add_kl_info, kl_divergence, register_kl
 from .inverse_gamma import InverseGamma
+from .kl import _add_kl_info, kl_divergence, register_kl
 from .kumaraswamy import Kumaraswamy
 from .laplace import Laplace
 from .lkj_cholesky import LKJCholesky

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -139,6 +139,7 @@ __all__ = [
     "HalfCauchy",
     "HalfNormal",
     "Independent",
+    "InverseGamma",
     "Kumaraswamy",
     "LKJCholesky",
     "Laplace",

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -91,6 +91,7 @@ from .half_cauchy import HalfCauchy
 from .half_normal import HalfNormal
 from .independent import Independent
 from .kl import _add_kl_info, kl_divergence, register_kl
+from .inverse_gamma import InverseGamma
 from .kumaraswamy import Kumaraswamy
 from .laplace import Laplace
 from .lkj_cholesky import LKJCholesky

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -1,3 +1,4 @@
+import torch
 from torch.distributions import constraints
 from torch.distributions.transforms import PowerTransform
 from torch.distributions.gamma import Gamma
@@ -47,7 +48,8 @@ class InverseGamma(TransformedDistribution):
 
     @property
     def mean(self):
-        return self.rate / (self.concentration - 1)
+        result = self.rate / (self.concentration - 1)
+        return torch.where(self.concentration > 1, result, torch.inf)
 
     @property
     def mode(self):
@@ -55,7 +57,8 @@ class InverseGamma(TransformedDistribution):
 
     @property
     def variance(self):
-        return self.rate.square() / ((self.concentration - 1).square() * (self.concentration - 2))
+        result = self.rate.square() / ((self.concentration - 1).square() * (self.concentration - 2))
+        return torch.where(self.concentration > 2, result, torch.inf)
 
     def entropy(self):
         return self.concentration + self.rate.log() + self.concentration.lgamma() \

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -1,0 +1,62 @@
+from torch.distributions import constraints
+from torch.distributions.transforms import PowerTransform
+from torch.distributions.gamma import Gamma
+from torch.distributions.transformed_distribution import TransformedDistribution
+
+
+class InverseGamma(TransformedDistribution):
+    r"""
+    Creates an inverse gamma distribution parameterized by :attr:`concentration` and :attr:`rate`
+    where:
+
+        X ~ Gamma(concentration, rate)
+        Y = 1 / X ~ InverseGamma(concentration, rate)
+
+    Example::
+
+        >>> # xdoctest: +IGNORE_WANT("non-deterinistic")
+        >>> m = InverseGamma(torch.tensor([2.0]), torch.tensor([3.0]))
+        >>> m.sample()
+        tensor([ 1.2953])
+
+    Args:
+        concentration (float or Tensor): shape parameter of the distribution
+            (often referred to as alpha)
+        rate (float or Tensor): rate = 1 / scale of the distribution
+            (often referred to as beta)
+    """
+    arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
+    support = constraints.positive
+    has_rsample = True
+
+    def __init__(self, concentration, rate, validate_args=None):
+        base_dist = Gamma(concentration, rate, validate_args=validate_args)
+        super().__init__(base_dist, PowerTransform(-1), validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(InverseGamma, _instance)
+        return super().expand(batch_shape, _instance=new)
+
+    @property
+    def concentration(self):
+        return self.base_dist.concentration
+
+    @property
+    def rate(self):
+        return self.base_dist.rate
+
+    @property
+    def mean(self):
+        return self.rate / (self.concentration - 1)
+
+    @property
+    def mode(self):
+        return self.rate / (self.concentration + 1)
+
+    @property
+    def variance(self):
+        return self.rate.square() / ((self.concentration - 1).square() * (self.concentration - 2))
+
+    def entropy(self):
+        return self.concentration + self.rate.log() + self.concentration.lgamma() \
+            - (1 + self.concentration) * self.concentration.digamma()

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -1,11 +1,11 @@
 import torch
 from torch.distributions import constraints
-from torch.distributions.transforms import PowerTransform
 from torch.distributions.gamma import Gamma
 from torch.distributions.transformed_distribution import TransformedDistribution
+from torch.distributions.transforms import PowerTransform
 
 
-__all__ = ['InverseGamma']
+__all__ = ["InverseGamma"]
 
 
 class InverseGamma(TransformedDistribution):
@@ -29,7 +29,10 @@ class InverseGamma(TransformedDistribution):
         rate (float or Tensor): rate = 1 / scale of the distribution
             (often referred to as beta)
     """
-    arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
+    arg_constraints = {
+        "concentration": constraints.positive,
+        "rate": constraints.positive,
+    }
     support = constraints.positive
     has_rsample = True
 
@@ -60,9 +63,15 @@ class InverseGamma(TransformedDistribution):
 
     @property
     def variance(self):
-        result = self.rate.square() / ((self.concentration - 1).square() * (self.concentration - 2))
+        result = self.rate.square() / (
+            (self.concentration - 1).square() * (self.concentration - 2)
+        )
         return torch.where(self.concentration > 2, result, torch.inf)
 
     def entropy(self):
-        return self.concentration + self.rate.log() + self.concentration.lgamma() \
+        return (
+            self.concentration
+            + self.rate.log()
+            + self.concentration.lgamma()
             - (1 + self.concentration) * self.concentration.digamma()
+        )

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -5,6 +5,9 @@ from torch.distributions.gamma import Gamma
 from torch.distributions.transformed_distribution import TransformedDistribution
 
 
+__all__ = ['InverseGamma']
+
+
 class InverseGamma(TransformedDistribution):
     r"""
     Creates an inverse gamma distribution parameterized by :attr:`concentration` and :attr:`rate`

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -38,7 +38,10 @@ class InverseGamma(TransformedDistribution):
 
     def __init__(self, concentration, rate, validate_args=None):
         base_dist = Gamma(concentration, rate, validate_args=validate_args)
-        super().__init__(base_dist, PowerTransform(-1), validate_args=validate_args)
+        neg_one = -base_dist.rate.new_ones(())
+        super().__init__(
+            base_dist, PowerTransform(neg_one), validate_args=validate_args
+        )
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(InverseGamma, _instance)

--- a/torch/distributions/inverse_gamma.py
+++ b/torch/distributions/inverse_gamma.py
@@ -7,7 +7,7 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 class InverseGamma(TransformedDistribution):
     r"""
     Creates an inverse gamma distribution parameterized by :attr:`concentration` and :attr:`rate`
-    where:
+    where::
 
         X ~ Gamma(concentration, rate)
         Y = 1 / X ~ InverseGamma(concentration, rate)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -564,7 +564,6 @@ class PowerTransform(Transform):
     domain = constraints.positive
     codomain = constraints.positive
     bijective = True
-    sign = +1
 
     def __init__(self, exponent, cache_size=0):
         super().__init__(cache_size=cache_size)
@@ -574,6 +573,10 @@ class PowerTransform(Transform):
         if self._cache_size == cache_size:
             return self
         return PowerTransform(self.exponent, cache_size=cache_size)
+
+    @lazy_property
+    def sign(self):
+        return self.exponent.sign()
 
     def __eq__(self, other):
         if not isinstance(other, PowerTransform):


### PR DESCRIPTION
This PR comprises a few small contributions:

1. `PowerTransform` returned a sign of `+1` irrespective of exponent. However, it should return the sign of the exponent because the gradient has the same sign as the exponent. That issue has been fixed.
2. Added tests to catch errors akin to 1. in the future.
3. Added an `InverseGamma` distribution as a `TransformedDistribution` with `PowerTransform(-1)` and `Gamma` base distribution. The `InverseGamma` is often used as a prior for the length scale of Gaussian processes to aggressively suppress short length scales (see [here](https://betanalpha.github.io/assets/case_studies/gaussian_processes.html#323_Informative_Prior_Model) for a discussion).

Note: I added a `positive` constraint for the support of the inverse gamma distribution because the `PowerTransform(-1)` can fail for `nonnegative` constraints if the random variable is zero. 

```python
>>> torch.distributions.InverseGamma(0.5, 1.0).log_prob(torch.zeros(1))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-758aa22deacd> in <module>
----> 1 torch.distributions.InverseGamma(0.5, 1.0).log_prob(torch.zeros(1))

~/git/pytorch/torch/distributions/transformed_distribution.py in log_prob(self, value)
    140         """
    141         if self._validate_args:
--> 142             self._validate_sample(value)
    143         event_dim = len(self.event_shape)
    144         log_prob = 0.0

~/git/pytorch/torch/distributions/distribution.py in _validate_sample(self, value)
    298         valid = support.check(value)
    299         if not valid.all():
--> 300             raise ValueError(
    301                 "Expected value argument "
    302                 f"({type(value).__name__} of shape {tuple(value.shape)}) "

ValueError: Expected value argument (Tensor of shape (1,)) to be within the support (GreaterThan(lower_bound=0.0)) of the distribution InverseGamma(), but found invalid values:
tensor([0.])
```

This differs from the scipy implementation.

```python
>>> scipy.stats.invgamma(0.5).pdf(0)
0.0
```

cc @fritzo @neerajprad @alicanb @nikitaved @lezcano 