### PR TITLE
Fix initializer naming at torch.onnx.ExportOutput.save_model_with_external_data

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -211,6 +211,30 @@ def skip_dynamic_fx_test(reason: str):
     return skip_dec
 
 
+def skip_op_level_debug_test(reason: str):
+    """Skip tests with op_level_debug enabled.
+
+    Args:
+        reason: The reason for skipping tests with op_level_debug enabled.
+
+    Returns:
+        A decorator for skipping tests with op_level_debug enabled.
+    """
+
+    def skip_dec(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if self.op_level_debug:
+                raise unittest.SkipTest(
+                    f"Skip test with op_level_debug enabled. {reason}"
+                )
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return skip_dec
+
+
 def skip_in_ci(reason: str):
     """Skip test in CI.
 

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -733,6 +733,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 onnx_initializer_location,
                 tuple(ctx.paths),
                 onnx_model,
+                rename_initializer=True,
             )
             # Generate random inputs.
             args = create_args()
@@ -798,7 +799,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     @pytorch_test_common.skip_dynamic_fx_test(
         "FakeTensor exporting is not supported by dynamic axes."
     )
-    def test_large_scale_exporter_with_tiny_gpt2(self):
+    def test_fx_symbolic_tracer_large_scale_exporter_with_tiny_gpt2(self):
         model_name = "sshleifer/tiny-gpt2"
 
         def create_model() -> nn.Module:
@@ -816,6 +817,117 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         self._test_fx_symbolic_tracer_large_scale_exporter(
             "tiny_gpt2",
+            create_model,
+            create_args,
+            create_pytorch_only_extra_kwargs,
+        )
+
+    @_beartype.beartype
+    def _test_fake_tensor_mode_exporter(
+        self,
+        model_name: str,
+        create_model: Callable,
+        create_args: Callable,
+        create_pytorch_only_kwargs: Callable,
+    ):
+        """Test helper for large-scale exporter.
+
+        Arguments:
+            model_name: Name of the model. It used to name temporary files.
+            create_model: A function that creates a model. It should always create the same model.
+            create_args: A function that creates random input arguments for the model.
+            create_pytorch_only_kwargs: A function that creates kwargs for calling PyTorch model with real tensors.
+
+        This test contains several steps.
+
+        1. Create a toy model.
+        2. Save the toy's state (parameters) to a file. This is for simulating a checkpoint file.
+        3. Load it back and export it to ONNX with large-scale exporter.
+            All operations (including model loading) are done under
+            FakeTensorMode so no real tensor is created and no real
+            computation happens.
+        4. Run PyTorch and ONNX models and compare their results.
+        """
+
+        # Create the toy model with real weight.
+        real_model = create_model()
+
+        with tempfile.NamedTemporaryFile(
+            prefix=model_name, suffix=".pt"
+        ) as tmp_checkpoint_file:
+            # Dump state_dict to a file to simulate how HuggingFace model is initialized.
+            # The file will be loaded via .load_state_dict(...)
+            torch.save(real_model.state_dict(), tmp_checkpoint_file.name)
+
+            with torch.onnx.enable_fake_mode() as fake_context:
+                fake_args = create_args()
+                fake_kwargs = create_pytorch_only_kwargs()
+                fake_model = create_model()
+
+            # Export the model with fake inputs and parameters
+            export_options = torch.onnx.ExportOptions(
+                opset_version=self.opset_version,
+                dynamic_shapes=self.dynamic_shapes,
+                op_level_debug=self.op_level_debug,
+                fake_context=fake_context,
+            )
+            export_output = torch.onnx.dynamo_export(
+                fake_model, *fake_args, **fake_kwargs, export_options=export_options
+            )
+
+            with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
+                export_output.save(
+                    tmp_onnx_file.name, model_state_dict=tmp_checkpoint_file.name
+                )
+
+                # Generate random inputs.
+                args = create_args()
+                kwargs = create_pytorch_only_kwargs()
+                # Original outputs.
+
+                # pdb.set_trace()
+                ref_outputs = export_output.adapt_torch_outputs_to_onnx(
+                    real_model(*args, **kwargs)
+                )
+                # ORT outputs.
+                args_not_none = export_output.adapt_torch_inputs_to_onnx(*args)
+                # Drop Parameters and buffers added by fx_serialization.save_model_with_external_data
+                args_not_none = args_not_none[: len(args) - len(kwargs)]
+
+                ort_outputs = onnx_test_common.run_ort(
+                    tmp_onnx_file.name,
+                    args_not_none,
+                )
+
+                assert len(ref_outputs) == len(ort_outputs)
+
+                for ref_output, ort_output in zip(ref_outputs, ort_outputs):
+                    torch.testing.assert_close(ref_output, torch.tensor(ort_output))
+
+    @pytorch_test_common.skip_op_level_debug_test(
+        "op_level_debug_test does not support FakeTensor yet."
+    )
+    def test_fake_tensor_mode_simple(self):
+        def create_model() -> nn.Module:
+            class Model(torch.nn.Module):
+                def __init__(self) -> None:
+                    super().__init__()
+                    self.linear = torch.nn.Linear(2, 2)
+
+                def forward(self, x):
+                    out = self.linear(x)
+                    return out
+
+            return Model()
+
+        def create_args():
+            return (torch.rand(5, 2, 2),)
+
+        def create_pytorch_only_extra_kwargs():
+            return {}
+
+        self._test_fake_tensor_mode_exporter(
+            "simple",
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -727,6 +727,10 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             # Initializers are saved to tmp_folder/onnx_initializer_location/*.onnx
             onnx_model_location = model_name + "_external_data.onnx"
             onnx_initializer_location = model_name + "_initializers"
+            # TODO: We are using the internal `save_model_with_external_data` instead of public
+            # `ExportOutput.save` because we need to rename ONNX initializers before saving.
+            # This is only needed/allowed because we are using `fx_tracer=FXSymbolicTracer`,
+            # which is not an official FX tracer.
             fx_serialization.save_model_with_external_data(
                 tmp_folder,
                 onnx_model_location,

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -838,9 +838,9 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         Arguments:
             model_name: Name of the model. It used to name temporary files.
-            create_model: A function that creates a model. It should always create the same model.
-            create_args: A function that creates random input arguments for the model.
-            create_kwargs: A function that creates kwargs for calling PyTorch model with real tensors.
+            create_model: A function that creates a model.
+            create_args: A function that creates positional inputs for the model.
+            create_kwargs: A function that creates keyword inputs for ther model.
 
         This test contains several steps.
 

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -889,7 +889,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 kwargs = create_pytorch_only_kwargs()
                 # Original outputs.
 
-                # pdb.set_trace()
                 ref_outputs = export_output.adapt_torch_outputs_to_onnx(
                     real_model(*args, **kwargs)
                 )

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -113,6 +113,10 @@ def save_model_with_external_data(
             If an input name matches a tensor loaded from "torch_load_paths",
             the tensor will be saved as that input's external initializer.
         rename_initializer: Replaces "." by "_" for all ONNX initializer names.
+            Not needed by the official torch.onnx.dynamo_export. This is a hack
+            for supporting `FXSymbolicTracer` tracer with fake tensor mode.
+            In short, `FXSymbolicTracer` lifts FX parameters (self.linear_weight)
+            as inputs (`def forward(self, linear_weight)`) and therefore, `.` cannot be used.
     """
     # FIXME: Avoid importing onnx into torch.onnx.
     import onnx
@@ -124,24 +128,25 @@ def save_model_with_external_data(
     for path in torch_load_paths:
         state_dict = torch.load(path)
         for name, tensor in state_dict.items():
-            # Basically, "transformer.attention.self.query.weight" is mapped
-            # to "transformer_attention_self_query_weight" for mimicking the
-            # name-modifying code in FX-to-ONNX exporter.
-            # See function _replace_get_attr_with_placeholder for details.
-            name = name.replace(".", "_") if rename_initializer else name
-            # For each PyTorch tensor name loaded by torch.load,
-            #  1.  Search its best match in ONNX model. E.g., the match of
-            #       "transformer_attention_weight" could be "attention_weight".
-            #  2.  Set "tensor" as the initializer of the matched ONNX input.
-            #      E.g., "tensor" is stored as the initializer of "attention_weight".
-            # Step 1 is required because sometimes, tensor names are stored with prefix the dictionary
-            # loaded by torch.load.
-            for onnx_input_name in onnx_input_names:
-                if onnx_input_name.endswith(name) or name.endswith(onnx_input_name):
-                    # Find a match. Change name to the matched ONNX input name, so that we
-                    # create initializer with the right ONNX name.
-                    name = onnx_input_name
-                    break
+            if rename_initializer:
+                # Basically, "transformer.attention.self.query.weight" is mapped
+                # to "transformer_attention_self_query_weight" for mimicking the
+                # name-modifying code in FX-to-ONNX exporter.
+                # See function _replace_get_attr_with_placeholder for details.
+                name = name.replace(".", "_")
+                # For each PyTorch tensor name loaded by torch.load,
+                #  1.  Search its best match in ONNX model. E.g., the match of
+                #       "transformer_attention_weight" could be "attention_weight".
+                #  2.  Set "tensor" as the initializer of the matched ONNX input.
+                #      E.g., "tensor" is stored as the initializer of "attention_weight".
+                # Step 1 is required because sometimes, tensor names are stored with prefix the dictionary
+                # loaded by torch.load.
+                for onnx_input_name in onnx_input_names:
+                    if onnx_input_name.endswith(name) or name.endswith(onnx_input_name):
+                        # Find a match. Change name to the matched ONNX input name, so that we
+                        # create initializer with the right ONNX name.
+                        name = onnx_input_name
+                        break
 
             relative_tensor_file_path = os.path.join(initializer_location, name)
             # Create one file per tensor.

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -124,6 +124,10 @@ def save_model_with_external_data(
     for path in torch_load_paths:
         state_dict = torch.load(path)
         for name, tensor in state_dict.items():
+            # Basically, "transformer.attention.self.query.weight" is mapped
+            # to "transformer_attention_self_query_weight" for mimicking the
+            # name-modifying code in FX-to-ONNX exporter.
+            # See function _replace_get_attr_with_placeholder for details.
             name = name.replace(".", "_") if rename_initializer else name
             # For each PyTorch tensor name loaded by torch.load,
             #  1.  Search its best match in ONNX model. E.g., the match of


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105002

This PR is only relevant for the Fake tensor Mode ONNX export. For the conventional export, everything is unchanged.

* An optional `rename_initializer=False` argument is added to an internal function `torch/onnx/_internal/fx/serialization.py::save_model_with_external_data` which is used by the public API `ExportOutput.save`. 
* The default behavior (`rename_initializer=False`) is meant to be used by public API `torch.onnx.dynamo_export` with the default Dynamo-based FX tracer (`DynamoExport`). In this scenario, both graph ONNX graph inputs and initializers have matching name with `.` in it (e.g. `linear.weight`)
* `rename_initializer=True` is meant to be used by `torch.onnx.dynamo_export` with a non-publicly-supported FX tracer called `FXSymbolicTracer`. This tracer lifts the FX graph initializers as inputs before FX->ONNX start, and because of this, the initializer names must be valid python identifiers (meaning `.` are not supported argument name and must be replaced by `_` or similar). This causes the graph inputs to have names with `_` (e.g. `linear_weight`) while the initializers have `.` (e.g. `linear.weight`) in their name. This flag resolves this mismatch by replacing `.` by `_` when saving the ONNX proto (`save_model_with_external_data`).
* This PR also adds unit tests for numerical validation against pytorch eager for onnx export using dynamo-based fx tracer and fake mode enabled. (There are already tests for export with fx symbolic tracer with fake mode)