### PR TITLE
[inductor][fx passes] batch layernom

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -91,8 +91,54 @@ class MyModule2(torch.nn.Module):
         return d0 + d1
 
 
+class MyModule3(torch.nn.Module):
+    def __init__(self, device, has_weight=True, has_bias=True):
+        super().__init__()
+        self.device = device
+        self.scale0 = torch.nn.ParameterList(
+            [torch.nn.Parameter(torch.randn(10)) for _ in range(5)]
+        ).to(self.device)
+        self.bias0 = torch.nn.ParameterList(
+            [torch.nn.Parameter(torch.randn(10)) for _ in range(5)]
+        ).to(self.device)
+        self.scale1 = (
+            torch.nn.ParameterList(
+                [torch.nn.Parameter(torch.randn(5, 10)) for _ in range(5)]
+            ).to(self.device)
+            if has_weight
+            else [None for _ in range(5)]
+        )
+        self.bias1 = (
+            torch.nn.ParameterList(
+                [torch.nn.Parameter(torch.randn(5, 10)) for _ in range(5)]
+            ).to(self.device)
+            if has_bias
+            else [None for _ in range(5)]
+        )
+
+    def forward(self, x):
+        l1_out = torch.split(x.to(self.device), 10, dim=2)
+        post_l1 = [
+            torch.nn.functional.layer_norm(
+                l1_out[i], (10,), weight=self.scale0[i], bias=self.bias0[i]
+            )
+            for i in range(len(l1_out))
+        ]
+        l1_out = torch.cat(post_l1, dim=2)
+
+        l2_out = torch.split(l1_out, 10, dim=2)
+        post_l2 = [
+            torch.nn.functional.layer_norm(
+                l2_out[i], (5, 10), weight=self.scale1[i], bias=self.bias1[i]
+            )
+            for i in range(len(l2_out))
+        ]
+
+        return torch.cat(post_l2, dim=2)
+
+
 @unittest.skipIf(not has_fbgemm, "requires fbgemm")
-@torch._inductor.config.patch(group_fusion=True)
+@torch._inductor.config.patch(group_fusion=True, batch_fusion=True)
 class TestGroupFusion(TestCase):
     def compare_dict_tensors(self, ref_dict, res_dict):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
@@ -125,9 +171,9 @@ class TestGroupFusion(TestCase):
             counters.clear()
             module = MyModule(z, has_bias).eval().to("cuda")
             input = [
-                torch.randn(4, z).to("cuda"),
-                torch.randn(4, z).to("cuda"),
-                torch.randn(4, z).to("cuda"),
+                torch.randn(4, z, device="cuda"),
+                torch.randn(4, z, device="cuda"),
+                torch.randn(4, z, device="cuda"),
             ]
             traced = torch.compile(module)
             ref = module(*input)
@@ -137,6 +183,10 @@ class TestGroupFusion(TestCase):
                 counters["inductor"]["group_fusion"],
                 2 if has_bias else 0,
             )
+            self.assertEqual(
+                counters["inductor"]["batch_fusion"],
+                0,
+            )
             ref.sum().backward()
             res.sum().backward()
             self.compare_parameters(module, traced)
@@ -145,15 +195,19 @@ class TestGroupFusion(TestCase):
                 counters["inductor"]["group_fusion"],
                 2 if has_bias else 0,
             )
+            self.assertEqual(
+                counters["inductor"]["batch_fusion"],
+                0,
+            )
             counters.clear()
 
     def test_group_linear_fusion_different_shapes(self):
         counters.clear()
         module = MyModule2().eval().to("cuda")
         input = [
-            torch.randn(4, 6).to("cuda"),
-            torch.randn(4, 8).to("cuda"),
-            torch.randn(4, 10).to("cuda"),
+            torch.randn(4, 6, device="cuda"),
+            torch.randn(4, 8, device="cuda"),
+            torch.randn(4, 10, device="cuda"),
         ]
         traced = torch.compile(module)
         ref = module(*input)
@@ -163,6 +217,10 @@ class TestGroupFusion(TestCase):
             counters["inductor"]["group_fusion"],
             1,
         )
+        self.assertEqual(
+            counters["inductor"]["batch_fusion"],
+            0,
+        )
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced)
@@ -171,7 +229,53 @@ class TestGroupFusion(TestCase):
             counters["inductor"]["group_fusion"],
             1,
         )
+        self.assertEqual(
+            counters["inductor"]["batch_fusion"],
+            0,
+        )
         counters.clear()
+
+    def test_batch_layer_norm_fusion(self):
+        for has_weight in [True, False]:
+            for has_bias in [True, False]:
+                counters.clear()
+                module = MyModule3("cuda", has_weight, has_bias).eval().to("cuda")
+                input = [torch.randn(2, 5, 50, device="cuda")]
+                traced = torch.compile(module)
+                ref = module(*input)
+                res = traced(*input)
+                self.compare_pred(module, traced, input)
+                self.assertEqual(
+                    counters["inductor"]["group_fusion"],
+                    0,
+                )
+                self.assertEqual(counters["inductor"]["batch_fusion"], 2)
+                self.assertEqual(
+                    counters["inductor"]["scmerge_split_removed"],
+                    3,
+                )
+                self.assertEqual(
+                    counters["inductor"]["scmerge_cat_removed"],
+                    3,
+                )
+                ref.sum().backward()
+                res.sum().backward()
+                self.compare_parameters(module, traced)
+                self.compare_gradients(module, traced)
+                self.assertEqual(
+                    counters["inductor"]["group_fusion"],
+                    0,
+                )
+                self.assertEqual(counters["inductor"]["batch_fusion"], 2)
+                self.assertEqual(
+                    counters["inductor"]["scmerge_split_removed"],
+                    3,
+                )
+                self.assertEqual(
+                    counters["inductor"]["scmerge_cat_removed"],
+                    3,
+                )
+                counters.clear()
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -51,6 +51,9 @@ split_cat_fx_passes = True
 # enable pattern match with group fusion (using fbgemm)
 group_fusion = False
 
+# enable pattern match with batch fusion (using torch op)
+batch_fusion = False
+
 # enable reordering pass
 reordering = True
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -6,7 +6,7 @@ import torch
 from torch._dynamo.utils import counters
 
 from .. import config
-from ..pattern_matcher import CallFunctionVarArgs
+from ..pattern_matcher import CallFunctionVarArgs, get_arg_value
 
 try:
     # importing this will register fbgemm lowerings for inductor
@@ -21,7 +21,7 @@ aten = torch.ops.aten
 
 log = logging.getLogger(__name__)
 
-maximum_group_size = 50
+maximum_group_size = 150
 
 
 def _has_path(src_node, dest_node, cache):
@@ -156,6 +156,120 @@ class GroupLinearFusion(GroupFusion):
             graph.erase_node(original_mm)
 
 
+class BatchLayernormFusion(BatchFusion):
+    """
+    Batch layer norm fusion in pre grad pass
+    """
+
+    def is_node_meta_valid(self, node):
+        if node is None:
+            return True
+        else:
+            if "example_value" in node.meta:
+                return True
+            else:
+                return False
+
+    def match(self, node):
+        if CallFunctionVarArgs(torch.nn.functional.layer_norm).match(node):
+            input = get_arg_value(node, 0, "input")
+            weight = get_arg_value(node, 2, "weight")
+            bias = get_arg_value(node, 3, "bias")
+            group_key = (
+                (
+                    "batch_layernorm",
+                    str(input.meta["example_value"].shape),
+                    str(weight.meta["example_value"].shape)
+                    if weight is not None
+                    else "",
+                    str(bias.meta["example_value"].shape) if bias is not None else "",
+                    str(get_arg_value(node, 1, "normalized_shape")),
+                    str(get_arg_value(node, 4, "eps")),
+                )
+                if "example_value" in input.meta
+                and self.is_node_meta_valid(weight)
+                and self.is_node_meta_valid(bias)
+                else None
+            )
+        else:
+            group_key = None
+        return group_key
+
+    def fuse(self, graph, subset):
+        group_inputs = []
+        group_shapes = []
+        group_weights = []
+        group_biases = []
+        group_epss = []
+        group_nodes = []
+        for node in subset:
+            group_nodes.append(node)
+            group_inputs.append(get_arg_value(node, 0, "input"))
+            group_shapes.append(get_arg_value(node, 1, "normalized_shape"))
+            group_weights.append(get_arg_value(node, 2, "weight"))
+            group_biases.append(get_arg_value(node, 3, "bias"))
+            eps = get_arg_value(node, 4, "eps")
+            if eps is None:
+                eps = 1e-5
+            group_epss.append(eps)
+        stack_dim = -1 - len(group_shapes[-1])
+
+        if all(bias is None for bias in group_biases):
+            group_biases = None
+        if all(weight is None for weight in group_weights):
+            group_weights = None
+        assert all(
+            eps == group_epss[0] for eps in group_epss
+        ), "all epsilon values must be equal"
+
+        with graph.inserting_before(subset[0]):
+            stack_input = graph.call_function(
+                torch.stack, args=(group_inputs, stack_dim)
+            )
+            if group_weights is not None:
+                stack_weight = graph.call_function(torch.stack, args=(group_weights,))
+            else:
+                stack_weight = None
+            if group_biases is not None:
+                stack_bias = graph.call_function(torch.stack, args=(group_biases,))
+            else:
+                stack_bias = None
+
+            batch_layer_norm = graph.call_function(
+                torch.nn.functional.layer_norm,
+                args=(stack_input, group_shapes[-1]),
+                kwargs={"eps": group_epss[-1]},
+            )
+
+            if group_weights is not None and group_biases is not None:
+                batch_layer_norm = graph.call_function(
+                    torch.addcmul, args=(stack_bias, stack_weight, batch_layer_norm)
+                )
+            elif group_weights is not None and group_biases is None:
+                batch_layer_norm = graph.call_function(
+                    torch.mul, args=(stack_weight, batch_layer_norm)
+                )
+            elif group_weights is None and group_biases is not None:
+                batch_layer_norm = graph.call_function(
+                    torch.add, args=(stack_bias, batch_layer_norm)
+                )
+
+            batch_layer_norm_unbind = graph.call_function(
+                torch.unbind,
+                args=(batch_layer_norm,),
+                kwargs={"dim": stack_dim},
+            )
+
+        for i, node in enumerate(group_nodes):
+            with graph.inserting_after(batch_layer_norm_unbind):
+                new_node = graph.call_function(
+                    operator.getitem, args=(batch_layer_norm_unbind, i)
+                )
+            node.replace_all_uses_with(new_node)
+            new_node.meta.update(node.meta)
+            graph.erase_node(node)
+
+
 def apply_group_batch_fusion(graph, rule):
     fusible_groups = collections.defaultdict(list)
 
@@ -180,11 +294,20 @@ def apply_group_batch_fusion(graph, rule):
                 counters["inductor"]["batch_fusion"] += 1
 
 
-def group_batch_fusion_passes(graph: torch.fx.Graph):
+def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
     fusions = []
-
     if config.group_fusion and has_fbgemm:
         fusions += [GroupLinearFusion()]
+
+    for rule in fusions:
+        apply_group_batch_fusion(graph, rule)
+
+
+def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
+    fusions = []
+
+    if config.batch_fusion and has_fbgemm:
+        fusions += [BatchLayernormFusion()]
 
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -28,7 +28,7 @@ from ..pattern_matcher import (
     stable_topological_sort,
 )
 from ..virtualized import V
-from .group_batch_fusion import group_batch_fusion_passes
+from .group_batch_fusion import group_batch_fusion_post_grad_passes
 
 
 log = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         if is_inference:
             inference_patterns.apply(gm.graph)
 
-        group_batch_fusion_passes(gm.graph)
+        group_batch_fusion_post_grad_passes(gm.graph)
 
     stable_topological_sort(gm.graph)
     gm.recompile()

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -22,6 +22,7 @@ from ..pattern_matcher import (
     stable_topological_sort,
 )
 from ..utils import is_cpu_device
+from .group_batch_fusion import group_batch_fusion_pre_grad_passes
 
 log = logging.getLogger(__name__)
 
@@ -62,6 +63,7 @@ def pre_grad_passes(gm, example_inputs):
     if config.pattern_matcher:
         lazy_init()
         gm = fuse_fx(gm, example_inputs)
+        group_batch_fusion_pre_grad_passes(gm.graph)
         for pattern_matcher_pass in pattern_matcher_passes:
             pattern_matcher_pass.apply(gm.graph)
 


### PR DESCRIPTION
Summary: Batch layernorm. Fuse independent horizontal layernorm with same size into one.

Test Plan:
# unit test
```
buck test mode/dev-nosan //caffe2/test/inductor:group_batch_fusion
File changed: fbcode//caffe2/test/inductor/test_group_batch_fusion.py
Buck UI: https://www.internalfb.com/buck2/68eb51e1-bdbc-4847-aabf-e50737d8485b
Test UI: https://www.internalfb.com/intern/testinfra/testrun/5066549764442206
Network: Up: 0 B  Down: 0 B
Jobs completed: 10. Time elapsed: 1:07.2s.
Tests finished: Pass 3. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D47447542



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov