### PR TITLE
[CUDA][cuBLAS] Separate reduced precision reductions on/off for `addmm` tests

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -57,11 +57,11 @@ class TestMatmulCuda(TestCase):
         #
         # Get dims
         n, m, p = (size + 1, size, size + 2)
-        # Disable reduced precision reductions in BFloat16 to bypass some kernels
-        # which fail the threshold check
-        orig = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
-        if dtype == torch.bfloat16 and torch.cuda.get_device_capability() >= (8, 6):
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+        # Disable reduced precision reductions to bypass some kernels
+        orig_fp16 = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+        orig_bf16 = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
         # Make random tensors on CPU (seed set on common_utils.py import)
         # (Not using numpy because it does not support bfloat16)
         make_arg = partial(make_tensor, dtype=dtype, device="cpu")
@@ -100,10 +100,13 @@ class TestMatmulCuda(TestCase):
         res_cuda = res_cuda.to("cpu")
         # Compare
         self.assertEqual(res_cpu, res_cuda)
-        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = orig
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = orig_fp16
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = orig_bf16
 
     @onlyCUDA
     def test_cublas_addmm_alignment(self):
+        orig = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
         dtype = torch.half
         device = 'cuda'
         # perturb X, A, or B alignment
@@ -120,6 +123,7 @@ class TestMatmulCuda(TestCase):
                 B = B[b_offset:].reshape(5120)
                 out = torch.nn.functional.linear(X, A, B)
                 self.assertEqual(out, torch.matmul(X, A.transpose(1, 0)) + B)
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = orig
 
     @onlyCUDA
     @unittest.skipIf(TEST_WITH_ROCM, "Only CUDA 11+ is supported")


### PR DESCRIPTION
CC @malfet @ptrblck 
~~We've been seeing a lot of noise from Ampere and later devices due to reduced precision reductions, so preemptively disabling them for `addmm` tests.~~

Breaking out `addmm` tests into one with and without reduced precision reductions.

cc @ptrblck @csarofeen @xwang233