### PR TITLE
[BE] Input check for torch.nn.MultiheadAttention

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -964,6 +964,11 @@ class MultiheadAttention(Module):
 
     def __init__(self, embed_dim, num_heads, dropout=0., bias=True, add_bias_kv=False, add_zero_attn=False,
                  kdim=None, vdim=None, batch_first=False, device=None, dtype=None) -> None:
+        if embed_dim <= 0 or num_heads <= 0:
+            raise ValueError(
+                f"embed_dim and num_heads must be greater than 0,"
+                f" got embed_dim={embed_dim} and num_heads={num_heads} instead"
+            )
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
         self.embed_dim = embed_dim


### PR DESCRIPTION
Summary: Check `embed_dim` and `num_heads ` of `torch.nn.MultiheadAttention`.

Test Plan: Please see GitHub Actions.

Differential Revision: D47943134

Fix: #105630
