### PR TITLE
Fix initializer naming at torch.onnx.ExportOutput.save_model_with_external_data

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -211,6 +211,30 @@ def skip_dynamic_fx_test(reason: str):
     return skip_dec
 
 
+def skip_op_level_debug_test(reason: str):
+    """Skip tests with op_level_debug enabled.
+
+    Args:
+        reason: The reason for skipping tests with op_level_debug enabled.
+
+    Returns:
+        A decorator for skipping tests with op_level_debug enabled.
+    """
+
+    def skip_dec(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if self.op_level_debug:
+                raise unittest.SkipTest(
+                    f"Skip test with op_level_debug enabled. {reason}"
+                )
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return skip_dec
+
+
 def skip_in_ci(reason: str):
     """Skip test in CI.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104976

Must be merged after: https://github.com/pytorch/pytorch/pull/103865 https://github.com/pytorch/pytorch/pull/104493 https://github.com/pytorch/pytorch/pull/104741
This PR fixes a hack in which ONNX initializers with `.` in their name were replaced by `_`.  After #104741, we can support `.` in the initializers name and this hack is no longer needed and the `.` can be preserved for better model readability (pytorch parameter name matches ONNX initializer name exactly).

The provided unit tests export the model to ONNX using fake mode. Next, random non-fake inputs are created and used to execute the ONNX model using ORT with "real tensors". The output is compared with PyTorch's eager run of the same model and real input.

Tests with ExportOptions.op_level_debug=True are temporarily disabled. We need to assess what needs to be done (if possible at all) to enable this flag with fake mode enabled.