### PR TITLE
[Profiler][Memory] Export raw timestamped events in export_memory_timeline_raw

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -266,7 +266,10 @@ class _KinetoProfile:
         elif path.endswith('.gz'):
             fp = tempfile.NamedTemporaryFile('w+t', suffix='.json', delete=False)
             fp.close()
-            self.mem_tl.export_memory_timeline(fp.name, device)
+            if path.endswith('raw.json.gz'):
+                self.mem_tl.export_memory_timeline_raw(fp.name, device)
+            else:
+                self.mem_tl.export_memory_timeline(fp.name, device)
             with open(fp.name) as fin:
                 with gzip.open(path, 'wt') as fout:
                     fout.writelines(fin)


### PR DESCRIPTION
Summary:
Rather than processing the events into a time and sizes plot, dump the actual events as (timestamp, action, num of bytes, category) when output file ends in `raw.json.gz`.

This can allow downstream analysis tools to process these events. It also avoids having to control the granularity of the previous json.gz in memory profiler.

Test Plan: CI Tests

Differential Revision: D47416544

Pulled By: aaronenyeshi

