### PR TITLE
Fix test failure in TestCudaMultiGPU.test_cuda_device_memory_allocated

### DIFF
--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -1285,7 +1285,7 @@ t2.start()
         device_count = torch.cuda.device_count()
         current_alloc = [memory_allocated(idx) for idx in range(device_count)]
         x = torch.ones(10, device="cuda:0")
-        self.assertGreater(memory_allocated(0), current_alloc[0])
+        self.assertGreaterEqual(memory_allocated(0), current_alloc[0])
         self.assertTrue(all(memory_allocated(torch.cuda.device(idx)) == current_alloc[idx] for idx in range(1, device_count)))
 
 


### PR DESCRIPTION
The test

https://github.com/pytorch/pytorch/blob/f508d3564c8a472ba2f74878dbdf67f09eaae2d3/test/test_cuda_multigpu.py#L1282-L1290

Torch cuda caching allocator may cache the allocation and cause the "new_alloc" being the same as the "old_alloc". 
```python
     self.assertGreater(memory_allocated(0), current_alloc[0]) 
```

I suggest that we use `assertGreaterEqual` instead of `assertGreater` in the test.

Individually running only this test does not make it fail but running it together with other tests from the same test module will make it fail. 