### PR TITLE
[inductor] Make graph.py pass mypy

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -135,7 +135,9 @@ def next_power_of_2(n):
     return n
 
 
-def convert_shape_to_inductor(lst: List[Union[int, torch.SymInt]]) -> List[sympy.Expr]:
+def convert_shape_to_inductor(
+    lst: Union[List[Union[int, torch.SymInt]], torch.Size, tuple[int, ...]]
+) -> List[sympy.Expr]:
     """
     Gets the shape and stride of a tensor. For non-symbolic tensors, this is
     trivial. But for symbolic tensors, we need to map from SymIntNode into


### PR DESCRIPTION
Apply fixes suggested by mypy to the file

* torch/_inductor/graph.py

Addressing following errors:

graph.py:111: error: Argument 1 to "convert_shape_to_inductor" has incompatible type "Size"; expected "list[int | SymInt]"  [arg-type]
graph.py:112: error: Argument 1 to "convert_shape_to_inductor" has incompatible type "tuple[int, ...]"; expected "list[int | SymInt]"  [arg-type]
graph.py:515: error: "Tensor" has no attribute "_has_symbolic_sizes_strides"  [attr-defined]
graph.py:936: error: "IRNode" has no attribute "get_name"; maybe "get_numel"?  [attr-defined]

See #105230

Fixes #105230 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov