### PR TITLE
[1/N] add _device_mesh to FSDP kwarg

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -208,10 +208,10 @@ def _check_flat_params_on_expected_device(state: _FSDPState, module: nn.Module):
 def _init_device_mesh(
     root_state: _FSDPState,
 ) -> Optional[DeviceMesh]:
-    # We are testing 1D DeviceMesh where dist.get_world_size(pg) == dist.get_world_size() for now.
-    # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size(). This would capture
-    #       what 1D DeviceMesh currently would not work for:
-    #       1) HSDP Hybrid Sharding, 2) 2D FSDP + TP, 3) dist.new_group() cannot be expressed in 1D DeviceMesh.
+    # TODO: Remove it once we fully introduce device_mesh as an kwarg of FSDP.
+    # Temporarily keeping it here so MS folks can use it to build out support for 1D DTensor state_dict.
+    if root_state._device_mesh is not None:
+        return root_state._device_mesh
     if root_state.process_group != dist.distributed_c10d._get_default_group():
         return None
     if get_backend() == "fake" or not root_state.compute_device:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -23,6 +23,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
+from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_WRAPPED_MODULE,
     ActivationWrapper,
@@ -398,6 +399,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         ignored_states: Union[
             Optional[Iterable[torch.nn.Parameter]], Optional[Iterable[torch.nn.Module]]
         ] = None,
+        _device_mesh: DeviceMesh = None,
     ):
         torch._C._log_api_usage_once("torch.distributed.fsdp")
         super().__init__()
@@ -413,7 +415,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # Note that this is done before auto_wrapping, so that child FSDP modules simply pick up
         # the same process group state as the root FSDP module.
         _init_process_group_state(
-            self, process_group, sharding_strategy, auto_wrap_policy
+            self, process_group, sharding_strategy, auto_wrap_policy, _device_mesh
         )
         if auto_wrap_policy is not None:
             fsdp_kwargs = {


### PR DESCRIPTION
This is the diff train to enable HSDP DTensor state_dict support. In this PR,

1. We add _device_mesh to FSDP kwarg
2. Validate process_group and _device_mesh is mutually exclusive. 
3. When _device_mesh is passed in, we re-use the PG from DeviceMesh for both 1D FSDP and 2D HSDP. 