### PR TITLE
Fix nullable-to-nonnull-conversion warnings

### DIFF
--- a/aten/src/ATen/native/metal/MetalContext.mm
+++ b/aten/src/ATen/native/metal/MetalContext.mm
@@ -78,7 +78,7 @@ C10_CLANG_DIAGNOSTIC_POP()
   if (state) {
     return state;
   }
-  id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
+  id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()] ?: @""];
   TORCH_CHECK(func, "Failed to load the Metal Shader function: ", kernel);
   NSError* errors = nil;
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
@@ -126,7 +126,7 @@ C10_CLANG_DIAGNOSTIC_POP()
     }
   }
   NSError* errors = nil;
-  id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]
+  id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()] ?: @""
                                         constantValues:constantValues
                                                  error:&errors];
   TORCH_CHECK(func, errors.localizedDescription.UTF8String);
@@ -160,7 +160,7 @@ C10_CLANG_DIAGNOSTIC_POP()
     [options setLanguageVersion:_deviceInfo.languageVersion];
     [options setFastMathEnabled:YES];
     _library = [_device
-        newLibraryWithSource:[NSString stringWithUTF8String:PT_METAL_SHADERS]
+        newLibraryWithSource:[NSString stringWithUTF8String:PT_METAL_SHADERS] ?: @""
                      options:options
                        error:&localError];
     compilationError = localError;


### PR DESCRIPTION
Summary:
Cleaning up some build warnings when Wnullable-to-nonnull-conversion is enabled.

Changelog: Fixes nullability warnings from `MetalContext.mm`.

Test Plan:
```
buck build fbsource//fbobjc/mode/iphonesimulator //fbobjc/Apps/MSQRD/MSQRDPlayer:ARStudioPlayer
```

Differential Revision: D47886793

