### PR TITLE
[inductur] coordesc tuner bug fix with no_x_dim kernel

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -2,6 +2,9 @@
 
 import sys
 import unittest
+from unittest import mock
+
+import torch
 
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import IS_LINUX
@@ -14,7 +17,31 @@ except ImportError:
         sys.exit(0)
     raise unittest.SkipTest("requires triton")
 
+from torch._inductor import config
 from torch._inductor.coordinate_descent_tuner import CoordescTuner
+
+config.benchmark_kernel = True
+config.coordinate_descent_tuning = True
+
+orig_compare_config = CoordescTuner.compare_config
+
+
+def mock_compare_config_prefer_larger_XBLOCK(
+    self, func, candidate_config, best_config, best_timing
+):
+    """
+    self is the CoordescTuner object
+    """
+    if "XBLOCK" in candidate_config.kwargs:
+        assert "XBLOCK" in best_config.kwargs
+        if candidate_config.kwargs["XBLOCK"] < best_config.kwargs["XBLOCK"]:
+            func(candidate_config)  # run func so the launcher will be created
+            return False, best_timing * 1.1
+        elif candidate_config.kwargs["XBLOCK"] > best_config.kwargs["XBLOCK"]:
+            func(candidate_config)
+            return True, best_timing * 0.9
+
+    return orig_compare_config(self, func, candidate_config, best_config, best_timing)
 
 
 class TestCoordinateDescentTuner(TestCase):
@@ -53,6 +80,23 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertEqual(set(neighbours), {1, 3, 4})
         neighbours = tuner.get_neighbour_values("num_warps", 2, radius=2)
         self.assertEqual(set(neighbours), {1, 4, 8})
+
+    def test_persistent_reduction(self):
+        def f(x):
+            return x / x.sum(dim=-1, keepdim=True)
+
+        with mock.patch.object(
+            CoordescTuner, "compare_config", mock_compare_config_prefer_larger_XBLOCK
+        ):
+            x = torch.ones(2, 256).cuda()
+            expected = f(x)
+            # the first call get correct result when cache miss. Don't know why yet
+            _ = torch.compile(f)(x)
+            actual = torch.compile(f)(x)
+            self.assertTrue(
+                torch.allclose(expected, actual, atol=1e-4, rtol=1e-4),
+                f"Expected:\n{expected}\nActual:\n{actual}",
+            )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1665,10 +1665,13 @@ class TritonKernel(Kernel):
         triton_meta["configs"] = [config_of(signature)]
 
         for tree in self.range_trees:
-            if tree.prefix != "r" or (
-                self.inside_reduction and not self.persistent_reduction
+            if tree.prefix == "r" and (
+                not self.inside_reduction or self.persistent_reduction
             ):
-                argdefs.append(f"{tree.prefix.upper()}BLOCK : tl.constexpr")
+                continue
+            if tree.prefix == "x" and self.no_x_dim:
+                continue
+            argdefs.append(f"{tree.prefix.upper()}BLOCK : tl.constexpr")
 
         if self.inside_reduction:
             reduction_hint = self.reduction_hint
@@ -1740,6 +1743,9 @@ class TritonKernel(Kernel):
                     continue
                 val = next_power_of_2(val)
                 code.writeline(f"RBLOCK: tl.constexpr = {val}")
+
+            if tree.prefix == "x" and self.no_x_dim:
+                code.writeline("XBLOCK: tl.constexpr = 1")
 
     def triton_tensor_ndim(self):
         no_x_dim = int(bool(self.no_x_dim))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104692

We recently have an optimization to squash x dimension for persistent reduction kernel when we are confident that XBLOCK will always be 1.  We need update the code so that coordinate descent tuner does not tune XBLOCK in this case.

Test command. Fail before the fix and pass after.
```
TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=1 python benchmarks/dynamo/huggingface.py --backend inductor --amp --accuracy --only BertForMaskedLM --inference
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng