### PR TITLE
Assert that `args` is of tuple type.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -530,6 +530,15 @@ class TestExport(TestCase):
         self.assertTrue(torch.allclose(ep(*inp_test)["a"], ep_rexported(*inp_test)["a"]))
         self.assertTrue(torch.allclose(ep(*inp_test)["b"], ep_rexported(*inp_test)["b"]))
 
+    def test_args_type_checked(self):
+        def fn(x):
+            return x + 1
+
+        inp = torch.rand(2, 2)
+        with self.assertRaisesRegex(torch._dynamo.exc.UserError, "to be a tuple"):
+            # Intentionally not wrapping `inp` in a tuple to trigger the error
+            _ = export(fn, inp)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -91,10 +91,10 @@ class AotInductorTests(TestCase):
                 return c
 
         model = Repro()
-        example_inputs = [
+        example_inputs = (
             torch.randn(10, 10, device="cuda"),
             torch.randn(10, 10, device="cuda"),
-        ]
+        )
         expected = model(*example_inputs)
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
@@ -114,10 +114,10 @@ class AotInductorTests(TestCase):
                 return x_sigmoid, y_getitem
 
         model = Repro()
-        example_inputs = [
+        example_inputs = (
             torch.randn(10, 10, device="cuda"),
             torch.randn(10, 10, device="cuda"),
-        ]
+        )
         expected = model(*example_inputs)
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -145,6 +145,10 @@ def export(
     constraints = constraints or []
     kwargs = kwargs or {}
 
+    if not isinstance(args, tuple):
+        raise UserError(UserErrorType.INVALID_INPUT,
+                        f"Expecting `args` to be a tuple of example positional inputs, got {type(args)}")
+
     with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
         try:
             gm_torch_level, _ = torch._dynamo.export(


### PR DESCRIPTION
This avoids accidental unpacking of tensor-type inputs.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov