### PR TITLE
Fixes to the torch.compile doc and doctest

### DIFF
--- a/docs/source/compile/index.rst
+++ b/docs/source/compile/index.rst
@@ -48,8 +48,7 @@ You can get the full list of community backends by running :func:`~torch._dynamo
 Troubleshooting
 ---------------
 
-If you experience issues with models failing to compile, running out of memory, recompiling too often, not giving accurate results,
-are can find the right tool to solve your problem in one of our guides.
+If you experience issues with models failing to compile, running out of memory, recompiling too often, not giving accurate results, you might find the right tool to solve your problem in one of our guides.
 
 .. WARNING::
     A few features are still in development and not likely to work for most users. Please do not use these features

--- a/docs/source/compile/index.rst
+++ b/docs/source/compile/index.rst
@@ -45,21 +45,15 @@ There is some nuance involved in benchmarking ``torch.compile`` so we've provide
 
 You can get the full list of community backends by running :func:`~torch._dynamo.list_backends`
 
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
+Troubleshooting
+---------------
 
-    compile
-
-Troubleshooting and Gotchas
----------------------------
-
-IF you experience issues with models failing to compile, running of out of memory, recompiling too often, not giving accurate results,
-odds are you will find the right tool to solve your problem in our guides.
+If you experience issues with models failing to compile, running out of memory, recompiling too often, not giving accurate results,
+are can find the right tool to solve your problem in one of our guides.
 
 .. WARNING::
-    A few features are still very much in development and not likely to work for most users. Please do not use these features
-    in production code and if you're a library maintainer please do not expose these options to your users
+    A few features are still in development and not likely to work for most users. Please do not use these features
+    in production code and if you're a library maintainer please do not expose these options to your users.
     Dynamic shapes ``dynamic=true`` and max autotune ``mode="max-autotune"`` which can be passed in to :func:`~torch.compile`.
     Distributed training has some quirks which you can follow in the troubleshooting guide below. Model export is not ready yet.
 
@@ -72,8 +66,8 @@ odds are you will find the right tool to solve your problem in our guides.
 Learn more
 ----------
 
-If you can't wait to get started and want to learn more about the internals of the PyTorch 2.0 stack then
-please check out the references below.
+To learn more about the internals of the PyTorch 2.0 stack, check out the
+following references:
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Fixing the user warning in doctest by removing autosummary from the compile/index.rst :
```
/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/__init__.py:docstring of torch.compile:1: WARNING: duplicate object description of torch.compile, other instance in compile/generated/torch.compile, use :noindex: for one of them
```
The error is no longer present in the log: https://github.com/pytorch/pytorch/actions/runs/5513741050/jobs/10052379357?pr=104911