### PR TITLE
[pt2][inductor] guard for __package__ is None

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -190,9 +190,12 @@ if is_fbcode():
     from libfb.py import parutil
 
     try:
-        global_cache_dir = parutil.get_dir_path(
-            os.path.join(__package__.replace(".", os.sep), "fb/cache")
-        )
+        if __package__:
+            global_cache_dir = parutil.get_dir_path(
+                os.path.join(__package__.replace(".", os.sep), "fb/cache")
+            )
+        else:
+            global_cache_dir = parutil.get_dir_path("fb/cache")
     except ValueError:
         global_cache_dir = None
 else:


### PR DESCRIPTION
Summary:
Guard against errors when __package__ is NoneType

Created from CodeHub with https://fburl.com/edit-in-codehub

Test Plan:
sandcastle + CI

Sandcastle run

Differential Revision: D47803386



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov