### PR TITLE
Set dir for aot_inductor output files

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -29,7 +29,7 @@ from importlib import abc
 from pathlib import Path
 from threading import Thread
 from time import sleep, time
-from typing import Any, Callable, Dict, List, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import torch
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -302,8 +302,14 @@ def code_hash(code, extra=""):
     )
 
 
-def get_path(basename: str, extension: str):
-    subdir = os.path.join(cache_dir(), basename[1:3])
+def get_path(basename: str, extension: str, specified_dir: str = ""):
+    if specified_dir:
+        if os.path.isabs(specified_dir):
+            subdir = specified_dir
+        else:
+            subdir = os.path.join(cache_dir(), specified_dir)
+    else:
+        subdir = os.path.join(cache_dir(), basename[1:3])
     path = os.path.join(subdir, f"{basename}.{extension}")
     return basename, subdir, path
 
@@ -317,10 +323,14 @@ def get_hash(content: Union[str, bytes], extra="", hash_type="code"):
 
 
 def write(
-    content: Union[str, bytes], extension: str, extra="", hash_type: str = "code"
+    content: Union[str, bytes],
+    extension: str,
+    extra="",
+    hash_type: str = "code",
+    specified_dir: str = "",
 ):
     key: str = get_hash(content, extra, hash_type)
-    basename, subdir, path = get_path(key, extension)
+    basename, subdir, path = get_path(key, extension, specified_dir)
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
     if not os.path.exists(path):
@@ -794,7 +804,12 @@ class CudaKernelParamCache:
 
     @classmethod
     def set(cls, key, params, cubin):
-        _, path = write(cubin, "cubin", hash_type="cubin")
+        _, path = write(
+            cubin,
+            "cubin",
+            hash_type="cubin",
+            specified_dir=config.aot_inductor_output_path,
+        )
         params["cubin_path"] = path
         cls.cache[key] = params
 
@@ -816,20 +831,19 @@ class AotCodeCache:
                 "i", "o", vec_isa=picked_vec_isa, cuda=cuda, aot_mode=graph.aot_mode
             )
         )
-        key, input_path = write(source_code, "cpp", extra=cpp_command)
+        key, input_path = write(
+            source_code,
+            "cpp",
+            extra=cpp_command,
+            specified_dir=config.aot_inductor_output_path,
+        )
         if key not in cls.cache:
             from filelock import FileLock
 
             lock_dir = get_lock_dir()
             lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
             with lock:
-                # Place the generated .so into a sub-folder with the full hex-hash to avoid
-                # any name collision.
-                output_so_dir = os.path.splitext(input_path)[0]
-                if not os.path.exists(output_so_dir):
-                    os.makedirs(output_so_dir, exist_ok=False)
-                so_name = f"{config.dll_name}.so"
-                output_so = os.path.join(output_so_dir, so_name)
+                output_so = f"{input_path[:-4]}.so"
                 if not os.path.exists(output_so):
                     cmd = cpp_compile_command(
                         input=input_path,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -19,7 +19,7 @@ import torch.utils._pytree as pytree
 from torch._dynamo import logging as dynamo_logging, utils as dynamo_utils
 from torch._dynamo.utils import detect_fake_mode
 from torch._functorch.aot_autograd import make_boxed_func
-from torch._inductor.codecache import CompiledFxGraph
+from torch._inductor.codecache import code_hash, CompiledFxGraph
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
@@ -771,6 +771,15 @@ def compile_fx_aot(
         if config_patches is None
         else {**config_patches, "cpp_wrapper": True}
     )
+    if (
+        "aot_inductor_output_path" not in config_patches
+        and not config.aot_inductor_output_path
+    ):
+        config_patches = {
+            **config_patches,
+            "aot_inductor_output_path": code_hash(model_.code),
+        }
+
     return compile_fx(
         model_,
         example_inputs_,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -54,8 +54,11 @@ group_fusion = False
 # enable reordering pass
 reordering = True
 
-# inductor engine name
-dll_name = "inductor_engine.so"
+# AOTInductor output path
+# If an absolute path is specified, the generated lib files will be stored under the directory;
+# If a relative path is specified, it will be used as a subdirectory under the default caching path;
+# If not specified, a temp directory will be created under the default caching path
+aot_inductor_output_path = ""
 
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"


### PR DESCRIPTION
Summary: Generate a random hash name as dir name for aot_inductor, all aot_inductor output files should write into this hash_name dir. This enables merge net predictor file package.

Differential Revision: D47487758



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel