### PR TITLE
Extend workflow sync to more workflow

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -870,6 +870,8 @@ include_patterns = [
     '.github/workflows/pull.yml',
     '.github/workflows/trunk.yml',
     '.github/workflows/periodic.yml',
+    '.github/workflows/mac-mps.yml',
+    '.github/workflows/slow.yml',
 ]
 command = [
     'python3',

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
                 del job["if"]
 
             # same is true for ['with']['test-matrix']
-            if "test-matrix" in job.get("with",{}):
+            if "test-matrix" in job.get("with", {}):
                 del job["with"]["test-matrix"]
 
             tag_to_jobs[sync_tag].append((path, {job_id: job}))

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -102,6 +102,10 @@ if __name__ == "__main__":
             if "if" in job:
                 del job["if"]
 
+            # same is true for ['with']['test-matrix']
+            if "test-matrix" in job.get("with",{}):
+                del job["with"]["test-matrix"]
+
             tag_to_jobs[sync_tag].append((path, {job_id: job}))
 
     # For each sync tag, check that all the jobs have the same code.


### PR DESCRIPTION
To `slow.yml` and `mac-mps.yaml`, based on the results of the following grep:
```
% grep "sync-tag: " .github/workflows/*.yml 
.github/workflows/mac-mps.yml:      sync-tag: macos-12-py3-arm64-build
.github/workflows/mac-mps.yml:      sync-tag: macos-12-py3-arm64-mps-test
.github/workflows/pull.yml:      sync-tag: asan-build
.github/workflows/pull.yml:      sync-tag: asan-test
.github/workflows/pull.yml:      sync-tag: win-cpu-build
.github/workflows/pull.yml:      sync-tag: rocm-build
.github/workflows/slow.yml:      sync-tag: asan-build
.github/workflows/slow.yml:      sync-tag: asan-test
.github/workflows/trunk.yml:      sync-tag: macos-12-py3-arm64-build
.github/workflows/trunk.yml:      sync-tag: macos-12-py3-arm64-mps-test
.github/workflows/trunk.yml:      sync-tag: win-cpu-build
.github/workflows/trunk.yml:      sync-tag: win-cuda-build
.github/workflows/trunk.yml:      sync-tag: rocm-build
```

Allow synced workflows to diverge with regards to `test-matrix`, to allow for both `mac-mps` and slow part of ASAN tests. 

Discovered while working on https://github.com/pytorch/pytorch/pull/105260 that slow sync-tag is not checked.