### PR TITLE
[pytorch] revert to previous autograd fallback

### DIFF
--- a/aten/src/ATen/core/VariableFallbackKernel.cpp
+++ b/aten/src/ATen/core/VariableFallbackKernel.cpp
@@ -33,7 +33,7 @@ void autograd_fallback(
     c10::DispatchKeySet dispatch_keys,
     torch::jit::Stack* stack);
 
-#define AUTOGRAD_FALLBACK torch::CppFunction::makeFromBoxedFunction<&autograd_fallback>()
+#define AUTOGRAD_FALLBACK torch::CppFunction::makeFallthrough()
 
 TORCH_LIBRARY_IMPL(_, AutogradOther, m) {
   m.fallback(AUTOGRAD_FALLBACK);

--- a/test/autograd/test_fallback.py
+++ b/test/autograd/test_fallback.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_utils import (
 )
 import contextlib
 import numpy as np
+import unittest
 import warnings
 
 @contextlib.contextmanager
@@ -21,6 +22,7 @@ def autograd_fallback_mode(mode):
     finally:
         torch._C._set_autograd_fallback_mode(prev)
 
+@unittest.skip
 class TestAutogradFallback(TestCase):
     test_ns = '_test_autograd_fallback'
 


### PR DESCRIPTION
Summary:
This is a partial revert of https://github.com/pytorch/pytorch/pull/105078.
Due to codev, it's a bit difficult to revert the PR as-is.

Test Plan: - existing tests

Differential Revision: D47671238

