### PR TITLE
[ONNX] Make unsupported node analysis result deterministic

### DIFF
--- a/torch/onnx/_internal/fx/analysis/unsupported_nodes.py
+++ b/torch/onnx/_internal/fx/analysis/unsupported_nodes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Dict, List, Set
+from typing import Dict, List
 
 import torch
 from torch.onnx._internal.fx import _pass, diagnostics
@@ -9,7 +9,7 @@ from torch.onnx._internal.fx import _pass, diagnostics
 
 @dataclasses.dataclass
 class UnsupportedFxNodesAnalysisResult(_pass.AnalysisResult):
-    unsupported_op_to_target_mapping: Dict[str, Set[str]]
+    unsupported_op_to_target_mapping: Dict[str, Dict[str, None]]
 
 
 class UnsupportedFxNodesAnalysis(_pass.Analysis):
@@ -25,7 +25,7 @@ class UnsupportedFxNodesAnalysis(_pass.Analysis):
             return
 
         normalized_op_targets_map = {
-            op: [str(target) for target in targets]
+            op: list(targets.keys())
             for op, targets in analysis_result.unsupported_op_to_target_mapping.items()
         }
 
@@ -63,12 +63,12 @@ class UnsupportedFxNodesAnalysis(_pass.Analysis):
                 except diagnostics.RuntimeErrorWithDiagnostic as e:
                     unsupported_nodes.append(node)
 
-        op_to_target_mapping: Dict[str, Set[str]] = {}
+        op_to_target_mapping: Dict[str, Dict[str, None]] = {}
 
         for node in unsupported_nodes:
             op = node.op
             target = node.target
-            op_to_target_mapping.setdefault(op, set()).add(str(target))
+            op_to_target_mapping.setdefault(op, {}).setdefault(str(target), None)
 
         analysis_result = UnsupportedFxNodesAnalysisResult(op_to_target_mapping)
         self._lint(analysis_result, diagnostic_level)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105231

Replace `Set` with `Dict` for node.target to keep insertion order.

Fixes https://github.com/pytorch/pytorch/issues/105200