### PR TITLE
[BE] Make ONNX imports lazy

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1710,10 +1710,6 @@ from torch import func as func
 from torch.func import vmap
 
 
-# ONNX must be imported after _dynamo, _ops, _subclasses, fx, func and jit
-from torch import onnx as onnx  # ONNX depends on a bunch of Dynamo stuff
-
-
 # The function _sparse_coo_tensor_unsafe is removed from PyTorch
 # Python API (v. 1.13), here we temporarily provide its replacement
 # with a deprecation warning.
@@ -1756,6 +1752,8 @@ _deprecated_attrs = {
 _lazy_modules = {
     "_dynamo",
     "_inductor",
+    # ONNX must be imported after _dynamo, _ops, _subclasses, fx, func and jit
+    "onnx",
 }
 
 def __getattr__(name):

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -245,7 +245,7 @@ def _fixup_graph_signature(
 ) -> ExportedProgram:
     def _get_output_node_names(gm: torch.fx.GraphModule) -> List[FQN]:
         output_node = next(n for n in gm.graph.nodes if n.op == "output")
-        return [str(arg) for arg in output_node.args[0]]
+        return [str(arg) for arg in output_node.args[0]]  # type: ignore[misc]
 
     # Update output names since after adding run time assertions, the names of
     # outputs could change.
@@ -263,9 +263,9 @@ def _fixup_graph_signature(
     gs = old_ep.graph_signature
     # Need to update graph signature fields related to output since after adding
     # runtime assertions, the output names could change.
-    new_user_outputs = [outputs_map[u] for u in gs.user_outputs]
+    new_user_outputs = [outputs_map[u] for u in gs.user_outputs]  # type: ignore[index]
     new_buffers_to_mutate = {
-        outputs_map[u]: b for u, b in gs.buffers_to_mutate.items()
+        outputs_map[u]: b for u, b in gs.buffers_to_mutate.items()  # type: ignore[index]
     }
 
     return _update_graph_signature(

--- a/torch/_export/passes/functionalize_side_effectful_ops_pass.py
+++ b/torch/_export/passes/functionalize_side_effectful_ops_pass.py
@@ -91,4 +91,4 @@ class _FunctionalizeSideEffectfulOpsPass(ExportPassBase):
     def output(self, results: List[Argument], meta: NodeMetadata) -> ProxyValue:
         assert self._dep_token is not None
 
-        return super().output(results=(*results, self._dep_token), meta=meta)
+        return super().output(results=(*results, self._dep_token), meta=meta)  # type: ignore[arg-type]


### PR DESCRIPTION
This reduces total number of imported modules by default from 1419 to 1322 according to
```
time python -c "import sys;before=len(sys.modules);import torch;after=len(sys.modules);print(f'torch-{torch.__version__} imported {after-before} modules')"
```

and slightly reduces import time, while having no effect on UX (i.e. `torch.onnx.` submodule is kept intact)

Suppress lint errors that appear after mypy accidentally starts listing more files, for more details see: https://github.com/pytorch/pytorch/issues/104940
