### PR TITLE
[FSDP][Easy] Move `_device_mesh` to avoid confusing comment

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -113,6 +113,7 @@ class _FSDPState(_State):
         self.process_group: Optional[dist.ProcessGroup] = None
         self.rank: int = -1
         self.world_size: int = -1
+        self._device_mesh: Optional[DeviceMesh] = None
         self.sharding_strategy = ShardingStrategy.FULL_SHARD
         self._use_orig_params: bool = False
         self.training_state = TrainingState.IDLE
@@ -133,7 +134,6 @@ class _FSDPState(_State):
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
-        self._device_mesh: Optional[DeviceMesh] = None
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106333

The comment above `_FSDPState._device_mesh` does not apply to it since every FSDP state uses `_device_mesh`:
```
# All following attributes should only be used for root states:
# Save these static lists to avoid the repeated tree traversals
```
This PR moves `_device_mesh` up so that it does not fall under the comment:
https://github.com/pytorch/pytorch/blob/018ac76362ef9f3b6136784723b474dac33e82fe/torch/distributed/fsdp/_runtime_utils.py#L273

cc @kwen2501 since we talked about this