### PR TITLE
aot inductor: opportunistically fix check_output -> check_call

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -807,7 +807,7 @@ class AotCodeCache:
                     ).split(" ")
                     log.debug("aot compilation command: %s", " ".join(cmd))
                     try:
-                        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                        subprocess.check_call(cmd)
                     except subprocess.CalledProcessError as e:
                         raise exc.CppCompileError(cmd, e.output) from e
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #104997

Summary:

This usage is not ideal:

    subprocess.check_output(cmd, stderr=subprocess.STDOUT)

* `check_output` will capture the command's stdout, and here we did not
  return it
* not ideal to redirect the sub-command's stderr to the host process's
  stdout (with `check_call`, stdout stays stdout, stderr stays stderr).

Test Plan:

CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov