### PR TITLE
[DTensor][EZ] op schema comparison so that no redistribute is called

### DIFF
--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -159,7 +159,10 @@ def _operator_dispatch(
     # tensors before calling the local op
     assert output_sharding.schema_suggestions is not None
     suggested_input_schema = output_sharding.schema_suggestions[0]
-    needs_redistribute = suggested_input_schema != sharding_propagator.prepare_op_schema(op_call, args, kwargs)
+    needs_redistribute = (
+        suggested_input_schema
+        != sharding_propagator.prepare_op_schema(op_call, args, kwargs)
+    )
 
     if mesh is not None and mesh.get_coordinate() is None:
         # For a non-participating device, we do:

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -159,7 +159,7 @@ def _operator_dispatch(
     # tensors before calling the local op
     assert output_sharding.schema_suggestions is not None
     suggested_input_schema = output_sharding.schema_suggestions[0]
-    needs_redistribute = suggested_input_schema is not op_schema
+    needs_redistribute = suggested_input_schema != op_schema
 
     if mesh is not None and mesh.get_coordinate() is None:
         # For a non-participating device, we do:

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -159,7 +159,7 @@ def _operator_dispatch(
     # tensors before calling the local op
     assert output_sharding.schema_suggestions is not None
     suggested_input_schema = output_sharding.schema_suggestions[0]
-    needs_redistribute = suggested_input_schema != op_schema
+    needs_redistribute = suggested_input_schema != sharding_propagator.prepare_op_schema(op_call, args, kwargs)
 
     if mesh is not None and mesh.get_coordinate() is None:
         # For a non-participating device, we do:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106158


When looking at traces of TP more carefully, I found that for cases when input reshard is not needed, we also call redistribute within sharding propogation. Upon carefully checking, looks like the way we compare different op_schema is not correct.

One example can be seen in the following trace:
<img width="1146" alt="image" src="https://github.com/pytorch/pytorch/assets/6937752/7322d26f-7029-41f9-8f8c-5f27a6bb98f9">


As you can see, no collectives are called, and this redistribute is not needed.

With this change:

<img width="1491" alt="image" src="https://github.com/pytorch/pytorch/assets/6937752/eb4a971f-44c1-4d83-8671-fce94cfa926c">

