### PR TITLE
[retry][dynamo][numpy] Add support for np.dtype

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1116,6 +1116,13 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         a = x.numpy()
         return a + a, a - a
 
+    @requires_numpy_pytorch_interop
+    @make_test
+    def test_numpy_dtype_argument_to_function(x):
+        import numpy as np
+
+        return np.empty_like(x, dtype=np.float64)
+
 
 def global_func_with_default_tensor_args(
     x=torch.zeros((2, 2)), *, kw_x=torch.zeros((1, 2))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1278,21 +1278,59 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             self.assertTrue(same(ref, res))
         self.assertEqual(cnts.frame_count, 2)
 
-    def test_(self):
-        def fn(x: torch.Tensor, y: int):
-            z = x.detach()
-            w = y + 1
-            torch._dynamo.graph_break()
-            return z + w
+    @requires_numpy_pytorch_interop
+    def test_mandelbrot_numpy(self):
+        def mandelbrot_numpy(max_iter):
+            # Define the boundaries of the complex plane
+            xn = 450
+            yn = 375
+            xmin = -2.25
+            xmax = 0.75
+            ymin = -1.25
+            ymax = 1.25
+
+            # Create the grid of complex numbers
+            x_values = np.linspace(xmin, xmax, xn, dtype=np.float64)
+            y_values = np.linspace(ymin, ymax, yn, dtype=np.float64)
+            rx, iy = np.meshgrid(x_values, y_values, indexing="xy")
+
+            x = rx.copy()
+            y = iy.copy()
+            mask = np.zeros_like(x)
+            for i in range(max_iter):
+                x_prev = x
+                y_prev = y
+                x = x_prev**2 - y_prev**2 + rx
+                y = 2 * x_prev * y_prev + iy
+                inside = np.sqrt(x**2 + y**2) <= 2
+                mask += inside
+            return mask
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(mandelbrot_numpy)
+        for _ in range(10):
+            x = torch.randint(100, (1,))
+            ref = mandelbrot_numpy(x.item())
+            res = opt_fn(x.item())
+            self.assertTrue(same(ref, res))
+
+    def test_graph_break_correctly_when_passing_numpy_ndarray_to_torch_function(self):
+        # from transformers/models/big_bird/modeling_big_bird.py
+        def fn(x: int, y: torch.Tensor):
+            ndarray_list = [np.ones([2, x])]
+            ndarray = np.stack(ndarray_list, axis=0)
+            tensor = torch.tensor(ndarray, dtype=torch.long)
+            tensor.unsqueeze_(0)
+            return tensor + y
 
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch._dynamo.optimize(cnts)(fn)
-        for _ in range(10):
-            x = torch.randn([1, 3])
-            y = 5
+        for x in range(1, 10):
+            y = torch.randn([1, 2, x])
             ref = fn(x, y)
             res = opt_fn(x, y)
             self.assertTrue(same(ref, res))
+        # we expect fn to have 2 frames
         self.assertEqual(cnts.frame_count, 2)
 
     def test_inplace_view_on_graph_input(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1330,7 +1330,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             ref = fn(x, y)
             res = opt_fn(x, y)
             self.assertTrue(same(ref, res))
-        # we expect fn to have 2 frames
+        # Graph break: call_function args: NumpyVariable() ConstantVariable(dtype) from user code at ...
+        #     tensor = torch.tensor(ndarray, dtype=torch.long)
         self.assertEqual(cnts.frame_count, 2)
 
     def test_inplace_view_on_graph_input(self):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -815,8 +815,12 @@ class NumpyVariable(VariableTracker):
         from .tensor import NumpyNdarrayVariable
 
         options = VariableTracker.propagate([[self]], [args], [list(kwargs.values())])
-        # lookup method name in torch_np
-        if hasattr(torch_np, self.value.__name__):
+        # lookup method name in torch_np. Things like np.dtype(float) are not supported yet.
+        if self.value.__name__ == "dtype":
+            unimplemented(
+                f"numpy dtype function is not supported yet. Got {self.value}."
+            )
+        elif hasattr(torch_np, self.value.__name__):
             func = getattr(torch_np, self.value.__name__)
             return wrap_fx_proxy_cls(
                 target_cls=NumpyNdarrayVariable,
@@ -846,6 +850,22 @@ class NumpyVariable(VariableTracker):
 
     def as_python_constant(self):
         return self.value
+
+    def as_proxy(self):
+        # this handles numpy dtype attribute such as np.float32.
+        if isinstance(self.value, type) and config.numpy_ndarray_as_tensor:
+            # retrieve attribute str. E.g., "float32" if given np.float32
+            import torch_np
+
+            attr = self.value.__name__
+            # get torch_np equivalent
+            tnp_dtype = torch_np.dtype(attr)
+            # returning a string here because we are assuming all `dtype` kwargs for numpy
+            # functions can take an equivalent string and the behavior of the function would
+            # be the same as taking a numpy dtype.
+            return tnp_dtype.name
+
+        return super().as_proxy()
 
 
 # Used to keep track of NULLs pushed on the stack for Python 3.11 function calls

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -13,9 +13,10 @@ from ..exc import unimplemented
 from ..source import AttrSource, ODictGetItemSource
 from ..utils import (
     check_constant_args,
+    get_custom_getattr,
     HAS_NUMPY_TORCH_INTEROP,
     identity,
-    proxy_args_kwargs, get_custom_getattr,
+    proxy_args_kwargs,
 )
 from .base import MutableLocal, VariableTracker
 from .dicts import DefaultDictVariable
@@ -825,7 +826,9 @@ class NumpyVariable(VariableTracker):
             #  wrapped by NumpyNdarrayVariable which is wrong!
             getattr_fn = get_custom_getattr(torch_np)
             if getattr_fn:
-                unimplemented("torch_np has custom getattr implementation and dynamo doesn't support it")
+                unimplemented(
+                    "torch_np has custom getattr implementation and dynamo doesn't support it"
+                )
             func = getattr(torch_np, self.value.__name__)
             return wrap_fx_proxy_cls(
                 target_cls=NumpyNdarrayVariable,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105034

Original PR: #103546

Trying to support numpy function call in dynamo, with numpy dtype as argument.

For example:

```
def fn(x: int):
    return np.empty_like(x, dtype=np.float64)
```

This currently doesn't work because `NumpyVariable` doesn't implement `as_proxy()`. The idea in `as_proxy()` for now is to convert `np.float64` and other np.<dtype> into `str` and then feed into the corresponding `torch_np` method. The assumption here is that all `torch_np` methods that are taking `dtype` kwarg will be able to also take `str` as `dtype`. This assumption stands for `numpy`.

For previous example, we convert `np.float64` to `"float64"` in `as_proxy()` and then feed it into `torch_np.empy_like()` method.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov