### PR TITLE
[WIP] Introduce a C wrapper to invoke CallBox

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -751,3 +751,12 @@ struct hash<c10::OperatorHandle> {
 };
 
 } // namespace std
+
+extern "C" {
+TORCH_API void callBoxedInC(
+    const char* name,
+    const char* overload_name,
+    void** args,
+    int num_args,
+    void** results);
+}

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -15,6 +15,8 @@ verbose_progress = False
 # use cpp wrapper instead of python wrapper
 cpp_wrapper = False
 
+aot_abi_compatible = True
+
 # dead code elimination
 dce = False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104714
* #104349

Summary: For fallback calls generated by AOTInductor, we need to call
them via a C wrapper instead of calling them directly, to avoid ABI
compatibility issues.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng