### PR TITLE
[quant][pt2e] change internal code to only import from _quantize_pt2e

### DIFF
--- a/torch/ao/quantization/_pt2e/quantizer/__init__.py
+++ b/torch/ao/quantization/_pt2e/quantizer/__init__.py
@@ -4,11 +4,13 @@ from .quantizer import (
     EdgeOrNode,
     FixedQParamsQuantizationSpec,
     OperatorConfig,
+    OperatorPatternType,
     QuantizationAnnotation,
     QuantizationSpec,
     QuantizationSpecBase,
     Quantizer,
     SharedQuantizationSpec,
+    QuantizationConfig,
 )
 from .x86_inductor_quantizer import X86InductorQuantizer
 
@@ -19,6 +21,8 @@ __all__ = [
     "ComposableQuantizer",
     "EdgeOrNode",
     "OperatorConfig",
+    "OperatorPatternType",
+    "QuantizationConfig",
     "EmbeddingQuantizer",
     "Quantizer",
     "QNNPackQuantizer",

--- a/torch/ao/quantization/_pt2e/quantizer/quantizer.py
+++ b/torch/ao/quantization/_pt2e/quantizer/quantizer.py
@@ -16,6 +16,8 @@ __all__ = [
     "SharedQuantizationSpec",
     "DerivedQuantizationSpec",
     "QuantizationAnnotation",
+    "QuantizationConfig",
+    "OperatorPatternType",
 ]
 
 # TODO: maybe remove torch.float32

--- a/torch/ao/quantization/_quantize_pt2e.py
+++ b/torch/ao/quantization/_quantize_pt2e.py
@@ -16,7 +16,31 @@ from ._pt2e.representation import reference_representation_rewrite
 from .fx.prepare import prepare as fx_prepare
 from .quantize_fx import _convert_to_reference_decomposed_fx
 from torch.ao.quantization import QConfigMapping
-from torch.ao.quantization._pt2e.quantizer import Quantizer
+# TODO: move quantizer to torch.ao.quantization
+from torch.ao.quantization._pt2e.quantizer import (  # noqa: F401
+    OperatorConfig,
+    OperatorPatternType,
+    QuantizationConfig,
+    Quantizer,
+    QuantizationSpecBase,
+    QuantizationSpec,
+    FixedQParamsQuantizationSpec,
+    SharedQuantizationSpec,
+    DerivedQuantizationSpec,
+    QuantizationAnnotation,
+    QNNPackQuantizer,
+    EmbeddingQuantizer,
+    ComposableQuantizer,
+)
+from torch.ao.quantization._pt2e.quantizer.utils import (  # noqa: F401
+    get_bias_qspec,
+    get_input_act_qspec,
+    get_output_act_qspec,
+    get_weight_qspec,
+)
+from torch.ao.quantization._pt2e.quantizer.qnnpack_quantizer import (  # noqa: F401
+    get_symmetric_quantization_config,
+)
 from torch.ao.quantization.backend_config import BackendConfig
 
 from typing import Any, Tuple


### PR DESCRIPTION
Summary: This is to make public api clear so that we can make implementation details change easier in the future

Test Plan: CIs

Differential Revision: D47445767

