### PR TITLE
Make libtorch CUDA12 builds actually build on CUDA-12

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -55,10 +55,10 @@ jobs:
     name: libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: libtorch-linux-bionic-cuda11.8-py3.7-gcc9
-      docker-image-name: pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc9
+      build-environment: libtorch-linux-bionic-cuda12.1-py3.7-gcc9
+      docker-image-name: pytorch-linux-bionic-cuda12.1-cudnn8-py3-gcc9
       build-generates-artifacts: false
-      runner: linux.2xlarge
+      runner: linux.4xlarge
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },


### PR DESCRIPTION
Not sure, why https://github.com/pytorch/pytorch/pull/102178 downgraded this build from CUDA-12.1 down to CUDA-11.8

Hattip to @ptrblck for spotting it.

