### PR TITLE
[MTPG] Use TLS propagation to enable MTPG from bwd.

### DIFF
--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -389,13 +389,19 @@ class WorldData:
     pg_default_device: Dict[dist.ProcessGroup, torch.device]
 
 
+MTPG_TLS_KEY = "__ThreadLocalWorld"
 class ThreadLocalWorld:
     _world = threading.local()
 
     def _get_world(self) -> WorldData:
+        if torch._C._is_key_in_tls(MTPG_TLS_KEY):
+            return torch._C._get_obj_in_tls(MTPG_TLS_KEY)
         if not hasattr(ThreadLocalWorld._world, "world"):
-            ThreadLocalWorld._world.world = WorldData(None, {}, {}, {}, {}, 0, {}, {}, {}, {})
-        return ThreadLocalWorld._world.world
+            obj = WorldData(None, {}, {}, {}, {}, 0, {}, {}, {}, {})
+            ThreadLocalWorld._world.world = obj
+            torch._C._stash_obj_in_tls(MTPG_TLS_KEY, obj)
+        res = ThreadLocalWorld._world.world
+        return res
 
     @property
     def default_pg(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104735

We use PyTorch's built-in tls propagation in ThreadLocalState to forward the world object
from the fwd thread to the bwd thread.

This further closes the gap on enabling FSDP.