### PR TITLE
[exir] Add deepcopy to ExportedProgram

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -170,6 +170,22 @@ class ExportedProgram:
         )
         return string
 
+    def __deepcopy__(
+        self, memo: Optional[Dict[int, Any]] = None
+    ) -> "ExportedProgram":
+        gm = copy.deepcopy(self.graph_module, memo)
+        new_ep = ExportedProgram(
+            gm,
+            gm.graph,
+            copy.deepcopy(self.graph_signature, memo),
+            copy.deepcopy(self.call_spec, memo),
+            copy.deepcopy(self.state_dict, memo),
+            copy.deepcopy(self.range_constraints, memo),
+            copy.deepcopy(self.equality_constraints, memo),
+        )
+        return new_ep
+
+
     @property
     def graph(self):
         return self.graph_module.graph


### PR DESCRIPTION
Summary: ExirExportedProgram would like to have this feature. Today it does it itself since it inherits from ExportedProgram but since we are moving it to composition I think it would be cleaner to upstream the behavior into the root object anyway

Test Plan: ci, but todo where are the tests for this file?

Differential Revision: D47645843

