### PR TITLE
[dynamo] Fix import if numpy is not installed

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -47,17 +47,19 @@ except ModuleNotFoundError:
     torch_np = None
     HAS_NUMPY_TORCH_INTEROP = False
 
-if HAS_NUMPY:
-    # NOTE: Make sure `NP_SUPPORTED_MODULES` and `NP_TO_TORCH_NP_MODULE` are in sync.
-    NP_SUPPORTED_MODULES = (np, np.fft, np.linalg, np.random)
+# NOTE: Make sure `NP_SUPPORTED_MODULES` and `NP_TO_TORCH_NP_MODULE` are in sync.
+NP_SUPPORTED_MODULES = (np, np.fft, np.linalg, np.random) if HAS_NUMPY else tuple()
 
-if HAS_NUMPY_TORCH_INTEROP:
-    NP_TO_TORCH_NP_MODULE = {
+NP_TO_TORCH_NP_MODULE = (
+    {
         np: torch_np,
         np.fft: torch_np.fft,
         np.linalg: torch_np.linalg,
         np.random: torch_np.random,
     }
+    if HAS_NUMPY_TORCH_INTEROP
+    else {}
+)
 
 import importlib
 


### PR DESCRIPTION
This [line](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/allowed_functions.py#L18) results in an import issue if numpy is not installed.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov