### PR TITLE
[Pytorch] Unary Ops

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/templates/unary_op.glslt
+++ b/aten/src/ATen/native/vulkan/glsl/templates/unary_op.glslt
@@ -1,0 +1,28 @@
+/*
+ * OPERATOR = $OPERATOR
+ */
+
+#define OP(X) $OPERATOR
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  ivec4 extents; // w=unused
+}
+uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (any(greaterThanEqual(pos, uBlock.extents.xyz))) {
+    return;
+  }
+
+  const vec4 v = texelFetch(uInput, pos, 0);
+  imageStore(uOutput, pos, OP(v));
+}

--- a/aten/src/ATen/native/vulkan/glsl/templates/unary_op_inplace.glslt
+++ b/aten/src/ATen/native/vulkan/glsl/templates/unary_op_inplace.glslt
@@ -1,0 +1,27 @@
+/*
+ * OPERATOR = $OPERATOR
+ */
+
+#define OP(X) $OPERATOR
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D uInput;
+layout(set = 0, binding = 1) uniform PRECISION restrict Block {
+  ivec4 extents; // w=unused
+}
+uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (any(greaterThanEqual(pos, uBlock.extents.xyz))) {
+    return;
+  }
+
+  vec4 v = imageLoad(uInput, pos);
+  imageStore(uInput, pos, OP(v));
+}

--- a/aten/src/ATen/native/vulkan/glsl/templates/unary_op_params.yaml
+++ b/aten/src/ATen/native/vulkan/glsl/templates/unary_op_params.yaml
@@ -1,0 +1,15 @@
+unary_op:
+  parameter_names_with_default_values:
+    NAME: exp
+    OPERATOR: exp(X)
+  parameter_values:
+    - NAME: sqrt
+      OPERATOR: sqrt(X)
+
+unary_op_inplace:
+  parameter_names_with_default_values:
+    NAME: exp_
+    OPERATOR: exp(X)
+  parameter_values:
+    - NAME: sqrt_
+      OPERATOR: sqrt(X)

--- a/aten/src/ATen/native/vulkan/ops/UnaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/UnaryOp.cpp
@@ -1,0 +1,135 @@
+#include <ATen/ArrayRef.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <torch/library.h>
+#include <vector>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+using namespace api::utils;
+
+Tensor unary_op(
+    const Tensor& self_arg,
+    const api::ShaderInfo& shader_descriptor) {
+  api::Context* const context = api::context();
+
+  const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
+  const vTensor& v_self = convert(self);
+
+  vTensor v_output{
+      context,
+      v_self.sizes(),
+      self_arg.scalar_type(),
+  };
+
+  const struct Block final {
+    uvec3 extents;
+    uint32_t fill0;
+  } block{
+      v_self.extents(),
+      0,
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      shader_descriptor,
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      // params buffer
+      params.buffer());
+
+  return convert(v_output);
+}
+
+Tensor& unary_op_(Tensor& self_arg, const api::ShaderInfo& shader_descriptor) {
+  TORCH_CHECK(
+      self_arg.is_vulkan(),
+      "Vulkan: In-place operator is only supported on Vulkan tensors.");
+
+  api::Context* const context = api::context();
+
+  vTensor& v_self = convert(self_arg);
+
+  const struct Block final {
+    uvec3 extents;
+    uint32_t fill0;
+  } block{
+      v_self.extents(),
+      0,
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      shader_descriptor,
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_self.extents(),
+      // local work group size
+      adaptive_work_group_size(v_self.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_self.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
+      // params buffer
+      params.buffer());
+
+  return self_arg;
+}
+
+Tensor exp(const Tensor& self_arg) {
+  return unary_op(self_arg, VK_KERNEL(exp));
+}
+
+Tensor& exp_(Tensor& self_arg) {
+  return unary_op_(self_arg, VK_KERNEL(exp_));
+}
+
+Tensor sqrt(const Tensor& self_arg) {
+  return unary_op(self_arg, VK_KERNEL(sqrt));
+}
+
+Tensor& sqrt_(Tensor& self_arg) {
+  return unary_op_(self_arg, VK_KERNEL(sqrt_));
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::exp"), TORCH_FN(exp));
+  m.impl(TORCH_SELECTIVE_NAME("aten::exp_"), TORCH_FN(exp_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::sqrt"), TORCH_FN(sqrt));
+  m.impl(TORCH_SELECTIVE_NAME("aten::sqrt_"), TORCH_FN(sqrt_));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3734,6 +3734,103 @@ TEST_F(VulkanAPITest, transpose_4d_height_and_width_large) {
   test_transpose({7, 51, 41, 3}, 2, 3);
 }
 
+// Test Unary Ops
+void test_exp(const at::IntArrayRef input_shape) {
+  c10::InferenceMode mode;
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = at::exp(in_cpu);
+
+  const auto in_vulkan = in_cpu.vulkan();
+  const auto out_vulkan = at::exp(in_vulkan);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+    std::cout << "exp test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, unary_op_exp) {
+  test_exp({5});
+  test_exp({5, 6});
+  test_exp({7, 3, 5});
+  test_exp({11, 1, 4, 2});
+}
+
+void test_exp_(const at::IntArrayRef input_shape) {
+  c10::InferenceMode mode;
+  const auto cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto vulkan = cpu.vulkan();
+
+  cpu.exp_();
+  vulkan.exp_();
+
+  const auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+    std::cout << "exp_ test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, unary_op_exp_) {
+  test_exp_({5});
+  test_exp_({5, 6});
+  test_exp_({7, 3, 5});
+  test_exp_({11, 1, 4, 2});
+}
+
+void test_sqrt(const at::IntArrayRef input_shape) {
+  c10::InferenceMode mode;
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = at::sqrt(in_cpu);
+
+  const auto in_vulkan = in_cpu.vulkan();
+  const auto out_vulkan = at::sqrt(in_vulkan);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+    std::cout << "sqrt test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, unary_op_sqrt) {
+  test_sqrt({5});
+  test_sqrt({5, 6});
+  test_sqrt({7, 3, 5});
+  test_sqrt({11, 1, 4, 2});
+}
+
+void test_sqrt_(const at::IntArrayRef input_shape) {
+  c10::InferenceMode mode;
+  const auto cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto vulkan = cpu.vulkan();
+
+  cpu.sqrt_();
+  vulkan.sqrt_();
+
+  const auto check = almostEqual(cpu, vulkan.cpu());
+  if (!check) {
+    showRtol(cpu, vulkan.cpu());
+    std::cout << "sqrt_ test failed with input shape: "
+              << input_shape << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, unary_op_sqrt_) {
+  test_sqrt_({5});
+  test_sqrt_({5, 6});
+  test_sqrt_({7, 3, 5});
+  test_sqrt_({11, 1, 4, 2});
+}
+
 void test_unsqueeze(const at::IntArrayRef input_shape, int64_t dim) {
   c10::InferenceMode mode;
   const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));


### PR DESCRIPTION
Summary:
Use templates to generate shaders for unary operators `exp` and `sqrt` for in-place and not in-place variants.

[sqrt](https://pytorch.org/docs/stable/generated/torch.sqrt.html)
[exp](https://pytorch.org/docs/stable/generated/torch.Tensor.exp.html#torch.Tensor.exp)

Refactor: use 'NAME' field in yaml for generated shader name in `gen_vulkan_spv.py`

Test Plan:
New tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*unary_op*"

Parsing buck files: finished in 16.1 sec
Creating action graph: finished in 0.7 sec
Downloaded 75/3986 artifacts, 248.89 Mbytes, 96.3% cache miss (for updated rules)
Building: finished in 08:24.0 min (100%) 2571/2571 jobs, 2571/2571 updated
  Total time: 08:40.9 min
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *unary_op*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.unary_op_exp
[       OK ] VulkanAPITest.unary_op_exp (479 ms)
[ RUN      ] VulkanAPITest.unary_op_exp_
[       OK ] VulkanAPITest.unary_op_exp_ (1 ms)
[ RUN      ] VulkanAPITest.unary_op_sqrt
[       OK ] VulkanAPITest.unary_op_sqrt (2 ms)
[ RUN      ] VulkanAPITest.unary_op_sqrt_
[       OK ] VulkanAPITest.unary_op_sqrt_ (2 ms)
[----------] 4 tests from VulkanAPITest (485 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (485 ms total)
[  PASSED  ] 4 tests.
```

All tests:
https://www.internalfb.com/phabricator/paste/view/P786547213

Run clang-format on shader files and `UnaryOp.cpp`

Differential Revision: D47271856

