### PR TITLE
[device mesh][BE] remove allreduce from DM

### DIFF
--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -6,6 +6,7 @@ from typing import Any, List, Type
 
 import torch
 import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
 import torch.fx as fx
 import torch.nn as nn
 from torch.distributed._spmd.api import compile, COMPILED_OBJECT_KEY, Override
@@ -53,7 +54,7 @@ class TraceDeviceMeshTestBase:
             ]
 
             def fn(tensor: torch.Tensor):
-                tensor = mesh.all_reduce(tensor, mesh_dim=dim)
+                tensor = funcol.all_reduce(tensor, "sum", group=(mesh, mesh_dim))
                 # multiply with 1 to trigger wait on read during tracing.
                 return tensor * 1
 

--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -54,7 +54,7 @@ class TraceDeviceMeshTestBase:
             ]
 
             def fn(tensor: torch.Tensor):
-                tensor = funcol.all_reduce(tensor, "sum", group=(mesh, mesh_dim))
+                tensor = funcol.all_reduce(tensor, "sum", group=(mesh, dim))
                 # multiply with 1 to trigger wait on read during tracing.
                 return tensor * 1
 

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -156,15 +156,6 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         return 8
 
     @with_comms
-    def test_all_reduce_1d(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
-        local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
-        # multiply with 1 to trigger wait
-        local_tensor = mesh.all_reduce(local_tensor, mesh_dim=0) * 1
-        res_num = ((0 + self.world_size - 1) * self.world_size) / 2
-        self.assertEqual(local_tensor, torch.ones(3, 3) * res_num)
-
-    @with_comms
     def test_broadcast_1d(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
@@ -392,21 +383,6 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 
             res_num = torch.sum(torch.tensor(global_ranks))
             self.assertEqual(scattered_tensor, torch.ones(3, 3, 3) * res_num)
-
-    @with_comms
-    def test_all_reduce_nd(self):
-        mesh_tensor = torch.arange(8).reshape(2, 2, 2)
-        mesh = DeviceMesh(self.device_type, mesh_tensor)
-        local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
-
-        # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
-        for dim, dim_group in enumerate(dim_to_subgroups):
-            global_ranks = get_process_group_ranks(dim_group)
-            cloned_local_tensor = local_tensor.clone()
-            cloned_local_tensor = mesh.all_reduce(cloned_local_tensor, mesh_dim=dim) * 1
-            res_num = sum(global_ranks)
-            self.assertEqual(cloned_local_tensor, torch.ones(3, 3) * res_num)
 
     @with_comms
     def test_broadcast_nd(self):

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -395,28 +395,6 @@ class DeviceMesh:
         assert isinstance(dim_group, ProcessGroup)
         return funcol.all_gather_tensor(tensor, gather_dim=gather_dim, group=dim_group)
 
-    def all_reduce(
-        self,
-        tensor: torch.Tensor,
-        op: ReduceOp.RedOpType = ReduceOp.SUM,
-        mesh_dim: int = 0,
-    ) -> torch.Tensor:
-        """
-        all_reduce the tensor on each rank on a device mesh dimension, and
-        return an output tensor on each rank after all_reduce.
-
-        Args:
-            tensor (torch.Tensor): tensor to be all_reduced on each rank.
-            op (:class:`torch.distributed.distributed_c10d.ReduceOp, optional):
-                the reduction op of all_reduce (i.e. ReduceOp.SUM)
-            mesh_dim (int, optional): indicate which mesh dimension we want
-                to reduce on.
-
-        Returns:
-            A :class:`AsyncCollectiveTensor` object
-        """
-        return funcol.all_reduce(tensor, reduceOp=op.name, group=(self, mesh_dim))
-
     def reduce_scatter(
         self,
         input: torch.Tensor,

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import cast, List, Optional, Sequence, Tuple
 
 import torch
+import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 
 from torch.distributed._tensor.device_mesh import DeviceMesh
@@ -329,7 +330,9 @@ class _Partial(Placement):
     def _to_replicate(
         self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
     ) -> torch.Tensor:
-        return mesh.all_reduce(tensor, self.reduce_op, mesh_dim=mesh_dim)
+        return funcol.all_reduce(
+            tensor, reduceOp=self.reduce_op.name, group=(mesh, mesh_dim)
+        )
 
     def _to_shard(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #105642
* #105614
* __->__ #105605
* #105604

This PR removes allreduce from DM and use functional collective instead,
the rationle is that we don't want to maintain yet another set of
collective apis, and since the DM's collective is now a thin wrapper to functional collective so we
don't really need these collective to live in DM