### PR TITLE
Parse TORCH_CPP_LOG_LEVEL in InitCaffeLogging

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -260,6 +260,8 @@ bool InitCaffeLogging(int* argc, char** argv) {
 
   initGoogleLogging(argv[0]);
 
+  detail::setLogLevelFlagFromEnv();
+
   UpdateLoggingLevelsFromFlags();
 
   return true;


### PR DESCRIPTION
Summary: Without the call to detail::setLogLevelFlagFromEnv() in InitCaffeLogging, TORCH_CPP_LOG_LEVEL has no effect on the logic inside UpdateLoggingLevelsFromFlags.

Differential Revision: D47497846

