### PR TITLE
Fix the Requirement of CMake Version

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -59,14 +59,14 @@ class CMake:
         cmake3_version = CMake._get_version(which("cmake3"))
         cmake_version = CMake._get_version(which("cmake"))
 
-        _cmake_min_version = LooseVersion("3.13.0")
+        _cmake_min_version = LooseVersion("3.18.0")
         if all(
             (
                 ver is None or ver < _cmake_min_version
                 for ver in [cmake_version, cmake3_version]
             )
         ):
-            raise RuntimeError("no cmake or cmake3 with version >= 3.13.0 found")
+            raise RuntimeError("no cmake or cmake3 with version >= 3.18.0 found")
 
         if cmake3_version is None:
             cmake_command = "cmake"


### PR DESCRIPTION
Fix the Requirement of CMake Version

Many CMakeLists.txt require cmake versions greater than 3.18.0, so the cmake version in cmake.py is not correct.
https://github.com/pytorch/pytorch/blob/1da41157028ee8224e456f6fab18bc22fa2637fe/CMakeLists.txt#L1