### PR TITLE
[export] Remove eliminate_dead_code

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -182,6 +182,7 @@ class TestDeserialize(TestCase):
 
         serialized_struct, state_dict = serialize(ep, opset_version={"aten": 0})
         deserialized_ep = deserialize(serialized_struct, state_dict, expected_opset_version={"aten": 0})
+        deserialized_ep.graph.eliminate_dead_code()
 
         orig_outputs = ep(*inputs)
         loaded_outputs = deserialized_ep(*inputs)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -855,7 +855,6 @@ class GraphModuleDeserializer:
         output_node.meta["val"] = tuple(
             arg.meta["val"] for arg in output_node.args[0]
         )
-        self.graph.eliminate_dead_code()
         return output_node
 
     def deserialize_node(self, serialized_node: Node, target: Callable) -> None:


### PR DESCRIPTION
Summary: Sometimes the graph that is being serialized contains nodes with side effects + no users (ex. out variants of operators), so we don't want to eliminate those when deserializing.

Test Plan: CI

Differential Revision: D47735009

