### PR TITLE
[DocString] Fix incorrect api Examples

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2589,7 +2589,7 @@ Examples::
 
     >>> A = torch.randn(4, 4)
     >>> Atensorinv = torch.linalg.tensorinv(A, ind=1)
-    >>> Ainv = torch.linalg.inverse(A)
+    >>> Ainv = torch.linalg.inv(A)
     >>> torch.allclose(Atensorinv, Ainv)
     True
 """)


### PR DESCRIPTION
Fix incorrect Examples in `torch.linalg.tensorinv`.

- before (bug) : `torch.linalg.inverse`
- after: `torch.linalg.inv`

cc @svekars @carljparker @jianyuh @nikitaved @pearu @mruberry @walterddr @IvanYashchuk @xwang233 @Lezcano