### PR TITLE
Add unit tests for numerical validation for onnx export with fake mode enabled

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -211,6 +211,30 @@ def skip_dynamic_fx_test(reason: str):
     return skip_dec
 
 
+def skip_op_level_debug_test(reason: str):
+    """Skip tests with op_level_debug enabled.
+
+    Args:
+        reason: The reason for skipping tests with op_level_debug enabled.
+
+    Returns:
+        A decorator for skipping tests with op_level_debug enabled.
+    """
+
+    def skip_dec(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if self.op_level_debug:
+                raise unittest.SkipTest(
+                    f"Skip test with op_level_debug enabled. {reason}"
+                )
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return skip_dec
+
+
 def skip_in_ci(reason: str):
     """Skip test in CI.
 


### PR DESCRIPTION
Must be merged after: https://github.com/pytorch/pytorch/pull/103865/ https://github.com/pytorch/pytorch/pull/104493 https://github.com/pytorch/pytorch/pull/104741

These unit tests export the model to ONNX using fake mode and a random `state_dict`. Next, random non-fake inputs are created and used to executed the model using ORT. The output is compared with PyTorch's eager run of the same model

Tests with `ExportOptions.op_level_debug=True` are temporarily disabled. I need to assess what might be done (if possible at all) to enable this flag with fake mode enabled.