### PR TITLE
[BE] QNNPACK Test - FC, use ASSERT_NEAR

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h
@@ -266,7 +266,7 @@ class FullyConnectedOperatorTester {
           // Attention! Bias size must be a multiple of 8.
           constexpr size_t kBiasSizeMultiple = 8u;
           std::vector<float, AlignedAllocator<float, 32>> bias_float(
-            (bias.size() + (kBiasSizeMultiple - 1)) & -kBiasSizeMultiple);
+              (bias.size() + (kBiasSizeMultiple - 1)) & -kBiasSizeMultiple);
           std::copy(bias.cbegin(), bias.cend(), bias_float.begin());
 
           const pytorch_qnnp_status runStatus = qnnpack::qnnpackLinearDynamic(
@@ -356,15 +356,16 @@ class FullyConnectedOperatorTester {
           }
           for (size_t i = 0; i < batchSize(); i++) {
             for (size_t c = 0; c < outputChannels(); c++) {
-              ASSERT_FLOAT_EQ(
+              float ref = ((float)accumulators[i * outputChannels() + c] *
+                           requantization_scales[c]) +
+                  float(bias[c]);
+              ASSERT_NEAR(
                   output_dynamic[i * outputChannels() + c],
-                  ((float)accumulators[i * outputChannels() + c] *
-                  requantization_scales[c]) + float(bias[c]))
-                  << "at " << i << ", " << c
-                  << ": reference = " <<
-                  ((float)accumulators[i * outputChannels() + c] *
-                  requantization_scales[c]) + float(bias[c])
-                  << ", optimized = " << output_dynamic[i * outputChannels() + c];
+                  ref,
+                  std::abs(ref) * 1.0e-4)
+                  << "at " << i << ", " << c << ": reference = " << ref
+                  << ", optimized = "
+                  << output_dynamic[i * outputChannels() + c];
             }
           }
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Compare fp numbers using assert_near with reference * 10e-4. Somewhat arbitrary threhold which makes the test to pass on SSE2, given the absolute numbers are in somewhat wider range.

Differential Revision: [D47195286](https://our.internmc.facebook.com/intern/diff/D47195286/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10