### PR TITLE
Do not graph break on Python built-in types.

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1321,9 +1321,10 @@ class MiscTests(torch._dynamo.test_case.TestCase):
     @requires_numpy_pytorch_interop
     @torch._dynamo.config.patch(numpy_ndarray_as_tensor=True)
     def test_no_graph_break_numpy_with_builtin_types(self):
-        x = np.ones(3, dtype='float64')
+        x = np.ones(3, dtype="float64")
 
         cnts = torch._dynamo.testing.CompileCounter()
+
         @torch._dynamo.optimize(cnts)
         def f(x):
             return x.astype(int)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1318,6 +1318,19 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             res = opt_fn(x.item())
             self.assertTrue(same(ref, res))
 
+    @requires_numpy_pytorch_interop
+    @torch._dynamo.config.patch(numpy_ndarray_as_tensor=True)
+    def test_no_graph_break_numpy_with_builtin_types(self):
+        x = np.ones(3, dtype='float64')
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        @torch._dynamo.optimize(cnts)
+        def f(x):
+            return x.astype(int)
+
+        r = f(x)
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_graph_break_correctly_when_passing_numpy_ndarray_to_torch_function(self):
         # from transformers/models/big_bird/modeling_big_bird.py
         def fn(x: int, y: torch.Tensor):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 
 import torch
 from torch import sym_float, sym_int
+from torch.fx.node import python_builtin_types
 
 from .. import config, variables
 from ..allowed_functions import is_allowed
@@ -408,6 +409,11 @@ class BuiltinVariable(VariableTracker):
 
     def as_python_constant(self):
         return self.fn
+
+    def as_proxy(self):
+        if self.fn in python_builtin_types:
+            return self.fn
+        return super().as_proxy()
 
     def reconstruct(self, codegen):
         name = self.fn.__name__

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -17,6 +17,7 @@ __all__ = ['Node', 'map_arg', 'map_aggregate', "has_side_effect"]
 BaseArgumentTypes = Union[str, int, float, bool, complex, torch.dtype,
                           torch.Tensor, torch.device, torch.memory_format, torch.layout, torch._ops.OpOverload]
 base_types = BaseArgumentTypes.__args__  # type: ignore[attr-defined]
+python_builtin_types = (str, int, float, bool, complex)
 
 Target = Union[Callable[..., Any], str]
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -12,7 +12,7 @@ from dataclasses import is_dataclass, fields
 
 from .graph import magic_methods, reflectable_magic_methods, Graph
 from typing import Tuple, Dict, OrderedDict, Optional, Iterable, Any, Iterator, Callable
-from .node import Target, Node, Argument, base_types, map_aggregate
+from .node import Target, Node, Argument, base_types, map_aggregate, python_builtin_types
 from ._compatibility import compatibility
 from .operator_schemas import check_for_mutable_operation
 import torch.fx.traceback as fx_traceback
@@ -269,7 +269,7 @@ class TracerBase:
             kwargs = {field.name: self.create_arg(getattr(a, field.name)) for field in fields(a)}
             return self.create_node("call_function", a.__class__, (), kwargs)
 
-        elif isinstance(a, base_types) or a is None or a is ...:
+        elif isinstance(a, base_types) or a in python_builtin_types or a is None or a is ...:
             return a
         raise NotImplementedError(f"argument of type: {type(a)}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105588

Fix: #105052

This PR plumbs Python builtin types (`bool`, `int`, `float`, `str`, and `complex`) to be
used inside dynamo function without triggering graph breaks.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov