### PR TITLE
Update export/export-aot-inductor benchmark code

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -421,4 +421,4 @@ def _process_constraints(
     return range_constraints, equality_constraints
 
 def combine_args_kwargs(args, kwargs):
-    return (args, kwargs) if kwargs else args
+    return (args, kwargs) if kwargs is not None else args

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -421,4 +421,4 @@ def _process_constraints(
     return range_constraints, equality_constraints
 
 def combine_args_kwargs(args, kwargs):
-    return (args, kwargs) if kwargs is not None else args
+    return (args, kwargs) if kwargs else args


### PR DESCRIPTION
Update export/export-aot-inductor benchmark code to use recent changes related to kwarg inputs and dataclass outputs.

Updated [dashboard](https://hud.pytorch.org/benchmark/compilers?startTime=Mon%2C%2031%20Jul%202023%2017%3A28%3A05%20GMT&stopTime=Tue%2C%2001%20Aug%202023%2017%3A28%3A05%20GMT&granularity=hour&suite=torchbench&mode=inference&dtype=bfloat16&lBranch=angelayi/benchmark&lCommit=f0987867a88b0b9510fcaf33307150e61517e7a1&rBranch=main&rCommit=f23d755e1f835485b8fef5661e7f983b520d844e)

80% pass rate on HF for export: P801372961
20% pass rate on HF for export-aot-inductor: [link](https://hud.pytorch.org/benchmark/huggingface/inductor_aot_inductor?startTime=Mon,%2031%20Jul%202023%2017:08:02%20GMT&stopTime=Tue,%2001%20Aug%202023%2017:08:02%20GMT&granularity=hour&mode=inference&dtype=bfloat16&lBranch=angelayi/benchmark&lCommit=f0987867a88b0b9510fcaf33307150e61517e7a1&rBranch=main&rCommit=f23d755e1f835485b8fef5661e7f983b520d844e)


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov