### PR TITLE
Follow file move for functorch bits for ciflow/inductor

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,8 +22,8 @@
 - torch/_subclasses/meta_utils.py
 - test/distributed/test_dynamo_distributed.py
 - test/distributed/test_inductor_collectives.py
-- functorch/_src/partitioners.py
-- functorch/_src/aot_autograd.py
+- torch/_functorch/partitioners.py
+- torch/_functorch/aot_autograd.py
 - .ci/docker/ci_commit_pins/**
 - .github/ci_commit_pins/**
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105019

Signed-off-by: Edward Z. Yang <ezyang@meta.com>