### PR TITLE
Kill process in `wait_for_process` if `SIGINT` fails to terminate it

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -692,7 +692,7 @@ def wait_for_process(p, timeout=None):
         # try to handle the case where p.wait(timeout=5) times out as well as
         # otherwise the wait() call in the finally block can potentially hang
         except subprocess.TimeoutExpired:
-            p.kill()
+            pass
         if exit_status is not None:
             return exit_status
         else:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -692,8 +692,8 @@ def wait_for_process(p, timeout=None):
                 return exit_status
             else:
                 p.kill()
-        # try to handle the case where p.wait() times out as well as otherwise
-        # the wait() call in the finally block can potentially hang
+        # try to handle the case where p.wait(timeout=5) times out as well as
+        # otherwise the wait() call in the finally block can potentially hang
         except subprocess.TimeoutExpired:
             p.kill()
         finally:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -686,6 +686,7 @@ def wait_for_process(p, timeout=None):
     except subprocess.TimeoutExpired:
         # send SIGINT to give pytest a chance to make xml
         p.send_signal(signal.SIGINT)
+        exit_status = None
         try:
             exit_status = p.wait(timeout=5)
         # try to handle the case where p.wait(timeout=5) times out as well as

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -686,10 +686,16 @@ def wait_for_process(p, timeout=None):
     except subprocess.TimeoutExpired:
         # send SIGINT to give pytest a chance to make xml
         p.send_signal(signal.SIGINT)
-        exit_status = p.wait(timeout=5)
-        if exit_status is not None:
-            return exit_status
-        else:
+        try:
+            exit_status = p.wait(timeout=5)
+            if exit_status is not None:
+                return exit_status
+            else:
+                p.kill()
+                raise
+        # try to handle the case where p.wait() times out as well as otherwise
+        # the wait() call in the finally block can potentially hang
+        except subprocess.TimeoutExpired:
             p.kill()
             raise
     except:  # noqa: B001,E722, copied from python core library

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -692,11 +692,11 @@ def wait_for_process(p, timeout=None):
                 return exit_status
             else:
                 p.kill()
-                raise
         # try to handle the case where p.wait() times out as well as otherwise
         # the wait() call in the finally block can potentially hang
         except subprocess.TimeoutExpired:
             p.kill()
+        finally:
             raise
     except:  # noqa: B001,E722, copied from python core library
         p.kill()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -688,16 +688,15 @@ def wait_for_process(p, timeout=None):
         p.send_signal(signal.SIGINT)
         try:
             exit_status = p.wait(timeout=5)
-            if exit_status is not None:
-                return exit_status
-            else:
-                p.kill()
         # try to handle the case where p.wait(timeout=5) times out as well as
         # otherwise the wait() call in the finally block can potentially hang
         except subprocess.TimeoutExpired:
             p.kill()
-        finally:
-            raise
+        if exit_status is not None:
+            return exit_status
+        else:
+            p.kill()
+        raise
     except:  # noqa: B001,E722, copied from python core library
         p.kill()
         raise


### PR DESCRIPTION
#98035 adds some additional logic `wait_for_process` that includes catching a timeout exception and sending `SIGINT` to the process before waiting on it again with a timeout. However, if the additional wait times out again, then the wait call in the `finally` block (which does not have a timeout) has the potential to hang indefinitely.

This PR kills the process if a second timeout exception occurs after the `SIGINT` signal is sent.

CC @clee2000 @ptrblck @xwang233 @kwen2501 

Also hoping that this has the potential to reduce turnaround time for distributed timeouts like those seen in https://hud.pytorch.org/pr/pytorch/pytorch/105274#15148799113