### PR TITLE
Allow for torch.sym_int to return int while tracing

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -304,6 +304,15 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         sample_input = torch.tensor([4, 4, 16, 32], dtype=torch.uint8)
         opt_fn(sample_input)
 
+    def test_sym_int_conversion(self):
+        def f(x):
+            y = x.size(0)
+            return x * int(y == 0)
+
+        opt_fn = torch.compile(f, backend="eager", fullgraph=True)
+        x = torch.randn(2, 3)
+        opt_fn(x)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1285,6 +1285,7 @@ def wrap_fx_proxy_cls(
         proxy.node.meta["example_value"] = example_value
         return CUDAStreamVariable(proxy, example_value, **options)
     elif isinstance(example_value, int) and proxy.node.target in [
+        torch.sym_int,
         getattr,
         operator.getitem,
     ]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104837

Per https://github.com/pytorch/pytorch/pull/103303 we cannot
universally allow tracing in all functions that return int,
as the graph breaks appear to be load bearing in some cases.
However, allowing for torch.sym_int to be traced in even if
the result is statically known is fine; this can happen in
case of a SymBool to int conversion.

This PR is not exhaustive but e.g., I fixed size/stride/numel
handling in https://github.com/pytorch/pytorch/pull/103438
The biggest risk is that arithmetic operations on sizes end
up getting constant-ified (this appears to have happened in
practice for modulus, which is why it's in this list.)  If
we don't care about spewing useless computation into the graph,
a more aggressive version of this PR would be to greatly expand
the list of allowed to specialize to int targets and then undo
https://github.com/pytorch/pytorch/pull/103438

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78