### PR TITLE
[Doc] Specify output parameters for FractionalMaxPool2d and FractionalMaxPool3d

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -741,6 +741,8 @@ class FractionalMaxPool2d(Module):
     step size determined by the target output size.
     The number of output features is equal to the number of input planes.
 
+    .. note:: Exactly one of ``output_size`` or ``output_ratio`` must be defined.
+
     Args:
         kernel_size: the size of the window to take a max over.
                      Can be a single number k (for a square kernel of k x k) or a tuple `(kh, kw)`
@@ -810,6 +812,8 @@ class FractionalMaxPool3d(Module):
     The max-pooling operation is applied in :math:`kT \times kH \times kW` regions by a stochastic
     step size determined by the target output size.
     The number of output features is equal to the number of input planes.
+
+    .. note:: Exactly one of ``output_size`` or ``output_ratio`` must be defined.
 
     Args:
         kernel_size: the size of the window to take a max over.


### PR DESCRIPTION
Summary: Specify one of the output parameters must be set for FractionalMaxPool2d and FractionalMaxPool3d.

Fix: #104861

Test Plan: Please see GitHub Actions

Differential Revision: D47357240



cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki