### PR TITLE
[aarch64][xplat/caffe2] Fix aarch64 build

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -860,6 +860,12 @@ def define_buck_targets(
         ]),
         visibility = ["PUBLIC"],
         labels = labels,
+        deps = select({
+            "DEFAULT": [],
+            "ovr_config//runtime:fbcode-arm64": [
+              third_party("sleef_arm"),
+            ],
+        }),
     )
 
     fb_xplat_cxx_library(


### PR DESCRIPTION
Summary: Add missing dep to pull in sleef headers.

Test Plan:
```
$ buck2 build -c fbcode.arch=aarch64 fbsource//xplat/caffe2:cpukernel_avx2
```

Reviewed By: r1mikey, ajaymh

Differential Revision: D47772650

