### PR TITLE
Enable the RUF013 rule in ruff

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
@@ -307,7 +307,7 @@ def write_decl_impl(
     family_name: str,
     impl_file: str,
     autogen_dir: Path,
-    disable_def: str = None,
+    disable_def: Optional[str] = None,
 ) -> None:
     cpp_file_header = """/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/benchmarks/functional_autograd_benchmark/utils.py
+++ b/benchmarks/functional_autograd_benchmark/utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -76,7 +76,9 @@ def load_weights(mod: nn.Module, names: List[str], params: Tuple[Tensor, ...]) -
 
 
 # Utilities to read/write markdown table-like content.
-def to_markdown_table(res: TimingResultType, header: Tuple[str, ...] = None) -> str:
+def to_markdown_table(
+    res: TimingResultType, header: Optional[Tuple[str, ...]] = None
+) -> str:
     if header is None:
         header = ("model", "task", "mean", "var")
     out = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,15 +68,15 @@ select = [
     "SIM1",
     "W",
     # Not included in flake8
-    "UP",
     "PERF",
     "PGH004",
     "PIE807",
     "PIE810",
     "PLE",
+    "RUF013",
     "RUF017",
     "TRY302",
-    "RUF013",
+    "UP",
 ]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ select = [
     "PLE",
     "RUF017",
     "TRY302",
+    "RUF013",
 ]
 
 [tool.ruff.per-file-ignores]

--- a/test/dynamo/test_global.py
+++ b/test/dynamo/test_global.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: dynamo"]
+from typing import Optional
+
 import torch
 
 import torch._dynamo.test_case
@@ -183,7 +185,7 @@ class TestGlobals(torch._dynamo.test_case.TestCase):
     def test_store_global_inline_1(self):
         # Borrowed from test_python_autograd.py
         class Variable:
-            def __init__(self, value: torch.Tensor, name: str = None):
+            def __init__(self, value: torch.Tensor, name: Optional[str] = None):
                 self.value = value
                 self.name = name or fresh_name()
 
@@ -203,12 +205,12 @@ class TestGlobals(torch._dynamo.test_case.TestCase):
     def test_store_global_inline_2(self):
         # Borrowed from test_python_autograd.py
         class Variable:
-            def __init__(self, value: torch.Tensor, name: str = None):
+            def __init__(self, value: torch.Tensor, name: Optional[str] = None):
                 self.value = value
                 self.name = name or fresh_name()
 
             @staticmethod
-            def constant(value: torch.Tensor, name: str = None):
+            def constant(value: torch.Tensor, name: Optional[str] = None):
                 return Variable(value, name)
 
         def fn(a, b):

--- a/test/dynamo/test_python_autograd.py
+++ b/test/dynamo/test_python_autograd.py
@@ -26,14 +26,14 @@ def fresh_name() -> str:
 
 
 class Variable:
-    def __init__(self, value: torch.Tensor, name: str = None):
+    def __init__(self, value: torch.Tensor, name: Optional[str] = None):
         self.value = value
         self.name = name or fresh_name()
 
     # We need to start with some tensors whose values were not computed
     # inside the autograd. This function constructs leaf nodes.
     @staticmethod
-    def constant(value: torch.Tensor, name: str = None):
+    def constant(value: torch.Tensor, name: Optional[str] = None):
         return Variable(value, name)
 
     def __repr__(self):

--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -67,7 +67,7 @@ torch.fx.proxy.Proxy.__init__(self, node: torch.fx.node.Node, tracer: 'Optional[
 torch.fx.proxy.Proxy.keys(self)
 torch.fx.proxy.TracerBase.create_arg(self, a: Any) -> torch.fx.node.Argument
 torch.fx.proxy.TracerBase.create_node(self, kind: str, target: torch.fx.node.Target, args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, torch.fx.node.Argument], name: Optional[str] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.proxy.TracerBase.create_proxy(self, kind: str, target: torch.fx.node.Target, args: Tuple[Any, ...], kwargs: Dict[str, Any], name: Optional[str] = None, type_expr: Optional[Any] = None, proxy_factory_fn: Callable[[torch.fx.node.Node], Proxy] = None)
+torch.fx.proxy.TracerBase.create_proxy(self, kind: str, target: torch.fx.node.Target, args: Tuple[Any, ...], kwargs: Dict[str, Any], name: Optional[str] = None, type_expr: Optional[Any] = None, proxy_factory_fn: Optional[Callable[[torch.fx.node.Node], Proxy]] = None)
 torch.fx.proxy.TracerBase.iter(self, obj: 'Proxy') -> Iterator
 torch.fx.proxy.TracerBase.keys(self, obj: 'Proxy') -> Any
 torch.fx.proxy.TracerBase.proxy(self, node: torch.fx.node.Node) -> 'Proxy'

--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: fx"]
 
-from typing import Set, Type
+from typing import Set, Type, Optional
 import torch
 import torch.fx
 
@@ -27,7 +27,7 @@ class TestDCE(TestCase):
         self,
         m: torch.nn.Module,
         expect_dce_changes: bool,
-        modules_to_be_leafs: Set[Type] = None,
+        modules_to_be_leafs: Optional[Set[Type]] = None,
     ):
         class TestTracer(torch.fx.Tracer):
             def is_leaf_module(self, m, qualname):

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -3,7 +3,7 @@
 import sys
 import textwrap
 import traceback
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.cuda._sanitizer as csan
@@ -140,8 +140,8 @@ class TestEventHandler(TestCase):
     def kernel_launch(
         self,
         stream: StreamId,
-        read_only: List[DataPtr] = None,
-        read_write: List[DataPtr] = None,
+        read_only: Optional[List[DataPtr]] = None,
+        read_write: Optional[List[DataPtr]] = None,
     ) -> List[csan.SynchronizationError]:
         if read_only is None:
             read_only = []
@@ -159,8 +159,8 @@ class TestEventHandler(TestCase):
     def assert_good_kernel_launch(
         self,
         stream: StreamId,
-        read_only: List[DataPtr] = None,
-        read_write: List[DataPtr] = None,
+        read_only: Optional[List[DataPtr]] = None,
+        read_write: Optional[List[DataPtr]] = None,
     ) -> None:
         self.assertEqual(self.kernel_launch(stream, read_only, read_write), [])
 
@@ -168,8 +168,8 @@ class TestEventHandler(TestCase):
         self,
         number_of_errors: int,
         stream: StreamId,
-        read_only: List[DataPtr] = None,
-        read_write: List[DataPtr] = None,
+        read_only: Optional[List[DataPtr]] = None,
+        read_write: Optional[List[DataPtr]] = None,
     ) -> None:
         errors = self.kernel_launch(stream, read_only, read_write)
         self.assertEqual(len(errors), number_of_errors)

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -605,7 +605,7 @@ class TestCustomOp(CustomOpTestCaseBase):
         with self.assertRaisesRegex(ValueError, "default value"):
 
             @custom_op(f"{TestCustomOp.test_ns}::foo")
-            def foo(x: Optional[Tensor] = None):
+            def foo(x: Optional[Tensor] = None):  # noqa: RUF013
                 raise NotImplementedError()
 
             del foo
@@ -613,7 +613,7 @@ class TestCustomOp(CustomOpTestCaseBase):
         with self.assertRaisesRegex(ValueError, "default value"):
 
             @custom_op(f"{TestCustomOp.test_ns}::foo")
-            def foo(x: Optional[Tensor] = None):
+            def foo(x: Optional[Tensor] = None):  # noqa: RUF013
                 raise NotImplementedError()
 
             del foo

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1337,7 +1337,7 @@ except RuntimeError as e:
         # [no auto-batching] multiprocessing loading
         num_workers = 3
         sizes_for_all_workers = [0, 4, 20]
-        expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
+        expected = sorted(itertools.chain.from_iterable(range(s) for s in sizes_for_all_workers))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
         for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
@@ -1396,7 +1396,7 @@ except RuntimeError as e:
         # [auto-batching] multiprocessing loading
         num_workers = 3
         sizes_for_all_workers = [0, 4, 20]
-        expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
+        expected = sorted(itertools.chain.from_iterable(range(s) for s in sizes_for_all_workers))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
         for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
@@ -1432,7 +1432,7 @@ except RuntimeError as e:
         # [auto-batching & drop_last] multiprocessing loading
         num_workers = 3
         sizes_for_all_workers = [0, 4, 20]
-        expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
+        expected = sorted(itertools.chain.from_iterable(range(s) for s in sizes_for_all_workers))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
         for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -3,7 +3,7 @@ import dataclasses
 import re
 import sys
 import types
-from typing import List
+from typing import List, Optional
 
 import torch.nn
 from . import utils
@@ -49,7 +49,7 @@ class PyCodegen:
         self,
         tx=None,
         root: torch.nn.Module = None,
-        graph_output_var: str = None,
+        graph_output_var: Optional[str] = None,
         tempvars=None,
     ):
         self.root = root

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -54,7 +54,9 @@ def aot_compile(
     return lib_path
 
 
-def list_mode_options(mode: str = None, dynamic: bool = None) -> Dict[str, Any]:
+def list_mode_options(
+    mode: Optional[str] = None, dynamic: Optional[bool] = None
+) -> Dict[str, Any]:
     r"""Returns a dictionary describing the optimizations that each of the available
     modes passed to `torch.compile()` performs.
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3807,7 +3807,7 @@ def _prepare_convolution_fusion_create(
     dilation: List[int],
     groups: int,
     transposed: bool = False,
-    output_padding: List[int] = None,
+    output_padding: Optional[List[int]] = None,
 ):
     """
     This function is a helper function to prepare inputs, layout and constant args

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 import logging
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import sympy
 from sympy import Expr
@@ -406,7 +406,7 @@ class SizeVarAllocator:
         def stride_vars(
             index: Expr,
             vars: List[sympy.Symbol],
-            support_vars: List[sympy.Symbol] = None,
+            support_vars: Optional[List[sympy.Symbol]] = None,
         ) -> List[Expr]:
             if not support_vars:
                 support_vars = vars
@@ -460,7 +460,7 @@ class SizeVarAllocator:
         self,
         index: Expr,
         vars: List[sympy.Symbol],
-        support_vars: List[sympy.Symbol] = None,
+        support_vars: Optional[List[sympy.Symbol]] = None,
     ) -> List[int]:
         for v in index.free_symbols:
             if v.name.startswith("indirect"):

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -4,7 +4,7 @@ import warnings
 import torch
 import torch.nn as nn
 from torch import Tensor  # noqa: F401
-from torch._jit_internal import Tuple, Optional, List, Union, Dict  # noqa: F401
+from typing import Tuple, Optional, List, Union, Dict  # noqa: F401
 from torch.nn.utils.rnn import PackedSequence
 from torch.ao.nn.quantized.modules.utils import _quantize_weight
 

--- a/torch/ao/nn/quantized/modules/embedding_ops.py
+++ b/torch/ao/nn/quantized/modules/embedding_ops.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from torch import Tensor  # noqa: F401
-from torch._jit_internal import Optional, List  # noqa: F401
+from typing import Optional, List  # noqa: F401
 
 from .utils import _hide_packed_params_repr
 from .utils import _quantize_weight

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -170,7 +170,7 @@ class TracerBase:
     @compatibility(is_backward_compatible=True)
     def create_proxy(self, kind: str, target: Target, args: Tuple[Any, ...], kwargs: Dict[str, Any],
                      name: Optional[str] = None, type_expr : Optional[Any] = None,
-                     proxy_factory_fn: Callable[[Node], 'Proxy'] = None):
+                     proxy_factory_fn: Optional[Callable[[Node], 'Proxy']] = None):
         '''
         Create a Node from the given arguments, then return the Node
         wrapped in a Proxy object.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -1,10 +1,9 @@
 import warnings
-from typing import Iterable, List, NamedTuple, Tuple, Union
+from typing import Iterable, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
 from ... import _VF
-from ..._jit_internal import Optional
 
 
 __all__ = ['PackedSequence', 'invert_permutation', 'pack_padded_sequence', 'pad_packed_sequence', 'pad_sequence',

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -186,7 +186,7 @@ def adagrad(
     state_steps: List[Tensor],
     # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
     # setting these as kwargs for now as functional API is compiled by torch/distributed/optim
-    has_sparse_grad: bool = None,
+    has_sparse_grad: Optional[bool] = None,
     foreach: Optional[bool] = None,
     differentiable: bool = False,
     *,

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -201,6 +201,9 @@ def adagrad(
     See :class:`~torch.optim.Adagrad` for details.
     """
 
+    if has_sparse_grad is None:
+        has_sparse_grad = False
+
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -602,7 +602,7 @@ class Optimizer:
         value: torch.Tensor,
         param_id: int,
         param_groups: List[Dict[Any, Any]],
-        key: Hashable = None,
+        key: Optional[Hashable] = None,
     ) -> torch.Tensor:
         # Floating-point types are a bit special here. They are the only ones
         # that are assumed to always match the type of params.

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -187,7 +187,7 @@ def sgd(params: List[Tensor],
         momentum_buffer_list: List[Optional[Tensor]],
         # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
         # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
-        has_sparse_grad: bool = None,
+        has_sparse_grad: Optional[bool] = None,
         foreach: Optional[bool] = None,
         *,
         weight_decay: float,

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1394,7 +1394,7 @@ def skipCUDAIfRocmVersionLessThan(version=None):
     return dec_fn
 
 # Skips a test for specified CUDA versions, given in the form of a list of [major, minor]s.
-def skipCUDAVersionIn(versions : List[Tuple[int, int]] = None):
+def skipCUDAVersionIn(versions : Optional[List[Tuple[int, int]]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
@@ -1410,7 +1410,7 @@ def skipCUDAVersionIn(versions : List[Tuple[int, int]] = None):
     return dec_fn
 
 # Skips a test for CUDA versions less than specified, given in the form of [major, minor].
-def skipCUDAIfVersionLessThan(versions : Tuple[int, int] = None):
+def skipCUDAIfVersionLessThan(versions : Optional[Tuple[int, int]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):


### PR DESCRIPTION
As suggested by @Skylion007 in https://github.com/pytorch/pytorch/pull/105791#issuecomment-1646644405

This rule enforces `Optional[...]` as the type for parameters having a default value of None.

Apply all RUF013 patches from ruff. Apply all other ruff patches in the affected files - otherwise lintrunner fails the build.

Fixes parts of #105230


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel @anijain2305