### PR TITLE
Enable intellisense for _dynamo, _inductor and onnx by importing under type_checking guard

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1753,6 +1753,14 @@ _deprecated_attrs = {
     "has_mkldnn": torch.backends.mkldnn.is_available,
 }
 
+if TYPE_CHECKING:
+    # Import the following modules during type checking to enable code intelligence features,
+    # such as auto-completion in tools like pylance, even when these modules are not explicitly
+    # imported in user code.
+    from torch import _dynamo as _dynamo
+    from torch import _inductor as _inductor
+    from torch import onnx as onnx
+
 _lazy_modules = {
     "_dynamo",
     "_inductor",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105361

