### PR TITLE
add qtensor support for custom device

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -19,6 +19,12 @@
 
 namespace at {
 
+using NewQTensorFuncType = std::function<at::Tensor(at::IntArrayRef,
+    const TensorOptions&, at::QuantizerPtr)>;
+
+TORCH_API void SetNewQTensorImpl(at::DeviceType t, at::NewQTensorFuncType impl);
+TORCH_API const at::NewQTensorFuncType& GetNewQTensorImpl(at::DeviceType t);
+
 /**
  * UnknownQuantizer is a placeholder quantizer for functions that implement
  * quantization in a two step process.  First a tensor is allocated but with

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -24,7 +24,7 @@ using NewQTensorFuncType = std::function<at::Tensor(at::IntArrayRef,
 
 TORCH_API void SetNewQTensorImpl(at::DeviceType t, at::NewQTensorFuncType impl);
 TORCH_API const at::NewQTensorFuncType& GetNewQTensorImpl(at::DeviceType t);
-
+TORCH_API bool HasRegisteredQTensorImpl(at::DeviceType t);
 /**
  * UnknownQuantizer is a placeholder quantizer for functions that implement
  * quantization in a two step process.  First a tensor is allocated but with

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -10,6 +10,7 @@
 #include <c10/macros/Macros.h>
 #include <torch/extension.h>
 
+#include <ATen/ceil_div.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/Resize.h>
@@ -17,6 +18,9 @@
 #include <ATen/ops/abs_native.h>
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
+#include <ATen/quantized/Quantizer.h>
+#include <ATen/quantized/QTensorImpl.h>
+#include <ATen/native/quantized/AffineQuantizer.h>
 
 static uint64_t add_counter = 0;
 static uint64_t last_saved_value = 0;
@@ -31,7 +35,9 @@ static uint64_t last_storageImpl_saved_value = 0;
 namespace at {
 namespace detail {
 
-C10_REGISTER_GUARD_IMPL(PrivateUse1, c10::impl::NoOpDeviceGuardImpl<DeviceType::PrivateUse1>);
+C10_REGISTER_GUARD_IMPL(
+    PrivateUse1,
+    c10::impl::NoOpDeviceGuardImpl<DeviceType::PrivateUse1>);
 
 }} // namespace at::detail
 
@@ -42,11 +48,22 @@ void abs_kernel(::at::TensorIteratorBase& iter) {
   abs_counter += 1;
 }
 
+void quantize_tensor_per_tensor_affine_foo(
+    const at::Tensor& rtensor,
+    at::Tensor& qtensor,
+    double scale,
+    int64_t zero_point) {
+  ;
+}
+
 } // namespace
 
 namespace at::native {
 
 REGISTER_PRIVATEUSE1_DISPATCH(abs_stub, &abs_kernel);
+REGISTER_PRIVATEUSE1_DISPATCH(
+    quantize_tensor_per_tensor_affine_stub,
+    &quantize_tensor_per_tensor_affine_foo);
 
 } // namespace at::native
 struct CustomBackendMetadata : public c10::BackendMeta {
@@ -55,8 +72,10 @@ struct CustomBackendMetadata : public c10::BackendMeta {
   int format_number_{-1};
   mutable bool cloned_{false};
   // define the constructor
-  CustomBackendMetadata(int backend_version_format, int format_number): backend_version_format_(backend_version_format), format_number_(format_number) {}
-  c10::intrusive_ptr<c10::BackendMeta> clone(const c10::intrusive_ptr<c10::BackendMeta>& ptr) const override {
+  CustomBackendMetadata(int backend_version_format, int format_number) :
+      backend_version_format_(backend_version_format), format_number_(format_number) {}
+  c10::intrusive_ptr<c10::BackendMeta> clone(
+      const c10::intrusive_ptr<c10::BackendMeta>& ptr) const override {
     cloned_ = true;
     return c10::BackendMeta::clone(ptr);
   }
@@ -67,7 +86,8 @@ void for_serialization(const at::Tensor& t, std::unordered_map<std::string, bool
   if (t.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr() == nullptr) {
     return;
   }
-  auto tmeta = dynamic_cast<CustomBackendMetadata*>(t.unsafeGetTensorImpl()->get_backend_meta());
+  auto tmeta = dynamic_cast<CustomBackendMetadata*>(
+      t.unsafeGetTensorImpl()->get_backend_meta());
   if (tmeta->backend_version_format_ == 1) {
     m["backend_version_format"] = true;
   }
@@ -85,18 +105,22 @@ void for_deserialization(const at::Tensor& t, std::unordered_map<std::string, bo
   if (m.find("format_number") != m.end()) {
     format_number = 29;
   }
-  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(new CustomBackendMetadata(backend_version_format, format_number))};
+  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(
+      new CustomBackendMetadata(backend_version_format, format_number))};
   t.unsafeGetTensorImpl()->set_backend_meta(new_tmeta);
 }
 
-void custom_serialization_registry(){
-torch::jit::TensorBackendMetaRegistry(c10::DeviceType::PrivateUse1, &for_serialization, &for_deserialization);
+void custom_serialization_registry() {
+  torch::jit::TensorBackendMetaRegistry(c10::DeviceType::PrivateUse1,
+                                        &for_serialization,
+                                        &for_deserialization);
 }
 
 //check if BackendMeta serialization correctly
 bool check_backend_meta(const at::Tensor& t) {
   if (t.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr()) {
-    CustomBackendMetadata* tmeta = dynamic_cast<CustomBackendMetadata*>(t.unsafeGetTensorImpl()->get_backend_meta());
+    CustomBackendMetadata* tmeta = dynamic_cast<CustomBackendMetadata*>(
+        t.unsafeGetTensorImpl()->get_backend_meta());
     if (tmeta->backend_version_format_==1 && tmeta->format_number_==29) {
       return true;
     }
@@ -108,13 +132,19 @@ bool check_backend_meta(const at::Tensor& t) {
 void custom_set_backend_meta(const at::Tensor& t) {
   int backend_version_format{1};
   int format_number{29};
-  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(new CustomBackendMetadata(backend_version_format, format_number))};
+  c10::intrusive_ptr<c10::BackendMeta> new_tmeta{std::unique_ptr<c10::BackendMeta>(
+      new CustomBackendMetadata(backend_version_format, format_number))};
   t.unsafeGetTensorImpl()->set_backend_meta(new_tmeta);
 }
 
 // A dummy storageImpl for our custom device, that secretly uses the CPU
-c10::intrusive_ptr<c10::StorageImpl> make_custom_storage_impl(c10::StorageImpl::use_byte_size_t, c10::SymInt size_bytes, c10::Allocator* allocator, bool resizable) {
-  c10::intrusive_ptr<c10::StorageImpl> custom_storage_impl = c10::make_intrusive<c10::StorageImpl>(c10::StorageImpl::use_byte_size_t(), size_bytes, allocator, resizable);
+c10::intrusive_ptr<c10::StorageImpl> make_custom_storage_impl(c10::StorageImpl::use_byte_size_t,
+                                                              c10::SymInt size_bytes,
+                                                              c10::Allocator* allocator,
+                                                              bool resizable) {
+  c10::intrusive_ptr<c10::StorageImpl> custom_storage_impl =
+      c10::make_intrusive<c10::StorageImpl>(c10::StorageImpl::use_byte_size_t(),
+      size_bytes, allocator, resizable);
   storageImpl_counter += 1;
   return custom_storage_impl;
 }
@@ -133,7 +163,9 @@ bool custom_storageImpl_called() {
 }
 
 // basic dummy add function
-at::Tensor custom_add_Tensor(const at::Tensor & self, const at::Tensor & other, const at::Scalar & alpha) {
+at::Tensor custom_add_Tensor(const at::Tensor & self,
+                             const at::Tensor & other,
+                             const at::Scalar & alpha) {
   add_counter += 1;
   // Since this custom device is just for testing, not bothering to implement kernels.
   return at::empty(self.sizes(), self.options());
@@ -170,13 +202,30 @@ REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &global_custom_alloc);
 
 // basic dummy empty function, so we can directly construct tensors on the custom device
 // This dummy test device will just use the CPU allocator, and ignores pinned memory.
-at::Tensor custom_empty_memory_format(at::IntArrayRef size, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, c10::optional<at::MemoryFormat> memory_format) {
+at::Tensor custom_empty_memory_format(at::IntArrayRef size,
+                                      c10::optional<at::ScalarType> dtype,
+                                      c10::optional<at::Layout> layout,
+                                      c10::optional<at::Device> device,
+                                      c10::optional<bool> pin_memory,
+                                      c10::optional<at::MemoryFormat> memory_format) {
   constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
-  return at::detail::empty_generic(size, &global_custom_alloc, private_use_ks, c10::dtype_or_default(dtype), memory_format);
+  return at::detail::empty_generic(size,
+                                   &global_custom_alloc,
+                                   private_use_ks,
+                                   c10::dtype_or_default(dtype),
+                                   memory_format);
 }
-at::Tensor custom_empty_symint(c10::IntArrayRef size, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, c10::optional<at::MemoryFormat> memory_format) {
+at::Tensor custom_empty_symint(c10::IntArrayRef size,
+                               c10::optional<at::ScalarType> dtype,
+                               c10::optional<at::Layout> layout,
+                               c10::optional<at::Device> device,
+                               c10::optional<bool> pin_memory,
+                               c10::optional<at::MemoryFormat> memory_format) {
   constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
-  return at::detail::empty_generic(size, &global_custom_alloc, private_use_ks, c10::dtype_or_default(dtype), memory_format);
+  return at::detail::empty_generic(size,
+                                   &global_custom_alloc,
+                                   private_use_ks,
+                                   c10::dtype_or_default(dtype), memory_format);
 }
 
 at::Tensor & custom_fill__scalar(at::Tensor & self, const at::Scalar & value) {
@@ -186,8 +235,10 @@ at::Tensor & custom_fill__scalar(at::Tensor & self, const at::Scalar & value) {
 
 // basic dummy copy_() function, so we can copy from the custom device to/from CPU
 at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
-  TORCH_CHECK(self.is_cpu() || self.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
-  TORCH_CHECK(dst.is_cpu() || dst.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
+  TORCH_CHECK(self.is_cpu() || self.device().type() == c10::DeviceType::PrivateUse1,
+      "Dummy test only allows copy from cpu -> dummy device.");
+  TORCH_CHECK(dst.is_cpu() || dst.device().type() == c10::DeviceType::PrivateUse1,
+      "Dummy test only allows copy from cpu -> dummy device.");
 
   // Some dummy asserts for the basic use case: inputs are the same size / dtype, all contiguous.
   TORCH_CHECK(self.sizes() == dst.sizes());
@@ -198,7 +249,12 @@ at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool
   return dst;
 }
 
-at::Tensor custom_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride, c10::optional<at::ScalarType> dtype_opt, c10::optional<at::Layout> layout_opt, c10::optional<at::Device> device_opt, c10::optional<bool> pin_memory_opt) {
+at::Tensor custom_empty_strided(c10::IntArrayRef size,
+                                c10::IntArrayRef stride,
+                                c10::optional<at::ScalarType> dtype_opt,
+                                c10::optional<at::Layout> layout_opt,
+                                c10::optional<at::Device> device_opt,
+                                c10::optional<bool> pin_memory_opt) {
   constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
   auto dtype = c10::dtype_or_default(dtype_opt);
   return  at::detail::empty_strided_generic(size, stride, &global_custom_alloc, private_use_ks, dtype);
@@ -210,15 +266,23 @@ at::Tensor& custom_set_source_Storage(at::Tensor& result, c10::Storage src) {
   c10::IntArrayRef stride = {};
   result.unsafeGetTensorImpl()->set_storage_offset(0);
   at::OptionalIntArrayRef stride_opt = stride.data() != nullptr ? at::OptionalIntArrayRef(stride) : c10::nullopt;
-  at::native::resize_impl_cpu_(result.unsafeGetTensorImpl(), new_size, stride_opt, /*resize_storage=*/!result.is_meta());
+  at::native::resize_impl_cpu_(result.unsafeGetTensorImpl(),
+                               new_size, stride_opt,
+                               /*resize_storage=*/!result.is_meta());
   return result;
 }
 
 // Some set operations for the basic use case
-at::Tensor& custom_set_source_Storage_storage_offset(at::Tensor& result, c10::Storage storage, int64_t storage_offset, c10::IntArrayRef size, c10::IntArrayRef stride) {
+at::Tensor& custom_set_source_Storage_storage_offset(at::Tensor& result,
+                                                     c10::Storage storage,
+                                                     int64_t storage_offset,
+                                                     c10::IntArrayRef size,
+                                                     c10::IntArrayRef stride) {
   result.unsafeGetTensorImpl()->set_storage_offset(storage_offset);
   at::OptionalIntArrayRef stride_opt = stride.data() != nullptr ? at::OptionalIntArrayRef(stride) : c10::nullopt;
-  at::native::resize_impl_cpu_(result.unsafeGetTensorImpl(), size, stride_opt, /*resize_storage=*/!result.is_meta());
+  at::native::resize_impl_cpu_(result.unsafeGetTensorImpl(),
+                               size, stride_opt,
+                               /*resize_storage=*/!result.is_meta());
   return result;
 }
 
@@ -226,7 +290,8 @@ at::Tensor& custom_set_source_Storage_storage_offset(at::Tensor& result, c10::St
 std::vector<void*> custom_pinned_data_ptr;
 
 at::Tensor custom__pin_memory(const at::Tensor& self, c10::optional<at::Device> device) {
-  TORCH_CHECK(self.device().is_cpu(), "cannot pin '", self.toString(), "' only dense CPU tensors can be pinned");
+  TORCH_CHECK(self.device().is_cpu(), "cannot pin '", self.toString(),
+      "' only dense CPU tensors can be pinned");
 
   // record pinned data ptr
   at::Tensor dump_pinned_tensor = self * 1.0;
@@ -250,8 +315,9 @@ bool custom_is_pinned(const at::Tensor& self, c10::optional<at::Device> device) 
   return false;
 }
 
-const at::Tensor& custom_resize_(const at::Tensor& self, at::IntArrayRef size,
-                          c10::optional<at::MemoryFormat> optional_memory_format) {
+const at::Tensor& custom_resize_(const at::Tensor& self,
+                                 at::IntArrayRef size,
+                                 c10::optional<at::MemoryFormat> optional_memory_format) {
   self.unsafeGetTensorImpl()->set_sizes_contiguous(size);
   const auto itemsize = self.unsafeGetTensorImpl()->dtype().itemsize();
   const auto offset = self.unsafeGetTensorImpl()->storage_offset();
@@ -260,7 +326,6 @@ const at::Tensor& custom_resize_(const at::Tensor& self, at::IntArrayRef size,
   if (storage_size > storage.nbytes()) {
     storage.unsafeGetStorageImpl()->set_nbytes(storage_size);
   }
-
   return self;
 }
 
@@ -285,6 +350,8 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("_pin_memory", &custom__pin_memory);
   m.impl("is_pinned", &custom_is_pinned);
   m.impl("resize_", &custom_resize_);
+  m.impl("resize_", &custom_resize_);
+  m.impl("quantize_per_tensor", &at::native::quantize_per_tensor);
 }
 
 // This basic implementation doesn't bother dealing with different device indices
@@ -337,6 +404,58 @@ void set_custom_device_index(c10::DeviceIndex device_index) {
   custom_device_index = device_index;
 }
 
+static int64_t _get_sub_byte_tensor_size(at::IntArrayRef sizes, size_t dtype_itemsize, at::ScalarType t) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  int64_t element_per_byte;
+  switch(t) {
+    case at::ScalarType::QUInt4x2:
+      element_per_byte = 2;
+      break;
+    case at::ScalarType::QUInt2x4:
+      element_per_byte = 4;
+      break;
+    default:
+      element_per_byte = 1;
+  }
+  // zero dim tensor
+  if (sizes.empty()) {
+    return c10::multiply_integers(sizes) * dtype_itemsize;
+  }
+  // Consider most inner dim as cols
+  int64_t cols = sizes.at(sizes.size()-1);
+  int64_t bytes_per_row = cols * dtype_itemsize;
+  // align qtensor most inner dim, compute ceil (bytes_per_row / element_per_byte)
+  return c10::multiply_integers(at::IntArrayRef(sizes.data(), sizes.size() - 1)) *
+      at::ceil_div(bytes_per_row, element_per_byte);
+}
+
+at::Tensor new_qtensor_foo(at::IntArrayRef sizes,
+    const at::TensorOptions& options, at::QuantizerPtr q_ptr) {
+  auto memory_format = options.memory_format_opt().value_or(c10::MemoryFormat::Contiguous);
+  at::DispatchKey tensorDispatchKey = options.computeDispatchKey();
+  at::native::check_size_nonnegative(sizes);
+  at::Allocator* allocator = at::GetAllocator(c10::DeviceType::PrivateUse1);
+  auto dtype = options.dtype();
+  auto scalar_type = at::typeMetaToScalarType(dtype);
+  int64_t size_bytes = _get_sub_byte_tensor_size(sizes, dtype.itemsize(), scalar_type);
+
+  auto storage = c10::make_intrusive<c10::StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      size_bytes,
+      allocator->allocate(size_bytes),
+      allocator,
+      /*resizable=*/true);
+  auto tensor = at::detail::make_tensor<at::QTensorImpl>(
+      storage, at::DispatchKeySet(tensorDispatchKey), dtype, q_ptr);
+  at::get_qtensorimpl(tensor)->set_sizes_contiguous(sizes);
+  at::get_qtensorimpl(tensor)->empty_tensor_restride(memory_format);
+  return tensor;
+}
+
+void enable_qtensor() {
+  at::SetNewQTensorImpl(at::DeviceType::PrivateUse1, &new_qtensor_foo);
+}
+
 // Here, we're exposing a custom device object that corresponds to our custom backend.
 // We do this using pybind: exposing an "extension_name.custom_device()" function in python,
 // that's implemented in C++.
@@ -352,4 +471,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("custom_set_backend_meta", &custom_set_backend_meta, "a fake set tensor BackendMeta function");
     m.def("check_backend_meta", &check_backend_meta, "check if BackendMeta serialization correctly");
     m.def("custom_serialization_registry", &custom_serialization_registry, "register custom serialization function");
+    m.def("enable_qtensor", &enable_qtensor, "enable qtensor for privateuse1");
 }

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -413,6 +413,15 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             torch.utils.rename_privateuse1_backend('foo')
             a = torch.empty([2, 3, 4, 5], device="foo", names=["N", "C", "H", "W"])
 
+        def test_open_device_qtensor():
+            torch.utils.rename_privateuse1_backend('foo')
+            device = self.module.custom_device()
+            x = torch.empty(4, 4, device=device)
+            self.module.enable_qtensor()
+            q_tensor = torch.quantize_per_tensor(x, 0.1, 10, torch.quint8)
+            self.assertEqual(q_tensor.device.type, torch._C._get_privateuse1_backend_name())
+
+
         test_base_device_registration()
         test_before_common_registration()
         test_common_registration()
@@ -428,6 +437,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         test_open_device_storage_type()
         test_open_device_faketensor()
         test_open_device_named_tensor()
+        test_open_device_qtensor()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
As QTensor with custom device, like Tensor, we also want to support it. But new a qtensor is different to the existing func for our custom-device, so we add a func so that we can register a func to new qtensor for custom device if needed, and we also could use the existing func if we do not need to  register a func. @albanD  could you have a look?