### PR TITLE
[profiler] Fix profiling shapes with PT2 + lists of dynamic shapes

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -79,6 +79,18 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
         with torch.profiler.profile(record_shapes=True):
             opt_fn(*inputs)
 
+    @patch.object(torch._dynamo.config, "assume_static_by_default", False)
+    def test_profile_dynamic_shapes_list_compilation(self):
+        def fn(x, y, z):
+            return torch.cat([x, y], dim=0) + z
+
+        opt_fn = torch._dynamo.optimize("aot_eager", dynamic=True, nopython=True)(fn)
+
+        inputs = (torch.rand(4, 16), torch.rand(12, 16), torch.rand(16, 16))
+
+        with torch.profiler.profile(record_shapes=True):
+            opt_fn(*inputs)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -216,11 +216,20 @@ auto InputOutputEncoder::getIValueGenerator(const IOType& io_type) {
 
         case Tag::TensorListBegin: {
           std::vector<TensorMetadata> arg;
+          bool found_undefined = false;
           while (*(++tag_it) != Tag::TERMINATOR) {
+            if (*tag_it == Tag::UndefinedTensor) {
+              found_undefined = true;
+              continue;
+            }
             TORCH_INTERNAL_ASSERT(*tag_it == Tag::Tensor, (int)(*tag_it));
             arg.emplace_back(decode_tensor());
           }
-          push_value(Tag::TensorListBegin, std::move(arg));
+          if (found_undefined) {
+            push_value(*tag_it, c10::nullopt);
+          } else {
+            push_value(Tag::TensorListBegin, std::move(arg));
+          }
         } break;
 
         case Tag::ScalarList:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105893

Fixes #105748

Follow-up to https://github.com/pytorch/pytorch/pull/104320. If we have a list that contains tensors with dynamic shapes, just mark the entire list as undefined.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov