### PR TITLE
Disable git fsmonitor daemon on Windows

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -48,6 +48,17 @@ jobs:
     outputs:
       test-matrix: ${{ steps.filter.outputs.test-matrix }}
     steps:
+      # Duplicated in win-test because this MUST go before a checkout
+      - name: Enable git symlinks on Windows and disable fsmonitor daemon
+        shell: bash
+        run: |
+          git config --global core.symlinks true
+
+          # https://git-scm.com/docs/git-fsmonitor--daemon.  The daemon could lock
+          # the directory on Windows and prevent GHA from checking out as reported
+          # in https://github.com/actions/checkout/issues/1018
+          git config --global core.fsmonitor false
+
       - name: Clean up leftover processes on non-ephemeral Windows runner
         uses: pytorch/test-infra/.github/actions/cleanup-runner@main
 
@@ -64,12 +75,6 @@ jobs:
             Activate miniconda and Visual Studio environment, by running:
               call C:\Jenkins\Miniconda3\Scripts\activate.bat C:\Jenkins\Miniconda3
               call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
-
-      # Duplicated in win-test because this MUST go before a checkout
-      - name: Enable git symlinks on Windows
-        shell: bash
-        run: |
-          git config --global core.symlinks true
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -36,10 +36,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 300
     steps:
-      - name: Enable git symlinks on Windows
+      # Duplicated in win-build because this MUST go before a checkout
+      - name: Enable git symlinks on Windows and disable fsmonitor daemon
         shell: bash
         run: |
           git config --global core.symlinks true
+
+          # https://git-scm.com/docs/git-fsmonitor--daemon.  The daemon could lock
+          # the directory on Windows and prevent GHA from checking out as reported
+          # in https://github.com/actions/checkout/issues/1018
+          git config --global core.fsmonitor false
 
       - name: Clean up leftover processes on non-ephemeral Windows runner
         uses: pytorch/test-infra/.github/actions/cleanup-runner@main


### PR DESCRIPTION
Looking at the issue on https://github.com/actions/checkout/issues/1018, I suspect that this is same flaky issue failing GHA checkout on Windows https://github.com/pytorch/pytorch/actions/runs/5459471366/jobs/9935736289