### PR TITLE
[DDP] Return `output` even if `_delay_all_reduce_all_params`

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1443,7 +1443,7 @@ class DistributedDataParallel(Module, Joinable):
     def _post_forward(self, output):
         if self._delay_all_reduce_all_params:
             self._clear_grad_buffer()
-            return
+            return output
 
         # sync params according to location (before/after forward) user
         # specified as part of hook, if hook was specified.


### PR DESCRIPTION
As `DistributedDataParallel.forward` seemed to return `output` previously even if `_delay_all_reduce_all_params` according to https://github.com/pytorch/pytorch/blob/170a1c3ace7b3d0b6d7e1107c85202ef00abc909/torch/nn/parallel/distributed.py#L1440-L1443, I suppose `_post_forward` should return `output`