### PR TITLE
[caffe2] Don't evaluate message in CAFFE_ENFORCE_THAT unless the check fails

### DIFF
--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -196,6 +196,40 @@ std::string enforceFailMsgImpl(const T1& x, const T2& y, const Args&... args) {
   return c10::str(x, " vs ", y, ". ", args...);
 }
 
+// GCC7 is getting an internal compiler error on the new
+// implementation, so keep the old one (which evaluates the error
+// message eagerly and therefore is undesirable for general use
+// compared to the new one) around for it.
+#if defined(__GNUG__) && __GNUC__ <= 7 && !defined(__clang__)
+template <typename Pred, typename T1, typename T2, typename... Args>
+void enforceThatImpl(
+    Pred p,
+    const T1& lhs,
+    const T2& rhs,
+    const char* file,
+    int line,
+    const char* expr,
+    const void* caller,
+    const Args&... args) {
+  if (C10_UNLIKELY(!(p(lhs, rhs)))) {
+    ::c10::ThrowEnforceNotMet(
+        file,
+        line,
+        expr,
+        ::c10::enforce_detail::enforceFailMsgImpl(lhs, rhs, args...),
+        caller);
+  }
+}
+
+#define CAFFE_ENFORCE_THAT_IMPL(op, lhs, rhs, expr, ...) \
+  ::c10::enforce_detail::enforceThatImpl(                \
+      op, lhs, rhs, __FILE__, __LINE__, expr, nullptr, ##__VA_ARGS__)
+
+#define CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER(op, lhs, rhs, expr, ...) \
+  ::c10::enforce_detail::enforceThatImpl(                            \
+      op, (lhs), (rhs), __FILE__, __LINE__, expr, this, ##__VA_ARGS__)
+
+#else
 template <typename Pred, typename T1, typename T2, typename GetFailMsgFunc>
 void enforceThatImpl(
     Pred p,
@@ -238,6 +272,7 @@ void enforceThatImpl(
         return ::c10::enforce_detail::enforceFailMsgImpl(            \
             arg1, arg2, ##__VA_ARGS__);                              \
       })
+#endif
 
 } // namespace enforce_detail
 

--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -222,13 +222,14 @@ bool SplitByLengthsOp<Context>::RunOnDevice() {
     length_data = lengths_host_.template data<int32_t>();
   }
 
+  const auto output_size = OutputSize();
   CAFFE_ENFORCE_EQ(
-      lengths_length % OutputSize(),
+      lengths_length % output_size,
       0,
       "len(Lengths) ",
       lengths_length,
       "should be divisible by OutputSize() ",
-      OutputSize(),
+      output_size,
       ".");
   int canonical_axis = input.canonical_axis_index(axis_);
   CAFFE_ENFORCE_LT(

--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -330,7 +330,8 @@ bool ConcatOp<Context>::RunOnDevice() {
     }
     // check the input dims are compatible.
     for (const auto j : c10::irange(1, InputSize())) {
-      int dim_j = Input(j).dim32(i);
+      const auto& input_j = Input(j);
+      int dim_j = input_j.dim32(i);
       CAFFE_ENFORCE_EQ(
           dim,
           dim_j,
@@ -346,9 +347,9 @@ bool ConcatOp<Context>::RunOnDevice() {
           "when arg 'add_axis' = 0 and along the axis = ",
           canonical_axis,
           " <",
-          Input(0).sizes(),
+          input_zero.sizes(),
           "> vs <",
-          Input(j).sizes(),
+          input_j.sizes(),
           ">.");
     }
   }

--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -299,17 +299,19 @@ bool ConcatOp<Context>::RunOnDevice() {
       1, at::IntArrayRef({InputSize()}), at::dtype<int>().device(CPU));
   int *const axis_data = split->template mutable_data<int>();
   auto& input_zero = Input(0);
+  const auto input_zero_dtype = input_zero.dtype();
   int adj_size = input_zero.dim() + (add_axis_ ? 1 : 0);
   int canonical_axis = canonical_axis_index_(axis_, adj_size);
   CAFFE_ENFORCE_LT(canonical_axis, adj_size, "Axis not in input ndim range.");
   for (const auto i : c10::irange(1, InputSize())) {
+    const auto input_dtype = Input(i).dtype();
     CAFFE_ENFORCE_EQ(
-        Input(i).dtype(),
-        input_zero.dtype(),
+        input_dtype,
+        input_zero_dtype,
         "All inputs must have the same type, expected: ",
-        input_zero.dtype().name(),
+        input_zero_dtype.name(),
         " but got: ",
-        Input(i).dtype().name(),
+        input_dtype.name(),
         " for input: ",
         i);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106145

D26829714 improved CAFFE_ENFORCE_THAT, but made us eagerly evaluate the message, which has costs.

Differential Revision: [D47809432](https://our.internmc.facebook.com/intern/diff/D47809432/)