### PR TITLE
fix some typos

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -696,7 +696,7 @@ TEST(
     IValue tuple = runtime(args, {});
     ASSERT_TRUE(tuple.isTuple());
     ASSERT_EQ(tuple.toTupleRef().elements().size(), 1);
-    // Do not manage intput value.
+    // Do not manage input value.
     EXPECT_FALSE(runtime.isManagedOutputTensor(args[0]));
     // Do not manage direct output value.
     EXPECT_FALSE(runtime.isManagedOutputTensor(tuple));
@@ -712,7 +712,7 @@ TEST(
     IValue tuple = runtime(args, {});
     ASSERT_TRUE(tuple.isTuple());
     ASSERT_EQ(tuple.toTupleRef().elements().size(), 1);
-    // Do not manage intput value.
+    // Do not manage input value.
     EXPECT_FALSE(runtime.isManagedOutputTensor(args[0]));
     // Do not manage direct output value.
     EXPECT_FALSE(runtime.isManagedOutputTensor(tuple));

--- a/caffe2/opt/backend_cutting_test.cc
+++ b/caffe2/opt/backend_cutting_test.cc
@@ -62,7 +62,7 @@ TEST(BackendCuttingTest, unit) {
 TEST(BackendCuttingTest, line) {
   caffe2::NetDef net;
   net.add_external_input("X");
-  // Adding weights as external intputs to test weight absorption
+  // Adding weights as external inputs to test weight absorption
   net.add_external_input("W0");
   net.add_external_input("W1");
   net.add_external_input("b0");

--- a/torchgen/api/types/types_base.py
+++ b/torchgen/api/types/types_base.py
@@ -22,7 +22,7 @@ from torchgen.model import Argument, SelfArgument, TensorOptionsArguments
 # An ArgName is just the str name of the argument in schema;
 # but in some special circumstances, we may add a little extra
 # context.  The Enum SpecialArgName covers all of these cases;
-# grep for their construction sites to see when they can occr.
+# grep for their construction sites to see when they can occur.
 
 
 class SpecialArgName(Enum):


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Fix typos in `test_static_module.cc`, `backend_cutting_test.cc` and `types_base.py`