### PR TITLE
[EZ][BE] Fix the massively annoying strict-weak-ordering issue.

### DIFF
--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -371,6 +371,11 @@ int convex_hull_graham(
       q + 1,
       q + num_in,
       [](const Eigen::Vector2f& A, const Eigen::Vector2f& B) -> bool {
+        if (A == B) {
+          // explicit irreflexivity handling to sate
+          // https://fburl.com/strict-weak-ordering
+          return false;
+        }
         float temp = cross_2d(A, B);
         if (fabs(temp) < 1e-6) {
           return A.squaredNorm() < B.squaredNorm();
@@ -412,7 +417,8 @@ int convex_hull_graham(
   // But if we're only interested in getting the area/perimeter of the shape
   // We can simply return.
   if (!shift_to_zero) {
-    for (const auto i : c10::irange(m))q[i] += s;
+    for (const auto i : c10::irange(m))
+      q[i] += s;
   }
 
   return m;


### PR DESCRIPTION
Summary:
kip_fist_pump

Running any EgoOCR workflow in non-opt modes was breaking with https://fburl.com/strict-weak-ordering

Painstakingly found out that the stable_sort comparator in the generate_proposals caffe2 op was the issue due to numerical imprecision. This was causing Word Detector model to barf with the error. Adding explicit handling for the [irreflexivity property](https://www.boost.org/sgi/stl/StrictWeakOrdering.html) fixes this annoying strict-weak-ordering issue that has bugged me and several others(https://fb.workplace.com/groups/1405155842844877/permalink/7079705785389826/) for a while.

We can finally run all OCR workflows in non-opt mode! :)

Test Plan:
Debugged this with `fdb --disable-auto-breakpoints --secondary-debugger=lldb buck2 run mode/dev-sand ai_demos/server_model_zoo/models/ego_ocr_e2e_prod:ego_ocr_e2e_prod_binary`

and running `breakpoint set -E c++` in the lldb terminal.

Differential Revision: D47446816

