### PR TITLE
[BE] switch fprintf to fmt::print

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1803,7 +1803,7 @@ Call this whenever a new thread is created in order to propagate values from
 inline void pytorch_duplicate_guard() {
   static int initialized = 0;
   if (initialized) {
-    fmt::println(stderr, "pytorch: _C shared library re-initialized");
+    fmt::print(stderr, "pytorch: _C shared library re-initialized\n");
     abort();
   }
   initialized = 1;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Optional.h>
+#include <fmt/core.h>
 #include <sys/types.h>
 #include <torch/csrc/python_headers.h>
 
@@ -1802,7 +1803,7 @@ Call this whenever a new thread is created in order to propagate values from
 inline void pytorch_duplicate_guard() {
   static int initialized = 0;
   if (initialized) {
-    fprintf(stderr, "pytorch: _C shared library re-initialized\n");
+    fmt::println(stderr, "pytorch: _C shared library re-initialized");
     abort();
   }
   initialized = 1;

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -283,7 +283,7 @@ char* tensor_repr(at::Tensor tensor) {
   result =
       static_cast<char*>(malloc(bufsize + 1)); // account for the trailing \0
   if (!result) {
-    fmt::println(stderr, "cannot allocate memory for the result");
+    fmt::print(stderr, "cannot allocate memory for the result\n");
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
   }

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -1,3 +1,4 @@
+#include <fmt/core.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/variable.h>
@@ -282,7 +283,7 @@ char* tensor_repr(at::Tensor tensor) {
   result =
       static_cast<char*>(malloc(bufsize + 1)); // account for the trailing \0
   if (!result) {
-    fprintf(stderr, "cannot allocate memory for the result\n");
+    fmt::println(stderr, "cannot allocate memory for the result");
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
   }


### PR DESCRIPTION
Testing out the new automated clang-tidy check in master. Code should be faster, more modern, and more efficient.