### PR TITLE
[opinfo] Fix logic in sample_inputs_linspace

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -997,7 +997,7 @@ def sample_inputs_linspace(op, device, dtype, requires_grad, **kwargs):
     # Extra case to replicate off-by-one issue on CUDA
     cases = list(product(starts, ends, nsteps)) + [(0, 7, 50)]
     for start, end, nstep in cases:
-        if dtype == torch.uint8 and end < 0 or start < 0:
+        if dtype == torch.uint8 and (end < 0 or start < 0):
             continue
         yield SampleInput(start, args=(end, nstep), kwargs={"dtype": dtype, "device": device})
 


### PR DESCRIPTION
Previously in `sample_inputs_linspace` the logic

```
dtype == torch.uint8 and end < 0 or start < 0
```

is equivalent to 

```
(dtype == torch.uint8 and end < 0) or start < 0
```

which skipped all `start < 0` cases. I think this is unintended and the negative inputs should only be skipped when dtype is `unit8`.
