### PR TITLE
[FSDP] Option for eval in fp32/bf16

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import itertools
+import os
 import sys
 from functools import partial
 from itertools import product
@@ -338,7 +339,11 @@ class TestFSDPMixedPrecision(FSDPTest):
             expected_dtype = _CURRENT_FULL_PRECISION_PARAM_DTYPE
 
         for t in tensors:
-            self.assertEqual(expected_dtype, t.dtype)
+            self.assertEqual(
+                expected_dtype,
+                t.dtype,
+                f"Expected to reduce in {expected_dtype} but got tensors in {t.dtype}"
+            )
 
         return orig_reduce_scatter(*args, **kwargs)
 
@@ -761,34 +766,46 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         """
         In a case where root module does not manage FSDP parameters,
         ensure that we don't cast forward inputs which could potentially
-        cause a dtype mismatch.
+        cause a dtype mismatch. Check that FSDP_USE_FULL_PREC_IN_EVAL controls
+        this.
         """
+
+        low_prec_dtype = torch.float16
 
         class MyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.a = nn.Linear(5, 5)
 
-            def forward(self, x):
-                assert x.dtype == torch.float32, f"Expected fp32, got {x.dtype}"
+            def forward(self, x, expect_full_prec_in_eval):
+                if expect_full_prec_in_eval:
+                    assert x.dtype == torch.float32, f"Expected fp32, got {x.dtype}"
+                else:
+                    assert x.dtype == low_prec_dtype, f"Expected {low_prec_dtype}, got {x.dtype}"
                 return self.a(x)
 
         mp_config = MixedPrecision(
-            param_dtype=torch.float16,
-            reduce_dtype=torch.float16,
-            buffer_dtype=torch.float16,
+            param_dtype=low_prec_dtype,
+            reduce_dtype=low_prec_dtype,
+            buffer_dtype=low_prec_dtype,
         )
-        m = MyModel().cuda()
-        m.a = FSDP(m.a, mixed_precision=mp_config)
-        model = FSDP(m, mixed_precision=mp_config)
-        model.eval()
-        inp = torch.randn(5, 5)
-        model(inp).sum().backward()
+
+        for full_prec_in_eval in [True, False]:
+            os.environ["FSDP_USE_FULL_PREC_IN_EVAL"] = "1" if full_prec_in_eval else "0"
+            m = MyModel().cuda()
+            m.a = FSDP(m.a, mixed_precision=mp_config)
+            model = FSDP(m, mixed_precision=mp_config)
+            model.eval()
+            inp = torch.randn(5, 5)
+            model(inp, full_prec_in_eval).sum().backward()
 
     @skip_if_lt_x_gpu(2)
     def test_full_precision_in_eval(self):
-        for use_composable, cast_forward_inputs in itertools.product(
-            [True, False], [True, False]
+        """
+        Tests that eval runs in full precision if FSDP_USE_FULL_PREC_IN_EVAL is set.
+        """
+        for use_composable, cast_forward_inputs, full_prec_in_eval in itertools.product(
+            [True, False], [True, False], [True, False]
         ):
             mp_config = MixedPrecision(
                 param_dtype=torch.float16,
@@ -796,6 +813,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 buffer_dtype=torch.float16,
                 cast_forward_inputs=cast_forward_inputs,
             )
+            os.environ["FSDP_USE_FULL_PREC_IN_EVAL"] = "1" if full_prec_in_eval else "0"
             model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP if use_composable else FSDPInitMode.RECURSIVE,
@@ -817,24 +835,29 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             # Loss should be in fp16
             self.assertEqual(torch.float16, loss.dtype)
             module_accessor.run_backward(loss)
-
-            # Now in eval mode, loss should be fp32
-            model.eval()
-            inp = module_accessor.get_input(torch.device("cuda"))
-            output = model(*inp)
-            loss = module_accessor.get_loss(inp, output).cuda()
-            self.assertEqual(torch.float32, loss.dtype)
-            module_accessor.run_backward(loss)
-            # gradients generated should be in fp32
+            # Grads should be in fp32 as we upcast them
             for p in model.parameters():
                 if p.grad is not None:
                     self.assertEqual(torch.float32, p.grad.dtype)
 
+            # Now in eval mode, loss should be fp32 if full_prec_in_eval is set.
+            model.eval()
+            inp = module_accessor.get_input(torch.device("cuda"))
+            output = model(*inp)
+            loss = module_accessor.get_loss(inp, output).cuda()
+            expected_dtype = (torch.float32 if full_prec_in_eval else torch.float16)
+            self.assertEqual(expected_dtype, loss.dtype)
+
     @skip_if_lt_x_gpu(2)
     def test_full_precision_in_eval_buffers(self):
-        for use_composable, cast_forward_inputs in itertools.product(
-            [True, False], [True, False]
+        """
+        Tests that when model.eval() and FSDP_USE_FULL_PREC_IN_EVAL is set,
+        buffers are in the full precision.
+        """
+        for use_composable, cast_forward_inputs, full_prec_in_eval in itertools.product(
+            [True, False], [True, False], [True, False]
         ):
+            os.environ["FSDP_USE_FULL_PREC_IN_EVAL"] = "1" if full_prec_in_eval else "0"
             mp_config = MixedPrecision(
                 param_dtype=torch.float16,
                 reduce_dtype=torch.float16,
@@ -860,9 +883,13 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             # model.eval() + forward pass should make the buffers in full prec again
             fsdp_model.eval()
             fsdp_model((inp, self, fsdp_model, mp_config, torch.float32))
-
+            # TODO: this test would be more robust if the buffer dtype was
+            # validated in the nn.Module pre-forward hook to ensure that the
+            # buffer computation takes place in the right precision.
+            # https://github.com/pytorch/pytorch/issues/104740
+            expected_dtype = _BUFFER_ORIG_DTYPE if full_prec_in_eval else torch.float16
             for buf in fsdp_model.buffers():
-                self.assertEqual(_BUFFER_ORIG_DTYPE, buf.dtype)
+                self.assertEqual(expected_dtype, buf.dtype)
 
             # model.train() + forward again should make buffers in fp16
             fsdp_model.train()
@@ -872,14 +899,18 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
 
     @skip_if_lt_x_gpu(2)
     def test_full_precision_in_eval_comm(self):
-        for use_composable, cast_forward_inputs in itertools.product(
-            [True, False], [True, False]
+        for use_composable, cast_forward_inputs, full_prec_in_eval in itertools.product(
+            [True, False], [True, False], [True, False]
         ):
+            os.environ["FSDP_USE_FULL_PREC_IN_EVAL"] = "1" if full_prec_in_eval else "0"
             mp_config = MixedPrecision(
                 param_dtype=torch.float32,
                 reduce_dtype=torch.float16,
                 buffer_dtype=torch.float32,
                 cast_forward_inputs=cast_forward_inputs,
+                # cast reduction for batchnorm also just in this test, to make
+                # validation easier.
+                _module_classes_to_ignore=[],
             )
             model = TransformerWithSharedParams.init(
                 self.process_group,
@@ -887,6 +918,8 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 CUDAInitMode.CUDA_BEFORE,
                 {"mixed_precision": mp_config},
             )
+            for fsdp_module in FSDP.fsdp_modules(model):
+                mp = fsdp_module.mixed_precision
             if use_composable:
                 auto_wrap_policy = ModuleWrapPolicy(
                     {
@@ -902,7 +935,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
                 self._reduce_scatter_validate_mp,
                 orig_reduce_scatter,
                 mp_config,
-                False,
+                not full_prec_in_eval,
             )
             model.eval()
             with patch_reduce_scatter(test_reduce_scatter, torch.float32):

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import os
 import warnings
 from typing import (
     Any,
@@ -52,6 +53,7 @@ from torch.distributed.fsdp.flat_param import (
     FlatParameter,
     FlatParamHandle,
     HandleShardingStrategy,
+    _FSDP_USE_FULL_PREC_IN_EVAL,
 )
 from torch.distributed.fsdp.wrap import _FSDPPolicy
 from torch.distributed.utils import _sync_params_and_buffers
@@ -395,6 +397,9 @@ def _init_core_state(
         torch._C._log_api_usage_once(
             f"torch.distributed.fsdp.mixed_precision.{str(state.mixed_precision)}"
         )
+    state._use_full_prec_in_eval = (
+        os.environ.get(_FSDP_USE_FULL_PREC_IN_EVAL, "") == "1"
+    )
     state.cpu_offload = cpu_offload or CPUOffload()
     state.limit_all_gathers = limit_all_gathers
     state._use_orig_params = use_orig_params

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -339,10 +339,11 @@ class TransformerWithSharedParams(FSDPTestModel):
             else:
                 tformer_pg = group
 
-            fsdp_model = FSDP(
-                TransformerWithSharedParams(
+            m = TransformerWithSharedParams(
                     tformer_pg, cuda_init_mode, add_bn, deterministic
-                ),
+                )
+            fsdp_model = FSDP(
+                m,
                 fsdp_pg,
                 auto_wrap_policy=auto_wrap_policy,
                 **fsdp_kwargs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Pull request resolved: https://github.com/pytorch/pytorch/pull/104682

In https://github.com/pytorch/pytorch/pull/97645 and some follow up diffs, we made FSDP run in full precision in eval mode, even if mixed precision was specified.

However, this is probably not the best idea and we should provide a flag for users to have control over this a bit more. Adding an env var FSDP_FULL_PREC_IN_EVAL and defaulting it to off, users who want to run eval in fp32 can toggle this before wrapping model in FSDP:

os.environ["FSDP_FULL_PREC_IN_EVAL"] = "1"

Verified that unittests, APS workflow, TNT workloads can run eval appropriately with this change.

Differential Revision: [D47246556](https://our.internmc.facebook.com/intern/diff/D47246556/)