### PR TITLE
Link compiled protobuf files to `protobuf::libprotobuf`

### DIFF
--- a/caffe2/proto/CMakeLists.txt
+++ b/caffe2/proto/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 caffe2_protobuf_generate_cpp_py(Caffe2_PROTO_SRCS Caffe2_PROTO_HEADERS Caffe2_PROTO_PY ${Caffe2_PROTOBUF_FILES})
 
 add_library(Caffe2_PROTO OBJECT ${Caffe2_PROTO_HEADERS} ${Caffe2_PROTO_SRCS})
+target_link_libraries(Caffe2_PROTO PRIVATE protobuf::libprotobuf)
 
 if(MSVC)
   if(BUILD_SHARED_LIBS)

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -122,10 +122,6 @@ if((NOT TARGET protobuf::libprotobuf) AND (NOT TARGET protobuf::libprotobuf-lite
   #     "Please set the proper paths so that I can find protobuf correctly.")
 endif()
 
-get_target_property(__tmp protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "Caffe2 protobuf include directory: " ${__tmp})
-include_directories(BEFORE SYSTEM ${__tmp})
-
 # If Protobuf_VERSION is known (true in most cases, false if we are building
 # local protobuf), then we will add a protobuf version check in
 # Caffe2Config.cmake.in.


### PR DESCRIPTION
This correctly propagates the required compile flags (such as `-DPROTOBUF_USE_DLLS` for shared builds of protobuf).

The manual extraction of the include path and adding that globally is also no longer required as that is part of that targets interface.

Fixes #106297   
Fixes #106206