### PR TITLE
[pt2][test] Loosen stack trace check in test

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -827,9 +827,11 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                     foo(*inps)
                 except Exception as e:
                     thrown = True
-                    FileCheck().check("at::cuda::getNewWorkspace").check(
-                        "at::cuda::blas::gemm<float>"
-                    ).run(str(e))
+                    self.assertTrue("at::cuda::blas::gemm<float>" in str(e))
+                    self.assertTrue(
+                        "getCurrentCUDABlasHandle" in str(e) or
+                        "getNewWorkspace" in str(e)
+                    )
 
                 self.assertTrue(thrown)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104902

Depending on inlining and demangling provided by the underlying
compiler, we may get different function names and namespaces in the stack
trace.  Allow everything I've seen so far.

Differential Revision: [D47344213](https://our.internmc.facebook.com/intern/diff/D47344213/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D47344213/)!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8