### PR TITLE
[Export] remove unused flags in export

### DIFF
--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -21,10 +21,7 @@ from torch._export.verifier import (
 
 @torch.no_grad()
 def capture(f, args):
-    torchdynamo.config.capture_scalar_outputs = True
-    torchdynamo.config.guard_nn_modules = True
     torchdynamo.config.allow_rnn = True
-    torchdynamo.config.verbose = True
     torchdynamo.reset()
     graphmodule, _ = torchdynamo.export(
         f,

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -110,14 +110,10 @@ def dynamic_dim(t: torch.Tensor, index: int):
 class ExportDynamoConfig:
     """
     Manage Export-specific configurations of Dynamo.
-    TODO add tests to make sure the flags are not outdated
     """
-    capture_scalar_outputs: bool = True
-    capture_dynamic_output_shape_ops: bool = True
-    guard_nn_modules: bool = True
-    dynamic_shapes: bool = True
-    specialize_int: bool = True
     allow_rnn: bool = True
+
+DEFAULT_EXPORT_DYNAMO_CONFIG = ExportDynamoConfig()
 
 
 DECOMP_TABLE = core_aten_decompositions()
@@ -149,7 +145,7 @@ def export(
     constraints = constraints or []
     kwargs = kwargs or {}
 
-    with torch._dynamo.config.patch(dataclasses.asdict(ExportDynamoConfig())):  # type: ignore[attr-defined]
+    with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
         try:
             gm_torch_level, _ = torch._dynamo.export(
                 f,


### PR DESCRIPTION
Remove unused flags from export_dynamo_config:
Among them:
- capture_scalar_outputs: bool = True. **True by default** in dynamo.export: 
- capture_dynamic_output_shape_ops: bool = True.  **True by default** in dynamo.export
- specialize_int: bool = True: **True by default** in dynamo.export. 
- guard_nn_modules: bool = True: this flag is **not being used** as we never look at nn module guards and assume modules are forzen. See the [doc](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/config.py#L77) of this flag.
- dynamic_shapes: bool = True: **deprecated by dynamo**:  [here](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/config.py#L55 ) 

test plan:
Added new test for allow_rnn to test its effectiveness.
