### PR TITLE
[NCCL][AVOID_RECORD_STREAMS] Initialize `stashed_for_allocator_safety_` in `endCoalescing` if `TORCH_NCCL_AVOID_RECORD_STREAMS=1`

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1468,7 +1468,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   work->store_ = store_;
   if (avoidRecordStreams_) {
     // other functions expect an initialized ptr if avoidRecordStreams_ is set
-    work->stashed_for_allocator_safety_ = std::make_shared<std::vector<at::Tensor>>();
+    work->stashed_for_allocator_safety_ =
+        std::make_shared<std::vector<at::Tensor>>();
   }
   c10::cuda::CaptureStatus capture_status =
       c10::cuda::currentStreamCaptureStatusMayInitCtx();

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -492,7 +492,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
     (*ncclEndEvents_)[i].block(currentStream);
   }
 
-  if (avoidRecordStreams_) {
+  if (avoidRecordStreams_ && stashed_for_allocator_safety_) {
     stashed_for_allocator_safety_->clear();
   }
 }
@@ -1455,6 +1455,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   // `getKeyFromDevices` is how we get keys for both collectives and batch P2P
   const auto key = getKeyFromDevices(devices);
   auto& ncclStreams = ncclStreams_[key];
+  // TODO(eqy): is this still necessary if avoidRecordStreams_ is set?
   for (const auto i : c10::irange(devices.size())) {
     auto& devEvent = (*work->ncclEndEvents_)[i];
     devEvent.record(ncclStreams[i]);
@@ -1465,7 +1466,10 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   work->avoidRecordStreams_ = avoidRecordStreams_;
   work->opTimeout_ = options_->timeout;
   work->store_ = store_;
-
+  if (avoidRecordStreams_) {
+    // other functions expect an initialized ptr if avoidRecordStreams_ is set
+    work->stashed_for_allocator_safety_ = std::make_shared<std::vector<at::Tensor>>();
+  }
   c10::cuda::CaptureStatus capture_status =
       c10::cuda::currentStreamCaptureStatusMayInitCtx();
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -492,7 +492,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
     (*ncclEndEvents_)[i].block(currentStream);
   }
 
-  if (avoidRecordStreams_ && stashed_for_allocator_safety_) {
+  if (avoidRecordStreams_) {
     stashed_for_allocator_safety_->clear();
   }
 }


### PR DESCRIPTION
Currently `stashed_for_allocator_safety_` is uninitialized in this path, which will crash if another operation assumes a non-nullptr (the case when `TORCH_NCCL_AVOID_RECORD_STREAMS=1` and `avoidRecordStreams_` is set).

CC @kwen2501 @ptrblck 

@kwen2501 
I'm not familiar with what happens to the coalesced work when `endCoalescing` is called. In theory, if the coalesced work has already "stashed for allocator safety," can we also avoid the record streams calls here? Or is the coalesced work discarded (and their `_stashed_for_allocator_safety` vectors also destroyed?