### PR TITLE
[inductor] Add lowering for aten.unfold

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -489,6 +489,7 @@ aten::trunc
 aten::trunc.out
 aten::trunc_
 aten::unbind.int
+aten::unfold
 aten::uniform
 aten::uniform.out
 aten::uniform_

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -486,6 +486,7 @@ inductor_all_samples = {
     "scatter_reduce.sum",
     "select_scatter",
     "squeeze",
+    "unfold",
     "unsqueeze",
     "sum",
     "amax",

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -346,7 +346,6 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.tril_,
             aten.triu,
             aten.triu_,
-            aten.unfold,
             aten.unfold_backward,
             aten.unfold_copy,
             aten.upsample_bilinear2d,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #105173
* __->__ #105165

The decomposition for unfold uses `as_strided` which forces the input to be
realized. Instead, this implements it as a `GenericView` with reindexing
which removes the need to realize, though it does call `mark_reuse` incase
the input computation is expensive and the windows overlap.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov