### PR TITLE
Expose TorchDispatchUtils Api for Extensions

### DIFF
--- a/aten/src/ATen/core/TorchDispatchUtils.h
+++ b/aten/src/ATen/core/TorchDispatchUtils.h
@@ -9,9 +9,9 @@
 namespace at {
 namespace impl {
 
-bool tensor_has_dispatch(const at::Tensor& t);
-bool tensorlist_has_dispatch(at::ITensorListRef li);
-bool tensorlist_has_dispatch(const c10::List<c10::optional<at::Tensor>>& li);
+TORCH_API bool tensor_has_dispatch(const at::Tensor& t);
+TORCH_API bool tensorlist_has_dispatch(at::ITensorListRef li);
+TORCH_API bool tensorlist_has_dispatch(const c10::List<c10::optional<at::Tensor>>& li);
 using c10::impl::dispatch_mode_enabled;
 
 }}


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Exporse some api in TorchDispatchUtils.h for custom devices. This can be used in DEBUG package.