### PR TITLE
[pytorch] put more to pytorch_fmha namespace

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha.h
@@ -41,6 +41,7 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_utils.h>
 
+namespace pytorch_fmha {
 
 constexpr int TOTAL_DIM = 0;
 constexpr int H_DIM = 1;
@@ -209,3 +210,5 @@ void run_fmha_bwd_hdim128(FMHA_dgrad_params &params, cudaStream_t stream, const 
 void run_fmha_block_fp16_sm80(Launch_params<FMHA_fprop_params> &launch_params, const bool configure);
 
 void run_fmha_block_dgrad_fp16_sm80(const FMHA_dgrad_params &params, cudaStream_t stream);
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim128.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim128.cu
@@ -4,9 +4,13 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_bwd_hdim128(FMHA_dgrad_params &params, cudaStream_t stream, const bool configure) {
     FP16_SWITCH(params.is_bf16, ([&] {
         using Kernel_traits = FMHA_kernel_traits<128, 128, 16, 1, 8, 0x100u, elem_type>;
         run_fmha_bwd_loop<Kernel_traits>(params, stream, configure);
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim32.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim32.cu
@@ -4,6 +4,8 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_bwd_hdim32(FMHA_dgrad_params &params, cudaStream_t stream, const bool configure) {
     FP16_SWITCH(params.is_bf16, ([&] {
         if (params.seqlen_k == 128) {
@@ -15,3 +17,5 @@ void run_fmha_bwd_hdim32(FMHA_dgrad_params &params, cudaStream_t stream, const b
         }
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim64.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_hdim64.cu
@@ -4,6 +4,8 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_bwd_hdim64(FMHA_dgrad_params &params, cudaStream_t stream, const bool configure) {
     FP16_SWITCH(params.is_bf16, ([&] {
         auto dprops = at::cuda::getCurrentDeviceProperties();
@@ -32,3 +34,5 @@ void run_fmha_bwd_hdim64(FMHA_dgrad_params &params, cudaStream_t stream, const b
         }
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h
@@ -8,6 +8,8 @@
 #include <ATen/native/transformers/cuda/flash_attn/fmha.h>
 #include <ATen/native/transformers/cuda/flash_attn/fmha_dgrad_kernel_1xN_loop.h>
 
+namespace pytorch_fmha {
+
 // Pick whether we should parallelize across seqlen_k (num_splits > 1) or not (num_splits=1).
 // Parallelizing will have better occupancy, but has some overhead due to having to zero out
 // dq_tmp and having to copy dq_tmp to dq.
@@ -113,3 +115,5 @@ void run_fmha_bwd_loop(FMHA_dgrad_params &params, cudaStream_t stream, const boo
         FMHA_CHECK_CUDA(cudaPeekAtLastError());
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim128.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim128.cu
@@ -4,9 +4,13 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_fwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_fwd_hdim128(Launch_params<FMHA_fprop_params> &launch_params) {
     FP16_SWITCH(launch_params.params.is_bf16, ([&] {
         using Kernel_traits = FMHA_kernel_traits<128, 128, 16, 1, 4, 0x08u, elem_type>;
         run_fmha_fwd_loop<Kernel_traits>(launch_params);
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim32.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim32.cu
@@ -4,6 +4,8 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_fwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_fwd_hdim32(Launch_params<FMHA_fprop_params> &launch_params) {
     FP16_SWITCH(launch_params.params.is_bf16, ([&] {
         if (launch_params.params.seqlen_k == 128) {
@@ -15,3 +17,5 @@ void run_fmha_fwd_hdim32(Launch_params<FMHA_fprop_params> &launch_params) {
         }
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim64.cu
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_hdim64.cu
@@ -4,6 +4,8 @@
 
 #include <ATen/native/transformers/cuda/flash_attn/fmha_fwd_launch_template.h>
 
+namespace pytorch_fmha {
+
 void run_fmha_fwd_hdim64(Launch_params<FMHA_fprop_params> &launch_params) {
     FP16_SWITCH(launch_params.params.is_bf16, ([&] {
         if (launch_params.params.seqlen_k == 128) {
@@ -15,3 +17,5 @@ void run_fmha_fwd_hdim64(Launch_params<FMHA_fprop_params> &launch_params) {
         }
     }));
 }
+
+}; // namespace pytorch_fmha

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_launch_template.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_fwd_launch_template.h
@@ -12,6 +12,8 @@
 #include <ATen/native/transformers/cuda/flash_attn/static_switch.h>
 #include <ATen/native/transformers/cuda/flash_attn/fmha_fprop_kernel_1xN.h>
 
+namespace pytorch_fmha {
+
 // Find the number of splits that maximizes the occupancy. For example, if we have
 // batch * n_heads = 48 and we have 108 SMs, having 2 splits (efficiency = 0.89) is
 // better than having 3 splits (efficiency = 0.67). However, we also don't want too many
@@ -90,3 +92,5 @@ void run_fmha_fwd_loop(Launch_params<FMHA_fprop_params> &launch_params) {
         FMHA_CHECK_CUDA(cudaPeekAtLastError());
     }));
 }
+
+}; // namespace pytorch_fmha


### PR DESCRIPTION
Summary:
Without this diff we get
```
CUDA error (./fbcode/caffe2/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_bwd_launch_template.h:113): an illegal memory access was encountered
```

Test Plan:
hg up e49463501
fbcode/ai_codesign/gen_ai/xlformers/scripts/run_xlformers_train_local.sh

Reviewed By: drisspg

Differential Revision: D47220255

