### PR TITLE
Fix flaky test failure in test_cuda_device_memory_allocated

### DIFF
--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -945,6 +945,10 @@ class TestCudaMultiGPU(TestCase):
         self.assertEqual(gpu_tensor1[0], 1)
         self.assertEqual(gpu_tensor0[0], 2)
 
+        # cleanup after `del t`
+        gc.collect()
+        torch.cuda.empty_cache()
+
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_get_set_rng_state_all(self):
         states = torch.cuda.get_rng_state_all()

--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -1281,6 +1281,8 @@ t2.start()
 
     @unittest.skipIf(not TEST_MULTIGPU, "Test needs multiple GPUs")
     def test_cuda_device_memory_allocated(self):
+        gc.collect()
+        torch.cuda.empty_cache()
         from torch.cuda import memory_allocated
         device_count = torch.cuda.device_count()
         current_alloc = [memory_allocated(idx) for idx in range(device_count)]


### PR DESCRIPTION
Test test_cuda_device_memory_allocated behaves flaky and fails in our CI test. However, it looks like it's passed in Github CI probably because there are those pytest `--rerun` options.

The test passes if runs by itself:
```python
root@a5bc36a88b05:/opt/pytorch/pytorch# python test/test_cuda_multigpu.py -v -f -k cuda_device_memory_allocated
test_cuda_device_memory_allocated (__main__.TestCudaMultiGPU) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.116s

OK
```

The test fails if runs together with `test_caching_pinned_memory_multi_gpu`:
```python
root@a5bc36a88b05:/opt/pytorch/pytorch# python test/test_cuda_multigpu.py -v -f -k cuda_device_memory_allocated -k caching_pinned_memory
test_caching_pinned_memory_multi_gpu (__main__.TestCudaMultiGPU) ... /opt/pytorch/pytorch/test/test_cuda_multigpu.py:931: UserWarning: The torch.cuda.*DtypeTensor constructors are no longer recommended. It's best to use methods such as torch.tensor(data, dtype=*, device='cuda') to create tensors. (Triggered internally at /opt/pytorch/pytorch/torch/csrc/tensor/python_tensor.cpp:83.)
  gpu_tensor0 = torch.cuda.FloatTensor([0], device=0)
ok
test_cuda_device_memory_allocated (__main__.TestCudaMultiGPU) ... FAIL

======================================================================
FAIL: test_cuda_device_memory_allocated (__main__.TestCudaMultiGPU)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 2362, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/test/test_cuda_multigpu.py", line 1291, in test_cuda_device_memory_allocated
    self.assertGreater(memory_allocated(0), current_alloc[0])
AssertionError: 512 not greater than 512

To execute this test, run the following from the base repo dir:
     python test/test_cuda_multigpu.py -k test_cuda_device_memory_allocated

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

----------------------------------------------------------------------
Ran 2 tests in 1.054s

FAILED (failures=1)
```

This fix will ensure it doesn't fail while running along with other tests in the same test module.

Related:
- my wrongful fix in https://github.com/pytorch/pytorch/pull/105501

internal ref: /4208024