### PR TITLE
Add option to disable rewriting index hints in default global save plan

### DIFF
--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -302,13 +302,15 @@ def create_default_local_save_plan(
 
 def create_default_global_save_plan(
     all_plans: List[SavePlan],
+    rewrite_index_hints: bool = True,
 ) -> Tuple[List[SavePlan], Metadata]:
     """
     Create the global plan and metadata used by DefaultSavePlanner.
 
     Metadata is produced by concatenating the metadata of all ``WriteItem`` from the supplied plans.
 
-    The only global planning change is to update index hints in all ``MetadataIndex`` objects.
+    The only global planning change is to update index hints in all ``MetadataIndex`` objects if
+    ``rewrite_index_hints`` is True.
     """
     md: Dict[str, STORAGE_TYPES] = {}
     new_plans = []
@@ -334,10 +336,12 @@ def create_default_global_save_plan(
                         ),
                     ),
                 )
-                new_index = dataclasses.replace(
-                    item.index, index=len(tensor_md.chunks)
-                )
-                new_item = dataclasses.replace(item, index=new_index)
+                new_item = item
+                if rewrite_index_hints:
+                    new_index = dataclasses.replace(
+                        item.index, index=len(tensor_md.chunks)
+                    )
+                    new_item = dataclasses.replace(item, index=new_index)
                 new_items.append(new_item)
 
                 assert (


### PR DESCRIPTION
With distributed checkpointing in PyTorch/XLA SPMD, the WriteItem index hints should not be modified when creating the global plan. In order to reuse the default planner logic for checkpoint metadata creation, we need to make the behavior of rewriting index hints optional.