### PR TITLE
Deallocate constant when it is no longer needed in constant folding

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten, tree_unflatten
+from torch.utils.weak import WeakTensorKeyDictionary
 
 if IS_WINDOWS and IS_CI:
     sys.stderr.write(
@@ -6932,6 +6933,46 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertFalse("to(tl.int64)" in code)
 
             self.assertEqual(fn_opt(*inps), fn(*inps))
+
+        def test_constant_folding_deallocation(self):
+            import torch._inductor
+
+            def fn():
+                x = torch.empty([100])
+                for _ in range(10):
+                    x = x + 1
+
+                return x
+
+            mod = make_fx(fn)()
+
+            live_tensors = WeakTensorKeyDictionary()
+            max_live_tensors = 0
+
+            class LiveTensors(TorchDispatchMode):
+                def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                    nonlocal live_tensors
+                    nonlocal max_live_tensors
+
+                    kwargs = kwargs if kwargs else {}
+                    for arg in tree_flatten((args, kwargs))[0]:
+                        if isinstance(arg, torch.Tensor):
+                            live_tensors[arg] = True
+
+                    out = func(*args, **kwargs)
+
+                    live_tensors[out] = True
+                    max_live_tensors = max(max_live_tensors, len(live_tensors))
+
+                    return out
+
+            mode = LiveTensors()
+            from torch._inductor.freezing import ConstantFolder
+
+            with mode:
+                ConstantFolder(mod).run()
+
+            self.assertTrue(max_live_tensors == 2)
 
         # See https://github.com/pytorch/pytorch/issues/100348
         def test_inductor_detach_view(self):

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -121,7 +121,8 @@ class ConstantFolder(torch.fx.Interpreter):
         if node.op != "get_attr" and isinstance(out, torch.Tensor):
             self.node_replacements[node] = out
 
-            flattened_node_inps = pytree.tree_flatten((node.args, node.kwargs)[0])
+            flattened_node_inps = pytree.tree_flatten((node.args, node.kwargs))[0]
+
             for n in flattened_node_inps:
                 if not isinstance(n, torch.fx.Node):
                     continue

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -118,9 +118,6 @@ class ConstantFolder(torch.fx.Interpreter):
 
         out = super().run_node(node)
 
-        # check inputs and remove if they are constants and have no more uses
-
-        # TODO - remove constant from node_replacement when it has no uses
         if node.op != "get_attr" and isinstance(out, torch.Tensor):
             self.node_replacements[node] = out
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106216



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov

Differential Revision: [D47881214](https://our.internmc.facebook.com/intern/diff/D47881214)

tested locally with :
```
@torch.compile()
def foo():
    size_gb = 1
    size_bytes = size_gb * 1024 * 1024 * 1024 * 20

    # Allocate the tensor on the GPU
    tensor = torch.empty(size_bytes // 4, device='cuda')  # Divide by 4 to allocate float32 elements

    for _ in range(10):
        tensor = tensor + 1

    return tensor

foo()
```