### PR TITLE
[Inductor] Provenance tracking for wrapper code

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2250,6 +2250,12 @@ class TritonScheduling:
 
         return tiled_groups, reduction_hint_val, mutations, index_dtype
 
+    def codegen_comment(self, node_schedule):
+        wrapper = V.graph.wrapper_code
+        origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+        if origins:
+            wrapper.writeline(origins)
+
     def codegen_node_schedule(self, node_schedule, numel, reduction_numel):
         tiled_groups, reduction_hint_val, mutations, index_dtype = self.get_kernel_args(
             node_schedule, numel, reduction_numel
@@ -2266,7 +2272,7 @@ class TritonScheduling:
 
         src_code = kernel.codegen_kernel()
         kernel_name = self.define_kernel(src_code, node_schedule)
-
+        self.codegen_comment(node_schedule)
         kernel.call_kernel(kernel_name)
 
         if config.warn_mix_layout:
@@ -2347,7 +2353,8 @@ class TritonScheduling:
             compile_wrapper.writeline("''')")
 
             metadata_comment = f"# kernel path: {kernel_path}"
-            metadata_comment += "\n" + get_kernel_metadata(node_schedule)
+            origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+            metadata_comment += "\n" + origins + "\n" + detailed_origins
             wrapper.define_kernel(
                 kernel_name, compile_wrapper.getvalue(), metadata_comment
             )
@@ -2368,7 +2375,9 @@ class TritonScheduling:
                 node.codegen(kernel.split_and_set_ranges(node.get_ranges()))
 
         src_code = render()
-        kernel_name = self.define_kernel(src_code, [template_node, *epilogue_nodes])
+        node_schedule = [template_node, *epilogue_nodes]
+        kernel_name = self.define_kernel(src_code, node_schedule)
+        self.codegen_comment(node_schedule)
         kernel.call_kernel(kernel_name)
         self.scheduler.free_buffers()
 
@@ -2407,6 +2416,7 @@ class TritonScheduling:
 
             src_code = kernel.codegen_kernel()
             kernel_name = self.define_kernel(src_code, [foreach_node])
+            self.codegen_comment([foreach_node])
             kernel.call_kernel(V.graph.wrapper_code, kernel_name)
 
         self.scheduler.free_buffers()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -53,6 +53,7 @@ from .utils import (
     convert_shape_to_inductor,
     convert_shape_to_symint,
     developer_warning,
+    get_kernel_metadata,
     pad_listlike,
     sympy_dot,
     sympy_product,
@@ -2615,6 +2616,11 @@ class ExternKernel(InputsKernel):
             self.apply_constraint()
             self.freeze_layout()
 
+    def codegen_comment(self, wrapper):
+        origin_str, detailed_origin_str = get_kernel_metadata(self, wrapper)
+        if origin_str:
+            wrapper.writeline(origin_str)
+
     def codegen(self, wrapper):
         raise NotImplementedError()
 
@@ -2954,6 +2960,7 @@ class ExternKernelOut(ExternKernel):
     output_view: Optional[ReinterpretView] = None
 
     def codegen(self, wrapper):
+        self.codegen_comment(wrapper)
         args = [*self.codegen_args(), *self.codegen_kwargs()]
         wrapper.generate_extern_kernel_out(
             self.output_view,
@@ -3003,6 +3010,7 @@ class RandomSeeds(ExternKernelOut):
 
 class ExternKernelAlloc(ExternKernel):
     def codegen(self, wrapper):
+        self.codegen_comment(wrapper)
         args = [*self.codegen_args(), *self.codegen_kwargs()]
         V.graph.wrapper_code.generate_extern_kernel_alloc(
             self.get_name(), self.kernel, args, self.get_origin_node()

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -276,15 +276,22 @@ def cache_on_self(fn):
 
 
 def aggregate_origins(node_schedule):
-    return functools.reduce(
-        operator.or_,
-        [
-            node.node.origins
-            for node in node_schedule
-            if hasattr(node, "node") and node.node
-        ],
-        set(),
-    )
+    from . import ir
+
+    if isinstance(node_schedule, list):
+        return functools.reduce(
+            operator.or_,
+            [
+                node.node.origins
+                for node in node_schedule
+                if hasattr(node, "node") and node.node
+            ],
+            set(),
+        )
+    elif isinstance(node_schedule, ir.ExternKernel):
+        return node_schedule.origins
+    else:
+        return set()
 
 
 def get_fused_kernel_name(node_schedule, descriptive_names):
@@ -317,21 +324,30 @@ def get_fused_kernel_name(node_schedule, descriptive_names):
     return "_".join(["fused"] + sources)
 
 
-def get_kernel_metadata(node_schedule):
+def get_kernel_metadata(node_schedule, wrapper):
     all_origins = aggregate_origins(node_schedule)
     inductor_nodes = [origin for origin in all_origins if origin.op == "call_function"]
+
+    from_node_dict = collections.defaultdict(list)
     original_aten_dict = collections.defaultdict(list)
     for node in inductor_nodes:
         if "original_aten" in node.meta:
-            original_aten_dict[str(node.meta["original_aten"]._overloadpacket)].append(
-                node.name
-            )
-    metadata = [
-        f"# Original ATen: {', '.join(sorted(original_aten_dict.keys()))}\n",
-    ]
-    for original_aten, nodes in sorted(original_aten_dict.items()):
-        metadata.append(f"# {original_aten} => {', '.join(sorted(nodes))}")
-    return "\n".join(metadata)
+            key = str(node.meta["original_aten"]._overloadpacket)
+            original_aten_dict[key].append(node.name)
+        if "from_node" in node.meta:
+            key = node.meta["from_node"][0][0]
+            from_node_dict[key].append(node.name)
+    metadata = (
+        f"{wrapper.comment} Source Nodes: [{', '.join(sorted(from_node_dict.keys()))}], "
+        f"Original ATen: [{', '.join(sorted(original_aten_dict.keys()))}]"
+    )
+    # trace back to original node here
+    detailed_metadata = []
+    for original_node, nodes in sorted(from_node_dict.items()):
+        detailed_metadata.append(
+            f"{wrapper.comment} {original_node} => {', '.join(sorted(nodes))}"
+        )
+    return metadata, "\n".join(detailed_metadata)
 
 
 def dominated_nodes(initial_queue: Iterable[torch.fx.Node], skip_filter=None):

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -171,6 +171,10 @@ class Interpreter:
 
     @contextmanager
     def _set_current_node(self, node):
+        if "from_node" not in node.meta:
+            node.meta["from_node"] = []
+        if not node.meta["from_node"] or node.meta["from_node"][-1][0] != node.name:
+            node.meta["from_node"].append((node.name, node.target))
         with fx_traceback.set_current_meta(node.meta):
             yield
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -138,10 +138,10 @@ class TracerBase:
                 node.stack_trace = stack_trace
             # Explicitly set the stack_trace, nn_module_stack and source_fn on the node.meta
             # If other meta fields are needed, they can be added here
-            copy_meta_fields = ["nn_module_stack", "source_fn", "original_aten", "recompute"]
+            copy_meta_fields = ["nn_module_stack", "source_fn", "original_aten", "recompute", "from_node"]
             for field in copy_meta_fields:
                 if field in current_meta:
-                    node.meta[field] = current_meta[field]
+                    node.meta[field] = copy.copy(current_meta[field])
         elif self.module_stack:
             node.meta['nn_module_stack'] = copy.copy(self.module_stack)
         return node


### PR DESCRIPTION
Summary:
Add comments in wrapper code for better provenance tracking

Sample inductor wrapper output:
```
# Source Nodes: [mm_1], Original ATen: [aten.mm]
extern_kernels.mm(as_strided(tangents_1, (500, 20), (1, 500)), view, out=buf1)

# Source Nodes: [l__self___linear], Original ATen: [aten.addmm]
extern_kernels.addmm(primals_2, as_strided(primals_3, (20, 500), (500, 1)), as_strided(primals_1, (500, 500), (1, 500)), alpha=1, beta=1, out=buf0)
```



in cpp wrapper
```
        // Source Nodes: [bmm_1], Original ATen: bmm
        at::bmm_out(buf0, arg0_1, arg1_1);
```


Test Plan: OSS CI

Differential Revision: D47657260



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov