### PR TITLE
[inductor] Allow specify a subdir to store .so and .cubin files

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -287,7 +287,7 @@ def get_lock_dir():
     return lock_dir
 
 
-def code_hash(code, extra=""):
+def code_hash(code, extra: str = ""):
     hashing_str = code
     if extra != "":
         hashing_str = hashing_str + "||" + extra
@@ -311,7 +311,7 @@ def get_path(basename: str, extension: str, specified_dir: str = ""):
     return basename, subdir, path
 
 
-def get_hash(content: Union[str, bytes], extra="", hash_type="code"):
+def get_hash(content: Union[str, bytes], extra: str = "", hash_type: str = "code"):
     assert hash_type in ["code", "cubin"], "Hash type not supported"
     if hash_type == "code":
         return code_hash(content, extra)
@@ -322,7 +322,7 @@ def get_hash(content: Union[str, bytes], extra="", hash_type="code"):
 def write(
     content: Union[str, bytes],
     extension: str,
-    extra="",
+    extra: str = "",
     hash_type: str = "code",
     specified_dir: str = "",
 ):
@@ -840,7 +840,8 @@ class AotCodeCache:
             lock_dir = get_lock_dir()
             lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
             with lock:
-                output_so = f"{input_path[:-4]}.so"
+                output_so = os.path.splitext(input_path)[0] + ".so"
+
                 if not os.path.exists(output_so):
                     cmd = cpp_compile_command(
                         input=input_path,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -299,8 +299,14 @@ def code_hash(code, extra=""):
     )
 
 
-def get_path(basename: str, extension: str):
-    subdir = os.path.join(cache_dir(), basename[1:3])
+def get_path(basename: str, extension: str, specified_dir: str = ""):
+    if specified_dir:
+        if os.path.isabs(specified_dir):
+            subdir = specified_dir
+        else:
+            subdir = os.path.join(cache_dir(), specified_dir)
+    else:
+        subdir = os.path.join(cache_dir(), basename[1:3])
     path = os.path.join(subdir, f"{basename}.{extension}")
     return basename, subdir, path
 
@@ -314,10 +320,14 @@ def get_hash(content: Union[str, bytes], extra="", hash_type="code"):
 
 
 def write(
-    content: Union[str, bytes], extension: str, extra="", hash_type: str = "code"
+    content: Union[str, bytes],
+    extension: str,
+    extra="",
+    hash_type: str = "code",
+    specified_dir: str = "",
 ):
     key: str = get_hash(content, extra, hash_type)
-    basename, subdir, path = get_path(key, extension)
+    basename, subdir, path = get_path(key, extension, specified_dir)
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
     if not os.path.exists(path):
@@ -791,7 +801,12 @@ class CudaKernelParamCache:
 
     @classmethod
     def set(cls, key, params, cubin):
-        _, path = write(cubin, "cubin", hash_type="cubin")
+        _, path = write(
+            cubin,
+            "cubin",
+            hash_type="cubin",
+            specified_dir=config.aot_inductor_output_path,
+        )
         params["cubin_path"] = path
         cls.cache[key] = params
 
@@ -813,20 +828,19 @@ class AotCodeCache:
                 "i", "o", vec_isa=picked_vec_isa, cuda=cuda, aot_mode=graph.aot_mode
             )
         )
-        key, input_path = write(source_code, "cpp", extra=cpp_command)
+        key, input_path = write(
+            source_code,
+            "cpp",
+            extra=cpp_command,
+            specified_dir=config.aot_inductor_output_path,
+        )
         if key not in cls.cache:
             from filelock import FileLock
 
             lock_dir = get_lock_dir()
             lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
             with lock:
-                # Place the generated .so into a sub-folder with the full hex-hash to avoid
-                # any name collision.
-                output_so_dir = os.path.splitext(input_path)[0]
-                if not os.path.exists(output_so_dir):
-                    os.makedirs(output_so_dir, exist_ok=False)
-                so_name = f"{config.dll_name}.so"
-                output_so = os.path.join(output_so_dir, so_name)
+                output_so = f"{input_path[:-4]}.so"
                 if not os.path.exists(output_so):
                     cmd = cpp_compile_command(
                         input=input_path,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -19,7 +19,7 @@ import torch.utils._pytree as pytree
 from torch._dynamo import logging as dynamo_logging, utils as dynamo_utils
 from torch._dynamo.utils import detect_fake_mode
 from torch._functorch.aot_autograd import make_boxed_func
-from torch._inductor.codecache import CompiledFxGraph
+from torch._inductor.codecache import code_hash, CompiledFxGraph
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
@@ -771,6 +771,15 @@ def compile_fx_aot(
         if config_patches is None
         else {**config_patches, "cpp_wrapper": True}
     )
+    if (
+        "aot_inductor_output_path" not in config_patches
+        and not config.aot_inductor_output_path
+    ):
+        config_patches = {
+            **config_patches,
+            "aot_inductor_output_path": code_hash(model_.code),
+        }
+
     return compile_fx(
         model_,
         example_inputs_,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -54,8 +54,11 @@ group_fusion = False
 # enable reordering pass
 reordering = True
 
-# inductor engine name
-dll_name = "inductor_engine.so"
+# AOTInductor output path
+# If an absolute path is specified, the generated lib files will be stored under the directory;
+# If a relative path is specified, it will be used as a subdirectory under the default caching path;
+# If not specified, a temp directory will be created under the default caching path
+aot_inductor_output_path = ""
 
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105466

Summary: The subdir is used to store .so and .cubin files generated by AOTInductor. It can either be specified, or created based on hash of the input graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov

Differential Revision: [D47556730](https://our.internmc.facebook.com/intern/diff/D47556730)