### PR TITLE
[POC] DynamicTensor

### DIFF
--- a/test/test_dynamic_tensor.py
+++ b/test/test_dynamic_tensor.py
@@ -1,0 +1,29 @@
+# Owner(s): ["module: meta tensors"]
+
+from torch.testing._internal.common_utils import (
+    TestCase, run_tests
+)
+import torch
+from torch._subclasses.dynamic_tensor import DynamicTensor
+
+class DynamicTensorTest(TestCase):
+    def test_basic(self):
+        r = DynamicTensor.wrap(torch.ones(2, 2), dim=0)
+        self.assertExpectedInline(r, '''\
+DynamicTensor.wrap(tensor([[1., 1.],
+        [1., 1.]]), dim=(0,))''')
+        self.assertEqual(r.dynamic_dims, (0,))
+        r2 = r + r
+        self.assertEqual(r2.dynamic_dims, (0,))
+
+        r = DynamicTensor.wrap(torch.randn(1, 2), dim=0)
+        self.assertEqual(r.dynamic_dims, (0,))
+        r + torch.randn(1, 2)  # OK, because RHS broadcasts
+        torch.randn(1, 2) + r  # OK, because LHS broadcasts
+        self.assertRaises(RuntimeError, lambda: r + torch.randn(5, 2))  # cannot broadcast
+
+        r2 = DynamicTensor.wrap(torch.randn(1, 2), dim=0)
+        self.assertRaises(RuntimeError, lambda: r + r2)  # unrelated
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_subclasses/dynamic_tensor.py
+++ b/torch/_subclasses/dynamic_tensor.py
@@ -1,0 +1,54 @@
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.fx.experimental.proxy_tensor import ShapeEnv
+from torch.fx.experimental.symbolic_shapes import DimDynamic, free_symbols
+import torch.utils._pytree as pytree
+from typing import Union, Tuple
+import torch
+
+class DynamicTensorMode(FakeTensorMode):
+    def __init__(self):
+        super().__init__(allow_fallback_kernels=False, allow_non_fake_inputs=True, shape_env=ShapeEnv(), cls=DynamicTensor)
+
+    def dispatch(self, func, types, args=(), kwargs=None):
+        # Fakeify all of the non-dynamic args and run the fake func
+        fake_args, fake_kwargs = pytree.tree_map_only(
+            torch.Tensor, lambda t: self.fake_tensor_converter(self, t), (args, kwargs)
+        )
+        fake_ret = super().dispatch(func, types, fake_args, fake_kwargs)
+        # Realify all of the args and run regular func
+        real_args, real_kwargs = pytree.tree_map_only(
+            DynamicTensor, lambda t: t._backing_tensor, (args, kwargs)
+        )
+        real_ret = func(*real_args, **real_kwargs)
+        flat_fake_ret, fake_spec = pytree.tree_flatten(fake_ret)
+        flat_real_ret, real_spec = pytree.tree_flatten(real_ret)
+        assert fake_spec == real_spec, f"{fake_spec} != {real_spec}"
+        assert len(flat_fake_ret) == len(flat_real_ret)
+        for fake_r, real_r in zip(flat_fake_ret, flat_real_ret):
+            fake_r._backing_tensor = real_r
+        return pytree.tree_unflatten(flat_fake_ret, fake_spec)
+
+class DynamicTensor(FakeTensor):
+    @staticmethod
+    def wrap(backing_tensor, dim: Union[Tuple[int,...], int, None]):
+        if isinstance(dim, int):
+            dim = (dim,)
+        elif dim is None:
+            dim = tuple(range(backing_tensor.dim()))
+        elem = GLOBAL_MODE.fake_tensor_converter.meta_converter(
+            backing_tensor,
+            shape_env=GLOBAL_MODE.shape_env,
+            dynamic_dims=[DimDynamic.UNBACKED if i in dim else DimDynamic.STATIC for i in range(backing_tensor.dim())]
+        )
+        self = DynamicTensor(GLOBAL_MODE, elem, backing_tensor.device)
+        self._backing_tensor = backing_tensor
+        return self
+
+    @property
+    def dynamic_dims(self):
+        return tuple(i for i, s in enumerate(self.size()) if free_symbols(s))
+
+    def __repr__(self):
+        return f"DynamicTensor.wrap({repr(self._backing_tensor)}, dim={self.dynamic_dims})"
+
+GLOBAL_MODE = DynamicTensorMode()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -499,6 +499,8 @@ class DimDynamic(Enum):
     DUCK = 1
     # Treat the dimension statically based on its hint
     STATIC = 2
+    # Treat the dimension symbolically and without a backing hint
+    UNBACKED = 3
 
 # NB: These constraints affect both clients and backends: given some
 # constraint C, the client must pass inputs that satisfy the constraint,
@@ -2321,6 +2323,13 @@ Target Guards:
     ) -> "sympy.Expr":
         assert isinstance(source, Source), f"{type(source)} {source}"
         assert not (positive and val < 0), f"positive set for negative value: {val}"
+
+        if dynamic_dim is DimDynamic.UNBACKED:
+            # TODO: this is naughty
+            s = self.create_unbacked_symint()
+            constrain_range(s, min=2)
+            return s.node.expr
+
         # It's always sound to allocate a symbol as DYNAMIC.  If the user
         # constrained the symbol, force the policy to DYNAMIC, because our
         # constraint code will do weird stuff if, e.g., it's duck shaped


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105535

DynamicTensor is a regular CPU/CUDA tensor, but where some dimensions are treated symbolically. If you have an (s0, 2) dynamic tensor, it is intended to vary dynamically over s0. This size propagates over operations, and always behaves uniformly, even if s0 = 0, 1 (so, for example, you cannot broadcast (s0, 2) with (5, 2), even when s0 == 1).

More discussion at https://docs.google.com/document/d/1Dge173HVbXnTysnvp8716mi_0BlEpJZbmhXbI_-WdqI/edit#heading=h.ey3z8v3k3z06

The implementation strategy is to subclass FakeTensor into DynamicTensor, but then embed a real backing tensor which also gets operated on. The implementation does some naughty things, putting the POC out there to get some comments.

TODO: When a DynamicTensor has no more symbolic dimensions, decay it into a regular tensor.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>