### PR TITLE
Fix mps unary op issue on non densely stored tensors

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -81,7 +81,7 @@ void unary_op(const Tensor& self,
       newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
     });
 
-    // If self is densely mapped in storage, create a dense representation
+    // If self is non-densely mapped in storage, create a dense representation
     at::Tensor self_;
     if (!is_dense_in_storage(self)) {
       self_ = at::empty_like(self);

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -81,10 +81,10 @@ void unary_op(const Tensor& self,
       newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
     });
 
-    // If self is densely mapped in storage, create a dense output-like representation
+    // If self is densely mapped in storage, create a dense representation
     at::Tensor self_;
     if (!is_dense_in_storage(self)) {
-      self_ = at::empty_like(output);
+      self_ = at::empty_like(self);
       mps::mps_copy_(self_, self, false);
     } else {
       self_ = self;

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -81,10 +81,10 @@ void unary_op(const Tensor& self,
       newCachedGraph->outputTensor_ = unaryBlock(mpsGraph, castTensor);
     });
 
-    // If self is non-densely mapped in storage, create a dense representation
+    // If self is non-densely mapped in storage, create a dense output-like representation
     at::Tensor self_;
     if (!is_dense_in_storage(self)) {
-      self_ = at::empty_like(self);
+      self_ = at::empty_like(output, self.scalar_type());
       mps::mps_copy_(self_, self, false);
     } else {
       self_ = self;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7551,6 +7551,24 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 8, 3, 5), torch.log)
         helper((2, 8, 3, 5), torch.cos)
 
+    def test_non_dense_in_storage_unary_ops(self):
+        def helper(op):
+            for dtypef in [torch.float32]:
+                cpu_x = torch.randn(100, device='cpu', dtype=dtypef, requires_grad=False)
+                mps_x = cpu_x.detach().clone().to('mps')
+                self.assertEqual(op(cpu_x[::2]), op(mps_x[::2]))
+
+            for dtypei in [torch.int32, torch.int16, torch.int8]:
+                cpu_x = torch.randint(127, device='cpu', size=(100,), dtype=dtypei, requires_grad=False)
+                mps_x = cpu_x.to('mps')
+                self.assertEqual(op(cpu_x[::2]), op(mps_x[::2]), rtol=1e-4, atol=1e-4)
+
+        helper(torch.exp)
+        helper(torch.exp2)
+        helper(torch.expm1)
+        helper(torch.log)
+        helper(torch.cos)
+
     def test_atan2(self):
         def helper(shape):
             input_cpu = torch.randn(shape)


### PR DESCRIPTION
This pr fixes a bug where non densely stored tensors were not converted to the dense tensors of the correct scalar type in the mps `unary_op` helper function

Fixes https://github.com/pytorch/pytorch/issues/105284