### PR TITLE
Grammatically updated documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,8 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
 Features described in this documentation are classified by release status:
 
-  *Stable:*  These features will be maintained long-term and there should generally
-  be no major performance limitations or gaps in documentation.
+  *Stable:*  These features are to be maintained long-term and generally should not 
+  have any major performance limitations nor gaps in documentation.
   We also expect to maintain backwards compatibility (although
   breaking changes can happen and notice will be given one release ahead
   of time).


### PR DESCRIPTION
A small grammatical update to the pytorch documentation
<img width="606" alt="Screen Shot 2023-07-16 at 4 30 03 AM" src="https://github.com/pytorch/pytorch/assets/139684548/bd98ca69-12cc-490d-abfc-41547df08694">
