### PR TITLE
[Pytorch][Vulkan] sum.dim_IntList

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/sum_dim.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sum_dim.glsl
@@ -1,0 +1,82 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // dim_info.x: dim to sum
+  // dim_info.y: size of dim (in the input)
+  uvec2 dim_info;
+  int channel;
+}
+uBlock;
+
+/*
+ * Local Work Group Size
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Returns a new tensor with values summed along dimension dim
+ * Dimension dim is squeezed
+ * For each pos:
+ *  - Iterate over the out_texel and the summed dimension
+ *  - For H,W; rearrange pos.x, pos.y
+ *  - For C,H,W;
+ *      When CHW are summed, batch moves into channel
+ *      The src N is determined by pos.z * 4 + out_index
+ */
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  int flattened_channels = int(ceil(uBlock.channel / 4.0));
+  vec4 out_texel = vec4(0, 0, 0, 0);
+
+  // Batch
+  if (uBlock.dim_info.x == 0) {
+    for (int batch = 0; batch < uBlock.dim_info.y; batch++) {
+      // src_n = batch
+      // src_c = pos.z
+      int src_z = batch * flattened_channels + pos.z;
+      vec4 v = texelFetch(uInput, ivec3(pos.x, pos.y, src_z), 0);
+      out_texel += v;
+    }
+    imageStore(uOutput, pos, out_texel);
+  }
+
+  // Channel
+  else if (uBlock.dim_info.x == 1) {
+    for (int out_index = 0; out_index < 4; out_index++) {
+      for (int channel = 0; channel < uBlock.dim_info.y; channel++) {
+        // src_n = pos.z * 4 + out_index
+        // src_c = channel
+        int src_z =
+            (pos.z * 4 + out_index) * flattened_channels + int(channel / 4);
+        vec4 v = texelFetch(uInput, ivec3(pos.x, pos.y, src_z), 0);
+        out_texel[out_index] += v[channel % 4];
+      }
+    }
+    imageStore(uOutput, pos, out_texel);
+  }
+
+  // Height, Width
+  else {
+    for (int out_index = 0; out_index < 4; out_index++) {
+      // src_n = pos.z * 4 + out_index
+      // src_c = pos.y
+      int src_z = (pos.z * 4 + out_index) * flattened_channels + pos.y / 4;
+      for (int hw = 0; hw < uBlock.dim_info.y; hw++) {
+        vec4 v = (uBlock.dim_info.x == 2)
+            ? texelFetch(uInput, ivec3(pos.x, hw, src_z), 0) // Height
+            : texelFetch(uInput, ivec3(hw, pos.x, src_z), 0); // Width
+        out_texel[out_index] += v[pos.y % 4];
+      }
+    }
+    imageStore(uOutput, pos, out_texel);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Sum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Sum.cpp
@@ -1,0 +1,137 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor sum_dim(
+    const at::Tensor& self,
+    int64_t dim,
+    bool keepdim,
+    const optional<ScalarType> dtype) {
+  TORCH_CHECK(
+      self.dim() >= 2 || self.dim() <= 4,
+      "Vulkan sum.dim_IntList supports 2d, 3d, 4d tensors as input!");
+  TORCH_CHECK(
+      dim >= -self.dim() - 1 && dim <= self.dim(),
+      "Vulkan sum.dim_IntList dimension out of range expected to be in range of [",
+      -self.dim() - 1,
+      ",",
+      self.dim(),
+      "], but got ",
+      dim);
+
+  // Get the global Vulkan context
+  api::Context* const context = api::context();
+
+  // Cast the input Tensor to a vTensor
+  const Tensor input = self.is_vulkan() ? self : self.vulkan();
+  const vTensor& v_input = convert(input);
+
+  // Normalize dim into range [0, self.dim()]
+  dim = utils::normalize(dim, self.dim());
+
+  // Create the output texture
+  std::vector<int64_t> output_size = self.sizes().vec();
+  uint32_t dim_size = output_size[dim];
+  output_size.erase(output_size.begin() + dim);
+
+  ScalarType type = self.scalar_type();
+  if (dtype.has_value()) {
+    type = dtype.value();
+  }
+
+  vTensor v_output{
+      context,
+      output_size,
+      type,
+  };
+
+  // Required to determine how to insert memory barriers in the command buffer
+  api::PipelineBarrier pipeline_barrier{};
+
+  // Shift dim into 4d range
+  if (self.dim() < 4) {
+    dim += (4 - self.dim());
+  }
+
+  // Create the params buffer
+  const struct Block final {
+    uvec2 dim_info;
+    int32_t channel;
+  } block{
+      {static_cast<uint32_t>(dim), dim_size},
+      static_cast<int32_t>(get_dim<Dim4D::Channel>(v_input)),
+  };
+
+  api::UniformParamsBuffer params(context, block);
+
+  context->submit_compute_job(
+      // shader descriptor
+      VK_KERNEL(sum_dim),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      // params buffer
+      params.buffer());
+  return convert(v_output);
+}
+
+Tensor sum_dim_IntList(
+    const at::Tensor& self,
+    const OptionalIntArrayRef opt_dim,
+    bool keepdim,
+    const optional<ScalarType> dtype) {
+  TORCH_CHECK(
+      opt_dim.has_value(),
+      "Vulkan sum.dim_IntList without a dim arg is not implemented");
+  TORCH_CHECK(
+      keepdim == false,
+      "Vulkan sum.dim_IntList with keepdim=true is not implemented");
+
+  std::set<int64_t> dims_set;
+  if (opt_dim.has_value()) {
+    auto dims = opt_dim.value();
+    for (const auto& d : dims) {
+      dims_set.insert(d);
+    }
+    Tensor result = self;
+    for (auto it = dims_set.rbegin(); it != dims_set.rend(); ++it) {
+      result = sum_dim(result, *it, keepdim, dtype);
+    }
+    return result;
+  }
+  return self;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::sum.dim_IntList"), TORCH_FN(sum_dim_IntList));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3702,6 +3702,57 @@ TEST_F(VulkanAPITest, sub_to_scalar_wrapped) {
   ASSERT_TRUE(check);
 }
 
+void test_sum_dim(const at::IntArrayRef input_shape, const at::IntArrayRef dim_list) {
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  const auto out_cpu = at::sum(in_cpu, dim_list);
+  const auto out_vulkan = at::sum(in_vulkan, dim_list);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    std::cout << "sum_dim test failed with input shape: "
+              << input_shape << " and dim_list: " << dim_list << std::endl;
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sum_dim_2d) {
+  test_sum_dim({2, 3}, {-1});
+  test_sum_dim({2, 7}, {-2});
+}
+
+TEST_F(VulkanAPITest, sum_dim_3d) {
+  test_sum_dim({9, 7, 5}, {-1});
+  test_sum_dim({5, 7, 9}, {-2});
+  test_sum_dim({5, 7, 9}, {-3});
+
+  test_sum_dim({10, 7, 5}, {0, 1});
+  test_sum_dim({10, 7, 5}, {0, 2});
+  test_sum_dim({10, 7, 5}, {1, 2});
+}
+
+TEST_F(VulkanAPITest, sum_dim_4d) {
+  test_sum_dim({7, 9, 6, 5}, {-1});
+  test_sum_dim({6, 5, 7, 9}, {-2});
+  test_sum_dim({6, 5, 7, 9}, {-3});
+  test_sum_dim({6, 5, 7, 9}, {-4});
+
+  test_sum_dim({10, 7, 5, 6}, {0, 1});
+  test_sum_dim({10, 7, 5, 6}, {0, 2});
+  test_sum_dim({10, 7, 5, 6}, {0, 3});
+  test_sum_dim({10, 7, 5, 6}, {1, 2});
+  test_sum_dim({10, 7, 5, 6}, {1, 3});
+  test_sum_dim({10, 7, 5, 6}, {2, 3});
+
+  test_sum_dim({10, 7, 5, 6}, {0, 1, 2});
+  test_sum_dim({10, 7, 5, 6}, {0, 1, 3});
+  test_sum_dim({10, 7, 5, 6}, {0, 2, 3});
+  test_sum_dim({10, 7, 5, 6}, {3, 2, 1});
+}
+
 TEST_F(VulkanAPITest, uniform) {
   float a_min = -8.2f;
   float a_max = -1.4f;


### PR DESCRIPTION
Summary:
Add Vulkan support for [sum](https://pytorch.org/docs/stable/generated/torch.sum.html).dim_IntList

[sum.dim_IntList](https://www.internalfb.com/code/fbsource/[49b7951b7eb6]/xplat/caffe2/aten/src/ATen/native/native_functions.yaml?lines=5466):
```
func: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None)
```
Some explanation
For each pos
 - Iterate over the out_texel and summed dimension
 - For H,W; rearrange pos.x, pos.y
 - For C,H,W;
When CHW are summed, batch moves into channel
The src N is determined by pos.z * 4 + out_index

Follow up:
Add support for `keepdim=true`
```
if keepdim is true, the output tensor is of the same size as input except in the dimension(s) dim, where it is of size 1
otherwise, the dim is squeezed, result in the output tensor having 1 fewer dimension/s.
```

Add support for [sum](https://www.internalfb.com/code/fbsource/[49b7951b7eb6]/xplat/caffe2/aten/src/ATen/native/native_functions.yaml?lines=5457)
```
func: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
```

Test Plan:
New tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*.sum*"
Downloaded 0/53 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 47.4 sec (100%) 536/536 jobs, 8/536 updated
  Total time: 47.5 sec
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *.sum*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.sum_2d
[       OK ] VulkanAPITest.sum_2d (426 ms)
[ RUN      ] VulkanAPITest.sum_3d
[       OK ] VulkanAPITest.sum_3d (2 ms)
[ RUN      ] VulkanAPITest.sum_4d
[       OK ] VulkanAPITest.sum_4d (3 ms)
[ RUN      ] VulkanAPITest.sum_3d_combined
[       OK ] VulkanAPITest.sum_3d_combined (1 ms)
[ RUN      ] VulkanAPITest.sum_4d_combined
[       OK ] VulkanAPITest.sum_4d_combined (5 ms)
[----------] 5 tests from VulkanAPITest (437 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (438 ms total)
[  PASSED  ] 5 tests.
```

clang-format on Sum.cpp and sum_dim.glsl

Differential Revision: D47580428

