### PR TITLE
Advance docker builds to cuda 11.8

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,7 +8,7 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION              = 11.7.0
+CUDA_VERSION              = 11.8.0
 CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:20.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu20.04


### PR DESCRIPTION
Advance docker builds to cuda 11.8
This should fix Docker build nightly failure: https://hud.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=Docker

The following docker image no longer exists: ``nvidia/cuda:11.7.0-cudnn8-devel-ubuntu20.04``
Hence advancing build to ``nvidia/cuda/11.8.0-cudnn8-devel-ubuntu20.04``