### PR TITLE
Add const reference and std::move in opportunities detected by clang-tidy

### DIFF
--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -14,6 +14,8 @@
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/tensor_types.h>
 
+#include <utility>
+
 #ifdef USE_CUDA
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #endif
@@ -33,7 +35,7 @@ PyObject* THPGenerator_initDefaultGenerator(at::Generator cdata) {
   if (!self)
     throw python_error();
   auto self_ = reinterpret_cast<THPGenerator*>(self.get());
-  self_->cdata = cdata;
+  self_->cdata = std::move(cdata);
   return self.release();
 }
 

--- a/torch/csrc/distributed/c10d/Work.cpp
+++ b/torch/csrc/distributed/c10d/Work.cpp
@@ -105,7 +105,7 @@ c10::intrusive_ptr<c10::ivalue::Future> Work::getFuture() {
 void Work::finish(std::exception_ptr exception) {
   std::unique_lock<std::mutex> lock(mutex_);
   completed_ = true;
-  exception_ = exception;
+  exception_ = std::move(exception);
   if (recordFunctionEndCallback_) {
     recordFunctionEndCallback_();
     recordFunctionEndCallback_ = nullptr;
@@ -117,7 +117,7 @@ void Work::finish(std::exception_ptr exception) {
 void Work::finishAndThrow(std::exception_ptr exception) {
   std::unique_lock<std::mutex> lock(mutex_);
   completed_ = true;
-  exception_ = exception;
+  exception_ = std::move(exception);
   if (recordFunctionEndCallback_) {
     recordFunctionEndCallback_();
     recordFunctionEndCallback_ = nullptr;
@@ -176,7 +176,7 @@ class FutureWrappingWork : public Work {
 };
 
 c10::intrusive_ptr<Work> Work::create_from_future(
-    c10::intrusive_ptr<c10::ivalue::Future> future) {
+    const c10::intrusive_ptr<c10::ivalue::Future>& future) {
   return c10::make_intrusive<FutureWrappingWork>(future);
 }
 

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -110,7 +110,7 @@ class TORCH_API Work : public torch::CustomClassHolder {
   OpType retrieveOpType();
 
   static c10::intrusive_ptr<Work> create_from_future(
-      c10::intrusive_ptr<c10::ivalue::Future>);
+      const c10::intrusive_ptr<c10::ivalue::Future>&);
 
  protected:
   // Completes the work object and optionally sets the exception in a

--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -60,7 +60,7 @@ class BroadcastWork {
 
 // Broadcast many tensors to all processes in the process group.
 void broadcast_coalesced(
-    c10::intrusive_ptr<c10d::ProcessGroup> process_group,
+    const c10::intrusive_ptr<c10d::ProcessGroup>& process_group,
     at::TensorList tensors,
     size_t buffer_size,
     int rank) {

--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -10,7 +10,7 @@ namespace c10d {
 
 // Broadcast many tensors to all processes in the process group.
 TORCH_API void broadcast_coalesced(
-    c10::intrusive_ptr<c10d::ProcessGroup> process_group,
+    const c10::intrusive_ptr<c10d::ProcessGroup>& process_group,
     at::TensorList tensors,
     size_t buffer_size,
     int rank = 0);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -76,7 +76,7 @@ class TensorCheck {
   std::string check_verbose(
       const LocalState& state,
       const at::Tensor& v,
-      std::string tensor_name) {
+      const std::string& tensor_name) {
     std::stringstream fail_reason;
     fail_reason << "tensor '" << tensor_name << "' ";
     if (dispatch_key_ != state.apply(v.key_set()).raw_repr()) {

--- a/torch/csrc/jit/operator_upgraders/version_map.cpp
+++ b/torch/csrc/jit/operator_upgraders/version_map.cpp
@@ -108,7 +108,7 @@ get_operator_version_map() {
 
 void test_only_add_entry(const std::string& op_name, UpgraderEntry entry) {
   test_only_reset_flag();
-  operatorVersionMap[op_name].push_back(entry);
+  operatorVersionMap[op_name].emplace_back(std::move(entry));
 }
 
 void test_only_remove_entry(const std::string& op_name) {

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -213,7 +213,7 @@ void initMonitorBindings(PyObject* module) {
             Event e;
             e.name = name;
             e.timestamp = timestamp;
-            e.data = data;
+            e.data = std::move(data);
             return e;
           }),
           py::arg("name"),
@@ -274,7 +274,7 @@ void initMonitorBindings(PyObject* module) {
   m.def(
       "register_event_handler",
       [](std::function<void(const Event&)> f) {
-        auto handler = std::make_shared<PythonEventHandler>(f);
+        auto handler = std::make_shared<PythonEventHandler>(std::move(f));
         registerEventHandler(handler);
         return handler;
       },

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -389,7 +389,7 @@ struct StealOrDefault {
 
 void ThreadLocalSubqueue::TorchOpStorage::materialize(
     std::vector<std::shared_ptr<Result>>& out,
-    const std::function<time_t(approx_time_t)> time_converter,
+    const std::function<time_t(approx_time_t)>& time_converter,
     const uint64_t tid,
     const kineto::DeviceAndResource& kineto_info) {
   // Plumb Autograd info to the top level annotation.

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -545,7 +545,7 @@ class TORCH_API ThreadLocalSubqueue {
     // NB: This is a destructive operation.
     void materialize(
         std::vector<std::shared_ptr<Result>>& out,
-        const std::function<time_t(approx_time_t)> time_converter,
+        const std::function<time_t(approx_time_t)>& time_converter,
         const uint64_t tid,
         const kineto::DeviceAndResource& kineto_info);
 

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -38,7 +38,7 @@ ProfilerConfig::ProfilerConfig(
     bool with_modules,
     ExperimentalConfig experimental_config)
     : state{state},
-      experimental_config{experimental_config},
+      experimental_config{std::move(experimental_config)},
       report_input_shapes{report_input_shapes},
       profile_memory{profile_memory},
       with_stack{with_stack},

--- a/torch/csrc/profiler/orchestration/vulkan.cpp
+++ b/torch/csrc/profiler/orchestration/vulkan.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/profiler/orchestration/vulkan.h>
 
+#include <utility>
+
 namespace torch {
 namespace profiler {
 namespace impl {
@@ -12,7 +14,8 @@ GetShaderNameAndDurationNsFn get_shader_name_and_duration_ns_fn;
 
 void registerGetShaderNameAndDurationNs(
     GetShaderNameAndDurationNsFn get_shader_name_and_duration_ns) {
-  get_shader_name_and_duration_ns_fn = get_shader_name_and_duration_ns;
+  get_shader_name_and_duration_ns_fn =
+      std::move(get_shader_name_and_duration_ns);
 }
 
 void deregisterGetShaderNameAndDurationNs() {

--- a/torch/csrc/profiler/standalone/nvtx_observer.cpp
+++ b/torch/csrc/profiler/standalone/nvtx_observer.cpp
@@ -66,8 +66,7 @@ std::pair<at::RecordFunctionHandle, int> NVTXThreadLocalState::getOpIdFromInput(
 }
 
 static std::list<std::pair<at::RecordFunctionHandle, int>> flattenOpIdList(
-    c10::List<c10::IValue> list,
-    std::string fn_name) {
+    const c10::List<c10::IValue>& list) {
   std::list<std::pair<at::RecordFunctionHandle, int>> input_op_id_list;
   auto state_ptr = NVTXThreadLocalState::getTLS();
   TORCH_INTERNAL_ASSERT(state_ptr, "Expected profiler state set");
@@ -95,7 +94,7 @@ static std::list<std::pair<at::RecordFunctionHandle, int>> getInputTensorOpIds(
     } else {
       if (input_item.isList()) {
         std::list<std::pair<at::RecordFunctionHandle, int>> tmp_op_ids =
-            flattenOpIdList(input_item.toList(), std::string(fn.name()));
+            flattenOpIdList(input_item.toList());
         // Extend the current sizes array by the array returned from input sizes
         if (!tmp_op_ids.empty()) {
           input_producer_ops_.splice(input_producer_ops_.end(), tmp_op_ids);

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -229,8 +229,7 @@ std::string stacksToStr(
 }
 
 static std::vector<std::vector<int64_t>> flattenList(
-    c10::List<c10::IValue> list,
-    std::string fn_name) {
+    const c10::List<c10::IValue>& list) {
   std::vector<std::vector<int64_t>> tensor_dims;
   for (const c10::IValue& input : list) {
     if (input.isTensor()) {
@@ -259,7 +258,7 @@ std::vector<std::vector<int64_t>> inputSizes(
     } else if (input.isList()) {
       std::vector<std::vector<int64_t>> tmp_sizes;
       if (flatten_list_enabled) {
-        tmp_sizes = flattenList(input.toList(), std::string(fn.name()));
+        tmp_sizes = flattenList(input.toList());
       }
       // Extend the current sizes array by the array returned from input sizes
       if (!tmp_sizes.empty()) {
@@ -319,7 +318,7 @@ std::string strListToStr(const std::vector<std::string>& types) {
         types.begin(),
         types.end(),
         std::ostream_iterator<std::string>(oss, ", "),
-        [](std::string s) -> std::string { return "\"" + s + "\""; });
+        [](const std::string& s) -> std::string { return "\"" + s + "\""; });
     auto rc = oss.str();
     rc.erase(rc.length() - 2); // remove last ", "
     return "[" + rc + "]";

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -71,8 +71,8 @@ template <class Input, class Output, class Model>
 class BenchmarkHelper {
  public:
   BenchmarkHelper();
-  // NOLINTNEXTLINE(modernize-pass-by-value)
-  explicit BenchmarkHelper(Model model) : model_(model), initialized_(true) {}
+  explicit BenchmarkHelper(Model model)
+      : model_(std::move(model)), initialized_(true) {}
 
   // This method to be used in benchmark() method
   // Note that there is no result. This way we don't have to call this under GIL


### PR DESCRIPTION
cc @EikanWang @jgong5 @voznesenskym @penguinwu @anijain2305 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov