### PR TITLE
[FSDP] Set (pre-)unshard streams priority=-1

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -318,13 +318,13 @@ def _init_streams(
     assert state._device_handle.is_available()
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._unshard_stream = state._device_handle.Stream()
+    state._unshard_stream = state._device_handle.Stream(priority=-1)
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
     state._post_backward_stream = state._device_handle.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._pre_unshard_stream = state._device_handle.Stream()
+    state._pre_unshard_stream = state._device_handle.Stream(priority=-1)
     # Default stream for computation
     state._default_stream = state._device_handle.current_stream()
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -316,15 +316,17 @@ def _init_streams(
     """
     assert state._is_root
     assert state._device_handle.is_available()
+    # Prioritize all-gathers since they block computation
+    unshard_priority = -1 if state.limit_all_gathers else 0
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves.
-    state._unshard_stream = state._device_handle.Stream(priority=-1)
+    state._unshard_stream = state._device_handle.Stream(priority=unshard_priority)
     # Stream for overlapping gradient reduction with the backward pass gradient
     # computation.
     state._post_backward_stream = state._device_handle.Stream()
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
-    state._pre_unshard_stream = state._device_handle.Stream(priority=-1)
+    state._pre_unshard_stream = state._device_handle.Stream(priority=unshard_priority)
     # Default stream for computation
     state._default_stream = state._device_handle.current_stream()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106080
* #106131
* #106072
* #106068
* #106034
* __->__ #106133
* #106033
* #106032

I moved this change to the bottom of the stack since I think it can be helpful generally. We should prioritize all-gather always because it blocks computation. Let us only do this if `limit_all_gathers == True` for now.

For the async HSDP all-reduce work, this makes a big difference.
- Before this change:
![hsdp_new_nopriority](https://github.com/pytorch/pytorch/assets/31054793/2b3f6c8d-23f2-4732-9426-8035ce1eee2f)


- After this change:
![hsdp_new](https://github.com/pytorch/pytorch/assets/31054793/8dde5b77-97ee-46bc-9631-b05828a03395)


Note how in the 'before', there is a case where the all-gather waits for a previous all-reduce to finish before even starting (without overlap), so there is a large gap in the GPU compute stream. However, after prioritizing the pre-unshard and unshard streams, this issue disappears.
