### PR TITLE
[C10D] Improve MTPG autograd test. Fixes #105106

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -254,6 +254,8 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
 
     @skip_if_lt_x_gpu(1)
     def test_bwd_sees_fwd_pg(self):
+        fwd_tid = threading.current_thread().ident
+
         class MyFunc(torch.autograd.Function):
             @staticmethod
             def forward(ctx, rank):
@@ -266,10 +268,13 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
             @staticmethod
             def backward(ctx, grad_output):
                 result, rank = ctx.saved_tensors
+                bwd_tid = threading.current_thread().ident
 
-                assert int(rank.item()) == dist.get_rank()
+                self.assertEqual(fwd_tid, bwd_tid, f"bwd not running in the same thread a fwd for rank {rank.item()}")
+                self.assertTrue(dist.is_initialized())
+                self.assertEqual(int(rank.item()), dist.get_rank())
                 dist.all_reduce(result)
-                assert int(result.item()) == 12  # (0 + 1 + 2 + 3) * 2
+                self.assertEqual(int(result.item()), 12)  # (0 + 1 + 2 + 3) * 2
 
                 return grad_output * result
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105356

Explicitly asserts that bwd is running from the same thread as fwd.