### PR TITLE
Removal of Object Check in CUDAPluggableAllocator::raw_delete()

### DIFF
--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -132,9 +132,6 @@ void CUDAPluggableAllocator::raw_delete(void* ptr) {
   size_t size;
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
-    TORCH_CHECK(
-        allocation_metadata_.count(ptr),
-        "Trying to free a pointer not allocated here");
     _AllocationMetadata& metadata = allocation_metadata_[ptr];
     size = metadata.size;
     device_idx = metadata.device_idx;


### PR DESCRIPTION
I've observed that the current sanity check is designed to prevent the deallocation of an illegal address and ensure the correctness of subsequent size and device information. The allocation_metadata_ is an unordered_map, indicating that a unique address can only correspond to a unique active object.

However, if users employ custom allocators based on a priori knowledge or profiling-based strategies, combined with Python's irregular garbage collection, it's plausible for multiple active objects to possess the same address. This doesn't necessarily lead to actual conflicts, but rather is due to Python not deallocating them in time.

In light of this situation, I would like to propose a consideration to possibly remove or at least downgrade this mandatory check to a mere warning. This is not to undermine the importance of maintaining object metadata integrity or checking for illegal addresses. Instead, it's a suggestion to potentially allow the responsibility to rest more with the user's custom allocator, since mature memory allocators should be capable of managing the object metadata independently. Their free() methods would primarily require the pointer information, and their methods would already include sufficient checks. 

This proposal is meant to foster a more flexible design space for user custom allocators. Please take this as a well-intended recommendation for an open discussion.