### PR TITLE
Create test/test_custom_ops.py, move test_custom_op_testing to it

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -267,7 +267,7 @@ test_dynamo_shard() {
       test_fx \
       test_package \
       test_legacy_vmap \
-      test_custom_op_testing \
+      test_custom_ops \
       test_content_store \
       export/test_db \
       functorch/test_dims \

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2,21 +2,23 @@
 
 from torch.testing._internal.common_utils import *  # noqa: F403
 from torch.testing._internal.common_device_type import *  # noqa: F403
-from torch.testing._internal.optests.compile_check import operator_compile_check
-from torch.testing._internal.custom_op_db import custom_op_db
 from torch._custom_op.impl import custom_op
+from torch.testing._internal.custom_op_db import custom_op_db
+from torch.testing._internal.optests.compile_check import operator_compile_check
+
 
 @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")
 class TestCustomOpTesting(TestCase):
     def setUp(self):
-        self.test_ns = '_test_custom_op'
+        self.test_ns = "_test_custom_op"
         self.libraries = []
 
     def tearDown(self):
         import torch._custom_op
+
         keys = list(torch._custom_op.impl.global_registry.keys())
         for key in keys:
-            if not key.startswith(f'{self.test_ns}::'):
+            if not key.startswith(f"{self.test_ns}::"):
                 continue
             torch._custom_op.impl.global_registry[key]._destroy()
         if hasattr(torch.ops, self.test_ns):
@@ -29,7 +31,7 @@ class TestCustomOpTesting(TestCase):
         return getattr(torch.ops, self.test_ns)
 
     def lib(self):
-        result = torch.library.Library(self.test_ns, 'FRAGMENT')
+        result = torch.library.Library(self.test_ns, "FRAGMENT")
         self.libraries.append(result)
         return result
 
@@ -67,8 +69,8 @@ class TestCustomOpTesting(TestCase):
 
         x = torch.tensor(3.14159 / 3, requires_grad=True, device=device)
         with self.assertRaisesRegex(
-                RuntimeError,
-                'Argument x is not defined as mutable but was mutated'):
+            RuntimeError, "Argument x is not defined as mutable but was mutated"
+        ):
             operator_compile_check(f, (x,), {})
 
     def test_incorrect_schema_view(self, device):
@@ -81,7 +83,9 @@ class TestCustomOpTesting(TestCase):
             def forward(ctx, x):
                 # Emulate AutoDispatchBelowADInplaceOrView, which is not bound into python
                 with torch._C._AutoDispatchBelowAutograd():
-                    with torch._C._ExcludeDispatchKeyGuard(torch._C.DispatchKeySet(torch._C.DispatchKey.ADInplaceOrView)):
+                    with torch._C._ExcludeDispatchKeyGuard(
+                        torch._C.DispatchKeySet(torch._C.DispatchKey.ADInplaceOrView)
+                    ):
                         return op(x)
 
             @staticmethod
@@ -106,8 +110,8 @@ class TestCustomOpTesting(TestCase):
 
         x = torch.tensor(3.14159 / 3, requires_grad=True)
         with self.assertRaisesRegex(
-                RuntimeError,
-                'Argument x is not defined to alias output but was aliasing'):
+            RuntimeError, "Argument x is not defined to alias output but was aliasing"
+        ):
             operator_compile_check(f, (x,), {})
 
     def test_missing_abstract_impl(self, device):
@@ -136,10 +140,11 @@ class TestCustomOpTesting(TestCase):
             y = op(x)
             return y.sum(0)
 
-        x = torch.tensor([0, 1.], requires_grad=True)
+        x = torch.tensor([0, 1.0], requires_grad=True)
         with self.assertRaisesRegex(
-                torch._subclasses.fake_tensor.UnsupportedOperatorException,
-                '_test_custom_op.foo.default'):
+            torch._subclasses.fake_tensor.UnsupportedOperatorException,
+            "_test_custom_op.foo.default",
+        ):
             operator_compile_check(f, (x,), {})
 
     def test_incorrect_abstract_impl(self, device):
@@ -152,7 +157,9 @@ class TestCustomOpTesting(TestCase):
             def forward(ctx, x):
                 # Emulate AutoDispatchBelowADInplaceOrView, which is not bound into python
                 guard = torch._C._AutoDispatchBelowAutograd()
-                guard2 = torch._C.ExcludeDispatchKeyGuard(torch._C.DispatchKeySet(torch._C.DispatchKey.ADInplaceOrView))
+                guard2 = torch._C.ExcludeDispatchKeyGuard(
+                    torch._C.DispatchKeySet(torch._C.DispatchKey.ADInplaceOrView)
+                )
                 try:
                     return op(x)
                 finally:
@@ -164,7 +171,7 @@ class TestCustomOpTesting(TestCase):
                 return gx
 
         def foo_impl(x):
-            return x ** 2
+            return x**2
 
         def foo_meta(x):
             return x.unsqueeze(1) ** 2
@@ -178,10 +185,8 @@ class TestCustomOpTesting(TestCase):
             y = op(x)
             return y.sum(0)
 
-        x = torch.tensor([0, 1.], requires_grad=True)
-        with self.assertRaisesRegex(
-                RuntimeError,
-                'Shapes .* are not equal'):
+        x = torch.tensor([0, 1.0], requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "Shapes .* are not equal"):
             operator_compile_check(f, (x,), {})
 
     def test_missing_functionalization(self, device):
@@ -216,10 +221,11 @@ class TestCustomOpTesting(TestCase):
             y = op(x)
             return y.sum(0)
 
-        x = torch.tensor([0, 1.], requires_grad=True)
+        x = torch.tensor([0, 1.0], requires_grad=True)
         with self.assertRaisesRegex(
-                RuntimeError,
-                'Getting these operators to work with functionalization requires some extra work'):
+            RuntimeError,
+            "Getting these operators to work with functionalization requires some extra work",
+        ):
             operator_compile_check(f, (x,), {})
 
     def test_autograd_registered_at_backend(self, device):
@@ -246,7 +252,7 @@ class TestCustomOpTesting(TestCase):
 
         x = torch.randn([], requires_grad=True)
 
-        with self.assertRaisesRegex(AssertionError, 'mismatched requires_grad-ness'):
+        with self.assertRaisesRegex(AssertionError, "mismatched requires_grad-ness"):
             operator_compile_check(f, (x,), {})
 
         # I'm not sure why this is necessary
@@ -280,49 +286,57 @@ class TestCustomOpTesting(TestCase):
 
     @ops(custom_op_db, dtypes=OpDTypes.any_one)
     def test_operator_compile_check_op(self, device, dtype, op):
-        for sample_input in op.sample_inputs(device, dtype, requires_grad=op.supports_autograd):
+        for sample_input in op.sample_inputs(
+            device, dtype, requires_grad=op.supports_autograd
+        ):
             dynamic_only = op.name in ("NumpyNMSCustomOp", "NumpyNonzeroCustomOp")
             args = [sample_input.input] + list(sample_input.args)
             kwargs = sample_input.kwargs
             operator_compile_check(
-                op.op, args, kwargs,
+                op.op,
+                args,
+                kwargs,
                 supports_autograd=op.supports_autograd,
                 dynamic_only=dynamic_only,
                 fullgraph=False,  # Dynamo graph breaks on CustomOp today
             )
 
     def test_operator_compile_check_fails_basic(self, device):
-        @custom_op(f'{self.test_ns}::foo')
+        @custom_op(f"{self.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
             ...
 
-        @foo.impl(['cpu', 'cuda'])
+        @foo.impl(["cpu", "cuda"])
         def foo_impl(x):
             return x.sum()
 
         x = torch.randn(3, device=device, requires_grad=True)
         # Triggers the CustomOp autograd NYI error
-        with self.assertRaisesRegex(RuntimeError, "Autograd has not been implemented for operator"):
+        with self.assertRaisesRegex(
+            RuntimeError, "Autograd has not been implemented for operator"
+        ):
             operator_compile_check(lambda x: foo(x), (x,), {})
 
     def test_assert_raises_regex(self, device):
         from torch.testing._internal.optests.aot_autograd import assert_raises_regex
-        with assert_raises_regex(RuntimeError, 'c'):
+
+        with assert_raises_regex(RuntimeError, "c"):
             raise RuntimeError("abcd")
-        with assert_raises_regex(RuntimeError, 'c.*'):
+        with assert_raises_regex(RuntimeError, "c.*"):
             raise RuntimeError("abcd")
-        with self.assertRaisesRegex(AssertionError, 'instead got'):
-            with assert_raises_regex(RuntimeError, 'c.*'):
+        with self.assertRaisesRegex(AssertionError, "instead got"):
+            with assert_raises_regex(RuntimeError, "c.*"):
                 raise ValueError("abcd")
-        with self.assertRaisesRegex(AssertionError, 'Expected exception'):
-            with assert_raises_regex(RuntimeError, 'c.*'):
+        with self.assertRaisesRegex(AssertionError, "Expected exception"):
+            with assert_raises_regex(RuntimeError, "c.*"):
                 pass
-        with self.assertRaisesRegex(AssertionError, 'to match regex'):
-            with assert_raises_regex(RuntimeError, 'f'):
+        with self.assertRaisesRegex(AssertionError, "to match regex"):
+            with assert_raises_regex(RuntimeError, "f"):
                 raise RuntimeError("abcd")
+
 
 only_for = ("cpu", "cuda")
 instantiate_device_type_tests(TestCustomOpTesting, globals(), only_for=only_for)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #106088
* #106076
* #106075
* #105947
* #106036
* __->__ #106035

I'm in the process of putting all the custom op tests into this file. I
got tired of trying to find the custom ops tests in
test_python_dispatch.py, which (1) is getting long and (2) should actually
be the torch_dispatch and python torch.library tests.