### PR TITLE
Fix kwargs for `checkpoint`; composition with  `fully_shard`

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -2,13 +2,18 @@
 
 import copy
 import sys
+from typing import Dict
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._composable import checkpoint, fully_shard, replicate
 from torch.distributed._shard.sharded_tensor import ShardedTensor
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, StateDictType
+from torch.distributed.fsdp import (
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+    StateDictType,
+)
 from torch.distributed.fsdp.api import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_dist_composable import (
@@ -16,7 +21,10 @@ from torch.testing._internal.common_dist_composable import (
     CompositeParamModel,
     UnitModule,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    SaveForwardInputsModel,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -144,6 +152,43 @@ class TestFSDPCheckpoint(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_checkpoint_fsdp_submodules_non_reentrant(self):
         self._test_checkpoint_fsdp_submodules(False)
+
+    @skip_if_lt_x_gpu(2)
+    def test_checkpoint_fully_shard_cast_forward_inputs(self):
+        self.run_subtests(
+            {
+                "use_reentrant": [False, True],
+                "checkpoint_strict_submodule": [False, True],
+            },
+            self._test_checkpoint_fully_shard_cast_forward_inputs,
+        )
+
+    def _test_checkpoint_fully_shard_cast_forward_inputs(
+        self, use_reentrant: bool, checkpoint_strict_submodule: bool
+    ):
+        forward_inputs: Dict[nn.Module, torch.Tensor] = {}
+        fp16_mp = MixedPrecision(param_dtype=torch.float16, cast_forward_inputs=True)
+        fp32_mp = MixedPrecision(param_dtype=torch.float32, cast_forward_inputs=True)
+
+        model = SaveForwardInputsModel(
+            forward_inputs=forward_inputs, cast_forward_inputs=False
+        ).cuda()
+        x = torch.zeros(2, 100, device="cuda")
+
+        fully_shard(model.c2, mixed_precision=fp16_mp)
+        if checkpoint_strict_submodule:
+            checkpoint(model.c2.l, use_reentrant=use_reentrant)
+        else:
+            checkpoint(model.c2, use_reentrant=use_reentrant)
+        fully_shard(model, mixed_precision=fp32_mp)
+
+        loss = model(x).sum()
+        loss.backward()
+
+        self.assertEqual(forward_inputs[model].dtype, torch.float32)
+        self.assertEqual(forward_inputs[model.c1].dtype, torch.float32)
+        # Notably, check that the recomputed forward preserves the right dtype
+        self.assertEqual(forward_inputs[model.c2].dtype, torch.float16)
 
     @skip_if_lt_x_gpu(2)
     def test_fully_shard_replicate_correct_replicate_params(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105090

This PR fixes kwargs for `checkpoint` and some composability issues with `fully_shard`, where the FSDP pre/post-forward incorrectly runs twice in backward causing errors.

Unlike for the module wrapper path, `checkpoint`'s `_no_hook` context only disables its own hooks, not FSDP's hooks. Hence, we need to make sure that FSDP does not re-run its forward hooks in backward. Checking against `BACKWARD_PRE` training state does this.