### PR TITLE
Bot message changes for -f and rebase

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -53,7 +53,7 @@ def _check_output(items: List[str], encoding: str = "utf-8") -> str:
         msg = f"Command `{' '.join(e.cmd)}` returned non-zero exit code {e.returncode}"
         stdout = e.stdout.decode(encoding) if e.stdout is not None else ""
         stderr = e.stderr.decode(encoding) if e.stderr is not None else ""
-        # These get swollowed up, so print them here for debugging
+        # These get swallowed up, so print them here for debugging
         print(f"stdout: \n{stdout}")
         print(f"stderr: \n{stderr}")
         if len(stderr) == 0:

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -53,6 +53,9 @@ def _check_output(items: List[str], encoding: str = "utf-8") -> str:
         msg = f"Command `{' '.join(e.cmd)}` returned non-zero exit code {e.returncode}"
         stdout = e.stdout.decode(encoding) if e.stdout is not None else ""
         stderr = e.stderr.decode(encoding) if e.stderr is not None else ""
+        # These get swollowed up, so print them here for debugging
+        print(f"stdout: \n{stdout}")
+        print(f"stderr: \n{stderr}")
         if len(stderr) == 0:
             msg += f"\n```\n{stdout}```"
         else:

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -4,7 +4,7 @@ from unittest import main, mock, TestCase
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from test_trymerge import mocked_gh_graphql
 from trymerge import GitHubPR
-from tryrebase import rebase_ghstack_onto, rebase_onto, additional_rebase_failure_info
+from tryrebase import additional_rebase_failure_info, rebase_ghstack_onto, rebase_onto
 
 
 def mocked_rev_parse(branch: str) -> str:
@@ -152,14 +152,18 @@ class TestRebase(TestCase):
         with self.assertRaisesRegex(Exception, "same sha as the target branch"):
             rebase_ghstack_onto(pr, repo, MAIN_BRANCH)
 
-
     def test_additional_rebase_failure_info(self) -> None:
-        error = """Command `git -C /Users/csl/zzzzzzzz/pytorch push --dry-run -f https://github.com/Lightning-Sandbox/pytorch.git pull/106089/head:fix/spaces` returned non-zero exit code 128
-```
-remote: Permission to Lightning-Sandbox/pytorch.git denied to clee2000.
-fatal: unable to access 'https://github.com/Lightning-Sandbox/pytorch.git/': The requested URL returned error: 403"""
+        error = (
+            "Command `git -C /Users/csl/zzzzzzzz/pytorch push --dry-run -f "
+            "https://github.com/Lightning-Sandbox/pytorch.git pull/106089/head:fix/spaces` returned non-zero exit code 128\n"
+            "```\n"
+            "remote: Permission to Lightning-Sandbox/pytorch.git denied to clee2000.\n"
+            "fatal: unable to access 'https://github.com/Lightning-Sandbox/pytorch.git/': The requested URL returned error: 403\n"
+            "```"
+        )
         additional_msg = additional_rebase_failure_info(Exception(error))
         self.assertTrue("This is likely because" in additional_msg)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -4,7 +4,7 @@ from unittest import main, mock, TestCase
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from test_trymerge import mocked_gh_graphql
 from trymerge import GitHubPR
-from tryrebase import rebase_ghstack_onto, rebase_onto
+from tryrebase import rebase_ghstack_onto, rebase_onto, additional_rebase_failure_info
 
 
 def mocked_rev_parse(branch: str) -> str:
@@ -152,6 +152,14 @@ class TestRebase(TestCase):
         with self.assertRaisesRegex(Exception, "same sha as the target branch"):
             rebase_ghstack_onto(pr, repo, MAIN_BRANCH)
 
+
+    def test_additional_rebase_failure_info(self) -> None:
+        error = """Command `git -C /Users/csl/zzzzzzzz/pytorch push --dry-run -f https://github.com/Lightning-Sandbox/pytorch.git pull/106089/head:fix/spaces` returned non-zero exit code 128
+```
+remote: Permission to Lightning-Sandbox/pytorch.git denied to clee2000.
+fatal: unable to access 'https://github.com/Lightning-Sandbox/pytorch.git/': The requested URL returned error: 403"""
+        additional_msg = additional_rebase_failure_info(Exception(error))
+        self.assertTrue("This is likely because" in additional_msg)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -55,8 +55,8 @@ class TryMergeExplainer:
                 "Your change will be merged immediately since you used the force (-f) flag, "
                 + "**bypassing any CI checks** (ETA: 1-5 minutes).  "
                 + "Please use `-f` as last resort and instead consider `-i/--ignore-current` "
-                + "to continue the merge ignoring current failures. " +
-                + "This will allow currently pending tests to finish and report signal before the merge."
+                + "to continue the merge ignoring current failures.  This will allow "
+                + "currently pending tests to finish and report signal before the merge."
             )
         elif self.ignore_current and ignore_current_checks is not None:
             msg = f"Your change will be merged while ignoring the following {len(ignore_current_checks)} checks: "

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -53,7 +53,10 @@ class TryMergeExplainer:
         if self.force:
             return (
                 "Your change will be merged immediately since you used the force (-f) flag, "
-                + "**bypassing any CI checks** (ETA: 1-5 minutes)."
+                + "**bypassing any CI checks** (ETA: 1-5 minutes).  "
+                + "Please use `-f` as last resort and instead consider `-i/--ignore-current` "
+                + "to continue the merge ignoring current failures. " +
+                + "This will allow currently pending tests to finish and report signal before the merge."
             )
         elif self.ignore_current and ignore_current_checks is not None:
             msg = f"Your change will be merged while ignoring the following {len(ignore_current_checks)} checks: "

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -170,7 +170,7 @@ def rebase_ghstack_onto(
 
 def additional_rebase_failure_info(e):
     print(str(e))
-    if re.search("remote: Permission to .* denied to pytorchmergebot\.\nfatal: unable to access", str(e)):
+    if re.search("remote: Permission to .* denied to .*\.\nfatal: unable to access", str(e)):
         return (
             "\nThis is likely because the PR author does not allow edits from maintainers on the PR or because the "
             "repo has additional permissions settings that mergebot does not qualify."

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -168,6 +168,15 @@ def rebase_ghstack_onto(
             post_already_uptodate(pr, repo, onto_branch, dry_run)
 
 
+def additional_rebase_failure_info(e):
+    if re.search("remote: Permission to .* denied to pytorchmergebot\.\nfatal: unable to access", str(e)):
+        return (
+            "\nThis is likely because the PR author does not allow edits from maintainers on the PR or because the "
+            "repo has additional permissions settings that mergebot does not qualify."
+        )
+    return ""
+
+
 @contextlib.contextmanager
 def git_config_guard(repo: GitRepo) -> Generator[None, None, None]:
     """Restores user.name and user.email global properties after context is finished"""
@@ -217,6 +226,7 @@ def main() -> None:
 
     except Exception as e:
         msg = f"Rebase failed due to {e}"
+        msg += additional_rebase_failure_info(e)
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             msg += f"\nRaised by {run_url}"

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -169,6 +169,7 @@ def rebase_ghstack_onto(
 
 
 def additional_rebase_failure_info(e):
+    print(str(e))
     if re.search("remote: Permission to .* denied to pytorchmergebot\.\nfatal: unable to access", str(e)):
         return (
             "\nThis is likely because the PR author does not allow edits from maintainers on the PR or because the "

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -169,7 +169,6 @@ def rebase_ghstack_onto(
 
 
 def additional_rebase_failure_info(e: Exception) -> str:
-    print(str(e))
     if re.search(
         r"remote: Permission to .* denied to .*\.\nfatal: unable to access", str(e)
     ):

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -171,7 +171,7 @@ def rebase_ghstack_onto(
 def additional_rebase_failure_info(e: Exception) -> str:
     print(str(e))
     if re.search(
-        r"remote: Permission to .* denied to .*\\.\nfatal: unable to access", str(e)
+        r"remote: Permission to .* denied to .*\.\nfatal: unable to access", str(e)
     ):
         return (
             "\nThis is likely because the author did not allow edits from maintainers on the PR or because the "

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -168,11 +168,13 @@ def rebase_ghstack_onto(
             post_already_uptodate(pr, repo, onto_branch, dry_run)
 
 
-def additional_rebase_failure_info(e):
+def additional_rebase_failure_info(e: Exception) -> str:
     print(str(e))
-    if re.search("remote: Permission to .* denied to .*\.\nfatal: unable to access", str(e)):
+    if re.search(
+        r"remote: Permission to .* denied to .*\\.\nfatal: unable to access", str(e)
+    ):
         return (
-            "\nThis is likely because the PR author does not allow edits from maintainers on the PR or because the "
+            "\nThis is likely because the author did not allow edits from maintainers on the PR or because the "
             "repo has additional permissions settings that mergebot does not qualify."
         )
     return ""


### PR DESCRIPTION
* Encourage people to use -i instead of -f for mergebot
* Add additional info for when rebase fails due to lacking permissions


<details><summary>dryrun</summary>

````
csl@csl-mbp ~/zzzzzzzz/pytorch [csl/errormsgs] $                                                                                                                                                                                 
(forpytorch) python3 .github/scripts/tryrebase.py 106089 --branch viable/strict --dry-run
+ git -C /Users/csl/zzzzzzzz/pytorch rev-parse --verify refs/remotes/origin/viable/strict
@pytorchbot started a rebase job onto [refs/remotes/origin/viable/strict](https://github.com/pytorch/pytorch/commit/7c97c943fbba4f6a58698aaa4312fcf4123a36cc). Check the current status [here](None)
+ git -C /Users/csl/zzzzzzzz/pytorch fetch origin pull/106089/head:pull/106089/head
+ git -C /Users/csl/zzzzzzzz/pytorch rebase refs/remotes/origin/viable/strict pull/106089/head
+ git -C /Users/csl/zzzzzzzz/pytorch rev-parse --verify pull/106089/head
+ git -C /Users/csl/zzzzzzzz/pytorch rev-parse --verify refs/remotes/origin/viable/strict
+ git -C /Users/csl/zzzzzzzz/pytorch push --dry-run -f https://github.com/Lightning-Sandbox/pytorch.git pull/106089/head:fix/spaces
stdout: 
remote: Permission to Lightning-Sandbox/pytorch.git denied to clee2000.
fatal: unable to access 'https://github.com/Lightning-Sandbox/pytorch.git/': The requested URL returned error: 403

stderr: 

Rebase failed due to Command `git -C /Users/csl/zzzzzzzz/pytorch push --dry-run -f https://github.com/Lightning-Sandbox/pytorch.git pull/106089/head:fix/spaces` returned non-zero exit code 128
```
remote: Permission to Lightning-Sandbox/pytorch.git denied to clee2000.
fatal: unable to access 'https://github.com/Lightning-Sandbox/pytorch.git/': The requested URL returned error: 403
```
This is likely because the author did not allow edits from maintainers on the PR or because the repo has additional permissions settings that mergebot does not qualify.
````
</details>