### PR TITLE
[Easy] remove unneeded sort

### DIFF
--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -192,8 +192,6 @@ def freeze(
     aot_example_inputs = [example_inputs[ind] for ind in preserved_arg_indices]
     freezing_passes(aot_autograd_gm, aot_example_inputs)
 
-    # TODO - apply legalization in pattern matcher
-    torch.fx.passes.tools_common.legalize_graph(aot_autograd_gm)
     constant_fold(aot_autograd_gm)
     # invalidate nn Modules
     if config.freezing_discard_parameters:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106146
* #106098
* #106092
* #106097
* #106091
* __->__ #106090

This isn't needed now that we call stable_topological_sort in `freezing_passes`. The non-stable sort can also hurt perf. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov