### PR TITLE
Perform value range analysis with rationals when possible

### DIFF
--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -66,17 +66,17 @@ def sympy_interp(
     analysis, env: Dict[sympy.Symbol, Any], expr: Union[sympy.Expr, SympyBoolean]
 ):
     # Handle base cases
-    if isinstance(expr, sympy.Expr) and expr.is_constant():
-        if isinstance(expr, BooleanAtom):
-            dtype = torch.bool
-        elif isinstance(expr, sympy.Integer):
-            dtype = torch.int64
-        elif isinstance(expr, sympy.Number):
-            dtype = torch.double
-        else:
-            raise RuntimeError(f"Unknown constant type: {expr}")
+    dtype = None
+    if isinstance(expr, BooleanAtom):
+        dtype = torch.bool
+    elif isinstance(expr, sympy.Integer):
+        dtype = torch.int64
+    elif isinstance(expr, sympy.Number):
+        dtype = torch.double
+
+    if dtype is not None:
         return analysis.constant(expr, dtype)
-    elif isinstance(expr, sympy.Symbol):
+    if isinstance(expr, sympy.Symbol):
         return env[expr]
 
     # Special cases

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -76,7 +76,7 @@ def sympy_interp(
 
     if dtype is not None:
         return analysis.constant(expr, dtype)
-    if isinstance(expr, sympy.Symbol):
+    elif isinstance(expr, sympy.Symbol):
         return env[expr]
 
     # Special cases

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -66,15 +66,16 @@ def sympy_interp(
     analysis, env: Dict[sympy.Symbol, Any], expr: Union[sympy.Expr, SympyBoolean]
 ):
     # Handle base cases
-    # TODO: not really sure if I'm passing the right dtype here
-    # TODO: wouldn't it be better to pass the sympy expression through
-    # sometimes?
-    if isinstance(expr, sympy.Integer):
-        return analysis.constant(int(expr), torch.int64)
-    elif isinstance(expr, sympy.Number):
-        return analysis.constant(float(expr), torch.double)
-    elif isinstance(expr, BooleanAtom):
-        return analysis.constant(bool(expr), torch.bool)
+    if isinstance(expr, sympy.Expr) and expr.is_constant():
+        if isinstance(expr, BooleanAtom):
+            dtype = torch.bool
+        elif isinstance(expr, sympy.Integer):
+            dtype = torch.int64
+        elif isinstance(expr, sympy.Number):
+            dtype = torch.double
+        else:
+            raise RuntimeError(f"Unknown constant type: {expr}")
+        return analysis.constant(expr, dtype)
     elif isinstance(expr, sympy.Symbol):
         return env[expr]
 

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -162,15 +162,27 @@ class SymPyValueRangeAnalysis:
     @staticmethod
     def constant(value, dtype):
         # NB: value is NOT a sympy expression, it's a constant!
-        assert isinstance(value, (int, float, bool))
+        is_python = isinstance(value, (int, float, bool))
+        assert is_python or (isinstance(value, sympy.Expr) and value.is_constant())
 
         # using nan makes subsequent computation throw, and for the purposes of optimization
         # returning -math.inf - math.inf is equivalent to giving up
         if math.isnan(value):
             return ValueRanges.unknown()
 
-        type_ = dtype_to_type(dtype)
-        value = type_(value)
+        if is_python:
+            type_ = dtype_to_type(dtype)
+            value = type_(value)
+        else:
+            # We do a type check on a best-effort basis
+            # We don't want to force a cast to sympy.Float if the value is Rational to avoid losing precision
+            if dtype == torch.bool:
+                assert isinstance(value, BooleanAtom)
+            elif dtype.is_floating_point:
+                assert not value.is_finite or value.is_real
+            else:
+                # dtype is intXX
+                assert value.is_integer
 
         return ValueRanges.wrap(value)
 
@@ -314,7 +326,9 @@ class SymPyValueRangeAnalysis:
             return ValueRanges.wrap(r)
 
         if b == 0:
-            type_ = sympy.Float if a.lower.is_Float else sympy.Integer
+            if not a.lower.is_finite:
+                return ValueRanges.unknown()
+            type_ = sympy.Float if a.lower.is_real else sympy.Integer
             return ValueRanges.wrap(type_(1))
 
         if b < 0:
@@ -381,12 +395,13 @@ class SymPyValueRangeAnalysis:
         def fn_(x, y):
             # Poorman's version of upcasting in Sympy
             # Inf is not a float...
-            if x.is_Float or not x.is_finite or y.is_Float or not y.is_finite:
-                result_type = sympy.Float
-            else:
-                assert x.is_Integer
-                assert y.is_Integer
+            if x.is_Integer and y.is_Integer:
                 result_type = sympy.Integer
+            elif x.is_rational and y.is_rational:
+                result_type = sympy.Rational
+            else:
+                assert x.is_real or not x.is_finite or y.is_real or not y.is_finite
+                result_type = sympy.Float
             return fn(result_type(x), result_type(y))
 
         return ValueRanges.coordinatewise_increasing_map(a, b, fn_)

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -163,7 +163,7 @@ class SymPyValueRangeAnalysis:
     def constant(value, dtype):
         # NB: value is NOT a sympy expression, it's a constant!
         is_python = isinstance(value, (int, float, bool))
-        assert is_python or (isinstance(value, sympy.Expr) and value.is_constant())
+        assert is_python or isinstance(value, (BooleanAtom, sympy.Integer, sympy.Number))
 
         # using nan makes subsequent computation throw, and for the purposes of optimization
         # returning -math.inf - math.inf is equivalent to giving up

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -163,7 +163,7 @@ class SymPyValueRangeAnalysis:
     def constant(value, dtype):
         # NB: value is NOT a sympy expression, it's a constant!
         is_python = isinstance(value, (int, float, bool))
-        assert is_python or isinstance(value, (BooleanAtom, sympy.Integer, sympy.Number))
+        assert is_python or (isinstance(value, sympy.Expr) and value.is_constant())
 
         # using nan makes subsequent computation throw, and for the purposes of optimization
         # returning -math.inf - math.inf is equivalent to giving up


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #105139
* #105138
* __->__ #105137

This is particularly useful for guards to avoid rounding errors, as most
guards (all?) are rational functions.

Fixes https://github.com/pytorch/pytorch/issues/105097

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8