### PR TITLE
Handle empty PR body in filter_test_configs

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -446,7 +446,12 @@ def set_output(name: str, val: Any) -> None:
         print(f"::set-output name={name}::{val}")
 
 
-def parse_reenabled_issues(s: str) -> List[str]:
+def parse_reenabled_issues(s: Optional[str]) -> List[str]:
+    # NB: When the PR body is empty, GitHub API returns a None value, which is
+    # passed into this function
+    if not s:
+        return []
+
     # The regex is meant to match all *case-insensitive* keywords that
     # GitHub has delineated would link PRs to issues, more details here:
     # https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -697,6 +697,9 @@ class TestConfigFilter(TestCase):
         )
         self.assertEqual(parse_reenabled_issues(pr_body), [])
 
+        pr_body = None
+        self.assertEqual(parse_reenabled_issues(pr_body), [])
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is a bug discovered by https://github.com/pytorch/pytorch/pull/104810.  Basically, when the PR body is empty, GitHub API returns a None value, which is passed into `parse_reenabled_issues` causing it to fail.

### Testing

```
python3 .github/scripts/filter_test_configs.py \
  --workflow "pull" \
  --job-name "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter," \
  --test-matrix "{ include: [ { config: 'default', shard: 1, num_shards: 1, runner: 'linux.2xlarge' }, ]}" \
  --pr-number "104810" \
  --tag "" \
  --event-name "pull_request" \
  --schedule "" \
  --branch ""
```

The command works correctly without failing now