### PR TITLE
[inductor] Make AOT CPU Inductor work in fbcode

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -688,6 +688,10 @@ def get_include_and_linking_paths(
 ):
     from torch.utils import cpp_extension
 
+    if aot_mode and config.is_fbcode():
+        # Hack.  The AOT inductor libs reference CUDA, so let's just include it for now.
+        cuda = True
+
     macros = ""
     if sys.platform == "linux" and (
         include_pytorch
@@ -712,6 +716,8 @@ def get_include_and_linking_paths(
         else:
             # internal remote execution is able to find omp, but not gomp
             libs += ["omp"]
+            if aot_mode:
+                ipaths += [os.path.dirname(cpp_prefix_path())]
         macros = vec_isa.build_macro()
         if macros:
             if config.is_fbcode() and vec_isa != invalid_vec_isa:


### PR DESCRIPTION
Summary:
This diff has a couple of hacks to make inductor-CPU work for AOT codegen in fbcode:

- We need to add the CUDA link flags; AOT-Inductor is specialized for CUDA
  right now and uses a lot of `at::cuda` stuff.  We should do a proper AOT CPU
  at some point but this unblocks perf measurement.

- Add an include path to the cpp_prefix.  It's kind of hilarious; we remove the
  include path for remote execution, but then for AOT we need it back. :shrug:

Test Plan: internal test

Differential Revision: D47882848



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov