### PR TITLE
Remove fake_mode arg from torch._dynamo.export API

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3012,48 +3012,6 @@ def forward(self, x):
                     + str(aten_graph),
                 )
 
-    def test_capture_symbolic_tracing(self) -> None:
-        from torch._dynamo.output_graph import config
-        from torch._subclasses import fake_tensor
-        from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-        class Model(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(2, 2)
-                self.linear2 = torch.nn.Linear(2, 2)
-
-            def forward(self, x):
-                out = self.linear(x)
-                out = self.linear2(out)
-                return out
-
-        # User-instantiated FakeTensorMode
-        fake_mode = fake_tensor.FakeTensorMode(
-            allow_non_fake_inputs=False,
-            allow_fallback_kernels=True,
-            shape_env=ShapeEnv(
-                allow_scalar_outputs=config.capture_scalar_outputs,
-                allow_dynamic_output_shape_ops=config.capture_dynamic_output_shape_ops,
-                frame_id=0,
-            ),
-        )
-        # Fakefy input+model before exporting it
-        with fake_mode:
-            x = torch.rand(5, 2, 2)
-            model = Model()
-
-        # Export the model with fake inputs and parameters
-        for aten_graph in [True, False]:
-            graph_module, _ = torch._dynamo.export(
-                model, x, aten_graph=aten_graph, fake_mode=fake_mode
-            )
-
-            self.assertTrue(
-                isinstance(graph_module, torch.fx.GraphModule),
-                msg="test_capture_symbolic_tracing_aten_graph_" + str(aten_graph),
-            )
-
     def test_capture_symbolic_tracing_within_fake_mode(self):
         from torch._dynamo.output_graph import config
         from torch._subclasses import fake_tensor

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import inspect
 from typing import (
@@ -187,16 +188,20 @@ class DynamoExport(exporter.FXGraphExtractor):
 
         # Translate callable to FX graph.
         #
-        fake_mode = options.fake_context.fake_mode if options.fake_context else None
-        fx_mode = "symbolic" if options.dynamic_shapes else "fake"
-        graph_module, graph_guard = torch._dynamo.export(
-            wrapped_model,
-            tracing_mode=fx_mode,
-            fake_mode=fake_mode,  # type: ignore[arg-type]
-        )(
-            *model_args,
-            **model_kwargs,
+        fake_mode = (
+            options.fake_context.fake_mode
+            if options.fake_context
+            else contextlib.nullcontext()
         )
+        fx_mode = "symbolic" if options.dynamic_shapes else "fake"
+        with fake_mode:  # type: ignore[attr-defined]
+            graph_module, graph_guard = torch._dynamo.export(
+                wrapped_model,
+                tracing_mode=fx_mode,
+            )(
+                *model_args,
+                **model_kwargs,
+            )
         del graph_guard  # Unused
         torch._dynamo.reset()
 


### PR DESCRIPTION
#105477 removes the need of explicitly specifying `fake_mode`. 
The same effect can be achieved by wrapping `torch._dynamo.export` around a `torch._subclasses.FakeTensorMode` context.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov