### PR TITLE
Update to RNN documentation (issue #106085)

### DIFF
--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -7,6 +7,7 @@ from torch import Tensor  # noqa: F401
 from torch._jit_internal import Tuple, Optional, List, Union, Dict  # noqa: F401
 from torch.nn.utils.rnn import PackedSequence
 from torch.ao.nn.quantized.modules.utils import _quantize_weight
+from typing import Type
 
 __all__ = ['pack_weight_bias', 'PackedParameter', 'RNNBase', 'LSTM', 'GRU', 'RNNCellBase', 'RNNCell', 'LSTMCell',
            'GRUCell', "apply_permutation"]
@@ -61,7 +62,7 @@ class PackedParameter(torch.nn.Module):
 
 class RNNBase(torch.nn.Module):
 
-    _FLOAT_MODULE = nn.RNNBase
+    _FLOAT_MODULE: Type[nn.RNNBase] = nn.RNNBase            # Annotation to ensure subclass attributes check against known type
 
     _version = 2
 
@@ -392,7 +393,7 @@ class LSTM(RNNBase):
         >>> c0 = torch.randn(2, 3, 20)
         >>> output, (hn, cn) = rnn(input, (h0, c0))
     """
-    _FLOAT_MODULE = nn.LSTM
+    _FLOAT_MODULE: Type[nn.LSTM] = nn.LSTM
 
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
@@ -638,7 +639,7 @@ class GRU(RNNBase):
         >>> h0 = torch.randn(2, 3, 20)
         >>> output, hn = rnn(input, h0)
     """
-    _FLOAT_MODULE = nn.GRU
+    _FLOAT_MODULE: Type[nn.GRU] = nn.GRU
 
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -7,7 +7,6 @@ from torch import Tensor  # noqa: F401
 from torch._jit_internal import Tuple, Optional, List, Union, Dict  # noqa: F401
 from torch.nn.utils.rnn import PackedSequence
 from torch.ao.nn.quantized.modules.utils import _quantize_weight
-from typing import Type
 
 __all__ = ['pack_weight_bias', 'PackedParameter', 'RNNBase', 'LSTM', 'GRU', 'RNNCellBase', 'RNNCell', 'LSTMCell',
            'GRUCell', "apply_permutation"]
@@ -62,8 +61,7 @@ class PackedParameter(torch.nn.Module):
 
 class RNNBase(torch.nn.Module):
 
-    # Annotation to ensure subclass attributes check against known type (and resolve mypy error)
-    _FLOAT_MODULE: Type[nn.RNNBase] = nn.RNNBase
+    _FLOAT_MODULE = nn.RNNBase
 
     _version = 2
 
@@ -394,7 +392,7 @@ class LSTM(RNNBase):
         >>> c0 = torch.randn(2, 3, 20)
         >>> output, (hn, cn) = rnn(input, (h0, c0))
     """
-    _FLOAT_MODULE: Type[nn.LSTM] = nn.LSTM
+    _FLOAT_MODULE = nn.LSTM
 
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
@@ -640,7 +638,7 @@ class GRU(RNNBase):
         >>> h0 = torch.randn(2, 3, 20)
         >>> output, hn = rnn(input, h0)
     """
-    _FLOAT_MODULE: Type[nn.GRU] = nn.GRU
+    _FLOAT_MODULE = nn.GRU
 
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -62,7 +62,8 @@ class PackedParameter(torch.nn.Module):
 
 class RNNBase(torch.nn.Module):
 
-    _FLOAT_MODULE: Type[nn.RNNBase] = nn.RNNBase            # Annotation to ensure subclass attributes check against known type
+    # Annotation to ensure subclass attributes check against known type (and resolve mypy error)
+    _FLOAT_MODULE: Type[nn.RNNBase] = nn.RNNBase
 
     _version = 2
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -460,7 +460,7 @@ class RNN(RNNBase):
 
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
                  non_linearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
-                 dropout: float = 0., bidirectional: bool = False, device=None, dtype=None):
+                 dropout: float = 0., bidirectional: bool = False, device=None, dtype=None) -> None:
         self.nonlinearity = non_linearity
         if self.nonlinearity == 'tanh':
             mode = 'RNN_TANH'
@@ -740,7 +740,7 @@ class LSTM(RNNBase):
 
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, bias: bool = True,
                  batch_first: bool = False, dropout: float = 0., bidirectional: bool = False,
-                 proj_size: int = 0, device=None, dtype=None):
+                 proj_size: int = 0, device=None, dtype=None) -> None:
         super().__init__('LSTM', input_size=input_size, hidden_size=hidden_size, num_layers=num_layers,
                          bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional,
                          proj_size=proj_size, device=device, dtype=dtype)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -34,6 +34,12 @@ class RNNBase(Module):
 
     Implements aspects of RNNs shared by the RNN, LSTM, and GRU classes, such as module initialization
     and utility methods for parameter storage management.
+
+    .. note::
+        The forward method is not implemented by the RNNBase class.
+
+    .. note::
+        LSTM and GRU classes override some methods implemented by RNNBase.
     """
     __constants__ = ['mode', 'input_size', 'hidden_size', 'num_layers', 'bias',
                      'batch_first', 'dropout', 'bidirectional', 'proj_size']
@@ -459,15 +465,15 @@ class RNN(RNNBase):
     """
 
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
-                 non_linearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
+                 nonlinearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
                  dropout: float = 0., bidirectional: bool = False, device=None, dtype=None) -> None:
-        self.nonlinearity = non_linearity
+        self.nonlinearity = nonlinearity
         if self.nonlinearity == 'tanh':
             mode = 'RNN_TANH'
         elif self.nonlinearity == 'relu':
             mode = 'RNN_RELU'
         else:
-            raise ValueError(f"Unknown nonlinearity '{self.nonlinearity}'. Select from: 'tanh', 'relu'.")
+            raise ValueError(f"Unknown nonlinearity '{self.nonlinearity}'. Select from 'tanh' or 'relu'.")
         super().__init__(mode, input_size=input_size, hidden_size=hidden_size, num_layers=num_layers,
                          bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional,
                          device=device, dtype=dtype)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -31,7 +31,7 @@ def apply_permutation(tensor: Tensor, permutation: Tensor, dim: int = 1) -> Tens
 
 class RNNBase(Module):
     r"""Base class for RNN modules (RNN, LSTM, GRU).
-    
+
     Implements aspects of RNNs shared by the RNN, LSTM, and GRU classes, such as module initialization
     and utility methods for parameter storage management.
 
@@ -464,7 +464,7 @@ class RNN(RNNBase):
         >>> output, hn = rnn(input, h0)
     """
 
-    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, 
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
                  non_linearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
                  dropout: float = 0., bidirectional: bool = False, device=None, dtype=None):
         self.nonlinearity = non_linearity
@@ -744,11 +744,11 @@ class LSTM(RNNBase):
         >>> output, (hn, cn) = rnn(input, (h0, c0))
     """
 
-    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, bias: bool = True, 
-                 batch_first: bool = False, dropout: float = 0., bidirectional: bool = False, 
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, bias: bool = True,
+                 batch_first: bool = False, dropout: float = 0., bidirectional: bool = False,
                  proj_size: int = 0, device=None, dtype=None):
         super().__init__('LSTM', input_size=input_size, hidden_size=hidden_size, num_layers=num_layers,
-                         bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional, 
+                         bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional,
                          proj_size=proj_size, device=device, dtype=dtype)
 
     def get_expected_cell_size(self, input: Tensor, batch_sizes: Optional[Tensor]) -> Tuple[int, int, int]:
@@ -1005,11 +1005,11 @@ class GRU(RNNBase):
         >>> output, hn = rnn(input, h0)
     """
 
-    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, bias: bool = True, 
-                 batch_first: bool = False, dropout: float = 0., bidirectional: bool = False, 
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1, bias: bool = True,
+                 batch_first: bool = False, dropout: float = 0., bidirectional: bool = False,
                  device=None, dtype=None):
         super().__init__('GRU', input_size=input_size, hidden_size=hidden_size, num_layers=num_layers,
-                         bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional, 
+                         bias=bias, batch_first=batch_first, dropout=dropout, bidirectional=bidirectional,
                          device=device, dtype=dtype)
 
     @overload  # type: ignore[override]

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -20,29 +20,6 @@ _rnn_impls = {
 }
 
 
-def _prepend_to_docstring(header_docstring: str):
-    r"""Prepends a line to a docstring. The original docstring is indented with four spaces.
-
-    This decorator is useful for creating documentation, since the first line replaces the function
-    signature in the docstring. The decorator adds long, single lines in docstrings without
-    violating a .py file's character limit.
-    """
-
-    def decorator(documented_object):
-        if documented_object.__doc__:
-            # fix indentation of the initial docstring
-            if not documented_object.__doc__.startswith(r"    "):
-                original_docstr = r"    " + documented_object.__doc__
-            else:
-                original_docstr = documented_object.__doc__
-            documented_object.__doc__ = "\n".join([header_docstring, original_docstr])
-        else:
-            documented_object = header_docstring
-        return documented_object
-
-    return decorator
-
-
 def _apply_permutation(tensor: Tensor, permutation: Tensor, dim: int = 1) -> Tensor:
     return tensor.index_select(dim, permutation)
 
@@ -383,10 +360,11 @@ class RNNBase(Module):
         replica._flat_weights_names = replica._flat_weights_names[:]
         return replica
 
-@_prepend_to_docstring("__init__(self,input_size,hidden_size,num_layers=1,nonlinearity='tanh',bias=True,"
-                       "batch_first=False,dropout=0.0,bidirectional=False,device=None,dtype=None)")
+
 class RNN(RNNBase):
-    r"""Applies a multi-layer Elman RNN with :math:`\tanh` or :math:`\text{ReLU}` non-linearity to an
+    r"""__init__(self,input_size,hidden_size,num_layers=1,nonlinearity='tanh',bias=True,batch_first=False,dropout=0.0,bidirectional=False,device=None,dtype=None)
+
+    Applies a multi-layer Elman RNN with :math:`\tanh` or :math:`\text{ReLU}` non-linearity to an
     input sequence.
 
     For each element in the input sequence, each layer computes the following
@@ -615,10 +593,11 @@ class RNN(RNNBase):
 # TODO: remove the overriding implementations for LSTM and GRU when TorchScript
 # support expressing these two modules generally.
 
-@_prepend_to_docstring("__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,"
-                       "dropout=0.0,bidirectional=False,proj_size=0,device=None,dtype=None)")
+
 class LSTM(RNNBase):
-    r"""Applies a multi-layer long short-term memory (LSTM) RNN to an input
+    r"""__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,dropout=0.0,bidirectional=False,proj_size=0,device=None,dtype=None)
+
+    Applies a multi-layer long short-term memory (LSTM) RNN to an input
     sequence.
 
     For each element in the input sequence, each layer computes the following
@@ -915,11 +894,10 @@ class LSTM(RNNBase):
             return output, self.permute_hidden(hidden, unsorted_indices)
 
 
-@_prepend_to_docstring("__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,"
-                       "dropout=0.0,bidirectional=False,device=None,dtype=None)")
 class GRU(RNNBase):
-    r"""Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
+    r"""__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,"dropout=0.0,bidirectional=False,device=None,dtype=None)
 
+    Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
 
     For each element in the input sequence, each layer computes the following
     function:

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -34,12 +34,6 @@ class RNNBase(Module):
 
     Implements aspects of RNNs shared by the RNN, LSTM, and GRU classes, such as module initialization
     and utility methods for parameter storage management.
-
-    .. note::
-        The forward method is not implemented by the RNNBase class.
-
-    .. note::
-        LSTM and GRU classes override some method implemented by RNNBase.
     """
     __constants__ = ['mode', 'input_size', 'hidden_size', 'num_layers', 'bias',
                      'batch_first', 'dropout', 'bidirectional', 'proj_size']

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -895,7 +895,7 @@ class LSTM(RNNBase):
 
 
 class GRU(RNNBase):
-    r"""__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,"dropout=0.0,bidirectional=False,device=None,dtype=None)
+    r"""__init__(self,input_size,hidden_size,num_layers=1,bias=True,batch_first=False,dropout=0.0,bidirectional=False,device=None,dtype=None)
 
     Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
 


### PR DESCRIPTION
Addresses [issue #106085](https://github.com/pytorch/pytorch/issues/106085).

In `torch/nn/modules/rnn.py`:
- Adds documentation string to RNNBase class.
- Adds parameters to __init__ methods for RNN, LSTM, and GRU, classes.
- Adds type annotations to __init__ methods for RNN, LSTM, and GRU.

In `torch/ao/nn/quantized/dynamic/modules/rnn.py`:
- Adds type specifications to `_FLOAT_MODULE` attributes in RNNBase, RNN, LSTM, and GRU classes. 
> This resolves a `mypy` assignment error `Incompatible types in assignment (expression has type "Type[LSTM]", base class "RNNBase" defined the type as "Type[RNNBase]")` that seemed to be a result of fully specified type annotations in `torch/nn/modules/rnn.py`).