### PR TITLE
Updated pillow version to 9.3.0 for Python version <= 3.8

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -124,7 +124,7 @@ opt-einsum==3.3
 #Pinned versions: 3.3
 #test that import: test_linalg.py
 
-pillow==9.2.0 ; python_version <= "3.8"
+pillow==9.3.0 ; python_version <= "3.8"
 pillow==9.5.0 ; python_version > "3.8"
 #Description:  Python Imaging Library fork
 #Pinned versions:


### PR DESCRIPTION
There are several vulnerabilities with pillow version 9.2.0. In the worst case, this can lead to arbitrary code execution - https://security.gentoo.org/glsa/202211-10. 