### PR TITLE
Remove redundant setuptools in pyproject.toml requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
     "numpy",
     "ninja",
     "pyyaml",
-    "setuptools",
     "cmake",
     "typing-extensions",
     "requests",


### PR DESCRIPTION
There are two `setuptools` require in requires. It was a typo in original PR: https://github.com/pytorch/pytorch/commit/e85dfb6203ed2e02604d684afb89a23e6536ec5c .

This PR just remove the redundant one.
