### PR TITLE
[export] Allow optional call-spec

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -45,8 +45,8 @@ LeafValue = Union[
 # Information to maintain user calling/returning specs
 @dataclasses.dataclass
 class CallSpec:
-    in_spec: pytree.TreeSpec
-    out_spec: pytree.TreeSpec
+    in_spec: Optional[pytree.TreeSpec]
+    out_spec: Optional[pytree.TreeSpec]
 
 
 # Extra information for joint graphs

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -215,15 +215,15 @@ def deserialize_operator(serialized_target: str):
 
 def serialize_call_spec(call_spec: ep.CallSpec) -> CallSpec:
     return CallSpec(
-        in_spec=pytree_to_str(call_spec.in_spec),
-        out_spec=pytree_to_str(call_spec.out_spec),
+        in_spec=pytree_to_str(call_spec.in_spec) if call_spec.in_spec else "",
+        out_spec=pytree_to_str(call_spec.out_spec) if call_spec.out_spec else "",
     )
 
 
 def deserialize_call_spec(call_spec: CallSpec) -> ep.CallSpec:
     return ep.CallSpec(
-        in_spec=str_to_pytree(call_spec.in_spec),
-        out_spec=str_to_pytree(call_spec.out_spec),
+        in_spec=str_to_pytree(call_spec.in_spec) if call_spec.in_spec else None,
+        out_spec=str_to_pytree(call_spec.out_spec) if call_spec.out_spec else None,
     )
 
 


### PR DESCRIPTION
Summary: Submodules may have a none call-spec values, which is ok. Updating types + serializer to handle this

Test Plan: CI

Differential Revision: D47353101

