### PR TITLE
[Deprecated][Dynamo] Enhanced onnxrt backend

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1649,7 +1649,8 @@ def compile(model: Optional[Callable] = None, *,
         - `trace.enabled` which is the most useful debugging flag to turn on
         - `trace.graph_diagram` which will show you a picture of your graph after fusion
         - For inductor you can see the full list of configs that it supports by calling `torch._inductor.list_options()`
-        - For onnxrt `providers` which will be useful to configure detailed EP information
+        - For onnxrt `providers` which will be useful to configure detailed EP information, refer to
+        https://onnxruntime.ai/docs/execution-providers/#summary-of-supported-execution-providers
        disable (bool): Turn torch.compile() into a no-op for testing
 
     Example::

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -33,7 +33,7 @@ if _running_with_deploy():
 else:
     from .torch_version import __version__ as __version__
 
-from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, TYPE_CHECKING, Union, List
 import builtins
 
 __all__ = [
@@ -1591,7 +1591,7 @@ def compile(model: Optional[Callable] = None, *,
             dynamic: Optional[builtins.bool] = None,
             backend: Union[str, Callable] = "inductor",
             mode: Union[str, None] = None,
-            options: Optional[Dict[str, Union[str, builtins.int, builtins.bool]]] = None,
+            options: Optional[Dict[str, Union[str, builtins.int, builtins.bool, List[Union[str, tuple]]]]] = None,
             disable: builtins.bool = False) -> Callable:
     """
     Optimizes given model/function using TorchDynamo and specified backend.
@@ -1649,6 +1649,7 @@ def compile(model: Optional[Callable] = None, *,
         - `trace.enabled` which is the most useful debugging flag to turn on
         - `trace.graph_diagram` which will show you a picture of your graph after fusion
         - For inductor you can see the full list of configs that it supports by calling `torch._inductor.list_options()`
+        - For onnxrt `providers` which will be useful to configure detailed EP information
        disable (bool): Turn torch.compile() into a no-op for testing
 
     Example::

--- a/torch/_dynamo/backends/onnxrt.py
+++ b/torch/_dynamo/backends/onnxrt.py
@@ -90,10 +90,15 @@ def onnxrt(
         providers = [default_provider(device_type)]
 
     for provider in providers:
+        available_providers: List[str] = onnxruntime.get_available_providers()
         if isinstance(provider, str):
-            assert provider in onnxruntime.get_available_providers()
+            assert (
+                provider in available_providers
+            ), f"the available providers are {available_providers}, but got {provider}"
         elif isinstance(provider, tuple):
-            assert provider[0] in onnxruntime.get_available_providers()
+            assert (
+                provider[0] in available_providers
+            ), f"the available providers are {available_providers}, but got {provider[0]}"
 
     session = onnxruntime.InferenceSession(filename, providers=providers)
 


### PR DESCRIPTION
1. onnxrt backend raise error when passing options parameter
2. onnxrt support more detailed EP configure capability by provider parameter

```python
import torch
import torch._dynamo

providers = [
    (
        "CUDAExecutionProvider",
        {
            "device_id": 0,
            "arena_extend_strategy": "kNextPowerOfTwo",
            "gpu_mem_limit": 2 * 1024 * 1024 * 1024,
            "do_copy_in_default_stream": True,
        },
    ),
    "CPUExecutionProvider",
]


@torch.compile(backend="onnxrt", options={"providers": providers})
def foo(x, y):
    return (x + y) * x


if __name__ == "__main__":
    a, b = torch.randn(10), torch.ones(10)
    print(foo(a, b))
```


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov