### PR TITLE
Fixes netName assignment for NCCL Config

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2789,6 +2789,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         pg_opts.config.max_ctas = 4
         pg_opts.config.min_ctas = 2
         pg_opts.config.cga_cluster_size = 2
+        pg_opts.config.net_name = "Socket"
         nccl_debug_file = tempfile.NamedTemporaryFile()
         os.environ["NCCL_DEBUG"] = "INFO"
         os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
@@ -2801,9 +2802,11 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         max_ctas = re.search(rb'Max CTAs.*(\d+)|$', nccl_debug_file_content).group(1)
         min_ctas = re.search(rb'Min CTAs.*(\d+)|$', nccl_debug_file_content).group(1)
         cga_cluster_size = re.search(rb'CGA cluster.*(\d+)|$', nccl_debug_file_content).group(1)
+        net_name = re.search(rb'Using network.([a-zA-z]+)|$', nccl_debug_file_content).group(1)
         self.assertEqual(pg_opts.config.max_ctas, int(max_ctas))
         self.assertEqual(pg_opts.config.min_ctas, int(min_ctas))
         self.assertEqual(pg_opts.config.cga_cluster_size, int(cga_cluster_size))
+        self.assertEqual(pg_opts.config.net_name, net_name.decode())
 
     @requires_nccl()
     @skip_if_lt_x_gpu(4)

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2190,7 +2190,9 @@ for details.
           // Note: NCCL calls free on the netName pointer
           // when destroying the communicator. So memory
           // shouldn't leak because of allocation in strdup.
-          [](ncclConfig_t& self, const char* tmp) { self.netName = strdup(tmp); });
+          [](ncclConfig_t& self, const char* tmp) {
+            self.netName = strdup(tmp);
+          });
 #endif
 
   intrusive_ptr_class_<::c10d::ProcessGroupNCCL::Options>(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2184,7 +2184,13 @@ for details.
       .def_readwrite("cga_cluster_size", &ncclConfig_t::cgaClusterSize)
       .def_readwrite("min_ctas", &ncclConfig_t::minCTAs)
       .def_readwrite("max_ctas", &ncclConfig_t::maxCTAs)
-      .def_readwrite("net_name", &ncclConfig_t::netName);
+      .def_property(
+          "net_name",
+          [](const ncclConfig_t& self) { return self.netName; },
+          // Note: NCCL calls free on the netName pointer
+          // when destroying the communicator. So memory
+          // shouldn't leak because of allocation in strdup.
+          [](ncclConfig_t& self, const char* tmp) { self.netName = strdup(tmp); });
 #endif
 
   intrusive_ptr_class_<::c10d::ProcessGroupNCCL::Options>(


### PR DESCRIPTION
Fixes #104340

The core issue is described here https://github.com/pybind/pybind11/issues/1168#issuecomment-341969643. Note that NCCL calls free on the netName pointer when destroying the communicator. So memory is safely managed here.

CC: @kwen2501 