### PR TITLE
Serialize pytree to json string

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -21,7 +21,14 @@ from torch._export.utils import (
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.utils._pytree import LeafSpec, tree_flatten, tree_unflatten, TreeSpec
+from torch.utils._pytree import (
+    LeafSpec,
+    tree_flatten,
+    tree_unflatten,
+    TreeSpec,
+    treespec_loads,
+    treespec_dumps
+)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
@@ -394,6 +401,9 @@ class TestExport(TestCase):
         self.assertEqual(orig_dt.y, 4)
         self.assertEqual(orig_dt.z, None)
 
+        roundtrip_spec = treespec_loads(treespec_dumps(spec))
+        self.assertEqual(roundtrip_spec, spec)
+
         # Override the registration with keep none fields
         register_dataclass_as_pytree_node(MyDataClass, return_none_fields=True)
 
@@ -417,6 +427,9 @@ class TestExport(TestCase):
         self.assertEqual(orig_dt.x, 3)
         self.assertEqual(orig_dt.y, 4)
         self.assertEqual(orig_dt.z, None)
+
+        roundtrip_spec = treespec_loads(treespec_dumps(spec))
+        self.assertEqual(roundtrip_spec, spec)
 
     def test_pytree_regster_nested_data_class(self):
 
@@ -443,6 +456,9 @@ class TestExport(TestCase):
 
         unflat = tree_unflatten(flat, spec)
         self.assertEqual(unflat, inp)
+
+        roundtrip_spec = treespec_loads(treespec_dumps(spec))
+        self.assertEqual(roundtrip_spec, spec)
 
     def test_param_util(self):
         class Basic(torch.nn.Module):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -479,9 +479,6 @@ class TestOpVersioning(TestCase):
 unittest.expectedFailure(
     TestDeserialize.test_exportdb_supported_case_tensor_setattr
 )
-unittest.expectedFailure(
-    TestDeserialize.test_exportdb_supported_case_pytree_flatten
-)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -335,7 +335,7 @@ TreeSpec(TupleVariable, None, [*,
             from_dumpable_context=lambda dumpable_context: None,
         )
         spec = TreeSpec(DummyType, None, [LeafSpec(), LeafSpec()])
-        serialized_spec = treespec_dumps(spec)
+        serialized_spec = treespec_dumps(spec, 1)
         self.assertTrue("moo" in serialized_spec)
         roundtrip_spec = treespec_loads(serialized_spec)
         self.assertEqual(roundtrip_spec, spec)

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -320,8 +320,20 @@ TreeSpec(TupleVariable, None, [*,
         self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
 
     def test_pytree_custom_type_serialize(self):
-        _register_pytree_node(torch.Size, lambda x: (list(x), None), lambda xs, _: tuple(xs))
-        spec = TreeSpec(torch.Size, "size1", [LeafSpec(), LeafSpec()])
+        class DummyType:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        _register_pytree_node(
+            DummyType,
+            lambda dummy: ([dummy.x, dummy.y], None),
+            lambda xs, _: Dummy(*xs),
+            "DummyType",
+            lambda spec: (None, "1"),
+            lambda context, version: None,
+        )
+        spec = TreeSpec(DummyType, None, [LeafSpec(), LeafSpec()])
         roundtrip_spec = str_to_pytree(pytree_to_str(spec))
         self.assertEqual(roundtrip_spec, spec)
 

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -11,7 +11,6 @@ from torch.utils._pytree import (
     treespec_dumps,
     treespec_loads,
     _register_pytree_node,
-    _register_treespec_serializer,
 )
 import unittest
 from torch.utils._pytree import _broadcast_to_and_flatten, tree_map_only, tree_all
@@ -330,11 +329,8 @@ TreeSpec(TupleVariable, None, [*,
             DummyType,
             lambda dummy: ([dummy.x, dummy.y], None),
             lambda xs, _: Dummy(*xs),
-        )
-        _register_treespec_serializer(
-            DummyType,
-            getstate=lambda context: "moo",
-            setstate=lambda dumpable_context: None,
+            to_dumpable_context=lambda context: "moo",
+            from_dumpable_context=lambda dumpable_context: None,
         )
         spec = TreeSpec(DummyType, None, [LeafSpec(), LeafSpec()])
         serialized_spec = treespec_dumps(spec)

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -393,6 +393,36 @@ TreeSpec(TupleVariable, None, [*,
         with self.assertRaisesRegex(ValueError, "Unknown protocol"):
             treespec_loads(bad_protocol_serialized_spec)
 
+    def test_saved_serialized(self):
+        complicated_spec = TreeSpec(OrderedDict, [1, 2, 3], [
+            TreeSpec(
+                tuple,
+                None,
+                [LeafSpec(), LeafSpec()]
+            ),
+            LeafSpec(),
+            TreeSpec(
+                dict,
+                [4, 5, 6],
+                [LeafSpec(), LeafSpec(), LeafSpec()]
+            ),
+        ])
+
+        serialized_spec = treespec_dumps(complicated_spec)
+        saved_spec = (
+            '[1, {"type": "collections.OrderedDict", "context": "[1, 2, 3]", '
+            '"children_spec": [{"type": "builtins.tuple", "context": "null", '
+            '"children_spec": [{"type": null, "context": null, '
+            '"children_spec": []}, {"type": null, "context": null, '
+            '"children_spec": []}]}, {"type": null, "context": null, '
+            '"children_spec": []}, {"type": "builtins.dict", "context": '
+            '"[4, 5, 6]", "children_spec": [{"type": null, "context": null, '
+            '"children_spec": []}, {"type": null, "context": null, "children_spec": '
+            '[]}, {"type": null, "context": null, "children_spec": []}]}]}]'
+        )
+        self.assertEqual(serialized_spec, saved_spec)
+        self.assertEqual(complicated_spec, treespec_loads(saved_spec))
+
 
 instantiate_parametrized_tests(TestPytree)
 

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -10,6 +10,7 @@ from torch.utils._pytree import (
     LeafSpec,
     pytree_to_str,
     str_to_pytree,
+    _register_pytree_node,
 )
 import unittest
 from torch.utils._pytree import _broadcast_to_and_flatten, tree_map_only, tree_all
@@ -317,6 +318,12 @@ TreeSpec(TupleVariable, None, [*,
         # The context in the namedtuple is different now because we recreated
         # the namedtuple type.
         self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
+
+    def test_pytree_custom_type_serialize(self):
+        _register_pytree_node(torch.Size, lambda x: (list(x), None), lambda xs, _: tuple(xs))
+        spec = TreeSpec(torch.Size, "size1", [LeafSpec(), LeafSpec()])
+        roundtrip_spec = str_to_pytree(pytree_to_str(spec))
+        self.assertEqual(roundtrip_spec, spec)
 
 
 instantiate_parametrized_tests(TestPytree)

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -377,6 +377,22 @@ TreeSpec(TupleVariable, None, [*,
         with self.assertRaises(AttributeError):
             treespec_dumps("random_blurb")
 
+    def test_pytree_serialize_bad_protocol(self):
+        import json
+
+        Point = namedtuple("Point", ["x", "y"])
+        spec = TreeSpec(namedtuple, Point, [LeafSpec(), LeafSpec()])
+
+        with self.assertRaisesRegex(ValueError, "Unknown protocol"):
+            treespec_dumps(spec, -1)
+
+        serialized_spec = treespec_dumps(spec)
+        protocol, data = json.loads(serialized_spec)
+        bad_protocol_serialized_spec = json.dumps((-1, data))
+
+        with self.assertRaisesRegex(ValueError, "Unknown protocol"):
+            treespec_loads(bad_protocol_serialized_spec)
+
 
 instantiate_parametrized_tests(TestPytree)
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -494,8 +494,8 @@ def _register_dynamo_dict_to_tree_spec():
         ConstDictVariable,
         _dictvariable_flatten,
         _dictvariable_unflatten,
-        pytree._dict_to_schema,
-        pytree._maybe_schema_to_dict,
+        pytree._dict_serialize,
+        pytree._dict_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -494,8 +494,8 @@ def _register_dynamo_dict_to_tree_spec():
         ConstDictVariable,
         _dictvariable_flatten,
         _dictvariable_unflatten,
-        pytree._dict_to_str,
-        pytree._maybe_str_to_dict,
+        pytree._dict_to_schema,
+        pytree._maybe_schema_to_dict,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -494,8 +494,6 @@ def _register_dynamo_dict_to_tree_spec():
         ConstDictVariable,
         _dictvariable_flatten,
         _dictvariable_unflatten,
-        pytree._dict_serialize,
-        pytree._dict_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -724,8 +724,8 @@ def _register_dynamo_list_to_tree_spec():
         ListVariable,
         _listvariable_flatten,
         _listvariable_unflatten,
-        pytree._list_to_schema,
-        pytree._maybe_schema_to_list,
+        pytree._list_serialize,
+        pytree._list_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(
@@ -752,8 +752,8 @@ def _register_dynamo_tuple_to_tree_spec():
         TupleVariable,
         _tuplevariable_flatten,
         _tuplevariable_unflatten,
-        pytree._tuple_to_schema,
-        pytree._maybe_schema_to_tuple,
+        pytree._tuple_serialize,
+        pytree._tuple_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -724,8 +724,6 @@ def _register_dynamo_list_to_tree_spec():
         ListVariable,
         _listvariable_flatten,
         _listvariable_unflatten,
-        pytree._list_serialize,
-        pytree._list_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(
@@ -752,8 +750,6 @@ def _register_dynamo_tuple_to_tree_spec():
         TupleVariable,
         _tuplevariable_flatten,
         _tuplevariable_unflatten,
-        pytree._tuple_serialize,
-        pytree._tuple_deserialize,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -724,8 +724,8 @@ def _register_dynamo_list_to_tree_spec():
         ListVariable,
         _listvariable_flatten,
         _listvariable_unflatten,
-        pytree._list_to_str,
-        pytree._maybe_str_to_list,
+        pytree._list_to_schema,
+        pytree._maybe_schema_to_list,
     )
 
     fx_pytree.register_pytree_flatten_spec(
@@ -752,8 +752,8 @@ def _register_dynamo_tuple_to_tree_spec():
         TupleVariable,
         _tuplevariable_flatten,
         _tuplevariable_unflatten,
-        pytree._tuple_to_str,
-        pytree._maybe_str_to_tuple,
+        pytree._tuple_to_schema,
+        pytree._maybe_schema_to_tuple,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 # NOTE: Please update this value if any modifications are made to the schema
 SCHEMA_VERSION = 1
+TREESPEC_VERSION = 1
 
 # TODO (zhxchen17) Move to a separate file.
 class _Union:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -189,8 +189,8 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
 
 def serialize_call_spec(call_spec: ep.CallSpec) -> CallSpec:
     return CallSpec(
-        in_spec=treespec_dumps(call_spec.in_spec) if call_spec.in_spec else "",
-        out_spec=treespec_dumps(call_spec.out_spec) if call_spec.out_spec else "",
+        in_spec=treespec_dumps(call_spec.in_spec, SCHEMA_VERSION) if call_spec.in_spec else "",
+        out_spec=treespec_dumps(call_spec.out_spec, SCHEMA_VERSION) if call_spec.out_spec else "",
     )
 
 
@@ -659,8 +659,8 @@ class GraphModuleSerializer:
         return ModuleCallSignature(
             inputs=[serialize_argument(x) for x in module_call_signature.inputs],
             outputs=[serialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=treespec_dumps(module_call_signature.in_spec),
-            out_spec=treespec_dumps(module_call_signature.out_spec),
+            in_spec=treespec_dumps(module_call_signature.in_spec, SCHEMA_VERSION),
+            out_spec=treespec_dumps(module_call_signature.out_spec, SCHEMA_VERSION),
         )
 
     def serialize_module_call_graph(self, module_call_graph: List[ep.ModuleCallEntry]) -> List[ModuleCallEntry]:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -189,15 +189,15 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
 
 def serialize_call_spec(call_spec: ep.CallSpec) -> CallSpec:
     return CallSpec(
-        in_spec=pytree_to_str(call_spec.in_spec) if call_spec.in_spec else "",
-        out_spec=pytree_to_str(call_spec.out_spec) if call_spec.out_spec else "",
+        in_spec=treespec_dumps(call_spec.in_spec) if call_spec.in_spec else "",
+        out_spec=treespec_dumps(call_spec.out_spec) if call_spec.out_spec else "",
     )
 
 
 def deserialize_call_spec(call_spec: CallSpec) -> ep.CallSpec:
     return ep.CallSpec(
-        in_spec=str_to_pytree(call_spec.in_spec) if call_spec.in_spec else None,
-        out_spec=str_to_pytree(call_spec.out_spec) if call_spec.out_spec else None,
+        in_spec=treespec_loads(call_spec.in_spec) if call_spec.in_spec else None,
+        out_spec=treespec_loads(call_spec.out_spec) if call_spec.out_spec else None,
     )
 
 
@@ -659,8 +659,8 @@ class GraphModuleSerializer:
         return ModuleCallSignature(
             inputs=[serialize_argument(x) for x in module_call_signature.inputs],
             outputs=[serialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=pytree_to_str(module_call_signature.in_spec),
-            out_spec=pytree_to_str(module_call_signature.out_spec),
+            in_spec=treespec_dumps(module_call_signature.in_spec),
+            out_spec=treespec_dumps(module_call_signature.out_spec),
         )
 
     def serialize_module_call_graph(self, module_call_graph: List[ep.ModuleCallEntry]) -> List[ModuleCallEntry]:
@@ -1299,8 +1299,8 @@ class GraphModuleDeserializer:
         return ep.ModuleCallSignature(
             inputs=[deserialize_argument(x) for x in module_call_signature.inputs],
             outputs=[deserialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=str_to_pytree(module_call_signature.in_spec),
-            out_spec=str_to_pytree(module_call_signature.out_spec),
+            in_spec=treespec_loads(module_call_signature.in_spec),
+            out_spec=treespec_loads(module_call_signature.out_spec),
         )
 
     def deserialize_module_call_graph(self, module_call_graph: List[ModuleCallEntry]) -> List[ep.ModuleCallEntry]:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -51,6 +51,7 @@ from .schema import (  # type: ignore[attr-defined]
     TensorArgument,
     TensorMeta,
     TensorValue,
+    TREESPEC_VERSION,
 )
 
 
@@ -189,8 +190,8 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
 
 def serialize_call_spec(call_spec: ep.CallSpec) -> CallSpec:
     return CallSpec(
-        in_spec=treespec_dumps(call_spec.in_spec, SCHEMA_VERSION) if call_spec.in_spec else "",
-        out_spec=treespec_dumps(call_spec.out_spec, SCHEMA_VERSION) if call_spec.out_spec else "",
+        in_spec=treespec_dumps(call_spec.in_spec, TREESPEC_VERSION) if call_spec.in_spec else "",
+        out_spec=treespec_dumps(call_spec.out_spec, TREESPEC_VERSION) if call_spec.out_spec else "",
     )
 
 
@@ -659,8 +660,8 @@ class GraphModuleSerializer:
         return ModuleCallSignature(
             inputs=[serialize_argument(x) for x in module_call_signature.inputs],
             outputs=[serialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=treespec_dumps(module_call_signature.in_spec, SCHEMA_VERSION),
-            out_spec=treespec_dumps(module_call_signature.out_spec, SCHEMA_VERSION),
+            in_spec=treespec_dumps(module_call_signature.in_spec, TREESPEC_VERSION),
+            out_spec=treespec_dumps(module_call_signature.out_spec, TREESPEC_VERSION),
         )
 
     def serialize_module_call_graph(self, module_call_graph: List[ep.ModuleCallEntry]) -> List[ModuleCallEntry]:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -19,7 +19,7 @@ import torch
 import torch._export.exported_program as ep
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
-from torch.utils._pytree import pytree_to_str, str_to_pytree, tree_map_only
+from torch.utils._pytree import treespec_dumps, treespec_loads, tree_map_only
 
 from .schema import (  # type: ignore[attr-defined]
     _Union,

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -65,6 +65,13 @@ def register_dataclass_as_pytree_node(
 
     flatten_fn = flatten_fn if flatten_fn is not None else default_flatten_fn
     unflatten_fn = unflatten_fn if unflatten_fn is not None else default_unflatten_fn
+
+    if (to_dumpable_context is None) ^ (from_dumpable_context is None):
+        raise ValueError(
+            f"Both to_dumpable_context and from_dumpable_context for {typ} must "
+            "be None or registered."
+        )
+
     to_dumpable_context = (
         to_dumpable_context
         if to_dumpable_context is not None

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import torch
 
@@ -9,9 +9,15 @@ from torch._export import ExportedProgram
 from torch.utils._pytree import (
     _register_pytree_node,
     Context,
+    DumpableContext,
     FlattenFunc,
+    FromDumpableContextFn,
+    ToDumpableContextFn,
     UnflattenFunc,
 )
+
+
+SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS: Dict[str, Type[Any]] = {}
 
 
 def register_dataclass_as_pytree_node(
@@ -19,11 +25,16 @@ def register_dataclass_as_pytree_node(
     flatten_fn: Optional[FlattenFunc] = None,
     unflatten_fn: Optional[UnflattenFunc] = None,
     *,
+    to_dumpable_context: Optional[ToDumpableContextFn] = None,
+    from_dumpable_context: Optional[FromDumpableContextFn] = None,
     return_none_fields: bool = False,
 ) -> None:
     assert dataclasses.is_dataclass(
         typ
     ), f"Only dataclasses can be registered with this function: {typ}"
+
+    serialized_type = f"{typ.__module__}.{typ.__name__}"
+    SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS[serialized_type] = typ
 
     def default_flatten_fn(obj: Any) -> Tuple[List[Any], Context]:
         flattened = []
@@ -42,10 +53,36 @@ def register_dataclass_as_pytree_node(
         typ, flat_names, none_names = context
         return typ(**dict(zip(flat_names, values)), **{k: None for k in none_names})
 
+    def default_to_dumpable_context(context: Context) -> DumpableContext:
+        return (serialized_type, context[1], context[2])
+
+    def default_from_dumpable_context(dumpable_context: DumpableContext) -> Context:
+        return (
+            SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS[dumpable_context[0]],
+            dumpable_context[1],
+            dumpable_context[2],
+        )
+
     flatten_fn = flatten_fn if flatten_fn is not None else default_flatten_fn
     unflatten_fn = unflatten_fn if unflatten_fn is not None else default_unflatten_fn
+    to_dumpable_context = (
+        to_dumpable_context
+        if to_dumpable_context is not None
+        else default_to_dumpable_context
+    )
+    from_dumpable_context = (
+        from_dumpable_context
+        if from_dumpable_context is not None
+        else default_from_dumpable_context
+    )
 
-    _register_pytree_node(typ, flatten_fn, unflatten_fn)
+    _register_pytree_node(
+        typ,
+        flatten_fn,
+        unflatten_fn,
+        to_dumpable_context=to_dumpable_context,
+        from_dumpable_context=from_dumpable_context,
+    )
 
 
 def is_param(program: ExportedProgram, node: torch.fx.Node) -> bool:

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -9,9 +9,7 @@ from torch._export import ExportedProgram
 from torch.utils._pytree import (
     _register_pytree_node,
     Context,
-    DeserializeFn,
     FlattenFunc,
-    SerializeFn,
     UnflattenFunc,
 )
 
@@ -20,9 +18,6 @@ def register_dataclass_as_pytree_node(
     typ: Any,
     flatten_fn: Optional[FlattenFunc] = None,
     unflatten_fn: Optional[UnflattenFunc] = None,
-    serialized_type_name: Optional[str] = None,
-    serialize_fn: Optional[SerializeFn] = None,
-    deserialize_fn: Optional[DeserializeFn] = None,
     *,
     return_none_fields: bool = False,
 ) -> None:
@@ -50,14 +45,7 @@ def register_dataclass_as_pytree_node(
     flatten_fn = flatten_fn if flatten_fn is not None else default_flatten_fn
     unflatten_fn = unflatten_fn if unflatten_fn is not None else default_unflatten_fn
 
-    _register_pytree_node(
-        typ,
-        flatten_fn,
-        unflatten_fn,
-        serialized_type_name,
-        serialize_fn,
-        deserialize_fn,
-    )
+    _register_pytree_node(typ, flatten_fn, unflatten_fn)
 
 
 def is_param(program: ExportedProgram, node: torch.fx.Node) -> bool:

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -10,8 +10,8 @@ from torch.utils._pytree import (
     _register_pytree_node,
     Context,
     FlattenFunc,
-    MaybeFromStrFunc,
-    ToStrFunc,
+    MaybeDeserializeFn,
+    SerializeFn,
     UnflattenFunc,
 )
 
@@ -20,8 +20,8 @@ def register_dataclass_as_pytree_node(
     typ: Any,
     flatten_fn: Optional[FlattenFunc] = None,
     unflatten_fn: Optional[UnflattenFunc] = None,
-    to_str_fn: Optional[ToStrFunc] = None,
-    maybe_from_str_fn: Optional[MaybeFromStrFunc] = None,
+    serialize_fn: Optional[SerializeFn] = None,
+    maybe_deserialize_fn: Optional[MaybeDeserializeFn] = None,
     *,
     return_none_fields: bool = False,
 ) -> None:
@@ -53,8 +53,8 @@ def register_dataclass_as_pytree_node(
         typ,
         flatten_fn,
         unflatten_fn,
-        None,
-        None,
+        serialize_fn,
+        maybe_deserialize_fn,
     )
 
 

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -9,8 +9,8 @@ from torch._export import ExportedProgram
 from torch.utils._pytree import (
     _register_pytree_node,
     Context,
+    DeserializeFn,
     FlattenFunc,
-    MaybeDeserializeFn,
     SerializeFn,
     UnflattenFunc,
 )
@@ -20,8 +20,9 @@ def register_dataclass_as_pytree_node(
     typ: Any,
     flatten_fn: Optional[FlattenFunc] = None,
     unflatten_fn: Optional[UnflattenFunc] = None,
+    serialized_type_name: Optional[str] = None,
     serialize_fn: Optional[SerializeFn] = None,
-    maybe_deserialize_fn: Optional[MaybeDeserializeFn] = None,
+    deserialize_fn: Optional[DeserializeFn] = None,
     *,
     return_none_fields: bool = False,
 ) -> None:
@@ -53,8 +54,9 @@ def register_dataclass_as_pytree_node(
         typ,
         flatten_fn,
         unflatten_fn,
+        serialized_type_name,
         serialize_fn,
-        maybe_deserialize_fn,
+        deserialize_fn,
     )
 
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -28,6 +28,14 @@ This pytree implementation is not very performant due to Python overhead
 To improve the performance we can move parts of the implementation to C++.
 """
 
+"""
+TreeSpecSchema is the schema used to serialize the TreeSpec
+It contains the following fields:
+- type: A string name of the type. null for the case of a LeafSpec.
+- context: A string format of the context, optional.
+- children_spec: A list of children serialized specs.
+"""
+
 @dataclasses.dataclass
 class TreeSpecSchema:
     type: Optional[str]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/102577#issuecomment-1650905536

Serializing to json is more stable, and renamed the API:

```
# Takes in a treespec and returns the serialized treespec as a string. Also optionally takes in a protocol version number.
def treespec_dumps(treespec: TreeSpec, protocol: Optional[int] = None) -> str:
# Takes in a serialized treespec and outputs a TreeSpec
def treespec_loads(data: str) -> TreeSpec:
```

If users want to register their own serialization format for a given pytree, they can go through the `_register_treespec_serializer` API which optionally takes in a `getstate` and `setstate` function.
```
_register_treespec_serializer(type_, *, getstate, setstate)
# Takes in the context, and outputs a json-dumpable context
def getstate(context: Context) -> DumpableContext:
# Takes in a json-dumpable context, and reconstructs the original context
def setstate(dumpable_context: DumpableContext) -> Context:
```

We will serialize to the following dataclass, and then json.dump this it to string.
```
class TreeSpec
    type: Optional[str]  # a string name of the type. null for the case of a LeafSpec
    context: Optional[Any]  # optional, a json dumpable format of the context
    children_specs: List[TreeSpec],
}   
```

If no getstate/setstate function is registered, we will by default serialize the context using `json.dumps/loads`. We will also serialize the type through `f"{typ.__module__}.{typ.__name__}"`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @ipiszy