### PR TITLE
Fix cuSparse CSR SPMM for using nullptr in csrRowOffsets

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
@@ -235,9 +235,9 @@ struct CusparseMatrixMultiplyOp {
     cusparseOperation_t opB = CUSPARSE_OPERATION_NON_TRANSPOSE;
 
     csrMatrixRef<scalar_t> C(
-      nullptr,
-      nullptr,
-      nullptr,
+      dC_columns,
+      dC_csrOffsets,
+      dC_values,
       /*nnz*/0,
       {A_num_rows, B_num_cols}
     );


### PR DESCRIPTION
cusparse from cuda 12.2 no longer allows passing nullptr to csrRowOffsets

Internal NVIDIA ref: 4208400