### PR TITLE
Add pull request target to bc lint

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -1,15 +1,25 @@
 name: BC Lint
 
 on:
+  # Copied from check-labels.yml to get around needing approval for first time contributors
+  # We need pull_request_target to be able to post comments on PRs from forks.
+  # See https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
+  # Only allow pull_request_target when merging to main, not some historical branch.
+  #
+  # Make sure to don't introduce explicit checking out and installing/running
+  # untrusted user code into this workflow!
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+    paths-ignore: [.github]
+
+  # To allow testing PRs that change workflows.
+  # May be triggered together with pull_request_target, it's OK.
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
-    branches-ignore:
-      - nightly
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths: [.github]
+    branches-ignore: [nightly]
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -11,13 +11,13 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
-    paths-ignore: [.github]
+    paths-ignore: [.github/workflows/lint-bc.yaml]
 
   # To allow testing PRs that change workflows.
   # May be triggered together with pull_request_target, it's OK.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths: [.github]
+    paths: [.github/workflows/lint-bc.yaml]
     branches-ignore: [nightly]
 
   workflow_dispatch:

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -2,7 +2,6 @@ name: BC Lint
 
 on:
   # Copied from check-labels.yml to get around needing approval for first time contributors
-  # We need pull_request_target to be able to post comments on PRs from forks.
   # See https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
   # Only allow pull_request_target when merging to main, not some historical branch.
   #
@@ -11,13 +10,13 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
-    paths-ignore: [.github/workflows/lint-bc.yaml]
+    paths-ignore: [.github/workflows/lint-bc.yml]
 
   # To allow testing PRs that change workflows.
   # May be triggered together with pull_request_target, it's OK.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths: [.github/workflows/lint-bc.yaml]
+    paths: [.github/workflows/lint-bc.yml]
     branches-ignore: [nightly]
 
   workflow_dispatch:


### PR DESCRIPTION
In order to get around the approval needed for first time contributors, add pull_request_target trigger for bc lint like for check labels.  

Documentation about approvals here https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks specifically:

> Note: Workflows triggered by pull_request_target events are run in the context of the base branch. Since the base branch is considered trusted, workflows triggered by these events will always run, regardless of approval settings. For more information about the pull_request_target event, see "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)."
