### PR TITLE
Use the newer g5.12xlarge instead of g3.16xlarge for multigpu tests

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,4 +1,7 @@
-edule:
+name: periodic
+
+on:
+  schedule:
     # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
     # Also run less frequently on weekends.
     - cron: 45 0,8,16 * * 1-5

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,7 +1,4 @@
-name: periodic
-
-on:
-  schedule:
+edule:
     # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
     # Also run less frequently on weekends.
     - cron: 45 0,8,16 * * 1-5
@@ -47,6 +44,7 @@ jobs:
     with:
       build-environment: linux-bionic-cuda11.8-py3.9-gcc7
       docker-image-name: pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7
+      cuda-arch-list: 8.6
       test-matrix: |
         { include: [
           { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -49,7 +49,7 @@ jobs:
       docker-image-name: pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7
       test-matrix: |
         { include: [
-          { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.16xlarge.nvidia.gpu" },
+          { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
         ]}
       build-with-debug: false
 


### PR DESCRIPTION
Both have 4 GPUs.  This is an attempt to mitigate the runner issue with `g3.16xlarge` where it starts to crash a lot recently https://github.com/pytorch/pytorch/issues/105721.  So, let's see if switching to a newer runner type helps.

The job also finishes slightly faster in ~120m https://github.com/pytorch/pytorch/actions/runs/5625775414/job/15246453229 v.s. ~140m as before https://github.com/pytorch/pytorch/actions/runs/5625238650/job/15244823174