### PR TITLE
Add torch.ops.aten.slice.Tensor to shared observer list

### DIFF
--- a/torch/ao/quantization/_pt2e/_propagate_annotation.py
+++ b/torch/ao/quantization/_pt2e/_propagate_annotation.py
@@ -19,6 +19,7 @@ def _is_share_obs_or_fq_op(op: Callable) -> bool:
         torch.ops.aten.adaptive_avg_pool2d.default,
         torch.ops.aten.view_copy.default,
         torch.ops.aten.view.default,
+        torch.ops.aten.slice.Tensor,
     ]
 
 


### PR DESCRIPTION
Pytorch 2 quantization has a list of functions that can trivially share observers for all different quantizers, and
`torch.ops.aten.slice.Tensor` (aka `torch.narrow`) can be part of that list, because most quantizers would want to
share quantization information before and after the slice.
