### PR TITLE
[MPS][BE] Use `Tensor::copy_`

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -263,7 +263,7 @@ void add_sub_lerp_template(const Tensor& self,
                            std::string op_name) {
   if (alpha.toDouble() == 0.0) {
     if (!self.is_alias_of(output)) { // if inplace, no-op
-      const_cast<Tensor&>(output) = self.clone();
+      output.copy_(self);
     }
     return;
   }

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -259,15 +259,15 @@ static void avg_pool2d_template(const Tensor& input,
               .to("mps"));
     } else {
       output.copy_(at::avg_pool2d_backward(grad_output.to("cpu"),
-                                                            input.to("cpu"),
-                                                            kernel_size,
-                                                            stride,
-                                                            padding,
-                                                            ceil_mode,
-                                                            count_include_pad,
-                                                            divisor_override)
-                                        .clone()
-                                        .to("mps"));
+                                           input.to("cpu"),
+                                           kernel_size,
+                                           stride,
+                                           padding,
+                                           ceil_mode,
+                                           count_include_pad,
+                                           divisor_override)
+                       .clone()
+                       .to("mps"));
     }
     return;
   }

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -224,7 +224,7 @@ static void pool2d_template(const Tensor& input,
     runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
 
     if (output_memory_format != suggested_memory_format) {
-      output.copy_(output.to(suggested_memory_format));
+      const_cast<Tensor&>(output) = output.to(suggested_memory_format);
     }
   }
 }
@@ -446,7 +446,7 @@ TORCH_IMPL_FUNC(max_pool2d_with_indices_out_mps)
                        "max_pool2d_indices");
 
   if (indices_memory_format == MemoryFormat::ChannelsLast) {
-    indices.copy_(indices.to(MemoryFormat::ChannelsLast));
+    const_cast<Tensor&>(indices) = indices.to(MemoryFormat::ChannelsLast);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -224,7 +224,7 @@ static void pool2d_template(const Tensor& input,
     runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
 
     if (output_memory_format != suggested_memory_format) {
-      const_cast<Tensor&>(output) = output.to(suggested_memory_format);
+      output.copy_(output.to(suggested_memory_format));
     }
   }
 }
@@ -253,12 +253,12 @@ static void avg_pool2d_template(const Tensor& input,
                     "not supported on MPS backend. ",
                     "Falling back on CPU. This may have performance implications.");
     if (!is_backward_pass) {
-      const_cast<Tensor&>(output) =
+      output.copy_(
           at::avg_pool2d(input.to("cpu"), kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
               .clone()
-              .to("mps");
+              .to("mps"));
     } else {
-      const_cast<Tensor&>(output) = at::avg_pool2d_backward(grad_output.to("cpu"),
+      output.copy_(at::avg_pool2d_backward(grad_output.to("cpu"),
                                                             input.to("cpu"),
                                                             kernel_size,
                                                             stride,
@@ -267,7 +267,7 @@ static void avg_pool2d_template(const Tensor& input,
                                                             count_include_pad,
                                                             divisor_override)
                                         .clone()
-                                        .to("mps");
+                                        .to("mps"));
     }
     return;
   }
@@ -446,7 +446,7 @@ TORCH_IMPL_FUNC(max_pool2d_with_indices_out_mps)
                        "max_pool2d_indices");
 
   if (indices_memory_format == MemoryFormat::ChannelsLast) {
-    const_cast<Tensor&>(indices) = indices.to(MemoryFormat::ChannelsLast);
+    indices.copy_(indices.to(MemoryFormat::ChannelsLast));
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -253,10 +253,8 @@ static void avg_pool2d_template(const Tensor& input,
                     "not supported on MPS backend. ",
                     "Falling back on CPU. This may have performance implications.");
     if (!is_backward_pass) {
-      output.copy_(
-          at::avg_pool2d(input.to("cpu"), kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-              .clone()
-              .to("mps"));
+      output.copy_(at::avg_pool2d(
+          input.to("cpu"), kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override));
     } else {
       output.copy_(at::avg_pool2d_backward(grad_output.to("cpu"),
                                            input.to("cpu"),
@@ -265,9 +263,7 @@ static void avg_pool2d_template(const Tensor& input,
                                            padding,
                                            ceil_mode,
                                            count_include_pad,
-                                           divisor_override)
-                       .clone()
-                       .to("mps"));
+                                           divisor_override));
     }
     return;
   }

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -264,7 +264,7 @@ TORCH_IMPL_FUNC(upsample_nearest1d_out_mps)
   if (check_mps_compatibility("nearest", scale)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, c10::nullopt, scale, output, false, "nearest");
   } else {
-    output.copy_(at::upsample_nearest1d(input.to("cpu"), output_size, scale).clone().to("mps"));
+    output.copy_(at::upsample_nearest1d(input.to("cpu"), output_size, scale));
   }
 }
 
@@ -277,8 +277,7 @@ TORCH_IMPL_FUNC(upsample_nearest1d_backward_out_mps)
   if (check_mps_compatibility("nearest", scale)) {
     mps::upsample_out_template(grad_output, output_size, input_size, c10::nullopt, scale, grad_input, false, "nearest");
   } else {
-    grad_input.copy_(
-        at::upsample_nearest1d_backward(grad_output.to("cpu"), output_size, input_size, scale).clone().to("mps"));
+    grad_input.copy_(at::upsample_nearest1d_backward(grad_output.to("cpu"), output_size, input_size, scale));
   }
 }
 
@@ -287,7 +286,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact1d_out_mps)
   if (check_mps_compatibility("nearest-exact", scale)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, c10::nullopt, scale, output, false, "nearest-exact");
   } else {
-    output.copy_(at::_upsample_nearest_exact1d(input.to("cpu"), output_size, scale).clone().to("mps"));
+    output.copy_(at::_upsample_nearest_exact1d(input.to("cpu"), output_size, scale));
   }
 }
 
@@ -301,9 +300,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact1d_backward_out_mps)
     mps::upsample_out_template(
         grad_output, output_size, input_size, c10::nullopt, scale, grad_input, false, "nearest-exact");
   } else {
-    grad_input.copy_(at::_upsample_nearest_exact1d_backward(grad_output.to("cpu"), output_size, input_size, scale)
-                         .clone()
-                         .to("mps"));
+    grad_input.copy_(at::_upsample_nearest_exact1d_backward(grad_output.to("cpu"), output_size, input_size, scale));
   }
 }
 
@@ -316,7 +313,7 @@ TORCH_IMPL_FUNC(upsample_nearest2d_out_mps)
   if (check_mps_compatibility("nearest", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, false, "nearest");
   } else {
-    output.copy_(at::upsample_nearest2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps"));
+    output.copy_(at::upsample_nearest2d(input.to("cpu"), output_size, scales_h, scales_w));
   }
 }
 
@@ -330,9 +327,8 @@ TORCH_IMPL_FUNC(upsample_nearest2d_backward_out_mps)
   if (check_mps_compatibility("nearest", scales_w)) {
     mps::upsample_out_template(grad_output, output_size, input_size, scales_h, scales_w, grad_input, false, "nearest");
   } else {
-    grad_input.copy_(at::upsample_nearest2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w)
-                         .clone()
-                         .to("mps"));
+    grad_input.copy_(
+        at::upsample_nearest2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w));
   }
 }
 
@@ -345,7 +341,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact2d_out_mps)
   if (check_mps_compatibility("nearest-exact", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, false, "nearest-exact");
   } else {
-    output.copy_(at::_upsample_nearest_exact2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps"));
+    output.copy_(at::_upsample_nearest_exact2d(input.to("cpu"), output_size, scales_h, scales_w));
   }
 }
 
@@ -361,9 +357,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact2d_backward_out_mps)
         grad_output, output_size, input_size, scales_h, scales_w, grad_input, false, "nearest-exact");
   } else {
     grad_input.copy_(
-        at::_upsample_nearest_exact2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w)
-            .clone()
-            .to("mps"));
+        at::_upsample_nearest_exact2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w));
   }
 }
 
@@ -377,8 +371,7 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_out_mps)
   if (check_mps_compatibility("bilinear", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, align_corners, "bilinear");
   } else {
-    output.copy_(
-        at::upsample_bilinear2d(input.to("cpu"), output_size, align_corners, scales_h, scales_w).clone().to("mps"));
+    output.copy_(at::upsample_bilinear2d(input.to("cpu"), output_size, align_corners, scales_h, scales_w));
   }
 }
 
@@ -395,9 +388,7 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_backward_out_mps)
         grad_output, output_size, input_size, scales_h, scales_w, grad_input, align_corners, "bilinear");
   } else {
     grad_input.copy_(at::upsample_bilinear2d_backward(
-                         grad_output.to("cpu"), output_size, input_size, align_corners, scales_h, scales_w)
-                         .clone()
-                         .to("mps"));
+        grad_output.to("cpu"), output_size, input_size, align_corners, scales_h, scales_w));
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -264,8 +264,7 @@ TORCH_IMPL_FUNC(upsample_nearest1d_out_mps)
   if (check_mps_compatibility("nearest", scale)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, c10::nullopt, scale, output, false, "nearest");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(output) = at::upsample_nearest1d(input.to("cpu"), output_size, scale).clone().to("mps");
+    output.copy_(at::upsample_nearest1d(input.to("cpu"), output_size, scale).clone().to("mps"));
   }
 }
 
@@ -278,9 +277,8 @@ TORCH_IMPL_FUNC(upsample_nearest1d_backward_out_mps)
   if (check_mps_compatibility("nearest", scale)) {
     mps::upsample_out_template(grad_output, output_size, input_size, c10::nullopt, scale, grad_input, false, "nearest");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(grad_input) =
-        at::upsample_nearest1d_backward(grad_output.to("cpu"), output_size, input_size, scale).clone().to("mps");
+    grad_input.copy_(
+        at::upsample_nearest1d_backward(grad_output.to("cpu"), output_size, input_size, scale).clone().to("mps"));
   }
 }
 
@@ -289,8 +287,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact1d_out_mps)
   if (check_mps_compatibility("nearest-exact", scale)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, c10::nullopt, scale, output, false, "nearest-exact");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(output) = at::_upsample_nearest_exact1d(input.to("cpu"), output_size, scale).clone().to("mps");
+    output.copy_(at::_upsample_nearest_exact1d(input.to("cpu"), output_size, scale).clone().to("mps"));
   }
 }
 
@@ -304,9 +301,9 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact1d_backward_out_mps)
     mps::upsample_out_template(
         grad_output, output_size, input_size, c10::nullopt, scale, grad_input, false, "nearest-exact");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(grad_input) =
-        at::_upsample_nearest_exact1d_backward(grad_output.to("cpu"), output_size, input_size, scale).clone().to("mps");
+    grad_input.copy_(at::_upsample_nearest_exact1d_backward(grad_output.to("cpu"), output_size, input_size, scale)
+                         .clone()
+                         .to("mps"));
   }
 }
 
@@ -319,9 +316,7 @@ TORCH_IMPL_FUNC(upsample_nearest2d_out_mps)
   if (check_mps_compatibility("nearest", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, false, "nearest");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(output) =
-        at::upsample_nearest2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps");
+    output.copy_(at::upsample_nearest2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps"));
   }
 }
 
@@ -335,11 +330,9 @@ TORCH_IMPL_FUNC(upsample_nearest2d_backward_out_mps)
   if (check_mps_compatibility("nearest", scales_w)) {
     mps::upsample_out_template(grad_output, output_size, input_size, scales_h, scales_w, grad_input, false, "nearest");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(grad_input) =
-        at::upsample_nearest2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w)
-            .clone()
-            .to("mps");
+    grad_input.copy_(at::upsample_nearest2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w)
+                         .clone()
+                         .to("mps"));
   }
 }
 
@@ -352,9 +345,7 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact2d_out_mps)
   if (check_mps_compatibility("nearest-exact", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, false, "nearest-exact");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(output) =
-        at::_upsample_nearest_exact2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps");
+    output.copy_(at::_upsample_nearest_exact2d(input.to("cpu"), output_size, scales_h, scales_w).clone().to("mps"));
   }
 }
 
@@ -369,11 +360,10 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact2d_backward_out_mps)
     mps::upsample_out_template(
         grad_output, output_size, input_size, scales_h, scales_w, grad_input, false, "nearest-exact");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(grad_input) =
+    grad_input.copy_(
         at::_upsample_nearest_exact2d_backward(grad_output.to("cpu"), output_size, input_size, scales_h, scales_w)
             .clone()
-            .to("mps");
+            .to("mps"));
   }
 }
 
@@ -387,9 +377,8 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_out_mps)
   if (check_mps_compatibility("bilinear", scales_w)) {
     mps::upsample_out_template(input, output_size, c10::nullopt, scales_h, scales_w, output, align_corners, "bilinear");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(output) =
-        at::upsample_bilinear2d(input.to("cpu"), output_size, align_corners, scales_h, scales_w).clone().to("mps");
+    output.copy_(
+        at::upsample_bilinear2d(input.to("cpu"), output_size, align_corners, scales_h, scales_w).clone().to("mps"));
   }
 }
 
@@ -405,12 +394,10 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_backward_out_mps)
     mps::upsample_out_template(
         grad_output, output_size, input_size, scales_h, scales_w, grad_input, align_corners, "bilinear");
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<Tensor&>(grad_input) =
-        at::upsample_bilinear2d_backward(
-            grad_output.to("cpu"), output_size, input_size, align_corners, scales_h, scales_w)
-            .clone()
-            .to("mps");
+    grad_input.copy_(at::upsample_bilinear2d_backward(
+                         grad_output.to("cpu"), output_size, input_size, align_corners, scales_h, scales_w)
+                         .clone()
+                         .to("mps"));
   }
 }
 


### PR DESCRIPTION
Replace `const_cast<Tensor&>(x) = y;` with `x.copy_(y);`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d2b7a0d</samp>

> _`copy_` not `clone`_
> _MPS backend runs faster_
> _Winter memory_
