### PR TITLE
[RFC]: Move add runtime assertions before AOT export

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -294,7 +294,7 @@ def _update_graph_signature(
 
 def _process_constraints(
     graph_module: torch.fx.GraphModule,
-    graph_signature: ExportGraphSignature,
+    param_buffer_names: List[str],
     example_inputs: List[torch.Tensor],
 ) -> Tuple[Dict[sympy.Symbol, RangeConstraint], List[Tuple[InputDim, InputDim]]]:
     """
@@ -317,8 +317,8 @@ def _process_constraints(
             of (node, dim) to mark that these dimensions are equal.
     """
     input_shape_constraints = graph_module.meta.get("input_shape_constraints", [])
-    inline_constraints = graph_module.meta.get("inline_constraints", [])
-    num_params_buffer = len(graph_signature.buffers) + len(graph_signature.parameters)
+    inline_constraints = graph_module.meta.get("inline_constraints", {})
+    num_params_buffer = len(param_buffer_names)
 
     # Create dict mapping tensor_id to node names
     tensor_id_to_nodes: Dict[int, List[str]] = defaultdict(list)

--- a/torch/_functorch/functional_assertions_helper.py
+++ b/torch/_functorch/functional_assertions_helper.py
@@ -115,6 +115,7 @@ class FunctionalAssertionsHelper:
         assert dep_token_arg.target in (
             aten._make_dep_token.default,
             aten._functional_assert_async.msg,
+            aten._functional_sym_constrain_range.default,
         )
 
         return dep_token_arg.name
@@ -135,10 +136,22 @@ def _register_decomposition(aten_op):
 
 @_register_decomposition(aten._assert_async.msg)
 def _assert_async_msg(val, assert_msg) -> None:
-    dep_token = DepTokenStateTracker.get_dep_token()
-    if dep_token is None:
-        dep_token = aten._make_dep_token()
-
+    dep_token = _get_dep_token()
     DepTokenStateTracker.set_dep_token(
         aten._functional_assert_async.msg(val, assert_msg, dep_token)
     )
+
+@_register_decomposition(aten.sym_constrain_range.default)
+def _sym_constrain_range(size, min, max) -> None:
+    dep_token = _get_dep_token()
+    DepTokenStateTracker.set_dep_token(
+        aten._functional_sym_constrain_range.default(
+            size, min=min, max=max, dep_token=dep_token,
+        )
+    )
+
+def _get_dep_token():
+    dep_token = DepTokenStateTracker.get_dep_token()
+    if dep_token is None:
+        dep_token = aten._make_dep_token()
+    return dep_token


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104716
* #104203

This is very exploratory PR which:
* Moves add runtime assertions before AOT export and purely rely on AOT for functionalization.
* Didn't bother fixing all the tests but will try to gather feedback first (just fixed a few to verify that it works at least).



