### PR TITLE
[ONNX] Fix the warnings of `aten overload fallback to default` in onnx dispatcher

### DIFF
--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -310,19 +310,19 @@ class OnnxFunctionDispatcher:
                 op_name=internal_opname.op_name,
                 overload=None,
             )
-
-            # NOTE: Currently, most of torchlib functions are not registered with overload
-            # in ONNX registry. So we will only log a warning in SARIF if we can't find the overload
-            # to avoid spammy warnings in printout.
-            # TODO: https://github.com/microsoft/onnxscript/issues/828
-            op_full_name = internal_opname.qualified_name()
-            diagnostic = diagnostic_context.inflight_diagnostic()
-            diagnostic.with_additional_message(
-                "### The operator overload is not found in onnx registry!\n"
-                "Cannot find the operator overload in onnx registry, but"
-                "the default overload is found. Please check the ONNX output carefully. \n",
-            )
-            diagnostic.level = diagnostics.levels.WARNING
+            if function_group is not None:
+                # NOTE: Currently, most of torchlib functions are not registered with overload
+                # in ONNX registry. So we will only log a warning in SARIF if we can't find the overload
+                # to avoid spammy warnings in printout.
+                # TODO: https://github.com/microsoft/onnxscript/issues/828
+                op_full_name = internal_opname.qualified_name()
+                diagnostic = diagnostic_context.inflight_diagnostic()
+                diagnostic.with_additional_message(
+                    "### The operator overload is not found in onnx registry!\n"
+                    "Cannot find the operator overload in onnx registry, but"
+                    "the default overload is found. Please check the ONNX output carefully. \n",
+                )
+                diagnostic.level = diagnostics.levels.WARNING
 
         # NOTE: If the ATen/Custom operators are not registered, the group will be None.
         if function_group is not None:

--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -304,6 +304,7 @@ class OnnxFunctionDispatcher:
         )
 
         # NOTE: Fall back to default overload if the ONNX registry doesn't have the overload.
+        # TODO: Should we have a better fallback mechanism?
         if function_group is None:
             function_group = self.onnx_registry.get_functions(
                 namespace=internal_opname.namespace,
@@ -319,7 +320,7 @@ class OnnxFunctionDispatcher:
                 diagnostic = diagnostic_context.inflight_diagnostic()
                 diagnostic.with_additional_message(
                     "### The operator overload is not found in onnx registry!\n"
-                    "Cannot find the operator overload in onnx registry, but"
+                    "Cannot find the operator overload in onnx registry, but "
                     "the default overload is found. Please check the ONNX output carefully. \n",
                 )
                 diagnostic.level = diagnostics.levels.WARNING


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #105972

Without this PR, the warning message is misleading as it says the default is found before the error message popped.
Next PR will start refactoring aten overload fallback with adding overloads supported by torchlib into OpSchema matching.