### PR TITLE
Create tensor from Numpy in current device.

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1318,6 +1318,22 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             res = opt_fn(x.item())
             self.assertTrue(same(ref, res))
 
+    @unittest.skipIf(not TEST_CUDA, "requires cuda")
+    @requires_numpy_pytorch_interop
+    @torch._dynamo.config.patch(numpy_ndarray_as_tensor=True)
+    def test_numpy_on_cuda(self):
+        x = np.arange(10)
+
+        @torch.compile
+        def fn(x):
+            return x**2
+
+        with torch.device("cuda"):
+            r = fn(x)
+
+        self.assertEqual(type(r), np.ndarray)
+        self.assertEqual(r, x**2)
+
     def test_graph_break_correctly_when_passing_numpy_ndarray_to_torch_function(self):
         # from transformers/models/big_bird/modeling_big_bird.py
         def fn(x: int, y: torch.Tensor):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -951,7 +951,7 @@ class VariableBuilder:
         assert isinstance(value, np.ndarray)
 
         source = self.get_source()
-        tensor_value = torch.from_numpy(value)
+        tensor_value = torch.as_tensor(value)
 
         proxy = self.tx.output.root_tracer.create_graph_input(
             re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(tensor_value)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105546

Fix: #105046

This PR changes how tensors are created from Numpy arrays, when tracing with
dynamo. Instead of using `from_numpy`, we use `as_tensor`. The latter takes into
consideration the current device.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov