### PR TITLE
[sigmoid] Prepare export frontend for Inference Runtime

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -1,7 +1,7 @@
 import copy
 import dataclasses
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Iterator, Tuple, Union
 
 import sympy
 
@@ -193,6 +193,14 @@ class ExportedProgram:
     @property
     def graph(self):
         return self.graph_module.graph
+
+    def named_parameters(self) -> Iterator[Tuple[str, torch.nn.Parameter]]:
+        for param_name in self.graph_signature.parameters:
+            yield param_name, self.state_dict[param_name]
+
+    def named_buffers(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        for buffer_name in self.graph_signature.buffers:
+            yield buffer_name, self.state_dict[buffer_name]
 
     def transform(self, *passes: PassType) -> "ExportedProgram":
         pm = PassManager(list(passes))


### PR DESCRIPTION
Summary:
parameters and buffers needs to be differentiated in ExportedProgram, since PT2 IR GraphModule differentiates them, as we need to support deserializing a exported GraphModule back to fx.GraphModule.

A bigger question is: Should ExportedProgram be a child class of fx.GraphModule? Has this been discussed before?

Test Plan: CI

Differential Revision: D47780877

