### PR TITLE
test_linalg: triangular_solve - make well_conditioned well conditioned

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3991,7 +3991,8 @@ class TestLinalg(TestCase):
                 size_b = size_b[1:]
 
             if well_conditioned:
-                PLU = torch.linalg.lu(make_randn(*size_a))
+                U, _, Vh = torch.linalg.svd(make_randn(*size_a), full_matrices=False)
+                PLU = torch.linalg.lu(U @ Vh)
                 if uni:
                     # A = L from PLU
                     A = PLU[1].transpose(-2, -1).contiguous()


### PR DESCRIPTION
`well_contioned=True` does not guarantee that the samples for `triangular_solve` are actually well-conditioned. This PR fixes that. This issues was discovered in https://github.com/pytorch/pytorch/pull/104425.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105919

