### PR TITLE
[export] Move attrs to properties and add BC decorator

### DIFF
--- a/torch/_export/serde/upgrade.py
+++ b/torch/_export/serde/upgrade.py
@@ -197,6 +197,6 @@ class GraphModuleOpUpgrader:
             # NB: we have to retrace the graph_module instead of ep because of some failure. Also, we need to turn of
             # _add_runtime_assertions because dynamo is not happy with sym_size.int.
             exported_program = export(upgraded_program.graph_module, inputs, {})
-            exported_program.call_spec = upgraded_program.call_spec
+            exported_program._call_spec = upgraded_program.call_spec
 
         return exported_program


### PR DESCRIPTION
@SherlockNoMad mentioned that it's not bc safe to directly access these attributes, so I moved them to @property fields, and added a `@compatibility` decorator. For now I just set it to True for graph_module/graph. 