### PR TITLE
Use shareable calculate-docker-image GHA

### DIFF
--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -1,4 +1,4 @@
-# Docker images for Jenkins
+# Docker images for GitHub CI
 
 This directory contains everything needed to build the Docker images
 that are used in our CI.

--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -1,7 +1,7 @@
 # Docker images for Jenkins
 
 This directory contains everything needed to build the Docker images
-that are used in our CI
+that are used in our CI.
 
 The Dockerfiles located in subdirectories are parameterized to
 conditionally run build stages depending on build arguments passed to

--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -12,12 +12,11 @@ each image as the `BUILD_ENVIRONMENT` environment variable.
 
 See `build.sh` for valid build environments (it's the giant switch).
 
-Docker builds are now defined with `.circleci/cimodel/data/simple/docker_definitions.py`
-
 ## Contents
 
 * `build.sh` -- dispatch script to launch all builds
 * `common` -- scripts used to execute individual Docker build stages
+* `ubuntu` -- Dockerfile for Ubuntu image for CPU jobs
 * `ubuntu-cuda` -- Dockerfile for Ubuntu image with CUDA support for nvidia-docker
 
 ## Usage

--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -18,6 +18,7 @@ See `build.sh` for valid build environments (it's the giant switch).
 * `common` -- scripts used to execute individual Docker build stages
 * `ubuntu` -- Dockerfile for Ubuntu image for CPU build and test jobs
 * `ubuntu-cuda` -- Dockerfile for Ubuntu image with CUDA support for nvidia-docker
+* `ubuntu-rocm` -- Dockerfile for Ubuntu image with ROCm support
 
 ## Usage
 

--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -16,7 +16,7 @@ See `build.sh` for valid build environments (it's the giant switch).
 
 * `build.sh` -- dispatch script to launch all builds
 * `common` -- scripts used to execute individual Docker build stages
-* `ubuntu` -- Dockerfile for Ubuntu image for CPU jobs
+* `ubuntu` -- Dockerfile for Ubuntu image for CPU build and test jobs
 * `ubuntu-cuda` -- Dockerfile for Ubuntu image with CUDA support for nvidia-docker
 
 ## Usage

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -71,10 +71,9 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
-          xla: ${{ contains(inputs.build-environment, 'xla') }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -83,10 +83,9 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
-          xla: ${{ contains(inputs.build-environment, 'xla') }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -83,10 +83,9 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
-          xla: ${{ contains(inputs.build-environment, 'xla') }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -68,10 +68,9 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
-          xla: ${{ contains(inputs.build-environment, 'xla') }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -65,10 +65,9 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
-          xla: ${{ contains(inputs.build-environment, 'xla') }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image }}
 

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -70,12 +70,11 @@ jobs:
 
       - name: Build docker image
         id: build-docker-image
-        uses: ./.github/actions/calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true
-          skip_push: false
-          force_push: true
+          push: true
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
@@ -109,5 +108,4 @@ jobs:
 
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
-
         if: always()

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build docker image
         id: build-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build docker image
         id: build-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build docker image
         id: build-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,7 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
+      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,43 +14,11 @@ on:
 # The names of steps that actually test the code should be suffixed with `(nonretryable)`.
 # When any other step fails, it's job will be retried once by retryBot.
 jobs:
-  docker-image:
-    name: docker-image
-    if: github.repository_owner == 'pytorch'
-    runs-on: [self-hosted, linux.2xlarge]
-    timeout-minutes: 30
-    outputs:
-      docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          submodules: false
-
-      - name: Setup Linux
-        uses: ./.github/actions/setup-linux
-
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: ./.github/actions/calculate-docker-image
-        with:
-          docker-image-name: 'pytorch-linux-focal-linter'
-          # TODO: This flag is needed to make the Docker image available on ECR
-          # to avoid "Requested image not found" error for linter workflow. The
-          # longer term fix would be to refactor linter so that building the new
-          # image and running lint are done in the same runner like _linux-build
-          skip_push: false
-
-      - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always()
-
   lintrunner:
-    needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@use-shareable-gha-calculate-docker-image
     with:
       runner: linux.2xlarge
-      docker-image: ${{ needs.docker-image.outputs.docker-image }}
+      docker-image: pytorch-linux-focal-linter
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -93,11 +61,10 @@ jobs:
         exit $RC
 
   quick-checks:
-    needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@use-shareable-gha-calculate-docker-image
     with:
       runner: linux.2xlarge
-      docker-image: ${{ needs.docker-image.outputs.docker-image }}
+      docker-image: pytorch-linux-focal-linter
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -147,11 +114,10 @@ jobs:
           bash .github/scripts/pr-sanity-check.sh
 
   workflow-checks:
-    needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@use-shareable-gha-calculate-docker-image
     with:
       runner: linux.2xlarge
-      docker-image: ${{ needs.docker-image.outputs.docker-image }}
+      docker-image: pytorch-linux-focal-linter
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -182,11 +148,10 @@ jobs:
         exit $RC
 
   toc:
-    needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@use-shareable-gha-calculate-docker-image
     with:
       runner: linux.2xlarge
-      docker-image: ${{ needs.docker-image.outputs.docker-image }}
+      docker-image: pytorch-linux-focal-linter
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -220,11 +185,10 @@ jobs:
   test-tools:
     name: Test tools
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@use-shareable-gha-calculate-docker-image
     with:
       runner: linux.2xlarge
-      docker-image: ${{ needs.docker-image.outputs.docker-image }}
+      docker-image: pytorch-linux-focal-linter
       fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
+      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -65,6 +66,7 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
+      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -118,6 +120,7 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
+      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -152,6 +155,7 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
+      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,6 @@ jobs:
     with:
       runner: linux.2xlarge
       docker-image: pytorch-linux-focal-linter
-      fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -264,7 +264,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-bionic-py3_8-clang8-xla
-      docker-image-name: xla_base
+      docker-image-name: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base:v1.0
       test-matrix: |
         { include: [
           { config: "xla", shard: 1, num_shards: 1, runner: "linux.12xlarge" },


### PR DESCRIPTION
Switch from PyTorch `calculate-docker-image` GHA to its shareable version on test-infra https://github.com/pytorch/test-infra/pull/4397.

I will clean up PyTorch `calculate-docker-image` GHA in a separate PR after landing this one.