### PR TITLE
[memory snapshot] track context for segments

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -208,6 +208,12 @@ struct Block {
   int gc_count{0}; // counter for prioritizing older / less useful blocks for
                    // garbage collection
   std::shared_ptr<GatheredContext> context_when_allocated;
+  // only set for the first block in the segment (when prev == null)
+  // this records the frame information when cudaMalloc was called
+  // whereas context_when_allocated records the last time we handed this
+  // memory out from our cache.
+  std::shared_ptr<GatheredContext> context_when_segment_allocated;
+
   ExpandableSegment* expandable_segment_{nullptr};
 
   Block(
@@ -1969,6 +1975,7 @@ class DeviceCachingAllocator {
       segment_info.stream = head_block->stream;
       segment_info.is_large = (!head_block->pool->is_small);
       segment_info.is_expandable = head_block->expandable_segment_;
+      segment_info.context_when_allocated = head_block->context_when_segment_allocated;
       auto mempool_id = pool_to_id.find(head_block->pool->owner_PrivatePool);
       if (mempool_id != pool_to_id.end()) {
         segment_info.owner_private_pool_id = mempool_id->second;
@@ -2292,6 +2299,9 @@ class DeviceCachingAllocator {
           mapped_range.size,
           to_map->stream,
           ctx);
+      if (!to_map->prev && !to_map->context_when_segment_allocated) {
+        to_map->context_when_segment_allocated = ctx;
+      }
     }
 
     return true;
@@ -2414,6 +2424,7 @@ class DeviceCachingAllocator {
       if (dst->prev) {
         dst->prev->next = dst;
       }
+      dst->context_when_segment_allocated = std::move(src->context_when_segment_allocated);
     } else { // [dest src]
       dst->next = src->next;
       if (dst->next) {
@@ -2688,6 +2699,7 @@ class DeviceCachingAllocator {
           p.block->size,
           p.stream(),
           ctx);
+      p.block->context_when_segment_allocated = ctx;
     }
     return true;
   }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1975,7 +1975,8 @@ class DeviceCachingAllocator {
       segment_info.stream = head_block->stream;
       segment_info.is_large = (!head_block->pool->is_small);
       segment_info.is_expandable = head_block->expandable_segment_;
-      segment_info.context_when_allocated = head_block->context_when_segment_allocated;
+      segment_info.context_when_allocated =
+          head_block->context_when_segment_allocated;
       auto mempool_id = pool_to_id.find(head_block->pool->owner_PrivatePool);
       if (mempool_id != pool_to_id.end()) {
         segment_info.owner_private_pool_id = mempool_id->second;
@@ -2424,7 +2425,8 @@ class DeviceCachingAllocator {
       if (dst->prev) {
         dst->prev->next = dst;
       }
-      dst->context_when_segment_allocated = std::move(src->context_when_segment_allocated);
+      dst->context_when_segment_allocated =
+          std::move(src->context_when_segment_allocated);
     } else { // [dest src]
       dst->next = src->next;
       if (dst->next) {

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -126,6 +126,7 @@ struct SegmentInfo {
   bool is_expandable = false;
   MempoolId_t owner_private_pool_id = {0, 0};
   std::vector<BlockInfo> blocks;
+  std::shared_ptr<GatheredContext> context_when_allocated;
 };
 
 struct AllocatorState {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3300,6 +3300,7 @@ class TestCudaMallocAsync(TestCase):
             ss = torch.cuda.memory._snapshot()
             found_it = False
             for seg in ss['segments']:
+                self.assertTrue('frames' in seg)
                 for b in seg['blocks']:
                     if b['requested_size'] == 311 * 411 * 4:
                         self.assertTrue('test_cuda' in b['frames'][0]['filename'])

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -661,6 +661,16 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   std::vector<CapturedTraceback*> to_gather_frames;
   std::vector<py::dict> to_gather_dest;
 
+  auto add_frame_key = [&](const py::dict& d, const std::shared_ptr<c10::GatheredContext> ctx) {
+    if (ctx) {
+        auto sc = getFromContext(ctx);
+        to_gather_frames.emplace_back(sc);
+        to_gather_dest.emplace_back(d);
+      } else {
+        d[frames_s] = empty_frames;
+      }
+  };
+
   const auto segmentInfoToDict = [&](const SegmentInfo& segmentInfo) {
     py::dict segmentDict;
     segmentDict[device_s] = segmentInfo.device;
@@ -675,6 +685,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
     segmentDict[segment_type_s] = (segmentInfo.is_large ? large_s : small_s);
     segmentDict[segment_pool_id] = segmentInfo.owner_private_pool_id;
     segmentDict[is_expandable_s] = segmentInfo.is_expandable;
+    add_frame_key(segmentDict, segmentInfo.context_when_allocated);
 
     py::list blocks;
     for (const auto& blockInfo : segmentInfo.blocks) {
@@ -685,13 +696,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
           (blockInfo.allocated
                ? active_allocated_s
                : (blockInfo.active ? active_pending_free_s : inactive_s));
-      if (blockInfo.context_when_allocated) {
-        auto sc = getFromContext(blockInfo.context_when_allocated);
-        to_gather_frames.emplace_back(sc);
-        to_gather_dest.emplace_back(blockDict);
-      } else {
-        blockDict[frames_s] = empty_frames;
-      }
+      add_frame_key(blockDict, blockInfo.context_when_allocated);
       blocks.append(blockDict);
     }
     segmentDict[blocks_s] = blocks;

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -661,14 +661,15 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   std::vector<CapturedTraceback*> to_gather_frames;
   std::vector<py::dict> to_gather_dest;
 
-  auto add_frame_key = [&](const py::dict& d, const std::shared_ptr<c10::GatheredContext> ctx) {
+  auto add_frame_key = [&](const py::dict& d,
+                           const std::shared_ptr<c10::GatheredContext> ctx) {
     if (ctx) {
-        auto sc = getFromContext(ctx);
-        to_gather_frames.emplace_back(sc);
-        to_gather_dest.emplace_back(d);
-      } else {
-        d[frames_s] = empty_frames;
-      }
+      auto sc = getFromContext(ctx);
+      to_gather_frames.emplace_back(sc);
+      to_gather_dest.emplace_back(d);
+    } else {
+      d[frames_s] = empty_frames;
+    }
   };
 
   const auto segmentInfoToDict = [&](const SegmentInfo& segmentInfo) {

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -148,6 +148,15 @@ std::string _memory_snapshot_pickled() {
   std::vector<CapturedTraceback*> frame_tracebacks;
   std::vector<Dict<IValue, IValue>> frame_dict;
 
+  auto add_frame_key = [&](const c10::Dict<IValue, IValue>& d, const std::shared_ptr<c10::GatheredContext> & ctx) {
+    if (ctx) {
+        frame_tracebacks.push_back(getFromContext(ctx));
+        frame_dict.push_back(d);
+      } else {
+        d.insert(frames_s, empty_frames);
+      }
+  };
+
   const auto segmentInfoToDict = [&](const SegmentInfo& segmentInfo) {
     auto segmentDict = new_dict();
     segmentDict.insert(device_s, segmentInfo.device);
@@ -164,6 +173,8 @@ std::string _memory_snapshot_pickled() {
         std::tuple<int64_t, int64_t>(segmentInfo.owner_private_pool_id));
     segmentDict.insert(is_expandable_s, segmentInfo.is_expandable);
 
+    add_frame_key(segmentDict, segmentInfo.context_when_allocated);
+
     auto blocks = new_list();
     for (const auto& blockInfo : segmentInfo.blocks) {
       auto blockDict = new_dict();
@@ -174,13 +185,8 @@ std::string _memory_snapshot_pickled() {
           (blockInfo.allocated
                ? active_allocated_s
                : (blockInfo.active ? active_pending_free_s : inactive_s)));
-      if (blockInfo.context_when_allocated) {
-        frame_tracebacks.push_back(
-            getFromContext(blockInfo.context_when_allocated));
-        frame_dict.push_back(blockDict);
-      } else {
-        blockDict.insert(frames_s, empty_frames);
-      }
+      add_frame_key(blockDict, blockInfo.context_when_allocated);
+
       blocks.push_back(blockDict);
     }
     segmentDict.insert(blocks_s, blocks);

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -148,13 +148,14 @@ std::string _memory_snapshot_pickled() {
   std::vector<CapturedTraceback*> frame_tracebacks;
   std::vector<Dict<IValue, IValue>> frame_dict;
 
-  auto add_frame_key = [&](const c10::Dict<IValue, IValue>& d, const std::shared_ptr<c10::GatheredContext> & ctx) {
+  auto add_frame_key = [&](const c10::Dict<IValue, IValue>& d,
+                           const std::shared_ptr<c10::GatheredContext>& ctx) {
     if (ctx) {
-        frame_tracebacks.push_back(getFromContext(ctx));
-        frame_dict.push_back(d);
-      } else {
-        d.insert(frames_s, empty_frames);
-      }
+      frame_tracebacks.push_back(getFromContext(ctx));
+      frame_dict.push_back(d);
+    } else {
+      d.insert(frames_s, empty_frames);
+    }
   };
 
   const auto segmentInfoToDict = [&](const SegmentInfo& segmentInfo) {

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -210,7 +210,7 @@ function MemoryView(outer, stack_info, snapshot, device) {
       continue;
     }
     sorted_segments.push(
-      Segment(seg.address, seg.total_size, seg.stream, [], seg.version),
+      Segment(seg.address, seg.total_size, seg.stream, seg.frames || [], seg.version),
     );
     for (const b of seg.blocks) {
       if (b.state !== 'active_pending_free' && b.state !== 'active_allocated') {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106113
* #106079

We want to display the stack for the original cudaMalloc that created a segment.
Previously we could only report the last time the segment memory was used,
or the record of the segment_alloc could appear in the list of allocator actions.
This PR ensure regardless of whether we still have the segment_alloc action,
the context for a segment is still available. The visualizer is updated to
be able to incorporate this information.

This PR adds a new field to Block. However the previous stacked cleanup PR
 removed a field of the same size, making the change to Block size-neutral.