### PR TITLE
[memory snaphots] record for all devices

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3163,13 +3163,13 @@ class NativeCachingAllocator : public CUDAAllocator {
       CreateContextFn context_recorder,
       size_t alloc_trace_max_entries,
       bool alloc_trace_record_context) override {
-    int device = 0;
-    C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
-    device_allocator[device]->recordHistory(
-        enabled,
-        context_recorder,
-        alloc_trace_max_entries,
-        alloc_trace_record_context);
+    for (auto& allocator : device_allocator) {
+      allocator->recordHistory(
+          enabled,
+          context_recorder,
+          alloc_trace_max_entries,
+          alloc_trace_record_context);
+    }
   }
 
   bool isHistoryEnabled() override {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106346

Previously calling _record_memory_history would only start recording
for a single device because snapshots were also device specific.

Now the visualizer packages all devices into a single page, so we snapshot
recording should also enable recording for all devices.

Verified locally that calling the method does not initialize cuda context
on devices that have not previously been used.