### PR TITLE
[caffe2] Replace `CAFFE_` prefixes in `static_tracepoint.h` macros with `TORCH_`

### DIFF
--- a/c10/util/static_tracepoint.h
+++ b/c10/util/static_tracepoint.h
@@ -1,34 +1,34 @@
 #pragma once
 
 #if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__)) && \
-    !CAFFE_DISABLE_SDT
+    !TORCH_DISABLE_SDT
 
-#define CAFFE_HAVE_SDT 1
+#define TORCH_HAVE_SDT 1
 
 #include <c10/util/static_tracepoint_elfx86.h>
 
-#define CAFFE_SDT(name, ...) \
-  CAFFE_SDT_PROBE_N(         \
-      caffe2, name, 0, CAFFE_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
-// Use CAFFE_SDT_DEFINE_SEMAPHORE(name) to define the semaphore
-// as global variable before using the CAFFE_SDT_WITH_SEMAPHORE macro
-#define CAFFE_SDT_WITH_SEMAPHORE(name, ...) \
-  CAFFE_SDT_PROBE_N(                        \
-      caffe2, name, 1, CAFFE_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
-#define CAFFE_SDT_IS_ENABLED(name) (CAFFE_SDT_SEMAPHORE(caffe2, name) > 0)
+#define TORCH_SDT(name, ...) \
+  TORCH_SDT_PROBE_N(         \
+      pytorch, name, 0, TORCH_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+// Use TORCH_SDT_DEFINE_SEMAPHORE(name) to define the semaphore
+// as global variable before using the TORCH_SDT_WITH_SEMAPHORE macro
+#define TORCH_SDT_WITH_SEMAPHORE(name, ...) \
+  TORCH_SDT_PROBE_N(                        \
+      pytorch, name, 1, TORCH_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#define TORCH_SDT_IS_ENABLED(name) (TORCH_SDT_SEMAPHORE(pytorch, name) > 0)
 
 #else
 
-#define CAFFE_HAVE_SDT 0
+#define TORCH_HAVE_SDT 0
 
-#define CAFFE_SDT(name, ...) \
+#define TORCH_SDT(name, ...) \
   do {                       \
   } while (0)
-#define CAFFE_SDT_WITH_SEMAPHORE(name, ...) \
+#define TORCH_SDT_WITH_SEMAPHORE(name, ...) \
   do {                                      \
   } while (0)
-#define CAFFE_SDT_IS_ENABLED(name) (false)
-#define CAFFE_SDT_DEFINE_SEMAPHORE(name)
-#define CAFFE_SDT_DECLARE_SEMAPHORE(name)
+#define TORCH_SDT_IS_ENABLED(name) (false)
+#define TORCH_SDT_DEFINE_SEMAPHORE(name)
+#define TORCH_SDT_DECLARE_SEMAPHORE(name)
 
 #endif

--- a/c10/util/static_tracepoint_elfx86.h
+++ b/c10/util/static_tracepoint_elfx86.h
@@ -4,130 +4,130 @@
 #include <cstddef>
 
 // Default constraint for the probe arguments as operands.
-#ifndef CAFFE_SDT_ARG_CONSTRAINT
-#define CAFFE_SDT_ARG_CONSTRAINT      "nor"
+#ifndef TORCH_SDT_ARG_CONSTRAINT
+#define TORCH_SDT_ARG_CONSTRAINT      "nor"
 #endif
 
 // Instruction to emit for the probe.
-#define CAFFE_SDT_NOP                 nop
+#define TORCH_SDT_NOP                 nop
 
 // Note section properties.
-#define CAFFE_SDT_NOTE_NAME           "stapsdt"
-#define CAFFE_SDT_NOTE_TYPE           3
+#define TORCH_SDT_NOTE_NAME           "stapsdt"
+#define TORCH_SDT_NOTE_TYPE           3
 
 // Semaphore variables are put in this section
-#define CAFFE_SDT_SEMAPHORE_SECTION   ".probes"
+#define TORCH_SDT_SEMAPHORE_SECTION   ".probes"
 
 // Size of address depending on platform.
 #ifdef __LP64__
-#define CAFFE_SDT_ASM_ADDR            .8byte
+#define TORCH_SDT_ASM_ADDR            .8byte
 #else
-#define CAFFE_SDT_ASM_ADDR            .4byte
+#define TORCH_SDT_ASM_ADDR            .4byte
 #endif
 
 // Assembler helper Macros.
-#define CAFFE_SDT_S(x)                #x
-#define CAFFE_SDT_ASM_1(x)            CAFFE_SDT_S(x) "\n"
-#define CAFFE_SDT_ASM_2(a, b)         CAFFE_SDT_S(a) "," CAFFE_SDT_S(b) "\n"
-#define CAFFE_SDT_ASM_3(a, b, c)      CAFFE_SDT_S(a) "," CAFFE_SDT_S(b) ","    \
-                                      CAFFE_SDT_S(c) "\n"
-#define CAFFE_SDT_ASM_STRING(x)       CAFFE_SDT_ASM_1(.asciz CAFFE_SDT_S(x))
+#define TORCH_SDT_S(x)                #x
+#define TORCH_SDT_ASM_1(x)            TORCH_SDT_S(x) "\n"
+#define TORCH_SDT_ASM_2(a, b)         TORCH_SDT_S(a) "," TORCH_SDT_S(b) "\n"
+#define TORCH_SDT_ASM_3(a, b, c)      TORCH_SDT_S(a) "," TORCH_SDT_S(b) ","    \
+                                      TORCH_SDT_S(c) "\n"
+#define TORCH_SDT_ASM_STRING(x)       TORCH_SDT_ASM_1(.asciz TORCH_SDT_S(x))
 
 // Helper to determine the size of an argument.
-#define CAFFE_SDT_IS_ARRAY_POINTER(x)  ((__builtin_classify_type(x) == 14) ||  \
+#define TORCH_SDT_IS_ARRAY_POINTER(x)  ((__builtin_classify_type(x) == 14) ||  \
                                         (__builtin_classify_type(x) == 5))
-#define CAFFE_SDT_ARGSIZE(x)  (CAFFE_SDT_IS_ARRAY_POINTER(x)                   \
+#define TORCH_SDT_ARGSIZE(x)  (TORCH_SDT_IS_ARRAY_POINTER(x)                   \
                                ? sizeof(void*)                                 \
                                : sizeof(x))
 
 // Format of each probe arguments as operand.
-// Size of the argument tagged with CAFFE_SDT_Sn, with "n" constraint.
-// Value of the argument tagged with CAFFE_SDT_An, with configured constraint.
-#define CAFFE_SDT_ARG(n, x)                                                    \
-  [CAFFE_SDT_S##n] "n"                ((size_t)CAFFE_SDT_ARGSIZE(x)),          \
-  [CAFFE_SDT_A##n] CAFFE_SDT_ARG_CONSTRAINT (x)
+// Size of the argument tagged with TORCH_SDT_Sn, with "n" constraint.
+// Value of the argument tagged with TORCH_SDT_An, with configured constraint.
+#define TORCH_SDT_ARG(n, x)                                                    \
+  [TORCH_SDT_S##n] "n"                ((size_t)TORCH_SDT_ARGSIZE(x)),          \
+  [TORCH_SDT_A##n] TORCH_SDT_ARG_CONSTRAINT (x)
 
 // Templates to append arguments as operands.
-#define CAFFE_SDT_OPERANDS_0()        [__sdt_dummy] "g" (0)
-#define CAFFE_SDT_OPERANDS_1(_1)      CAFFE_SDT_ARG(1, _1)
-#define CAFFE_SDT_OPERANDS_2(_1, _2)                                           \
-  CAFFE_SDT_OPERANDS_1(_1), CAFFE_SDT_ARG(2, _2)
-#define CAFFE_SDT_OPERANDS_3(_1, _2, _3)                                       \
-  CAFFE_SDT_OPERANDS_2(_1, _2), CAFFE_SDT_ARG(3, _3)
-#define CAFFE_SDT_OPERANDS_4(_1, _2, _3, _4)                                   \
-  CAFFE_SDT_OPERANDS_3(_1, _2, _3), CAFFE_SDT_ARG(4, _4)
-#define CAFFE_SDT_OPERANDS_5(_1, _2, _3, _4, _5)                               \
-  CAFFE_SDT_OPERANDS_4(_1, _2, _3, _4), CAFFE_SDT_ARG(5, _5)
-#define CAFFE_SDT_OPERANDS_6(_1, _2, _3, _4, _5, _6)                           \
-  CAFFE_SDT_OPERANDS_5(_1, _2, _3, _4, _5), CAFFE_SDT_ARG(6, _6)
-#define CAFFE_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7)                       \
-  CAFFE_SDT_OPERANDS_6(_1, _2, _3, _4, _5, _6), CAFFE_SDT_ARG(7, _7)
-#define CAFFE_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8)                   \
-  CAFFE_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7), CAFFE_SDT_ARG(8, _8)
-#define CAFFE_SDT_OPERANDS_9(_1, _2, _3, _4, _5, _6, _7, _8, _9)               \
-  CAFFE_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8), CAFFE_SDT_ARG(9, _9)
+#define TORCH_SDT_OPERANDS_0()        [__sdt_dummy] "g" (0)
+#define TORCH_SDT_OPERANDS_1(_1)      TORCH_SDT_ARG(1, _1)
+#define TORCH_SDT_OPERANDS_2(_1, _2)                                           \
+  TORCH_SDT_OPERANDS_1(_1), TORCH_SDT_ARG(2, _2)
+#define TORCH_SDT_OPERANDS_3(_1, _2, _3)                                       \
+  TORCH_SDT_OPERANDS_2(_1, _2), TORCH_SDT_ARG(3, _3)
+#define TORCH_SDT_OPERANDS_4(_1, _2, _3, _4)                                   \
+  TORCH_SDT_OPERANDS_3(_1, _2, _3), TORCH_SDT_ARG(4, _4)
+#define TORCH_SDT_OPERANDS_5(_1, _2, _3, _4, _5)                               \
+  TORCH_SDT_OPERANDS_4(_1, _2, _3, _4), TORCH_SDT_ARG(5, _5)
+#define TORCH_SDT_OPERANDS_6(_1, _2, _3, _4, _5, _6)                           \
+  TORCH_SDT_OPERANDS_5(_1, _2, _3, _4, _5), TORCH_SDT_ARG(6, _6)
+#define TORCH_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7)                       \
+  TORCH_SDT_OPERANDS_6(_1, _2, _3, _4, _5, _6), TORCH_SDT_ARG(7, _7)
+#define TORCH_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8)                   \
+  TORCH_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7), TORCH_SDT_ARG(8, _8)
+#define TORCH_SDT_OPERANDS_9(_1, _2, _3, _4, _5, _6, _7, _8, _9)               \
+  TORCH_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8), TORCH_SDT_ARG(9, _9)
 
 // Templates to reference the arguments from operands in note section.
-#define CAFFE_SDT_ARGFMT(no)        %n[CAFFE_SDT_S##no]@%[CAFFE_SDT_A##no]
-#define CAFFE_SDT_ARG_TEMPLATE_0    /*No arguments*/
-#define CAFFE_SDT_ARG_TEMPLATE_1    CAFFE_SDT_ARGFMT(1)
-#define CAFFE_SDT_ARG_TEMPLATE_2    CAFFE_SDT_ARG_TEMPLATE_1 CAFFE_SDT_ARGFMT(2)
-#define CAFFE_SDT_ARG_TEMPLATE_3    CAFFE_SDT_ARG_TEMPLATE_2 CAFFE_SDT_ARGFMT(3)
-#define CAFFE_SDT_ARG_TEMPLATE_4    CAFFE_SDT_ARG_TEMPLATE_3 CAFFE_SDT_ARGFMT(4)
-#define CAFFE_SDT_ARG_TEMPLATE_5    CAFFE_SDT_ARG_TEMPLATE_4 CAFFE_SDT_ARGFMT(5)
-#define CAFFE_SDT_ARG_TEMPLATE_6    CAFFE_SDT_ARG_TEMPLATE_5 CAFFE_SDT_ARGFMT(6)
-#define CAFFE_SDT_ARG_TEMPLATE_7    CAFFE_SDT_ARG_TEMPLATE_6 CAFFE_SDT_ARGFMT(7)
-#define CAFFE_SDT_ARG_TEMPLATE_8    CAFFE_SDT_ARG_TEMPLATE_7 CAFFE_SDT_ARGFMT(8)
-#define CAFFE_SDT_ARG_TEMPLATE_9    CAFFE_SDT_ARG_TEMPLATE_8 CAFFE_SDT_ARGFMT(9)
+#define TORCH_SDT_ARGFMT(no)        %n[TORCH_SDT_S##no]@%[TORCH_SDT_A##no]
+#define TORCH_SDT_ARG_TEMPLATE_0    /*No arguments*/
+#define TORCH_SDT_ARG_TEMPLATE_1    TORCH_SDT_ARGFMT(1)
+#define TORCH_SDT_ARG_TEMPLATE_2    TORCH_SDT_ARG_TEMPLATE_1 TORCH_SDT_ARGFMT(2)
+#define TORCH_SDT_ARG_TEMPLATE_3    TORCH_SDT_ARG_TEMPLATE_2 TORCH_SDT_ARGFMT(3)
+#define TORCH_SDT_ARG_TEMPLATE_4    TORCH_SDT_ARG_TEMPLATE_3 TORCH_SDT_ARGFMT(4)
+#define TORCH_SDT_ARG_TEMPLATE_5    TORCH_SDT_ARG_TEMPLATE_4 TORCH_SDT_ARGFMT(5)
+#define TORCH_SDT_ARG_TEMPLATE_6    TORCH_SDT_ARG_TEMPLATE_5 TORCH_SDT_ARGFMT(6)
+#define TORCH_SDT_ARG_TEMPLATE_7    TORCH_SDT_ARG_TEMPLATE_6 TORCH_SDT_ARGFMT(7)
+#define TORCH_SDT_ARG_TEMPLATE_8    TORCH_SDT_ARG_TEMPLATE_7 TORCH_SDT_ARGFMT(8)
+#define TORCH_SDT_ARG_TEMPLATE_9    TORCH_SDT_ARG_TEMPLATE_8 TORCH_SDT_ARGFMT(9)
 
 // Semaphore define, declare and probe note format
 
-#define CAFFE_SDT_SEMAPHORE(provider, name)                                    \
-  caffe_sdt_semaphore_##provider##_##name
+#define TORCH_SDT_SEMAPHORE(provider, name)                                    \
+  torch_sdt_semaphore_##provider##_##name
 
-#define CAFFE_SDT_DEFINE_SEMAPHORE(name)                                       \
+#define TORCH_SDT_DEFINE_SEMAPHORE(name)                                       \
   extern "C" {                                                                 \
-    volatile unsigned short CAFFE_SDT_SEMAPHORE(caffe2, name)                  \
-    __attribute__((section(CAFFE_SDT_SEMAPHORE_SECTION), used)) = 0;           \
+    volatile unsigned short TORCH_SDT_SEMAPHORE(pytorch, name)                 \
+    __attribute__((section(TORCH_SDT_SEMAPHORE_SECTION), used)) = 0;           \
   }
 
-#define CAFFE_SDT_DECLARE_SEMAPHORE(name)                                      \
-  extern "C" volatile unsigned short CAFFE_SDT_SEMAPHORE(caffe2, name)
+#define TORCH_SDT_DECLARE_SEMAPHORE(name)                                      \
+  extern "C" volatile unsigned short TORCH_SDT_SEMAPHORE(pytorch, name)
 
-#define CAFFE_SDT_SEMAPHORE_NOTE_0(provider, name)                             \
-  CAFFE_SDT_ASM_1(     CAFFE_SDT_ASM_ADDR 0) /*No Semaphore*/                  \
+#define TORCH_SDT_SEMAPHORE_NOTE_0(provider, name)                             \
+  TORCH_SDT_ASM_1(     TORCH_SDT_ASM_ADDR 0) /*No Semaphore*/                  \
 
-#define CAFFE_SDT_SEMAPHORE_NOTE_1(provider, name)                             \
-  CAFFE_SDT_ASM_1(CAFFE_SDT_ASM_ADDR CAFFE_SDT_SEMAPHORE(provider, name))
+#define TORCH_SDT_SEMAPHORE_NOTE_1(provider, name)                             \
+  TORCH_SDT_ASM_1(TORCH_SDT_ASM_ADDR TORCH_SDT_SEMAPHORE(provider, name))
 
 // Structure of note section for the probe.
-#define CAFFE_SDT_NOTE_CONTENT(provider, name, has_semaphore, arg_template)    \
-  CAFFE_SDT_ASM_1(990: CAFFE_SDT_NOP)                                          \
-  CAFFE_SDT_ASM_3(     .pushsection .note.stapsdt,"","note")                   \
-  CAFFE_SDT_ASM_1(     .balign 4)                                              \
-  CAFFE_SDT_ASM_3(     .4byte 992f-991f, 994f-993f, CAFFE_SDT_NOTE_TYPE)       \
-  CAFFE_SDT_ASM_1(991: .asciz CAFFE_SDT_NOTE_NAME)                             \
-  CAFFE_SDT_ASM_1(992: .balign 4)                                              \
-  CAFFE_SDT_ASM_1(993: CAFFE_SDT_ASM_ADDR 990b)                                \
-  CAFFE_SDT_ASM_1(     CAFFE_SDT_ASM_ADDR 0) /*Reserved for Base Address*/     \
-  CAFFE_SDT_SEMAPHORE_NOTE_##has_semaphore(provider, name)                     \
-  CAFFE_SDT_ASM_STRING(provider)                                               \
-  CAFFE_SDT_ASM_STRING(name)                                                   \
-  CAFFE_SDT_ASM_STRING(arg_template)                                           \
-  CAFFE_SDT_ASM_1(994: .balign 4)                                              \
-  CAFFE_SDT_ASM_1(     .popsection)
+#define TORCH_SDT_NOTE_CONTENT(provider, name, has_semaphore, arg_template)    \
+  TORCH_SDT_ASM_1(990: TORCH_SDT_NOP)                                          \
+  TORCH_SDT_ASM_3(     .pushsection .note.stapsdt,"","note")                   \
+  TORCH_SDT_ASM_1(     .balign 4)                                              \
+  TORCH_SDT_ASM_3(     .4byte 992f-991f, 994f-993f, TORCH_SDT_NOTE_TYPE)       \
+  TORCH_SDT_ASM_1(991: .asciz TORCH_SDT_NOTE_NAME)                             \
+  TORCH_SDT_ASM_1(992: .balign 4)                                              \
+  TORCH_SDT_ASM_1(993: TORCH_SDT_ASM_ADDR 990b)                                \
+  TORCH_SDT_ASM_1(     TORCH_SDT_ASM_ADDR 0) /*Reserved for Base Address*/     \
+  TORCH_SDT_SEMAPHORE_NOTE_##has_semaphore(provider, name)                     \
+  TORCH_SDT_ASM_STRING(provider)                                               \
+  TORCH_SDT_ASM_STRING(name)                                                   \
+  TORCH_SDT_ASM_STRING(arg_template)                                           \
+  TORCH_SDT_ASM_1(994: .balign 4)                                              \
+  TORCH_SDT_ASM_1(     .popsection)
 
 // Main probe Macro.
-#define CAFFE_SDT_PROBE(provider, name, has_semaphore, n, arglist)             \
+#define TORCH_SDT_PROBE(provider, name, has_semaphore, n, arglist)             \
     __asm__ __volatile__ (                                                     \
-      CAFFE_SDT_NOTE_CONTENT(                                                  \
-        provider, name, has_semaphore, CAFFE_SDT_ARG_TEMPLATE_##n)             \
-      :: CAFFE_SDT_OPERANDS_##n arglist                                        \
+      TORCH_SDT_NOTE_CONTENT(                                                  \
+        provider, name, has_semaphore, TORCH_SDT_ARG_TEMPLATE_##n)             \
+      :: TORCH_SDT_OPERANDS_##n arglist                                        \
     )                                                                          \
 
 // Helper Macros to handle variadic arguments.
-#define CAFFE_SDT_NARG_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
-#define CAFFE_SDT_NARG(...)                                                    \
-  CAFFE_SDT_NARG_(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
-#define CAFFE_SDT_PROBE_N(provider, name, has_semaphore, N, ...)               \
-  CAFFE_SDT_PROBE(provider, name, has_semaphore, N, (__VA_ARGS__))
+#define TORCH_SDT_NARG_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
+#define TORCH_SDT_NARG(...)                                                    \
+  TORCH_SDT_NARG_(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define TORCH_SDT_PROBE_N(provider, name, has_semaphore, N, ...)               \
+  TORCH_SDT_PROBE(provider, name, has_semaphore, N, (__VA_ARGS__))

--- a/caffe2/core/net_dag_utils.cc
+++ b/caffe2/core/net_dag_utils.cc
@@ -6,7 +6,6 @@
 #include <unordered_set>
 
 #include "caffe2/core/operator.h"
-#include "c10/util/static_tracepoint.h"
 #include "caffe2/core/timer.h"
 #include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -62,11 +62,11 @@ bool SimpleNet::Run() {
     const auto& op_type = op->debug_def().type().c_str();
     auto* op_ptr = op.get();
     const auto& net_name = name_.c_str();
-    CAFFE_SDT(operator_start, net_name, op_name, op_type, op_ptr);
+    TORCH_SDT(operator_start, net_name, op_name, op_type, op_ptr);
 #endif
     bool res = op->Run();
 #ifdef CAFFE2_ENABLE_SDT
-    CAFFE_SDT(operator_done, net_name, op_name, op_type, op_ptr);
+    TORCH_SDT(operator_done, net_name, op_name, op_type, op_ptr);
 #endif
     // workaround for async cpu ops, we need to explicitly wait for them
     if (res && op->HasAsyncPart() &&

--- a/caffe2/core/net_simple_refcount.cc
+++ b/caffe2/core/net_simple_refcount.cc
@@ -7,7 +7,6 @@
 #include <unordered_set>
 
 #include "caffe2/core/operator.h"
-#include "c10/util/static_tracepoint.h"
 #include "caffe2/core/timer.h"
 #include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/utils/proto_utils.h"

--- a/caffe2/core/stats.h
+++ b/caffe2/core/stats.h
@@ -343,7 +343,7 @@ _ScopeGuard<T> ScopeGuard(T f) {
 #define CAFFE_EVENT(stats, field, ...)                              \
   {                                                                 \
     auto __caffe_event_value_ = stats.field.increment(__VA_ARGS__); \
-    CAFFE_SDT(                                                      \
+    TORCH_SDT(                                                      \
         field,                                                      \
         stats.field.groupName.c_str(),                              \
         __caffe_event_value_,                                       \

--- a/caffe2/queue/blobs_queue.cc
+++ b/caffe2/queue/blobs_queue.cc
@@ -62,7 +62,7 @@ bool BlobsQueue::blockingRead(
   Timer readTimer;
   auto keeper = this->shared_from_this();
   C10_UNUSED const auto& name = name_.c_str();
-  CAFFE_SDT(queue_read_start, name, (void*)this, SDT_BLOCKING_OP);
+  TORCH_SDT(queue_read_start, name, (void*)this, SDT_BLOCKING_OP);
   std::unique_lock<std::mutex> g(mutex_);
   auto canRead = [this]() {
     CAFFE_ENFORCE_LE(reader_, writer_);
@@ -81,9 +81,9 @@ bool BlobsQueue::blockingRead(
   if (!canRead()) {
     if (timeout_secs > 0 && !closing_) {
       LOG(ERROR) << "DequeueBlobs timed out in " << timeout_secs << " secs";
-      CAFFE_SDT(queue_read_end, name, (void*)this, SDT_TIMEOUT);
+      TORCH_SDT(queue_read_end, name, (void*)this, SDT_TIMEOUT);
     } else {
-      CAFFE_SDT(queue_read_end, name, (void*)this, SDT_CANCEL);
+      TORCH_SDT(queue_read_end, name, (void*)this, SDT_CANCEL);
     }
     return false;
   }
@@ -96,7 +96,7 @@ bool BlobsQueue::blockingRead(
     using std::swap;
     swap(*(inputs[i]), *(result[i]));
   }
-  CAFFE_SDT(queue_read_end, name, (void*)this, writer_ - reader_);
+  TORCH_SDT(queue_read_end, name, (void*)this, writer_ - reader_);
   CAFFE_EVENT(stats_, queue_dequeued_records);
   ++reader_;
   cv_.notify_all();
@@ -108,10 +108,10 @@ bool BlobsQueue::tryWrite(const std::vector<Blob*>& inputs) {
   Timer writeTimer;
   auto keeper = this->shared_from_this();
   C10_UNUSED const auto& name = name_.c_str();
-  CAFFE_SDT(queue_write_start, name, (void*)this, SDT_NONBLOCKING_OP);
+  TORCH_SDT(queue_write_start, name, (void*)this, SDT_NONBLOCKING_OP);
   std::unique_lock<std::mutex> g(mutex_);
   if (!canWrite()) {
-    CAFFE_SDT(queue_write_end, name, (void*)this, SDT_ABORT);
+    TORCH_SDT(queue_write_end, name, (void*)this, SDT_ABORT);
     return false;
   }
   // Increase queue balance before writing to indicate queue write pressure is
@@ -127,14 +127,14 @@ bool BlobsQueue::blockingWrite(const std::vector<Blob*>& inputs) {
   Timer writeTimer;
   auto keeper = this->shared_from_this();
   C10_UNUSED const auto& name = name_.c_str();
-  CAFFE_SDT(queue_write_start, name, (void*)this, SDT_BLOCKING_OP);
+  TORCH_SDT(queue_write_start, name, (void*)this, SDT_BLOCKING_OP);
   std::unique_lock<std::mutex> g(mutex_);
   // Increase queue balance before writing to indicate queue write pressure is
   // being increased (+ve queue balance indicates more writes than reads)
   CAFFE_EVENT(stats_, queue_balance, 1);
   cv_.wait(g, [this]() { return closing_ || canWrite(); });
   if (!canWrite()) {
-    CAFFE_SDT(queue_write_end, name, (void*)this, SDT_ABORT);
+    TORCH_SDT(queue_write_end, name, (void*)this, SDT_ABORT);
     return false;
   }
   DCHECK(canWrite());
@@ -167,7 +167,7 @@ void BlobsQueue::doWrite(const std::vector<Blob*>& inputs) {
     using std::swap;
     swap(*(inputs[i]), *(result[i]));
   }
-  CAFFE_SDT(
+  TORCH_SDT(
       queue_write_end, name, (void*)this, reader_ + queue_.size() - writer_);
   ++writer_;
   cv_.notify_all();


### PR DESCRIPTION
Summary: Rename static tracepoint macros to better describe their targeted usage.

Test Plan:
Same as for D47159249:

Tested the following macros on test scripts with libbpf USDTs:
* `CAFFE_SDT`
* `CAFFE_DISABLE_SDT`
* `CAFFE_SDT_WITH_SEMAPHORE`

Reviewed By: chaekit

Differential Revision: D47727339

