### PR TITLE
remove tensorpipe code which forgot to delete

### DIFF
--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -8,10 +8,6 @@
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <torch/csrc/utils/byte_order.h>
 
-namespace tensorpipe {
-class Message;
-} // namespace tensorpipe
-
 namespace torch {
 namespace distributed {
 namespace rpc {


### PR DESCRIPTION
When analyzing the rpc code, I found redundant tensorpipe code, which was submitted synchronously with #40846, but was not deleted synchronously when the code was subsequently deleted.
The tensorpipe namespace is not useful in neither utils.h nor utils.cpp.
cc @ezyang @malfet 