### PR TITLE
[Doc] Add proj_size < hidden_size in LSTM

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -715,6 +715,9 @@ class LSTM(RNNBase):
     .. note::
         ``batch_first`` argument is ignored for unbatched inputs.
 
+    .. note::
+        ``proj_size`` should be smaller than ``hidden_size``.
+
     .. include:: ../cudnn_rnn_determinism.rst
 
     .. include:: ../cudnn_persistent_rnn.rst


### PR DESCRIPTION
Summary:
Add parameter constraint: `proj_size` has to be smaller than `hidden_size` in RNNBase doc.

Ref:
https://github.com/pytorch/pytorch/blob/ceea08a986805030014fac203d5b2411e23ff091/torch/nn/modules/rnn.py#L83

https://github.com/pytorch/pytorch/blob/ceea08a986805030014fac203d5b2411e23ff091/torch/nn/modules/rnn.py#L458

Test Plan: Please see GitHub Actions.

Differential Revision: D47943365

Fix: #105628
