### PR TITLE
[PyTorch TB] Refactor formatting

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -4,11 +4,14 @@ import os
 from typing import Optional
 
 import numpy as np
+
 from google.protobuf import struct_pb2
 
-from tensorboard.compat.proto.summary_pb2 import HistogramProto
-from tensorboard.compat.proto.summary_pb2 import Summary
-from tensorboard.compat.proto.summary_pb2 import SummaryMetadata
+from tensorboard.compat.proto.summary_pb2 import (
+    HistogramProto,
+    Summary,
+    SummaryMetadata,
+)
 from tensorboard.compat.proto.tensor_pb2 import TensorProto
 from tensorboard.compat.proto.tensor_shape_pb2 import TensorShapeProto
 from tensorboard.plugins.custom_scalar import layout_pb2
@@ -18,9 +21,26 @@ from tensorboard.plugins.text.plugin_data_pb2 import TextPluginData
 from ._convert_np import make_np
 from ._utils import _prepare_video, convert_to_HWC
 
-__all__ = ['hparams', 'scalar', 'histogram_raw', 'histogram', 'make_histogram', 'image', 'image_boxes', 'draw_boxes',
-           'make_image', 'video', 'make_video', 'audio', 'custom_scalars', 'text', 'pr_curve_raw', 'pr_curve', 'compute_curve',
-           'mesh']
+__all__ = [
+    "hparams",
+    "scalar",
+    "histogram_raw",
+    "histogram",
+    "make_histogram",
+    "image",
+    "image_boxes",
+    "draw_boxes",
+    "make_image",
+    "video",
+    "make_video",
+    "audio",
+    "custom_scalars",
+    "text",
+    "pr_curve_raw",
+    "pr_curve",
+    "compute_curve",
+    "mesh",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -93,19 +113,19 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
     """
     import torch
     from tensorboard.plugins.hparams.api_pb2 import (
+        DataType,
         Experiment,
         HParamInfo,
         MetricInfo,
         MetricName,
         Status,
-        DataType,
     )
     from tensorboard.plugins.hparams.metadata import (
-        PLUGIN_NAME,
-        PLUGIN_DATA_VERSION,
         EXPERIMENT_TAG,
-        SESSION_START_INFO_TAG,
+        PLUGIN_DATA_VERSION,
+        PLUGIN_NAME,
         SESSION_END_INFO_TAG,
+        SESSION_START_INFO_TAG,
     )
     from tensorboard.plugins.hparams.plugin_data_pb2 import (
         HParamsPluginData,
@@ -456,7 +476,10 @@ def image_boxes(
     tensor_boxes = make_np(tensor_boxes)
     tensor_image = tensor_image.astype(np.float32) * _calc_scale_factor(tensor_image)
     image = make_image(
-        tensor_image.clip(0, 255).astype(np.uint8), rescale=rescale, rois=tensor_boxes, labels=labels
+        tensor_image.clip(0, 255).astype(np.uint8),
+        rescale=rescale,
+        rois=tensor_boxes,
+        labels=labels,
     )
     return Summary(value=[Summary.Value(tag=tag, image=image)])
 
@@ -494,6 +517,7 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
         ANTIALIAS = Image.ANTIALIAS
     image = image.resize((scaled_width, scaled_height), ANTIALIAS)
     import io
+
     output = io.BytesIO()
     image.save(output, format="PNG")
     image_string = output.getvalue()
@@ -818,8 +842,8 @@ def mesh(
     Returns:
       Merged summary for mesh/point cloud representation.
     """
-    from tensorboard.plugins.mesh.plugin_data_pb2 import MeshPluginData
     from tensorboard.plugins.mesh import metadata
+    from tensorboard.plugins.mesh.plugin_data_pb2 import MeshPluginData
 
     json_config = _get_json_config(config_dict)
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -3,43 +3,38 @@ consumed by TensorBoard for visualization."""
 
 import os
 import time
+
 import torch
 
 from tensorboard.compat import tf
-from tensorboard.compat.proto.event_pb2 import SessionLog
-from tensorboard.compat.proto.event_pb2 import Event
 from tensorboard.compat.proto import event_pb2
+from tensorboard.compat.proto.event_pb2 import Event, SessionLog
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
 from tensorboard.summary.writer.event_file_writer import EventFileWriter
 
 from ._convert_np import make_np
-from ._embedding import (
-    make_mat,
-    make_sprite,
-    make_tsv,
-    write_pbtxt,
-    get_embedding_info,
-)
+from ._embedding import get_embedding_info, make_mat, make_sprite, make_tsv, write_pbtxt
 from ._onnx_graph import load_onnx_graph
 from ._pytorch_graph import graph
 from ._utils import figure_to_image
 from .summary import (
-    scalar,
+    audio,
+    custom_scalars,
     histogram,
     histogram_raw,
+    hparams,
     image,
-    audio,
-    text,
-    pr_curve,
-    pr_curve_raw,
-    video,
-    custom_scalars,
     image_boxes,
     mesh,
-    hparams,
+    pr_curve,
+    pr_curve_raw,
+    scalar,
+    text,
+    video,
 )
 
-__all__ = ['FileWriter', 'SummaryWriter']
+__all__ = ["FileWriter", "SummaryWriter"]
+
 
 class FileWriter:
     """Writes protocol buffers to event files to be consumed by TensorBoard.
@@ -844,6 +839,7 @@ class SummaryWriter:
             # Caffe2 models do not have the 'forward' method
             from caffe2.proto import caffe2_pb2
             from caffe2.python import core
+
             from ._caffe2_graph import (
                 model_to_graph_def,
                 nets_to_graph_def,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #104908
* __->__ #105027

This is the first diff to support logging of raw tensors for [TensorBoard Intermediate Logging](https://www.internalfb.com/intern/wiki/TensorBoard/Intermediate_Logging/)

Ultimately, we aim to support the feature where store full tensor is stored as a tensor protobuf to TB. Protobuf contains shape, dtype, and elements of the given tensor.

This diff only contains formatting changes.
-------------


Differential Revision: [D47302017](https://our.internmc.facebook.com/intern/diff/D47302017/)