### PR TITLE
s390x: fix special_hermite_polynomial_h for '+/-inf' and '+/-nan'

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -3042,7 +3042,7 @@ static inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x + x;
-    T r;
+    T r = T(0.0);
 
     for (int64_t k = 2; k < n + n; k += 2) {
         r = (x + x) * q - k * p;
@@ -3053,9 +3053,14 @@ static inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, int64_t n) {
     return r;
 } // hermite_polynomial_h_forward(T x, int64_t n)
 
-template<typename T, bool is_cuda=false>
+template<typename T, bool is_cuda=false, std::enable_if_t<!std::is_floating_point<T>::value, int> = 0>
 static inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, T n) {
     return hermite_polynomial_h_forward(x, static_cast<int64_t>(n));
+} // hermite_polynomial_h_forward(T x, T n)
+
+template<typename T, bool is_cuda=false, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+static inline C10_HOST_DEVICE T hermite_polynomial_h_forward(T x, T n) {
+    return hermite_polynomial_h_forward(x, ((!std::isinf(n)) && (!std::isnan(n))) ? static_cast<int64_t>(n) : static_cast<int64_t>(-1));
 } // hermite_polynomial_h_forward(T x, T n)
 
 template<typename T>

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -2150,7 +2150,7 @@ const auto hermite_polynomial_h_string = jiterator_stringify(
 
         T p = T(1.0);
         T q = x + x;
-        T r;
+        T r = T(0.0);
 
         for (int64_t k = 2; k < n + n; k += 2) {
             r = (x + x) * q - k * p;


### PR DESCRIPTION
On s390x static cast may return big positive number, in that case uninitialized value of 'r' is returned. In case of +/-inf or +/-nan use -1 explicitely.
Also initialize 'r' to 0 in case 'n+n' overflows anyway.

This change fixes
test_vmap_exhaustive_special_hermite_polynomial_h_cpu_float32 from test/functorch/test_vmap.py on s390x.
