### PR TITLE
[torch_np] update test to use ones_like instead of empty_like

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1130,7 +1130,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_numpy_dtype_argument_to_function(x):
         import numpy as np
 
-        return np.empty_like(x, dtype=np.float64)
+        return np.ones_like(x, dtype=np.float64)
 
 
 def global_func_with_default_tensor_args(


### PR DESCRIPTION
This test fails locally (probably because deterministic mode is not on by default). 

We replace the use of `empty_like` to `ones_like` as this test doesn't need `empty_like`.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov