### PR TITLE
Clean up Windows GHA actions directory when tearing down

### DIFF
--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -49,6 +49,12 @@ runs:
             rm -rf "${EXTRA_DELETE_DIR}" || true
           fi
 
+          # NB: Clean up checkout GHA to avoid having the folder locked later on. The cleanup-runner
+          # GHA previously run has already ensured that there is no lock on this directory. The dir
+          # would be deleted anyway according to https://github.com/actions/runner
+          rm -rf "${{ runner.workspace }}/../_actions/*"
+
+          # Clean up the current workspace
           rm -rf ./*
 
     - name: Print all processes locking the runner workspace

--- a/.github/actions/teardown-win/action.yml
+++ b/.github/actions/teardown-win/action.yml
@@ -52,7 +52,7 @@ runs:
           # NB: Clean up checkout GHA to avoid having the folder locked later on. The cleanup-runner
           # GHA previously run has already ensured that there is no lock on this directory. The dir
           # would be deleted anyway according to https://github.com/actions/runner
-          rm -rf "${{ runner.workspace }}/../_actions/*"
+          rm -rf "${{ runner.workspace }}"/../_actions/*
 
           # Clean up the current workspace
           rm -rf ./*


### PR DESCRIPTION
This is my 2nd attempt to fix the flaky checkout on Windows where the runner fails to clean up GHA actions directory because it's locked by an unknown process (likely to be git), i.e. https://github.com/pytorch/pytorch/actions/runs/5514008233/jobs/10052783742.

According to the runner code at https://github.com/actions/runner/blob/main/src/Runner.Worker/ActionManager.cs#L84-L87, the directory is removed at the start of a job anyway.  Cleaning it up during the teardown process has the benefit that it's in our control and `pytorch/test-infra/.github/actions/cleanup-runner` has already killed all potential processes holding a lock to this folder.