### PR TITLE
[DO NOT MERGE][NCCL][CUDA][CUDA Graphs] Set watchdog runtime capture mode to thread local to handle cleaning straggling work

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -433,10 +433,10 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
     for (const auto i : c10::irange(devices_.size())) {
       // Checking the work's corresponding CUDA events' status
       if (!(*ncclEndEvents_)[i].query()) {
-        //C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+        // C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
         return false;
       }
-      //C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+      // C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     }
   } catch (const std::exception& e) {
     C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -427,8 +427,8 @@ bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
 }
 
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
-  auto mode = cudaStreamCaptureModeGlobal; // should not change existing mode, testing to see if any API call is a problem here
-  C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+  auto mode = cudaStreamCaptureModeGlobal;
+  cudaThreadExchangeStreamCaptureMode(&mode);
   try {
     for (const auto i : c10::irange(devices_.size())) {
       // Checking the work's corresponding CUDA events' status

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -902,6 +902,8 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
 void ProcessGroupNCCL::ncclCommWatchdog() {
   try {
     VLOG(2) << "[Rank " << rank_ << "] NCCL watchdog thread started!";
+    auto mode = cudaStreamCaptureModeThreadLocal;
+    cudaThreadExchangeStreamCaptureMode(&mode);
     workCleanupLoop();
     VLOG(2) << "[Rank " << rank_
             << "] NCCL watchdog thread terminated normally";

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -903,8 +903,9 @@ void ProcessGroupNCCL::ncclCommWatchdog() {
   try {
     VLOG(2) << "[Rank " << rank_ << "] NCCL watchdog thread started!";
     auto mode = cudaStreamCaptureModeThreadLocal;
-    cudaThreadExchangeStreamCaptureMode(&mode);
+    C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     workCleanupLoop();
+    C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     VLOG(2) << "[Rank " << rank_
             << "] NCCL watchdog thread terminated normally";
   } catch (std::exception& e) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -427,16 +427,16 @@ bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
 }
 
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
-  auto mode = cudaStreamCaptureModeThreadLocal;
+  auto mode = cudaStreamCaptureModeGlobal; // should not change existing mode, testing to see if any API call is a problem here
   C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   try {
     for (const auto i : c10::irange(devices_.size())) {
       // Checking the work's corresponding CUDA events' status
       if (!(*ncclEndEvents_)[i].query()) {
-	C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+        //C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
         return false;
       }
-      C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+      //C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     }
   } catch (const std::exception& e) {
     C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -427,7 +427,7 @@ bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
 }
 
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
-  auto mode = cudaStreamCaptureModeGlobal;
+  auto mode = cudaStreamCaptureModeThreadLocal;
   // push
   cudaThreadExchangeStreamCaptureMode(&mode);
   try {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -439,7 +439,7 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
       // C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     }
   } catch (const std::exception& e) {
-    C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
+    // C10_CUDA_CHECK(cudaThreadExchangeStreamCaptureMode(&mode));
     if (std::string(e.what()).find("driver shutting down") ==
         std::string::npos) {
       throw;


### PR DESCRIPTION
A more minimal alternative to #104487 and #104555 that should not unwittingly suppress errors during graph captures.

I've tested this locally and it appears to fix the repro used to test #104487 and #104555, while checking that the watchdog is attempting to call `cudaEventQuery` (on an event recorded before the capture) in the middle of a capture on another thread.

X-posting summary from #104555 here:
1. The issue is a crash caused by the watchdog thread calling `cudaEventQuery` on work that was enqueued before a graph capture.
2. The initial proposal was to change the capture mode of the thread performing the capture to the "thread local" mode, so that other threads querying events (the watchdog) don't crash as the events in question were created before the actual capture and therefore shouldn't interfere with the capture.
3. Many such as @eellison and @albanD were concerned with how we changed the capture mode of the capturing thread in this PR (by globally changing the constructor), as we could potentially miss errors/failures caused by always using this more lenient mode.
4. @albanD pointed out that it is really just the watchdog thread that we are concerned with issuing a disallowed `cudaEventQuery` call, so another potential solution is to just have the watchdog thread operate in a more lenient mode. This seems to be fairly minimal change that shouldn't have unexpected effects on the correctness or debuggability of code involving graph captures. To clarify, while the watchdog thread itself is not capturing anything, since the watchdog thread never calls `cudaThreadExchangeStreamCaptureMode`, it is operating with the "global" mode when another thread is in the middle of a capture, and hence crash the capture because `cudaEventQuery` is disallowed in this scenario.
4a. Our current understanding is the following (assuming the `cudaEventQuery` is for an event outside of a capture).

capturing thread mode | watchdog thread mode | watchdog event query allowed |
--------------------------|---------------------------|-----------------------------------|
global (default)             | global (default)              | no                                                |
global (default)             | thread local                    | yes  (this PR)                               |
thread local                   | global (default)              | yes  (#104555)                             |
thread local                   |thread local                     | yes                                              |


CC @kwen2501 @eellison @albanD @ptrblck @Aidyn-A 

cc @ptrblck @mcarilli @ezyang