### PR TITLE
Do not call decref if python runtime is already dead

### DIFF
--- a/torch/csrc/utils/object_ptr.cpp
+++ b/torch/csrc/utils/object_ptr.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/utils/object_ptr.h>
+#include <c10/macros/Macros.h>
 
 #include <torch/csrc/python_headers.h>
 

--- a/torch/csrc/utils/object_ptr.cpp
+++ b/torch/csrc/utils/object_ptr.cpp
@@ -4,7 +4,7 @@
 
 template <>
 void THPPointer<PyObject>::free() {
-  if (ptr)
+  if (ptr && C10_LIKELY(Py_IsInitialized()))
     Py_DECREF(ptr);
 }
 
@@ -12,7 +12,7 @@ template class THPPointer<PyObject>;
 
 template <>
 void THPPointer<PyCodeObject>::free() {
-  if (ptr)
+  if (ptr && C10_LIKELY(Py_IsInitialized()))
     Py_DECREF(ptr);
 }
 
@@ -20,7 +20,7 @@ template class THPPointer<PyCodeObject>;
 
 template <>
 void THPPointer<PyFrameObject>::free() {
-  if (ptr)
+  if (ptr && C10_LIKELY(Py_IsInitialized()))
     Py_DECREF(ptr);
 }
 

--- a/torch/csrc/utils/object_ptr.cpp
+++ b/torch/csrc/utils/object_ptr.cpp
@@ -1,5 +1,5 @@
-#include <torch/csrc/utils/object_ptr.h>
 #include <c10/macros/Macros.h>
+#include <torch/csrc/utils/object_ptr.h>
 
 #include <torch/csrc/python_headers.h>
 


### PR DESCRIPTION
Same treatment as many other objects such as https://github.com/pytorch/pytorch/blob/main/torch/csrc/autograd/python_hook.cpp#L99
This one can outlive the python runtime due to structs like: https://github.com/pytorch/pytorch/blob/2f35715f0d230f8d5527bdf01b9793f6613f3a2e/torch/csrc/autograd/python_cpp_function.cpp#L232

With the pybind patch and this one, the 3.12 build at https://github.com/pytorch/pytorch/pull/106083 stops segfaulting and runs test_autograd.py just fine.