### PR TITLE
[MPS] Add lerp implementation

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -276,7 +276,7 @@ void add_sub_lerp_template(const Tensor& self,
 
   if (!alpha_has_value && op_name == "lerp") {
     if (!self.is_alias_of(other)) { // if inplace, no-op
-      const_cast<Tensor&>(output) = other.clone();
+      output.copy_(other);
     }
     return;
   }

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -260,7 +260,7 @@ void add_sub_lerp_template(const Tensor& self,
                            const Tensor& other,
                            const Scalar& alpha,
                            const Tensor& output,
-                            std::string op_name) {
+                           std::string op_name) {
   if (alpha.toDouble() == 0.0) {
     if (!self.is_alias_of(output)) { // if inplace, no-op
       const_cast<Tensor&>(output) = self.clone();
@@ -286,9 +286,9 @@ void add_sub_lerp_template(const Tensor& self,
     MPSGraphTensor* secondaryTensor = secondaryCastTensor;
 
     if (op_name == "lerp") {
-        secondaryCastTensor = [mpsGraph subtractionWithPrimaryTensor: secondaryCastTensor
-                                                     secondaryTensor: primaryCastTensor
-                                                                name: nil];
+      secondaryCastTensor = [mpsGraph subtractionWithPrimaryTensor:secondaryCastTensor
+                                                   secondaryTensor:primaryCastTensor
+                                                              name:nil];
     }
 
     // if alpha is 1.0, then we don't bother adding another multiply to graph
@@ -506,8 +506,7 @@ TORCH_IMPL_FUNC(xlogy_out_mps)(const Tensor& self, const Tensor& other, const Te
   mps::binaryOpTensor(self, other, Scalar(1.0), output, "xlogy_out_mps", xlogy_op_block);
 }
 
-TORCH_IMPL_FUNC(lerp_Scalar_mps)(
-    const Tensor& self, const Tensor& end, const Scalar& weight, const Tensor& out) {
+TORCH_IMPL_FUNC(lerp_Scalar_mps)(const Tensor& self, const Tensor& end, const Scalar& weight, const Tensor& out) {
   mps::add_sub_lerp_template(self, end, weight, out, "lerp");
 }
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -18,6 +18,7 @@
 #include <ATen/ops/gt_native.h>
 #include <ATen/ops/hypot_native.h>
 #include <ATen/ops/le_native.h>
+#include <ATen/ops/lerp_native.h>
 #include <ATen/ops/logaddexp2_native.h>
 #include <ATen/ops/logaddexp_native.h>
 #include <ATen/ops/lt_native.h>
@@ -46,7 +47,7 @@ typedef MPSGraphTensor* (^BinaryOpBlock)(BinaryOpCachedGraph*, MPSGraphTensor*, 
 #define BinaryOpFn(graph, primary, secondary) \
   MPSGraphTensor*(mps::BinaryOpCachedGraph * graph, MPSGraphTensor * primary, MPSGraphTensor * secondary)
 
-// alpha is always 1.0 except when this function is called from add_sub_template()
+// alpha is always 1.0 except when this function is called from add_sub_lerp_template()
 void binaryOpTensor(const Tensor& self,
                     const Tensor& other,
                     const Scalar& alpha,
@@ -173,7 +174,7 @@ void binaryOpTensor(const Tensor& self,
       feeds[otherPlaceholder.getMPSGraphTensor()] = otherPlaceholder.getMPSGraphTensorData();
     }
 
-    // 'cachedGraph->alphaTensor' is not nil only if add_sub_template() was called with an alpha value != 1.0
+    // 'cachedGraph->alphaTensor' is not nil only if add_sub_lerp_template() was called with an alpha value != 1.0
     if (cachedGraph->alphaTensor) {
       alpha_scalar = getMPSScalar(alpha, other.scalar_type());
       feeds[cachedGraph->alphaTensor] = getMPSGraphTensorFromScalar(mpsStream, alpha_scalar);
@@ -255,11 +256,11 @@ void div_mode_template(const Tensor& self,
                  div_mode_op_block);
 }
 
-void add_sub_template(const Tensor& self,
-                      const Tensor& other,
-                      const Scalar& alpha,
-                      const Tensor& output,
-                      std::string op_name) {
+void add_sub_lerp_template(const Tensor& self,
+                           const Tensor& other,
+                           const Scalar& alpha,
+                           const Tensor& output,
+                            std::string op_name) {
   if (alpha.toDouble() == 0.0) {
     if (!self.is_alias_of(output)) { // if inplace, no-op
       const_cast<Tensor&>(output) = self.clone();
@@ -273,9 +274,22 @@ void add_sub_template(const Tensor& self,
     at::native::alpha_check(commonDtype, alpha);
   }
 
-  BinaryOpBlock add_sub_op_block = ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) {
+  if (!alpha_has_value && op_name == "lerp") {
+    if (!self.is_alias_of(other)) { // if inplace, no-op
+      const_cast<Tensor&>(output) = other.clone();
+    }
+    return;
+  }
+
+  BinaryOpBlock add_sub_lerp_op_block = ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) {
     MPSGraph* mpsGraph = cachedGraph->graph();
     MPSGraphTensor* secondaryTensor = secondaryCastTensor;
+
+    if (op_name == "lerp") {
+        secondaryCastTensor = [mpsGraph subtractionWithPrimaryTensor: secondaryCastTensor
+                                                     secondaryTensor: primaryCastTensor
+                                                                name: nil];
+    }
 
     // if alpha is 1.0, then we don't bother adding another multiply to graph
     if (alpha_has_value) {
@@ -284,7 +298,7 @@ void add_sub_template(const Tensor& self,
                                                   secondaryTensor:cachedGraph->alphaTensor
                                                              name:nil];
     }
-    if (op_name == "add")
+    if (op_name == "add" || op_name == "lerp")
       return [mpsGraph additionWithPrimaryTensor:primaryCastTensor secondaryTensor:secondaryTensor name:nil];
     else
       return [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor secondaryTensor:secondaryTensor name:nil];
@@ -295,7 +309,7 @@ void add_sub_template(const Tensor& self,
                  alpha,
                  output,
                  op_name + "_out_mps:" + (alpha_has_value ? getMPSTypeString(alpha.type()) : ""),
-                 add_sub_op_block);
+                 add_sub_lerp_op_block);
 }
 
 } // namespace mps
@@ -389,11 +403,11 @@ TORCH_IMPL_FUNC(div_out_mps)(const Tensor& self, const Tensor& other, const Tens
 }
 
 TORCH_IMPL_FUNC(add_out_mps)(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output) {
-  mps::add_sub_template(self, other, alpha, output, "add");
+  mps::add_sub_lerp_template(self, other, alpha, output, "add");
 }
 
 TORCH_IMPL_FUNC(sub_out_mps)(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output) {
-  mps::add_sub_template(self, other, alpha, output, "sub");
+  mps::add_sub_lerp_template(self, other, alpha, output, "sub");
 }
 
 TORCH_IMPL_FUNC(pow_Scalar_out_mps)(const Scalar& base, const Tensor& exp, const Tensor& out) {
@@ -492,4 +506,8 @@ TORCH_IMPL_FUNC(xlogy_out_mps)(const Tensor& self, const Tensor& other, const Te
   mps::binaryOpTensor(self, other, Scalar(1.0), output, "xlogy_out_mps", xlogy_op_block);
 }
 
+TORCH_IMPL_FUNC(lerp_Scalar_mps)(
+    const Tensor& self, const Tensor& end, const Scalar& weight, const Tensor& out) {
+  mps::add_sub_lerp_template(self, end, weight, out, "lerp");
+}
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Lerp.mm
+++ b/aten/src/ATen/native/mps/operations/Lerp.mm
@@ -1,0 +1,19 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/lerp_native.h>
+#include <ATen/ops/add.h>
+#endif
+
+namespace at::native {
+TORCH_IMPL_FUNC(lerp_Tensor_mps)(
+    const Tensor& self, const Tensor& end, const Tensor& weight, const Tensor& out) {
+  // TODO: Write a much better implementation
+  at::add_out(const_cast<Tensor&>(out), self, weight.mul(end.sub(self)));
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Lerp.mm
+++ b/aten/src/ATen/native/mps/operations/Lerp.mm
@@ -5,13 +5,12 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/lerp_native.h>
 #include <ATen/ops/add.h>
+#include <ATen/ops/lerp_native.h>
 #endif
 
 namespace at::native {
-TORCH_IMPL_FUNC(lerp_Tensor_mps)(
-    const Tensor& self, const Tensor& end, const Tensor& weight, const Tensor& out) {
+TORCH_IMPL_FUNC(lerp_Tensor_mps)(const Tensor& self, const Tensor& end, const Tensor& weight, const Tensor& out) {
   // TODO: Write a much better implementation
   at::add_out(const_cast<Tensor&>(out), self, weight.mul(end.sub(self)));
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9237,6 +9237,7 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: lerp_Scalar
+    MPS: lerp_Scalar_mps
   tags: pointwise
 
 - func: lerp.Tensor_out(Tensor self, Tensor end, Tensor weight, *, Tensor(a!) out) -> Tensor(a!)
@@ -9245,6 +9246,7 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: lerp_Tensor
+    MPS: lerp_Tensor_mps
   tags: pointwise
 
 - func: lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -424,7 +424,6 @@ def mps_ops_modifier(ops):
         'isposinf': None,
         'kthvalue': None,
         'lcm': None,
-        'lerp': None,
         'lgamma': None,
         'linalg.cholesky': None,
         'linalg.cholesky_ex': None,


### PR DESCRIPTION
lerp.Scalar fits very well into binary op template
Add a very naive implementation for `lerp.Tensor` as `add_out(self, weights.mul(end.sub(self)))`

Enable `lerp` testing in `test_mps`

Fixes https://github.com/pytorch/pytorch/issues/105382
