### PR TITLE
Remove TORCH_API from OpaqueTensorImpl

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -18,7 +18,7 @@ namespace at {
 // "shallow copy" in order to add support.
 
 template <typename OpaqueHandle>
-struct TORCH_API OpaqueTensorImpl : public TensorImpl {
+struct OpaqueTensorImpl : public TensorImpl {
   // public constructor for now...
   OpaqueTensorImpl(
       at::DispatchKeySet key_set,


### PR DESCRIPTION
Removes the TORCH_API qualifier macro from the OpaqueTensorImpl class template, so that the class template can be inherited from by classes defined outside torch_cpu.dll and correctly generate class template implementation.