### PR TITLE
Add TensorPipe header files to Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1238,6 +1238,21 @@ def main():
             'include/caffe2/utils/*.h',
             'include/caffe2/utils/**/*.h',
         ])
+    if get_cmake_cache_vars()['USE_TENSORPIPE']:
+        torch_package_data.extend([
+            'include/tensorpipe/*.h',
+            'include/tensorpipe/channel/*.h',
+            'include/tensorpipe/channel/basic/*.h',
+            'include/tensorpipe/channel/cma/*.h',
+            'include/tensorpipe/channel/mpt/*.h',
+            'include/tensorpipe/channel/xth/*.h',
+            'include/tensorpipe/common/*.h',
+            'include/tensorpipe/core/*.h',
+            'include/tensorpipe/transport/*.h',
+            'include/tensorpipe/transport/ibv/*.h',
+            'include/tensorpipe/transport/shm/*.h',
+            'include/tensorpipe/transport/uv/*.h',
+        ])
     torchgen_package_data = [
         # Recursive glob doesn't work in setup.py,
         # https://github.com/pypa/setuptools/issues/1806


### PR DESCRIPTION
This change adds the TensorPipe header files to `torch_package_data` if `USE_DISTRIBUTED` is set to `ON` in the CMake cache. The TensorPipe library and CMake config is already available in the Torch wheel, but the headers are not. This resolves issue where out-of-tree backends could not implement TensorPipe converters, because the definition of the `tensorpipe::Message` struct is defined in the TensorPipe headers.

Fixes #105224.
