### PR TITLE
Fix reference cycle in our test suite

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1235,7 +1235,13 @@ def not_close_error_metas(
                 "please except the previous error and raise an expressive `ErrorMeta` instead."
             ) from error
 
-    return error_metas
+    # Any ErrorMeta objects in this list will have captured
+    # traceback that refer to the frame of this function,
+    # if the local variable `error_metas` creates a reference cycle
+    # back to the ErrorMeta objects. By poping the actual list of
+    # error_metas on return we break the cycle.
+    error_metas = [error_metas]
+    return error_metas.pop()
 
 
 def assert_close(

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1235,11 +1235,13 @@ def not_close_error_metas(
                 "please except the previous error and raise an expressive `ErrorMeta` instead."
             ) from error
 
-    # Any ErrorMeta objects in this list will have captured
-    # traceback that refer to the frame of this function,
-    # if the local variable `error_metas` creates a reference cycle
-    # back to the ErrorMeta objects. By poping the actual list of
-    # error_metas on return we break the cycle.
+    # ErrorMeta objects in this list captured
+    # tracebacks that refer to the frame of this function.
+    # The local variable `error_metas` refers to the error meta
+    # objects, creating a reference cycle. Frames in the traceback
+    # would not get freed on cycle collection, leaking cuda memory in tests.
+    # We break the cycle by remove the reference to the error_meta objects
+    # from this frame as it returns.
     error_metas = [error_metas]
     return error_metas.pop()
 

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1235,12 +1235,12 @@ def not_close_error_metas(
                 "please except the previous error and raise an expressive `ErrorMeta` instead."
             ) from error
 
-    # ErrorMeta objects in this list captured
+    # ErrorMeta objects in this list capture
     # tracebacks that refer to the frame of this function.
     # The local variable `error_metas` refers to the error meta
     # objects, creating a reference cycle. Frames in the traceback
-    # would not get freed on cycle collection, leaking cuda memory in tests.
-    # We break the cycle by remove the reference to the error_meta objects
+    # would not get freed until cycle collection, leaking cuda memory in tests.
+    # We break the cycle by removing the reference to the error_meta objects
     # from this frame as it returns.
     error_metas = [error_metas]
     return error_metas.pop()

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1235,6 +1235,7 @@ def not_close_error_metas(
                 "please except the previous error and raise an expressive `ErrorMeta` instead."
             ) from error
 
+    # [ErrorMeta Cycles]
     # ErrorMeta objects in this list capture
     # tracebacks that refer to the frame of this function.
     # The local variable `error_metas` refers to the error meta

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -3253,6 +3253,7 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
         )
 
         if error_metas:
+            # See [ErrorMeta Cycles]
             error_metas = [error_metas]
             # TODO: compose all metas into one AssertionError
             raise error_metas.pop()[0].to_error(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -3253,8 +3253,9 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
         )
 
         if error_metas:
+            error_metas = [error_metas]
             # TODO: compose all metas into one AssertionError
-            raise error_metas[0].to_error(
+            raise error_metas.pop()[0].to_error(
                 # This emulates unittest.TestCase's behavior if a custom message passed and
                 # TestCase.longMessage (https://docs.python.org/3/library/unittest.html#unittest.TestCase.longMessage)
                 # is True (default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106328

In certain cases we capture ErrorMeta in a list. The ErrorMeta objects hold
tracebacks which contain a frame with a local variable that refers to that list.
This change mutates the list on exit from the frame so that it doesn't refer
to the ErrorMeta objects, breaking the cycle.