### PR TITLE
Functions to support logging raw tensors on tensorboard

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -6,7 +6,6 @@ from typing import Optional
 import numpy as np
 
 import torch
-from caffe2.torch.utils.tensorboard.summary import tensor_proto
 from google.protobuf import struct_pb2
 
 from tensorboard.compat.proto.summary_pb2 import (
@@ -38,6 +37,7 @@ __all__ = [
     "audio",
     "custom_scalars",
     "text",
+    "tensor_proto",
     "pr_curve_raw",
     "pr_curve",
     "compute_curve",

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -4,11 +4,16 @@ import os
 from typing import Optional
 
 import numpy as np
+
+import torch
+from caffe2.torch.utils.tensorboard.summary import tensor_proto
 from google.protobuf import struct_pb2
 
-from tensorboard.compat.proto.summary_pb2 import HistogramProto
-from tensorboard.compat.proto.summary_pb2 import Summary
-from tensorboard.compat.proto.summary_pb2 import SummaryMetadata
+from tensorboard.compat.proto.summary_pb2 import (
+    HistogramProto,
+    Summary,
+    SummaryMetadata,
+)
 from tensorboard.compat.proto.tensor_pb2 import TensorProto
 from tensorboard.compat.proto.tensor_shape_pb2 import TensorShapeProto
 from tensorboard.plugins.custom_scalar import layout_pb2
@@ -18,9 +23,26 @@ from tensorboard.plugins.text.plugin_data_pb2 import TextPluginData
 from ._convert_np import make_np
 from ._utils import _prepare_video, convert_to_HWC
 
-__all__ = ['hparams', 'scalar', 'histogram_raw', 'histogram', 'make_histogram', 'image', 'image_boxes', 'draw_boxes',
-           'make_image', 'video', 'make_video', 'audio', 'custom_scalars', 'text', 'pr_curve_raw', 'pr_curve', 'compute_curve',
-           'mesh']
+__all__ = [
+    "hparams",
+    "scalar",
+    "histogram_raw",
+    "histogram",
+    "make_histogram",
+    "image",
+    "image_boxes",
+    "draw_boxes",
+    "make_image",
+    "video",
+    "make_video",
+    "audio",
+    "custom_scalars",
+    "text",
+    "pr_curve_raw",
+    "pr_curve",
+    "compute_curve",
+    "mesh",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -93,19 +115,19 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
     """
     import torch
     from tensorboard.plugins.hparams.api_pb2 import (
+        DataType,
         Experiment,
         HParamInfo,
         MetricInfo,
         MetricName,
         Status,
-        DataType,
     )
     from tensorboard.plugins.hparams.metadata import (
-        PLUGIN_NAME,
-        PLUGIN_DATA_VERSION,
         EXPERIMENT_TAG,
-        SESSION_START_INFO_TAG,
+        PLUGIN_DATA_VERSION,
+        PLUGIN_NAME,
         SESSION_END_INFO_TAG,
+        SESSION_START_INFO_TAG,
     )
     from tensorboard.plugins.hparams.plugin_data_pb2 import (
         HParamsPluginData,
@@ -303,6 +325,85 @@ def scalar(name, tensor, collections=None, new_style=False, double_precision=Fal
         return Summary(value=[Summary.Value(tag=name, simple_value=scalar)])
 
 
+def tensor_proto(tag, tensor):
+    """Outputs a `Summary` protocol buffer containing the tensor.
+    The generated Summary has a Tensor.proto containing the input Tensor.
+    Args:
+      name: A name for the generated node. Will also serve as the series name in
+        TensorBoard.
+      tensor: Tensor to be converted to protobuf
+    Returns:
+      A tensor protobuf in a `Summary` protobuf.
+    Raises:
+      ValueError: If tensor is too big to be converted to protobuf
+    """
+    if tensor.numel() * tensor.itemsize >= (1 << 31):
+        raise ValueError(
+            "tensor is bigger than protocol buffer's hard limit of 2GB in size"
+        )
+
+    # type maps: torch.Tensor type -> (protobuf type, protobuf val field)
+    type_map = {
+        torch.half: ("DT_HALF", "half_val"),
+        torch.float16: ("DT_HALF", "half_val"),
+        torch.bfloat16: ("DT_BFLOAT", "float_val"),
+        torch.float32: ("DT_FLOAT", "float_val"),
+        torch.float: ("DT_FLOAT", "float_val"),
+        torch.float64: ("DT_DOUBLE", "double_val"),
+        torch.double: ("DT_DOUBLE", "double_val"),
+        torch.int8: ("DT_INT8", "int_val"),
+        torch.uint8: ("DT_UINT8", "int_val"),
+        torch.qint8: ("DT_UINT8", "int_val"),
+        torch.int16: ("DT_INT16", "int_val"),
+        torch.short: ("DT_INT16", "int_val"),
+        torch.int: ("DT_INT32", "int_val"),
+        torch.int32: ("DT_INT32", "int_val"),
+        torch.qint32: ("DT_INT32", "int_val"),
+        torch.complex32: ("DT_COMPLEX32", "scomplex_val"),
+        torch.chalf: ("DT_COMPLEX32", "scomplex_val"),
+        torch.complex64: ("DT_COMPLEX64", "scomplex_val"),
+        torch.cfloat: ("DT_COMPLEX64", "scomplex_val"),
+        torch.bool: ("DT_BOOL", "bool_val"),
+        torch.complex128: ("DT_COMPLEX128", "dcomplex_val"),
+        torch.cdouble: ("DT_COMPLEX128", "dcomplex_val"),
+        torch.uint8: ("DT_UINT8", "uint32_val"),
+        torch.quint8: ("DT_UINT8", "uint32_val"),
+        torch.quint4x2: ("DT_UINT8", "uint32_val"),
+    }
+
+    if tensor.dtype in type_map:
+        tensor_proto_args = {
+            "dtype": type_map[tensor.dtype][0],
+            "dim": [
+                TensorShapeProto.Dim(size=tensor.shape[i]) for i in range(tensor.dim())
+            ],
+        }
+        proto_val_field = type_map[tensor.dtype][1]
+        if proto_val_field == "scomplex_val" or proto_val_field == "dcomplex_val":
+            # construct value so that complex_val(2*i) and complex_val(2*i+1) are
+            # real and imaginary parts of i-th complex number
+            tensor_proto_args.update(
+                proto_val_field,
+                [
+                    val.item()
+                    for real_imag in zip(tensor.real, tensor.imag)
+                    for val in real_imag
+                ],
+            )
+        else:
+            tensor_proto_args.update(proto_val_field, tensor.reshape(-1).tolist())
+        tensor_proto = TensorProto(**tensor_proto_args)
+    else:
+        tensor_proto = TensorProto(
+            dtype="DT_STRING", string_val=f"{tag} has unsupported tensor dtype"
+        )
+
+    plugin_data = SummaryMetadata.PluginData(plugin_name="tensor")
+    smd = SummaryMetadata(plugin_data=plugin_data)
+
+    return Summary(value=[Summary.Value(tag=tag, metadata=smd, tensor=tensor_proto)])
+
+
 def histogram_raw(name, min, max, num, sum, sum_squares, bucket_limits, bucket_counts):
     # pylint: disable=line-too-long
     """Outputs a `Summary` protocol buffer with a histogram.
@@ -456,7 +557,10 @@ def image_boxes(
     tensor_boxes = make_np(tensor_boxes)
     tensor_image = tensor_image.astype(np.float32) * _calc_scale_factor(tensor_image)
     image = make_image(
-        tensor_image.clip(0, 255).astype(np.uint8), rescale=rescale, rois=tensor_boxes, labels=labels
+        tensor_image.clip(0, 255).astype(np.uint8),
+        rescale=rescale,
+        rois=tensor_boxes,
+        labels=labels,
     )
     return Summary(value=[Summary.Value(tag=tag, image=image)])
 
@@ -494,6 +598,7 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
         ANTIALIAS = Image.ANTIALIAS
     image = image.resize((scaled_width, scaled_height), ANTIALIAS)
     import io
+
     output = io.BytesIO()
     image.save(output, format="PNG")
     image_string = output.getvalue()
@@ -818,8 +923,8 @@ def mesh(
     Returns:
       Merged summary for mesh/point cloud representation.
     """
-    from tensorboard.plugins.mesh.plugin_data_pb2 import MeshPluginData
     from tensorboard.plugins.mesh import metadata
+    from tensorboard.plugins.mesh.plugin_data_pb2 import MeshPluginData
 
     json_config = _get_json_config(config_dict)
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -3,43 +3,39 @@ consumed by TensorBoard for visualization."""
 
 import os
 import time
+
 import torch
 
 from tensorboard.compat import tf
-from tensorboard.compat.proto.event_pb2 import SessionLog
-from tensorboard.compat.proto.event_pb2 import Event
 from tensorboard.compat.proto import event_pb2
+from tensorboard.compat.proto.event_pb2 import Event, SessionLog
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
 from tensorboard.summary.writer.event_file_writer import EventFileWriter
 
 from ._convert_np import make_np
-from ._embedding import (
-    make_mat,
-    make_sprite,
-    make_tsv,
-    write_pbtxt,
-    get_embedding_info,
-)
+from ._embedding import get_embedding_info, make_mat, make_sprite, make_tsv, write_pbtxt
 from ._onnx_graph import load_onnx_graph
 from ._pytorch_graph import graph
 from ._utils import figure_to_image
 from .summary import (
-    scalar,
+    audio,
+    custom_scalars,
     histogram,
     histogram_raw,
+    hparams,
     image,
-    audio,
-    text,
-    pr_curve,
-    pr_curve_raw,
-    video,
-    custom_scalars,
     image_boxes,
     mesh,
-    hparams,
+    pr_curve,
+    pr_curve_raw,
+    scalar,
+    tensor_proto,
+    text,
+    video,
 )
 
-__all__ = ['FileWriter', 'SummaryWriter']
+__all__ = ["FileWriter", "SummaryWriter"]
+
 
 class FileWriter:
     """Writes protocol buffers to event files to be consumed by TensorBoard.
@@ -388,6 +384,42 @@ class SummaryWriter:
         summary = scalar(
             tag, scalar_value, new_style=new_style, double_precision=double_precision
         )
+        self._get_file_writer().add_summary(summary, global_step, walltime)
+
+    def add_tensor(
+        self,
+        tag,
+        tensor,
+        global_step=None,
+        walltime=None,
+    ):
+        """Add tensor data to summary.
+
+        Args:
+            tag (str): Data identifier
+            tensor (torch.Tensor): tensor to save
+            global_step (int): Global step value to record
+        Examples::
+
+            from torch.utils.tensorboard import SummaryWriter
+            writer = SummaryWriter()
+            x = torch.tensor([1,2,3])
+            writer.add_scalar('x', x)
+            writer.close()
+
+        Expected result:
+            Summary::tensor::float_val [1,2,3]
+                   ::tensor::shape [3]
+                   ::tag 'x'
+
+        """
+        torch._C._log_api_usage_once("tensorboard.logging.add_tensor")
+        if self._check_caffe2_blob(tensor):
+            from caffe2.python import workspace
+
+            tensor = workspace.FetchBlob(tensor)
+
+        summary = tensor_proto(tag, tensor)
         self._get_file_writer().add_summary(summary, global_step, walltime)
 
     def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None):
@@ -844,6 +876,7 @@ class SummaryWriter:
             # Caffe2 models do not have the 'forward' method
             from caffe2.proto import caffe2_pb2
             from caffe2.python import core
+
             from ._caffe2_graph import (
                 model_to_graph_def,
                 nets_to_graph_def,

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -411,7 +411,6 @@ class SummaryWriter:
             Summary::tensor::float_val [1,2,3]
                    ::tensor::shape [3]
                    ::tag 'x'
-
         """
         torch._C._log_api_usage_once("tensorboard.logging.add_tensor")
         if self._check_caffe2_blob(tensor):


### PR DESCRIPTION
Summary:
This is the first diff to support logging of raw tensors for TensorBoard logging

Ultimately, we aim to support the feature where store full tensor is stored as a tensor protobuf to TB. Protobuf contains shape, dtype, and elements of the given tensor.

1. add `tensor_proto()` to `summary.py` which takes a tensor and convert to protobuf
2. add `add_tensor()` to `writer.py`
3. formatting changes introduced by linting

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104786

Differential Revision: [D47277072](https://our.internmc.facebook.com/intern/diff/D47277072/)