### PR TITLE
[inductor] Make autotune_process.py pass mypy

### DIFF
--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -7,6 +7,7 @@ import re
 import sys
 import types
 import unittest
+from typing import Sequence, Union
 from unittest.mock import patch
 
 import torch
@@ -315,7 +316,13 @@ def requires_numpy(fn):
     return _fn
 
 
-def rand_strided(size, stride, dtype=torch.float32, device="cpu", extra_size=0):
+def rand_strided(
+    size: Sequence[int],
+    stride: Sequence[int],
+    dtype: torch.dtype = torch.float32,
+    device: Union[str, torch.device] = "cpu",
+    extra_size: int = 0,
+):
     needed_size = (
         sum((shape - 1) * stride for shape, stride in zip(size, stride))
         + 1

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -35,13 +35,13 @@ class Pong:
 @dataclasses.dataclass
 class TuningProcess:
     process: Optional[BaseProcess] = None
-    request_queue: Optional[Queue[Any]] = None
-    response_queue: Optional[Queue[Any]] = None
+    request_queue: "Optional[Queue[Any]]" = None
+    response_queue: "Optional[Queue[Any]]" = None
 
     @staticmethod
     def process_main(
-        request_queue: Queue[Any],
-        response_queue: Queue[Any],
+        request_queue: "Queue[Any]",
+        response_queue: "Queue[Any]",
     ) -> None:
         print("enter child process main")
         while True:
@@ -97,13 +97,13 @@ class TuningProcess:
             atexit.register(lambda: self.terminate())
 
         # wait for the initialization to be done
-        cast(Queue[Any], self.request_queue).put(Ping())
-        resp = cast(Queue[Any], self.response_queue).get()
+        cast("Queue[Any]", self.request_queue).put(Ping())
+        resp = cast("Queue[Any]", self.response_queue).get()
         assert isinstance(resp, Pong)
 
     def terminate(self) -> None:
         if self.valid():
-            cast(Queue[Any], self.request_queue).put(None)
+            cast("Queue[Any]", self.request_queue).put(None)
             cast(BaseProcess, self.process).join()
 
 
@@ -231,11 +231,11 @@ def benchmark_in_sub_process(
     tuning_process.initialize()
     assert tuning_process.valid()
 
-    cast(Queue[Any], tuning_process.request_queue).put(choice.bmreq)
+    cast("Queue[Any]", tuning_process.request_queue).put(choice.bmreq)
 
     while True:
         try:
-            timing = cast(Queue[Any], tuning_process.response_queue).get(timeout=1.0)
+            timing = cast("Queue[Any]", tuning_process.response_queue).get(timeout=1.0)
         except queue.Empty:
             status = cast(BaseProcess, tuning_process.process).exitcode
             if status is None:

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -35,8 +35,8 @@ class Pong:
 @dataclasses.dataclass
 class TuningProcess:
     process: Optional[BaseProcess] = None
-    request_queue: "Optional[Queue[Any]]" = None
-    response_queue: "Optional[Queue[Any]]" = None
+    request_queue: Optional["Queue[Any]"] = None
+    response_queue: Optional["Queue[Any]"] = None
 
     @staticmethod
     def process_main(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -995,7 +995,7 @@ class CppCodeCache:
 
 
 class PyCodeCache:
-    cache = dict()
+    cache: Dict[Any, types.ModuleType] = dict()
     linemaps = dict()
     clear = staticmethod(cache.clear)
 


### PR DESCRIPTION
`TensorMeta.from_irnodes` handles either a single `IRNode` or a tuple or list of them. I tried to express this with overloading, but because this file is in MYPYNOFOLLOW, the `IRNode` subclasses become `Any`, which causes the overloads to be overlapping.

This changes the type of the argument to `benchmark_in_sub_process` to the more specific `TritonTemplateCaller`, since that one has the `bmreq` member and existing docstrings indicate that only the triton template benchmark is handled.

The `rand_strided` call caused a mypy error because the default value for device was a string. This is fixed by adding type hints to `rand_strided` in `torch/_dynamo/testing.py`. Likewise, the return value of `PyCodeCache.load_by_key_path` can be inferred from the type hint on `PyCodeCache.cache`.

Fixes one part of #105230


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305