### PR TITLE
Higher order operator util for raising if inputs require grads

### DIFF
--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -131,11 +131,7 @@ def cond_dense(pred, true_fn, false_fn, operands):
         return false_fn(*operands)
 
 
-@cond.py_impl(DispatchKey.Autograd)
-def cond_autograd(pred, true_fn, false_fn, *operands):
-    # TODO: support autograd
-    return autograd_not_implemented(
-        lambda *operands: cond(pred, true_fn, false_fn, *operands), "cond", True, *operands)
+cond.py_impl(DispatchKey.Autograd)(autograd_not_implemented(cond, deferred_error=True))
 
 
 @cond.py_impl(ProxyTorchDispatchMode)

--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -11,8 +11,8 @@ from torch._functorch.eager_transforms import (
     _wrap_all_tensors_to_functional,
     functionalize,
 )
-from torch._ops import HigherOrderOperator
 from torch._higher_order_ops.utils import autograd_not_implemented
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -26,7 +26,6 @@ from torch.utils._python_dispatch import (
     _get_current_dispatch_mode,
     _pop_mode_temporarily,
 )
-from torch.utils._pytree import tree_flatten
 
 
 @dataclass

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1100,8 +1100,11 @@ class TestControlFlowTraced(TestCase):
             return control_flow.cond(x.shape[0] > 4, true_fn, false_fn, [y])
 
         example_inputs = (torch.ones(3, 2, 4, requires_grad=True), torch.ones(4, requires_grad=True))
-        with self.assertRaisesRegex(RuntimeError, "NYI: torch.cond doesn't support autograd"):
+        with self.assertRaisesRegex(RuntimeError, "Autograd not implemented for cond"):
             f(*example_inputs).sum().backward()
+
+        # Ensure no error is thrown when not running backward
+        f(*example_inputs)
 
     def test_map_functionalized_elem_alias(self):
         def map_fn(x):

--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -141,7 +141,7 @@ class TestOutDtypeOp(TestCase):
             )
 
         inp = (torch.randn(5, 5, requires_grad=True), torch.randn(5, 5, requires_grad=True))
-        with self.assertRaisesRegex(RuntimeError, "Autograd is not supported for out_dtype"):
+        with self.assertRaisesRegex(RuntimeError, "Autograd not implemented for out_dtype"):
             f(*inp)
 
         with torch.no_grad():

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -117,14 +117,7 @@ def out_dtype_dense(
     return res
 
 
-@out_dtype.py_impl(DispatchKey.Autograd)
-def out_dtype_autograd(
-    op: torch._ops.OpOverload,
-    output_dtype: torch.dtype,
-    *args
-):
-    return autograd_not_implemented(lambda *args, **kwargs: out_dtype(op, output_dtype, *args),
-                                    "out_dtype", False, *args)
+out_dtype.py_impl(DispatchKey.Autograd)(autograd_not_implemented(out_dtype, deferred_error=False))
 
 
 @out_dtype.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -18,7 +18,7 @@ from torch._functorch.eager_transforms import (
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._prims_common import elementwise_dtypes, ELEMENTWISE_TYPE_PROMOTION_KIND
-from torch._higher_order_ops.utils import autograd_not_implemented_check
+from torch._higher_order_ops.utils import autograd_not_implemented
 
 # TODO to figure out a more generic approach
 ALLOWABLE_OPS = [
@@ -123,10 +123,10 @@ def out_dtype_autograd(
     output_dtype: torch.dtype,
     *args
 ):
-    # TODO: maybe support autograd
-    autograd_not_implemented_check(args, "out_dtype")
     with torch._C._AutoDispatchBelowAutograd():
-        return out_dtype(op, output_dtype, *args)
+        result = out_dtype(op, output_dtype, *args)
+        # TODO: maybe support autograd
+        return autograd_not_implemented(result, args, "out_dtype", delayed=False)
 
 
 @out_dtype.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -18,7 +18,7 @@ from torch._functorch.eager_transforms import (
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch._prims_common import elementwise_dtypes, ELEMENTWISE_TYPE_PROMOTION_KIND
-
+from torch._higher_order_ops.utils import autograd_not_implemented_check
 
 # TODO to figure out a more generic approach
 ALLOWABLE_OPS = [
@@ -124,12 +124,7 @@ def out_dtype_autograd(
     *args
 ):
     # TODO: maybe support autograd
-    flat_operands, _ = pytree.tree_flatten(args)
-    if torch.is_grad_enabled() and any(
-        f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
-    ):
-        raise RuntimeError("Autograd is not supported for out_dtype")
-
+    autograd_not_implemented_check(args, "out_dtype")
     with torch._C._AutoDispatchBelowAutograd():
         return out_dtype(op, output_dtype, *args)
 

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -123,10 +123,8 @@ def out_dtype_autograd(
     output_dtype: torch.dtype,
     *args
 ):
-    with torch._C._AutoDispatchBelowAutograd():
-        result = out_dtype(op, output_dtype, *args)
-        # TODO: maybe support autograd
-        return autograd_not_implemented(result, args, "out_dtype", delayed=False)
+    return autograd_not_implemented(lambda *args, **kwargs: out_dtype(op, output_dtype, *args),
+                                    "out_dtype", False, *args)
 
 
 @out_dtype.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1,40 +1,46 @@
-from typing import Any
+from typing import Any, Callable
 
 import torch
 import torch.utils._pytree as pytree
 
 
 def autograd_not_implemented(
-    result: torch.Tensor, args: Any, op_name: str, delayed=False
+    operator: Callable, op_name: str, delayed: bool, *args: Any, **kwargs: Any
 ) -> Any:
-    """If autograd is enabled and any of the operands require grad this will either
+    """If autograd is enabled and any of the arguments require grad this will either
     raise an error or return a DelayedError depending on the value of delayed.
 
     Args:
-        result: The result of the HigherOrderOperator, must be a Tensor that supports grad if delayed is set to True
-        args: The flattened operands to the HigherOrderOperator
-        message: The name of the HigherOrderOperator
+        operator: The HigherOrderOperator to call with the *args and **kwargs with
+        op_name: The name of the HigherOrderOperator
         delayed: If True, return a DelayedError instead of raising an error
+        args: The flattened operands to the HigherOrderOperator
+        kwargs: The keyword arguments to the HigherOrderOperator
 
     Raises:
-        RuntimeError: If autograd is enabled and any of the operands require grad
+        RuntimeError: If autograd is enabled and any of the arguments to the HigherOrderOperator
     """
-    flat_operands, _ = pytree.tree_flatten(args)
-    if torch.is_grad_enabled() and any(
-        f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
-    ):
-        if delayed:
-            err_fn = torch._C._functions.DelayedError(
-                f"Autograd is not supported for {op_name}",
-                1,
-            )
+    with torch._C._AutoDispatchBelowAutograd():
+        result = operator(*args, **kwargs)
+        flat_operands, _ = pytree.tree_flatten(args)
+        if torch.is_grad_enabled() and any(
+            f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
+        ):
+            if delayed:
+                err_fn = torch._C._functions.DelayedError(
+                    f"Autograd not implemented for {op_name}",
+                    1,
+                )
 
-            def fake_requires_grad(var):
-                var = var.detach()
-                var.requires_grad = True
-                return var
+                def fake_requires_grad(tensor):
+                    if torch.is_floating_point(tensor) or torch.is_complex(tensor):
+                        tensor = tensor.detach()
+                        tensor.requires_grad = True
+                    return tensor
 
-            return err_fn(fake_requires_grad(result))
-        else:
-            raise RuntimeError(f"Autograd is not supported for {op_name}")
-    return result
+                pytree.tree_map_only(torch.Tensor, fake_requires_grad, (args, kwargs))
+
+                return err_fn(fake_requires_grad(result))
+            else:
+                raise RuntimeError(f"Autograd not implemented for {op_name}")
+        return result

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -4,8 +4,8 @@ import torch
 import torch.utils._pytree as pytree
 
 
-def autograd_not_implemented(
-    operator: Callable, op_name: str, delayed: bool, *args: Any, **kwargs: Any
+def autograd_not_implemented_inner(
+    operator: Callable, op_name: str, delayed_error: bool, *args: Any, **kwargs: Any
 ) -> Any:
     """If autograd is enabled and any of the arguments require grad this will either
     raise an error or return a DelayedError depending on the value of delayed.
@@ -13,7 +13,7 @@ def autograd_not_implemented(
     Args:
         operator: The HigherOrderOperator to call with the *args and **kwargs with
         op_name: The name of the HigherOrderOperator
-        delayed: If True, return a DelayedError instead of raising an error
+        delayed_error: If True, return a DelayedError instead of raising an error
         args: The flattened operands to the HigherOrderOperator
         kwargs: The keyword arguments to the HigherOrderOperator
 
@@ -26,7 +26,7 @@ def autograd_not_implemented(
         if torch.is_grad_enabled() and any(
             f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
         ):
-            if delayed:
+            if delayed_error:
                 err_fn = torch._C._functions.DelayedError(
                     f"Autograd not implemented for {op_name}",
                     1,
@@ -38,9 +38,13 @@ def autograd_not_implemented(
                         tensor.requires_grad = True
                     return tensor
 
-                pytree.tree_map_only(torch.Tensor, fake_requires_grad, (args, kwargs))
-
-                return err_fn(fake_requires_grad(result))
+                return pytree.tree_map_only(torch.Tensor, lambda x: err_fn(fake_requires_grad(x)), result)
             else:
                 raise RuntimeError(f"Autograd not implemented for {op_name}")
         return result
+
+
+def autograd_not_implemented(op, deferred_error):
+    def inner(*args, **kwargs):
+        return autograd_not_implemented_inner(op, op.__name__, deferred_error, *args, **kwargs)
+    return inner

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -4,12 +4,17 @@ import torch
 import torch.utils._pytree as pytree
 
 
-def autograd_not_implemented_check(args: Any, op_name: str) -> None:
-    """If autograd is enabled and any of the operands require grad this will raise an error with message.
+def autograd_not_implemented(
+    result: torch.Tensor, args: Any, op_name: str, delayed=False
+) -> Any:
+    """If autograd is enabled and any of the operands require grad this will either
+    raise an error or return a DelayedError depending on the value of delayed.
 
     Args:
-        operands (List[Any]): The flattened operands to the HigherOrderOperator
-        message (str): The name of the HigherOrderOperator
+        result: The result of the HigherOrderOperator, must be a Tensor that supports grad if delayed is set to True
+        args: The flattened operands to the HigherOrderOperator
+        message: The name of the HigherOrderOperator
+        delayed: If True, return a DelayedError instead of raising an error
 
     Raises:
         RuntimeError: If autograd is enabled and any of the operands require grad
@@ -18,4 +23,18 @@ def autograd_not_implemented_check(args: Any, op_name: str) -> None:
     if torch.is_grad_enabled() and any(
         f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
     ):
-        raise RuntimeError(f"Autograd is not supported for {op_name}")
+        if delayed:
+            err_fn = torch._C._functions.DelayedError(
+                f"Autograd is not supported for {op_name}",
+                1,
+            )
+
+            def fake_requires_grad(var):
+                var = var.detach()
+                var.requires_grad = True
+                return var
+
+            return err_fn(fake_requires_grad(result))
+        else:
+            raise RuntimeError(f"Autograd is not supported for {op_name}")
+    return result

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import torch
+import torch.utils._pytree as pytree
+
+
+def autograd_not_implemented_check(args: Any, op_name: str) -> None:
+    """If autograd is enabled and any of the operands require grad this will raise an error with message.
+
+    Args:
+        operands (List[Any]): The flattened operands to the HigherOrderOperator
+        message (str): The name of the HigherOrderOperator
+
+    Raises:
+        RuntimeError: If autograd is enabled and any of the operands require grad
+    """
+    flat_operands, _ = pytree.tree_flatten(args)
+    if torch.is_grad_enabled() and any(
+        f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
+    ):
+        raise RuntimeError(f"Autograd is not supported for {op_name}")

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -169,7 +169,9 @@ def register_run_and_save_rng_state_op():
     run_and_save_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
     run_and_save_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
 
-    run_and_save_rng_state.py_impl(DispatchKey.Autograd)(autograd_not_implemented(run_and_save_rng_state, deferred_error=True))
+    run_and_save_rng_state.py_impl(DispatchKey.Autograd)(
+        autograd_not_implemented(run_and_save_rng_state, deferred_error=True)
+    )
 
     @run_and_save_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(op, *args, **kwargs):
@@ -220,7 +222,9 @@ def register_run_with_rng_state_op():
     run_with_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
     run_with_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
 
-    run_with_rng_state.py_impl(DispatchKey.Autograd)(autograd_not_implemented(run_with_rng_state, deferred_error=True))
+    run_with_rng_state.py_impl(DispatchKey.Autograd)(
+        autograd_not_implemented(run_with_rng_state, deferred_error=True)
+    )
 
     @run_with_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(rng_state, op, *args, **kwargs):

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -4,6 +4,7 @@ import torch
 import torch.utils._pytree as pytree
 from torch import _prims
 from torch._C import DispatchKey
+from torch._higher_order_ops.utils import autograd_not_implemented
 from torch._ops import HigherOrderOperator
 
 from torch._prims_common import CUDARngStateHelper, make_contiguous_strides_for
@@ -170,8 +171,13 @@ def register_run_and_save_rng_state_op():
 
     @run_and_save_rng_state.py_impl(DispatchKey.Autograd)
     def impl_autograd(op, *args, **kwargs):
-        with torch._C._AutoDispatchBelowAutograd():
-            return run_and_save_rng_state(op, *args, **kwargs)
+        return autograd_not_implemented(
+            lambda *args, **kwargs: run_and_save_rng_state(op, *args, **kwargs),
+            "run_and_save_rng_state",
+            True,
+            *args,
+            **kwargs,
+        )
 
     @run_and_save_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(op, *args, **kwargs):
@@ -224,8 +230,13 @@ def register_run_with_rng_state_op():
 
     @run_with_rng_state.py_impl(DispatchKey.Autograd)
     def impl_autograd(rng_state, op, *args, **kwargs):
-        with torch._C._AutoDispatchBelowAutograd():
-            return run_with_rng_state(rng_state, op, *args, **kwargs)
+        return autograd_not_implemented(
+            lambda *args, **kwargs: run_with_rng_state(rng_state, op, *args, **kwargs),
+            "run_with_rng_state",
+            True,
+            *args,
+            **kwargs,
+        )
 
     @run_with_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(rng_state, op, *args, **kwargs):

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -169,15 +169,7 @@ def register_run_and_save_rng_state_op():
     run_and_save_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
     run_and_save_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
 
-    @run_and_save_rng_state.py_impl(DispatchKey.Autograd)
-    def impl_autograd(op, *args, **kwargs):
-        return autograd_not_implemented(
-            lambda *args, **kwargs: run_and_save_rng_state(op, *args, **kwargs),
-            "run_and_save_rng_state",
-            True,
-            *args,
-            **kwargs,
-        )
+    run_and_save_rng_state.py_impl(DispatchKey.Autograd)(autograd_not_implemented(run_and_save_rng_state, deferred_error=True))
 
     @run_and_save_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(op, *args, **kwargs):
@@ -228,15 +220,7 @@ def register_run_with_rng_state_op():
     run_with_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
     run_with_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
 
-    @run_with_rng_state.py_impl(DispatchKey.Autograd)
-    def impl_autograd(rng_state, op, *args, **kwargs):
-        return autograd_not_implemented(
-            lambda *args, **kwargs: run_with_rng_state(rng_state, op, *args, **kwargs),
-            "run_with_rng_state",
-            True,
-            *args,
-            **kwargs,
-        )
+    run_with_rng_state.py_impl(DispatchKey.Autograd)(autograd_not_implemented(run_with_rng_state, deferred_error=True))
 
     @run_with_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(rng_state, op, *args, **kwargs):


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08bd685</samp>

Added a utility function `autograd_not_implemented_check` to `torch._higher_order_ops.utils` and used it in `out_dtype_autograd` to simplify and standardize the error handling for higher order operators that do not support autograd.