### PR TITLE
[ONNX] Perform Shape inference on added "Cast" node

### DIFF
--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -27,7 +27,11 @@ Node* CreateCastToBoolNode(Value* val, Graph* graph) {
   return cast_node;
 }
 
-Node* InsertCastForCond(Value* cond_val, Graph* graph, Node* consumer_node) {
+Node* InsertCastForCond(
+    Value* cond_val,
+    Graph* graph,
+    Node* consumer_node,
+    int opset_version) {
   // prev:  cond_val -> consumer_node
   // after: cond_val -> cast -> consumer_node
   // NOTE: The cast is required because operators like PyTorch Greater/Less
@@ -37,6 +41,8 @@ Node* InsertCastForCond(Value* cond_val, Graph* graph, Node* consumer_node) {
   cast_node->insertBefore(consumer_node);
 
   consumer_node->replaceInputWith(cond_val, cast_node->output());
+  const ParamMap empty_params_dict = {};
+  ONNXShapeTypeInference(cast_node, empty_params_dict, opset_version);
   return cast_node;
 }
 
@@ -288,7 +294,7 @@ void FixupONNXLoopBlockOutputs(Node* n) {
   FixupONNXSubblockOutputs(n);
 }
 
-void FixupONNXLoopNodeInputs(Node* node) {
+void FixupONNXLoopNodeInputs(Node* node, int opset_version) {
   if (node->kind() != ::c10::onnx::Loop) {
     return;
   }
@@ -298,7 +304,7 @@ void FixupONNXLoopNodeInputs(Node* node) {
   // add cast to condition input outside the loop.
   Value* cond_val = node->input(1);
   if (IsCondCastRequired(cond_val)) {
-    auto* cast_node = InsertCastForCond(cond_val, graph, node);
+    auto* cast_node = InsertCastForCond(cond_val, graph, node, opset_version);
     cast_node->copyMetadata(node);
   }
 
@@ -314,8 +320,8 @@ void FixupONNXLoopNodeInputs(Node* node) {
   // add cast to condition input inside the loop.
   Value* next_cond_val = sub_block->outputs().at(0);
   if (IsCondCastRequired(next_cond_val)) {
-    auto* cast_node =
-        InsertCastForCond(next_cond_val, graph, sub_block->return_node());
+    auto* cast_node = InsertCastForCond(
+        next_cond_val, graph, sub_block->return_node(), opset_version);
     cast_node->copyMetadata(node);
   }
 
@@ -355,7 +361,7 @@ std::vector<Value*> FixupONNXLoopNode(Node* node, int opset_version) {
   GRAPH_DEBUG("before FixupONNXLoopBlockInputs: ", *node->owningGraph());
   FixupONNXLoopBlockInputs(node);
   GRAPH_DEBUG("after FixupONNXLoopBlockInputs: ", *node->owningGraph());
-  FixupONNXLoopNodeInputs(node);
+  FixupONNXLoopNodeInputs(node, opset_version);
   GRAPH_DEBUG("after FixupONNXLoopNodeInputs: ", *node->owningGraph());
   FixupONNXLoopBlockOutputs(node);
   GRAPH_DEBUG("after FixupONNXLoopBlockOutputs: ", *node->owningGraph());
@@ -471,10 +477,9 @@ void ONNXFixupUninitializedOutput(Node* node, int opset_version) {
   // Check if the input to ONNX If node is node Bool, and insert
   // cast to Bool if needed.
   if (!if_node->input()->type()->isSubtypeOf(*BoolType::get())) {
-    Node* cast_node = CreateCastToBoolNode(if_node->input(), graph);
-    cast_node->insertBefore(if_node);
+    Node* cast_node =
+        InsertCastForCond(if_node->input(), graph, if_node, opset_version);
     cast_node->copyMetadata(if_node);
-    if_node->replaceInputWith(if_node->input(), cast_node->output());
   }
 
   Block* then_block = if_node->blocks()[0];


### PR DESCRIPTION
This commit fixes a bug where some "If" nodes blocked shape inference during the onnx graph building.

In fixup_onnx_controlflow, a "Cast" node is added to conditions in "If" and "Loop" nodes if the condition type is not bool.

This commit performs shape inference on this new "Cast" node which allows its output to be marked as "reliable" in ConstantValueMap during further shape inference. This would have eventually happened when shape inference is performed on the entire graph, but the inferred shapes are also useful to have during onnx graph building, since it allows some ops (like Squeeze) to export into simpler subgraphs.

Also adds a test for this.
