### PR TITLE
[inductor][easy] Improved warning message for missing OMP on mac

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -951,7 +951,10 @@ def compile_file(input_path, output_path, cmd) -> None:
         else:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        raise exc.CppCompileError(cmd, e.output) from e
+        output = e.output
+        if "'omp.h' file not found" in output.decode("utf-8") and sys.platform == "darwin":
+            output = (output.decode("utf-8") + "\n\nTry setting OMP_PREFIX; see https://github.com/pytorch/pytorch/issues/95708").encode("utf-8")
+        raise exc.CppCompileError(cmd, output) from e
 
 
 class CppCodeCache:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -951,15 +951,12 @@ def compile_file(input_path, output_path, cmd) -> None:
         else:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        output = e.output
-        if (
-            "'omp.h' file not found" in output.decode("utf-8")
-            and sys.platform == "darwin"
-        ):
+        output = e.output.decode("utf-8")
+        if "'omp.h' file not found" in output and sys.platform == "darwin":
             output = (
-                output.decode("utf-8")
+                output
                 + "\n\nTry setting OMP_PREFIX; see https://github.com/pytorch/pytorch/issues/95708"
-            ).encode("utf-8")
+            )
         raise exc.CppCompileError(cmd, output) from e
 
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -952,8 +952,14 @@ def compile_file(input_path, output_path, cmd) -> None:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         output = e.output
-        if "'omp.h' file not found" in output.decode("utf-8") and sys.platform == "darwin":
-            output = (output.decode("utf-8") + "\n\nTry setting OMP_PREFIX; see https://github.com/pytorch/pytorch/issues/95708").encode("utf-8")
+        if (
+            "'omp.h' file not found" in output.decode("utf-8")
+            and sys.platform == "darwin"
+        ):
+            output = (
+                output.decode("utf-8")
+                + "\n\nTry setting OMP_PREFIX; see https://github.com/pytorch/pytorch/issues/95708"
+            ).encode("utf-8")
         raise exc.CppCompileError(cmd, output) from e
 
 

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -67,6 +67,9 @@ class InvalidCxxCompiler(RuntimeError):
 
 class CppCompileError(RuntimeError):
     def __init__(self, cmd, output):
+        if isinstance(output, bytes):
+            output = output.decode("utf-8")
+
         super().__init__(
             textwrap.dedent(
                 """
@@ -80,5 +83,5 @@ class CppCompileError(RuntimeError):
                 """
             )
             .strip()
-            .format(cmd=" ".join(cmd), output=output.decode("utf-8"))
+            .format(cmd=" ".join(cmd), output=output)
         )


### PR DESCRIPTION
If 'omp.h' file not found is encountered, link to https://github.com/pytorch/pytorch/issues/95708 for suggestions on how to work around this

Error message after this change:
```
(pytorch-docs) dberard@dberard-mbp scripts % python inductor_mac_cpu.py
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] WON'T CONVERT fn /Users/dberard/Documents/scripts/inductor_mac_cpu.py line 3
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] due to:
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] Traceback (most recent call last):
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]   File "/Users/dberard/Documents/pytorch/torch/_inductor/codecache.py", line 953, in compile_file
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]     raise exc.CppCompileError(cmd, output) from e
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] CppCompileError: C++ compile error
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] Command:
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] g++ /var/folders/1k/9l4kxkgx6jn28jn_pp2th63c0000gn/T/torchinductor_dberard/4s/c4sg7sknpldhmeuikjbbjt7lcjvndzrr7h2ml2iqprmzyjjw6sn4.cpp -shared -fPIC -Wall -std=c++17 -Wno-unused-variable -I/Users/dberard/Documents/pytorch/torch/include -I/Users/dberard/Documents/pytorch/torch/include/torch/csrc/api/include -I/Users/dberard/Documents/pytorch/torch/include/TH -I/Users/dberard/Documents/pytorch/torch/include/THC -I/Users/dberard/miniconda3/envs/pytorch-docs/include/python3.9 -I/Users/dberard/miniconda3/envs/pytorch-docs/include -L/Users/dberard/miniconda3/envs/pytorch-docs/lib -lomp -O3 -ffast-math -fno-finite-math-only -Xclang -fopenmp -D C10_USING_CUSTOM_GENERATED_MACROS -o /var/folders/1k/9l4kxkgx6jn28jn_pp2th63c0000gn/T/torchinductor_dberard/4s/c4sg7sknpldhmeuikjbbjt7lcjvndzrr7h2ml2iqprmzyjjw6sn4.so
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] Output:
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] In file included from /var/folders/1k/9l4kxkgx6jn28jn_pp2th63c0000gn/T/torchinductor_dberard/4s/c4sg7sknpldhmeuikjbbjt7lcjvndzrr7h2ml2iqprmzyjjw6sn4.cpp:2:
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] /var/folders/1k/9l4kxkgx6jn28jn_pp2th63c0000gn/T/torchinductor_dberard/i5/ci5uspp363v3ky6jkccllm3bxudy2fkdpqinkqhmpehfihejs7ko.h:8:10: fatal error: 'omp.h' file not found
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] #include <omp.h>
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]          ^~~~~~~
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] 1 error generated.
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING] Try setting OMP_PREFIX; see https://github.com/pytorch/pytorch/issues/95708
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,731] torch._dynamo.convert_frame: [WARNING]
[2023-07-28 17:15:25,732] torch._dynamo.convert_frame: [WARNING] converting frame raised error, suppressing error
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov