### PR TITLE
[inductor] Add min/max to index propagation pass

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -246,6 +246,11 @@ class ExprPrinterTests(TorchTestCase):
             x = sympy.Symbol("x", integer=True)
             expr = f(-2, x)
             self.assertEqual(texpr(expr), f"tl.math.{s}(-2, x)")
+            self.assertEqual(cexpr(expr), f"std::{s}(-2L, x)")
+
+            expr = f(x, 2 * x, 3 * x)
+            self.assertEqual(texpr(expr), f"tl.math.{s}(x, tl.math.{s}(2*x, 3*x))")
+            self.assertEqual(cexpr(expr), f"std::{s}({{x, 2L*x, 3L*x}})")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -346,6 +346,24 @@ class CppPrinter(ExprPrinter):
         r = f"std::ceil({self._print(expr.args[0])})"
         return f"static_cast<{INDEX_TYPE}>({r})" if expr.is_integer else r
 
+    def _print_Min(self, expr):
+        args = [self._print(a) for a in expr.args]
+        if len(args) == 2:
+            return f"std::min({args[0]}, {args[1]})"
+        else:
+            # Initializer list overload
+            il = "{" + ", ".join(args) + "}"
+            return f"std::min({il})"
+
+    def _print_Max(self, expr):
+        args = [self._print(a) for a in expr.args]
+        if len(args) == 2:
+            return f"std::max({args[0]}, {args[1]})"
+        else:
+            # Initializer list overload
+            il = "{" + ", ".join(args) + "}"
+            return f"std::max({il})"
+
 
 cexpr = CppPrinter().doprint
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -63,13 +63,23 @@ class TritonPrinter(PythonPrinter):
         return f"tl.math.sqrt({self.paren(self._print(expr))}.to(tl.float32))"
 
     def _print_Min(self, expr):
-        a = self._print(expr.args[0])
-        b = self._print(expr.args[1])
+        nargs = len(expr.args)
+        if len(expr.args) == 1:
+            return self._print(expr.args[0])
+
+        mid = len(expr.args) // 2
+        a = self._print(sympy.Min(*expr.args[:mid]))
+        b = self._print(sympy.Min(*expr.args[mid:]))
         return f"tl.math.min({a}, {b})"
 
     def _print_Max(self, expr):
-        a = self._print(expr.args[0])
-        b = self._print(expr.args[1])
+        nargs = len(expr.args)
+        if len(expr.args) == 1:
+            return self._print(expr.args[0])
+
+        mid = len(expr.args) // 2
+        a = self._print(sympy.Max(*expr.args[:mid]))
+        b = self._print(sympy.Max(*expr.args[mid:]))
         return f"tl.math.max({a}, {b})"
 
 

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -116,6 +116,16 @@ class SymPyOps:
         result_expr = ModularIndexing(x.expr, sympy.Integer(1), y.expr)
         return TypedExpr(result_expr, result_type)
 
+    @staticmethod
+    def minimum(x, y):
+        result_type = torch.promote_types(x.dtype, y.dtype)
+        return TypedExpr(sympy.Min(x.expr, y.expr), result_type)
+
+    @staticmethod
+    def maximum(x, y):
+        result_type = torch.promote_types(x.dtype, y.dtype)
+        return TypedExpr(sympy.Max(x.expr, y.expr), result_type)
+
 
 @dataclass
 class IndexPropVar:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -393,9 +393,9 @@ def sympy_symbol(name) -> sympy.Symbol:
     # This should never be used for creating shape/stride symbols, as those
     # should all be allocated before Inductor.
     assert name[0] != "s"
-    # NOTE: shape symbols are defined with positive=True, which means > 0.
-    # Index variables may be zero so use negative=False, which means >= 0.
-    return sympy.Symbol(name, integer=True, negative=False)
+    # NOTE: shape symbols are positive (> 0), but index variables are only
+    # non-negative (>= 0).
+    return sympy.Symbol(name, integer=True, nonnegative=True)
 
 
 def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]) -> sympy.Expr:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -393,7 +393,9 @@ def sympy_symbol(name) -> sympy.Symbol:
     # This should never be used for creating shape/stride symbols, as those
     # should all be allocated before Inductor.
     assert name[0] != "s"
-    return sympy.Symbol(name, integer=True, positive=True)
+    # NOTE: shape symbols are defined with positive=True, which means > 0.
+    # Index variables may be zero so use negative=False, which means >= 0.
+    return sympy.Symbol(name, integer=True, negative=False)
 
 
 def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]) -> sympy.Expr:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #105021
* __->__ #105020

This allows `ops.minimum` and `ops.maximum` to be hoisted for indirect indexing
into direct indexing expressions. I also add support to the cpp printer for
Min/Max and fix the triton printer to support multi-argument Min/Max.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8