### PR TITLE
Update expected inference for torchbench sam

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -43,6 +43,7 @@ resnet152,pass,0
 resnet18,pass,0
 resnet50,pass,0
 resnext50_32x4d,pass,0
+sam,pass,0
 shufflenet_v2_x1_0,pass,0
 soft_actor_critic,pass,0
 squeezenet1_1,pass,0
@@ -55,4 +56,3 @@ timm_vovnet,pass,0
 tts_angular,pass,2
 vgg16,pass,0
 yolov3,pass,2
-sam,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -47,6 +47,7 @@ resnet152,pass,0
 resnet18,pass,0
 resnet50,pass,0
 resnext50_32x4d,pass,0
+sam,pass,0
 shufflenet_v2_x1_0,pass,0
 soft_actor_critic,pass,0
 speech_transformer,pass,10


### PR DESCRIPTION
This is currently failing `inductor_torchbench` trunk job https://github.com/pytorch/pytorch/actions/runs/5650538848/job/15308150238.  The job was marked as unstable to mitigate another issue few weeks ago (https://github.com/pytorch/pytorch/issues/104337) but was left open and hide the failure from view.

As the model passes as expected, I just add it into the list with `python benchmarks/dynamo/ci_expected_accuracy/update_expected.py becb8dc91a80e03455f7574dc0739fe93a2d199b`

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov