### PR TITLE
[inductor][easy] Skip inductor generated_kernel_count for bucketize on CPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6665,7 +6665,6 @@ class CommonTemplate:
         """
         Causes a @pointwise(size_hints) where size_hints is 2D
         """
-
         def fn(input, offsets, add_value):
             return torch.ops.prims._inductor_bucketize(input, offsets) + add_value
 
@@ -6677,7 +6676,9 @@ class CommonTemplate:
 
         self.common(fn, (input, boundaries, add_value), check_lowp=False)
 
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+        if self.device == "cuda":
+            # Bucketize doesn't have CPU lowerings, so we shouldn't check this on CPU.
+            self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
 
     @config.patch(implicit_fallbacks=True)
     def test_custom_op(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #106167

Bucketize on CPU doesn't have a lowering, so it just falls back. For some reason, it's generating a lot of

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov