### PR TITLE
fix x.numpy() breaks in #106211

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -129,7 +129,7 @@ class PyCodegen:
             self.load_graph_output(graph_outputs[graph_outputs_key].index)
 
             if isinstance(value, NumpyNdarrayVariable):
-                output.extend(create_call_function(1, False))
+                output.extend(create_call_function(1, True))
             elif isinstance(value, UnspecializedPythonVariable) and value.need_unwrap:
                 output.extend(
                     [self.create_load_attr("item")] + create_call_function(0, True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106327

Fixes https://github.com/pytorch/pytorch/issues/106316. Need to promote [this](https://dev-discuss.pytorch.org/t/supporting-dynamo-in-python-3-11-null/1393) a little more I guess. I'm going to make a PR soon that will add `push_null` arg to `load_import_from` and other function call codegen methods that are missing the field, so that we can push null as early in the function call sequence as possible. 


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov