### PR TITLE
Remove dead sizevars.__getitem__

### DIFF
--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -342,9 +342,6 @@ class SizeVarAllocator:
     def guard_static_shapes(self, left: List[Expr]) -> List[int]:
         return [self.guard_static_shape(x) for x in left]
 
-    def __getitem__(self, val: int) -> Expr:
-        return self.shape_env.duck_int(val)
-
     def size_hint(self, expr: Expr) -> int:
         if not isinstance(expr, Expr):
             return int(expr)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105579

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov