### PR TITLE
[inductor] AOTInductor w/ saved weights

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -44,7 +44,6 @@ class AOTInductorModelRunner:
         source = (
             """
         #include <torch/csrc/inductor/aot_inductor_model.h>
-        #include <torch/torch.h>
         #include <torch/script.h>
 
         torch::aot_inductor::AOTInductorModel model;

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -391,8 +391,13 @@ def aot_compile(
     )
     all_args = (*param_buffer_values, *flat_example_inputs)
 
+    if options is None:
+        options = {"freezing": True}
+    else:
+        options["freezing"] = True
+
     so_path = compile_fx_aot(
-        ep.graph_module,
+        ep,
         all_args,  # type: ignore[arg-type]
         config_patches=options,
     )

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -385,20 +385,13 @@ def aot_compile(
     # Reset the global value
     DECOMP_TABLE = core_aten_decompositions()
 
-    param_buffer_values = list(ep.state_dict.values())
     flat_example_inputs = fx_pytree.tree_flatten_spec(
         combine_args_kwargs(args, kwargs), ep.call_spec.in_spec  # type: ignore[arg-type]
     )
-    all_args = (*param_buffer_values, *flat_example_inputs)
-
-    if options is None:
-        options = {"freezing": True}
-    else:
-        options["freezing"] = True
 
     so_path = compile_fx_aot(
         ep,
-        all_args,  # type: ignore[arg-type]
+        flat_example_inputs,  # type: ignore[arg-type]
         config_patches=options,
     )
     return so_path, ep

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -887,11 +887,11 @@ class AotCodeCache:
             specified_dir=config.aot_inductor_output_path,
         )
 
-        # Write constants to file
-        torch.save(
-            list(graph.constants.values()),
-            f"{os.path.splitext(input_path)[0]}_constants.pkl",
-        )
+        # Write list of constants to file
+        path = f"{os.path.splitext(input_path)[0]}_constants.pt"
+        m = torch.nn.Module()
+        m.tensor_list = list(graph.constants.values())
+        torch.jit.save(torch.jit.script(m), path)
 
         if key not in cls.cache:
             from filelock import FileLock

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -887,7 +887,9 @@ class AotCodeCache:
             specified_dir=config.aot_inductor_output_path,
         )
 
-        # Write list of constants to file
+        # Write list of constants to file.
+        # We have to do this hack with torch.nn.Module because torch::load()
+        # cannot directly load List[Tensor].
         path = f"{os.path.splitext(input_path)[0]}_constants.pt"
         m = torch.nn.Module()
         m.tensor_list = list(graph.constants.values())

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -886,6 +886,13 @@ class AotCodeCache:
             extra=cpp_command,
             specified_dir=config.aot_inductor_output_path,
         )
+
+        # Write constants to file
+        torch.save(
+            list(graph.constants.values()),
+            f"{os.path.splitext(input_path)[0]}_constants.pkl",
+        )
+
         if key not in cls.cache:
             from filelock import FileLock
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -887,12 +887,12 @@ class AotCodeCache:
             specified_dir=config.aot_inductor_output_path,
         )
 
-        # Write list of constants to file.
+        # Write state dict to a file.
         # We have to do this hack with torch.nn.Module because torch::load()
-        # cannot directly load List[Tensor].
+        # cannot directly load Dict[Tensor].
         path = f"{os.path.splitext(input_path)[0]}_constants.pt"
         m = torch.nn.Module()
-        m.tensor_list = list(graph.constants.values())
+        m.state_dict = graph.constants
         torch.jit.save(torch.jit.script(m), path)
 
         if key not in cls.cache:

--- a/torch/_inductor/codegen/aot_inductor_interface.cpp
+++ b/torch/_inductor/codegen/aot_inductor_interface.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/inductor/aot_inductor_interface.h>
 #include <torch/csrc/inductor/aot_inductor_model_container.h>
+#include <torch/script.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
@@ -143,6 +144,33 @@ AOTInductorError AOTInductorModelContainerGetMaxOutputShape(
     *output_shape =
         AOTInductorParamShape(max_output_shape.data(), max_output_shape.size());
   })
+}
+
+AOTInductorError AOTInductorModelContainerSetConstants(
+  std::map<std::string, at::Tensor>& constantTensors) {
+
+    std::string currentFilePath = __FILE__;
+
+    // Get the constants file (current path + file name + "_constants.pt")
+    std::string constantsFilePath = currentFilePath;
+    size_t pos = constantsFilePath.find_last_of(".");
+    if (pos != std::string::npos) {
+      constantsFilePath = constantsFilePath.substr(0, pos);
+    }
+    constantsFilePath += "_constants.pt";
+
+    // Load the list of constant tensors from the constants file
+    CONVERT_EXCEPTION_TO_ERROR_CODE({
+      auto module = torch::jit::load(constantsFilePath);
+      if (module.hasattr("state_dict")) {
+        for (const auto& item : module.attr("state_dict").toGenericDict()) {
+          auto& key = item.key();
+          auto& val = item.value();
+
+          constantTensors[key.toStringRef()] = val.toTensor();
+        }
+      }
+    })
 }
 
 } // extern "C"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -996,6 +996,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     else:
                         self.prefix.writeline(f"at::Tensor {input_key} = args[{idx}];")
 
+            # Append constants as inputs to the graph
             assert all(
                 isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
             ), "Expect all constants to be Tensor"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1033,7 +1033,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         outputs_info_[0].shape.emplace_back(10, 10, nullptr);
         }
         """
-        num_inputs = len(V.graph.graph_inputs)
+        num_inputs = len(V.graph.graph_inputs) + len(V.graph.constants)
         num_outputs = len(V.graph.graph_outputs)
         self.prefix.splice(
             f"""
@@ -1057,6 +1057,14 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     self.prefix.writeline(
                         f"inputs_info_[{idx}].shape.emplace_back({size}, {size}, nullptr);"
                     )
+
+            # Append constants as inputs to the graph
+            inputs_len = len(V.graph.graph_inputs.keys())
+            for idx, name in enumerate(V.graph.constants.keys()):
+                constants_idx = inputs_len + idx
+                self.prefix.writeline(
+                    f"""inputs_info_[{constants_idx}].name = "{name}";"""
+                )
 
             for idx, output in enumerate(V.graph.graph_outputs):
                 # TODO: handle symbolic expressions later.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -292,9 +292,10 @@ class WrapperCodeGen(CodeGen):
         self.write_header()
         self.write_prefix()
 
-        for name, hashed in V.graph.constant_reprs.items():
-            # include a hash so our code cache gives different constants different files
-            self.write_constant(name, hashed)
+        if not V.graph.cpp_wrapper:
+            for name, hashed in V.graph.constant_reprs.items():
+                # include a hash so our code cache gives different constants different files
+                self.write_constant(name, hashed)
 
         self.allocated = set()
         self.freed = set()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1055,17 +1055,7 @@ def compile_fx(
 
     fw_compiler = functools.partial(fw_compiler_base, is_inference=False)
 
-    if _in_aot_compilation and config.freezing and not torch.is_grad_enabled():
-        inference_compiler = functools.partial(
-            fw_compiler_freezing,
-            dynamo_model=model_,
-            num_example_inputs=num_example_inputs,
-            inner_compile=inner_compile,
-            cudagraphs=cudagraphs,
-            graph_id=graph_id,
-            forward_device=forward_device,
-        )
-    elif config.freezing and not torch.is_grad_enabled():
+    if config.freezing and not torch.is_grad_enabled():
         inference_compiler = functools.partial(
             fw_compiler_freezing,
             dynamo_model=model_,

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -12,7 +12,6 @@ from torch._functorch.compile_utils import fx_graph_cse
 
 from torch._inductor.fx_passes.freezing_patterns import freezing_passes
 from torch._inductor.fx_passes.post_grad import view_to_reshape
-from torch._inductor.virtualized import V
 
 from . import config
 
@@ -73,40 +72,6 @@ def replace_params_with_constants(gm, flat_params, fw_metadata) -> List[int]:
     preserved_arg_indices.extend(range(len(flat_params), len(params)))
     # is this necessary ?
     gm.recompile()
-    return preserved_arg_indices
-
-
-def replace_exported_params_with_constants(gm, ep) -> List[int]:
-    """
-    Replaces the parameters of a PyTorch GraphModule with constants wherever possible.
-    Returns a list of indices representing the input parameters that were not converted to constants.
-    """
-    param_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
-    flat_named_params = list(ep.state_dict.items())
-    preserved_arg_indices = []
-    for i, (param_name, param) in enumerate(flat_named_params):
-        if param_name in ep.graph_signature.buffers_to_mutate:
-            preserved_arg_indices.append(i)
-            continue
-        else:
-            replace_node_with_constant(gm, param_nodes[i], param)
-
-            # Remove these from the original exported graph to reflect the freezing
-            del ep.state_dict[param_name]
-            if param_name in ep.graph_signature.parameters:
-                ep.graph_signature.parameters.remove(param_name)
-            if param_name in ep.graph_signature.buffers:
-                ep.graph_signature.buffers.remove(param_name)
-
-    # add on non param inputs
-    preserved_arg_indices.extend(range(len(flat_named_params), len(param_nodes)))
-    # is this necessary ?
-    gm.recompile()
-
-    # Update the real inputs so later the cpp_wrapper can get the correct inputs
-    if V.real_inputs:
-        V.set_real_inputs(tuple(V.real_inputs[ind] for ind in preserved_arg_indices))
-
     return preserved_arg_indices
 
 
@@ -245,13 +210,7 @@ def freeze(
     # See the details in fx_codegen_and_compile of compile_fx.py.
     view_to_reshape(aot_autograd_gm)
 
-    from torch._export.exported_program import ExportedProgram
-
-    if isinstance(dynamo_gm, ExportedProgram):
-        preserved_arg_indices = replace_exported_params_with_constants(
-            aot_autograd_gm, dynamo_gm
-        )
-    else:
+    if torch._guards.TracingContext.get():
         fw_metadata = torch._guards.TracingContext.get().fw_metadata
         params_flat = torch._guards.TracingContext.get().params_flat
         assert fw_metadata is not None and params_flat is not None
@@ -259,6 +218,11 @@ def freeze(
         preserved_arg_indices = replace_params_with_constants(
             aot_autograd_gm, params_flat, fw_metadata
         )
+    else:
+        inputs = [
+            node for node in aot_autograd_gm.graph.nodes if node.op == "placeholder"
+        ]
+        preserved_arg_indices = list(range(len(inputs)))
 
     # TODO - further restrict cse ? right now needed to dedup aliasing ops
     cse_graph = fx_graph_cse(aot_autograd_gm.graph)

--- a/torch/csrc/inductor/aot_inductor_interface.h
+++ b/torch/csrc/inductor/aot_inductor_interface.h
@@ -2,6 +2,10 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <map>
+#include <string>
+
+#include <ATen/ATen.h>
 
 #ifdef __GNUC__
 #define AOT_INDUCTOR_EXPORT __attribute__((__visibility__("default")))
@@ -98,5 +102,9 @@ AOTInductorError AOTInductorModelContainerGetMaxOutputShape(
     AOTInductorModelContainerHandle container_handle,
     size_t output_idx,
     AOTInductorParamShape* output_shape);
+
+// Reads the constants used by the model from a file and stores it in memory.
+AOTInductorError AOTInductorModelContainerSetConstants(
+    std::map<std::string, at::Tensor>& constantTensors);
 
 } // extern "C"

--- a/torch/csrc/inductor/aot_inductor_model.h
+++ b/torch/csrc/inductor/aot_inductor_model.h
@@ -141,6 +141,7 @@ class AOTInductorModelBase {
   };
 
   std::vector<ParamInfo> inputs_info_;
+  std::map<std::string, at::Tensor> constants_info_;
   std::vector<ParamInfo> outputs_info_;
 
   // Record if the model finishes an inference run so that its owning


### PR DESCRIPTION
When generating the C++ code, we will unlift the parameters from the module inputs, and output the constants as a dictionary mapping constant name to the constant tensor to a separate file (the same file name where the code is generated, suffixed with `_constants.pt`). These constants can then be loaded through the `AOTInductorModelContainerSetConstants` function, which can be called before `AOTInductorModel.run_impl` to update the global `AOTInductorModel.constants_info_` dictionary of constant name to constant tensor. During `run_impl`, we can query `constants_info_` for the tensor values. 

An example of the resulting C++ code is: [P805713957](https://www.internalfb.com/phabricator/paste/view/P805713957?lines=233%2C242).

This diff is mainly addressing the frontend of AOTInductor, where we save the constants to a different file. The changes to the cpp wrapper are for some initial testing to make sure the flow works. @muchulee8 will follow up with more legit changes on the codegen/cpp wrapper related to `AOTInductorModelContainer`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305