### PR TITLE
Fix a docstring

### DIFF
--- a/torch/nn/parallel/comm.py
+++ b/torch/nn/parallel/comm.py
@@ -162,7 +162,7 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
           into equal chunks.
         dim (int, optional): A dimension along which to chunk :attr:`tensor`.
           Default: ``0``.
-        streams (Iterable[Stream], optional): an iterable of Streams, among
+        streams (Iterable"[Stream]", optional): an iterable of Streams, among
           which to execute the scatter. If not specified, the default stream will
           be utilized.
         out (Sequence[Tensor], optional, keyword-only): the GPU tensors to

--- a/torch/nn/parallel/comm.py
+++ b/torch/nn/parallel/comm.py
@@ -162,7 +162,7 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
           into equal chunks.
         dim (int, optional): A dimension along which to chunk :attr:`tensor`.
           Default: ``0``.
-        streams (Iterable"[Stream]", optional): an iterable of Streams, among
+        streams (Iterable[torch.cuda.Stream], optional): an iterable of Streams, among
           which to execute the scatter. If not specified, the default stream will
           be utilized.
         out (Sequence[Tensor], optional, keyword-only): the GPU tensors to


### PR DESCRIPTION
Since there is now more than one reference to Stream updating the `Stream` ref to `torch.cuda.Stream` to address this failure https://github.com/pytorch/pytorch/actions/runs/5614044578/job/15211767897#step:9:1139.