### PR TITLE
Fix torch.compile g++ flag error on ppc64le

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -8,6 +8,7 @@ import json
 import logging
 import multiprocessing
 import os
+import platform
 import pathlib
 import re
 import shutil
@@ -619,7 +620,10 @@ def optimization_flags():
         # Also, `-march=native` is unrecognized option on M1
         base_flags += " -Xclang"
     else:
-        base_flags += " -march=native"
+        if platform.machine() == "ppc64le":
+            base_flags += " -mcpu=native"
+        else:
+            base_flags += " -march=native"
 
     # Internal cannot find libgomp.so
     if not config.is_fbcode():

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -8,8 +8,8 @@ import json
 import logging
 import multiprocessing
 import os
-import platform
 import pathlib
+import platform
 import re
 import shutil
 import signal


### PR DESCRIPTION
g++ flag -march is not recognised on ppc64le. So adding a check for platform machine to be ppc64le and using -mcpu flag instead. Other architectures will still use -march flag

This fixes the torch.compile feature failure on ppc64le


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8