### PR TITLE
[CUDA][CUDA Graphs] Fix potential race with autograd thread during a graph capture

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -84,6 +84,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/) {
   capture_gen_ = gen;
   capture_dev_ = c10::cuda::current_device();
 
+  c10::cuda::CUDACachingAllocator::incOngoingCaptures(capture_dev_);
   // cudaStreamCaptureModeGlobal is the most conservative option to
   // prevent potentially unsafe CUDA API calls during capture.  See
   // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
@@ -139,6 +140,7 @@ void CUDAGraph::capture_end() {
   c10::cuda::CUDACachingAllocator::endAllocateStreamToPool(capture_dev_, capture_stream_);
 
   AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));
+  c10::cuda::CUDACachingAllocator::decOngoingCaptures(capture_dev_);
   TORCH_CHECK(graph_ != NULL, "Invalid capture.");
   has_graph_ = true;
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2117,7 +2117,9 @@ class DeviceCachingAllocator {
   // Called by CUDAGraph::capture_end
   void decOngoingCaptures() {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    TORCH_INTERNAL_ASSERT(captures_underway > 0, "Attempted to decrement the number of graph captures when it was already 0. Please report a bug to PyTorch");
+    TORCH_INTERNAL_ASSERT(
+        captures_underway > 0,
+        "Attempted to decrement the number of graph captures when it was already 0. Please report a bug to PyTorch");
     captures_underway--;
   }
 

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -213,6 +213,8 @@ class CUDAAllocator : public Allocator {
       cudaStream_t stream,
       MempoolId_t mempool_id) = 0;
   virtual void endAllocateStreamToPool(int device, cudaStream_t stream) = 0;
+  virtual void incOngoingCaptures(int device) = 0;
+  virtual void decOngoingCaptures(int device) = 0;
   virtual void releasePool(int device, MempoolId_t mempool_id) = 0;
   // returns true if the allocated blocks are equal to expected live allocations
   virtual bool checkPoolLiveAllocations(
@@ -356,6 +358,14 @@ inline void beginAllocateStreamToPool(
 
 inline void endAllocateStreamToPool(int device, cudaStream_t stream) {
   return get()->endAllocateStreamToPool(device, stream);
+}
+
+inline void incOngoingCaptures(int device) {
+  return get()->incOngoingCaptures(device);
+}
+
+inline void decOngoingCaptures(int device) {
+  return get()->decOngoingCaptures(device);
 }
 
 inline void recordHistory(

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -801,7 +801,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     std::lock_guard<std::mutex> lk(general_mutex);
     TORCH_CHECK(
         capture_underway,
-        "CudaMallocAsync::notifyCaptureEnded called, "
+        "decOngoingCaptures called, "
         "but CudaMallocAsync::capture_underway is false.");
     capture_underway = false;
   }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3989,11 +3989,13 @@ class TestBlockStateAbsorption(TestCase):
             stream.wait_stream(torch.cuda.current_stream())
             stream_context = torch.cuda.stream(stream)
             stream_context.__enter__()
+            torch._C._cuda_incOngoingCaptures(device)
             torch._C._cuda_beginAllocateCurrentStreamToPool(device, mem_pool)
             try:
                 yield
             finally:
                 torch._C._cuda_endAllocateCurrentStreamToPool(device)
+                torch._C._cuda_decOngoingCaptures(device)
                 torch._C._cuda_releasePool(device, mem_pool)
                 stream_context.__exit__(None, None, None)
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -507,11 +507,13 @@ def _use_cuda_memory_pool_manager(device, mem_pool, stream):
     stream.wait_stream(torch.cuda.current_stream())
 
     with torch.cuda.stream(stream), torch.device(device):
+        torch._C._cuda_incOngoingCaptures(device)
         torch._C._cuda_beginAllocateCurrentStreamToPool(device, mem_pool)
         try:
             yield
         finally:
             torch._C._cuda_endAllocateCurrentStreamToPool(device)
+            torch._C._cuda_decOngoingCaptures(device)
             torch._C._cuda_releasePool(device, mem_pool)
 
 

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -82,7 +82,7 @@ void CUDAPluggableAllocator::set_end_allocate_stream_to_pool_fn(
 }
 
 void CUDAPluggableAllocator::set_inc_ongoing_captures_fn(
-     std::function<void(int)> inc_ongoing_captures_fn) {
+    std::function<void(int)> inc_ongoing_captures_fn) {
   inc_ongoing_captures_fn_ = inc_ongoing_captures_fn;
 }
 
@@ -257,17 +257,23 @@ void CUDAPluggableAllocator::endAllocateStreamToPool(
   }
 }
 
-void CUDAPluggableAllocator::incOngoingCaptures(
-    int device) {
+void CUDAPluggableAllocator::incOngoingCaptures(int device) {
   if (inc_ongoing_captures_fn_) {
     inc_ongoing_captures_fn_(device);
+  } else {
+    TORCH_WARN(
+        "incOngoingCaptures called but no function was set. This is"
+        "dangerous and can cause a crash due to invalid event recording.");
   }
 }
 
-void CUDAPluggableAllocator::decOngoingCaptures(
-    int device) {
+void CUDAPluggableAllocator::decOngoingCaptures(int device) {
   if (dec_ongoing_captures_fn_) {
     dec_ongoing_captures_fn_(device);
+  } else {
+    TORCH_WARN(
+        "decOngoingCaptures called but no function was set. This is"
+        "dangerous and can cause a crash due to invalid event recording.");
   }
 }
 

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -43,7 +43,9 @@ CUDAPluggableAllocator::CUDAPluggableAllocator(CUDAPluggableAllocator& other)
       begin_allocate_stream_to_pool_fn_(
           other.begin_allocate_stream_to_pool_fn_),
       end_allocate_stream_to_pool_fn_(other.end_allocate_stream_to_pool_fn_),
-      relase_pool_fn_(other.relase_pool_fn_) {}
+      relase_pool_fn_(other.relase_pool_fn_),
+      inc_ongoing_captures_fn_(other.inc_ongoing_captures_fn_),
+      dec_ongoing_captures_fn_(other.dec_ongoing_captures_fn_) {}
 
 void CUDAPluggableAllocator::set_init_fn(std::function<void(int)> init_fn) {
   init_fn_ = init_fn;
@@ -77,6 +79,16 @@ void CUDAPluggableAllocator::set_begin_allocate_stream_to_pool(
 void CUDAPluggableAllocator::set_end_allocate_stream_to_pool_fn(
     std::function<void(int, cudaStream_t)> capture_about_to_end_fn) {
   end_allocate_stream_to_pool_fn_ = capture_about_to_end_fn;
+}
+
+void CUDAPluggableAllocator::set_inc_ongoing_captures_fn(
+     std::function<void(int)> inc_ongoing_captures_fn) {
+  inc_ongoing_captures_fn_ = inc_ongoing_captures_fn;
+}
+
+void CUDAPluggableAllocator::set_dec_ongoing_captures_fn(
+    std::function<void(int)> dec_ongoing_captures_fn) {
+  dec_ongoing_captures_fn_ = dec_ongoing_captures_fn;
 }
 
 void CUDAPluggableAllocator::set_release_pool(
@@ -242,6 +254,20 @@ void CUDAPluggableAllocator::endAllocateStreamToPool(
     cudaStream_t stream) {
   if (end_allocate_stream_to_pool_fn_) {
     end_allocate_stream_to_pool_fn_(device, stream);
+  }
+}
+
+void CUDAPluggableAllocator::incOngoingCaptures(
+    int device) {
+  if (inc_ongoing_captures_fn_) {
+    inc_ongoing_captures_fn_(device);
+  }
+}
+
+void CUDAPluggableAllocator::decOngoingCaptures(
+    int device) {
+  if (dec_ongoing_captures_fn_) {
+    dec_ongoing_captures_fn_(device);
   }
 }
 

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -67,8 +67,7 @@ struct CUDAPluggableAllocator
       std::function<void(int, cudaStream_t)> capture_about_to_end_fn);
 
   void set_inc_ongoing_captures_fn(
-      std::function<void(int)>
-          inc_ongoing_captures_fn);
+      std::function<void(int)> inc_ongoing_captures_fn);
 
   void set_dec_ongoing_captures_fn(
       std::function<void(int)> dec_ongoing_captures_fn);
@@ -146,9 +145,9 @@ struct CUDAPluggableAllocator
   std::function<void(int, cudaStream_t, c10::cuda::MempoolId_t)>
       begin_allocate_stream_to_pool_fn_;
   std::function<void(int, cudaStream_t)> end_allocate_stream_to_pool_fn_;
+  std::function<void(int, c10::cuda::MempoolId_t)> relase_pool_fn_;
   std::function<void(int)> inc_ongoing_captures_fn_;
   std::function<void(int)> dec_ongoing_captures_fn_;
-  std::function<void(int, c10::cuda::MempoolId_t)> relase_pool_fn_;
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators
   std::unordered_map<void*, _AllocationMetadata> allocation_metadata_;

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -66,6 +66,13 @@ struct CUDAPluggableAllocator
   void set_end_allocate_stream_to_pool_fn(
       std::function<void(int, cudaStream_t)> capture_about_to_end_fn);
 
+  void set_inc_ongoing_captures_fn(
+      std::function<void(int)>
+          inc_ongoing_captures_fn);
+
+  void set_dec_ongoing_captures_fn(
+      std::function<void(int)> dec_ongoing_captures_fn);
+
   void set_release_pool(
       std::function<void(int, c10::cuda::MempoolId_t)> capture_destroy_fn);
 
@@ -98,6 +105,8 @@ struct CUDAPluggableAllocator
       c10::cuda::MempoolId_t mempool_id) override;
   virtual void endAllocateStreamToPool(int device, cudaStream_t stream)
       override;
+  virtual void incOngoingCaptures(int device) override;
+  virtual void decOngoingCaptures(int device) override;
   virtual void releasePool(int device, c10::cuda::MempoolId_t mempool_id)
       override;
   virtual std::shared_ptr<void> getIpcDevPtr(std::string handle) override;
@@ -137,6 +146,8 @@ struct CUDAPluggableAllocator
   std::function<void(int, cudaStream_t, c10::cuda::MempoolId_t)>
       begin_allocate_stream_to_pool_fn_;
   std::function<void(int, cudaStream_t)> end_allocate_stream_to_pool_fn_;
+  std::function<void(int)> inc_ongoing_captures_fn_;
+  std::function<void(int)> dec_ongoing_captures_fn_;
   std::function<void(int, c10::cuda::MempoolId_t)> relase_pool_fn_;
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1054,6 +1054,24 @@ static void registerCudaPluggableAllocator(PyObject* module) {
             self.set_end_allocate_stream_to_pool_fn(func);
           })
       .def(
+          "set_inc_ongoing_captures_fn",
+          [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
+             uint64_t func_ptr) {
+            using FuncType = void(int);
+            std::function<FuncType> func =
+                reinterpret_cast<FuncType*>(func_ptr);
+            self.set_inc_ongoing_captures_fn(func);
+          })
+      .def(
+          "set_dec_ongoing_captures_fn",
+          [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
+             uint64_t func_ptr) {
+            using FuncType = void(int);
+            std::function<FuncType> func =
+                reinterpret_cast<FuncType*>(func_ptr);
+            self.set_dec_ongoing_captures_fn(func);
+          })
+      .def(
           "set_release_pool",
           [](torch::cuda::CUDAPluggableAllocator::CUDAPluggableAllocator& self,
              uint64_t func_ptr) {
@@ -1156,6 +1174,14 @@ static void registerCudaPluggableAllocator(PyObject* module) {
     auto stream = at::cuda::getCurrentCUDAStream(device);
     TORCH_CHECK(stream, "Expected stream capture to be under way");
     c10::cuda::CUDACachingAllocator::endAllocateStreamToPool(device, stream);
+  });
+
+  m.def("_cuda_incOngoingCaptures", [](int device) {
+    c10::cuda::CUDACachingAllocator::incOngoingCaptures(device);
+  });
+
+  m.def("_cuda_decOngoingCaptures", [](int device) {
+    c10::cuda::CUDACachingAllocator::decOngoingCaptures(device);
   });
 
   m.def("_cuda_releasePool", [](int device, at::cuda::MempoolId_t mempool_id) {


### PR DESCRIPTION
Currently the beginning/ending of a capture occurs before/after the caching allocator is notified that the number of captures underway is supposed to increase/decrease, respectively. If everything of interest is happening on the main thread, then this is fine as no potentially unsafe behavior occurs between the actual beginning of a capture and the notification of the caching allocator and no potentially unsafe behavior occurs between notification of the caching allocator the actual ending of the capture.

However, with somewhat more unusual use cases such as repeatedly instantiating models and then capturing the backward pass of each newly instantiated model, an unsafe interaction can occur with the current timing of when the caching allocator is notified of captures beginning/ending.

Consider the moment where the main thread is between these two lines:
```
  c10::cuda::CUDACachingAllocator::endAllocateStreamToPool(capture_dev_, capture_stream_);

  AT_CUDA_CHECK(cudaStreamEndCapture(capture_stream_, &graph_));
  ```
  of `capture_end()` in `aten/src/ATen/cuda/CUDAGraph.cpp`.
At this point, the caching allocator has updated its internal `captures_underway` variable to reflect that there are no ongoing captures, yet `cudaStreamEndCapture` has not actually been called yet. If the side thread makes a `free()` call at this point, it will erroneously insert (record) an event _during_ the capture according to
```
    if (!block->stream_uses.empty()) {
      if (C10_UNLIKELY(captures_underway)) {
        // It's forbidden to cudaEventQuery an event recorded during CUDA graph
        // capture. We conservatively defer recording end-of-life events until
        // the next call to process_events() (which won't happen until no
        // captures are underway)
        needs_events_deferred_until_no_capture.push_back(block);
      } else {
        insert_events(block);
      }
    } else {
      free_block(block);
    }
```
This recording of an event during a capture will be fatal to the main thread the next time it decides to query outstanding events outside of a capture.

This PR does the minimal fix of adding explicit functions incrementing/decrementing the number of ongoing captures so that the caching allocator can be notified _before_ a capture starts and _after_ a capture ends in a thread-safe manner.

cc @mcarilli @ezyang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ptrblck 