### PR TITLE
Read out real strides from compilation result, rather than real args

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -737,6 +737,25 @@ class CudaReproTests(TestCase):
         with torch.no_grad():
             self.common(mod, (torch.randn(4, 4),))
 
+    @config.patch({"fallback_random": True, "triton.cudagraphs": True})
+    def test_xlnet_lm_stride_repro(self):
+        class Repro(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dropout = nn.Dropout(p=0.1, inplace=False)
+
+            def forward(self, x):
+                y = torch._C._nn.gelu(x)
+                return self.dropout(y)
+
+        mod = Repro()
+        x = torch.randn((512, 1, 4096), requires_grad=True, device="cuda")
+        y = torch.compile(mod)(x)
+        # Inductor claims the output layout of gelu's saved variable for
+        # backwards will be (4096, 4096, 1) but in actuality it is (4096,
+        # 2097152, 1).  Fortunately this doesn't actually matter in practice.
+        y.sum().backward()
+
     def test_lookup_seed_backward(self):
         @torch.compile(fullgraph=True)
         def forward(inductor_seeds, mul_4, view_15):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -3029,12 +3029,12 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                         if real_stride is None:
                             continue
 
-                        assert _get_hints(real_stride) == all_args[i].stride(), f"{real_stride} {all_args[i].stride()}"
+                        assert real_stride == all_args[i].stride(), f"{real_stride} {all_args[i].stride()}"
 
                         # Comparing ph_arg.stride() with real_stride directly may
                         # cause dynamic dimensions in ph_arg being specialized to static
                         # value. Using the hints to avoid that.
-                        if _get_hints(ph_arg.stride()) != _get_hints(real_stride):
+                        if _get_hints(ph_arg.stride()) != real_stride:
                             # Note that here we use the stride of the real tensor to
                             # restride a FakeTensor. This does not cause trouble
                             # for dynamic shape since this code path only get

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -485,7 +485,12 @@ class TracingContext:
         # this is for extended return calling convention from backend
         # compiler to aot_autograd
         # Per output, what the compiler specified stride of the output is,
-        # or None if no stride is known
+        # or None if no stride is known.  This is always the HINT, it
+        # is never a SymInt (it would be better if it was a SymInt, but
+        # I can't conveniently get this from Inductor atm.  Also, be
+        # careful not to accidentally induce guards on the SymInt if
+        # you ever do change this in aot_autograd.py; you should check
+        # on permutations preferentially.)
         self.output_strides: Optional[List[Optional[List[int]]]] = None
 
     @staticmethod

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -482,6 +482,11 @@ class TracingContext:
         # this is only set after aot_autograd
         self.fw_metadata = None
         self.params_flat = None
+        # this is for extended return calling convention from backend
+        # compiler to aot_autograd
+        # Per output, what the compiler specified stride of the output is,
+        # or None if no stride is known
+        self.output_strides: Optional[List[Optional[List[int]]]] = None
 
     @staticmethod
     def extract_stack():
@@ -519,6 +524,20 @@ class TracingContext:
             yield
         finally:
             tc.frame_summary_stack.pop()
+
+    @staticmethod
+    @contextlib.contextmanager
+    def report_output_strides():
+        tc = TracingContext.get()
+        if tc is None:
+            yield None
+            return
+        old_output_strides = tc.output_strides
+        tc.output_strides = []
+        try:
+            yield tc.output_strides
+        finally:
+            tc.output_strides = old_output_strides
 
     @staticmethod
     def set_current_loc(filename, lineno, frame_name):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -496,6 +496,15 @@ def fx_codegen_and_compile(
         )
         with V.set_graph_handler(graph):
             graph.run(*example_inputs)
+            context = torch._guards.TracingContext.get()
+            if context is not None and context.output_strides is not None:
+                # Return the output strides to the caller via TracingContext
+                assert len(context.output_strides) == 0
+                for out in graph.graph_outputs:
+                    if hasattr(out, "layout"):
+                        context.output_strides.append(tuple(out.layout.stride))
+                    else:
+                        context.output_strides.append(None)
             compiled_fn = graph.compile_to_fn()
             compiled_graph = CompiledFxGraph(
                 compiled_artifact=compiled_fn,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -203,6 +203,7 @@ def inner_compile_with_cpp_wrapper(inner_compile):
                 compiled = inner_compile(
                     clone_graph(gm), example_inputs, **kwargs_patched
                 )
+                torch._guards.TracingContext.get().output_strides.clear()
 
                 def materialize(x):
                     if isinstance(x, (torch.SymInt, torch.SymFloat)):
@@ -502,7 +503,11 @@ def fx_codegen_and_compile(
                 assert len(context.output_strides) == 0
                 for out in graph.graph_outputs:
                     if hasattr(out, "layout"):
-                        context.output_strides.append(tuple(out.layout.stride))
+                        context.output_strides.append(
+                            tuple(
+                                V.graph.sizevars.size_hint(s) for s in out.layout.stride
+                            )
+                        )
                     else:
                         context.output_strides.append(None)
             compiled_fn = graph.compile_to_fn()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -203,7 +203,8 @@ def inner_compile_with_cpp_wrapper(inner_compile):
                 compiled = inner_compile(
                     clone_graph(gm), example_inputs, **kwargs_patched
                 )
-                torch._guards.TracingContext.get().output_strides.clear()
+                if torch._guards.TracingContext.get().output_strides:
+                    torch._guards.TracingContext.get().output_strides.clear()
 
                 def materialize(x):
                     if isinstance(x, (torch.SymInt, torch.SymFloat)):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104971
* __->__ #105010
* #105009

This prefigures a refactor that will move the backward compilation
to entirely ahead of time, so I need to extract these strides some
other way.  Straight from the compiler's mouth will do it.

I can't easily get the information via the return result of `fw_compiler` without changing the calling convention, so instead I smuggle it via TracingContext. TracingContext may be None when we are compiling patterns for the joint graph pattern matcher.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8