### PR TITLE
use more informative error message for ConstandPad2d/3d

### DIFF
--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -178,7 +178,8 @@ Tensor _pad_circular_symint(const Tensor &self, c10::SymIntArrayRef padding) {
 Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mode_int, c10::optional<double> value) {
   const auto input_dim = self.dim();
   TORCH_CHECK(pad.size() % 2 == 0, "Padding length must be divisible by 2");
-  TORCH_CHECK(static_cast<int64_t>(pad.size()) <= input_dim * 2, "Padding length too large");
+  TORCH_CHECK(static_cast<int64_t>(pad.size()) <= input_dim * 2,
+              "Input dimension should be at least ", pad.size() / 2, " but got ", input_dim);
   auto mode = static_cast<at::padding_mode>(mode_int);
 
   if (mode == at::padding_mode::constant) {

--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -179,7 +179,7 @@ Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mod
   const auto input_dim = self.dim();
   TORCH_CHECK(pad.size() % 2 == 0, "Padding length must be divisible by 2");
   TORCH_CHECK(static_cast<int64_t>(pad.size()) <= input_dim * 2,
-              "Input dimension should be at least ", pad.size() / 2, " but got ", input_dim);
+              "Padding length should be less than or equal to two times the input dimension but got padding length ", pad.size(), " and input of dimension ", input_dim);
   auto mode = static_cast<at::padding_mode>(mode_int);
 
   if (mode == at::padding_mode::constant) {


### PR DESCRIPTION
Fixes #104508 

As discussed in #104508, the current error message for `torch.nn.ConstantPad2d` and `torch.nn.ConstantPad3d` is misleading, this PR fixes the problem.
The fixed error message is shown below:
For `torch.nn.ConstantPad2d`:
<img width="619" alt="image" src="https://github.com/pytorch/pytorch/assets/6964699/dd15f42a-b6ad-4c6d-aa41-f26d08144189">
For `torch.nn.ConstantPad3d`:
<img width="630" alt="image" src="https://github.com/pytorch/pytorch/assets/6964699/ac99b80f-73c1-4d7f-b9a1-74bf45ee4c21">


cc:
@mikaylagawarecki Please help me check this PR, thanks!