### PR TITLE
Some minor improvements to FakeTensor testing

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1857,7 +1857,7 @@ def print_repro_on_failure(repro_str):
         # NB: Hacking the exception args is the cleanest way I've found to append
         # failure reproduction info without poisoning the stack trace.
         if len(e.args) >= 1:
-            e.args = (e.args[0] + f"\n{repro_str}",) + e.args[1:]
+            e.args = (str(e.args[0]) + f"\n{repro_str}",) + e.args[1:]
         raise
 
 #  "min_satisfying_examples" setting has been deprecated in hypothesis


### PR DESCRIPTION
Summary:
- PyTorch testing chokes sometimes when it sees an exception where the first
  argument is not a string. fake_tensor.UnsupportedOperatorException's first
  arg is an OpOverload. This PR fixes PyTorch testing to not choke. I'm not
  really sure how to reproduce this in OSS.
- It turns out that if an operator does not have a meta kernel, the FakeTensor
  rule is really slow (30ms in OSS in debug mode, 3s on some internal config).
  The thing that is slow (aside from the previous diff) is waiting for the Dispatcher to
  report NotImplemented and then attempting to catch that. I'm not really sure
  why this is slow but it's easy to workaround so I added a workaround.

Test Plan: - existing tests

Differential Revision: D47917554

