### PR TITLE
add fused support for xpu devices

### DIFF
--- a/torch/utils/_foreach_utils.py
+++ b/torch/utils/_foreach_utils.py
@@ -14,7 +14,7 @@ def _get_fused_kernels_supported_devices() -> List[str]:
     r"""
     Return the device type list that supports fused kernels in optimizer.
     """
-    return ["cuda", torch._C._get_privateuse1_backend_name()]
+    return ["cuda", "xpu", torch._C._get_privateuse1_backend_name()]
 
 # This util function splits tensors into groups by device and dtype, which is useful before sending
 # tensors off to a foreach implementation, which requires tensors to be on one device and dtype.


### PR DESCRIPTION
We want to add fused support for xpu devices in optimizer so we add 'xpu' to the fused support list.