### PR TITLE
Fix CPUFallback Mechinasm on TensorList Type

### DIFF
--- a/aten/src/ATen/native/CPUFallback.cpp
+++ b/aten/src/ATen/native/CPUFallback.cpp
@@ -1,11 +1,13 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/CPUFallback.h>
 
-#include <sstream>
-
 #include <ATen/core/ivalue.h>
 #include <ATen/core/stack.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+
+#include <sstream>
+#include <vector>
+
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -64,6 +66,16 @@ static c10::optional<c10::Device> compute_target_device(std::vector<at::Tensor>&
   return c10::nullopt;
 }
 
+static bool validate_tensor_list(const c10::List<at::Tensor>& tensorlist) {
+  bool flag = false;
+
+  for (const auto& i : c10::irange(tensorlist.size())) {
+    if (tensorlist[i].defined())
+      flag = true;
+  }
+
+  return flag;
+}
 
 void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool error_on_views) {
   auto& schema_args = op.schema().arguments();
@@ -75,6 +87,10 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
   std::vector<int> tensor_args_indices;
 
   std::vector<c10::List<at::Tensor>> tensorlist_args;
+  std::vector<int> tensorlist_args_indices;
+
+  // save converted cpu tensor for TensorList
+  std::vector<c10::IValue> cpu_ivalues;
 
   // Step 1: Convert all non-CPU tensor inputs into CPU tensors
   // and put them on the stack at the correct indices.
@@ -87,9 +103,11 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
       // Note: we copy each TensorList argument to CPU individually out of convenience,
       // but XLA would benefit from materializing all tensor and TensorList args onto the CPU at the same time.
       // We can improve this if we need better perf for XLA's CPU fallbacks.
-      auto cpu_ivalue = c10::IValue(c10::List<at::Tensor>(to_cpu(ivalue.toTensorList().vec())));
-      (*stack)[arguments_begin + idx] = std::move(cpu_ivalue);
       tensorlist_args.push_back(ivalue.toTensorList());
+      tensorlist_args_indices.push_back(idx);
+      auto cpu_ivalue = c10::IValue(c10::List<at::Tensor>(to_cpu(ivalue.toTensorList().vec())));
+      cpu_ivalues.push_back(cpu_ivalue);
+      (*stack)[arguments_begin + idx] = std::move(cpu_ivalue);
     }
   }
   // XLA requires all of the tensor arguments to be gathered up and converted to CPU together.
@@ -111,6 +129,17 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
     const AliasInfo* alias_info = schema_args[tensor_idx].alias_info();
     if (alias_info != nullptr && alias_info->isWrite()) {
       at::_copy_from_and_resize(cpu_tensors[i], tensor_args[i]);
+    }
+  }
+
+  for (const auto i : c10::irange(tensorlist_args_indices.size())) {
+    auto tensorlist_idx = tensorlist_args_indices[i];
+    const AliasInfo* alias_info = schema_args[tensorlist_idx].alias_info();
+    if (alias_info != nullptr && alias_info->isWrite()) {
+      const auto& cpu_tensors = cpu_ivalues[i].toTensorList().vec();
+      for (const auto idx : c10::irange(tensorlist_args[i].size())) {
+        at::_copy_from_and_resize(cpu_tensors[idx], tensorlist_args[i][idx]);
+      }
     }
   }
 
@@ -137,62 +166,124 @@ void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack, bool 
   auto returns = torch::jit::last(stack, num_returns);
   const auto returns_begin = stack->size() - num_returns;
 
-  for (const auto idx : c10::irange(returns.size())) {
-    if (returns[idx].isTensor()) {
-      const auto& return_tens = returns[idx].toTensor();
-      if (return_tens.defined()) {
-        const AliasInfo* alias_info = schema_returns[idx].alias_info();
-        if (alias_info != nullptr && alias_info->isWrite()) {
-          // Case (1): mutable alias case. Move the input ivalue directly onto the stack
-          // in place of the existing cpu output tensor.
-          bool found_alias = false;
-          // We could store some extra metadata on the function schema to avoid the loop here
-          // if we need to improve perf.
-          for (const auto i : c10::irange(tensor_args_indices.size())) {
-            auto input_tensor_idx = tensor_args_indices[i];
-            const auto& input_tensor = cpu_tensors[i];
-            const AliasInfo* input_alias_info = schema_args[input_tensor_idx].alias_info();
-            // Checked above; adding assert to guard against breakage of the below condition due to changing the above if test.
-            TORCH_INTERNAL_ASSERT_DEBUG_ONLY(alias_info != nullptr);
-            if (input_tensor.defined() && (alias_info == input_alias_info || (input_alias_info != nullptr && *alias_info == *input_alias_info))) {
-              // We've found the original input tensor that aliases with the current output.
-              // Wrap it in an IValue and put it directly on the stack.
-              (*stack)[returns_begin + idx] = c10::IValue(tensor_args[i]);
-              found_alias = true;
-              break;
-            }
-          }
-          TORCH_CHECK(found_alias, "The operator ", op.schema().operator_name(), " appears to have invalid alias information. ",
-                      "Found a return tensor argument with a mismatched mutable alias: ", schema_returns[idx]);
-        } else {
-          c10::optional<c10::Device> tgt_device = compute_target_device(tensor_args, tensorlist_args);
-          if (alias_info != nullptr && !alias_info->isWrite()) {
-            // immutable alias (view) case: Warn here, since we're copying and not creating a view.
-            //If this operator is needed, the backend should provide a kernel for it.
-            // See Note [CPU Fallback Does Not Handle View Operators]
-            std::stringstream dev_str;
-            if (tgt_device) {
-                dev_str << *tgt_device;
-            } else {
-                dev_str << "<none>";
-            }
-            if (error_on_views) {
-                TORCH_CHECK(false, "The operator ", op.schema().operator_name(), " appears to be a view operator, ",
-                            "but it has no implementation for the backend \"", dev_str.str(), "\". View operators don't support ",
-                            "falling back to run on the CPU, since the tensor's storage cannot be shared across devices.");
-            } else {
-                TORCH_WARN(false, "The operator ", op.schema().operator_name(), " appears to be a view operator, ",
-                            "but it has no implementation for the backend \"", dev_str.str(), "\". View operators don't support ",
-                            "falling back to run on the CPU, since the tensor's storage cannot be shared across devices.");
-            }
-          }
-          // Case (2): copy case. Copy the cpu output tensor to the original device.
+  c10::optional<c10::Device> tgt_device =
+      compute_target_device(tensor_args, tensorlist_args);
 
-          // We technically  might not have a target device, e.g. if you call torch.cat() with an empty list
-          // In that case, we shouldn't have any tensors to schlep across devices anyway.
-          if (tgt_device) {
-              (*stack)[returns_begin + idx] = c10::IValue(returns[idx].toTensor().to(*tgt_device));
+  for (const auto idx : c10::irange(returns.size())) {
+    const AliasInfo* alias_info = schema_returns[idx].alias_info();
+    if (alias_info != nullptr && alias_info->isWrite()) {
+      // Case (1): mutable alias case.
+      // Move the input ivalue directly onto the stack in place of
+      // the existing cpu output tensor.
+      bool found_alias = false;
+      if (returns[idx].isTensor() && returns[idx].toTensor().defined()) {
+        // We could store some extra metadata on the function schema to avoid
+        // the loop here if we need to improve perf.
+        for (const auto i : c10::irange(tensor_args_indices.size())) {
+          auto input_tensor_idx = tensor_args_indices[i];
+          const auto& input_tensor = cpu_tensors[i];
+          const AliasInfo* input_alias_info =
+              schema_args[input_tensor_idx].alias_info();
+          // Checked above; adding assert to guard against breakage of the below
+          // condition due to changing the above if test.
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(alias_info != nullptr);
+          if (input_tensor.defined() &&
+              (alias_info == input_alias_info ||
+               (input_alias_info != nullptr &&
+                *alias_info == *input_alias_info))) {
+            // We've found the original input tensor that aliases with the
+            // current output. Wrap it in an IValue and put it directly on the
+            // stack.
+            (*stack)[returns_begin + idx] = c10::IValue(tensor_args[i]);
+            found_alias = true;
+            break;
           }
+        }
+      } else if (
+          returns[idx].isTensorList() &&
+          validate_tensor_list(returns[idx].toTensorList())) {
+        for (const auto i : c10::irange(tensorlist_args_indices.size())) {
+          auto input_tensor_idx = tensorlist_args_indices[i];
+          const AliasInfo* input_alias_info =
+              schema_args[input_tensor_idx].alias_info();
+          // Checked above; adding assert to guard against breakage of the below
+          // condition due to changing the above if test.
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(alias_info != nullptr);
+          if (validate_tensor_list(tensorlist_args[i]) &&
+              (alias_info == input_alias_info ||
+               (input_alias_info != nullptr &&
+                *alias_info == *input_alias_info))) {
+            // We've found the original input tensor that aliases with the
+            // current output. Wrap it in an IValue and put it directly on the
+            // stack.
+            (*stack)[returns_begin + idx] = c10::IValue(tensorlist_args[i]);
+            found_alias = true;
+            break;
+          }
+        }
+      }
+      TORCH_CHECK(
+          found_alias,
+          "The operator ",
+          op.schema().operator_name(),
+          " appears to have invalid alias information. ",
+          "Found a return tensor argument with a mismatched mutable alias: ",
+          schema_returns[idx]);
+    } else {
+      if (alias_info != nullptr && !alias_info->isWrite()) {
+        // Case (3): immutable alias (view) case.
+        // Warn here, since we're copying and not creating a view.
+        // If this operator is needed, the backend should provide a kernel for
+        // it. See Note [CPU Fallback Does Not Handle View Operators]
+        std::stringstream dev_str;
+        if (tgt_device) {
+          dev_str << *tgt_device;
+        } else {
+          dev_str << "<none>";
+        }
+        if (error_on_views) {
+          TORCH_CHECK(
+              false,
+              "The operator ",
+              op.schema().operator_name(),
+              " appears to be a view operator, ",
+              "but it has no implementation for the backend \"",
+              dev_str.str(),
+              "\". View operators don't support ",
+              "since the tensor's storage cannot be shared across devices.");
+        } else {
+          TORCH_WARN(
+              false,
+              "The operator ",
+              op.schema().operator_name(),
+              " appears to be a view operator, ",
+              "but it has no implementation for the backend \"",
+              dev_str.str(),
+              "\". View operators don't support falling back to run on the CPU, ",
+              "since the tensor's storage cannot be shared across devices.");
+        }
+      }
+      // Case (2): copy case.
+      // Copy the cpu output tensor to the original device.
+
+      // We technically  might not have a target device, e.g. if you call
+      // torch.cat() with an empty list In that case, we shouldn't have any
+      // tensors to schlep across devices anyway.
+      if (tgt_device) {
+        if (returns[idx].isTensor() && returns[idx].toTensor().defined()) {
+          (*stack)[returns_begin + idx] =
+              c10::IValue(returns[idx].toTensor().to(*tgt_device));
+        } else if (
+            returns[idx].isTensorList() &&
+            validate_tensor_list(returns[idx].toTensorList())) {
+          const auto& cpu_tensors = returns[idx].toTensorList().vec();
+          std::vector<at::Tensor> tensors;
+
+          for (const auto& tensor : cpu_tensors) {
+            tensors.push_back(tensor.to(*tgt_device));
+          }
+          (*stack)[returns_begin + idx] =
+              c10::IValue(c10::List<at::Tensor>(tensors));
         }
       }
     }

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/UnaryOps.h>
+#include <ATen/native/CPUFallback.h>
 #include <ATen/ops/abs_native.h>
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
@@ -232,6 +233,10 @@ at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool
   return dst;
 }
 
+at::Tensor custom__copy_from_and_resize(const at::Tensor& self, const at::Tensor& dst) {
+  return custom__copy_from(self, dst, false);
+}
+
 at::Tensor custom_empty_strided(c10::IntArrayRef size,
                                 c10::IntArrayRef stride,
                                 c10::optional<at::ScalarType> dtype_opt,
@@ -330,12 +335,21 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", &custom_empty_symint);
   m.impl("fill_.Scalar", &custom_fill__scalar);
   m.impl("_copy_from", &custom__copy_from);
+  m.impl("_copy_from_and_resize", &custom__copy_from_and_resize);
   m.impl("empty_strided", &custom_empty_strided);
   m.impl("set_.source_Storage", &custom_set_source_Storage);
   m.impl("set_.source_Storage_storage_offset",&custom_set_source_Storage_storage_offset);
   m.impl("_pin_memory", &custom__pin_memory);
   m.impl("is_pinned", &custom_is_pinned);
   m.impl("resize_", &custom_resize_);
+}
+
+void custom_cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+  at::native::cpu_fallback(op, stack);
+}
+
+TORCH_LIBRARY_IMPL(_, PrivateUse1, m) {
+  m.fallback(torch::CppFunction::makeFromBoxedFunction<&custom_cpu_fallback>());
 }
 
 // This basic implementation doesn't bother dealing with different device indices

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -348,8 +348,9 @@ void custom_cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack
   at::native::cpu_fallback(op, stack);
 }
 
-TORCH_LIBRARY_IMPL(_, PrivateUse1, m) {
-  m.fallback(torch::CppFunction::makeFromBoxedFunction<&custom_cpu_fallback>());
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+  m.impl("sub.Tensor", torch::CppFunction::makeFromBoxedFunction<&custom_cpu_fallback>());
+  m.impl("_foreach_add.List", torch::CppFunction::makeFromBoxedFunction<&custom_cpu_fallback>());
 }
 
 // This basic implementation doesn't bother dealing with different device indices

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -441,6 +441,41 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             self.assertEqual(out_ref, out_test)
             self.assertEqual(x_ref.grad, x_test.grad)
 
+        def test_open_device_tensor_type_fallback():
+            torch.utils.rename_privateuse1_backend('foo')
+            # create tensors located in custom device
+            x = torch.Tensor([1, 2, 3]).to('foo')
+            y = torch.Tensor([1, 0, 2]).to('foo')
+            # create result tensor located in cpu
+            z_cpu = torch.Tensor([0, 2, 1])
+            # Check that our device is correct.
+            device = self.module.custom_device()
+            self.assertTrue(x.device == device)
+            self.assertFalse(x.is_cpu)
+            # call sub op, which will fallback to cpu
+            z = torch.sub(x, y)
+
+            self.assertEqual(z_cpu, z)
+
+        def test_open_device_tensorlist_type_fallback():
+            torch.utils.rename_privateuse1_backend('foo')
+            # create tensors located in custom device
+            v_foo = torch.Tensor([1, 2, 3]).to('foo')
+            # create result tensor located in cpu
+            v_cpu = torch.Tensor([2, 4, 6])
+            # create tensorlist for foreach_add op
+            x = (v_foo, v_foo)
+            y = (v_foo, v_foo)
+            # Check that our device is correct.
+            device = self.module.custom_device()
+            self.assertTrue(v_foo.device == device)
+            self.assertFalse(v_foo.is_cpu)
+            # call _foreach_add op, which will fallback to cpu
+            z = torch._foreach_add(x, y)
+
+            self.assertEqual(v_cpu, z[0])
+            self.assertEqual(v_cpu, z[1])
+
         test_base_device_registration()
         test_before_common_registration()
         test_common_registration()
@@ -459,6 +494,9 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         test_compile_autograd_function_returns_self()
         test_compile_autograd_function_aliasing()
+
+        test_open_device_tensor_type_fallback()
+        test_open_device_tensorlist_type_fallback()
 
 
 if __name__ == "__main__":

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -462,7 +462,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             # create tensors located in custom device
             v_foo = torch.Tensor([1, 2, 3]).to('foo')
             # create result tensor located in cpu
-            v_cpu = torch.Tensor([2, 4, 6])
+            z_cpu = torch.Tensor([2, 4, 6])
             # create tensorlist for foreach_add op
             x = (v_foo, v_foo)
             y = (v_foo, v_foo)
@@ -473,8 +473,8 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             # call _foreach_add op, which will fallback to cpu
             z = torch._foreach_add(x, y)
 
-            self.assertEqual(v_cpu, z[0])
-            self.assertEqual(v_cpu, z[1])
+            self.assertEqual(z_cpu, z[0])
+            self.assertEqual(z_cpu, z[1])
 
         test_base_device_registration()
         test_before_common_registration()


### PR DESCRIPTION
Fixes #104965

Currently, the cpufallback mechinasm lack the code logic of TensorList, so some operators like _foreach_add_/_foreach_add don`t work well.

cc  @bdhirsh 
