### PR TITLE
Dynamo tensor aliasing guards, dedup graphargs

### DIFF
--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -121,7 +121,7 @@ class End2EndTests(torch._dynamo.test_case.TestCase):
         batch = {"x": input1, "y": input2}
         for _ in range(2):
             opt_training_iter_fn(batch, net, optimizer)
-        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.frame_count, 3)
 
     def test_state_dict(self):
         @torch.compile(backend="eager")

--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -189,6 +189,7 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
     def test_aliasing_guard_failures_with_globals(self):
         g1 = torch.randn([3])
         g2 = torch.randn([3])
+
         def foo(a):
             a.add_(g1)
             return g2 + 1
@@ -197,9 +198,7 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
         compiled_foo = torch._dynamo.optimize(cnt, nopython=True)(foo)
 
         z = torch.randn([3])
-        cmp_result = compiled_foo(
-            z.clone().detach()
-        )
+        cmp_result = compiled_foo(z.clone().detach())
         eager_result = foo(z.clone().detach())
         self.assertEqual(cmp_result, eager_result)
         self.assertEqual(cnt.frame_count, 1)

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -6,7 +6,6 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
-from torch._dynamo import config
 from torch._dynamo.testing import unsupported
 from torch._dynamo.utils import ifdynstaticdefault
 
@@ -408,10 +407,7 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
         # guards for when x and y didn't duck size together, so we end up
         # with a generic graph that also works when x and y happen to duck
         # size together.
-        if config.assume_static_by_default:
-            self.assertEqual(cnt_dynamic.frame_count, 2)
-        else:
-            self.assertEqual(cnt_dynamic.frame_count, 1)
+        self.assertEqual(cnt_dynamic.frame_count, 2)
 
         torch._dynamo.reset()
         cnt_dynamic.frame_count = 0

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -29,7 +29,7 @@ from torch._guards import (
     TracingContext,
 )
 from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
-from torch.utils.weak import WeakIdKeyDictionary
+from torch.utils.weak import WeakIdKeyDictionary, WeakTensorKeyDictionary
 
 from . import config, logging as torchdynamo_logging, variables
 from .backends.registry import CompiledFn, CompilerFn
@@ -235,9 +235,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
 
         # Used to maintain an alias between real values variable tracker for tensors we have seen.
         # This map ensures that the only tensors in graph inputs, and the only tensors in guards are unique.
-        self.real_value_tensor_positive_aliases: Dict[
-            torch.Tensor, VariableTracker
-        ] = {}
+        self.real_value_tensor_positive_aliases = WeakTensorKeyDictionary()
 
         # In export mode, we force the shape_env to strictly disallow any constraining
         # of the user marked dynamic dims

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -234,6 +234,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.tensor_weakref_to_sizes_strides: WeakIdKeyDictionary = {}
 
         # Used to maintain an alias between real values variable tracker for tensors we have seen.
+        # This map ensures that the only tensors in graph inputs, and the only tensors in guards are unique.
         self.real_value_tensor_positive_aliases: Dict[
             torch.Tensor, VariableTracker
         ] = {}

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -232,6 +232,12 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.export_constraints = export_constraints
         self.frame_state = frame_state
         self.tensor_weakref_to_sizes_strides: WeakIdKeyDictionary = {}
+
+        # Used to maintain an alias between real values variable tracker for tensors we have seen.
+        self.real_value_tensor_positive_aliases: Dict[
+            torch.Tensor, VariableTracker
+        ] = {}
+
         # In export mode, we force the shape_env to strictly disallow any constraining
         # of the user marked dynamic dims
         fake_mode = torch._guards.EXPORT_FAKE_MODE or torch._subclasses.FakeTensorMode(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -912,7 +912,6 @@ class VariableBuilder:
             dup_guard = self._make_dupe_guard(stored_value)
             if dup_guard:
                 stored_value = stored_value.add_guards(self.make_guards(dup_guard))
-            breakpoint()
             return stored_value
 
         tensor_proxy = self.tx.output.root_tracer.create_graph_input(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -899,7 +899,12 @@ class VariableBuilder:
         # then the relevant SubgraphTracer will lift it to being an input of
         # the subgraph.
         # See NOTE [HigherOrderOperator tracing design] for more details.
-        assert not isinstance(value, torch._subclasses.fake_tensor.FakeTensor)
+
+        if not self.tx.output.export:
+            # Export has (supposedly) valid cases for fake tensors as inputs here.
+            # I am not convinced, atm, but out of scope for what this assert was added for (protecting value checks
+            # in real_value_tensor_positive_aliases in the common case)
+            assert not isinstance(value, torch._subclasses.fake_tensor.FakeTensor)
 
         if value in self.tx.output.real_value_tensor_positive_aliases:
             stored_value = self.tx.output.real_value_tensor_positive_aliases[value]
@@ -907,6 +912,7 @@ class VariableBuilder:
             dup_guard = self._make_dupe_guard(stored_value)
             if dup_guard:
                 stored_value = stored_value.add_guards(self.make_guards(dup_guard))
+            breakpoint()
             return stored_value
 
         tensor_proxy = self.tx.output.root_tracer.create_graph_input(
@@ -921,6 +927,7 @@ class VariableBuilder:
             ignore_subclass=ignore_subclass,
             source=source,
         )
+        self.tx.output.real_value_tensor_positive_aliases[value] = tensor_variable
         self.tx.output.input_source_to_var[source] = tensor_variable
         assert "tensor_dict" not in tensor_proxy.node.meta
         tensor_proxy.node.meta["tensor_dict"] = value.__dict__.copy()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -912,6 +912,7 @@ class VariableBuilder:
             dup_guard = self._make_dupe_guard(stored_value)
             if dup_guard:
                 stored_value = stored_value.add_guards(self.make_guards(dup_guard))
+            breakpoint()
             return stored_value
 
         tensor_proxy = self.tx.output.root_tracer.create_graph_input(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -221,19 +221,16 @@ class VariableBuilder:
         # Note - we may not have a source, that is fine, it just means we had an object that is safe to have
         # leave unsourced - like a local list created and discharged entirely within a local scope.
         if deduped_object.source and deduped_object.source != self.source:
-            ser_source_is_local = is_from_local_source(deduped_object.source)
-            source_is_local = is_from_local_source(self.source)
             # Note - both must be local, or global, or we will run afoul of a lack of merging in how we currently
             # reconcile guards builder scopes in compile_check_fn. This technically means we miss a guard here,
             # so maybe we should do this refactor before we land this...
             # TODO(voz): Combine local and global guard builders.
-            if ser_source_is_local == source_is_local:
-                # Note - this is a little agressive - these being duplicate input does not always matter.
-                # However, this should always be a sound guard to add here.
-                dup_guard = functools.partial(
-                    GuardBuilder.DUPLICATE_INPUT, source_b=deduped_object.source
-                )
-                return dup_guard
+            # Note - this is a little agressive - these being duplicate input does not always matter.
+            # However, this should always be a sound guard to add here.
+            dup_guard = functools.partial(
+                GuardBuilder.DUPLICATE_INPUT, source_b=deduped_object.source
+            )
+            return dup_guard
         return None
 
     def _can_lift_attrs_to_inputs(self, vt):

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/extension.h>
+#include <set>
 #include <sstream>
 
 namespace {
@@ -253,6 +254,9 @@ static int TensorGuards_init(
   auto len = PyTuple_GET_SIZE(args);
   checks.reserve(len);
   LocalState state;
+
+  // Every tensor in here in unique, they are not aliased, and we need to
+  // protect that.
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
     if (!THPVariable_CheckExact(item) && !THPVariable_Check(item)) {
@@ -260,6 +264,7 @@ static int TensorGuards_init(
       return -1;
     }
     auto tensor = THPVariable_Unpack(item);
+
     std::vector<std::optional<int64_t>> tensor_dims_size =
         per_tensor_dynamic_dims_sizes.size() == 0
         ? wrapIntegersInOptional(tensor.sizes())
@@ -292,11 +297,19 @@ PyObject* TensorGuards_check(TensorGuards* self, PyObject* args) {
   }
 
   LocalState state;
-
+  std::set<PyObject*> unique_tensors;
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
+
     if (Py_TYPE(item) != checks[i].pytype) {
       Py_RETURN_FALSE;
+    }
+    auto it = unique_tensors.find(item);
+    if (it != unique_tensors.end()) {
+      // Violates uniqueness
+      Py_RETURN_FALSE;
+    } else {
+      unique_tensors.insert(item);
     }
     if (!checks[i].check(state, THPVariable_Unpack(item))) {
       Py_RETURN_FALSE;
@@ -355,6 +368,7 @@ PyObject* TensorGuards_check_verbose(
   }
 
   LocalState state;
+  std::set<PyObject*> unique_tensors;
   for (auto i : c10::irange(len)) {
     PyObject* item = PyTuple_GET_ITEM(args, i);
     if (Py_TYPE(item) != checks[i].pytype) {
@@ -368,6 +382,17 @@ PyObject* TensorGuards_check_verbose(
         fail_reason << "' but found " << PyUnicode_AsUTF8(type_str);
       }
       return Py_BuildValue("s", fail_reason.str().c_str());
+    }
+
+    auto it = unique_tensors.find(item);
+    if (it != unique_tensors.end()) {
+      std::stringstream fail_reason;
+      fail_reason << "Duplicate tensor found where not expected! ";
+      fail_reason << tensor_check_names[i]
+                  << "should not alias to anything, but is aliased";
+      return Py_BuildValue("s", fail_reason.str().c_str());
+    } else {
+      unique_tensors.insert(item);
     }
     std::string fail_reason = checks[i].check_verbose(
         state, THPVariable_Unpack(item), tensor_check_names[i]);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #103205
* __->__ #104921

The story here is relatively simple - when we go to wrap a tensor, we (1) ensure that it is a real, not fake tensor (2) check if we have seen it before. (3) If we have seen it, we create a positive alias guard and return the associated variable. If not, we proceed. 

By short circuiting here, we avoid lifting it to a graph input, and guarantee that the only names passed to tensors are unique. This allows us to guard on the unique relationships (pyboject addresses, aka IDs, cannot match) to give us guards for negative aliases. 

cc @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78