### PR TITLE
[FSDP][Docs] Make model/optim state dict configs visible in docs

### DIFF
--- a/docs/source/fsdp.rst
+++ b/docs/source/fsdp.rst
@@ -17,3 +17,6 @@ FullyShardedDataParallel
 
 .. autoclass:: torch.distributed.fsdp.CPUOffload
   :members:
+
+.. autoclass:: torch.distributed.fsdp.StateDictConfig
+  :members:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105848
* #105847
* #105738

This closes https://github.com/pytorch/pytorch/issues/104717.

Rendered docs:
![Screenshot 2023-07-25 at 11 15 23 AM](https://github.com/pytorch/pytorch/assets/31054793/3c38166a-70c0-472c-805d-452d3bd9c700)
![Screenshot 2023-07-25 at 11 15 30 AM](https://github.com/pytorch/pytorch/assets/31054793/6d275d94-020a-44a2-a64c-0eeba083d47f)

