### PR TITLE
Add empty/empty_like to core aten decomps

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -185,8 +185,6 @@ aten::div_.Tensor
 aten::div_.Tensor_mode
 aten::embedding
 aten::embedding.out
-aten::empty_like
-aten::empty_like.out
 aten::empty_strided
 aten::empty_strided.out
 aten::eq.Scalar

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -211,7 +211,6 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.elu_backward,
             aten._embedding_bag,
             aten.embedding_dense_backward,
-            aten.empty,
             aten.empty_like,
             aten._euclidean_dist.default,
             aten.expand_as,

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -211,6 +211,8 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.elu_backward,
             aten._embedding_bag,
             aten.embedding_dense_backward,
+            aten.empty,
+            aten.empty_like,
             aten._euclidean_dist.default,
             aten.expand_as,
             aten.eye,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/104871


cc @SherlockNoMad