### PR TITLE
[MPS] Fix MPS clamp issue with different dtypes between input and min/max tensors

### DIFF
--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -26,38 +26,38 @@ struct CachedGraph : public MPSCachedGraph {
 void clamp_mps_graph(CachedGraph* cachedGraph, const Tensor& input_tensor)
                           const Tensor& min_tensor, const Tensor& max_tensor)
     auto input_dtype = input_tensor.scalar_type();
-    auto min_dtype = input_dtype;
-    auto max_dtype = input_dtype;
-    if (cachedGraph->minTensor)
-        min_dtype = min_tensor.scalar_type();
-    if (cachedGraph->maxTensor)
-        max_dtype = max_tensor.scalar_type();
-  MPSGraph* mpsGraph = cachedGraph->graph();
+auto min_dtype = input_dtype;
+auto max_dtype = input_dtype;
+if (cachedGraph->minTensor)
+  min_dtype = min_tensor.scalar_type();
+if (cachedGraph->maxTensor)
+  max_dtype = max_tensor.scalar_type();
+MPSGraph* mpsGraph = cachedGraph->graph();
 
-  cachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
+cachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
 
-    MPSGraphTensor* minTensor = cachedGraph->minTensor;
-    MPSGraphTensor* maxTensor = cachedGraph->maxTensor;
-    if (input_dtype != min_dtype) {
-        minTensor = castMPSTensor(mpsGraph, cachedGraph->minTensor, input_dtype);
-    }
-    if (input_dtype != max_dtype) {
-        maxTensor = castMPSTensor(mpsGraph, cachedGraph->maxTensor, input_dtype);
-    }
-  if (cachedGraph->minTensor && cachedGraph->maxTensor) {
-    cachedGraph->outputTensor = [mpsGraph clampWithTensor:cachedGraph->inputTensor
-                                               minValueTensor:minTensor
-                                               maxValueTensor:maxTensor
-                                                     name:nil];
-  } else if (cachedGraph->maxTensor) {
-    cachedGraph->outputTensor = [mpsGraph minimumWithPrimaryTensor:cachedGraph->inputTensor
-                                                       secondaryTensor:maxTensor
-                                                              name:nil];
-  } else if (cachedGraph->minTensor) {
-    cachedGraph->outputTensor = [mpsGraph maximumWithPrimaryTensor:cachedGraph->inputTensor
-                                                       secondaryTensor:minTensor
-                                                              name:nil];
-  }
+MPSGraphTensor* minTensor = cachedGraph->minTensor;
+MPSGraphTensor* maxTensor = cachedGraph->maxTensor;
+if (input_dtype != min_dtype) {
+  minTensor = castMPSTensor(mpsGraph, cachedGraph->minTensor, input_dtype);
+}
+if (input_dtype != max_dtype) {
+  maxTensor = castMPSTensor(mpsGraph, cachedGraph->maxTensor, input_dtype);
+}
+if (cachedGraph->minTensor && cachedGraph->maxTensor) {
+  cachedGraph->outputTensor = [mpsGraph clampWithTensor:cachedGraph->inputTensor
+                                         minValueTensor:minTensor
+                                         maxValueTensor:maxTensor
+                                                   name:nil];
+} else if (cachedGraph->maxTensor) {
+  cachedGraph->outputTensor = [mpsGraph minimumWithPrimaryTensor:cachedGraph->inputTensor
+                                                 secondaryTensor:maxTensor
+                                                            name:nil];
+} else if (cachedGraph->minTensor) {
+  cachedGraph->outputTensor = [mpsGraph maximumWithPrimaryTensor:cachedGraph->inputTensor
+                                                 secondaryTensor:minTensor
+                                                            name:nil];
+}
 }
 
 void check_min_max_dims(const OptionalTensorRef clamp_opt, const Tensor& input_t, string op_name) {
@@ -150,14 +150,15 @@ void clamp_tensor_out_mps(const Tensor& input_t,
 
     string key = op_name + (has_min ? "_min" : "") + (has_max ? "_max" : "") + "_tensor" + tensor_key;
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-                    if (has_min) {
+      if (has_min) {
         newCachedGraph->minTensor = mpsGraphRankedPlaceHolder(mpsGraph, min_opt_tensor);
-                    }
-                    if (has_max) {
-                        newCachedGraph->maxTensor = mpsGraphRankedPlaceHolder(mpsGraph, max_opt_tensor);;
-                    }
+      }
+      if (has_max) {
+        newCachedGraph->maxTensor = mpsGraphRankedPlaceHolder(mpsGraph, max_opt_tensor);
+        ;
+      }
 
-                    clamp_mps_graph(newCachedGraph, input_t, min_opt_tensor, max_opt_tensor);
+      clamp_mps_graph(newCachedGraph, input_t, min_opt_tensor, max_opt_tensor);
     });
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, output_t);
@@ -216,7 +217,7 @@ void clamp_scalar_out_mps(const Tensor& input_t,
             constantWithScalar:max_scalar
                          shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
 
-                    clamp_mps_graph(newCachedGraph, input_t, input_t, input_t);
+      clamp_mps_graph(newCachedGraph, input_t, input_t, input_t);
     });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_t);

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -23,23 +23,39 @@ struct CachedGraph : public MPSCachedGraph {
   MPSGraphTensor *minTensor = nil, *maxTensor = nil;
 };
 
-void clamp_mps_graph(CachedGraph* cachedGraph, const Tensor& input_tensor) {
+void clamp_mps_graph(CachedGraph* cachedGraph, const Tensor& input_tensor)
+                          const Tensor& min_tensor, const Tensor& max_tensor)
+    auto input_dtype = input_tensor.scalar_type();
+    auto min_dtype = input_dtype;
+    auto max_dtype = input_dtype;
+    if (cachedGraph->minTensor)
+        min_dtype = min_tensor.scalar_type();
+    if (cachedGraph->maxTensor)
+        max_dtype = max_tensor.scalar_type();
   MPSGraph* mpsGraph = cachedGraph->graph();
 
   cachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
 
+    MPSGraphTensor* minTensor = cachedGraph->minTensor;
+    MPSGraphTensor* maxTensor = cachedGraph->maxTensor;
+    if (input_dtype != min_dtype) {
+        minTensor = castMPSTensor(mpsGraph, cachedGraph->minTensor, input_dtype);
+    }
+    if (input_dtype != max_dtype) {
+        maxTensor = castMPSTensor(mpsGraph, cachedGraph->maxTensor, input_dtype);
+    }
   if (cachedGraph->minTensor && cachedGraph->maxTensor) {
     cachedGraph->outputTensor = [mpsGraph clampWithTensor:cachedGraph->inputTensor
-                                           minValueTensor:cachedGraph->minTensor
-                                           maxValueTensor:cachedGraph->maxTensor
+                                               minValueTensor:minTensor
+                                               maxValueTensor:maxTensor
                                                      name:nil];
   } else if (cachedGraph->maxTensor) {
     cachedGraph->outputTensor = [mpsGraph minimumWithPrimaryTensor:cachedGraph->inputTensor
-                                                   secondaryTensor:cachedGraph->maxTensor
+                                                       secondaryTensor:maxTensor
                                                               name:nil];
   } else if (cachedGraph->minTensor) {
     cachedGraph->outputTensor = [mpsGraph maximumWithPrimaryTensor:cachedGraph->inputTensor
-                                                   secondaryTensor:cachedGraph->minTensor
+                                                       secondaryTensor:minTensor
                                                               name:nil];
   }
 }
@@ -134,14 +150,15 @@ void clamp_tensor_out_mps(const Tensor& input_t,
 
     string key = op_name + (has_min ? "_min" : "") + (has_max ? "_max" : "") + "_tensor" + tensor_key;
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      if (has_min)
+                    if (has_min) {
         newCachedGraph->minTensor = mpsGraphRankedPlaceHolder(mpsGraph, min_opt_tensor);
-      if (has_max)
-        newCachedGraph->maxTensor = mpsGraphRankedPlaceHolder(mpsGraph, max_opt_tensor);
+                    }
+                    if (has_max) {
+                        newCachedGraph->maxTensor = mpsGraphRankedPlaceHolder(mpsGraph, max_opt_tensor);;
+                    }
 
-      clamp_mps_graph(newCachedGraph, input_t);
+                    clamp_mps_graph(newCachedGraph, input_t, min_opt_tensor, max_opt_tensor);
     });
-
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_t);
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, output_t);
 
@@ -199,7 +216,7 @@ void clamp_scalar_out_mps(const Tensor& input_t,
             constantWithScalar:max_scalar
                          shape:(mps::getMPSShape(input_t))dataType:(mps::getMPSScalarType(input_t.scalar_type()))];
 
-      clamp_mps_graph(newCachedGraph, input_t);
+                    clamp_mps_graph(newCachedGraph, input_t, input_t, input_t);
     });
 
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor, input_t);

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -23,8 +23,10 @@ struct CachedGraph : public MPSCachedGraph {
   MPSGraphTensor *minTensor = nil, *maxTensor = nil;
 };
 
-void clamp_mps_graph(CachedGraph* cachedGraph, const Tensor& input_tensor,
-                          const Tensor& min_tensor, const Tensor& max_tensor) {
+void clamp_mps_graph(CachedGraph* cachedGraph,
+                     const Tensor& input_tensor,
+                     const Tensor& min_tensor,
+                     const Tensor& max_tensor) {
   auto input_dtype = input_tensor.scalar_type();
   auto min_dtype = input_dtype;
   auto max_dtype = input_dtype;
@@ -52,9 +54,9 @@ void clamp_mps_graph(CachedGraph* cachedGraph, const Tensor& input_tensor,
                                            maxValueTensor:maxTensor
                                                      name:nil];
   } else if (cachedGraph->maxTensor) {
-  cachedGraph->outputTensor = [mpsGraph minimumWithPrimaryTensor:cachedGraph->inputTensor
-                                                 secondaryTensor:maxTensor
-                                                            name:nil];
+    cachedGraph->outputTensor = [mpsGraph minimumWithPrimaryTensor:cachedGraph->inputTensor
+                                                   secondaryTensor:maxTensor
+                                                              name:nil];
   } else if (cachedGraph->minTensor) {
     cachedGraph->outputTensor = [mpsGraph maximumWithPrimaryTensor:cachedGraph->inputTensor
                                                    secondaryTensor:minTensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5452,20 +5452,20 @@ class TestNLLLoss(TestCaseMPS):
         helper(1, 1, 4, 5)
 
     def test_clamp_fp16_fp32(self):
-          cpu_x = torch.randn(10, device='cpu', dtype=torch.float, requires_grad=False)
-          x = cpu_x.detach().clone().to('mps')
+        cpu_x = torch.randn(10, device='cpu', dtype=torch.float, requires_grad=False)
+        x = cpu_x.detach().clone().to('mps')
 
-          dtype = torch.float16
+        dtype = torch.float16
 
-          clamp_min_vals_mps = torch.ones(10, device="mps").to(torch.float16)
-          clamp_max_vals_mps = torch.ones(10, device="mps").to(torch.float16) * 10
-          clamp_result_mps = torch.clamp(x, clamp_min_vals_mps, clamp_max_vals_mps)
+        clamp_min_vals_mps = torch.ones(10, device="mps").to(torch.float16)
+        clamp_max_vals_mps = torch.ones(10, device="mps").to(torch.float16) * 10
+        clamp_result_mps = torch.clamp(x, clamp_min_vals_mps, clamp_max_vals_mps)
 
-          clamp_min_vals_cpu = torch.ones(10, device="cpu").to(torch.float16)
-          clamp_max_vals_cpu = torch.ones(10, device="cpu").to(torch.float16) * 10
-          clamp_result_cpu = torch.clamp(cpu_x, clamp_min_vals_cpu, clamp_max_vals_cpu)
+        clamp_min_vals_cpu = torch.ones(10, device="cpu").to(torch.float16)
+        clamp_max_vals_cpu = torch.ones(10, device="cpu").to(torch.float16) * 10
+        clamp_result_cpu = torch.clamp(cpu_x, clamp_min_vals_cpu, clamp_max_vals_cpu)
 
-          self.assertEqual(clamp_result_mps, clamp_result_cpu)
+        self.assertEqual(clamp_result_mps, clamp_result_cpu)
 
     # Test clamp_min
     def test_clamp_min(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5451,6 +5451,22 @@ class TestNLLLoss(TestCaseMPS):
 
         helper(1, 1, 4, 5)
 
+    def test_clamp_fp16_fp32(self):
+          cpu_x = torch.randn(10, device='cpu', dtype=torch.float, requires_grad=False)
+          x = cpu_x.detach().clone().to('mps')
+
+          dtype = torch.float16
+
+          clamp_min_vals_mps = torch.ones(10, device="mps").to(torch.float16)
+          clamp_max_vals_mps = torch.ones(10, device="mps").to(torch.float16) * 10
+          clamp_result_mps = torch.clamp(x, clamp_min_vals_mps, clamp_max_vals_mps)
+
+          clamp_min_vals_cpu = torch.ones(10, device="cpu").to(torch.float16)
+          clamp_max_vals_cpu = torch.ones(10, device="cpu").to(torch.float16) * 10
+          clamp_result_cpu = torch.clamp(cpu_x, clamp_min_vals_cpu, clamp_max_vals_cpu)
+
+          self.assertEqual(clamp_result_mps, clamp_result_cpu)
+
     # Test clamp_min
     def test_clamp_min(self):
         def helper(n, c, h, w):


### PR DESCRIPTION
- Fix the FP16 clamp issue (FP32 and FP16 are not broadcast compatible)
- Fix clamp (cached graph nodes were previously replaced with the cast version)
