### PR TITLE
Fix bug in fuse_modules

### DIFF
--- a/torch/ao/quantization/fuse_modules.py
+++ b/torch/ao/quantization/fuse_modules.py
@@ -58,11 +58,11 @@ def fuse_known_modules(mod_list, is_qat, additional_fuser_method_mapping=None):
     # Move pre forward hooks of the base module to resulting fused module
     for handle_id, pre_hook_fn in mod_list[0]._forward_pre_hooks.items():
         fused.register_forward_pre_hook(pre_hook_fn)
-        del mod_list[0]._forward_pre_hooks[handle_id]
+    mod_list[0]._forward_pre_hooks.clear()
     # Move post forward hooks of the last module to resulting fused module
     for handle_id, hook_fn in mod_list[-1]._forward_hooks.items():
         fused.register_forward_hook(hook_fn)
-        del mod_list[-1]._forward_hooks[handle_id]
+    mod_list[-1]._forward_hooks.clear()
     new_mod[0] = fused
 
     for i in range(1, len(mod_list)):


### PR DESCRIPTION
Summary: This diff fixes the issue reported in https://github.com/pytorch/pytorch/issues/105063 and also related to internal caffe2 bug (reproduced error in internal fb pytorch: N3945540)

Test Plan: Wait for sandcastle with the added unit test in caffe2/torch/ao/quantization/eager/test_fuse_eager

Differential Revision: D47402357

