### PR TITLE
[MPS] aten::erfinv bug fix: add storage offset buffers to handle slicing

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7653,14 +7653,14 @@ class TestNLLLoss(TestCaseMPS):
                 cpu_x = torch.randint(0, 1000, shape, device='cpu', dtype=dtypei, requires_grad=False)
                 mps_x = cpu_x.to('mps')
                 self.assertEqual(op(cpu_x), op(mps_x), rtol=1e-4, atol=1e-4)
-            # test slice 
+            # test slice
             for dtypef in [torch.float32]:
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
                 # create slice of tensor on the 2nd dimension
                 cpu_slice = cpu_x[:, ::2, :, :]
                 mps_slice = cpu_slice.detach().clone().to('mps')
                 self.assertEqual(op(cpu_slice), op(mps_slice))
-            # test view 
+            # test view
             for dtypef in [torch.float32]:
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
                 # create view of tensor by reducing the 3rd and 4th dimension
@@ -7668,7 +7668,7 @@ class TestNLLLoss(TestCaseMPS):
                 reshaped_dims = list(shape[:-2]) + [combined_dim]
                 cpu_view = cpu_x.view(*reshaped_dims)
                 mps_view = cpu_view.detach().clone().to('mps')
-                self.assertEqual(op(cpu_view), op(mps_view))               
+                self.assertEqual(op(cpu_view), op(mps_view))
 
         helper((2, 8, 4, 5), torch.exp)
         helper((2, 8, 3, 5), torch.exp2)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7653,6 +7653,22 @@ class TestNLLLoss(TestCaseMPS):
                 cpu_x = torch.randint(0, 1000, shape, device='cpu', dtype=dtypei, requires_grad=False)
                 mps_x = cpu_x.to('mps')
                 self.assertEqual(op(cpu_x), op(mps_x), rtol=1e-4, atol=1e-4)
+            # test slice 
+            for dtypef in [torch.float32]:
+                cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
+                # create slice of tensor on the 2nd dimension
+                cpu_slice = cpu_x[:, ::2, :, :]
+                mps_slice = cpu_slice.detach().clone().to('mps')
+                self.assertEqual(op(cpu_slice), op(mps_slice))
+            # test view 
+            for dtypef in [torch.float32]:
+                cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
+                # create view of tensor by reducing the 3rd and 4th dimension
+                combined_dim = shape[-1] * shape[-2]
+                reshaped_dims = list(shape[:-2]) + [combined_dim]
+                cpu_view = cpu_x.view(*reshaped_dims)
+                mps_view = cpu_view.detach().clone().to('mps')
+                self.assertEqual(op(cpu_view), op(mps_view))               
 
         helper((2, 8, 4, 5), torch.exp)
         helper((2, 8, 3, 5), torch.exp2)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7656,18 +7656,19 @@ class TestNLLLoss(TestCaseMPS):
             # test slice
             for dtypef in [torch.float32]:
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
-                # create slice of tensor on the 2nd dimension
+                mps_x = cpu_x.detach().clone().to('mps')
                 cpu_slice = cpu_x[:, ::2, :, :]
-                mps_slice = cpu_slice.detach().clone().to('mps')
+                mps_slice = mps_x[:, ::2, :, :]
                 self.assertEqual(op(cpu_slice), op(mps_slice))
             # test view
             for dtypef in [torch.float32]:
                 cpu_x = torch.randn(shape, device='cpu', dtype=dtypef, requires_grad=False)
+                mps_x = cpu_x.detach().clone().to('mps')
                 # create view of tensor by reducing the 3rd and 4th dimension
                 combined_dim = shape[-1] * shape[-2]
                 reshaped_dims = list(shape[:-2]) + [combined_dim]
                 cpu_view = cpu_x.view(*reshaped_dims)
-                mps_view = cpu_view.detach().clone().to('mps')
+                mps_view = mps_x.view(*reshaped_dims)
                 self.assertEqual(op(cpu_view), op(mps_view))
 
         helper((2, 8, 4, 5), torch.exp)


### PR DESCRIPTION
A bug fix of a recently merged PR per comment: https://github.com/pytorch/pytorch/pull/101507#discussion_r1271393706

The follow test would fail without this bug fix:

```
import torch
def test_erfinv():
    for device in ['cpu', 'mps']:
        x = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5], device=device)
        y = x[2:].erfinv()

        x2 = torch.tensor([0.3, 0.4, 0.5], device=device)
        y2 = x2.erfinv()

        print(y)
        print(y2)

        torch.testing.assert_close(y, y2)
        print(f"{device} passes.")

test_erfinv()
```
