### PR TITLE
Hack FSDP to work with CPU training

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -28,7 +28,7 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.distributed.optim import _apply_optimizer_in_backward
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu, skip_if_win32
 from torch.testing._internal.common_fsdp import (
     _assert_module_states,
     CUDAInitMode,
@@ -397,6 +397,16 @@ class TestFSDPMiscMultiProcess(FSDPTest):
                     fsdp_overlap_prev_params = [
                         (n, p.clone()) for n, p in fsdp_overlap.named_parameters()
                     ]
+
+    @skip_if_lt_x_gpu(2)
+    def test_fsdp_cpu_training(self):
+        """Tests FSDP training on CPU."""
+        torch.manual_seed(0)
+        model = MyModel()
+        gloo_pg = dist.new_group(backend="gloo")
+        fsdp = FSDP(model, auto_wrap_policy=always_wrap_policy, process_group=gloo_pg, device_id=torch.device("cpu"))
+        inp = torch.randn(2, 2)
+        fsdp(inp, inp).sum().backward()
 
     @skip_if_lt_x_gpu(2)
     def test_fsdp_cpu_init_stays_on_cpu(self):

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -34,6 +34,7 @@ def is_available() -> bool:
     """
     return True
 
+
 def synchronize(device: _device_t = None) -> None:
     r"""Waits for all kernels in all streams on the CPU device to complete.
 
@@ -48,7 +49,24 @@ class Stream:
     """
     N.B. This class only exists to facilitate device-agnostic code
     """
-    pass
+    def wait_stream(self, stream) -> None:
+        r""" TODO: doc"""
+        pass
+
+class Event:
+    def query(self) -> bool:
+        return True
+
+    def record(self,stream=None):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def wait(self,stream=None):
+        pass
+
+
 
 _default_cpu_stream = Stream()
 _current_stream = _default_cpu_stream


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106099

Quick demo how FSDP on CPU can work. We need to improve the Stream
stub and add an Event stub that are noops for CPU, and fallback to collectives
that gloo does support.

To actually enable this, we may not want Gloo to fallback to allgather / reduce + scatter when using the unsupported collectives, and maybe handle this at the FSDP level instead. But that seems a little more brittle since future changes to FSDP can again use these unsupported colls directly, causing CPU training to break.

Differential Revision: [D47821700](https://our.internmc.facebook.com/intern/diff/D47821700/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10