### PR TITLE
[pytorch profiler] fix profiler test for windows

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1489,6 +1489,11 @@ class TestProfiler(TestCase):
         finally:
             torch._C._profiler._set_fwd_bwd_enabled_val(True)
 
+    # This test is broken on Windows, the likely reason is that kineto/CUPTI
+    # is not supported that particular environment. Once the CI stabilizes
+    # we can narrow the condition so Windows is checked as well (TODO)
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @unittest.skipIf(IS_WINDOWS, "Test does not work on Windows")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     def test_profiler_cuda_sync_events(self):
         device = torch.device("cuda:0")


### PR DESCRIPTION
Summary:
Fixes Windows tests, I am not seeing any CUDA events in the output so this test does not apply there
https://github.com/pytorch/pytorch/pull/105187#issuecomment-1652669293

Test Plan: buck2 run //caffe2/caffe2:caffe2_test_gpu

Reviewed By: chaekit, aaronenyeshi, huydhn

Differential Revision: D47841663

