### PR TITLE
add xpu support for foreach kernels

### DIFF
--- a/torch/utils/_foreach_utils.py
+++ b/torch/utils/_foreach_utils.py
@@ -9,7 +9,7 @@ def _get_foreach_kernels_supported_devices() -> List[str]:
     r"""
     Return the device type list that supports foreach kernels.
     """
-    return ["cuda", torch._C._get_privateuse1_backend_name()]
+    return ["cuda", "xpu", torch._C._get_privateuse1_backend_name()]
 
 def _get_fused_kernels_supported_devices() -> List[str]:
     r"""


### PR DESCRIPTION
We want to add xpu support for foreach kernels, so we add the "xpu" devices to the support list.

Besides, for fused kernels in Adam and AdamW,  the devices check is enabled by the support list in adam.py (lines 44-46) and adamw.py (lines 60-64),  so we remove the repetitive check for cuda devices as it will block the other devices in the support list.
