### PR TITLE
[caffe2] Update tracepoint USDT macros

### DIFF
--- a/caffe2/core/static_tracepoint.h
+++ b/caffe2/core/static_tracepoint.h
@@ -1,11 +1,34 @@
 #pragma once
 
-#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
+#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__)) && !CAFFE_DISABLE_SDT
+
+#define CAFFE_HAVE_SDT 1
+
 #include <caffe2/core/static_tracepoint_elfx86.h>
 
-#define CAFFE_SDT(name, ...)                                         \
-  CAFFE_SDT_PROBE_N(                                                 \
-    caffe2, name, CAFFE_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#define CAFFE_SDT(name, ...) \
+  CAFFE_SDT_PROBE_N(                   \
+      caffe2, name, 0, CAFFE_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+// Use CAFFE_SDT_DEFINE_SEMAPHORE(name) to define the semaphore
+// as global variable before using the CAFFE_SDT_WITH_SEMAPHORE macro
+#define CAFFE_SDT_WITH_SEMAPHORE(name, ...) \
+  CAFFE_SDT_PROBE_N(                                  \
+      caffe2, name, 1, CAFFE_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#define CAFFE_SDT_IS_ENABLED(name) \
+  (CAFFE_SDT_SEMAPHORE(caffe2, name) > 0)
+
 #else
-#define CAFFE_SDT(name, ...) do {} while(0)
+
+#define CAFFE_HAVE_SDT 0
+
+#define CAFFE_SDT(name, ...) \
+  do {                                 \
+  } while (0)
+#define CAFFE_SDT_WITH_SEMAPHORE(name, ...) \
+  do {                                                \
+  } while (0)
+#define CAFFE_SDT_IS_ENABLED(name) (false)
+#define CAFFE_SDT_DEFINE_SEMAPHORE(name)
+#define CAFFE_SDT_DECLARE_SEMAPHORE(name)
+
 #endif


### PR DESCRIPTION
Summary:
Fix existing CAFFE static tracepoint macros and make them match the latest FOLLY version.

Per anakryiko, current `CAFE_SDT` definition is broken. Quote:
```
"Arguments: -5@-16(%rbp) -4@$100

Arguments: -8@-16(%rbp) -4@$100

#define FOLLY_SDT_IS_ARRAY_POINTER(x)  ((__builtin_classify_type(x) == 14) ||  \
                                        (__builtin_classify_type(x) == 5))

vs

#define CAFFE_SDT_ISARRAY(x)  (__builtin_classify_type(x) == 14)

https://github.com/atgreen/gcc/blob/master/gcc/typeclass.h

that 5 is "pointer_type_class"
so you were right, it's just fixed up version of header
I think it should be 8, not 5
5 is the size of literal, but you don't pass string literal as an argument, you pass its address, so actual argument is a pointer, and so 8 byte long

you can try just fixing up CAFFE_SDT macro
```
 {F1048035373}

Test Plan:

Tested the following macros on test scripts with libbpf USDTs:
CAFFE_SDT
CAFFE_DISABLE_SDT
CAFFE_SDT_WITH_SEMAPHORE


Reviewed By: RihamSelim

Differential Revision: D47159249

