### PR TITLE
Allow NumPy code in torch.compile to run on cuda

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1604,9 +1604,9 @@ def nnmodule_has_hooks(
 def to_numpy_helper(value):
     """Convert tensor and torch_np.ndarray to numpy.ndarray."""
     if isinstance(value, torch_np.ndarray):
-        return value.tensor.numpy()
+        return to_numpy_helper(value.tensor)
     elif isinstance(value, torch.Tensor):
-        return value.numpy()
+        return value.cpu().numpy()
     elif isinstance(value, (tuple, list)):
         return type(value)(to_numpy_helper(obj) for obj in value)
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104699

This can be achieved by doing `torch.set_default_device("cuda")`.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78