### PR TITLE
Revert D47423192: Multisect successfully blamed "D47423192: [Typing] Fix PEP 484 Violation (#105022)" for test or build failures

### DIFF
--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -12,7 +12,7 @@ def functional_call(
     module: "torch.nn.Module",
     parameter_and_buffer_dicts: Union[Dict[str, Tensor], Sequence[Dict[str, Tensor]]],
     args: Union[Any, Tuple],
-    kwargs: Optional[Dict[str, Any]] = None,
+    kwargs: Dict[str, Any] = None,
     *,
     tie_weights: bool = True,
     strict: bool = False,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1064,7 +1064,7 @@ def _linalg_svd_meta(
     A: Tensor,
     full_matrices: bool = False,
     compute_uv: bool = True,
-    driver: Optional[str] = None,
+    driver: str = None,
 ):
     checkIsMatrix(A, "linalg.svd")
     checkFloatingOrComplex(A, "linalg.svd")
@@ -1207,7 +1207,7 @@ def linalg_solve_triangular_meta(
     upper: bool,
     left: bool = True,
     unitriangular: bool = False,
-    out: Optional[Tensor] = None,
+    out: Tensor = None,
 ) -> Tensor:
     if out is None:
         out = A.new_empty([0])
@@ -4755,8 +4755,8 @@ def upsample_nearest2d_backward(
     grad_output: Tensor,
     output_size: Sequence[Union[int, torch.types.SymInt]],
     input_size: Sequence[Union[int, torch.types.SymInt]],
-    scales_h: Optional[float] = None,
-    scales_w: Optional[float] = None,
+    scales_h: float = None,
+    scales_w: float = None,
 ):
     full_output_size = upsample_common_check(
         input_size, output_size, num_spatial_dims=2

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -331,7 +331,7 @@ class ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND(Enum):
 def _elementwise_meta(
     *args,
     type_promotion: ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND,
-    args_with_fixed_dtypes: Optional[Tuple[TensorLikeType, ...]] = None,
+    args_with_fixed_dtypes: Tuple[TensorLikeType, ...] = None,
 ) -> FakeTensor:
     """
     Meta function for elementwise operations that produce outputs in the same dtype

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -1,6 +1,6 @@
 import functools
 from contextlib import nullcontext
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Sequence
 from warnings import warn
 
 import torch
@@ -111,7 +111,7 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
         orig_func: Callable,
         types: Sequence,
         args: Sequence[Any] = (),
-        kwargs: Optional[Dict] = None,
+        kwargs: Dict = None,
     ):
         if kwargs is None:
             kwargs = {}
@@ -161,7 +161,7 @@ class TorchRefsMode(torch.overrides.TorchFunctionMode):
         orig_func: Callable,
         types: Sequence,
         args: Sequence[Any] = (),
-        kwargs: Optional[Dict] = None,
+        kwargs: Dict = None,
     ):
         if kwargs is None:
             kwargs = {}
@@ -374,7 +374,7 @@ class TorchRefsNvfuserCapabilityMode(TorchRefsMode):
         orig_func: Callable,
         types: Sequence,
         args: Sequence[Any] = (),
-        kwargs: Optional[Dict] = None,
+        kwargs: Dict = None,
     ):
         if kwargs is None:
             kwargs = {}

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1832,7 +1832,7 @@ def clamp(
 @out_wrapper()
 def clamp_min(
     self: TensorLikeType,
-    min: Optional[TensorOrNumberLikeType] = None,
+    min: TensorOrNumberLikeType = None,
 ) -> TensorLikeType:
     return torch.clamp(self, min=min)  # type: ignore[arg-type]
 
@@ -1841,7 +1841,7 @@ def clamp_min(
 @out_wrapper()
 def clamp_max(
     self: TensorLikeType,
-    max: Optional[TensorOrNumberLikeType] = None,
+    max: TensorOrNumberLikeType = None,
 ) -> TensorLikeType:
     return torch.clamp(self, max=max)  # type: ignore[arg-type]
 
@@ -4654,7 +4654,7 @@ def logspace(
     ret = torch.linspace(
         start,
         end,
-        steps,  # type: ignore[arg-type]
+        steps,
         dtype=torch.float64,
         layout=layout,
         device=device,

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -63,7 +63,7 @@ class MultiheadAttention(nn.MultiheadAttention):
     def __init__(self, embed_dim: int, num_heads: int,
                  dropout: float = 0., bias: bool = True,
                  add_bias_kv: bool = False, add_zero_attn: bool = False,
-                 kdim: Optional[int] = None, vdim: Optional[int] = None, batch_first: bool = False,
+                 kdim: int = None, vdim: int = None, batch_first: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__(embed_dim, num_heads, dropout,

--- a/torch/ao/pruning/_experimental/activation_sparsifier/activation_sparsifier.py
+++ b/torch/ao/pruning/_experimental/activation_sparsifier/activation_sparsifier.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Dict, Any, List
 import torch
 from collections import defaultdict
 from torch import nn
@@ -205,7 +205,7 @@ class ActivationSparsifier:
         # or sparsify_hook()
         self.data_groups[name]['hook_state'] = "aggregate"  # aggregate hook is attached
 
-    def get_mask(self, name: Optional[str] = None, layer: Optional[nn.Module] = None):
+    def get_mask(self, name: str = None, layer: nn.Module = None):
         """
         Returns mask associated to the layer.
 

--- a/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
@@ -1,7 +1,7 @@
 import torch
 from torch.nn import functional as F
 from functools import reduce
-from typing import Any, List, Optional, Tuple
+from typing import Tuple, Any, List
 
 from .base_data_sparsifier import BaseDataSparsifier
 
@@ -31,9 +31,9 @@ class DataNormSparsifier(BaseDataSparsifier):
         arguments and could be overriden by the configuration provided in the
         `add_data` step.
     """
-    def __init__(self, data_list: Optional[List[Tuple[str, Any]]] = None, sparsity_level: float = 0.5,
+    def __init__(self, data_list: List[Tuple[str, Any]] = None, sparsity_level: float = 0.5,
                  sparse_block_shape: Tuple[int, int] = (1, 4),
-                 zeros_per_block: Optional[int] = None, norm: str = 'L1'):
+                 zeros_per_block: int = None, norm: str = 'L1'):
         if zeros_per_block is None:
             zeros_per_block = reduce((lambda x, y: x * y), sparse_block_shape)
 

--- a/torch/ao/pruning/_experimental/data_sparsifier/quantization_utils.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/quantization_utils.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from torch.ao.pruning.sparsifier.utils import module_to_fqn, fqn_to_module
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 SUPPORTED_MODULES = {
     nn.Embedding,
@@ -28,7 +28,7 @@ def _fetch_all_embeddings(model):
 def post_training_sparse_quantize(model,
                                   data_sparsifier_class,
                                   sparsify_first=True,
-                                  select_embeddings: Optional[List[nn.Module]] = None,
+                                  select_embeddings: List[nn.Module] = None,
                                   **sparse_config):
     """Takes in a model and applies sparsification and quantization to only embeddings & embeddingbags.
     The quantization step can happen before or after sparsification depending on the `sparsify_first` argument.

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -210,7 +210,7 @@ def full(
 def zeros(
     *size,
     requires_grad: bool = False,
-    dtype: Optional[torch.dtype] = None,
+    dtype: torch.dtype = None,
     layout: torch.layout = torch.strided,
     device_mesh: Optional[DeviceMesh] = None,
     placements: Optional[Sequence[Placement]] = None,

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -1,7 +1,6 @@
 import functools
 import torch
 import torch.distributed as dist
-from typing import Optional
 
 
 class DefaultState:
@@ -128,7 +127,7 @@ def _low_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch
         allreduce_hook(state, grad)
         _decompress(state, grad)
 
-def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
+def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor = None):
     r"""
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
@@ -145,7 +144,7 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Opt
     fp16_hook = functools.partial(_low_precision_hook, torch.float16)
     return fp16_hook(state, grad, output)
 
-def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
+def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor = None):
     r"""
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -20,7 +20,7 @@ def load_state_dict(
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
     no_dist: bool = False,
-    planner: Optional[LoadPlanner] = None,
+    planner: LoadPlanner = None,
 ) -> None:
     """
     Loads a distributed ``state_dict`` in SPMD style.

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -22,7 +22,7 @@ def save_state_dict(
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
     no_dist: bool = False,
-    planner: Optional[SavePlanner] = None,
+    planner: SavePlanner = None,
 ) -> Metadata:
     """
     Saves a distributed model in SPMD style.

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -58,7 +58,7 @@ def broadcast(
         raise AssertionError("Data or Function is expected to be None if not successful")
 
     payload: Optional[T] = None
-    exception : Optional[Exception] = None
+    exception : Exception = None
     # if no pg is passed then execute if rank is 0
     if (pg is None and rank == 0) or (pg is not None and pg.rank() == rank):
         # determine if it is an executable function or data payload only
@@ -119,7 +119,7 @@ def all_gather(
     >> all_ids = all_gather(data_or_fn=allocate_id, pg=ext_pg.my_pg)
     """
     payload: Optional[T] = None
-    exception : Optional[Exception] = None
+    exception : Exception = None
     success = True
     # determine if it is an executable function or data payload only
     if callable(data_or_fn):
@@ -143,7 +143,7 @@ def all_gather(
         total_list = [None] * dist.get_world_size(pg)
         all_gather_object_enforce_type(pg, total_list, sync_obj)
         # Each rank will throw RuntimeError in case of failure on any rank.
-        stage_name = cast(SyncPayload[T], total_list[0]).stage_name
+        stage_name: Optional[str] = cast(SyncPayload[T], total_list[0]).stage_name
         exception_list: List[Tuple[int, Exception]] = []
         ret_list: List[T] = []
         error_msg: str = ""

--- a/torch/distributed/elastic/metrics/api.py
+++ b/torch/distributed/elastic/metrics/api.py
@@ -68,7 +68,7 @@ _default_metrics_handler: MetricHandler = NullMetricHandler()
 
 
 # pyre-fixme[9]: group has type `str`; used as `None`.
-def configure(handler: MetricHandler, group: Optional[str] = None):
+def configure(handler: MetricHandler, group: str = None):
     if group is None:
         global _default_metrics_handler
         # pyre-fixme[9]: _default_metrics_handler has type `NullMetricHandler`; used

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -158,7 +158,7 @@ class FileTimerServer:
         file_path: str,
         max_interval: float = 10,
         daemon: bool = True,
-        log_event: Optional[Callable[[str, Optional[FileTimerRequest]], None]] = None
+        log_event: Callable[[str, Optional[FileTimerRequest]], None] = None
     ) -> None:
         self._file_path = file_path
         self._max_interval = max_interval

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -129,8 +129,8 @@ class _RemoteModule(nn.Module):
         self,
         remote_device: str,
         module_cls: Type[nn.Module],
-        args: Optional[Tuple] = None,
-        kwargs: Optional[Dict[str, Any]] = None,
+        args: Tuple = None,
+        kwargs: Dict[str, Any] = None,
         _module_interface_cls: Any = None,
     ):
         """
@@ -685,8 +685,8 @@ class RemoteModule(_RemoteModule):
         self,
         remote_device: str,
         module_cls: Type[nn.Module],
-        args: Optional[Tuple] = None,
-        kwargs: Optional[Dict[str, Any]] = None,
+        args: Tuple = None,
+        kwargs: Dict[str, Any] = None,
     ):
         super().__init__(remote_device, module_cls, args, kwargs)
 

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -63,8 +63,8 @@ class _NamedOptimizer(optim.Optimizer):
         self,
         named_parameters: Mapping[str, Union[torch.Tensor, ShardedTensor]],
         optimizer_class: optim.Optimizer,
-        param_groups: Optional[Collection[Mapping[str, Any]]] = None,
-        module: Optional[nn.Module] = None,
+        param_groups: Collection[Mapping[str, Any]] = None,
+        module: nn.Module = None,
         *args,
         **kwargs,
     ) -> None:

--- a/torch/distributed/pipeline/sync/utils.py
+++ b/torch/distributed/pipeline/sync/utils.py
@@ -1,12 +1,12 @@
 from torch import nn
-from typing import List, Optional
+from typing import List
 
 __all__ = ["partition_model"]
 
 def partition_model(
         module: nn.Sequential,
         balance: List[int],
-        devices: Optional[List[int]] = None):
+        devices: List[int] = None):
     """
     Given an :class:`nn.Sequential <torch.nn.Sequential>` module, partitions
     the model across multiple GPU devices according the provided ``balance``

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -1,7 +1,7 @@
 import math
 import warnings
 from numbers import Number
-from typing import Optional, Union
+from typing import Union
 
 import torch
 from torch import nan
@@ -72,9 +72,9 @@ class Wishart(ExponentialFamily):
 
     def __init__(self,
                  df: Union[torch.Tensor, Number],
-                 covariance_matrix: Optional[torch.Tensor] = None,
-                 precision_matrix: Optional[torch.Tensor] = None,
-                 scale_tril: Optional[torch.Tensor] = None,
+                 covariance_matrix: torch.Tensor = None,
+                 precision_matrix: torch.Tensor = None,
+                 scale_tril: torch.Tensor = None,
                  validate_args=None):
         assert (covariance_matrix is not None) + (scale_tril is not None) + (precision_matrix is not None) == 1, \
             "Exactly one of covariance_matrix or precision_matrix or scale_tril may be specified."

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -259,7 +259,7 @@ class MetaTracer(torch.fx.Tracer):
 
 
 def symbolic_trace(root : Union[torch.nn.Module, Callable[..., Any]],
-                   meta_args : Optional[Dict[str, torch.Tensor]] = None,
+                   meta_args : Dict[str, torch.Tensor] = None,
                    concrete_args: Optional[Dict[str, Any]] = None) -> torch.fx.GraphModule:
     tracer = MetaTracer()
     graph = tracer.trace(root, meta_args, concrete_args)

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 class Partition:
-    def __init__(self, id: Optional[int] = None, nodes: Optional[Iterable[Node]] = None):
+    def __init__(self, id: int = None, nodes: Iterable[Node] = None):
         self.id = id
         self.nodes: Set[Node] = set(nodes) if nodes is not None else set()
 

--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from inspect import unwrap
-from typing import Callable, List, Optional
+from typing import Callable, List
 import logging
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ def log_hook(fn: Callable, level=logging.INFO) -> Callable:
 
 
 
-def loop_pass(base_pass: Callable, n_iter: Optional[int] = None, predicate: Optional[Callable] = None):
+def loop_pass(base_pass: Callable, n_iter: int = None, predicate: Callable = None):
     """
     Convenience wrapper for passes which need to be applied multiple times.
 

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -1302,7 +1302,7 @@ def amin(
 @_apply_docstring_templates
 def argmax(
     input: Union[Tensor, MaskedTensor],
-    dim: Optional[int] = None,
+    dim: int = None,
     *,
     keepdim: Optional[bool] = False,
     dtype: Optional[DType] = None,
@@ -1328,7 +1328,7 @@ def argmax(
 @_apply_docstring_templates
 def argmin(
     input: Union[Tensor, MaskedTensor],
-    dim: Optional[int] = None,
+    dim: int = None,
     *,
     keepdim: Optional[bool] = False,
     dtype: Optional[DType] = None,

--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -1,7 +1,7 @@
 import contextlib
 import warnings
 from collections import defaultdict
-from typing import Any, Dict, Iterator, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, Set, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -148,7 +148,7 @@ def functional_call(
     module: "torch.nn.Module",
     parameters_and_buffers: Dict[str, Tensor],
     args: Union[Any, Tuple],
-    kwargs: Optional[Dict[str, Any]] = None,
+    kwargs: Dict[str, Any] = None,
     *,
     tie_weights: bool = True,
     strict: bool = False,
@@ -233,7 +233,7 @@ def _functional_call(
     module: "torch.nn.Module",
     parameters_and_buffers: Dict[str, Tensor],
     args: Union[Any, Tuple],
-    kwargs: Optional[Dict[str, Any]] = None,
+    kwargs: Dict[str, Any] = None,
     *,
     tie_weights: bool = True,
     strict: bool = False,

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -242,7 +242,7 @@ class _KinetoProfile:
         assert self.profiler is not None and self.profiler.kineto_results is not None
         return MemoryProfile(self.profiler.kineto_results)
 
-    def export_memory_timeline(self, path: str, device: Optional[str] = None) -> None:
+    def export_memory_timeline(self, path: str, device: str = None) -> None:
         """Extract the memory information from the memory profile collected
         tree for a given device, and export a timeline plot consisting of
         [times, [sizes by category]], where times are timestamps and sizes

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -861,7 +861,7 @@ def load(
     pickle_module: Any = None,
     *,
     weights_only: bool = False,
-    mmap: Optional[bool] = None,
+    mmap: bool = None,
     **pickle_load_args: Any
 ) -> Any:
     # Reference: https://github.com/pytorch/pytorch/issues/54354

--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -422,9 +422,9 @@ Examples::
 def hamming(M: int,
             *,
             sym: bool = True,
-            dtype: Optional[torch.dtype] = None,
+            dtype: torch.dtype = None,
             layout: torch.layout = torch.strided,
-            device: Optional[torch.device] = None,
+            device: torch.device = None,
             requires_grad: bool = False) -> Tensor:
     return general_hamming(M, sym=sym, dtype=dtype, layout=layout, device=device, requires_grad=requires_grad)
 
@@ -469,9 +469,9 @@ Examples::
 def hann(M: int,
          *,
          sym: bool = True,
-         dtype: Optional[torch.dtype] = None,
+         dtype: torch.dtype = None,
          layout: torch.layout = torch.strided,
-         device: Optional[torch.device] = None,
+         device: torch.device = None,
          requires_grad: bool = False) -> Tensor:
     return general_hamming(M,
                            alpha=0.5,
@@ -521,9 +521,9 @@ Examples::
 def blackman(M: int,
              *,
              sym: bool = True,
-             dtype: Optional[torch.dtype] = None,
+             dtype: torch.dtype = None,
              layout: torch.layout = torch.strided,
-             device: Optional[torch.device] = None,
+             device: torch.device = None,
              requires_grad: bool = False) -> Tensor:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -575,9 +575,9 @@ Examples::
 def bartlett(M: int,
              *,
              sym: bool = True,
-             dtype: Optional[torch.dtype] = None,
+             dtype: torch.dtype = None,
              layout: torch.layout = torch.strided,
-             device: Optional[torch.device] = None,
+             device: torch.device = None,
              requires_grad: bool = False) -> Tensor:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -644,9 +644,9 @@ Examples::
 def general_cosine(M, *,
                    a: Iterable,
                    sym: bool = True,
-                   dtype: Optional[torch.dtype] = None,
+                   dtype: torch.dtype = None,
                    layout: torch.layout = torch.strided,
-                   device: Optional[torch.device] = None,
+                   device: torch.device = None,
                    requires_grad: bool = False) -> Tensor:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -721,9 +721,9 @@ def general_hamming(M,
                     *,
                     alpha: float = 0.54,
                     sym: bool = True,
-                    dtype: Optional[torch.dtype] = None,
+                    dtype: torch.dtype = None,
                     layout: torch.layout = torch.strided,
-                    device: Optional[torch.device] = None,
+                    device: torch.device = None,
                     requires_grad: bool = False) -> Tensor:
     return general_cosine(M,
                           a=[alpha, 1. - alpha],

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -184,7 +184,7 @@ def _generate_module_methods_for_privateuse1_backend(custom_backend_name: str) -
 
 
 def _generate_storage_methods_for_privateuse1_backend(custom_backend_name: str,
-                                                      unsupported_dtype: Optional[List[torch.dtype]] = None) -> None:
+                                                      unsupported_dtype: List[torch.dtype] = None) -> None:
     # Attribute is registered in the _StorageBase class
     # and UntypedStorage obtains through inheritance.
     @property  # type: ignore[misc]
@@ -255,7 +255,7 @@ def _generate_storage_methods_for_privateuse1_backend(custom_backend_name: str,
 
 def generate_methods_for_privateuse1_backend(for_tensor: bool = True, for_module: bool = True,
                                              for_storage: bool = False,
-                                             unsupported_dtype: Optional[List[torch.dtype]] = None) -> None:
+                                             unsupported_dtype: List[torch.dtype] = None) -> None:
     r"""
     generate_methods_for_privateuse1_backend(for_tensor, for_module, for_storage, unsupported_dtype) -> None
 

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -37,8 +37,8 @@ if HAS_TABULATE:
         model: Union[torch.nn.Module, Callable],
         sample_input: Union[torch.Tensor, Any],
         num_iters: int = 5,
-        optimizer: Optional[torch.optim.Optimizer] = None,
-        loss_fn: Optional[Callable] = None,
+        optimizer: torch.optim.Optimizer = None,
+        loss_fn: Callable = None,
     ):
         # Define the statement and setup for the benchmark
         if optimizer and loss_fn:
@@ -73,8 +73,8 @@ if HAS_TABULATE:
         num_iters: int = 5,
         backend: Optional[str] = None,
         mode: Optional[str] = "default",
-        optimizer: Optional[torch.optim.Optimizer] = None,
-        loss_fn : Union[torch.nn.Module, Callable, None] = None,
+        optimizer: torch.optim.Optimizer = None,
+        loss_fn : Union[torch.nn.Module, Callable] = None,
     ):
         """
         Use this utility to benchmark torch.compile
@@ -117,7 +117,7 @@ if HAS_TABULATE:
         sample_input: Union[torch.Tensor, Any],
         num_iters : int = 5,
         optimizer: Optional[torch.optim.Optimizer] = None,
-        loss_fn : Union[torch.nn.Module, Callable, None] = None,
+        loss_fn : Union[torch.nn.Module, Callable] = None,
     ):
         """
         This is a simple utility that can be used to benchmark torch.compile


### PR DESCRIPTION
Summary:
This diff is reverting D47423192
D47423192: [Typing] Fix PEP 484 Violation (#105022) by malfet has been identified to be causing the following test or build failures:

Tests affected:
- [aps/rec/tests:rec_train_factory_gpu_test - aps.rec.tests.rec_train_factory_gpu_test.RecTrainFactoryGpuTest: test_create_optimizer_composable](https://www.internalfb.com/intern/test/844425029730501/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2429621
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D47461496

