### PR TITLE
Use ProcessPoolExecutor in the ufmt adapter

### DIFF
--- a/tools/linter/adapters/ufmt_linter.py
+++ b/tools/linter/adapters/ufmt_linter.py
@@ -124,9 +124,8 @@ def main() -> None:
         stream=sys.stderr,
     )
 
-    with concurrent.futures.ThreadPoolExecutor(
+    with concurrent.futures.ProcessPoolExecutor(
         max_workers=os.cpu_count(),
-        thread_name_prefix="Thread",
     ) as executor:
         futures = {executor.submit(check_file, x): x for x in args.filenames}
         for future in concurrent.futures.as_completed(futures):

--- a/tools/linter/adapters/ufmt_linter.py
+++ b/tools/linter/adapters/ufmt_linter.py
@@ -115,7 +115,7 @@ def main() -> None:
     args = parser.parse_args()
 
     logging.basicConfig(
-        format="<%(threadName)s:%(levelname)s> %(message)s",
+        format="<%(processName)s:%(levelname)s> %(message)s",
         level=logging.NOTSET
         if args.verbose
         else logging.DEBUG


### PR DESCRIPTION
When running on a host with multiple CPUs, the ufmt linter was not able to use them very effectively. The biggest single culprit seems to be debug logging inside blib2to3 trying to acquire a lock, but disabling that doesn't help much - I suppose this must be GIL contention. Changing to a ProcessPoolExecutor makes it much faster.

The following timings are on a PaperSpace GPU+ instance with 8 vCPUs (the cores show up as Intel(R) Xeon(R) CPU E5-2623 v4 @ 2.60GHz but I'm not entirely clear if those are shared with other instances).

On main:

```
$ time lintrunner --all-files --take UFMT
ok No lint issues.

real    7m46.140s
user    8m0.828s
sys     0m5.446s
```

On this branch:

```
$ time lintrunner --all-files --take UFMT
ok No lint issues.

real    1m7.255s
user    8m13.388s
sys     0m3.506s
```