### PR TITLE
Use nodejs-16 for docs builds

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -77,20 +77,6 @@ install_ubuntu() {
   # see: https://github.com/pytorch/pytorch/issues/65931
   apt-get install -y libgnutls30
 
-  # cuda-toolkit does not work with gcc-11.2.0 which is default in Ubunutu 22.04
-  # see: https://github.com/NVlabs/instant-ngp/issues/119
-  if [[ "$UBUNTU_VERSION" == "22.04"* ]]; then
-    apt-get install -y g++-10
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 30
-    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-10 30
-
-    # https://www.spinics.net/lists/libreoffice/msg07549.html
-    sudo rm -rf /usr/lib/gcc/x86_64-linux-gnu/11
-    wget https://github.com/gcc-mirror/gcc/commit/2b2d97fc545635a0f6aa9c9ee3b017394bc494bf.patch -O noexecpt.patch
-    sudo patch  /usr/include/c++/10/bits/range_access.h noexecpt.patch
-  fi
-
   # Cleanup package manager
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.ci/docker/common/install_docs_reqs.sh
+++ b/.ci/docker/common/install_docs_reqs.sh
@@ -7,7 +7,7 @@ if [ -n "$KATEX" ]; then
   # Ignore error if gpg-agent doesn't exist (for Ubuntu 16.04)
   apt-get install -y gpg-agent || :
 
-  curl --retry 3 -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+  curl --retry 3 -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
   sudo apt-get install -y nodejs
 
   curl --retry 3 -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -


### PR DESCRIPTION
As node-12 EOLed long time ago and not available for Ubuntu-22.04 (Discovered while working on bionic deprecation).
Remove artificial constraint on gcc-10 downgrade (and some in-pace patching) for Jammy, as CUDA-11.8+ works perfectly fine with gcc-11.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6367120</samp>

> _`nodejs` version_
> _upgraded for security_
> _autumn leaves fall fast_