### PR TITLE
[pytorch] Fix MSVC unexpected tokens following preprocessor directive

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -134,6 +134,10 @@
 #define C10_UNUSED __attribute__((__unused__))
 #endif //_MSC_VER
 
+#if !defined(__has_attribute)
+#define __has_attribute(x) 0
+#endif
+
 // Direct port of LLVM_ATTRIBUTE_USED.
 #if __has_attribute(used)
 #define C10_USED __attribute__((__used__))


### PR DESCRIPTION
Summary:
Fix this warning:
```
caffe2\c10\macros\Macros.h(138): warning C4067: unexpected tokens following preprocessor directive - expected a newline
```
`caffe2/c10/util/variant.h` already has a similar to check and define a stub for `__has_attribute(x)`, so this would not be new to caffe2/pytorch.

Test Plan: CI should complete, still with plenty of caffe2 warnings but this one should be gone from the Windows build log

Differential Revision: D47735319

