### PR TITLE
[BE] Fix warning in top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,7 +732,7 @@ if(DEBUG_CUDA)
     string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
     string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
   endif()
-endif(NOT MSVC)
+endif(DEBUG_CUDA)
 
 
 if(USE_FBGEMM)


### PR DESCRIPTION
Fixes warning introduced by https://github.com/pytorch/pytorch/issues/102594:
```
CMake Warning (dev) in CMakeLists.txt:
  A logical block opening on the line
    /pytorch/CMakeLists.txt:726 (if)
  closes on the line
    /pytorch/CMakeLists.txt:735 (endif)
  with mis-matching arguments.
```

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7555d5</samp>

> _`DEBUG_CUDA` on_
> _No more CUDA in exe_
> _Winter bug is fixed_
