### PR TITLE
[pt2][inductor] fix LoweringException: TypeError: '<' not supported between instances of 'ExternKernelCaller' and 'ExternKernelCaller'

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -271,7 +271,10 @@ class PersistentCache(CacheBase):
                 self.update_local_cache(local_cache)
 
                 if use_global_cache():
-                    log_vals(timings)
+                    timings_to_log = {
+                        choice.hash_key(): timings[choice] for choice in choices
+                    }
+                    log_vals(timings_to_log)
         elif use_global_cache():
             # only check global cache, not local one
             check_cache(self.get_global_cache(), callback=log_stats)


### PR DESCRIPTION
Summary: `sort_keys=True` for autotuning results fails because we can't compare ExternKernelCaller objects. besides, it isn't really necessary to sort the keys, either for the autotuning results or the sysinfo. let's just drop sorting all together

Test Plan: sandcastle + CI

Reviewed By: aaronenyeshi

Differential Revision: D47544587



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov