### PR TITLE
Reordering tests experiment

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -128,6 +128,7 @@ python -c "import os, glob; os.system('python -mpip install --no-index --no-deps
     :: export test times so that potential sharded tests that'll branch off this build will use consistent data
     python tools/stats/export_test_times.py
     copy /Y ".pytorch-test-times.json" "%PYTORCH_FINAL_PACKAGE_DIR%"
+    copy /Y ".pytorch-test-file-ratings.json" "%PYTORCH_FINAL_PACKAGE_DIR%"
 
     :: Also save build/.ninja_log as an artifact
     copy /Y "build\.ninja_log" "%PYTORCH_FINAL_PACKAGE_DIR%\"

--- a/.ci/pytorch/win-test-helpers/test_python_jit_legacy.bat
+++ b/.ci/pytorch/win-test-helpers/test_python_jit_legacy.bat
@@ -2,6 +2,7 @@ call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%PROJECT_DIR_WIN%"
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-file-ratings.json" "%PROJECT_DIR_WIN%"
 
 pushd test
 

--- a/.ci/pytorch/win-test-helpers/test_python_shard.bat
+++ b/.ci/pytorch/win-test-helpers/test_python_shard.bat
@@ -23,6 +23,7 @@ if "%SHARD_NUMBER%" == "1" (
 
 echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%PROJECT_DIR_WIN%"
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-file-ratings.json" "%PROJECT_DIR_WIN%"
 
 echo Run nn tests
 python run_test.py --exclude-jit-executor --exclude-distributed-tests --shard "%SHARD_NUMBER%" "%NUM_TEST_SHARDS%" --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,7 +652,7 @@ jobs:
             - run:
                 name: Archive artifacts into zip
                 command: |
-                  zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json
+                  zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json .pytorch-test-file-ratings.json
                   cp artifacts.zip /Users/distiller/workspace
 
       - persist_to_workspace:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -177,7 +177,7 @@
             - run:
                 name: Archive artifacts into zip
                 command: |
-                  zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json
+                  zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json .pytorch-test-file-ratings.json
                   cp artifacts.zip /Users/distiller/workspace
 
       - persist_to_workspace:

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped'
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json .pytorch-test-file-ratings.json
 
       - name: Store PyTorch Build Artifacts on S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped'
         run: |
-          zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json
+          zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json .pytorch-test-file-ratings.json
 
       - name: Store PyTorch Build Artifacts on GHA
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage.xml
 **/.pytorch-disabled-tests.json
 **/.pytorch-slow-tests.json
 **/.pytorch-test-times.json
+**/.pytorch-test-file-ratings.json
 */*.pyc
 */*.so*
 */**/__pycache__

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1695,8 +1695,9 @@ def main():
         if IS_CI and HAVE_TEST_SELECTION_TOOLS:
             emit_metric("cats_td_experiment_1", metrics_dict)
 
-    if len(failures) != 0:
-        for _, err in failures:
+    all_failures = prioritized_failures + general_failures
+    if len() != 0:
+        for _, err in all_failures:
             print_to_stderr(err)
 
         # A disabled test is expected to fail, so there is no need to report a failure here

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1571,13 +1571,14 @@ def run_tests(
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
-            test, err_message = run_test_module(test, test_directory, options_clone)
-            test_failed = handle_error_messages((test, err_message))
+            failure = run_test_module(test, test_directory, options_clone)
+            test_failed = handle_error_messages(failure)
             if (
                 test_failed
                 and not options.continue_through_error
                 and not RERUN_DISABLED_TESTS
             ):
+                _, err_message = failure
                 raise RuntimeError(err_message)
 
     finally:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1696,7 +1696,7 @@ def main():
             emit_metric("cats_td_experiment_1", metrics_dict)
 
     all_failures = prioritized_failures + general_failures
-    if len() != 0:
+    if len(all_failures) != 0:
         for _, err in all_failures:
             print_to_stderr(err)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1693,7 +1693,7 @@ def main():
                     cov.html_report()
 
         if IS_CI and HAVE_TEST_SELECTION_TOOLS:
-            emit_metric("cats_td_experiment_1", metrics_dict)
+            emit_metric("td_experiment_1", metrics_dict)
 
     all_failures = prioritized_failures + general_failures
     if len(all_failures) != 0:

--- a/tools/stats/export_test_times.py
+++ b/tools/stats/export_test_times.py
@@ -3,14 +3,16 @@ import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(REPO_ROOT))
-from tools.stats.import_test_stats import get_test_times
+from tools.stats.import_test_stats import get_test_file_ratings, get_test_times
 
 TEST_TIMES_FILE = ".pytorch-test-times.json"
+TEST_FILE_RATINGS_FILE = ".pytorch-test-file-ratings.json"
 
 
 def main() -> None:
     print(f"Exporting test times from test-infra to {TEST_TIMES_FILE}")
     get_test_times(str(REPO_ROOT), filename=TEST_TIMES_FILE)
+    get_test_file_ratings(str(REPO_ROOT), filename=TEST_FILE_RATINGS_FILE)
 
 
 if __name__ == "__main__":

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -19,6 +19,8 @@ IGNORE_DISABLED_ISSUES: List[str] = get_disabled_issues()
 
 SLOW_TESTS_FILE = ".pytorch-slow-tests.json"
 DISABLED_TESTS_FILE = ".pytorch-disabled-tests.json"
+TEST_FILE_RATINGS_FILE = ".pytorch-test-file-ratings.json"
+
 
 FILE_CACHE_LIFESPAN_SECONDS = datetime.timedelta(hours=3).seconds
 
@@ -115,4 +117,15 @@ def get_disabled_tests(
         return fetch_and_cache(dirpath, filename, url, process_disabled_test)
     except Exception:
         print("Couldn't download test skip set, leaving all tests enabled...")
+        return {}
+
+
+def get_test_file_ratings(
+    dirpath: str, filename: str = TEST_FILE_RATINGS_FILE
+) -> Optional[Dict[str, Any]]:
+    url = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/file_test_rating.json"
+    try:
+        return fetch_and_cache(dirpath, filename, url, lambda x: x)
+    except Exception:
+        print("Couldn't download test file ratings file, not reordering...")
         return {}

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -19,7 +19,6 @@ IGNORE_DISABLED_ISSUES: List[str] = get_disabled_issues()
 
 SLOW_TESTS_FILE = ".pytorch-slow-tests.json"
 DISABLED_TESTS_FILE = ".pytorch-disabled-tests.json"
-TEST_FILE_RATINGS_FILE = ".pytorch-test-file-ratings.json"
 
 
 FILE_CACHE_LIFESPAN_SECONDS = datetime.timedelta(hours=3).seconds
@@ -120,9 +119,7 @@ def get_disabled_tests(
         return {}
 
 
-def get_test_file_ratings(
-    dirpath: str, filename: str = TEST_FILE_RATINGS_FILE
-) -> Optional[Dict[str, Any]]:
+def get_test_file_ratings(dirpath: str, filename: str) -> Optional[Dict[str, Any]]:
     url = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/file_test_rating.json"
     try:
         return fetch_and_cache(dirpath, filename, url, lambda x: x)

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -263,7 +263,7 @@ class EnvVarMetric:
         value = os.environ.get(self.env_var)
         if value is None and self.required:
             raise ValueError(
-                f"Missing {self.name}. Please set the {self.env_var}"
+                f"Missing {self.name}. Please set the {self.env_var} "
                 "environment variable to pass in this value."
             )
         if self.type_conversion_fn:

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -394,28 +394,24 @@ class TestParsePrevTests(unittest.TestCase):
         "tools.testing.test_selections._get_modified_tests",
         return_value={"test2", "test4"},
     )
+    @mock.patch(
+        "tools.testing.test_selections._get_file_rating_tests", return_value=["test1"]
+    )
     def test_get_reordered_tests(
-        self, mock_get_prev_failing_tests: Any, mock_get_modified_tests: Any
+        self,
+        mock_get_prev_failing_tests: Any,
+        mock_get_modified_tests: Any,
+        mock_get_file_rating_tests: Any,
     ) -> None:
-        tests = [
-            ShardedTest(name="test1", shard=1, num_shards=2, time=600.0),
-            ShardedTest(name="test2", shard=1, num_shards=2, time=500.0),
-            ShardedTest(name="test3", shard=1, num_shards=2, time=400.0),
-            ShardedTest(name="test4", shard=1, num_shards=2, time=300.0),
-            ShardedTest(name="test5", shard=1, num_shards=2, time=200.0),
-        ]
+        tests = ["test1", "test2", "test3", "test4", "test5"]
 
-        expected_prioritized_tests = {"test4", "test2"}
-        expected_remaining_tests = {"test1", "test3", "test5"}
+        expected_prioritized_tests = ["test4", "test2", "test1"]
+        expected_remaining_tests = {"test3", "test5"}
 
         prioritized_tests, remaining_tests = get_reordered_tests(tests)
 
-        # Just want to check the names of the tests
-        prioritized_tests_name = {test.name for test in prioritized_tests}
-        remaining_tests_name = {test.name for test in remaining_tests}
-
-        self.assertSetEqual(expected_prioritized_tests, prioritized_tests_name)
-        self.assertSetEqual(expected_remaining_tests, remaining_tests_name)
+        self.assertListEqual(expected_prioritized_tests, prioritized_tests)
+        self.assertSetEqual(expected_remaining_tests, set(remaining_tests))
 
     def test_compute_prioritization_time_savings_with_multiple_threads(self) -> None:
         tests = [

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -6,17 +6,13 @@ import subprocess
 from collections import defaultdict
 from pathlib import Path
 
-from typing import Callable, cast, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import Callable, cast, Dict, List, NamedTuple, Optional, Set, Tuple
 from warnings import warn
 
 from tools.shared.logging_utils import duration_to_str, pluralize
+from tools.stats.export_test_times import TEST_FILE_RATINGS_FILE
 
-from tools.stats.import_test_stats import (
-    get_disabled_tests,
-    get_slow_tests,
-    get_test_file_ratings,
-    TEST_FILE_RATINGS_FILE,
-)
+from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
 from tools.stats.upload_stats_lib import emit_metric
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -284,7 +280,7 @@ def log_time_savings(
 
 
 def _get_file_rating_tests() -> List[str]:
-    path = REPO_ROOT / "test" / TEST_FILE_RATINGS_FILE
+    path = REPO_ROOT / TEST_FILE_RATINGS_FILE
     if not os.path.exists(path):
         print(f"could not find path {path}")
         return []
@@ -312,9 +308,7 @@ def get_reordered_tests(
     """
     prioritized_tests: List[str] = []
 
-    def add_tests(
-        tests_to_add: Union[List[str], Set[str]], test_group_description: str
-    ) -> None:
+    def add_tests(tests_to_add: List[str], test_group_description: str) -> None:
         if not tests_to_add:
             return
 
@@ -326,12 +320,12 @@ def get_reordered_tests(
                     prioritized_tests.append(test)
 
     add_tests(
-        _get_previously_failing_tests(),
+        sorted(_get_previously_failing_tests()),
         "If run, these tests will prioritized because they previously failed",
     )
 
     add_tests(
-        _get_modified_tests(),
+        sorted(_get_modified_tests()),
         "If run, these tests will be prioritized because they were modified",
     )
 
@@ -365,4 +359,3 @@ def get_reordered_tests(
 def get_test_case_configs(dirpath: str) -> None:
     get_slow_tests(dirpath=dirpath)
     get_disabled_tests(dirpath=dirpath)
-    get_test_file_ratings(dirpath=dirpath)

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -5,13 +5,20 @@ import os
 import subprocess
 from pathlib import Path
 
-from typing import Callable, Dict, List, NamedTuple, Optional, Set, Tuple
+from typing import Callable, cast, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 from warnings import warn
 
 from tools.shared.logging_utils import duration_to_str, pluralize
 
-from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
+from tools.stats.import_test_stats import (
+    get_disabled_tests,
+    get_slow_tests,
+    get_test_file_ratings,
+    TEST_FILE_RATINGS_FILE,
+)
 from tools.stats.upload_stats_lib import emit_metric
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 
@@ -81,8 +88,8 @@ def get_with_pytest_shard(
 ) -> List[ShardedTest]:
     sharded_tests: List[ShardedTest] = []
     for test in tests:
-        duration = test_file_times[test]
-        if duration > THRESHOLD:
+        duration = test_file_times.get(test, None)
+        if duration and duration > THRESHOLD:
             num_shards = math.ceil(duration / THRESHOLD)
             for i in range(num_shards):
                 sharded_tests.append(
@@ -98,20 +105,24 @@ def calculate_shards(
     tests: List[str],
     test_file_times: Dict[str, float],
     must_serial: Optional[Callable[[str], bool]] = None,
+    sort: bool = True,
 ) -> List[Tuple[float, List[ShardedTest]]]:
     must_serial = must_serial or (lambda x: True)
 
-    known_tests = [x for x in tests if x in test_file_times]
-    unknown_tests: List[str] = [x for x in tests if x not in known_tests]
+    known_tests = tests
+    unknown_tests = []
 
-    sorted_tests = sorted(
-        get_with_pytest_shard(known_tests, test_file_times),
-        key=lambda j: j.get_time(),
-        reverse=True,
-    )
+    if sort:
+        known_tests = [x for x in tests if x in test_file_times]
+        unknown_tests = [x for x in tests if x not in known_tests]
+
+    known_tests = get_with_pytest_shard(known_tests, test_file_times)
+
+    if sort:
+        known_tests = sorted(known_tests, key=lambda j: j.get_time(), reverse=True)
 
     sharded_jobs: List[ShardJob] = [ShardJob() for _ in range(num_shards)]
-    for test in sorted_tests:
+    for test in known_tests:
         if must_serial(test.name):
             min_sharded_job = min(sharded_jobs, key=lambda j: j.get_total_time())
             min_sharded_job.serial.append(test)
@@ -127,7 +138,7 @@ def calculate_shards(
     return [job.convert_to_tuple() for job in sharded_jobs]
 
 
-def _query_changed_test_files() -> List[str]:
+def _query_changed_files() -> List[str]:
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
     merge_base = (
         subprocess.check_output(["git", "merge-base", default_branch, "HEAD"])
@@ -186,7 +197,7 @@ def _parse_prev_failing_test_files(last_failed_tests: Dict[str, bool]) -> Set[st
 
 def _get_modified_tests() -> Set[str]:
     try:
-        changed_files = _query_changed_test_files()
+        changed_files = _query_changed_files()
     except Exception as e:
         warn(f"Can't query changed test files due to {e}")
         # If unable to get changed files from git, quit without doing any sorting
@@ -271,78 +282,88 @@ def log_time_savings(
     return max_time_savings_sec
 
 
+def _get_file_rating_tests() -> List[str]:
+    path = REPO_ROOT / "test" / TEST_FILE_RATINGS_FILE
+    if not os.path.exists(path):
+        print(f"could not find path {path}")
+        return []
+    with open(path) as f:
+        test_file_ratings = cast(Dict[str, Dict[str, float]], json.load(f))
+    try:
+        changed_files = _query_changed_files()
+    except Exception as e:
+        warn(f"Can't query changed test files due to {e}")
+        return []
+    ratings: Dict[str, float] = {}
+    for file in changed_files:
+        for test_file, score in test_file_ratings.get(file, {}).items():
+            if test_file not in ratings:
+                ratings[test_file] = 0
+            ratings[test_file] += score
+    prioritize = sorted(ratings, key=lambda x: ratings[x])
+    return prioritize
+
+
 def get_reordered_tests(
-    tests: List[ShardedTest],
-) -> Tuple[List[ShardedTest], List[ShardedTest]]:
+    tests: List[str],
+) -> Tuple[List[str], List[str]]:
     """
     Get the reordered test filename list based on github PR history or git changed file.
     We prioritize running test files that were changed.
     """
+    prioritized_tests: List[str] = []
 
-    def print_tests(tests: Set[str], test_group_description: str) -> None:
-        if not tests:
+    def add_tests(
+        tests_to_add: Union[List[str], Set[str]], test_group_description: str
+    ) -> None:
+        if not tests_to_add:
             return
 
         print(f"{test_group_description}:")
-        for test in tests:
-            print(f"  {test}")
+        for test in tests_to_add:
+            if test in tests:
+                print(f"  {test}")
+                if test not in prioritized_tests:
+                    prioritized_tests.append(test)
 
-    prioritized_tests: Set[str] = set()
-
-    pri_test = _get_previously_failing_tests()
-    print_tests(
-        pri_test, "If run, these tests will prioritized because they previously failed"
+    add_tests(
+        _get_previously_failing_tests(),
+        "If run, these tests will prioritized because they previously failed",
     )
-    prioritized_tests |= pri_test
 
-    pri_test |= _get_modified_tests()
-    print_tests(
-        pri_test, "If run, these tests will be prioritized because they were modified"
+    add_tests(
+        _get_modified_tests(),
+        "If run, these tests will be prioritized because they were modified",
     )
-    prioritized_tests |= pri_test
 
-    bring_to_front = []
-    the_rest = []
+    add_tests(
+        _get_file_rating_tests(),
+        "If run, these tests will be preioritized for an experiment in TD",
+    )
 
-    for test in tests:
-        if test.name in prioritized_tests:
-            bring_to_front.append(test)
-        else:
-            the_rest.append(test)
+    prioritized_tests = [x for x in prioritized_tests if x in tests]
+    the_rest = [x for x in tests if x not in prioritized_tests]
 
-    if len(tests) != len(bring_to_front) + len(the_rest):
-        print(
-            f"Something went wrong in CI reordering, expecting total of {len(tests)}:\n"
-            f"but found prioritized: {len(bring_to_front)}\nthe rest: {len(the_rest)}\n"
-        )
-        return ([], tests)
-
-    prioritized_test_names = []
-    remaining_test_names = []
-    if bring_to_front:
+    if prioritized_tests:
         test_cnt_str = pluralize(len(tests), "test")
-        print(f"Reordering tests: Prioritizing {len(bring_to_front)} of {test_cnt_str}")
-
-        prioritized_test_names = [t.name for t in bring_to_front]
-        print(f"Prioritized: {prioritized_test_names}")
-        remaining_test_names = [t.name for t in the_rest]
-        print(f"The Rest: {remaining_test_names}")
-    else:
-        print("Didn't find any tests to prioritize")
+        print(
+            f"Reordering tests: Prioritizing {len(prioritized_tests)} of {test_cnt_str}"
+        )
 
     emit_metric(
         "test_reordering_prioritized_tests",
         {
-            "prioritized_test_cnt": len(bring_to_front),
+            "prioritized_test_cnt": len(prioritized_tests),
             "total_test_cnt": len(tests),
-            "prioritized_tests": prioritized_test_names,
-            "remaining_tests": remaining_test_names,
+            "prioritized_tests": prioritized_tests,
+            "remaining_tests": the_rest,
         },
     )
 
-    return (bring_to_front, the_rest)
+    return (prioritized_tests, the_rest)
 
 
 def get_test_case_configs(dirpath: str) -> None:
     get_slow_tests(dirpath=dirpath)
     get_disabled_tests(dirpath=dirpath)
+    get_test_file_ratings(dirpath=dirpath)


### PR DESCRIPTION
Companion with https://github.com/pytorch/test-infra/pull/4424

Uses the file rating generated by the test infra PR to re order tests.  For each test file, sum the file ratings from the changed files in the PR, and put the tests in order of sum.  

A lot of tests are probably going to end up as "prioritized" since it takes anything with a rating > 0 right now.

Sharding is done twice, once on the prioritized tests, and once on the general/non prioritized tests.  Prioritized tests have an order, so they should be sharded according to that order, while general tests don't have an order and are sharded by test time, which should result in more balanced shards.  

I'll change the metric name before I merge, i want to quarantine my testing stuff from actual results 
