### PR TITLE
Force device index to 0 in MPS devices

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -27,6 +27,7 @@ using DeviceIndex = int8_t;
 /// 1. A negative index represents the current device, a non-negative index
 /// represents a specific, concrete device,
 /// 2. When the device type is CPU, the device index must be zero.
+/// 3. When the device type is MPS, the device index is forced to be zero.
 struct C10_API Device final {
   using Type = DeviceType;
 
@@ -169,6 +170,9 @@ struct C10_API Device final {
   DeviceType type_;
   DeviceIndex index_ = -1;
   void validate() {
+    if (is_mps()) {
+      index_ = 0;
+    }
     // Removing these checks in release builds noticeably improves
     // performance in micro-benchmarks.
     // This is safe to do, because backends that use the DeviceIndex

--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1470,7 +1470,7 @@ static mpy::object create_dim(mpy::object name, mpy::handle size) {
     if (!mpy::is_none(size)) {
         d->set_size(mpy::to_int(size));
     }
-    return std::move(d);
+    return mpy::object(std::move(d));
 }
 
 static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
@@ -1486,7 +1486,7 @@ static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
             }
         }
     }
-    return std::move(d);
+    return mpy::object(std::move(d));
 }
 
 

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -118,8 +118,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   explicit SequentialImpl(std::initializer_list<NamedAnyModule> named_modules) {
     modules_.reserve(named_modules.size());
     for (const auto& named_module : named_modules) {
-      push_back(
-          std::move(named_module.name()), std::move(named_module.module()));
+      push_back(named_module.name(), named_module.module());
     }
   }
 

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -594,7 +594,7 @@ py::object toPyObject(IValue ivalue) {
     for (const auto i : c10::irange(list.size())) {
       t[i] = toPyObject(IValue{list.get(i)});
     }
-    return std::move(t);
+    return py::object(std::move(t));
   } else if (ivalue.isTuple()) {
     auto tuple = std::move(ivalue).toTuple();
     const auto& elements = tuple->elements();
@@ -629,7 +629,7 @@ py::object toPyObject(IValue ivalue) {
           .attr("_create_named_tuple")(
               t, unqualName, fieldNames, py::make_tuple(defaults));
     } else {
-      return std::move(t);
+      return py::object(std::move(t));
     }
   } else if (ivalue.isDevice()) {
     return py::cast<py::object>(THPDevice_New(std::move(ivalue).toDevice()));
@@ -642,7 +642,7 @@ py::object toPyObject(IValue ivalue) {
       py_dict[toPyObject(IValue{pair.key()})] =
           toPyObject(IValue{pair.value()});
     }
-    return std::move(py_dict);
+    return py::object(std::move(py_dict));
   } else if (ivalue.isRRef()) {
 #ifdef USE_RPC
     auto RRefPtr =

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -922,7 +922,7 @@ inline py::object createPyObjectForStack(Stack&& stack) {
     return_values[ret] = toPyObject(std::move(stack[ret]));
   }
 
-  return std::move(return_values);
+  return py::object(std::move(return_values));
 }
 
 // TODO: Remove once we clean up the GraphExecutor usage.


### PR DESCRIPTION
To fix the following errors
```

self = <torch.utils._device.DeviceContext object at 0x157f4a710>
func = <built-in method randperm of type object at 0x119c35460>, types = (), args = (60000,)
kwargs = {'device': device(type='mps', index=0), 'generator': <torch._C.Generator object at 0x29ac691f0>}

    def __torch_function__(self, func, types, args=(), kwargs=None):
        kwargs = kwargs or {}
        if func in _device_constructors() and kwargs.get('device') is None:
            kwargs['device'] = self.device
>       return func(*args, **kwargs)
E       RuntimeError: Expected a 'mps:0' generator device but found 'mps'

../.local/lib/python3.11/site-packages/torch/utils/_device.py:76: RuntimeError
```
