### PR TITLE
Support CUDA Unified Memory

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -217,6 +217,14 @@ elif [[ $TEST_CONFIG == 'nogpu_AVX512' ]]; then
   export ATEN_CPU_CAPABILITY=avx2
 fi
 
+test_python_cuda_uvm() {
+  export PYTORCH_CUDA_ALLOC_CONF='use_uvm:True'
+  time python test/test_cuda.py
+  unset PYTORCH_CUDA_ALLOC_CONF
+
+  assert_git_not_dirty
+}
+
 test_python_legacy_jit() {
   time python test/run_test.py --include test_jit_legacy test_jit_fuser_legacy --verbose
   assert_git_not_dirty
@@ -1074,6 +1082,7 @@ else
   install_torchvision
   install_monkeytype
   test_python
+  test_python_cuda_uvm
   test_aten
   test_vec256
   test_libtorch

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -440,6 +440,9 @@ Available options:
   reused. The threshold value should be between greater than 0.0 and less than 1.0.
   ``garbage_collection_threshold`` is only meaningful with ``backend:native``.
   With ``backend:cudaMallocAsync``, ``garbage_collection_threshold`` is ignored.
+* ``use_uvm`` enables CUDA Unified Memory when set to ``True``. Using CUDA Unified
+  Memory reduces OOM possibility, but may slow down the training. We advise you
+  profile before enabling it.
 
 .. note::
 


### PR DESCRIPTION
# Motivation

Occasionally we found some overlarge samples (e.g. long sequence during training a Transformer-based model) that could cause OOM. Although carefully filtering them out or applying some manually-designed transformation can reduce OOM possibility, these methods can hardly eliminate the issue completely.

# Resolution here

This PR adds support for [CUDA Unified Memory](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/), or UVM, to PyTorch, such that we effectively makes device RAM "swappable" to system RAM. We usually have plenty of system RAM (e.g., several terabytes) compared to device RAM (tens of gigabytes), therefore UVM brings us a much large safe margin before hitting OOM.

The feature can be optionally enabled by setting `PYTORCH_CUDA_USE_UVM=1` in environment variables.

# Performance implications

UVM degrades CUDA performance, but how much does it affects depends on the actual workload.

From our earlier experience, UVM hardly harms CUDA kernels, however, D2H/H2D memcpy are slowed down to a certain degree. Therefore, for memcpy-heavy workload, UVM can makes things much slower.

However, for training workload with an adequately large batch size, the performance should degrade much. This is also empirically verified by [QLoRA: Efficient Finetuning of Quantized LLMs](https://arxiv.org/abs/2305.14314) ("Paged Optimizers"). This makes UVM appealing to training workload.

# Possibly related

https://github.com/pytorch/pytorch/issues/98481 seems related, which also tried to add UVM support to PyTorch, albeit via a difference approach.


cc @ptrblck