### PR TITLE
Test builder PR 1463 to add pytorch-triton-rocm as install dependency for ROCm wheels

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -7,8 +7,8 @@
 
 # NOTE: If testing pytorch/builder changes you can change this variable to change what pytorch/builder reference
 #       the binary builds will check out
-{%- set builder_repo = "pytorch/builder" -%}
-{%- set builder_branch = "main" -%}
+{%- set builder_repo = "jithunnair-amd/builder" -%}
+{%- set builder_branch = "add_triton_dependency_for_rocm_wheels" -%}
 
 {%- macro concurrency(build_environment) -%}
 concurrency:

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -28,7 +28,7 @@ on:
       BUILDER_ROOT:
         required: true
         type: string
-        description: Root directory for the pytorch/builder repository
+        description: Root directory for the jithunnair-amd/builder repository
       PACKAGE_TYPE:
         required: true
         type: string
@@ -176,16 +176,16 @@ jobs:
           git clean -fxd
         working-directory: pytorch
 
-      - name: Checkout pytorch/builder to builder dir
+      - name: Checkout jithunnair-amd/builder to builder dir
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
 
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -837,15 +837,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -941,15 +941,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1045,15 +1045,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1149,15 +1149,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -837,15 +837,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -941,15 +941,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1045,15 +1045,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1149,15 +1149,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -389,15 +389,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -490,15 +490,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -889,15 +889,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -990,15 +990,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1389,15 +1389,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1490,15 +1490,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1889,15 +1889,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1990,15 +1990,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
@@ -84,15 +84,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -196,15 +196,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -308,15 +308,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -420,15 +420,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -84,15 +84,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -196,15 +196,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -308,15 +308,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -420,15 +420,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-macos-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-binary-conda-nightly.yml
@@ -82,15 +82,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -194,15 +194,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -306,15 +306,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -418,15 +418,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
@@ -86,15 +86,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -203,15 +203,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -320,15 +320,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -437,15 +437,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-macos-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-binary-wheel-nightly.yml
@@ -82,15 +82,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -194,15 +194,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -306,15 +306,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -418,15 +418,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -101,15 +101,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -217,15 +217,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -340,15 +340,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -457,15 +457,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -581,15 +581,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -698,15 +698,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -821,15 +821,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -937,15 +937,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1060,15 +1060,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1177,15 +1177,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1301,15 +1301,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1418,15 +1418,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1541,15 +1541,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1657,15 +1657,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1780,15 +1780,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1897,15 +1897,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2021,15 +2021,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2138,15 +2138,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2261,15 +2261,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2377,15 +2377,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2500,15 +2500,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2617,15 +2617,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2741,15 +2741,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2858,15 +2858,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -98,15 +98,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -218,15 +218,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -105,15 +105,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -225,15 +225,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -355,15 +355,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -475,15 +475,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -605,15 +605,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -725,15 +725,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -855,15 +855,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -975,15 +975,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1106,15 +1106,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1227,15 +1227,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1359,15 +1359,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1480,15 +1480,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1612,15 +1612,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1733,15 +1733,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1865,15 +1865,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1986,15 +1986,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2118,15 +2118,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2239,15 +2239,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2371,15 +2371,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2492,15 +2492,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2624,15 +2624,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2745,15 +2745,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2877,15 +2877,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2998,15 +2998,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -98,15 +98,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -218,15 +218,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -105,15 +105,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -225,15 +225,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -355,15 +355,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -475,15 +475,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -605,15 +605,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -725,15 +725,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -855,15 +855,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -975,15 +975,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1106,15 +1106,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1227,15 +1227,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1359,15 +1359,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1480,15 +1480,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1612,15 +1612,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1733,15 +1733,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1865,15 +1865,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1986,15 +1986,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2118,15 +2118,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2239,15 +2239,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2371,15 +2371,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2492,15 +2492,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2624,15 +2624,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2745,15 +2745,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2877,15 +2877,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2998,15 +2998,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -101,15 +101,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -217,15 +217,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -340,15 +340,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -457,15 +457,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -581,15 +581,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -698,15 +698,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -821,15 +821,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -937,15 +937,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1060,15 +1060,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1177,15 +1177,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1301,15 +1301,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1418,15 +1418,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1541,15 +1541,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1657,15 +1657,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1780,15 +1780,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -1897,15 +1897,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2021,15 +2021,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2138,15 +2138,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2261,15 +2261,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2377,15 +2377,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2500,15 +2500,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2617,15 +2617,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2741,15 +2741,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
@@ -2858,15 +2858,15 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
         working-directory: pytorch
-      - name: Checkout pytorch/builder
+      - name: Checkout jithunnair-amd/builder
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: add_triton_dependency_for_rocm_wheels
           submodules: recursive
-          repository: pytorch/builder
+          repository: jithunnair-amd/builder
           path: builder
           quiet-checkout: true
-      - name: Clean pytorch/builder checkout
+      - name: Clean jithunnair-amd/builder checkout
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd


### PR DESCRIPTION
https://github.com/pytorch/builder/pull/1463


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang