### PR TITLE
Fix broken link to torch.compile docs

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1620,7 +1620,7 @@ def compile(model: Optional[Callable] = None, *,
         - "inductor" is the default backend, which is a good balance between performance and overhead
         - Non experimental in-tree backends can be seen with `torch._dynamo.list_backends()`
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
-        - To register an out-of-tree custom backend: https://pytorch.org/docs/master/dynamo/custom-backends.html
+        - To register an out-of-tree custom backend: https://pytorch.org/docs/main/compile/custom-backends.html
        mode (str): Can be either "default", "reduce-overhead" or "max-autotune"
         - "default" is the default mode, which is a good balance between performance and overhead
 


### PR DESCRIPTION
The existing link https://pytorch.org/docs/master/dynamo/custom-backends.html is 404. Updating to use the new link.

cc @carljparker