### PR TITLE
aot_inductor_interface: surface previously eaten error messages

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -876,6 +876,10 @@ class AotCodeCache:
                         subprocess.check_call(cmd)
                     except subprocess.CalledProcessError as e:
                         raise exc.CppCompileError(cmd, e.output) from e
+                else:
+                    log.debug(
+                        "aot_inductor dynamic library already exist: %s", output_so
+                    )
 
                 cls.cache[key] = output_so
 

--- a/torch/_inductor/codegen/aot_inductor_interface.cpp
+++ b/torch/_inductor/codegen/aot_inductor_interface.cpp
@@ -1,18 +1,19 @@
 #include <torch/csrc/inductor/aot_inductor_interface.h>
 #include <torch/csrc/inductor/aot_inductor_model_container.h>
+#include <iostream>
 #include <stdexcept>
 #include <vector>
 
-#define CONVERT_EXCEPTION_TO_ERROR_CODE(...)     \
-  try {                                          \
-    __VA_ARGS__                                  \
-  } catch (const std::exception& e) {            \
-    LOG(ERROR) << "Error: " << e.what();         \
-    return AOTInductorError::Failure;            \
-  } catch (...) {                                \
-    LOG(ERROR) << "Unknown exception occurred."; \
-    return AOTInductorError::Failure;            \
-  }                                              \
+#define CONVERT_EXCEPTION_TO_ERROR_CODE(...)                                  \
+  try {                                                                       \
+    __VA_ARGS__                                                               \
+  } catch (const std::exception& e) {                                         \
+    std::cerr << "Error: " << e.what() << std::endl;                          \
+    return AOTInductorError::Failure;                                         \
+  } catch (...) {                                                             \
+    std::cerr << "Unknown exception occurred." << std::endl;                  \
+    return AOTInductorError::Failure;                                         \
+  }                                                                           \
   return AOTInductorError::Success;
 
 extern "C" {


### PR DESCRIPTION
Summary:
tldr:

* change glog -> cout for important logging inside aot_inductor.so
* bring a small amount of important python logging from debug to info

Test Plan: CI

Differential Revision: D47464665



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov