### PR TITLE
[FSDP][Easy] Rename to `_comm_hook`, `_comm_hook_state`

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -433,8 +433,8 @@ def _init_runtime_state(
     _post_forward_handles: List[RemovableHandle] = []
     state._post_forward_handles = _post_forward_handles
     state._sync_gradients = True
-    state._communication_hook = _get_default_comm_hook(state.sharding_strategy)
-    state._communication_hook_state = _get_default_comm_hook_state(state.process_group)
+    state._comm_hook = _get_default_comm_hook(state.sharding_strategy)
+    state._comm_hook_state = _get_default_comm_hook_state(state.process_group)
     state._hook_registered = False
     # Used to prevent running the pre-backward hook multiple times
     _ran_pre_backward_hook: Dict[FlatParamHandle, bool] = {}

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -769,9 +769,7 @@ def _post_backward_hook(
         with state._device_handle.stream(state._post_backward_stream):
             autograd_computed_grad = flat_param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
-                _check_comm_hook(
-                    state._communication_hook, state._communication_hook_state
-                )
+                _check_comm_hook(state._comm_hook, state._comm_hook_state)
             if (
                 not _low_precision_hook_enabled(state)
                 and flat_param.grad.dtype != handle._reduce_dtype
@@ -799,8 +797,8 @@ def _post_backward_hook(
                     else unsharded_grad
                 )
                 new_sharded_grad = torch.empty_like(chunks[0])  # padded
-                state._communication_hook(
-                    state._communication_hook_state,
+                state._comm_hook(
+                    state._comm_hook_state,
                     padded_unsharded_grad,
                     new_sharded_grad,
                 )
@@ -826,9 +824,7 @@ def _post_backward_hook(
                     flat_param._saved_grad_shard = new_sharded_grad
                 grad_to_offload = flat_param._saved_grad_shard
             else:
-                state._communication_hook(
-                    state._communication_hook_state, flat_param.grad
-                )
+                state._comm_hook(state._comm_hook_state, flat_param.grad)
                 # For `NO_SHARD`, we can keep the low precision gradients by
                 # simply omitting the cast altogether
                 if not handle._keep_low_precision_grads:
@@ -1006,7 +1002,7 @@ def _check_grad_to_accumulate(
 
 @no_type_check
 def _low_precision_hook_enabled(state: _FSDPState) -> bool:
-    return state._communication_hook in LOW_PRECISION_HOOKS
+    return state._comm_hook in LOW_PRECISION_HOOKS
 
 
 @no_type_check

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -598,10 +598,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         """
         Whether a low precision hook is registered or not.
         """
-        return (
-            self._communication_hook is not None
-            and self._communication_hook in LOW_PRECISION_HOOKS
-        )
+        return self._comm_hook is not None and self._comm_hook in LOW_PRECISION_HOOKS
 
     def _reset_lazy_init(self) -> None:
         """
@@ -1950,11 +1947,11 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 not submodule._hook_registered
             ), "communication hook can be only registered once"
             submodule._hook_registered = True
-            assert submodule._communication_hook == _get_default_comm_hook(
+            assert submodule._comm_hook == _get_default_comm_hook(
                 self.sharding_strategy
-            ), f"communication hook should be default, but it is {submodule._communication_hook.__name__} instead"
-            submodule._communication_hook_state = state
-            submodule._communication_hook = hook
+            ), f"communication hook should be default, but it is {submodule._comm_hook.__name__} instead"
+            submodule._comm_hook_state = state
+            submodule._comm_hook = hook
 
 
 def _get_grad_norm(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106068
* #106034
* __->__ #106033
* #106032
* #105985
* #105984

This is just out of preference to make the naming convention consistent with `register_comm_hook()`.

Differential Revision: [D47852462](https://our.internmc.facebook.com/intern/diff/D47852462)