### PR TITLE
Back out "[dynamo][ac] Remove disable monkeypatching of utils.checkpoint (#104397)"

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1284,6 +1284,18 @@ class TorchPatcher:
             # disable future hooking
             opt.step.hooked = True
 
+        # TorchDynamo does not step inside utils.checkpoint function.  The flow
+        # looks likes this
+        #  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
+        #     speculatively checking if the forward function is safe to trace.
+        #  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
+        #     order op. As a result, TorchDynamo does not look inside utils.checkpoint.
+        #  3) If not, then TorchDynamo falls back to eager by performing a graph
+        #     break. And here, the following disable wrapper ensures that
+        #     TorchDynamo does not trigger again on the frames created by
+        #     utils.checkpoint innards.
+        torch.utils.checkpoint.checkpoint = disable(torch.utils.checkpoint.checkpoint)
+
         torch._dynamo.variables.lists._register_dynamo_list_to_tree_spec()
         torch._dynamo.variables.lists._register_dynamo_tuple_to_tree_spec()
         torch._dynamo.variables.dicts._register_dynamo_dict_to_tree_spec()

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -287,17 +287,7 @@ class CheckpointFunction(torch.autograd.Function):
 def noop_context_fn():
     return contextlib.nullcontext(), contextlib.nullcontext()
 
-# TorchDynamo does not step inside utils.checkpoint function.  The flow
-# looks likes this
-#  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
-#     speculatively checking if the forward function is safe to trace.
-#  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
-#     order op. As a result, TorchDynamo does not look inside utils.checkpoint.
-#  3) If not, then TorchDynamo falls back to eager by performing a graph
-#     break. And here, the following disable wrapper ensures that
-#     TorchDynamo does not trigger again on the frames created by
-#     utils.checkpoint innards.
-@torch._disable_dynamo
+
 def checkpoint(
     function,
     *args,


### PR DESCRIPTION
Summary:
Original commit changeset: f50a250c0ac4

Original Phabricator Diff: D47165952

Test Plan: > BUILD=1 CUDA_VISIBLE_DEVICES=0 MODEL_ID=967500590 SNAPSHOT_ID=1360 CPU_NUMA_NODES=0 sh hpc/inference/scripts/gif/prospector/1_cards/launch_gpu_sigrid_predictor_task_0.sh

Reviewed By: wqfish, huydhn, 842974287

Differential Revision: D47216591



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78