### PR TITLE
[Fix Bug] Cannot assign index like x[[1,2], :] = 2 when torch.use_deterministic_algorithms(True) to main

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -458,7 +458,7 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<c10::optional<Ten
     if (nElemBefore > 1) {
       expanded_size.insert(expanded_size.begin(), nElemBefore);
     }
-    if(sliceSize > 1){
+    if (sliceSize > 1) {
       expanded_size.insert(expanded_size.end(), sliceSize);
     }
     expandedValue = expandedValue.expand(expanded_size);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -458,6 +458,9 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<c10::optional<Ten
     if (nElemBefore > 1) {
       expanded_size.insert(expanded_size.begin(), nElemBefore);
     }
+    if(sliceSize > 1){
+      expanded_size.insert(expanded_size.end(), sliceSize);
+    }
     expandedValue = expandedValue.expand(expanded_size);
   }
   expandedValue = expandedValue.contiguous();

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1331,7 +1331,6 @@ class TestIndexing(TestCase):
     @onlyCUDA
     def test_cuda_broadcast_index_use_deterministic_algorithms(self, device):
         with DeterministicGuard(True):
-
             idx1 = torch.tensor([0])
             idx2 = torch.tensor([2, 6])
             

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1334,7 +1334,7 @@ class TestIndexing(TestCase):
             idx1 = torch.tensor([0])
             idx2 = torch.tensor([2, 6])
             idx3 = torch.tensor([1, 5, 7])
-            
+
             tensor_a = torch.rand(13, 11, 12, 13, 12).cpu()
             tensor_b = tensor_a.to(device=device)
             tensor_a[idx1] = 1.0
@@ -1357,10 +1357,16 @@ class TestIndexing(TestCase):
             tensor_b[:, idx1] = 4.0
             self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
 
-            tensor_a = torch.rand(10).cpu()
+            tensor_a = torch.rand(10, 10).cpu()
             tensor_b = tensor_a.to(device=device)
             tensor_a[[8]] = 1.0
             tensor_b[[8]] = 1.0
+            self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
+
+            tensor_a = torch.rand(10).cpu()
+            tensor_b = tensor_a.to(device=device)
+            tensor_a[6] = 1.0
+            tensor_b[6] = 1.0
             self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1333,24 +1333,25 @@ class TestIndexing(TestCase):
         with DeterministicGuard(True):
             idx1 = torch.tensor([0])
             idx2 = torch.tensor([2, 6])
+            idx3 = torch.tensor([1, 5, 7])
             
             tensor_a = torch.rand(13, 11, 12, 13, 12).cpu()
             tensor_b = tensor_a.to(device=device)
             tensor_a[idx1] = 1.0
             tensor_a[idx1, :, idx2, idx2, :] = 2.0
-            tensor_a[:, idx1, idx2, :, idx2] = 3.0
+            tensor_a[:, idx1, idx3, :, idx3] = 3.0
             tensor_b[idx1] = 1.0
             tensor_b[idx1, :, idx2, idx2, :] = 2.0
-            tensor_b[:, idx1, idx2, :, idx2] = 3.0
+            tensor_b[:, idx1, idx3, :, idx3] = 3.0
             self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
 
             tensor_a = torch.rand(10, 11).cpu()
             tensor_b = tensor_a.to(device=device)
-            tensor_a[idx1] = 1.0
+            tensor_a[idx3] = 1.0
             tensor_a[idx2, :] = 2.0
             tensor_a[:, idx2] = 3.0
             tensor_a[:, idx1] = 4.0
-            tensor_b[idx1] = 1.0
+            tensor_b[idx3] = 1.0
             tensor_b[idx2, :] = 2.0
             tensor_b[:, idx2] = 3.0
             tensor_b[:, idx1] = 4.0

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1328,6 +1328,17 @@ class TestIndexing(TestCase):
                                     r"Expected tensor to have .* but got tensor with .* torch.take_along_dim()"):
             torch.take_along_dim(t.cpu(), indices, dim=0)
 
+    @onlyCUDA
+    def test_cuda_broadcast_index_use_deterministic_algorithms(self, device):
+        torch.use_deterministic_algorithms(True)
+        tensor_a = torch.rand(100, 4).cpu()
+        tensor_b = tensor_a.to(device=device)
+        idx = torch.tensor([0, 1])
+        tensor_a[idx, :] = 1.0
+        tensor_b[idx, :] = 1.0
+        self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
+        torch.use_deterministic_algorithms(False)
+
 # The tests below are from NumPy test_indexing.py with some modifications to
 # make them compatible with PyTorch. It's licensed under the BDS license below:
 #

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
-    TestCase, run_tests, skipIfTorchDynamo)
+    TestCase, run_tests, skipIfTorchDynamo, DeterministicGuard)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests, onlyCUDA, dtypes, dtypesIfCPU, dtypesIfCUDA,
     onlyNativeDeviceTypes, skipXLA)
@@ -1330,14 +1330,39 @@ class TestIndexing(TestCase):
 
     @onlyCUDA
     def test_cuda_broadcast_index_use_deterministic_algorithms(self, device):
-        torch.use_deterministic_algorithms(True)
-        tensor_a = torch.rand(100, 4).cpu()
-        tensor_b = tensor_a.to(device=device)
-        idx = torch.tensor([0, 1])
-        tensor_a[idx, :] = 1.0
-        tensor_b[idx, :] = 1.0
-        self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
-        torch.use_deterministic_algorithms(False)
+        with DeterministicGuard(True):
+
+            idx1 = torch.tensor([0])
+            idx2 = torch.tensor([2, 6])
+            
+            tensor_a = torch.rand(13, 11, 12, 13, 12).cpu()
+            tensor_b = tensor_a.to(device=device)
+            tensor_a[idx1] = 1.0
+            tensor_a[idx1, :, idx2, idx2, :] = 2.0
+            tensor_a[:, idx1, idx2, :, idx2] = 3.0
+            tensor_b[idx1] = 1.0
+            tensor_b[idx1, :, idx2, idx2, :] = 2.0
+            tensor_b[:, idx1, idx2, :, idx2] = 3.0
+            self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
+
+            tensor_a = torch.rand(10, 11).cpu()
+            tensor_b = tensor_a.to(device=device)
+            tensor_a[idx1] = 1.0
+            tensor_a[idx2, :] = 2.0
+            tensor_a[:, idx2] = 3.0
+            tensor_a[:, idx1] = 4.0
+            tensor_b[idx1] = 1.0
+            tensor_b[idx2, :] = 2.0
+            tensor_b[:, idx2] = 3.0
+            tensor_b[:, idx1] = 4.0
+            self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
+
+            tensor_a = torch.rand(10).cpu()
+            tensor_b = tensor_a.to(device=device)
+            tensor_a[[8]] = 1.0
+            tensor_b[[8]] = 1.0
+            self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
+
 
 # The tests below are from NumPy test_indexing.py with some modifications to
 # make them compatible with PyTorch. It's licensed under the BDS license below:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/105819 and fix https://github.com/pytorch/pytorch/issues/96724
cc @kurtamohler
