### PR TITLE
[memory snapshots] removed chained history

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2244,7 +2244,8 @@ class DeviceCachingAllocator {
       const std::shared_ptr<GatheredContext>& ctx) {
     TORCH_INTERNAL_ASSERT(!to_map->mapped && size <= to_map->size);
     TORCH_INTERNAL_ASSERT(
-        !to_map->context_when_allocated); // unmapped blocks should not keep history
+        !to_map->context_when_allocated); // unmapped blocks should not keep
+                                          // history
     auto mapped_range =
         to_map->expandable_segment_->map(SegmentRange{to_map->ptr, size});
     // failed to map the memory

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -186,12 +186,6 @@ struct BlockPool {
   PrivatePool* owner_PrivatePool;
 };
 
-struct HistoryChain {
-  History h;
-  std::unique_ptr<HistoryChain> next; // when blocks are merged we keep records
-                                      // of what used to be in the block
-};
-
 struct ExpandableSegment;
 
 struct Block {
@@ -213,8 +207,7 @@ struct Block {
   int event_count{0}; // number of outstanding CUDA events
   int gc_count{0}; // counter for prioritizing older / less useful blocks for
                    // garbage collection
-  std::unique_ptr<HistoryChain> history;
-  HistoryChain* history_last{nullptr};
+  std::shared_ptr<GatheredContext> context_when_allocated;
   ExpandableSegment* expandable_segment_{nullptr};
 
   Block(
@@ -644,18 +637,6 @@ struct AllocParams {
   StatTypes stat_types = {false};
   cudaError_t err;
 };
-
-int trimHistoryBefore(Block* block, void* point) {
-  int n = 0;
-  while (block->history && block->history->h.addr < point) {
-    block->history = std::move(block->history->next);
-    ++n;
-  }
-  if (!block->history) {
-    block->history_last = nullptr;
-  }
-  return n;
-}
 
 // Note: cudaEventCreate when concurrently invoked from multiple threads can be
 // very expensive (at least on certain device/driver combinations). Thus, we a)
@@ -1501,9 +1482,6 @@ class DeviceCachingAllocator {
       remaining->size -= size;
       bool inserted = pool->blocks.insert(remaining).second;
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inserted);
-      if (record_history) {
-        trimHistoryBefore(remaining, (char*)block->ptr + size);
-      }
 
       if (already_split && !block->expandable_segment_) {
         // An already-split inactive block is being shrunk by size bytes.
@@ -1535,19 +1513,13 @@ class DeviceCachingAllocator {
     block->allocated = true;
     block->requested_size = orig_size;
     if (record_history) {
-      trimHistoryBefore(block, (char*)block->ptr + size);
-      block->history = std::make_unique<HistoryChain>(HistoryChain{
-          History{block->ptr, orig_size, std::move(context)},
-          std::move(block->history)});
-      if (!block->history_last) {
-        block->history_last = block->history.get();
-      }
+      block->context_when_allocated = std::move(context);
       record_trace(
           TraceEntry::ALLOC,
           int64_t(block->ptr),
           orig_size,
           block->stream,
-          block->history->h.context);
+          block->context_when_allocated);
     }
 
     bool inserted = active_blocks.insert(block).second;
@@ -1596,13 +1568,13 @@ class DeviceCachingAllocator {
           stats.allocated_bytes[stat_type],
           -static_cast<std::int64_t>(block->size));
     });
-    if (block->history) {
+    if (record_history) {
       record_trace(
           TraceEntry::FREE_REQUESTED,
           int64_t(block->ptr),
-          block->history->h.real_size,
+          block->requested_size,
           block->stream,
-          block->history->h.context);
+          block->context_when_allocated);
     }
     if (block->size >= CachingAllocatorConfig::max_split_size())
       update_stat(stats.oversize_allocations, -1);
@@ -2021,11 +1993,7 @@ class DeviceCachingAllocator {
           segment_info.active_size += block_info.size;
           segment_info.requested_size += block_info.requested_size;
         }
-        HistoryChain* h = block->history.get();
-        while (h) {
-          block_info.history.push_back(h->h);
-          h = h->next.get();
-        }
+        block_info.context_when_allocated = block->context_when_allocated;
         block = block->next;
       }
       total_active += segment_info.active_size;
@@ -2276,7 +2244,7 @@ class DeviceCachingAllocator {
       const std::shared_ptr<GatheredContext>& ctx) {
     TORCH_INTERNAL_ASSERT(!to_map->mapped && size <= to_map->size);
     TORCH_INTERNAL_ASSERT(
-        !to_map->history); // unmapped blocks should not keep history
+        !to_map->context_when_allocated); // unmapped blocks should not keep history
     auto mapped_range =
         to_map->expandable_segment_->map(SegmentRange{to_map->ptr, size});
     // failed to map the memory
@@ -2366,13 +2334,14 @@ class DeviceCachingAllocator {
     TORCH_INTERNAL_ASSERT(
         !block->allocated && block->event_count == 0 &&
         block->stream_uses.empty());
-    if (block->history) {
+    if (record_history) {
       record_trace(
           TraceEntry::FREE_COMPLETED,
           int64_t(block->ptr),
-          block->history->h.real_size,
+          block->requested_size,
           block->stream,
-          block->history->h.context);
+          block->context_when_allocated);
+      block->context_when_allocated = nullptr;
     }
     size_t original_block_size = block->size;
     size_t requested_size = block->requested_size;
@@ -2444,27 +2413,11 @@ class DeviceCachingAllocator {
       if (dst->prev) {
         dst->prev->next = dst;
       }
-      if (!dst->history) {
-        dst->history = std::move(src->history);
-        dst->history_last = src->history_last;
-      } else if (src->history) {
-        src->history_last->next = std::move(dst->history);
-        dst->history = std::move(src->history);
-      }
-      src->history_last = nullptr;
     } else { // [dest src]
       dst->next = src->next;
       if (dst->next) {
         dst->next->prev = dst;
       }
-      if (!dst->history) {
-        dst->history = std::move(src->history);
-        dst->history_last = src->history_last;
-      } else if (src->history) {
-        dst->history_last->next = std::move(src->history);
-        dst->history_last = src->history_last;
-      }
-      src->history_last = nullptr;
     }
     const size_t subsumed_size = src->size;
     dst->size += subsumed_size;
@@ -2858,7 +2811,7 @@ class DeviceCachingAllocator {
           int64_t(block->ptr),
           block->size,
           block->stream,
-          block->history ? block->history->h.context : nullptr);
+          nullptr);
     }
     pool->blocks.erase(block);
     delete block;
@@ -2900,8 +2853,6 @@ class DeviceCachingAllocator {
     block->ptr = unmapped.ptr;
     block->size = unmapped.size;
     block->mapped = false;
-    block->history.reset();
-    block->history_last = nullptr;
 
     try_merge_blocks(block, block->prev, *block->pool);
     try_merge_blocks(block, block->next, *block->pool);
@@ -2919,7 +2870,7 @@ class DeviceCachingAllocator {
           int64_t(unmapped.ptr),
           unmapped.size,
           block->stream,
-          block->history ? block->history->h.context : nullptr);
+          nullptr);
     }
   }
   void release_blocks(BlockPool& pool) {

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -109,7 +109,8 @@ struct BlockInfo {
   int32_t gc_counter = 0;
   bool allocated = false;
   bool active = false;
-  std::shared_ptr<GatheredContext> context_when_allocated; // per-watcher context
+  std::shared_ptr<GatheredContext>
+      context_when_allocated; // per-watcher context
 };
 
 // Struct containing info of a memory segment (i.e. one contiguous cudaMalloc).

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -101,12 +101,6 @@ struct DeviceStats {
 
 typedef std::shared_ptr<GatheredContext> (*CreateContextFn)(void);
 
-struct History {
-  void* addr;
-  size_t real_size; // unrounded, actually requested size
-  std::shared_ptr<GatheredContext> context; // per-watcher context
-};
-
 // Struct containing info of an allocation block (i.e. a fractional part of a
 // cudaMalloc)..
 struct BlockInfo {
@@ -115,7 +109,7 @@ struct BlockInfo {
   int32_t gc_counter = 0;
   bool allocated = false;
   bool active = false;
-  std::vector<History> history;
+  std::shared_ptr<GatheredContext> context_when_allocated; // per-watcher context
 };
 
 // Struct containing info of a memory segment (i.e. one contiguous cudaMalloc).
@@ -123,7 +117,7 @@ struct SegmentInfo {
   int64_t device = 0;
   int64_t address = 0;
   int64_t total_size = 0;
-  int64_t requested_size = 0;
+  int64_t requested_size = 0; // unrounded, actually requested size
   int64_t allocated_size = 0;
   int64_t active_size = 0;
   cudaStream_t stream = 0;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3301,11 +3301,9 @@ class TestCudaMallocAsync(TestCase):
             found_it = False
             for seg in ss['segments']:
                 for b in seg['blocks']:
-                    if 'history' in b:
-                        for h in b['history']:
-                            if h['real_size'] == 311 * 411 * 4:
-                                self.assertTrue('test_cuda' in h['frames'][0]['filename'])
-                                found_it = True
+                    if b['requested_size'] == 311 * 411 * 4:
+                        self.assertTrue('test_cuda' in b['frames'][0]['filename'])
+                        found_it = True
             self.assertTrue(found_it)
 
             if not IS_WINDOWS:
@@ -3343,11 +3341,9 @@ class TestCudaMallocAsync(TestCase):
             found_it = False
             for seg in ss:
                 for b in seg['blocks']:
-                    if 'history' in b:
-                        for h in b['history']:
-                            if h['real_size'] == 311 * 411 * 4:
-                                self.assertTrue('::rand' in str(h['frames']))
-                                found_it = True
+                    if b['requested_size'] == 311 * 411 * 4:
+                        self.assertTrue('::rand' in str(b['frames']))
+                        found_it = True
             self.assertTrue(found_it)
 
         finally:
@@ -3450,11 +3446,9 @@ class TestCudaMallocAsync(TestCase):
             found_it = False
             for seg in ss:
                 for b in seg['blocks']:
-                    if 'history' in b:
-                        for h in b['history']:
-                            if h['real_size'] == 311 * 411 * 4:
-                                self.assertTrue(h['frames'][0]['name'] == 'foo')
-                                found_it = True
+                    if b['requested_size'] == 311 * 411 * 4:
+                        self.assertTrue(b['frames'][0]['name'] == 'foo')
+                        found_it = True
             self.assertTrue(found_it)
 
         finally:
@@ -3578,11 +3572,10 @@ class TestCudaMallocAsync(TestCase):
                 found = False
                 for s in mem['segments']:
                     for b in s['blocks']:
-                        if b['state'] == 'active_allocated' and 'history' in b:
-                            history = b['history']
-                            if history and history[0]['real_size'] == 311 * 411 * 4:
+                        if b['state'] == 'active_allocated':
+                            if b['requested_size'] == 311 * 411 * 4:
                                 if ctx:
-                                    frame_text = str(history[0]['frames'])
+                                    frame_text = str(b['frames'])
                                     # C++ frame
                                     self.assertTrue('::rand' in frame_text)
                                     # script frame

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1545,10 +1545,10 @@ def get_block_addrs(pool_id, live_only=True):
     return blocks
 
 
-def format_tb(caching_allocator_trace):
+def format_tb(frames):
     formatted_traceback = []
 
-    for entry in caching_allocator_trace["frames"]:
+    for entry in frames:
         formatted_traceback.append(
             traceback.FrameSummary(entry["filename"], entry["line"], entry["name"])
         )
@@ -1594,9 +1594,7 @@ def check_memory_pool(device, pool_id, live_storages_ptrs: List[StorageWeakRefWr
     if allocated_not_in_live_storages != 0:
         formatted = []
         for dp, block in allocated_not_in_live_storages.items():
-            trace = (
-                format_tb(block["history"][-1]) if block.get("history", None) else None
-            )
+            trace = format_tb(block.get("frames", []))
             formatted.append(f"Data Pointer: {dp}, history: \n{trace}")
         formatted_s = "\n".join(formatted)
         msg = (

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -633,7 +633,6 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
 
   using c10::cuda::CUDACachingAllocator::BlockInfo;
-  using c10::cuda::CUDACachingAllocator::History;
   using c10::cuda::CUDACachingAllocator::SegmentInfo;
 
   py::str device_s = "device";
@@ -653,11 +652,10 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   py::str active_pending_free_s = "active_pending_free";
   py::str inactive_s = "inactive";
   py::str addr_s = "addr";
-  py::str real_size_s = "real_size";
   py::str cpp_frames_s = "cpp_frames";
-  py::str history_s = "history";
   py::str blocks_s = "blocks";
   py::str is_expandable_s = "is_expandable";
+  py::str frames_s = "frames";
 
   std::vector<CapturedTraceback*> to_gather_frames;
   std::vector<py::dict> to_gather_dest;
@@ -686,20 +684,11 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
           (blockInfo.allocated
                ? active_allocated_s
                : (blockInfo.active ? active_pending_free_s : inactive_s));
-      if (blockInfo.history.size()) {
-        py::list history;
-        for (const History& h : blockInfo.history) {
-          py::dict history_entry;
-          history_entry[addr_s] = (int64_t)h.addr;
-          history_entry[real_size_s] = h.real_size;
-          if (h.context) {
-            auto sc = getFromContext(h.context);
-            to_gather_frames.emplace_back(sc);
-            to_gather_dest.emplace_back(history_entry);
-          }
-          history.append(std::move(history_entry));
-        }
-        blockDict[history_s] = std::move(history);
+      blockDict[frames_s] = py::none();
+      if (blockInfo.context_when_allocated) {
+        auto sc = getFromContext(blockInfo.context_when_allocated);
+        to_gather_frames.emplace_back(sc);
+        to_gather_dest.emplace_back(blockDict);
       }
       blocks.append(blockDict);
     }
@@ -780,7 +769,6 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   result["segments"] = segments;
   result["device_traces"] = traces;
 
-  py::str frames_s = "frames";
   auto frames = py_symbolize(to_gather_frames);
   for (auto i : c10::irange(frames.size())) {
     to_gather_dest.at(i)[frames_s] = frames.at(i);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -657,6 +657,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   py::str is_expandable_s = "is_expandable";
   py::str frames_s = "frames";
 
+  py::list empty_frames;
   std::vector<CapturedTraceback*> to_gather_frames;
   std::vector<py::dict> to_gather_dest;
 
@@ -684,11 +685,12 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
           (blockInfo.allocated
                ? active_allocated_s
                : (blockInfo.active ? active_pending_free_s : inactive_s));
-      blockDict[frames_s] = py::none();
       if (blockInfo.context_when_allocated) {
         auto sc = getFromContext(blockInfo.context_when_allocated);
         to_gather_frames.emplace_back(sc);
         to_gather_dest.emplace_back(blockDict);
+      } else {
+        blockDict[frames_s] = empty_frames;
       }
       blocks.append(blockDict);
     }

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -174,10 +174,12 @@ std::string _memory_snapshot_pickled() {
           (blockInfo.allocated
                ? active_allocated_s
                : (blockInfo.active ? active_pending_free_s : inactive_s)));
-      blockDict.insert(frames_s, IValue());
       if (blockInfo.context_when_allocated) {
-        frame_tracebacks.push_back(getFromContext(blockInfo.context_when_allocated));
+        frame_tracebacks.push_back(
+            getFromContext(blockInfo.context_when_allocated));
         frame_dict.push_back(blockDict);
+      } else {
+        blockDict.insert(frames_s, empty_frames);
       }
       blocks.push_back(blockDict);
     }
@@ -257,7 +259,7 @@ std::string _memory_snapshot_pickled() {
 
   auto frames = ivalue_symbolize(frame_tracebacks);
   for (auto i : c10::irange(frames.size())) {
-    frame_dict.at(i).insert_or_assign(frames_s, frames.at(i));
+    frame_dict.at(i).insert(frames_s, frames.at(i));
   }
 
   return write_pickle(result);

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -59,7 +59,7 @@ def _frames_fmt(frames, full_filename=False, reverse=False):
         frames = reversed(frames)
     return [_frame_fmt(f, full_filename) for f in frames if _frame_filter(f['name'], f['filename'])]
 
-def _block_extra(b):
+def _block_extra_legacy(b):
     if 'history' in b:
         frames = b['history'][0].get('frames', [])
         real_size = b['history'][0]['real_size']
@@ -67,6 +67,12 @@ def _block_extra(b):
         real_size = b.get('requested_size', b['size'])
         frames = []
     return frames, real_size
+
+def _block_extra(b):
+    if 'frames' not in b:
+        # old snapshot format made it more complicated to get frames/allocated size
+        return _block_extra_legacy(b)
+    return b['frames'], b['requested_size']
 
 def format_flamegraph(flamegraph_lines, flamegraph_script=None):
     if flamegraph_script is None:
@@ -90,23 +96,24 @@ def format_flamegraph(flamegraph_lines, flamegraph_script=None):
     return result
 
 def _write_blocks(f, prefix, blocks):
+    def frames_fragment(frames):
+        if not frames:
+            return "<non-python>"
+        return ';'.join(_frames_fmt(frames, reverse=True))
     for b in blocks:
         if 'history' not in b:
-            f.write(f'{prefix};{b["state"]} {b["size"]}\n')
-            continue
-        accounted_for_size = 0
-        for h in b['history']:
-            sz = h['real_size']
-            accounted_for_size += sz
-            if 'frames' in h:
-                frames = h['frames']
-                if frames:
-                    frame_s = ';'.join(_frames_fmt(frames, reverse=True))
+            frames, accounted_for_size = _block_extra(b)
+            f.write(f'{prefix};{b["state"]};{frames_fragment(frames)} {accounted_for_size}\n')
+        else:
+            accounted_for_size = 0
+            for h in b['history']:
+                sz = h['real_size']
+                accounted_for_size += sz
+                if 'frames' in h:
+                    frames = h['frames']
+                    f.write(f'{prefix};{b["state"]};{frames_fragment(frames)} {sz}\n')
                 else:
-                    frame_s = "<non-python>"
-                f.write(f'{prefix};{b["state"]};{frame_s} {sz}\n')
-            else:
-                f.write(f'{prefix};{b["state"]};<no-context> {sz}\n')
+                    f.write(f'{prefix};{b["state"]};<no-context> {sz}\n')
         gaps = b['size'] - accounted_for_size
         if gaps:
             f.write(f'{prefix};{b["state"]};<gaps> {gaps}\n')
@@ -218,19 +225,12 @@ def segsum(data):
         boffset = 0
         for b in seg['blocks']:
             active = b['state'] == 'active_allocated'
-            if 'history' in b:
-                # use the more accurate real_size to account for internal fragmentation if we have it
-                for h in b['history']:
-                    if active:
-                        all_ranges.append((h['addr'] - seg['address'], h['real_size'], active))
-                        seg_allocated += h['real_size']
-                        assert len(b['history']) == 1
-                        seg_free_internal += b['size'] - h['real_size']
+            if active:
+                _, allocated_size = _block_extra(b)
+                all_ranges.append((boffset, allocated_size, True))
+                seg_allocated += allocated_size
+                seg_free_internal += b['size'] - allocated_size
             else:
-                if active:
-                    all_ranges.append((boffset, b['size'], True))
-                    seg_allocated += b['size']
-            if not active:
                 seg_free_external += b['size']
 
             boffset += b['size']
@@ -504,8 +504,7 @@ def _profile_to_snapshot(profile):
         for _, addr, size, frames in blocks:
             if last_addr < addr:
                 seg['blocks'].append({'size': addr - last_addr, 'state': 'inactive'})
-            seg['blocks'].append({'size': size, 'state': 'active_allocated',
-                                  'history': [{'addr': addr, 'frames': frames, 'real_size': size}]})
+            seg['blocks'].append({'size': size, 'state': 'active_allocated', 'requested_size': size, 'frames': frames})
             last_addr = addr + size
         if last_addr < seg['total_size']:
             seg['blocks'].append({'size': seg['total_size'] - last_addr, 'state': 'inactive'})

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -37,8 +37,8 @@ function Segment(addr, size, stream, frames, version) {
   return {addr, size, stream, version, frames};
 }
 
-function Block(addr, size, real_size, frames, free_requested, version) {
-  return {addr, size, real_size, frames, free_requested, version};
+function Block(addr, size, requested_size, frames, free_requested, version) {
+  return {addr, size, requested_size, frames, free_requested, version};
 }
 
 function EventSelector(outer, events, stack_info, memory_view) {
@@ -219,7 +219,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
       block_map[b.addr] = Block(
         b.addr,
         b.size,
-        b.real_size,
+        b.requested_size,
         b.frames,
         b.state === 'active_pending_free',
         b.version,
@@ -457,8 +457,8 @@ function MemoryView(outer, stack_info, snapshot, device) {
 
       for (const b of blocks) {
         b.segment = find_segment(b.addr);
-        b.segment.occupied += b.real_size;
-        b.segment.internal_free += b.size - b.real_size;
+        b.segment.occupied += b.requested_size;
+        b.segment.internal_free += b.size - b.requested_size;
       }
 
       const block_selection = block_g
@@ -468,7 +468,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
         .append('rect')
         .attr('x', x => xScale(x.segment.offset + (x.addr - x.segment.addr)))
         .attr('y', x => yScale(x.segment.row))
-        .attr('width', x => xScale(x.real_size))
+        .attr('width', x => xScale(x.requested_size))
         .attr('height', yScale(4 / 5))
         .attr('fill', (x, _i) =>
           x.free_requested
@@ -489,7 +489,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
           }
           return (
             `b${t.addr.toString(16)}_${t.version} ` +
-            `${formatSize(t.real_size)} allocation${requested} (stream ${
+            `${formatSize(t.requested_size)} allocation${requested} (stream ${
               t.segment.stream
             })\n` +
             format_frames(t.frames)
@@ -504,10 +504,10 @@ function MemoryView(outer, stack_info, snapshot, device) {
         .enter()
         .append('rect')
         .attr('x', x =>
-          xScale(x.segment.offset + (x.addr - x.segment.addr) + x.real_size),
+          xScale(x.segment.offset + (x.addr - x.segment.addr) + x.requested_size),
         )
         .attr('y', x => yScale(x.segment.row))
-        .attr('width', x => xScale(x.size - x.real_size))
+        .attr('width', x => xScale(x.size - x.requested_size))
         .attr('height', yScale(4 / 5))
         .attr('fill', (_x, _i) => 'red');
 
@@ -518,7 +518,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
           const t = d.datum();
           return (
             `Free space lost due to rounding ${formatSize(
-              t.size - t.real_size,
+              t.size - t.requested_size,
             )}` +
             ` (stream ${t.segment.stream})\n` +
             format_frames(t.frames)
@@ -528,7 +528,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
       );
 
       const reserved = segments.reduce((x, y) => x + y.size, 0);
-      const allocated = blocks.reduce((x, y) => x + y.real_size, 0);
+      const allocated = blocks.reduce((x, y) => x + y.requested_size, 0);
       return [reserved, allocated];
     },
   };
@@ -656,13 +656,18 @@ function annotate_snapshot(snapshot) {
     let addr = seg.address;
     for (const b of seg.blocks) {
       b.addr = addr;
-      if ('history' in b) {
-        b.frames = b.history[0].frames || empty_list;
-        b.real_size = b.history[0].real_size;
-      } else {
-        b.frames = empty_list;
-        b.real_size = b.requested_size || b.size;
+      if (!('frames' in b)) {
+        // legacy format where 'requested_size' may be missing
+        // and frames might be in history rather than directly on block
+        if ('history' in b) {
+          b.frames = b.history[0].frames || empty_list;
+          b.requested_size = b.requested_size || b.history[0].real_size;
+        } else {
+          b.frames = empty_list;
+          b.requested_size = b.requested_size || b.size;
+        }
       }
+
       b.version = snapshot.block_version(b.addr, false);
       addr += b.size;
     }
@@ -802,7 +807,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
           const element = {
             action: 'alloc',
             addr: b.addr,
-            size: b.real_size,
+            size: b.requested_size,
             frames: b.frames,
             stream: seg.stream,
             version: b.version,

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -667,7 +667,6 @@ function annotate_snapshot(snapshot) {
           b.requested_size = b.requested_size || b.size;
         }
       }
-
       b.version = snapshot.block_version(b.addr, false);
       addr += b.size;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106113
* __->__ #106079

For free blocks of memory in the allocator, we previously kept a linked list
of the stack frames of previous allocations that lived there. This was only
ever used in one flamegraph visualization and never proved useful at
understanding what was going on. When memory history tracing was added, it
became redundant, since we can see the history of the free space from recording
the previous actions anyway.

This patch removes this functionality and simplifies the snapshot format:
allocated blocks directly have a 'frames' attribute rather than burying stack frames in the history.
Previously the memory history tracked the real size of allocations before rounding.
Since history was added, 'requested_size' has been added directly to the block which records the same information,
so this patch also removes that redundancy.

None of this functionality has been part of a PyTorch release with BC guarentees, so it should be safe to alter
this part of the format.

This patch also updates our visualization tools to work with the simplified format. Visualization tools keep
support for the old format in `_legacy` functions so that during the transition old snapshot files can still be read.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov