### PR TITLE
fix `hash_storage`'s padding calculation

### DIFF
--- a/torch/utils/_content_store.py
+++ b/torch/utils/_content_store.py
@@ -117,7 +117,7 @@ def hash_storage(storage: torch.UntypedStorage, *, stable_hash: bool = False) ->
         # The dtype-casting view cannot be compiled, and so the
         # padding/reshaping also needs to be done externally even
         # though it could be profitably fused
-        pad = x.numel() % 4
+        pad = -x.numel() % 4
         if pad > 0:
             x = F.pad(x, (0, pad), "constant", 0)
         x = x.view(torch.int32)


### PR DESCRIPTION
Fixes #105035.

The existing implementation attempts to make `x.numel() % 4 == 0` by appending `x.numel() % 4` zeros. This is backwards, e.g if `x.numel() % 4 == 1`, we need to append `[0, 0, 0]`, not `[0]`.