### PR TITLE
[ONNX] Fix UnsupportedFxNodesAnalysis after onnx dispatcher changes

### DIFF
--- a/test/onnx/test_fx_passes.py
+++ b/test/onnx/test_fx_passes.py
@@ -1,8 +1,9 @@
 # Owner(s): ["module: onnx"]
-from __future__ import annotations
-
+import torch
 import torch._dynamo
 import torch.fx
+
+from torch._custom_op import impl as custom_op
 from torch.onnx._internal.fx.passes import _utils as pass_utils
 from torch.testing._internal import common_utils
 
@@ -55,6 +56,50 @@ class TestFxPasses(common_utils.TestCase):
         assert len({node.name for node in nodes}) == len(
             nodes
         ), f"Expected all names to be unique, got {nodes}"
+
+    def test_onnx_dynamo_export_raises_when_model_contains_unsupported_fx_nodes(self):
+        @custom_op.custom_op("mylibrary::foo_op")
+        def foo_op(x: torch.Tensor) -> torch.Tensor:
+            ...
+
+        @custom_op.custom_op("mylibrary::bar_op")
+        def bar_op(x: torch.Tensor) -> torch.Tensor:
+            ...
+
+        @foo_op.impl_abstract()
+        def foo_op_impl_abstract(x):
+            return torch.empty_like(x)
+
+        @foo_op.impl("cpu")
+        def foo_op_impl(x):
+            return x + 1
+
+        @bar_op.impl_abstract()
+        def bar_op_impl_abstract(x):
+            return torch.empty_like(x)
+
+        @bar_op.impl("cpu")
+        def bar_op_impl(x):
+            return x + 2
+
+        torch._dynamo.allow_in_graph(foo_op)
+        torch._dynamo.allow_in_graph(bar_op)
+
+        def func(x, y, z):
+            return foo_op(x) + bar_op(y) + z
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        z = torch.randn(3)
+        with self.assertRaises(torch.onnx.OnnxExporterError) as ctx:
+            torch.onnx.dynamo_export(func, x, y, z)
+        inner_exception = ctx.exception.__cause__
+        self.assertRegex(
+            str(inner_exception),
+            r"Unsupported FX nodes.*mylibrary\.foo_op.*mylibrary\.bar_op",
+        )
+
+        torch._dynamo.reset()
 
 
 if __name__ == "__main__":

--- a/torch/onnx/_internal/fx/analysis/unsupported_nodes.py
+++ b/torch/onnx/_internal/fx/analysis/unsupported_nodes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Dict, List, Set
 
+import torch
 from torch.onnx._internal.fx import _pass, diagnostics
 
 
@@ -51,7 +52,7 @@ class UnsupportedFxNodesAnalysis(_pass.Analysis):
             RuntimeErrorWithDiagnostic: If diagnostics are emitted and the diagnostic
                 level is `ERROR`.
         """
-        errors: List[diagnostics.RuntimeErrorWithDiagnostic] = []
+        unsupported_nodes: List[torch.fx.Node] = []
         for node in self.module.graph.nodes:
             if node.op == "call_function":
                 try:
@@ -60,21 +61,14 @@ class UnsupportedFxNodesAnalysis(_pass.Analysis):
                         node, self.diagnostic_context
                     )
                 except diagnostics.RuntimeErrorWithDiagnostic as e:
-                    errors.append(e)
+                    unsupported_nodes.append(node)
 
         op_to_target_mapping: Dict[str, Set[str]] = {}
 
-        if errors:
-            for error in errors:
-                node_diagnostic = error.diagnostic
-                assert isinstance(
-                    node_diagnostic, diagnostics.UnsupportedFxNodeDiagnostic
-                )
-                node = node_diagnostic.unsupported_fx_node
-                assert node is not None
-                op = node.op
-                target = node.target
-                op_to_target_mapping.setdefault(op, set()).add(str(target))
+        for node in unsupported_nodes:
+            op = node.op
+            target = node.target
+            op_to_target_mapping.setdefault(op, set()).add(str(target))
 
         analysis_result = UnsupportedFxNodesAnalysisResult(op_to_target_mapping)
         self._lint(analysis_result, diagnostic_level)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105156

Simplifies the logic to not depend on info within the exception raised. Due to changes
in onnx dispatcher, the diagnostic within exception raised is now different, which broke
this pass in retrieving the unsupported fx node kind. Adds proper unittest.
