### PR TITLE
[Pytorch][Vulkan] aten::pow

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/pow_scalar_tensor.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/pow_scalar_tensor.glsl
@@ -1,8 +1,6 @@
-/*
- * OPERATOR = $OPERATOR
- */
-
-#define OP(X, Y) $OPERATOR
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
 
 layout(std430) buffer;
 
@@ -11,8 +9,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
 layout(set = 0, binding = 1) uniform PRECISION sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // output texture size (x=width, y=height, z=depth, w=unused)
-  ivec4 extents;
+  ivec4 size;
   float other;
 }
 uBlock;
@@ -22,13 +19,11 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
-  if (any(greaterThanEqual(pos, uBlock.extents.xyz))) {
+  if (any(greaterThanEqual(pos, uBlock.size.xyz))) {
     return;
   }
 
-  vec4 v = texelFetch(uInput, pos, 0);
-  vec4 v_other = vec4(uBlock.other);
-  vec4 out_texel = OP(v, v_other);
-
-  imageStore(uOutput, pos, out_texel);
+  const vec4 v = texelFetch(uInput, pos, 0);
+  const vec4 base = vec4(uBlock.other);
+  imageStore(uOutput, pos, pow(base, v));
 }

--- a/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
+++ b/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
@@ -5,6 +5,8 @@ binary_op_scalar:
   parameter_values:
       - NAME: mul_scalar
         OPERATOR: X * Y
+      - NAME: pow_tensor_scalar
+        OPERATOR: pow (X, Y)
 
 binary_op_scalar_inplace:
   parameter_names_with_default_values:
@@ -13,6 +15,8 @@ binary_op_scalar_inplace:
   parameter_values:
       - NAME: mul_scalar_
         OPERATOR: X * Y
+      - NAME: pow_tensor_scalar_
+        OPERATOR: pow (X, Y)
 
 binary_op_tensor:
   parameter_names_with_default_values:
@@ -29,6 +33,9 @@ binary_op_tensor:
       - NAME: div
         IS_DIV: 1
         OPERATOR: X / Y
+      - NAME: pow
+        IS_DIV: 0
+        OPERATOR: pow(X, Y)
 
 binary_op_tensor_inplace:
   parameter_names_with_default_values:
@@ -45,3 +52,6 @@ binary_op_tensor_inplace:
       - NAME: div_
         IS_DIV: 1
         OPERATOR: X / Y
+      - NAME: pow_
+        IS_DIV: 0
+        OPERATOR: pow(X, Y)

--- a/aten/src/ATen/native/vulkan/glsl/templates/binary_op_scalar_inplace.glslt
+++ b/aten/src/ATen/native/vulkan/glsl/templates/binary_op_scalar_inplace.glslt
@@ -25,5 +25,9 @@ void main() {
     return;
   }
 
-  imageStore(uOutput, pos, OP(imageLoad(uOutput, pos), uBlock.other));
+  vec4 out_texel = imageLoad(uOutput, pos);
+  vec4 v_other = vec4(uBlock.other);
+  out_texel = OP(out_texel, v_other);
+
+  imageStore(uOutput, pos, out_texel);
 }

--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -560,6 +560,30 @@ Tensor& div_tensor_(Tensor& self, const Tensor& other_arg) {
       self, other_arg, c10::optional<Scalar>(), VK_KERNEL(div_));
 }
 
+Tensor pow(const Tensor& self, const Tensor& other) {
+  return binary_op_tensor(self, other, c10::optional<Scalar>(), VK_KERNEL(pow));
+}
+
+Tensor& pow_(Tensor& self, const Tensor& other) {
+  return binary_op_tensor_(
+      self, other, c10::optional<Scalar>(), VK_KERNEL(pow_));
+}
+
+Tensor pow_tensor_scalar(const Tensor& self, const Scalar& other) {
+  return binary_op_scalar(
+      self, other, c10::optional<Scalar>(), VK_KERNEL(pow_tensor_scalar));
+}
+
+Tensor& pow_tensor_scalar_(Tensor& self, const Scalar& other) {
+  return binary_op_scalar_(
+      self, other, c10::optional<Scalar>(), VK_KERNEL(pow_tensor_scalar_));
+}
+
+Tensor pow_scalar_tensor(const Scalar& self, const Tensor& other) {
+  return binary_op_scalar(
+      other, self, c10::optional<Scalar>(), VK_KERNEL(pow_scalar_tensor));
+}
+
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
@@ -579,6 +603,14 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::div_.Scalar"), TORCH_FN(div_scalar_));
   m.impl(TORCH_SELECTIVE_NAME("aten::div.Tensor"), TORCH_FN(div_tensor));
   m.impl(TORCH_SELECTIVE_NAME("aten::div_.Tensor"), TORCH_FN(div_tensor_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::pow.Tensor_Tensor"), TORCH_FN(pow));
+  m.impl(TORCH_SELECTIVE_NAME("aten::pow_.Tensor"), TORCH_FN(pow_));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::pow.Tensor_Scalar"),
+      TORCH_FN(pow_tensor_scalar));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::pow_.Scalar"), TORCH_FN(pow_tensor_scalar_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::pow.Scalar"), TORCH_FN(pow_scalar_tensor));
 }
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
Add support for [aten::pow](https://pytorch.org/docs/stable/generated/torch.pow.html#torch.pow) in [various forms](https://www.internalfb.com/code/fbsource/[c717e1fa980ed47c6580778dcfa49c21d3270a67]/xplat/caffe2/aten/src/ATen/native/native_functions.yaml?lines=9656%2C9670%2C9685%2C9693%2C9699):

|Not in-place| Base | Exp |
|--| -- | -- |
|pow| Tensor | Tensor |
|pow_tensor_scalar| Tensor | Scalar |
|pow_scalar_tensor| Scalar | Tensor |
|In-place| Base | Exp |
|--| -- | -- |
|pow_ | Tensor | Tensor |
|pow_tensor_scalar_| Tensor | Scalar |

Test Plan:
pow tests
```
[lfq@35771.od /data/sandcastle/boxes/fbsource (97d4bdf9e)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*pow*"
Building: finished in 0.1 sec (100%) 329/329 jobs, 0/329 updated
  Total time: 0.2 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *pow*
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.pow
[       OK ] VulkanAPITest.pow (255 ms)
[ RUN      ] VulkanAPITest.pow_broadcast
[       OK ] VulkanAPITest.pow_broadcast (3 ms)
[ RUN      ] VulkanAPITest.pow_
[       OK ] VulkanAPITest.pow_ (90 ms)
[ RUN      ] VulkanAPITest.pow_broadcast_other_
[       OK ] VulkanAPITest.pow_broadcast_other_ (0 ms)
[ RUN      ] VulkanAPITest.pow_tensor_scalar
[       OK ] VulkanAPITest.pow_tensor_scalar (57 ms)
[ RUN      ] VulkanAPITest.pow_tensor_scalar_
[       OK ] VulkanAPITest.pow_tensor_scalar_ (83 ms)
[ RUN      ] VulkanAPITest.pow_scalar_tensor
[       OK ] VulkanAPITest.pow_scalar_tensor (50 ms)
[----------] 7 tests from VulkanAPITest (542 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (542 ms total)
[  PASSED  ] 7 tests.
```

All tests
```
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 317 tests from VulkanAPITest (18448 ms total)

[----------] Global test environment tear-down
[==========] 317 tests from 1 test suite ran. (18448 ms total)
[  PASSED  ] 316 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```
clang-format on glsl and cpp files

Reviewed By: SS-JIA

Differential Revision: D46704167

