### PR TITLE
fix AsyncCollectiveTensor interaction with view ops, provide torch.compile support

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -926,7 +926,6 @@ def forward(self, detach_13, clone, tangents_1):
 
         # Assert that they are both `AsyncCollectiveTensor`s
         self.assertEqual(type(ref), type(res))
-        import pdb; pdb.set_trace()
         self.assertEqual(ref, res)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105237
* #105236
* #105235
* #104974
* #104483
* #104482

