### PR TITLE
Use random inputs for mps extension tests

### DIFF
--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -90,8 +90,8 @@ class TestCppExtensionAOT(common.TestCase):
         import torch_test_cpp_extension.mps as mps_extension
 
         tensor_length = 100000
-        x = torch.zeros(tensor_length, device="cpu", dtype=torch.float32)
-        y = torch.zeros(tensor_length, device="cpu", dtype=torch.float32)
+        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
 
         cpu_output = mps_extension.get_cpu_add_output(x, y)
         mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -129,8 +129,8 @@ class TestCppExtensionJIT(common.TestCase):
         )
 
         tensor_length = 100000
-        x = torch.zeros(tensor_length, device="cpu", dtype=torch.float32)
-        y = torch.zeros(tensor_length, device="cpu", dtype=torch.float32)
+        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
 
         cpu_output = module.get_cpu_add_output(x, y)
         mps_output = module.get_mps_add_output(x.to("mps"), y.to("mps"))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104597

The tested function simply adds `x` and `y`, given this fact, using random inputs instead of zeros makes more sense.