### PR TITLE
revise err msgs about weight param of multimarginloss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1407,7 +1407,10 @@ class MultiMarginLoss(_WeightedLoss):
         super().__init__(weight, size_average, reduce, reduction)
         if p != 1 and p != 2:
             raise ValueError("only p == 1 and p == 2 supported")
-        assert weight is None or weight.dim() == 1
+        if weight is not None and weight.dim() != 1 : 
+            raise ValueError(
+                f"MultiMarginLoss: expected weight to be None or 1D tensor, got {weight.dim()}D instead"
+            )
         self.p = p
         self.margin = margin
 


### PR DESCRIPTION
Summary: Use ValueError for weight.dim check instead of Assertion Error.

Fix: https://github.com/pytorch/pytorch/issues/106020
