### PR TITLE
Supress eager fallback suggestions when exporting

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -372,5 +372,21 @@ class TestExport(TestCase):
                 self.assertTrue("source_fn" in node.meta)
                 self.assertTrue("nn_module_stack" in node.meta)
 
+    def test_error_does_not_reference_eager_fallback(self):
+        def fn_ddo(x):
+            y = x.nonzero()
+            z = y.shape[0]
+            if z > 2:
+                return x.cos()
+            else:
+                return x.sin()
+
+        with self.assertRaisesRegex(
+            torchdynamo.exc.UserError,
+            r"^(?!.*fall back to eager).*"
+        ):
+            _ = export(fn_ddo, (torch.tensor([2, 3, 5]),), constraints=None)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -205,14 +205,14 @@ def has_tensor_in_frame(frame):
     return False
 
 
-def exception_handler(e, code, frame=None):
+def exception_handler(e, code, frame=None, export=False):
     record_filename = None
     if hasattr(e, "exec_record"):
         record_filename = gen_record_file_name(e, code)
         write_record_to_file(record_filename, e.exec_record)
         e.record_filename = record_filename
 
-    augment_exc_message(e)
+    augment_exc_message(e, export=export)
     # Only log the exception if we are going to suppress it
     # if aren't suppressing it, a higher level except block will handle it
     if config.suppress_errors:
@@ -540,10 +540,10 @@ def _compile(
         ConstraintViolationError,
         GuardOnDataDependentSymNode,
     ) as e:
-        exception_handler(e, code, frame)
+        exception_handler(e, code, frame, export=export)
         raise
     except Exception as e:
-        exception_handler(e, code, frame)
+        exception_handler(e, code, frame, export=export)
         raise InternalTorchDynamoError(str(e)).with_traceback(e.__traceback__) from None
 
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -159,7 +159,7 @@ class KeyErrorMsg:
         return self.__str__()
 
 
-def augment_exc_message(exc, msg="\n"):
+def augment_exc_message(exc, msg="\n", export=False):
     import traceback
 
     if (
@@ -191,7 +191,7 @@ def augment_exc_message(exc, msg="\n"):
                 "this script to find the smallest traced graph which reproduces this error.\n"
             )
 
-    if not config.suppress_errors:
+    if not config.suppress_errors and not export:
         msg += (
             "\n\n"
             "You can suppress this exception and fall back to eager by setting:\n"


### PR DESCRIPTION
Previously during torch.export(), when an exception is raised during tracing, Dynamo displays this error:

“You can suppress this exception and fall back to eager by setting: import torch._dynamo torch._dynamo.config.suppress_errors = True”

This is not viable in torch.export(), thus this diff suppresses this suggestion during export.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov