### PR TITLE
doc: fix fake quantize per channel doc

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11996,7 +11996,7 @@ Example::
 add_docstr(
     torch.fake_quantize_per_channel_affine,
     r"""
-fake_quantize_per_channel_affine(input, scale, zero_point, quant_min, quant_max) -> Tensor
+fake_quantize_per_channel_affine(input, scale, zero_point, axis, quant_min, quant_max) -> Tensor
 
 Returns a new tensor with the data in :attr:`input` fake quantized per channel using :attr:`scale`,
 :attr:`zero_point`, :attr:`quant_min` and :attr:`quant_max`, across the channel specified by :attr:`axis`.


### PR DESCRIPTION
another doc bug for fake_quantize_per_channel 

function doc now matches https://github.com/pytorch/pytorch/blob/e7142700ede35bc0e8520b9fc9572f4a09672830/aten/src/ATen/native/quantized/FakeQuantPerChannelAffine.cpp#L32

cc: @jimwu6