### PR TITLE
[Pytorch][Vulkan] Reuse broadcast checks

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ArrayRef.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <ATen/native/vulkan/ops/Utils.h>
 #include <torch/library.h>
 #include <vector>
 
@@ -8,73 +9,7 @@ namespace at {
 namespace native {
 namespace vulkan {
 namespace ops {
-namespace {
 
-void check_inputs(const Tensor& input1, const Tensor& input2) {
-  const std::string broadcast_error_msg =
-      "Incompatible dimensions for broadcasting for binary elementwise op!";
-  if (get_dim<Dim4D::Batch>(input1) != get_dim<Dim4D::Batch>(input2)) {
-    TORCH_CHECK(
-        get_dim<Dim4D::Batch>(input1) == 1 ||
-            get_dim<Dim4D::Batch>(input2) == 1,
-        broadcast_error_msg);
-  }
-  if (get_dim<Dim4D::Channel>(input1) != get_dim<Dim4D::Channel>(input2)) {
-    TORCH_CHECK(
-        get_dim<Dim4D::Channel>(input1) == 1 ||
-            get_dim<Dim4D::Channel>(input2) == 1,
-        broadcast_error_msg);
-  }
-  if (get_dim<Dim4D::Height>(input1) != get_dim<Dim4D::Height>(input2)) {
-    TORCH_CHECK(
-        get_dim<Dim4D::Height>(input1) == 1 ||
-            get_dim<Dim4D::Height>(input2) == 1,
-        broadcast_error_msg);
-  }
-  if (get_dim<Dim4D::Width>(input1) != get_dim<Dim4D::Width>(input2)) {
-    TORCH_CHECK(
-        get_dim<Dim4D::Width>(input1) == 1 ||
-            get_dim<Dim4D::Width>(input2) == 1,
-        broadcast_error_msg);
-  }
-}
-
-std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
-  int64_t t1_size = t1.dim();
-  int64_t t2_size = t2.dim();
-
-  std::vector<int64_t> out;
-  if (t1_size > t2_size) {
-    for (int64_t i = 0; i < t1_size; i++) {
-      out.push_back(t1.sizes()[i]);
-    }
-  } else {
-    for (int64_t i = 0; i < t2_size; i++) {
-      out.push_back(t2.sizes()[i]);
-    }
-  }
-
-  if (!out.empty()) {
-    out[out.size() - 1] =
-        std::max(get_dim<Dim4D::Width>(t1), get_dim<Dim4D::Width>(t2));
-  }
-  if (out.size() > 1) {
-    out[out.size() - 2] =
-        std::max(get_dim<Dim4D::Height>(t1), get_dim<Dim4D::Height>(t2));
-  }
-  if (out.size() > 2) {
-    out[out.size() - 3] =
-        std::max(get_dim<Dim4D::Channel>(t1), get_dim<Dim4D::Channel>(t2));
-  }
-  if (out.size() > 3) {
-    out[out.size() - 4] =
-        std::max(get_dim<Dim4D::Batch>(t1), get_dim<Dim4D::Batch>(t2));
-  }
-
-  return out;
-}
-
-} // namespace
 using namespace api::utils;
 
 Tensor binary_op_scalar(
@@ -186,7 +121,7 @@ Tensor binary_op_tensor(
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
     const api::ShaderInfo& shader_descriptor) {
-  check_inputs(self_arg, other_arg);
+  utils::is_broadcastable(self_arg, other_arg);
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -197,7 +132,7 @@ Tensor binary_op_tensor(
 
   vTensor v_output{
       context,
-      broadcast_size(self_arg, other_arg),
+      utils::broadcast_size(self_arg, other_arg),
       self_arg.scalar_type(),
   };
 
@@ -259,7 +194,7 @@ Tensor quantized_binary_op_tensor(
     const double scale,
     const int64_t zero_point,
     const api::ShaderInfo& shader_descriptor) {
-  check_inputs(self_arg, other_arg);
+  utils::is_broadcastable(self_arg, other_arg);
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -272,7 +207,7 @@ Tensor quantized_binary_op_tensor(
 
   vTensor v_output{
       context,
-      broadcast_size(self_arg, other_arg),
+      utils::broadcast_size(self_arg, other_arg),
       scale,
       zero_point,
       c10::kQUInt8,
@@ -356,7 +291,7 @@ Tensor& binary_op_tensor_(
       "Dimensions of input tensor to Vulkan in-place binary elementwise op "
       "must be less than or equal the dimensions of the underlying tensor.");
 
-  check_inputs(self_arg, other_arg);
+  utils::is_broadcastable(self_arg, other_arg);
 
   TORCH_CHECK(
       self_arg.is_vulkan(),

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -236,6 +236,83 @@ void pack_vtensor_to_staging(
   }
 }
 
+/*
+ * Broadcasting Utils
+ */
+
+// check if two tensors are broadcastable
+void is_broadcastable(const Tensor& input1, const Tensor& input2) {
+  TORCH_CHECK(
+      input1.dim() <= 4 && input2.dim() <= 4,
+      "Vulkan only supports tensors <= 4 dimensions");
+
+  // check if the shapes of input tensors are broadcastable
+  // see https://pytorch.org/docs/stable/notes/broadcasting.html
+  // for broadcasting semantics
+  const std::string broadcast_error_msg = "Tensors are not broadcastable!";
+
+  if (get_dim<Dim4D::Batch>(input1) != get_dim<Dim4D::Batch>(input2)) {
+    TORCH_CHECK(
+        get_dim<Dim4D::Batch>(input1) == 1 ||
+            get_dim<Dim4D::Batch>(input2) == 1,
+        broadcast_error_msg);
+  }
+  if (get_dim<Dim4D::Channel>(input1) != get_dim<Dim4D::Channel>(input2)) {
+    TORCH_CHECK(
+        get_dim<Dim4D::Channel>(input1) == 1 ||
+            get_dim<Dim4D::Channel>(input2) == 1,
+        broadcast_error_msg);
+  }
+  if (get_dim<Dim4D::Height>(input1) != get_dim<Dim4D::Height>(input2)) {
+    TORCH_CHECK(
+        get_dim<Dim4D::Height>(input1) == 1 ||
+            get_dim<Dim4D::Height>(input2) == 1,
+        broadcast_error_msg);
+  }
+  if (get_dim<Dim4D::Width>(input1) != get_dim<Dim4D::Width>(input2)) {
+    TORCH_CHECK(
+        get_dim<Dim4D::Width>(input1) == 1 ||
+            get_dim<Dim4D::Width>(input2) == 1,
+        broadcast_error_msg);
+  }
+}
+
+// compute the output shape by broadcasting the shapes of t1 and t2
+std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
+  int64_t t1_size = t1.dim();
+  int64_t t2_size = t2.dim();
+
+  std::vector<int64_t> out;
+  if (t1_size > t2_size) {
+    for (int64_t i = 0; i < t1_size; i++) {
+      out.push_back(t1.sizes()[i]);
+    }
+  } else {
+    for (int64_t i = 0; i < t2_size; i++) {
+      out.push_back(t2.sizes()[i]);
+    }
+  }
+
+  if (!out.empty()) {
+    out[out.size() - 1] =
+        std::max(get_dim<Dim4D::Width>(t1), get_dim<Dim4D::Width>(t2));
+  }
+  if (out.size() > 1) {
+    out[out.size() - 2] =
+        std::max(get_dim<Dim4D::Height>(t1), get_dim<Dim4D::Height>(t2));
+  }
+  if (out.size() > 2) {
+    out[out.size() - 3] =
+        std::max(get_dim<Dim4D::Channel>(t1), get_dim<Dim4D::Channel>(t2));
+  }
+  if (out.size() > 3) {
+    out[out.size() - 4] =
+        std::max(get_dim<Dim4D::Batch>(t1), get_dim<Dim4D::Batch>(t2));
+  }
+
+  return out;
+}
+
 } // namespace utils
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -50,6 +50,10 @@ void pack_vtensor_to_staging(
     api::VulkanBuffer&,
     const VkFence fence_handle = VK_NULL_HANDLE);
 
+// Broadcasting Utils
+void is_broadcastable(const Tensor& input1, const Tensor& input2);
+std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2);
+
 } // namespace utils
 } // namespace ops
 } // namespace vulkan


### PR DESCRIPTION
Summary:
Place broadcast checks into `Broadcast.h` and `Broadcast.cpp` for code re-use.

Rename `check_inputs` to `is_broadcastable`

https://pytorch.org/docs/stable/notes/broadcasting.html

Test Plan:
All tests
https://www.internalfb.com/phabricator/paste/view/P797165124
```
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 318 tests from VulkanAPITest (8693 ms total)

[----------] Global test environment tear-down
[==========] 318 tests from 1 test suite ran. (8693 ms total)
[  PASSED  ] 317 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```

Differential Revision: D47741937

