### PR TITLE
[foreach] Set `SavedVariable.is_output` to `true` for `grad_fn->result_`

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -923,33 +923,41 @@ class TestForeach(TestCase):
     )
     def test_lifetime_of_grad_fn_with_result(self, device, dtype, op):
 
-        def get_ref():
-            func = self._get_funcs(op)[0]
-            for sample in op.sample_inputs(device, dtype, requires_grad=True, num_input_tensors=[1]):
-                for key in ("is_fastpath", "disable_fastpath"):
-                    if key in sample.kwargs:
-                        del sample.kwargs[key]
-                if op.name == "_foreach_pow":
-                    if not isinstance(sample.args[0], Number):
-                        continue
-                    print(f"{(sample.args[0], sample.input)}")
-                    out = func((sample.args[0], sample.input), is_cuda=False, is_fastpath=False, **sample.kwargs)
-                else:
-                    out = func((sample.input, *sample.args), is_cuda=False, is_fastpath=False, **sample.kwargs)
+        def get_ref(func, sample):
+            class Foo:
+                pass
 
-                class Foo:
-                    pass
+            out = func((sample.input, *sample.args), is_cuda=False, is_fastpath=False, **sample.kwargs)
+            foo = Foo()
+            meta_dict = out[0].grad_fn.metadata
+            meta_dict[0] = foo
+            ref = weakref.ref(foo)
+            return out, ref
 
-                foo = Foo()
-                meta_dict = out[0].grad_fn.metadata
-                meta_dict[0] = foo
-                ref = weakref.ref(foo)
-                return out, ref
+        def _test(func, sample):
+            out, ref = get_ref(func, sample)
+            self.assertIsNotNone(ref())
+            del out
+            self.assertIsNone(ref())
 
-        out, ref = get_ref()
-        self.assertIsNotNone(ref())
-        del out
-        self.assertIsNone(ref())
+        func = self._get_funcs(op)[0]
+        for sample in op.sample_inputs(device, dtype, requires_grad=True, num_input_tensors=[1]):
+            for key in ("is_fastpath", "disable_fastpath"):
+                if key in sample.kwargs:
+                    del sample.kwargs[key]
+            # note: `_foreach_pow.Scalar` and `_foreach_pow.ScalarList` don't depend on `result`
+            # see: https://github.com/pytorch/pytorch/blob/5403c7770cd9cdc05f6c216d593ea8e8ae328ff3/tools/autograd/derivatives.yaml#L3048-L3049  # noqa: B950
+            if op.name == "_foreach_pow":
+                if (
+                    (isinstance(sample.args[0], list) and isinstance(sample.args[0][0], Number))
+                    or (isinstance(sample.args[0], Number) and not isinstance(sample.args[0], float))
+                ):
+                    continue
+                if isinstance(sample.args[0], float):
+                    new_args = (sample.input,)
+                    sample.input = sample.args[0]
+                    sample.args = new_args
+            _test(func, sample)
 
     @ops(
         foreach_unary_op_db + foreach_binary_op_db + foreach_pointwise_op_db + foreach_lerp_op_db,

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -921,7 +921,7 @@ class TestForeach(TestCase):
         ),
         dtypes=(torch.float32,),
     )
-    def test_lifetime_of_grad_fn_with_result(self, device, dtype, op):
+    def test_lifetime_of_grad_fn_when_result_is_saved(self, device, dtype, op):
 
         def get_ref(func, sample):
             class Foo:

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -589,6 +589,18 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             or type == BaseCType(iTensorListRefT)
             or type == VectorCType(BaseCType(tensorT))
         ):
+            # note(crcrpar): [nuanced return type of out-of-place foreach functions]
+            # When an out-of-place foreach function whose return signature is `Tensor[]`
+            # spells out its backward definitions in `derivatives.yaml`, and some of them depend on
+            # `result`, `result`'s type is interpreted and treated as `std::vector<Tensor>`.
+            # An out-of-place foreach whose backwards rely on their output doesn't suffer from this
+            # difference if the definitions are codegen'ed.
+            # This special case is needed for `_foreach_pow.List` and `_foreach_pow.ScalarAndTensor`
+            # as of https://github.com/pytorch/pytorch/pull/105504.
+            if type == VectorCType(BaseCType(tensorT)):
+                assert (
+                    info.func.func.name.name.base.startswith("_foreach") and is_output
+                )
             saved_variables.append(f"std::vector<SavedVariable> {name}_;")
             saved_variables.append(f"bool {name}_released_ = false;")
             # Just clear() is sufficient, we don't need to loop and clear each variable.

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -35,6 +35,7 @@ from torchgen.api.types import (
     TENSOR_LIST_LIKE_CTYPES,
     tensorListT,
     tensorT,
+    VectorCType,
 )
 from torchgen.code_template import CodeTemplate
 from torchgen.model import Argument, FunctionSchema
@@ -583,7 +584,11 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             )
             should_append_raw_getsetdef = True
             visit_name = f"{name}_"
-        elif type == BaseCType(tensorListT) or type == BaseCType(iTensorListRefT):
+        elif (
+            type == BaseCType(tensorListT)
+            or type == BaseCType(iTensorListRefT)
+            or type == VectorCType(BaseCType(tensorT))
+        ):
             saved_variables.append(f"std::vector<SavedVariable> {name}_;")
             saved_variables.append(f"bool {name}_released_ = false;")
             # Just clear() is sufficient, we don't need to loop and clear each variable.

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -590,7 +590,8 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             # Because the SavedVariable owns a tensor and a grad_fn, removing the SavedVariable makes them go away as well.
             release_variables.append(f"{name}_.clear();")
             release_variables.append(f"{name}_released_ = true;")
-            unpack.append(f"auto {name} = unpack_list({name}_);")
+            ptr = "shared_from_this()" if is_output else "nullptr"
+            unpack.append(f"auto {name} = unpack_list({name}_, {ptr});")
             asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
             getter_definitions.append(
                 GETTER_DEFINITION_VEC_SAVEDVAR.substitute(

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1459,6 +1459,7 @@ def emit_body(
                 type == BaseCType(tensorListT)
                 or type == ListCType(OptionalCType(BaseCType(tensorT)))
                 or type == BaseCType(iTensorListRefT)
+                or type == VectorCType(BaseCType(tensorT))
             ):
                 expr = f"make_saved_variable_list({name}, {str(is_foreach and is_output).lower()})"
                 name += "_"

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1461,6 +1461,9 @@ def emit_body(
                 or type == BaseCType(iTensorListRefT)
                 or type == VectorCType(BaseCType(tensorT))
             ):
+                # See Note [nuanced return type of out-of-place foreach functions]
+                if type == VectorCType(BaseCType(tensorT)):
+                    assert is_foreach and is_output
                 expr = f"make_saved_variable_list({name}, {str(is_foreach and is_output).lower()})"
                 name += "_"
             elif type == BaseCType(intArrayRefT):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1028,7 +1028,8 @@ def emit_body(
     base_name = get_base_name(f)
     view_info = get_view_info(f)
 
-    is_inplace_foreach = name.startswith("_foreach") and inplace
+    is_foreach = name.startswith("_foreach")
+    is_inplace_foreach = is_foreach and inplace
     if is_inplace_foreach:
         inplace_foreacharg2refarg: Dict[Argument, Argument] = {}
         refargname2inplace_foreacharg: Dict[str, Argument] = {}
@@ -1459,7 +1460,10 @@ def emit_body(
                 or type == ListCType(OptionalCType(BaseCType(tensorT)))
                 or type == BaseCType(iTensorListRefT)
             ):
-                expr = f"make_saved_variable_list({name})"
+                if is_foreach and is_output:
+                    expr = f"make_saved_variable_list_foreach_output({name})"
+                else:
+                    expr = f"make_saved_variable_list({name})"
                 name += "_"
             elif type == BaseCType(intArrayRefT):
                 expr = expr + ".vec()"

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1460,10 +1460,7 @@ def emit_body(
                 or type == ListCType(OptionalCType(BaseCType(tensorT)))
                 or type == BaseCType(iTensorListRefT)
             ):
-                if is_foreach and is_output:
-                    expr = f"make_saved_variable_list_foreach_output({name})"
-                else:
-                    expr = f"make_saved_variable_list({name})"
+                expr = f"make_saved_variable_list({name}, {str(is_foreach and is_output).lower()})"
                 name += "_"
             elif type == BaseCType(intArrayRefT):
                 expr = expr + ".vec()"

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -29,7 +29,7 @@ inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shar
   // NB: we must explicitly do the conversion in the lambda, otherwise template
   // deduction will give a Tensor of Variable which is not convertible
   return fmap(xs, [&saved_for](const SavedVariable& x) {
-    return static_cast<Tensor>(x.unpack(std::move(saved_for)));
+    return static_cast<Tensor>(x.unpack(saved_for));
   });
 }
 
@@ -37,7 +37,7 @@ inline c10::List<c10::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariab
   torch::List<c10::optional<Tensor>> result;
   result.reserve(xs.size());
   for (const SavedVariable& v : xs) {
-    auto var = v.unpack(std::move(saved_for));
+    auto var = v.unpack(saved_for);
     result.push_back(var.defined() ? c10::optional<Tensor>(var) : c10::nullopt);
   }
   return result;

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -29,7 +29,7 @@ inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shar
   // NB: we must explicitly do the conversion in the lambda, otherwise template
   // deduction will give a Tensor of Variable which is not convertible
   return fmap(xs, [&saved_for](const SavedVariable& x) {
-    return static_cast<Tensor>(x.unpack(saved_for));
+    return static_cast<Tensor>(x.unpack(std::move(saved_for)));
   });
 }
 
@@ -37,7 +37,7 @@ inline c10::List<c10::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariab
   torch::List<c10::optional<Tensor>> result;
   result.reserve(xs.size());
   for (const SavedVariable& v : xs) {
-    auto var = v.unpack(saved_for);
+    auto var = v.unpack(std::move(saved_for));
     result.push_back(var.defined() ? c10::optional<Tensor>(var) : c10::nullopt);
   }
   return result;

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -29,6 +29,7 @@ inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shar
   // NB: we must explicitly do the conversion in the lambda, otherwise template
   // deduction will give a Tensor of Variable which is not convertible
   return fmap(xs, [&saved_for](const SavedVariable& x) {
+    // TODO(crcrpar): Use `std::move(saved_for)` to avoid incrementing refcount, which would need refactoring.
     return static_cast<Tensor>(x.unpack(saved_for));
   });
 }

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -25,19 +25,19 @@ using at::ScalarType;
 using c10::optional;
 using c10::fmap;
 
-inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs) {
+inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shared_ptr<Node> saved_for = nullptr) {
   // NB: we must explicitly do the conversion in the lambda, otherwise template
   // deduction will give a Tensor of Variable which is not convertible
-  return fmap(xs, [](const SavedVariable& x) {
-    return static_cast<Tensor>(x.unpack());
+  return fmap(xs, [&saved_for](const SavedVariable& x) {
+    return static_cast<Tensor>(x.unpack(saved_for));
   });
 }
 
-inline c10::List<c10::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariable> xs) {
+inline c10::List<c10::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariable> xs, std::shared_ptr<Node> saved_for = nullptr) {
   torch::List<c10::optional<Tensor>> result;
   result.reserve(xs.size());
   for (const SavedVariable& v : xs) {
-    auto var = v.unpack();
+    auto var = v.unpack(saved_for);
     result.push_back(var.defined() ? c10::optional<Tensor>(var) : c10::nullopt);
   }
   return result;

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -425,30 +425,26 @@ inline void check_no_requires_grad(
 
 // Assumed that saved tensor lists are never inplace outputs
 inline std::vector<SavedVariable> make_saved_variable_list(
-    at::ITensorListRef tensors) {
-  return fmap(tensors, [](const at::Tensor& tensor) -> SavedVariable {
-    return SavedVariable{tensor, false /* is output */};
+    at::ITensorListRef tensors,
+    const bool is_output = false) {
+  return fmap(tensors, [&is_output](const at::Tensor& tensor) -> SavedVariable {
+    return SavedVariable{tensor, is_output /* is output */};
   });
 }
 
 // Assumed that saved tensor lists are never inplace outputs
 inline std::vector<SavedVariable> make_saved_variable_list(
-    const c10::List<c10::optional<at::Tensor>>& tensors) {
+    const c10::List<c10::optional<at::Tensor>>& tensors,
+    const bool is_output = false) {
   return fmap(
-      tensors, [](const c10::optional<at::Tensor>& tensor) -> SavedVariable {
+      tensors,
+      [&is_output](const c10::optional<at::Tensor>& tensor) -> SavedVariable {
         if (tensor.has_value()) {
-          return SavedVariable{*tensor, false /* is output */};
+          return SavedVariable{*tensor, is_output /* is output */};
         } else {
-          return SavedVariable{at::Tensor(), false /* is output */};
+          return SavedVariable{at::Tensor(), is_output /* is output */};
         }
       });
-}
-
-inline std::vector<SavedVariable> make_saved_variable_list_foreach_output(
-    at::ITensorListRef tensors) {
-  return fmap(tensors, [](const at::Tensor& tensor) -> SavedVariable {
-    return SavedVariable{tensor, true /* is output */};
-  });
 }
 
 inline std::vector<std::vector<int64_t>> to_args_sizes(

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -444,6 +444,13 @@ inline std::vector<SavedVariable> make_saved_variable_list(
       });
 }
 
+inline std::vector<SavedVariable> make_saved_variable_list_foreach_output(
+    at::ITensorListRef tensors) {
+  return fmap(tensors, [](const at::Tensor& tensor) -> SavedVariable {
+    return SavedVariable{tensor, true /* is output */};
+  });
+}
+
 inline std::vector<std::vector<int64_t>> to_args_sizes(
     at::ITensorListRef tensors) {
   std::vector<std::vector<int64_t>> args_sizes(tensors.size());

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -67,7 +67,7 @@ inline bool compute_requires_grad(Args&&... args) {
 inline void set_history(
     at::Tensor& variable,
     const std::shared_ptr<Node>& grad_fn) {
-  AT_ASSERT(grad_fn);
+  TORCH_CHECK(grad_fn != nullptr);
   if (variable.defined()) {
     // If the codegen triggers this, you most likely want to add your newly
     // added function to the DONT_REQUIRE_DERIVATIVE list in

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8559,6 +8559,7 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
     ForeachFuncInfo(
         'acos',
@@ -8613,12 +8614,14 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
     ForeachFuncInfo(
         'tanh',
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
     ForeachFuncInfo(
         'sin',
@@ -8649,6 +8652,7 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
 
     ForeachFuncInfo(
@@ -8685,6 +8689,7 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
 
     ForeachFuncInfo(
@@ -8730,6 +8735,7 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
 
     ForeachFuncInfo(
@@ -8739,6 +8745,7 @@ foreach_unary_op_db: List[OpInfo] = [
         sample_inputs_func=foreach_inputs_sample_func(1, False, False),
         supports_autograd=True,
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
 
     ForeachFuncInfo(
@@ -8864,6 +8871,7 @@ foreach_binary_op_db: List[OpInfo] = [
                          "TestForeach", "test_binary_op"),
         ),
         supports_forward_ad=True,
+        backward_requires_result=True,
     ),
 ]
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2678,6 +2678,7 @@ class ForeachFuncInfo(OpInfo):
         supports_autograd=False,
         supports_scalar_self_arg=False,
         supports_forward_ad=False,
+        backward_requires_result=False,
         **kwargs,
     ):
         (
@@ -2711,6 +2712,7 @@ class ForeachFuncInfo(OpInfo):
 
         self.ref_inplace = torch_ref_inplace
         self.supports_alpha_param = supports_alpha_param
+        self.backward_requires_result = backward_requires_result
 
         if name == "norm":
             self.ref = torch.linalg.vector_norm


### PR DESCRIPTION
fixes #105502

The scope of this pull request is out-of-place foreach functions that depend on their output tensorlist for backward such as `_foreach_exp`. An example of the generated code with this update is as follows:

```c++
variable_list ForeachExpBackward0::apply(variable_list&& grads) {
  std::lock_guard<std::mutex> lock(mutex_);
  TORCH_CHECK(!result_released_, ERR_BACKWARD_TWICE);
  IndexRangeGenerator gen;
  auto self_ix = gen.range(self_size_);
  variable_list grad_inputs(gen.size());
  auto result = unpack_list(result_, shared_from_this());
  if (task_should_compute_output({ self_ix })) {
    std::vector<Tensor> grad_result;
    grad_result.reserve(grads.size());
    for (const auto & i : c10::irange(grads.size())) {
      if (grads[i].defined()) {
        grad_result.emplace_back(grads[i] * result[i].conj());
      } else {
        grad_result.emplace_back(Tensor());
      }
    }
    copy_range(grad_inputs, self_ix, grad_result);
  }
  return grad_inputs;
}

::std::vector<at::Tensor> _foreach_exp(c10::DispatchKeySet ks, at::TensorList self) {
  auto self_ = unpack(self, "self", 0);
  [[maybe_unused]] auto _any_requires_grad = compute_requires_grad( self );

  std::shared_ptr<ForeachExpBackward0> grad_fn;
  if (_any_requires_grad) {
    grad_fn = std::shared_ptr<ForeachExpBackward0>(new ForeachExpBackward0(), deleteNode);
    grad_fn->set_next_edges(collect_next_edges( self ));
    grad_fn->self_size_ = self.size();
  }
  #ifndef NDEBUG
  std::vector<c10::optional<Storage>> self__storage_saved(self_.size());
  for (const Tensor& tensor : self_)
    self__storage_saved.push_back(
      tensor.has_storage() ? c10::optional<Storage>(tensor.storage()) : c10::nullopt);
  std::vector<c10::intrusive_ptr<TensorImpl>> self__impl_saved(self_.size());
  for (size_t i=0; i<self_.size(); i++)
    if (self_[i].defined()) self__impl_saved[i] = self_[i].getIntrusivePtr();
  #endif
  auto _tmp = ([&]() {
    if ((isFwGradDefinedTensorList(self))) {
      static c10::OperatorName full_name("aten::_foreach_exp", "");
      static c10::optional<c10::OperatorHandle> opt_op = c10::Dispatcher::singleton().findSchema(full_name);
      return impl::run_jit_decomposition_with_args_for_jvp<::std::vector<at::Tensor>>("_foreach_exp", *opt_op, ks, self);
    } else {
      at::AutoDispatchBelowADInplaceOrView guard;
      return at::redispatch::_foreach_exp(ks & c10::after_autograd_keyset, self_);
    }
  })();
  auto result = std::move(_tmp);
  #ifndef NDEBUG
  for (size_t i=0; i<self_.size() && !at::impl::dispatch_mode_enabled(); i++) {
    if (self__storage_saved[i].has_value() && !at::impl::tensorlist_has_dispatch(self_))
      TORCH_INTERNAL_ASSERT(self__storage_saved[i].value().is_alias_of(self_[i].storage()));
  }
  for (size_t i=0; i<self_.size() && !at::impl::dispatch_mode_enabled(); i++) {
    if (self__impl_saved[i] && !at::impl::tensorlist_has_dispatch(self_))
      TORCH_INTERNAL_ASSERT(self__impl_saved[i] == self_[i].getIntrusivePtr());
  }
  #endif
  if (grad_fn) {
      set_history(flatten_tensor_args( result ), grad_fn);
  }
  if (grad_fn) {
    grad_fn->result_ = make_saved_variable_list(result, true);
  }
  return result;
}
```

A bit of context:
- https://github.com/pytorch/pytorch/pull/105368#issuecomment-1640912479