### PR TITLE
correct the generated code and corresponding text to make them consistent

### DIFF
--- a/docs/source/compile/get-started.rst
+++ b/docs/source/compile/get-started.rst
@@ -36,9 +36,9 @@ CUDA graphs help eliminate the overhead from launching individual
 kernels from a Python program which is especially relevant for newer GPUs.
 
 TorchDynamo supports many different backends but inductor specifically works
-by generating `Triton <https://github.com/openai/triton>`__ kernels and
-we can inspect them by running ``TORCH_COMPILE_DEBUG=1 python trig.py``
-with the actual generated kernel being
+by generating `Triton <https://github.com/openai/triton>`__ kernels. Suppose our example above
+was called ``trig.py`` we can inspect the code generated triton kernels by 
+running ``TORCH_COMPILE_DEBUG=1 python trig.py`` with the actual generated kernel being
 
 .. code-block:: python
 
@@ -47,16 +47,17 @@ with the actual generated kernel being
    def kernel(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
        xnumel = 10000
        xoffset = tl.program_id(0) * XBLOCK
-       xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
+       xindex = xoffset + tl.arange(0, XBLOCK)[:]
        xmask = xindex < xnumel
        x0 = xindex
        tmp0 = tl.load(in_ptr0 + (x0), xmask)
-       tmp1 = tl.sin(tmp0)
-       tmp2 = tl.sin(tmp1)
-       tl.store(out_ptr0 + (x0 + tl.zeros([XBLOCK], tl.int32)), tmp2, xmask)
+       tmp1 = tl.cos(tmp0)
+       tmp2 = tl.sin(tmp0)
+       tmp3 = tmp1 + tmp2
+       tl.store(out_ptr0 + (x0), tmp3, xmask)
 
-And you can verify that fusing the two ``sin`` did actually occur
-because the two ``sin`` operations occur within a single Triton kernel
+And you can verify that fusing the ``cos`` and ``sin`` did actually occur
+because the ``cos`` and ``sin`` operations occur within a single Triton kernel
 and the temporary variables are held in registers with very fast access.
 
 You can read up a lot more on Triton’s performance

--- a/docs/source/compile/get-started.rst
+++ b/docs/source/compile/get-started.rst
@@ -37,7 +37,7 @@ kernels from a Python program which is especially relevant for newer GPUs.
 
 TorchDynamo supports many different backends but inductor specifically works
 by generating `Triton <https://github.com/openai/triton>`__ kernels. Suppose our example above
-was called ``trig.py`` we can inspect the code generated triton kernels by 
+was called ``trig.py`` we can inspect the code generated triton kernels by
 running ``TORCH_COMPILE_DEBUG=1 python trig.py`` with the actual generated kernel being
 
 .. code-block:: python


### PR DESCRIPTION

Fixes #104500

As discussed in #104500, the [corresponding doc](https://pytorch.org/docs/stable/dynamo/get-started.html#getting-started) for dynamo is inconsistent between the code and explanation. I have run the code example to get the correct code.
![image](https://github.com/pytorch/pytorch/assets/6964699/d11e0f2f-2225-4ba9-8934-b06c9fc78721)
This PR fixes the problem and makes the doc more readable.

cc:
@davidberard98 @ezyang  please help me check this PR, thanks!