### PR TITLE
Only do TLS access when necessary in basicAutogradNotImplementedFallback

### DIFF
--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -104,7 +104,6 @@ static void basicAutogradNotImplementedFallbackImpl(
   const auto num_arguments = schema.arguments().size();
   const auto num_returns = schema.returns().size();
   const auto stack_start = stack->size() - num_arguments;
-  const bool grad_mode = GradMode::is_enabled();
 
   if (getAutogradFallbackMode() == AutogradFallbackMode::Nothing) {
     op.redispatchBoxed(dispatch_keys & c10::after_autograd_keyset, stack);
@@ -114,17 +113,18 @@ static void basicAutogradNotImplementedFallbackImpl(
       getAutogradFallbackMode() == AutogradFallbackMode::Warn);
 
   bool any_input_requires_grad = false;
-  if (grad_mode) {
-    _foreach_tensor(
-        [&](size_t _, size_t idx_arg, const at::Tensor& t) {
-          if (t.requires_grad()) {
-            any_input_requires_grad = true;
-          }
-        },
-        stack,
-        stack_start,
-        num_arguments);
-  }
+  _foreach_tensor(
+      [&](size_t _, size_t idx_arg, const at::Tensor& t) {
+        if (t.requires_grad()) {
+          any_input_requires_grad = true;
+        }
+      },
+      stack,
+      stack_start,
+      num_arguments);
+  // Optimization: TLS access can be slow. So we only check if it necessary
+  // by putting it after the requires_grad checks.
+  any_input_requires_grad = any_input_requires_grad && GradMode::is_enabled();
 
   std::shared_ptr<WarnNotImplemented> grad_fn;
   if (any_input_requires_grad) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #105592
* __->__ #105845
* #105660

This is an optimization that may or may not matter (it's difficult to
see the impact on benchmarks).

This PR is a resubmit of #105737 to go directly through github first.

Test Plan:
- existing tests