### PR TITLE
Update slow CI jobs to rocm5.6

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -84,25 +84,25 @@ jobs:
       docker-image: ${{ needs.linux-bionic-py3_8-clang9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_8-clang9-build.outputs.test-matrix }}
 
-  linux-focal-rocm5_4_2-py3_8-build:
-    name: linux-focal-rocm5.4.2-py3.8
+  linux-focal-rocm5_6-py3_8-build:
+    name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-rocm5.4.2-py3.8
+      build-environment: linux-focal-rocm5.6-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
         ]}
 
-  linux-focal-rocm5_4_2-py3_8-test:
-    name: linux-focal-rocm5.4.2-py3.8
+  linux-focal-rocm5_6-py3_8-test:
+    name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_4_2-py3_8-build
+    needs: linux-focal-rocm5_6-py3_8-build
     with:
-      build-environment: linux-focal-rocm5.4.2-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.test-matrix }}
+      build-environment: linux-focal-rocm5.6-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/pytorch/pull/103092, which missed updating the slow CI jobs to ROCm5.6, as they were recently moved to slow.yml by https://github.com/pytorch/pytorch/commit/def50d253401540cfdc6c0fffa444d0ee643cc11

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang