### PR TITLE
[DTensor] Fix device detection logic for TestDTensorPlacementTypes::test_split_tensor.

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -567,7 +567,7 @@ class TestDTensorPlacementTypes(DTensorTestBase):
         # Keep everything deterministic.
         torch.manual_seed(0)
         tensor = torch.rand(size)
-        if torch.cuda.is_available():
+        if self.device_type == "cuda":
             return tensor.cuda()
         else:
             return tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105357

The test should respect self.device_type as it checks whether the environment
has enough GPUs to serve the requested world size.

The test will lead to hangs if we try to run 8 ranks over our 2-4 GPUs CI instances.

Fixes #104769