### PR TITLE
[MPS] Set the default optimization level

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -92,6 +92,7 @@ private:
   MPSCommandBuffer* _prevCommandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
+  MPSGraphCompilationDescriptor *_compilationDescriptor = nil;
   dispatch_queue_t _serialQueue = nullptr;
   // CommitAndContinue is enabled by default
   bool _enableCommitAndContinue = true;

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -20,18 +20,26 @@ MPSStream::MPSStream(Stream stream) : _stream(stream) {
   TORCH_CHECK(_stream.device_type() == DeviceType::MPS);
   _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
   _executionDescriptor = [MPSGraphExecutionDescriptor new];
+  _compilationDescriptor = [MPSGraphCompilationDescriptor new];
+
   // disable commitAndContinue if Signpost tracing is enabled
   if (getMPSProfiler().isSignpostTracingEnabled()) {
     _enableCommitAndContinue = false;
   }
   _executionDescriptor.enableCommitAndContinue = _enableCommitAndContinue;
+
+  // Choose level which optimizes for GPU
+  _compilationDescriptor.optimizationLevel = MPSGraphOptimizationLevel0;
+  _executionDescriptor.compilationDescriptor =  _compilationDescriptor;
 }
 
 MPSStream::~MPSStream() {
   [_commandQueue release];
   _commandQueue = nil;
   [_executionDescriptor release];
+  [_compilationDescriptor release];
   _executionDescriptor = nil;
+  _compilationDescriptor = nil;
 
   assert(_commandBuffer == nil);
 }

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -30,7 +30,7 @@ MPSStream::MPSStream(Stream stream) : _stream(stream) {
 
   // Choose level which optimizes for GPU
   _compilationDescriptor.optimizationLevel = MPSGraphOptimizationLevel0;
-  _executionDescriptor.compilationDescriptor =  _compilationDescriptor;
+  _executionDescriptor.compilationDescriptor = _compilationDescriptor;
 }
 
 MPSStream::~MPSStream() {


### PR DESCRIPTION
Set the graph optimization level to 0 (avoids dispatches to Neural Engine).
Fixes https://github.com/pytorch/pytorch/issues/104642