### PR TITLE
Fix test flakiness in test_sparse_triangular_solve

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2259,8 +2259,12 @@ class TestSparseCSR(TestCase):
     def test_sparse_triangular_solve(self, device, dtype):
 
         def run_test(n, k, upper, unitriangular, transpose, zero):
+            # Weird interactions with other tests can happen and cause `discontiguous strides` output be partially NaN.
+            # The cuda test passes if run by itself but may fail with flakiness if run together with the full test suite in CI.
+            # We need to clean those caches as a workaround and further investigations may be needed.
             if torch.device(device).type == 'cuda':
                 torch.cuda.empty_cache()
+
             if not unitriangular:
                 triangle_function = torch.triu if upper else torch.tril
             else:

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2259,6 +2259,8 @@ class TestSparseCSR(TestCase):
     def test_sparse_triangular_solve(self, device, dtype):
 
         def run_test(n, k, upper, unitriangular, transpose, zero):
+            if torch.device(device).type == 'cuda':
+                torch.cuda.empty_cache()
             if not unitriangular:
                 triangle_function = torch.triu if upper else torch.tril
             else:


### PR DESCRIPTION
Test test_sparse_triangular_solve_cuda_DTYPE sometimes fails with `nan` values in the output tensor. The tests only fail if run along together with the full test suite, but pass if run by itself. I think there are some flakiness in the memory management.

By running `empty_cache` before the test, the flakiness can be fully removed, and the test is fixed. It might slow down the test suites by a few seconds, but I think the time can be saved from reruns if it fails in the first few reruns.

internal ref: /4185082