### PR TITLE
[pytorch] Suppress C4624 warnings on Windows

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -56,6 +56,11 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-conversion")
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4624) // destructor was implicitly defined as deleted
+#endif
+
 #define TR2_OPTIONAL_REQUIRES(...) \
   typename std::enable_if<__VA_ARGS__::value, bool>::type = false
 
@@ -1258,5 +1263,9 @@ struct hash<c10::optional<T&>> {
 #undef TR2_OPTIONAL_HOST_CONSTEXPR
 
 C10_CLANG_DIAGNOSTIC_POP()
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 
 #endif // C10_UTIL_OPTIONAL_H_

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -31,6 +31,11 @@ C10_CLANG_DIAGNOSTIC_PUSH()
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4624) // destructor was implicitly defined as deleted
+#endif
+
 #ifdef _MSC_VER
 #define SKA_NOINLINE(...) __declspec(noinline) __VA_ARGS__
 #else
@@ -2106,3 +2111,7 @@ struct power_of_two_std_hash : std::hash<T> {
 } // end namespace ska
 
 C10_CLANG_DIAGNOSTIC_POP()
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
Summary:
Building on Microsoft Visual Studio can show excessive warnings of the form:
```
caffe2\c10\util\Optional.h(212): warning C4624: 'c10::constexpr_storage_t<T>': destructor was implicitly defined as deleted
        with
        [
            T=std::string
        ]
caffe2\c10\util\Optional.h(411): note: see reference to class template instantiation 'c10::constexpr_storage_t<T>' being compiled
        with
        [
            T=std::string
        ]
caffe2\c10\util\Optional.h(549): note: see reference to class template instantiation 'c10::trivially_copyable_optimization_optional_base<T>' being compiled
        with
        [
            T=std::string
        ]
```

While we have macros such as `C10_CLANG_DIAGNOSTIC_{PUSH,POP,IGNORE}`, no there's no equivalent `C10_MSVC_DIAGNOSTIC_*`, so just do the suppressions explicitly.

Test Plan: CI should complete, but Windows build log will no longer contain C4624 warnings

Differential Revision: D47736268

