### PR TITLE
[caffe2] Clean up platform-specific fbobjc deps/flags

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -324,43 +324,15 @@ def get_c2_default_cxx_args():
     )
 
 def get_c2_aten_cpu_fbobjc_macosx_deps():
-    if is_focus_enabled():
-        # focus2 is broken when using platform deps (T80070498) so in the case
-        # where it's focus2 we just add fbgemm as a standard dep. Otherwise we
-        # use platform deps to select correctly for arm64.
-        return [
+    return select({
+        "DEFAULT": [],
+        "ovr_config//os:macos-x86_64": [
             "fbsource//xplat/deeplearning/fbgemm:fbgemm",
-            "fbsource//xplat/caffe2:cpukernel_avx2",
-        ]
-    else:
-        return select({
-            "DEFAULT": [],
-            "ovr_config//os:macos-x86_64": ["fbsource//xplat/deeplearning/fbgemm:fbgemm"],
-        }) if is_arvr_mode() else []
-
-def get_c2_aten_cpu_fbobjc_macosx_platform_deps():
-    if is_focus_enabled():
-        # focus2 is broken when using platform deps (T80070498) so in the case
-        # where it's focus2 we just add fbgemm as a standard dep. Otherwise we
-        # use platform deps to select correctly for arm64.
-        return []
-    else:
-        return compose_platform_setting_list([
-            {
-                "cpu": "x86_64",
-                "flags": [
-                    "fbsource//xplat/deeplearning/fbgemm:fbgemmAppleMac",
-                ] + ([
-                    "fbsource//xplat/caffe2:cpukernel_avx2AppleMac",
-                ] if not is_arvr_mode() else []),
-                "os": "macosx",
-            },
-            {
-                "cpu": "arm64",
-                "flags": ["fbsource//xplat/third-party/XNNPACK:XNNPACKAppleMac"],
-                "os": "macosx",
-            },
-        ])
+        ] + (["fbsource//xplat/caffe2:cpukernel_avx2"] if not is_arvr_mode() else []),
+        "ovr_config//os:macos-arm64": [
+            "fbsource//xplat/third-party/XNNPACK:XNNPACK",
+        ],
+    })
 
 def using_protobuf_v3():
     # Consider migrating this to `read_config("protobuf", "use_v3")`


### PR DESCRIPTION
Summary:
Replace `platform_deps` with `select()`s and use to make sure the `cpukernel_avx2`
dep is x86-specific.

https://fb.prod.workplace.com/groups/buck2users/posts/3469961626593527/

Test Plan:
```
$ buck2 build //xplat/rtc/media/tools/newton:newton_pcAppleMac#macosx-arm64 --target-platforms //xplat/rtc/webrtc/platforms:bwe-dbg-arm64
```

Differential Revision: D47844555

