### PR TITLE
Generalize sympy.Rel test to sympy.logic.boolalg.Boolean

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -596,7 +596,7 @@ class GraphLowering(torch.fx.Interpreter):
                     type(None),
                     ir.ConstantBuffer,
                     sympy.Expr,
-                    sympy.Rel,
+                    sympy.logic.boolalg.Boolean,
                     int,
                 ),
             )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -113,8 +113,7 @@ def validate_ir(node_or_nodes):
                     DynamicScalar,
                     TensorBox,
                     sympy.Symbol,
-                    sympy.core.relational.Relational,
-                    sympy.core.relational.Unequality,
+                    sympy.logic.boolalg.Boolean,
                     Expr,
                     torch._inductor.ir.ExpandView,
                 ),
@@ -2695,7 +2694,7 @@ class ExternKernel(InputsKernel):
     def realize_input(cls, x):
         if x is None:
             return NoneAsConstantBuffer()
-        if isinstance(x, (sympy.Expr, sympy.Rel, int)):
+        if isinstance(x, (sympy.Expr, sympy.logic.boolalg.Boolean, int)):
             return ShapeAsConstantBuffer(x)
         if isinstance(x, Constant):
             return V.graph.add_tensor_constant(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104833

Constant booleans are not relational, but you typically
will still want to match against them.

I grepped the codebase and this appears to be exhaustive.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8