### PR TITLE
[ONNX] Limit number of elements to display for list/tuple/dict in diagnostics

### DIFF
--- a/torch/onnx/_internal/diagnostics/infra/formatter.py
+++ b/torch/onnx/_internal/diagnostics/infra/formatter.py
@@ -65,7 +65,7 @@ def _convert_key(
         else:
             new_v = v
         if new_v is None:
-            # Otherwise unnesseraily bloated sarif log with "null"s.
+            # Otherwise unnecessarily bloated sarif log with "null"s.
             continue
         if new_v == -1:
             # WAR: -1 as default value shouldn't be logged into sarif.

--- a/torch/onnx/_internal/fx/diagnostics.py
+++ b/torch/onnx/_internal/fx/diagnostics.py
@@ -21,8 +21,10 @@ from torch.onnx._internal.fx import registration, type_utils as fx_type_utils
 # Tensor(i64[s0, 64, (s1//2) - 2, (s1//2) - 2]) where s0 and s1 are symbolic
 # so we need to relax the length limit.
 _LENGTH_LIMIT: int = 120
-# NOTE: The following limits are for the number of items in a list, tuple or dict.
-# The limits are set to be small to avoid heavy workload.
+# NOTE: The following limits are for the number of items to display in diagnostics for
+# a list, tuple or dict. The limit is picked such that common useful scenarios such as
+# operator arguments are covered, while preventing excessive processing loads on considerably
+# large containers such as the dictionary mapping from fx to onnx nodes.
 _CONTAINER_ITEM_LIMIT: int = 10
 
 # NOTE(bowbao): This is a shim over `torch.onnx._internal.diagnostics`, which is

--- a/torch/onnx/_internal/fx/diagnostics.py
+++ b/torch/onnx/_internal/fx/diagnostics.py
@@ -21,6 +21,9 @@ from torch.onnx._internal.fx import registration, type_utils as fx_type_utils
 # Tensor(i64[s0, 64, (s1//2) - 2, (s1//2) - 2]) where s0 and s1 are symbolic
 # so we need to relax the length limit.
 _LENGTH_LIMIT: int = 120
+# NOTE: The following limits are for the number of items in a list, tuple or dict.
+# The limits are set to be small to avoid heavy workload.
+_CONTAINER_ITEM_LIMIT: int = 10
 
 # NOTE(bowbao): This is a shim over `torch.onnx._internal.diagnostics`, which is
 # used in `torch.onnx`, and loaded with `torch`. Hence anything related to `onnxscript`
@@ -132,7 +135,11 @@ def _list(obj: list) -> str:
     list_string = f"List[length={len(obj)}](\n"
     if not obj:
         return list_string + "None)"
-    for item in obj:
+    for i, item in enumerate(obj):
+        if i >= _CONTAINER_ITEM_LIMIT:
+            # NOTE: Print only first _CONTAINER_ITEM_LIMIT items.
+            list_string += "...,\n"
+            break
         list_string += f"{format_argument(item)},\n"
     return list_string + ")"
 
@@ -142,7 +149,11 @@ def _tuple(obj: tuple) -> str:
     tuple_string = f"Tuple[length={len(obj)}](\n"
     if not obj:
         return tuple_string + "None)"
-    for item in obj:
+    for i, item in enumerate(obj):
+        if i >= _CONTAINER_ITEM_LIMIT:
+            # NOTE: Print only first _CONTAINER_ITEM_LIMIT items.
+            tuple_string += "...,\n"
+            break
         tuple_string += f"{format_argument(item)},\n"
     return tuple_string + ")"
 
@@ -152,7 +163,11 @@ def _dict(obj: dict) -> str:
     dict_string = f"Dict[length={len(obj)}](\n"
     if not obj:
         return dict_string + "None)"
-    for key, value in obj.items():
+    for i, (key, value) in enumerate(obj.items()):
+        if i >= _CONTAINER_ITEM_LIMIT:
+            # NOTE: Print only first _CONTAINER_ITEM_LIMIT items.
+            dict_string += "...\n"
+            break
         dict_string += f"{key}: {format_argument(value)},\n"
     return dict_string + ")"
 

--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -419,7 +419,7 @@ class _OnnxSchemaChecker:
         self.onnxfunction = onnxfunction
         self.param_schema = self.onnxfunction.param_schemas()
         op_schema = self.onnxfunction.op_schema
-        # TODO: Both `OnnxFunction` and `TracedOnnxFunction` never returns None for `op_schema`.
+        # Both `OnnxFunction` and `TracedOnnxFunction` never return None for `op_schema`.
         # However their base class would. Hence return type is annotated as Optional[OpSchema].
         assert op_schema is not None
         self.op_schema = op_schema

--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -27,7 +27,6 @@ from torch.onnx._internal.fx import (
 )
 
 if TYPE_CHECKING:
-    import onnx.defs.OpSchema  # type: ignore[import]
     import onnxscript  # type: ignore[import]
 
 
@@ -419,7 +418,11 @@ class _OnnxSchemaChecker:
         """
         self.onnxfunction = onnxfunction
         self.param_schema = self.onnxfunction.param_schemas()
-        self.op_schema: onnx.defs.OpSchema = self.onnxfunction.op_schema
+        op_schema = self.onnxfunction.op_schema
+        # TODO: Both `OnnxFunction` and `TracedOnnxFunction` never returns None for `op_schema`.
+        # However their base class would. Hence return type is annotated as Optional[OpSchema].
+        assert op_schema is not None
+        self.op_schema = op_schema
         self.type_constraints = {
             # "T": {"tensor(int64)"}
             constraint.type_param_str: set(constraint.allowed_type_strs)
@@ -498,7 +501,7 @@ class _OnnxSchemaChecker:
                 # of this input defined in the OpSchema, we know the function
                 # and the input are not compatible
                 diagnostic.with_additional_message(
-                    f"#### Failed: input type mismatch! \n"
+                    f"#### Failed: input type mismatch for input '{schema_input.name}'! \n"
                     f"Actual {torch_input_compatible_types} vs\n"
                     f"expected {allowed_types}\n"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106048

In a recent change, diagnostics started logging contents within tuple/list/dict
for diagnosed function arguments and return types. This brought slow down
to export due to some extremely large container instances, such as the fx to 
onnx node mapping dictionary.

This PR adds a limit to how many elements the diagnostic would record for
these types. Together with https://github.com/microsoft/onnxscript/pull/922, the performance of
export w/ diagnostics is restored and improved. As shown by pyinstrument:

GPT2 time for `fx_to_onnx_interpreter.run` 17.767s -> 1.961s
xcit_large_24_p8_224 time for `fx_to_onnx_interpreter.run` 144.729s -> 4.067s