### PR TITLE
[dynamo][torchrec] Skip frame if it has JaggedTensor as inputs

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1565,6 +1565,13 @@ def format_bytecode(prefix, name, filename, line_no, code):
     return f"{prefix} {name} {filename} line {line_no} \n{dis.Bytecode(code).dis()}\n"
 
 
+def format_frame_info(frame):
+    name = frame.f_code.co_name
+    filename = frame.f_code.co_filename
+    lineno = frame.f_code.co_firstlineno
+    return f"{name}({filename}:{lineno})"
+
+
 forward_hook_names = ["_forward_pre_hooks", "_forward_hooks"]
 backward_hook_names = ["_backward_pre_hooks", "_backward_hooks"]
 state_dict_hook_names = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105890


    This is a short term solution to skip Dynamo tracing on frame whose inputs
    are Jagged tensors. These tensors contain a list of integers on the side
    which in current state causes excessive recompilations and guards.

    We are looking at ways on how to better handle this situation. Meawhile this
    stop gap solution will allow full model compilation without the slow
    recompilation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov