### PR TITLE
[BE] QNNPACK - Q8[g]avg, loosen threshold to allow fp compare to pass

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/avgpool-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/avgpool-microkernel-tester.h
@@ -299,7 +299,7 @@ class AvgPoolMicrokernelTester {
               << "at pixel " << i << ", channel " << k << ", n = " << n()
               << ", kc = " << kc();
           ASSERT_NEAR(
-              float(int32_t(y[i * yStride() + k])), yFP[i * kc() + k], 0.5f)
+              float(int32_t(y[i * yStride() + k])), yFP[i * kc() + k], 0.5001f)
               << "at pixel " << i << ", channel " << k << ", n = " << n()
               << ", ks = " << kh() << "x" << kw() << " (" << ks()
               << "), kc = " << kc() << ", acc = " << yAcc[i * kc() + k];
@@ -394,7 +394,7 @@ class AvgPoolMicrokernelTester {
               << "at pixel " << i << ", channel " << k << ", n = " << n()
               << ", kc = " << kc();
           ASSERT_NEAR(
-              float(int32_t(y[i * yStride() + k])), yFP[i * kc() + k], 0.5f)
+              float(int32_t(y[i * yStride() + k])), yFP[i * kc() + k], 0.5001f)
               << "at pixel " << i << ", channel " << k << ", n = " << n()
               << ", ks = " << kh() << "x" << kw() << " (" << ks()
               << "), kc = " << kc() << ", acc = " << yAcc[i * kc() + k];

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gavgpool-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gavgpool-microkernel-tester.h
@@ -201,7 +201,7 @@ class GAvgPoolMicrokernelTester {
             << "at position " << i << ", m = " << m() << ", n = " << n();
         ASSERT_GE(uint32_t(y[i]), uint32_t(yMin()))
             << "at position " << i << ", m = " << m() << ", n = " << n();
-        ASSERT_NEAR(float(int32_t(y[i])), yFP[i], 0.5f)
+        ASSERT_NEAR(float(int32_t(y[i])), yFP[i], 0.5001f)
             << "at position " << i << ", m = " << m() << ", n = " << n()
             << ", acc = " << yAcc[i];
         ASSERT_EQ(uint32_t(yRef[i]), uint32_t(y[i]))
@@ -276,7 +276,7 @@ class GAvgPoolMicrokernelTester {
             << "at position " << i << ", m = " << m() << ", n = " << n();
         ASSERT_GE(uint32_t(y[i]), uint32_t(yMin()))
             << "at position " << i << ", m = " << m() << ", n = " << n();
-        ASSERT_NEAR(float(int32_t(y[i])), yFP[i], 0.5f)
+        ASSERT_NEAR(float(int32_t(y[i])), yFP[i], 0.5001f)
             << "at position " << i << ", m = " << m() << ", n = " << n()
             << ", acc = " << yAcc[i];
         ASSERT_EQ(uint32_t(yRef[i]), uint32_t(y[i]))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104651
* #104650
* __->__ #104649
* #104648

0.5 --> 0.5001 to tolorate fp-op reordering surfaced with LLVM15. Not the best fix.

Differential Revision: [D47195289](https://our.internmc.facebook.com/intern/diff/D47195289/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10