### PR TITLE
[BE] QNNPACK Test - Sparsegemm tests, use ASSERT_NEAR

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
@@ -478,9 +478,10 @@ class GemmBlockSparseMicrokernelTester {
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
-          ASSERT_FLOAT_EQ(
+          ASSERT_NEAR(
               c[mIndex * cStride() + nIndex],
-              acc[mIndex * n() + nIndex])
+              acc[mIndex * n() + nIndex],
+              std::abs(acc[mIndex * n() + nIndex]) * 1.0e-3f)
               << "at " << mIndex << ", " << nIndex
               << ": reference = " << acc[mIndex * n() + nIndex]
               << ", optimized = " << c[mIndex * cStride() + nIndex]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Compare fp numbers using assert_near with reference * 10e-3. Somewhat arbitrary threhold which makes the test to pass on SSE2, given the absolute numbers are in somewhat wider range.

Differential Revision: [D47195288](https://our.internmc.facebook.com/intern/diff/D47195288/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10