### PR TITLE
[Inductor][FX passes] New group/batch fusion pattern searching algorithm + group mm fusion + preserve memory layout

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -63,14 +63,13 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     if config.pattern_matcher:
         lazy_init()
 
+        group_batch_fusion_post_grad_passes(gm.graph)
         remove_extra_clones(gm.graph)
 
         for patterns in pass_patterns:
             patterns.apply(gm.graph)
         if is_inference:
             inference_patterns.apply(gm.graph)
-
-        group_batch_fusion_post_grad_passes(gm.graph)
 
     stable_topological_sort(gm.graph)
     gm.recompile()


### PR DESCRIPTION
Summary:

Major changes:
* Implement a new group/batch fusion pattern searching algorithm: only fuse patterns that are in a certain depth difference (locally).
* Search FX graph in reverse order since most of ops have more inputs than outputs.
* Support fuse mm (linear backward)
* Preserve memory layout for fbgemm.gmm.

We tested in Ads models and saw consistent gains.

Test Plan: Unit tests and integration test.

Differential Revision: D47581710



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov