### PR TITLE
[PyTorch] Add Vulkan support for at::softmax 1,2,3 dimension tensors

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3388,29 +3388,34 @@ TEST_F(VulkanAPITest, sigmoid_) {
   ASSERT_TRUE(check);
 }
 
-void test_softmax_4d(int64_t dim) {
+
+TEST_F(VulkanAPITest, softmax) {
   c10::InferenceMode mode;
-
-  at::Tensor test_in[] = {
-    at::rand({1, 3, 4, 2}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    at::rand({4, 8, 5, 7}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    at::rand({9, 11, 12, 12}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+  std::vector<std::vector<int64_t>> test_in_dims = {
+    {1, 3, 4, 2},
+    {4, 8, 5, 7},
+    {9, 11, 12, 12},
   };
-  for (auto in_cpu : test_in) {
-      const auto out_cpu = at::softmax(in_cpu, dim);
-      const auto in_vulkan = in_cpu.vulkan();
-      const auto out_vulkan = at::softmax(in_vulkan, dim);
-      const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-      if (!check) {
-        showRtol(out_cpu, out_vulkan.cpu());
+  for (const std::vector<int64_t >& dim_vec : test_in_dims) {
+    for (uint32_t trunc = 0; trunc < dim_vec.size(); trunc++) {
+      const std::vector<int64_t> trunc_dim_vec = std::vector<int64_t>(dim_vec.begin(), dim_vec.end() - trunc);
+      at::Tensor in_cpu = at::rand(trunc_dim_vec, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+      for (uint32_t dim = 0; dim < trunc_dim_vec.size(); dim++) {
+        const at::Tensor out_cpu = at::softmax(in_cpu, dim);
+        const at::Tensor in_vulkan = in_cpu.vulkan();
+        const at::Tensor out_vulkan = at::softmax(in_vulkan, dim);
+        const bool check = almostEqual(out_cpu, out_vulkan.cpu());
+        if (!check) {
+          std::cout << "Softmax test failed on axis " << dim << "for tensor dims {";
+          for (uint32_t place = 0; place < trunc_dim_vec.size() - 1; place++) {
+            std::cout << trunc_dim_vec[place] << " ";
+          }
+          std::cout << trunc_dim_vec.back() << "}" << std::endl;
+          showRtol(out_cpu, out_vulkan.cpu());
+        }
+        ASSERT_TRUE(check);
       }
-      ASSERT_TRUE(check);
-  }
-}
-
-TEST_F(VulkanAPITest, softmax_4d) {
-  for (int dim = 0; dim < 4; dim++) {
-    test_softmax_4d(dim);
+    }
   }
 }
 


### PR DESCRIPTION
Summary: This rounds out the support for the [softmax function](https://pytorch.org/docs/stable/generated/torch.nn.Softmax.html) on the Vulkan GPU backend. The test inputs of the 1,2,3 dimension cases are simply the truncated existing 4 dimension inputs. The existing shader algorithms are reused.

Test Plan:
1. `buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1` on Apple M1 MacBook
2. Confirm all tests pass with no regression, and the added tests `*softmax*` pass under `-- --gtest_filter="*softmax*"`
2a. All tests P782531732
2b. `softmax` tests P782529114

```
~/fbsource » buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*softmax*"
Buck UI: https://www.internalfb.com/buck2/692eb82d-c2ee-49bb-833f-3c11d6e2fea9
Jobs completed: 4. Time elapsed: 0.1s.
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *softmax*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VulkanAPITest
[ RUN      ] VulkanAPITest.softmax
[       OK ] VulkanAPITest.softmax (42 ms)
[ DISABLED ] VulkanAPITest.DISABLED_log_softmax
[----------] 1 test from VulkanAPITest (42 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (42 ms total)
[  PASSED  ] 1 test.

  YOU HAVE 1 DISABLED TEST

```

Reviewed By: SS-JIA

Differential Revision: D46985319

