### PR TITLE
No need to wait for pending unstable jobs when merging

### DIFF
--- a/.github/scripts/gql_mocks.json
+++ b/.github/scripts/gql_mocks.json
@@ -43588,5 +43588,1447 @@
         }
       }
     }
+  },
+  "query_sha=987321fccb8ab37e061c69e26e83543eca6f4d1c0a8f8f55d4d34df8f46009b4 name=pytorch number=105998 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "closed": true,
+          "isCrossRepository": true,
+          "author": {
+            "login": "huydhn"
+          },
+          "title": "Increase ignorable failures limit",
+          "body": "Given the number of unstable job atm (rocm, distributed), having the limit of 3 for ignorable failures is too low.  When I manually look into force merges, I could find many examples like like https://github.com/pytorch/pytorch/pull/105848 where there are 3+ unrelated failures.  As the classification is getting more accurate, we can aim to ignore all flaky and broken trunk failures.\r\n\r\n* Default `ok_failed_checks_threshold` to `-1` to ignore all unrelated failures\r\n* Increase the `IGNORABLE_FAILED_CHECKS_THESHOLD` to 10.  The only concern I have before setting it to `-1` is the fog of war situation when a sev occurs.  So 10 is a good middle ground before we agree to set it to `-1`",
+          "headRefName": "lift-broken-trunk-limit",
+          "headRepository": {
+            "nameWithOwner": "huydhn/pytorch"
+          },
+          "baseRefName": "main",
+          "baseRefOid": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+          "baseRepository": {
+            "nameWithOwner": "pytorch/pytorch",
+            "isPrivate": false,
+            "defaultBranchRef": {
+              "name": "main"
+            }
+          },
+          "mergeCommit": null,
+          "commits_with_authors": {
+            "nodes": [
+              {
+                "commit": {
+                  "author": {
+                    "user": {
+                      "login": "huydhn"
+                    },
+                    "email": "huydhn@gmail.com",
+                    "name": "Huy Do"
+                  },
+                  "oid": "17d48a09283daff95d73bf8c606be59a2db79c06"
+                }
+              },
+              {
+                "commit": {
+                  "author": {
+                    "user": {
+                      "login": "huydhn"
+                    },
+                    "email": "huydhn@gmail.com",
+                    "name": "Huy Do"
+                  },
+                  "oid": "4f4ebfa05e34b9ecfa3a908dfb703f12b1c9521b"
+                }
+              },
+              {
+                "commit": {
+                  "author": {
+                    "user": {
+                      "login": "huydhn"
+                    },
+                    "email": "huydhn@gmail.com",
+                    "name": "Huy Do"
+                  },
+                  "oid": "e0d214c31ef529bcbd53285149fcbda5de535931"
+                }
+              },
+              {
+                "commit": {
+                  "author": {
+                    "user": {
+                      "login": "huydhn"
+                    },
+                    "email": "huydhn@gmail.com",
+                    "name": "Huy Do"
+                  },
+                  "oid": "814f5d7cc32d98d39d61e042f875815b743e6b8b"
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "NA",
+              "hasNextPage": false
+            },
+            "totalCount": 4
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "checkSuites": {
+                    "edges": [
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Facebook GitHub Tools",
+                            "databaseId": 12274
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Meta Internal-Only Changes Check",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://opensource.facebook.com/",
+                                "databaseId": 15374527386,
+                                "title": "There is no internal Diff connected, this can be merged now"
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5Rkq5o=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbOKI="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Check Labels"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324473"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Check labels",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324473/job/15374528235",
+                                "databaseId": 15374528235,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5Rkrus=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbOag="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Labeler"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324474"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "triage",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324474/job/15374528238",
+                                "databaseId": 15374528238,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5Rkru4=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbOa4="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "BC Lint"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324726"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "bc_linter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324726/job/15374528819",
+                                "databaseId": 15374528819,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5RksTM=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbO-A="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "TorchBench CI (pytorch-linux-py3.8-cu116)"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324727"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "run-torchbench",
+                                "conclusion": "NEUTRAL",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324727/job/15374528851",
+                                "databaseId": 15374528851,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5RksVM=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SKIPPED"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbO-U="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "pull"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324786"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374529746",
+                                "databaseId": 15374529746,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374529954",
+                                "databaseId": 15374529954,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530220",
+                                "databaseId": 15374530220,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530451",
+                                "databaseId": 15374530451,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530749",
+                                "databaseId": 15374530749,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-mobile-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531003",
+                                "databaseId": 15374531003,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-no-ops / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531230",
+                                "databaseId": 15374531230,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531461",
+                                "databaseId": 15374531461,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531717",
+                                "databaseId": 15374531717,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531903",
+                                "databaseId": 15374531903,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-pch / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532083",
+                                "databaseId": 15374532083,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532297",
+                                "databaseId": 15374532297,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532520",
+                                "databaseId": 15374532520,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532708",
+                                "databaseId": 15374532708,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532922",
+                                "databaseId": 15374532922,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533138",
+                                "databaseId": 15374533138,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533354",
+                                "databaseId": 15374533354,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533627",
+                                "databaseId": 15374533627,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533879",
+                                "databaseId": 15374533879,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3_8-clang8-xla / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374534281",
+                                "databaseId": 15374534281,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374534554",
+                                "databaseId": 15374534554,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540072",
+                                "databaseId": 15374540072,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540299",
+                                "databaseId": 15374540299,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540467",
+                                "databaseId": 15374540467,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540704",
+                                "databaseId": 15374540704,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3_8-clang8-xla / test",
+                                "conclusion": "NEUTRAL",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374716745",
+                                "databaseId": 15374716745,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test",
+                                "conclusion": "NEUTRAL",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374757392",
+                                "databaseId": 15374757392,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374874704",
+                                "databaseId": 15374874704,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374874901",
+                                "databaseId": 15374874901,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-docs / build-docs-cpp-false",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374889716",
+                                "databaseId": 15374889716,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-docs / build-docs-python-false",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374889914",
+                                "databaseId": 15374889914,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-docs / build-docs-functorch-false",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890102",
+                                "databaseId": 15374890102,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890302",
+                                "databaseId": 15374890302,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890468",
+                                "databaseId": 15374890468,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890654",
+                                "databaseId": 15374890654,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892191",
+                                "databaseId": 15374892191,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892433",
+                                "databaseId": 15374892433,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892588",
+                                "databaseId": 15374892588,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906468",
+                                "databaseId": 15374906468,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906746",
+                                "databaseId": 15374906746,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906961",
+                                "databaseId": 15374906961,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 1, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374915743",
+                                "databaseId": 15374915743,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 2, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374915934",
+                                "databaseId": 15374915934,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 3, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916113",
+                                "databaseId": 15374916113,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 4, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916348",
+                                "databaseId": 15374916348,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 5, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916543",
+                                "databaseId": 15374916543,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.9-clang7-asan / test (default, 6, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916782",
+                                "databaseId": 15374916782,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813493",
+                                "databaseId": 15375813493,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813669",
+                                "databaseId": 15375813669,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813836",
+                                "databaseId": 15375813836,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5R4TMw=",
+                              "hasNextPage": true
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbPGQ="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Lint"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673324822"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Test `run_test.py` is usable without boto3/rockset",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529251",
+                                "databaseId": 15374529251,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (with_torch)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529595",
+                                "databaseId": 15374529595,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (without_torch)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529788",
+                                "databaseId": 15374529788,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (older_python_version)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530009",
+                                "databaseId": 15374530009,
+                                "title": null
+                              },
+                              {
+                                "name": "pr-sanity-checks",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530214",
+                                "databaseId": 15374530214,
+                                "title": null
+                              },
+                              {
+                                "name": "Test tools / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530516",
+                                "databaseId": 15374530516,
+                                "title": null
+                              },
+                              {
+                                "name": "lintrunner / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530758",
+                                "databaseId": 15374530758,
+                                "title": null
+                              },
+                              {
+                                "name": "quick-checks / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531000",
+                                "databaseId": 15374531000,
+                                "title": null
+                              },
+                              {
+                                "name": "toc / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531252",
+                                "databaseId": 15374531252,
+                                "title": null
+                              },
+                              {
+                                "name": "workflow-checks / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531498",
+                                "databaseId": 15374531498,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5Rku6o=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XbPLg="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "BC Lint"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673395725"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "bc_linter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673395725/job/15374761372",
+                                "databaseId": 15374761372,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5RoPZw=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeUWQ="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Check Labels"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673395750"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Check labels",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673395750/job/15374761407",
+                                "databaseId": 15374761407,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5RoPb8=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeUZI="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-libtorch-cxx11-abi"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673397054"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397054/job/15374765968",
+                                "databaseId": 15374765968,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397054/job/15375683471",
+                                "databaseId": 15375683471,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5R2T48=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeX9I="
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": true
+                    }
+                  },
+                  "status": {
+                    "contexts": [
+                      {
+                        "context": "EasyCLA",
+                        "state": "SUCCESS",
+                        "targetUrl": "https://easycla.lfx.linuxfoundation.org/#/?version=2"
+                      }
+                    ]
+                  },
+                  "pushedDate": null,
+                  "oid": "814f5d7cc32d98d39d61e042f875815b743e6b8b"
+                }
+              }
+            ]
+          },
+          "changedFiles": 2,
+          "files": {
+            "nodes": [
+              {
+                "path": ".github/scripts/test_trymerge.py"
+              },
+              {
+                "path": ".github/scripts/trymerge.py"
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mg",
+              "hasNextPage": false
+            }
+          },
+          "reviews": {
+            "nodes": [
+              {
+                "author": {
+                  "login": "clee2000"
+                },
+                "state": "APPROVED"
+              }
+            ],
+            "pageInfo": {
+              "startCursor": "Y3Vyc29yOnYyOpO5MjAyMy0wNy0yNlQxMzowNjoxOS0wNzowMLkyMDIzLTA3LTI2VDEzOjA2OjE5LTA3OjAwzlxMc3A=",
+              "hasPreviousPage": false
+            }
+          },
+          "comments": {
+            "nodes": [
+              {
+                "bodyText": "@pytorchbot merge",
+                "createdAt": "2023-07-26T22:53:48Z",
+                "author": {
+                  "login": "huydhn"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1652648725,
+                "url": "https://github.com/pytorch/pytorch/pull/105998#issuecomment-1652648725"
+              },
+              {
+                "bodyText": "Merge started\nYour change will be merged once all checks pass (ETA 0-4 Hours).\nLearn more about merging in the wiki.\nQuestions? Feedback? Please reach out to the PyTorch DevX TeamAdvanced Debugging\nCheck the merge workflow status\nhere",
+                "createdAt": "2023-07-26T22:57:14Z",
+                "author": {
+                  "login": "pytorchmergebot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1652651952,
+                "url": "https://github.com/pytorch/pytorch/pull/105998#issuecomment-1652651952"
+              },
+              {
+                "bodyText": "@pytorchbot merge -f 'Long queue on ROCm runner'",
+                "createdAt": "2023-07-27T00:12:20Z",
+                "author": {
+                  "login": "huydhn"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1652712262,
+                "url": "https://github.com/pytorch/pytorch/pull/105998#issuecomment-1652712262"
+              },
+              {
+                "bodyText": "The merge job was canceled. If you believe this is a mistake,then you can re trigger it through pytorch-bot.",
+                "createdAt": "2023-07-27T00:12:38Z",
+                "author": {
+                  "login": "pytorchmergebot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1652712444,
+                "url": "https://github.com/pytorch/pytorch/pull/105998#issuecomment-1652712444"
+              },
+              {
+                "bodyText": "Merge started\nYour change will be merged immediately since you used the force (-f) flag, bypassing any CI checks (ETA: 1-5 minutes).\nLearn more about merging in the wiki.\nQuestions? Feedback? Please reach out to the PyTorch DevX TeamAdvanced Debugging\nCheck the merge workflow status\nhere",
+                "createdAt": "2023-07-27T00:14:33Z",
+                "author": {
+                  "login": "pytorchmergebot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1652713888,
+                "url": "https://github.com/pytorch/pytorch/pull/105998#issuecomment-1652713888"
+              }
+            ],
+            "pageInfo": {
+              "startCursor": "Y3Vyc29yOnYyOpHOYoFrFQ==",
+              "hasPreviousPage": true
+            }
+          },
+          "labels": {
+            "edges": [
+              {
+                "node": {
+                  "name": "Merged"
+                }
+              },
+              {
+                "node": {
+                  "name": "ciflow/trunk"
+                }
+              },
+              {
+                "node": {
+                  "name": "topic: not user facing"
+                }
+              },
+              {
+                "node": {
+                  "name": "test-config/default"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "query_sha=7d01fb92d2ac98a33cbeff4e8b490a40433f3110e3bf9dd70d88bc496d846e56 cursor=Y3Vyc29yOnYyOpHPAAAAA2XeX9I= name=pytorch number=105998 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+                  "checkSuites": {
+                    "edges": [
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-libtorch-pre-cxx11"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673397059"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397059/job/15374766003",
+                                "databaseId": 15374766003,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397059/job/15375864417",
+                                "databaseId": 15375864417,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5R5EmE=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeX9s="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-manywheel"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673397081"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15374766009",
+                                "databaseId": 15374766009,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda11_8-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15374766201",
+                                "databaseId": 15374766201,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15376419065",
+                                "databaseId": 15376419065,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda11_8-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15376960244",
+                                "databaseId": 15376960244,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5SJyvQ=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeYBM="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "trunk"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5673397086"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766231",
+                                "databaseId": 15374766231,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766439",
+                                "databaseId": 15374766439,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cuda11.8-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766604",
+                                "databaseId": 15374766604,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766761",
+                                "databaseId": 15374766761,
+                                "title": null
+                              },
+                              {
+                                "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766945",
+                                "databaseId": 15374766945,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767144",
+                                "databaseId": 15374767144,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767322",
+                                "databaseId": 15374767322,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767508",
+                                "databaseId": 15374767508,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767715",
+                                "databaseId": 15374767715,
+                                "title": null
+                              },
+                              {
+                                "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374776746",
+                                "databaseId": 15374776746,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64-mps / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978239",
+                                "databaseId": 15374978239,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978503",
+                                "databaseId": 15374978503,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978711",
+                                "databaseId": 15374978711,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978868",
+                                "databaseId": 15374978868,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test",
+                                "conclusion": "NEUTRAL",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374983142",
+                                "databaseId": 15374983142,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374988990",
+                                "databaseId": 15374988990,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327588",
+                                "databaseId": 15375327588,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327803",
+                                "databaseId": 15375327803,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327972",
+                                "databaseId": 15375327972,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": null,
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349362",
+                                "databaseId": 15375349362,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": null,
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349568",
+                                "databaseId": 15375349568,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": null,
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349766",
+                                "databaseId": 15375349766,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5RxOAY=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2XeYEU="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "BC Lint"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5674494394"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "bc_linter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5674494394/job/15378134478",
+                                "databaseId": 15378134478,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5Sbtc4=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2YLbeE="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Check Labels"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5674494405"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Check labels",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5674494405/job/15378134464",
+                                "databaseId": 15378134464,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5SbtcA=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2YLbgg="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Check Labels"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5674978660"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Check labels",
+                                "conclusion": "CANCELLED",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5674978660/job/15379476818",
+                                "databaseId": 15379476818,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5SwMVI=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "CANCELLED"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2YchnA="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Check Labels"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5674978721"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Check labels",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5674978721/job/15379478535",
+                                "databaseId": 15379478535,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5SwOAc=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA2Ych0k="
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": false
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "query_sha=ada119ceda3e867b82ccea3406111b1cab554821289b906c554518aeaffdfde2 cr_cursor=Y3Vyc29yOnYyOpHPAAAAA5R4TMw= cs_cursor=Y3Vyc29yOnYyOpHPAAAAA2XbO-U= name=pytorch number=105998 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+                  "checkSuites": {
+                    "nodes": [
+                      {
+                        "checkRuns": {
+                          "nodes": [
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375814575",
+                              "databaseId": 15375814575,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375814713",
+                              "databaseId": 15375814713,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865492",
+                              "databaseId": 15375865492,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865716",
+                              "databaseId": 15375865716,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865864",
+                              "databaseId": 15375865864,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375866051",
+                              "databaseId": 15375866051,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375866246",
+                              "databaseId": 15375866246,
+                              "title": null
+                            }
+                          ],
+                          "pageInfo": {
+                            "endCursor": "Y3Vyc29yOnYyOpHPAAAAA5R5GYY=",
+                            "hasNextPage": false
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/.github/scripts/rockset_mocks.json
+++ b/.github/scripts/rockset_mocks.json
@@ -37902,5 +37902,4753 @@
       "failure_captures": null,
       "steps": 3
     }
+  ],
+  "814f5d7cc32d98d39d61e042f875815b743e6b8b e18d53e2df44bccd7231cdf3dad6ea1255221bd4": [
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15347064513,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:09:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664187156/job/15347064513",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15345999586,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:32:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758567/job/15345999586",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346007657,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:10:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346007657",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374533354,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533354",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346957460,
+      "name": "Upload test stats for 5660560685, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:03:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664143017/job/15346957460",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346955595,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:59:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664143017/job/15346955595",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346141862,
+      "name": "Upload test stats for 5658962709, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813995/job/15346141862",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347108903,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:08:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664204933/job/15347108903",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346224318,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663848305/job/15346224318",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346118489,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:05:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663805480/job/15346118489",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347094301,
+      "name": "Upload test stats for 5658630479, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:12:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664198102/job/15347094301",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100566,
+      "name": "docker-build (pytorch-linux-focal-rocm-n-1-py3)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:06:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100566",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15347064826,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:06:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664187156/job/15347064826",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346912071,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:56:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664126895/job/15346912071",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15346890546,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:54:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664119034/job/15346890546",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374906961,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:59:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906961",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 20:57:10,155] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/tz/ctzduttae3cubxdnjdop74ot7azmxk5rgwglgqkjipdsc75mq6md.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346250713,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:13:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663861108/job/15346250713",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346120741,
+      "name": "Upload test stats for 5659447626, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:08:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663805480/job/15346120741",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374766761,
+      "name": "macos-12-py3-arm64 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:34:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766761",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374540467,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:51:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540467",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374534554,
+      "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:03:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374534554",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374530451,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530451",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346876710,
+      "name": "Upload test stats for 5661455908, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:57:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664112449/job/15346876710",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346141525,
+      "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:53:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346141525",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "inductor/test_torchinductor_codegen_dynamic_shapes.py::DynamicShapesCodegenCpuTests::test_inductor_bucketize_add_autotune_dynamic_shapes_cpu"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346118376,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:05:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663805480/job/15346118376",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999626,
+      "name": "Test collect_env (older_python_version)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999626",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "You are using pip version 20.3.4, however version 23.2.1 is available."
+      ],
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374890102,
+      "name": "linux-docs / build-docs-functorch-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:38:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890102",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347101346,
+      "name": "docker-build (pytorch-linux-focal-py3-clang10-onnx)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:24:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347101346",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "BC Lint",
+      "id": 15378134478,
+      "name": "bc_linter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:59:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5674494394/job/15378134478",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346945097,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:59:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664139297/job/15346945097",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346383655,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:48:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663914806/job/15346383655",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347080171,
+      "name": "docker-build (pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7-inductor-benchmarks)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:04:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347080171",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347079784,
+      "name": "docker-build (pytorch-linux-bionic-cuda12.1-cudnn8-py3-gcc9)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:10:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347079784",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374916348,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 4, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:10:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916348",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374874901,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:59:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374874901",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000494,
+      "name": "macos-12-py3-arm64 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000494",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375349568,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+      "conclusion": null,
+      "completed_at": null,
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349568",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374978239,
+      "name": "macos-12-py3-arm64-mps / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:35:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978239",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374874704,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:49:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374874704",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100286,
+      "name": "docker-build (pytorch-linux-bionic-py3.11-clang9)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:31:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100286",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346528637,
+      "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:00:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346528637",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374531717,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:26:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531717",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15346176142,
+      "name": "try_merge_pr_105897",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663828152/job/15346176142",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: Not merging any PRs at the moment because there is a merge blocking https://github.com/pytorch/pytorch/labels/ci:%20sev issue open at: "
+      ],
+      "steps": 10
+    },
+    {
+      "workflow_name": "BC Lint",
+      "id": 15374528819,
+      "name": "bc_linter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:20:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324726/job/15374528819",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346475550,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:27:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663954962/job/15346475550",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374532083,
+      "name": "linux-focal-py3.8-gcc7-pch / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:31:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532083",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346218263,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:11:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844393/job/15346218263",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346943703,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:58:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664138653/job/15346943703",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15346819979,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:51:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664092388/job/15346819979",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347091413,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:07:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664198102/job/15347091413",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-release",
+      "id": 15345998885,
+      "name": "libtorch-cpu-shared-with-deps-release-build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:29:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758382/job/15345998885",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "sccache: error: couldn't connect to server"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374534281,
+      "name": "linux-bionic-py3_8-clang8-xla / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:24:51Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374534281",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100891,
+      "name": "docker-build (pytorch-linux-focal-py3-clang7-android-ndk-r19c)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:26:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100891",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15374765968,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:02:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397054/job/15374765968",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375327972,
+      "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:16:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327972",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "RuntimeError: state INTERNAL ASSERT FAILED at \"C:\\\\actions-runner\\\\_work\\\\pytorch\\\\pytorch\\\\aten\\\\src\\\\ATen\\\\core\\\\PythonFallbackKernel.cpp\":97, please report a bug to PyTorch. Hit PythonDispatcher dispatch key but PythonDispatcherTLS was not set"
+      ],
+      "steps": 23
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374978711,
+      "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:13:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978711",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "inductor/test_torchinductor_codegen_dynamic_shapes.py::DynamicShapesCodegenCpuTests::test_inductor_bucketize_add_autotune_dynamic_shapes_cpu"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374889716,
+      "name": "linux-docs / build-docs-cpp-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:42:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374889716",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346077722,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663789300/job/15346077722",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346215663,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844415/job/15346215663",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346169849,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:08:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663825915/job/15346169849",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15374766003,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:08:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397059/job/15374766003",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347108760,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:08:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664204933/job/15347108760",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346709855,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:07:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664044262/job/15346709855",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374531903,
+      "name": "linux-bionic-py3.11-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:32:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531903",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346215710,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844393/job/15346215710",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346236067,
+      "name": "Upload test stats for 5658350820, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:18:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663852820/job/15346236067",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346709757,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:42:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664044262/job/15346709757",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346218488,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:11:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844415/job/15346218488",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15345999840,
+      "name": "manywheel-py3_8-cuda11_8-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:28:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758583/job/15345999840",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346874205,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:53:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664112449/job/15346874205",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346233268,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663852820/job/15346233268",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375349766,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+      "conclusion": null,
+      "completed_at": null,
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349766",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346363284,
+      "name": "Upload test stats for 5659912461, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663905967/job/15346363284",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346204773,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:53:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346204773",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 03:04:14,473] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/ky/ckywhqgh2obvkzouvnqilior7lck6dzxwq2rrsvkagx25mv7ujpy.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346052719,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:01:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663779202/job/15346052719",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346825042,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664094332/job/15346825042",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346334887,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-07-26T07:09:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346334887",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "inductor/test_max_autotune.py::TestDoBench::test_triton_template_with_epilogues_and_dynamic_shape"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000810,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:46:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000810",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15346000095,
+      "name": "workflow-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:00:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15346000095",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347080248,
+      "name": "docker-build (pytorch-linux-bionic-py3.8-clang9)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:31:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347080248",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374532708,
+      "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:28:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532708",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Check Labels",
+      "id": 15374761407,
+      "name": "Check labels",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:27:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673395750/job/15374761407",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346178556,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:09:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663828988/job/15346178556",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346147434,
+      "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346147434",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 14
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374530214,
+      "name": "pr-sanity-checks",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:20:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530214",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Labeler",
+      "id": 15374528238,
+      "name": "triage",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324474/job/15374528238",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822387,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_timm_dynamic, 1, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:14:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822387",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15346770683,
+      "name": "try_merge_pr_105669",
+      "conclusion": "cancelled",
+      "completed_at": "2023-07-26T08:45:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664069815/job/15346770683",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "##[error]The operation was canceled."
+      ],
+      "steps": 10
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205983,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:33:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205983",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200254,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_torchbench_cpu_accuracy, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:00:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200254",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346438836,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:25:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663938514/job/15346438836",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375866246,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:35:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375866246",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346710189,
+      "name": "Upload test stats for 5660250137, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:44:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664043314/job/15346710189",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346141741,
+      "name": "macos-12-py3-arm64-mps / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:07:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346141741",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346787150,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:32:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346787150",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346204957,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:08:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346204957",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200364,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_huggingface_dynamic_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:40:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200364",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000272,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000272",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374529788,
+      "name": "Test collect_env (without_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529788",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347003903,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:02:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664162586/job/15347003903",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15345999649,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:02:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758583/job/15345999649",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15347064744,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:34:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664187156/job/15347064744",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346980081,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T03:01:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664151336/job/15346980081",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000338,
+      "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:37:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000338",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346217922,
+      "name": "linux-docs / build-docs-python-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:32:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346217922",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346052881,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:01:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663779202/job/15346052881",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "unstable",
+      "id": 15345998830,
+      "name": "introduction",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758384/job/15345998830",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374766231,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:27:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766231",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374892191,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:22:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892191",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 21:13:53,414] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/ky/ckywhqgh2obvkzouvnqilior7lck6dzxwq2rrsvkagx25mv7ujpy.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346481821,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:28:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663957439/job/15346481821",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346178384,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:09:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663828988/job/15346178384",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346823376,
+      "name": "cuda11.8-py3.10-gcc7-sm80 / test (inductor_torchbench_smoketest_perf, 1, 1, linux.gcp.a100)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:09:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346823376",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 28
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822487,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_timm_dynamic, 2, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:17:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822487",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: query: last dimension must be contiguous"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346002134,
+      "name": "linux-focal-py3.8-gcc7-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346002134",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999964,
+      "name": "quick-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:01:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999964",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375327803,
+      "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:22:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327803",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346828040,
+      "name": "Upload test stats for 5659725235, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:52:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664094332/job/15346828040",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346316106,
+      "name": "Upload test stats for 5663839712, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:21:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663888877/job/15346316106",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205712,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:06:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205712",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346199885,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_huggingface_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:40:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346199885",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Create Release",
+      "id": 15345998826,
+      "name": "Create Release",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758386/job/15345998826",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347015379,
+      "name": "Upload test stats for 5660244416, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:06:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664165801/job/15347015379",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346684852,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:40:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034639/job/15346684852",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346383355,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663914806/job/15346383355",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375814575,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:44:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375814575",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374890654,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:04:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890654",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 21:17:15,977] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/ky/ckywhqgh2obvkzouvnqilior7lck6dzxwq2rrsvkagx25mv7ujpy.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347101015,
+      "name": "docker-build (pytorch-linux-focal-py3.8-gcc7)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:30:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347101015",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000634,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000634",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822282,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_huggingface_dynamic, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:21:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822282",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218423,
+      "name": "linux-focal-py3.8-gcc7 / test (jit_legacy, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:19:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218423",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346215546,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844415/job/15346215546",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346003185,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663760545/job/15346003185",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347079883,
+      "name": "docker-build (pytorch-linux-bionic-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:07:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347079883",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346285430,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:16:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663876383/job/15346285430",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346077949,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663789300/job/15346077949",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000083,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:47:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000083",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200145,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_cpu_accuracy, 2, 2, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:33:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200145",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15376419065,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:48:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15376419065",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346684742,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:40:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034639/job/15346684742",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999395,
+      "name": "Test collect_env (with_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:59:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999395",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "TorchBench CI (pytorch-linux-py3.8-cu116)",
+      "id": 15374528851,
+      "name": "run-torchbench",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T20:18:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324727/job/15374528851",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000216,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:19:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000216",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346839305,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:50:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664100459/job/15346839305",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346786862,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:31:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346786862",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218506,
+      "name": "linux-focal-py3.8-gcc7 / test (backwards_compat, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218506",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15347008776,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:19:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758583/job/15347008776",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374767508,
+      "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:06:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767508",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374766945,
+      "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:42:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766945",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374533627,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:37:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533627",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15346680925,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:50:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758588/job/15346680925",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346788889,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:19:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346788889",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346484711,
+      "name": "Upload test stats for 5660244415, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:31:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663957439/job/15346484711",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346430082,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663934422/job/15346430082",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346074884,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663788140/job/15346074884",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999206,
+      "name": "pr-sanity-checks",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T01:58:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999206",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374890468,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:17:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890468",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374889914,
+      "name": "linux-docs / build-docs-python-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:57:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374889914",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346915820,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:56:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664128446/job/15346915820",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346528479,
+      "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:20:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346528479",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[  FAILED  ] IOptTensorListRefTest.Unboxed_Iterate"
+      ],
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346138835,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813939/job/15346138835",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346478577,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:27:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663954962/job/15346478577",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346383519,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:23:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663914806/job/15346383519",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374540704,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:48:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540704",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374532922,
+      "name": "linux-focal-py3.9-clang7-asan / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:32:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532922",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374530220,
+      "name": "linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:31:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530220",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15346570602,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:42:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758567/job/15346570602",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "undefined reference to `c10::detail::torchInternalAssertFail(char const*, char const*, unsigned int, char const*, std::string const&)'"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822036,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_timm, 1, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:06:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822036",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346685135,
+      "name": "Upload test stats for 5659117465, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:44:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034115/job/15346685135",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346002260,
+      "name": "linux-focal-py3.8-gcc7-pch / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346002260",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374988990,
+      "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:51:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374988990",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 14
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100784,
+      "name": "docker-build (pytorch-linux-jammy-cuda11.8-cudnn8-py3.8-clang12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:34:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100784",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374757392,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T20:26:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374757392",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346334994,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-07-26T07:00:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346334994",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: test_unary_ufuncs 1/1 failed"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346313339,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:18:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663888877/job/15346313339",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346193605,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:26:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346193605",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999519,
+      "name": "Test collect_env (without_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999519",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346282877,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:16:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663876383/job/15346282877",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346914016,
+      "name": "Upload test stats for 5661608540, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:00:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664126895/job/15346914016",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346788959,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:23:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346788959",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346230909,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 5, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:41:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346230909",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218002,
+      "name": "linux-docs / build-docs-functorch-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:17:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218002",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347091312,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:07:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664198102/job/15347091312",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15346000418,
+      "name": "toc / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:00:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15346000418",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374978503,
+      "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:19:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978503",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346172564,
+      "name": "Upload test stats for 5663773685, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663825915/job/15346172564",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374915934,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 2, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:33:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374915934",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374533138,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:08:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533138",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346976656,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:01:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664151336/job/15346976656",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822557,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_torchbench_dynamic, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:45:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822557",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346143228,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:06:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663814650/job/15346143228",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346002000,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:30:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346002000",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-release",
+      "id": 15346511315,
+      "name": "libtorch-cpu-shared-with-deps-release-test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:33:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758382/job/15346511315",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346243095,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:13:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663857648/job/15346243095",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374906468,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:24:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906468",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 20:55:32,534] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/o3/co36ka2whgqumc63fbkwwty3yrpvpo2d66hzrrjrse4f34zvidy4.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346915923,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:56:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664128446/job/15346915923",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205481,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:00:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205481",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 02:51:20,384] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/o3/co36ka2whgqumc63fbkwwty3yrpvpo2d66hzrrjrse4f34zvidy4.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346139902,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:06:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663812968/job/15346139902",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374767715,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:48:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767715",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346945151,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:59:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664139297/job/15346945151",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-debug",
+      "id": 15346815615,
+      "name": "libtorch-cpu-shared-with-deps-debug-test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:53:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758388/job/15346815615",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "An error occurred while attempting to read the response stream"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346215585,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663844393/job/15346215585",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346943630,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:58:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664138653/job/15346943630",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346313508,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:18:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663888877/job/15346313508",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346829824,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664096690/job/15346829824",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346140306,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663814650/job/15346140306",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346709671,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:44:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664044262/job/15346709671",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346245353,
+      "name": "Upload test stats for 5663809912, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:16:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663857648/job/15346245353",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375865864,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:37:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865864",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374540072,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:02:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540072",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374532297,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:06:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532297",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346182674,
+      "name": "Upload test stats for 5659503163, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663828988/job/15346182674",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346360063,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:20:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663905967/job/15346360063",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346141995,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:06:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813939/job/15346141995",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000974,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000974",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374767144,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:48:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767144",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347011623,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:03:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664165801/job/15347011623",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346947067,
+      "name": "Upload test stats for 5661471752, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:03:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664139297/job/15346947067",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15346782349,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:47:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664075046/job/15346782349",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374916113,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 3, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:00:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916113",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374530749,
+      "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:27:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374530749",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346724315,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:42:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664049679/job/15346724315",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346233396,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663852820/job/15346233396",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346080260,
+      "name": "Upload test stats for 5661142566, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:07:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663789300/job/15346080260",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Close stale pull requests",
+      "id": 15346000620,
+      "name": "stale",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663759308/job/15346000620",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346833653,
+      "name": "Upload test stats for 5659425288, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:53:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664096690/job/15346833653",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346786979,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:19:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346786979",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346231003,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 6, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:49:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346231003",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15345999639,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15345999639",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346709947,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:41:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664044262/job/15346709947",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374716745,
+      "name": "linux-bionic-py3_8-clang8-xla / test",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T20:24:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374716745",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374529954,
+      "name": "linux-bionic-py3.8-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:31:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374529954",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347147151,
+      "name": "Upload test stats for 5659270916, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:15:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664220081/job/15347147151",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346955687,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:59:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664143017/job/15346955687",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346874274,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:53:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664112449/job/15346874274",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346917824,
+      "name": "Upload test stats for 5659983856, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:59:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664128446/job/15346917824",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346724407,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:42:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664049679/job/15346724407",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346007266,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:28:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346007266",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374766439,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:15:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766439",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346825140,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664094332/job/15346825140",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346707050,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:41:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664043314/job/15346707050",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346208281,
+      "name": "Upload test stats for 5659699866, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:14:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663840003/job/15346208281",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15375683471,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:12:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397054/job/15375683471",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "undefined reference to `c10::detail::torchInternalAssertFail(char const*, char const*, unsigned int, char const*, std::string const&)'"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346912168,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:56:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664126895/job/15346912168",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15345999921,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:30:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15345999921",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374530758,
+      "name": "lintrunner / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:32:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530758",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999041,
+      "name": "Test `run_test.py` is usable without boto3/rockset",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999041",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347144337,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:10:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664220081/job/15347144337",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100452,
+      "name": "docker-build (pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:07:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100452",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375813836,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:45:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813836",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374890302,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:18:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374890302",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 20:59:42,160] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/yd/cydrqybhxjo43gaxzuq7tlpahczxb7lk3r6bnmgoi6qlsgaoumiq.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346141406,
+      "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:50:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346141406",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346475694,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:27:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663954962/job/15346475694",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346839184,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:50:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664100459/job/15346839184",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374531498,
+      "name": "workflow-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:21:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531498",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374916782,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 6, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:24:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916782",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15347039025,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:06:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664176591/job/15347039025",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346946010,
+      "name": "Upload test stats for 5661464158, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:02:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664138653/job/15346946010",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346528784,
+      "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:57:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346528784",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "ossf-scorecard",
+      "id": 15345998719,
+      "name": "Scorecards analysis",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T01:58:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758385/job/15345998719",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375327588,
+      "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:26:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375327588",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[  FAILED  ] IOptTensorListRefTest.Unboxed_Iterate"
+      ],
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346682929,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:39:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034115/job/15346682929",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15346512461,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:32:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663970174/job/15346512461",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346008760,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:23:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346008760",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374906746,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:08:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374906746",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 21:03:17,930] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/jm/cjmeu74nve4mqwstenawlhj4qgxnl6k5x255tbftvgwem2mq3j47.cpp:38:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347168551,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:12:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664229803/job/15347168551",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-debug",
+      "id": 15345998880,
+      "name": "libtorch-cpu-shared-with-deps-debug-build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:48:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758388/job/15345998880",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "sccache: error: couldn't connect to server"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347112294,
+      "name": "Upload test stats for 5661377466, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:13:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664204933/job/15347112294",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346976774,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:01:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664151336/job/15346976774",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346141612,
+      "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:46:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346141612",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346787067,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:17:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346787067",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346136776,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663812968/job/15346136776",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15345999757,
+      "name": "linux-focal-rocm5.6-py3.8",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T01:58:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15345999757",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15346688534,
+      "name": "try_merge_pr_105142",
+      "conclusion": "cancelled",
+      "completed_at": "2023-07-26T08:40:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664036168/job/15346688534",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "##[error]The operation was canceled."
+      ],
+      "steps": 10
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346438715,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:25:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663938514/job/15346438715",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15346383770,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:22:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663914806/job/15346383770",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374532520,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:40:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374532520",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347101478,
+      "name": "docker-build (pytorch-linux-focal-linter)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:16:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347101478",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346227603,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:12:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663848305/job/15346227603",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218194,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:51:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218194",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 03:12:09,488] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/mb/cmbwohvwkbux46s4fqqjwrzaqv6nywzz5pc65n6nk3vr3uzleybx.cpp:38:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347006983,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T03:02:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664162586/job/15347006983",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346003331,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:59:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663760545/job/15346003331",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347170960,
+      "name": "Upload test stats for 5661277183, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:16:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664229803/job/15347170960",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347101146,
+      "name": "docker-build (pytorch-linux-focal-py3.8-gcc7-inductor-benchmarks)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:31:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347101146",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347079987,
+      "name": "docker-build (pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc9)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:07:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347079987",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346282748,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:16:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663876383/job/15346282748",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375865716,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:43:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865716",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "test_jit.py::TestModels::test_super_resolution_cuda"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374531461,
+      "name": "linux-focal-py3.8-clang10-onnx / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:30:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531461",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346481718,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:28:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663957439/job/15346481718",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346000944,
+      "name": "win-vs2019-cuda11.8-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:52:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346000944",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15345999766,
+      "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15345999766",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346217833,
+      "name": "linux-docs / build-docs-cpp-false",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:21:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346217833",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15347408482,
+      "name": "manywheel-py3_8-cuda11_8-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:45:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758583/job/15347408482",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346169980,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:08:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663825915/job/15346169980",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374892588,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:08:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892588",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346726720,
+      "name": "Upload test stats for 5659912488, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:45:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664049679/job/15346726720",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346254385,
+      "name": "Upload test stats for 5659116577, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:18:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663861108/job/15346254385",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346224471,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663848305/job/15346224471",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346230785,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 3, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:43:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346230785",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001343,
+      "name": "linux-focal-py3-clang7-mobile-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:07:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001343",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347011800,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:03:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664165801/job/15347011800",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Close stale pull requests",
+      "id": 15346702533,
+      "name": "stale",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:41:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664041228/job/15346702533",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346006551,
+      "name": "Upload test stats for 5663758384, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663760545/job/15346006551",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347168420,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:12:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664229803/job/15347168420",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347144439,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:10:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664220081/job/15347144439",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Check Labels",
+      "id": 15379478535,
+      "name": "Check labels",
+      "conclusion": "success",
+      "completed_at": "2023-07-27T00:15:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5674978721/job/15379478535",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346789018,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:01:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346789018",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15346334760,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T07:27:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758570/job/15346334760",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15346581798,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:34:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663994620/job/15346581798",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346254002,
+      "name": "linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:22:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346254002",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'torch.version'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346441632,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:25:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663938514/job/15346441632",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15346000265,
+      "name": "Test tools / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:01:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15346000265",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346250852,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:13:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663861108/job/15346250852",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375814713,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:52:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375814713",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822641,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_distributed, 1, 1, linux.g5.12xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:01:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822641",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822201,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_torchbench, 1, 1, linux.g5.4xlarge.nvidia.gpu, unstable)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:59:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822201",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001104,
+      "name": "linux-focal-py3.8-clang10-onnx / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001104",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15347004035,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:02:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664162586/job/15347004035",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375813493,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:57:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813493",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Check Labels",
+      "id": 15378134464,
+      "name": "Check labels",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:57:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5674494405/job/15378134464",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374529595,
+      "name": "Test collect_env (with_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:19:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529595",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205785,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:51:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205785",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205203,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:33:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205203",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374983142,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T20:34:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374983142",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374531230,
+      "name": "linux-focal-py3.8-gcc7-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:31:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531230",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346707205,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:41:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664043314/job/15346707205",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346138917,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813995/job/15346138917",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346077190,
+      "name": "Upload test stats for 5659725232, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:05:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663788140/job/15346077190",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15375349362,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+      "conclusion": null,
+      "completed_at": null,
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15375349362",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15347064639,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:07:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664187156/job/15347064639",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374531003,
+      "name": "linux-focal-py3-clang7-mobile-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:27:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374531003",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200629,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_dynamic_cpu_accuracy, 2, 2, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:33:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200629",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346193717,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:34:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346193717",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374776746,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:41:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374776746",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374531000,
+      "name": "quick-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:21:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531000",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374529251,
+      "name": "Test `run_test.py` is usable without boto3/rockset",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:19:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374529251",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374766604,
+      "name": "win-vs2019-cuda11.8-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:06:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374766604",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374529746,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374529746",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Check Labels",
+      "id": 15374528235,
+      "name": "Check labels",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324473/job/15374528235",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15375864417,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:20:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397059/job/15375864417",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347101234,
+      "name": "docker-build (pytorch-linux-focal-py3-clang7-asan)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:31:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347101234",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346205467,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663840003/job/15346205467",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15345999603,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:39:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758588/job/15345999603",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346007135,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:11:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346007135",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15345999825,
+      "name": "lintrunner / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:09:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758453/job/15345999825",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374892433,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:10:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374892433",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 21:00:23,685] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/yd/cydrqybhxjo43gaxzuq7tlpahczxb7lk3r6bnmgoi6qlsgaoumiq.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218333,
+      "name": "linux-focal-py3.8-gcc7 / test (docs_test, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:18:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218333",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346689383,
+      "name": "Upload test stats for 5662314422, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:44:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034639/job/15346689383",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374978868,
+      "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:19:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374978868",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "[2023-07-26 20:48:44,701] torch._dynamo.convert_frame: [WARNING] /var/folders/xq/_s_zr8fx7879r5bx0nqtqzsh0000gn/T/torchinductor_ec2-user/w5/cw5e4hbah532ofboqxcg4iazaicv66odyiiproutv2nbgkfhup26.cpp:25:17: error: no matching function for call to 'atomic_add'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15374767322,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:34:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397086/job/15374767322",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347080072,
+      "name": "docker-build (pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:07:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347080072",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15346280286,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:16:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663874824/job/15346280286",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346138797,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813995/job/15346138797",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375866051,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:30:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375866051",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "RuntimeError: This choice caller will always throw"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374916543,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 5, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:06:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374916543",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346822128,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_timm, 2, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:08:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346822128",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: query: last dimension must be contiguous"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346243007,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:13:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663857648/job/15346243007",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374915743,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 1, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:14:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374915743",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374530516,
+      "name": "Test tools / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:21:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530516",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346360226,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:20:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663905967/job/15346360226",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200480,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_dynamic_cpu_accuracy, 1, 2, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:31:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200480",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375865492,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:48:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375865492",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374540299,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:40:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374540299",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15374533879,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:18:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15374533879",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "docker-builds",
+      "id": 15347100672,
+      "name": "docker-build (pytorch-linux-focal-rocm-n-py3)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:11:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664193359/job/15347100672",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 11
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346821830,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T05:14:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346821830",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346140435,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663814650/job/15346140435",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15375813669,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:53:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324786/job/15375813669",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346205573,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663840003/job/15346205573",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374530009,
+      "name": "Test collect_env (older_python_version)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:19:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374530009",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "You are using pip version 20.3.4, however version 23.2.1 is available."
+      ],
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346682852,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:39:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664034115/job/15346682852",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15345999985,
+      "name": "cuda11.8-py3.10-gcc7-sm80 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15345999985",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346787231,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:19:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346787231",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346230839,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 4, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:46:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346230839",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000864,
+      "name": "linux-bionic-py3_8-clang8-xla / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:13:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000864",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205058,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:56:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205058",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346060523,
+      "name": "Upload test stats for 5659508586, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:05:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663779202/job/15346060523",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15374766201,
+      "name": "manywheel-py3_8-cuda11_8-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:57:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15374766201",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346074797,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:02:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663788140/job/15346074797",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "BC Lint",
+      "id": 15374761372,
+      "name": "bc_linter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:29:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673395725/job/15374761372",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15374531252,
+      "name": "toc / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T20:21:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673324822/job/15374531252",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346007362,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:20:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346007362",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15345999981,
+      "name": "linux-bionic-py3.8-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15345999981",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346230659,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 1, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:10:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346230659",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218101,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:12:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218101",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 02:57:49,643] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/yd/cydrqybhxjo43gaxzuq7tlpahczxb7lk3r6bnmgoi6qlsgaoumiq.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346204708,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:57:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346204708",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346204867,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:46:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346204867",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 03:00:54,156] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/yd/cydrqybhxjo43gaxzuq7tlpahczxb7lk3r6bnmgoi6qlsgaoumiq.cpp:17:58: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000120,
+      "name": "linux-bionic-py3.11-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:10:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000120",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15374766009,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T21:31:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15374766009",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346429957,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:24:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663934422/job/15346429957",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218589,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:26:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218589",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "RuntimeError: simulation"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218691,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:16:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218691",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "AttributeError: Can't get attribute 'foo_add' on <module 'torch.testing._internal.distributed.rpc.rpc_test' from '/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/testing/_internal/distributed/rpc/rpc_test.py'> Default RPC pickler does not serialize"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200743,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_torchbench_dynamic_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:58:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200743",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346136893,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663812968/job/15346136893",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000732,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000732",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205133,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:32:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205133",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346143021,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:06:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346143021",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001588,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001588",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15345999845,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15345999845",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346829956,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:49:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664096690/job/15346829956",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346433344,
+      "name": "Upload test stats for 5661186759, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:28:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663934422/job/15346433344",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346230729,
+      "name": "linux-focal-py3.9-clang7-asan / test (default, 2, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:12:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346230729",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205564,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:42:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205564",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001731,
+      "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:42:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001731",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001461,
+      "name": "linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:11:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001461",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001251,
+      "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:07:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001251",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15346906754,
+      "name": "try_merge_pr_105939",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:12:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664124817/job/15346906754",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 10
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346002545,
+      "name": "linux-focal-py3.9-clang7-asan / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:12:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346002545",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000441,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:46:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000441",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205639,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:45:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205639",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 02:53:27,791] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/tz/ctzduttae3cubxdnjdop74ot7azmxk5rgwglgqkjipdsc75mq6md.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346000590,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:05:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346000590",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15376960244,
+      "name": "manywheel-py3_8-cuda11_8-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T22:14:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5673397081/job/15376960244",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346821936,
+      "name": "cuda11.8-py3.10-gcc7-sm86 / test (inductor_huggingface, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T04:24:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346821936",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346218258,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:47:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346218258",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": [
+        "[2023-07-26 02:56:10,041] torch._dynamo.convert_frame: [WARNING] /tmp/torchinductor_jenkins/ky/ckywhqgh2obvkzouvnqilior7lck6dzxwq2rrsvkagx25mv7ujpy.cpp:25:78: error: no matching function for call to \u2018atomic_add(half*, float&)\u2019"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15346200031,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_cpu_accuracy, 1, 2, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:31:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758571/job/15346200031",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346001837,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T01:58:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346001837",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Check Labels",
+      "id": 15379476818,
+      "name": "Check labels",
+      "conclusion": "cancelled",
+      "completed_at": "2023-07-27T00:14:51Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5674978660/job/15379476818",
+      "head_sha": "814f5d7cc32d98d39d61e042f875815b743e6b8b",
+      "failure_captures": [
+        "A task was canceled."
+      ],
+      "steps": 1
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346002403,
+      "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:08:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346002403",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346787311,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:58:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346787311",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346205862,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T03:29:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346205862",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346842192,
+      "name": "Upload test stats for 5661119094, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:54:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5664100459/job/15346842192",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15346138684,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-07-26T02:06:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663813939/job/15346138684",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15346125493,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test",
+      "conclusion": "skipped",
+      "completed_at": "2023-07-26T02:05:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5663758576/job/15346125493",
+      "head_sha": "e18d53e2df44bccd7231cdf3dad6ea1255221bd4",
+      "failure_captures": null,
+      "steps": 0
+    }
   ]
 }

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -702,6 +702,18 @@ class TestBypassFailures(TestCase):
         self.assertTrue(len(pending) == 0)
         self.assertTrue(len(failed) == 0)
 
+    def test_get_classifications_pending_unstable(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 105998)
+        checks = pr.get_checkrun_conclusions()
+        checks = get_classifications(
+            checks, pr.last_commit()["oid"], pr.get_merge_base(), [], []
+        )
+        pending, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=1
+        )
+        self.assertTrue(len(pending) == 0)
+        self.assertTrue(len(failed) == 0)
+
     def test_get_classifications_broken_trunk(self, *args: Any) -> None:
         # The mock merge base is the actual value returned by gh_fetch_merge_base
         test_cases = [

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1762,7 +1762,10 @@ def categorize_checks(
         classification = check_runs[checkname].classification
         job_id = check_runs[checkname].job_id
 
-        if status is None:
+        if status is None and classification != "UNSTABLE":
+            # NB: No need to wait if the job classification is unstable as it would be
+            # ignored anyway. This is useful to not need to wait for scarce resources
+            # like ROCm, which is also frequently in unstable mode
             pending_checks.append((checkname, url, job_id))
         elif not is_passing_status(check_runs[checkname].status):
             if classification == "IGNORE_CURRENT_CHECK":


### PR DESCRIPTION
No need to wait if the job classification is unstable as it would be ignored anyway. This is useful to not need to wait for scarce resources like ROCm, which is also frequently in unstable mode (There is a ROCm queue atm)

cc @albanD