### PR TITLE
[inductor] handle `Min` and `Max` in `TritonPrinter`

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -237,6 +237,16 @@ class ExprPrinterTests(TorchTestCase):
                     "at::native::div_floor_floating(static_cast<double>(s1), static_cast<double>(s2))",
                 )
 
+    def test_print_Min_Max(self):
+        cases = (
+            (sympy.Min, "min"),
+            (sympy.Max, "max"),
+        )
+        for f, s in cases:
+            x = sympy.Symbol("x", integer=True)
+            expr = f(-2, x)
+            self.assertEqual(texpr(expr), f"tl.math.{s}(-2, x)")
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -62,6 +62,16 @@ class TritonPrinter(PythonPrinter):
     def _helper_sqrt(self, expr):
         return f"tl.math.sqrt({self.paren(self._print(expr))}.to(tl.float32))"
 
+    def _print_Min(self, expr):
+        a = self._print(expr.args[0])
+        b = self._print(expr.args[1])
+        return f"tl.math.min({a}, {b})"
+
+    def _print_Max(self, expr):
+        a = self._print(expr.args[0])
+        b = self._print(expr.args[1])
+        return f"tl.math.max({a}, {b})"
+
 
 texpr = TritonPrinter().doprint
 pexpr = PythonPrinter().doprint


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #104844
* #104578
* __->__ #104944



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8