### PR TITLE
[DeviceMesh]Add validate mesh flag to DeviceMesh

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -118,13 +118,12 @@ class DeviceMesh(object):
             if isinstance(mesh, torch.Tensor)
             else torch.tensor(mesh, dtype=torch.int)
         )
-        self._validate_mesh = _validate_mesh
         # always try to create default (world) pg, even if it is not initialized
         # already. The world pg is used for device mesh identity (rank) on each
         # process (we need to know if the current global rank is in the mesh or not)
         self._get_or_create_default_group()
         if _init_process_groups:
-            self._init_process_groups()
+            self._init_process_groups(_validate_mesh)
 
     def _get_or_create_default_group(self):
         default_initialized = is_initialized()
@@ -158,19 +157,19 @@ class DeviceMesh(object):
         )
         return _get_default_group()
 
-    def _init_process_groups(self):
+    def _validate_mesh(self):
         # check mesh tensor validity
         unique_mesh_values = self.mesh.unique(sorted=True)
         if unique_mesh_values.numel() != self.mesh.numel():
             raise RuntimeError(
                 f"DeviceMesh cannot have duplicate values, but found {self.mesh.tolist()}"
             )
+
         # validate that all calling ranks pass in the same `mesh` argument.
-        if self._validate_mesh:
-            self_mesh = self.mesh.to(self.device_type)
-            mesh_tensor = funcol.all_gather_tensor(
-                self_mesh, gather_dim=0, group=_get_default_group()
-            )
+        self_mesh = self.mesh.to(self.device_type)
+        mesh_tensor = funcol.all_gather_tensor(
+            self_mesh, gather_dim=0, group=_get_default_group()
+        )
         mesh_tensor_chunked = torch.chunk(mesh_tensor, get_world_size())
         for other_rank, other_mesh in enumerate(mesh_tensor_chunked):
             if not torch.equal(self_mesh, other_mesh):
@@ -180,11 +179,15 @@ class DeviceMesh(object):
                     f"has mesh {other_mesh}!"
                 )
 
+    def _init_process_groups(self, _validate_mesh):
+        if _validate_mesh:
+            self._validate_mesh()
+
         # group tag/ranks associated with each mesh dimension, each mesh dimension should
         # have one sub-group per rank
         dim_group_infos: List[Tuple[str, List[int]]] = []
 
-        if self.mesh.ndim == 1 and len(unique_mesh_values) == get_world_size():
+        if self.mesh.ndim == 1 and self.mesh.numel() == get_world_size():
             # if the mesh is the same as world_pg, we just append the default
             # pg to the first dim groups, as new_group cannot have the exact
             # same ranks as world

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -14,7 +14,6 @@ from torch.autograd.graph import register_multi_grad_hook
 from torch.distributed import get_backend, get_world_size
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
-from torch.distributed.distributed_c10d import _get_group_tag
 from torch.distributed.fsdp._common_utils import (
     _assert_in_training_states,
     _FSDPState,
@@ -221,13 +220,7 @@ def _init_device_mesh(
 
     device_type = root_state.compute_device.type
     mesh_tensor = torch.arange(get_world_size(root_state.process_group))
-    device_mesh = DeviceMesh(device_type, mesh_tensor, _init_process_groups=False)
-    device_mesh._dim_group_infos = [
-        (
-            _get_group_tag(root_state.process_group),
-            mesh_tensor.tolist(),
-        )
-    ]
+    device_mesh = DeviceMesh(device_type, mesh_tensor, _validate_mesh=False)
     return device_mesh
 
 


### PR DESCRIPTION
When creating DeviceMesh, _init_process_group() would validate that all calling ranks pass in the same `mesh` argument. In FSDP, we are currently creating the DeviceMesh based on the pg of the root state so the mesh will always be valid. Adding the flag to DeviceMesh, so we can skip the all_gather_tensor of the validation during construction time. 

_validate_mesh is default to True, but we manually flip it to False when initializing device mesh in FSDP's  _runtime_utils.py. 

Will modify skipping pg creation if existed for both 1D and 2D cases and then delete _init_process_groups flag in a follow up PR. 

cc @zhaojuanmao @mrshenli @rohan-varma @awgu