### PR TITLE
[BE] Use ValueError for input.dim check in torch.nn.modules

### DIFF
--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -192,7 +192,8 @@ class CrossMapLRN2d(Function):
         ctx.k = k
         ctx.scale = None
 
-        assert input.dim() == 4
+        if input.dim() != 4:
+            raise ValueError("CrossMapLRN2d: Expected input to be 4D, got {}D instead.".format(input.dim()))
 
         ctx.scale = ctx.scale or input.new()
         output = input.new()

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1526,7 +1526,10 @@ class Softmax2d(Module):
     """
 
     def forward(self, input: Tensor) -> Tensor:
-        assert input.dim() == 4 or input.dim() == 3, 'Softmax2d requires a 3D or 4D tensor as input'
+        if input.dim() not in (3, 4):
+            raise ValueError(
+                "Softmax2d: expected input to be 3D or 4D, got {}D instead".format(input.dim())
+            )
         return F.softmax(input, -3, _stacklevel=5)
 
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -488,7 +488,8 @@ class RNN(RNNBase):
                 hx = self.permute_hidden(hx, sorted_indices)
         else:
             batch_sizes = None
-            assert (input.dim() in (2, 3)), f"RNN: Expected input to be 2-D or 3-D but received {input.dim()}-D tensor"
+            if input.dim() not in (2, 3):
+                raise ValueError("RNN: Expected input to be 2D or 3D, got {}D tensor instead".format(input.dim()))
             is_batched = input.dim() == 3
             batch_dim = 0 if self.batch_first else 1
             if not is_batched:
@@ -796,7 +797,8 @@ class LSTM(RNNBase):
                 # the user believes he/she is passing in.
                 hx = self.permute_hidden(hx, sorted_indices)
         else:
-            assert (input.dim() in (2, 3)), f"LSTM: Expected input to be 2-D or 3-D but received {input.dim()}-D tensor"
+            if input.dim() not in (2, 3):
+                raise ValueError("LSTM: Expected input to be 2D or 3D, got {}D instead".format(input.dim()))
             is_batched = input.dim() == 3
             batch_dim = 0 if self.batch_first else 1
             if not is_batched:
@@ -1014,7 +1016,8 @@ class GRU(RNNBase):
                 hx = self.permute_hidden(hx, sorted_indices)
         else:
             batch_sizes = None
-            assert (input.dim() in (2, 3)), f"GRU: Expected input to be 2-D or 3-D but received {input.dim()}-D tensor"
+            if input.dim() not in (2, 3):
+                raise ValueError("GRU: Expected input to be 2D or 3D, got {}D instead".format(input.dim()))
             is_batched = input.dim() == 3
             batch_dim = 0 if self.batch_first else 1
             if not is_batched:
@@ -1170,8 +1173,8 @@ class RNNCell(RNNCellBase):
         self.nonlinearity = nonlinearity
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
-        assert input.dim() in (1, 2), \
-            f"RNNCell: Expected input to be 1-D or 2-D but received {input.dim()}-D tensor"
+        if input.dim() not in (1, 2):
+            raise ValueError("RNNCell: Expected input to be 1D or 2D, got {}D instead".format(input.dim()))
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -1270,8 +1273,8 @@ class LSTMCell(RNNCellBase):
         super().__init__(input_size, hidden_size, bias, num_chunks=4, **factory_kwargs)
 
     def forward(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]] = None) -> Tuple[Tensor, Tensor]:
-        assert input.dim() in (1, 2), \
-            f"LSTMCell: Expected input to be 1-D or 2-D but received {input.dim()}-D tensor"
+        if input.dim() not in (1, 2):
+            raise ValueError("LSTMCell: Expected input to be 1D or 2D, got {}D instead".format(input.dim()))
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -1361,8 +1364,8 @@ class GRUCell(RNNCellBase):
         super().__init__(input_size, hidden_size, bias, num_chunks=3, **factory_kwargs)
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
-        assert input.dim() in (1, 2), \
-            f"GRUCell: Expected input to be 1-D or 2-D but received {input.dim()}-D tensor"
+        if input.dim() not in (1, 2):
+            raise ValueError("GRUCell: Expected input to be 1D or 2D, got {}D instead".format(input.dim()))
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)


### PR DESCRIPTION
Summary: Use ValueError for input.dim check instead of Assertion Error.

Fix: #104839

Test Plan: Please see GitHub actions.

Differential Revision: D47427998

