### PR TITLE
[pytorch] replace __FILE__ with __FILE_NAME__ for exceptions

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -295,7 +295,7 @@ C10_API std::string GetExceptionString(const std::exception& e);
 // very useful, but hard to fix in a macro so suppressing the warning.
 #define C10_THROW_ERROR(err_type, msg) \
   throw ::c10::err_type(               \
-      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, msg)
+      {__func__, __FILE_NAME__, static_cast<uint32_t>(__LINE__)}, msg)
 
 // Private helper macro for workaround MSVC misexpansion of nested macro
 // invocations involving __VA_ARGS__.  See
@@ -361,9 +361,9 @@ C10_API std::string GetExceptionString(const std::exception& e);
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                               \
     ::c10::detail::torchCheckFail(                                    \
         __func__,                                                     \
-        __FILE__,                                                     \
+        __FILE_NAME__,                                                     \
         static_cast<uint32_t>(__LINE__),                              \
-        #cond " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__)); \
+        #cond " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE_NAME__)); \
   }
 #else
 // It would be nice if we could build a combined string literal out of
@@ -375,10 +375,10 @@ C10_API std::string GetExceptionString(const std::exception& e);
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                                          \
     ::c10::detail::torchInternalAssertFail(                                      \
         __func__,                                                                \
-        __FILE__,                                                                \
+        __FILE_NAME__,                                                                \
         static_cast<uint32_t>(__LINE__),                                         \
         #cond                                                                    \
-        " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__) ":" C10_STRINGIZE( \
+        " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE_NAME__) ":" C10_STRINGIZE( \
             __LINE__) ", please report a bug to PyTorch. ",                      \
         c10::str(__VA_ARGS__));                                                  \
   }
@@ -409,7 +409,7 @@ C10_API std::string GetExceptionString(const std::exception& e);
 
 #ifdef STRIP_ERROR_MESSAGES
 #define TORCH_CHECK_MSG(cond, type, ...) \
-  (#cond #type " CHECK FAILED at " C10_STRINGIZE(__FILE__))
+  (#cond #type " CHECK FAILED at " C10_STRINGIZE(__FILE_NAME__))
 #define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)                \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                               \
     C10_THROW_ERROR(Error, TORCH_CHECK_MSG(cond, type, __VA_ARGS__)); \
@@ -494,7 +494,7 @@ namespace detail {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {          \
     ::c10::detail::torchCheckFail(               \
         __func__,                                \
-        __FILE__,                                \
+        __FILE_NAME__,                                \
         static_cast<uint32_t>(__LINE__),         \
         TORCH_CHECK_MSG(cond, "", __VA_ARGS__)); \
   }
@@ -503,7 +503,7 @@ namespace detail {
   if (C10_UNLIKELY_OR_CONST(!(cond))) {            \
     ::c10::detail::torchCheckFail(                 \
         __func__,                                  \
-        __FILE__,                                  \
+        __FILE_NAME__,                                  \
         static_cast<uint32_t>(__LINE__),           \
         TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
   }
@@ -571,7 +571,7 @@ namespace detail {
 #define _TORCH_WARN_WITH(warning_t, ...)                     \
   ::c10::warn(::c10::Warning(                                \
       warning_t(),                                           \
-      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+      {__func__, __FILE_NAME__, static_cast<uint32_t>(__LINE__)}, \
       WARNING_MESSAGE_STRING(__VA_ARGS__),                   \
       false));
 #endif


### PR DESCRIPTION
Summary: Replace uses of the `__FILE__` macro with `__FILE_NAME__` for pytorch exceptions. This will prevent embedding build system paths in the build output, which will cause varying output depending on configuration.

Test Plan:
Build and inspect assert strings before change:
```
$ buck2 build --show-output //fbobjc/Libraries/FBPyTorchCore:torch_core_msg_opsApple
$ strings buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_opsApple__/libtorch_core_msg_opsApple.pic.a | grep FAIL | grep buck | head -n 3
*current_device == options.device() INTERNAL ASSERT FAILED at "buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_ops_aten__/out/RegisterCompositeExplicitAutogradNonFunctional.cpp":99, please report a bug to PyTorch.
*current_device == options.device() INTERNAL ASSERT FAILED at "buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_ops_aten__/out/RegisterCompositeExplicitAutogradNonFunctional.cpp":118, please report a bug to PyTorch.
*current_device == options.device() INTERNAL ASSERT FAILED at "buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_ops_aten__/out/RegisterCompositeExplicitAutogradNonFunctional.cpp":151, please report a bug to PyTorch.
```
After change:
```
$ buck2 build --show-output //fbobjc/Libraries/FBPyTorchCore:torch_core_msg_opsApple
$ strings buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_opsApple__/libtorch_core_msg_opsApple.pic.a | grep FAIL | head -n 10
isBool() INTERNAL ASSERT FAILED at "ivalue.h":666, please report a bug to PyTorch.
new_refcount != 1 INTERNAL ASSERT FAILED at "intrusive_ptr.h":268, please report a bug to PyTorch.
false INTERNAL ASSERT FAILED at "ivalue.h":1239, please report a bug to PyTorch.
owning_ptr == NullType::singleton() || owning_ptr->refcount_.load() == 0 || owning_ptr->weakcount_.load() INTERNAL ASSERT FAILED at "intrusive_ptr.h":474, please report a bug to PyTorch.
target_->refcount_ == 0 && target_->weakcount_ == 0 INTERNAL ASSERT FAILED at "intrusive_ptr.h":315, please report a bug to PyTorch.
refcount_.load() == 0 || refcount_.load() >= 2147483647 INTERNAL ASSERT FAILED at "intrusive_ptr.h":125, please report a bug to PyTorch.
weakcount_.load() == 1 || weakcount_.load() == 0 || weakcount_.load() == 2147483647 - 1 || weakcount_.load() == 2147483647 INTERNAL ASSERT FAILED at "intrusive_ptr.h":131, please report a bug to PyTorch.
isDouble() INTERNAL ASSERT FAILED at "ivalue.h":542, please report a bug to PyTorch.
isTensorList() INTERNAL ASSERT FAILED at "ivalue_inl.h":2019, please report a bug to PyTorch.
isTensorList() INTERNAL ASSERT FAILED at "ivalue_inl.h":2023, please report a bug to PyTorch.

$ strings buck-out/v2/gen/fbsource/c969ccb4ab4ae099/fbobjc/Libraries/FBPyTorchCore/__torch_core_msg_opsApple__/libtorch_core_msg_opsApple.pic.a | grep FAIL | grep buck
```

Reviewed By: milend

Differential Revision: D47637795

