### PR TITLE
[Pytorch][Vulkan] aten::gt

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
+++ b/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
@@ -7,6 +7,8 @@ binary_op_scalar:
         OPERATOR: X * Y
       - NAME: pow_tensor_scalar
         OPERATOR: pow (X, Y)
+      - NAME: gt_scalar
+        OPERATOR: uvec4(greaterThan(X, Y))
 
 binary_op_scalar_inplace:
   parameter_names_with_default_values:
@@ -17,6 +19,8 @@ binary_op_scalar_inplace:
         OPERATOR: X * Y
       - NAME: pow_tensor_scalar_
         OPERATOR: pow (X, Y)
+      - NAME: gt_scalar_
+        OPERATOR: uvec4(greaterThan(X, Y))
 
 binary_op_tensor:
   parameter_names_with_default_values:
@@ -36,6 +40,9 @@ binary_op_tensor:
       - NAME: pow
         IS_DIV: 0
         OPERATOR: pow(X, Y)
+      - NAME: gt
+        IS_DIV: 0
+        OPERATOR: uvec4(greaterThan(X, Y))
 
 binary_op_tensor_inplace:
   parameter_names_with_default_values:
@@ -55,3 +62,6 @@ binary_op_tensor_inplace:
       - NAME: pow_
         IS_DIV: 0
         OPERATOR: pow(X, Y)
+      - NAME: gt_
+        IS_DIV: 0
+        OPERATOR: uvec4(greaterThan(X, Y))

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -52,6 +52,7 @@ void pack_vtensor_to_staging(
 
 // Broadcasting Utils
 void is_broadcastable(const Tensor& input1, const Tensor& input2);
+void is_broadcastable_with_self(const Tensor& self, const Tensor& other);
 std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2);
 
 } // namespace utils


### PR DESCRIPTION
Summary:
Add support for Vulkan [greater than](https://pytorch.org/docs/stable/generated/torch.gt.html) and its variants.

Note, gt is broadcastable one-way:
```
The second argument can be a number or a tensor whose shape is broadcastable with the first argument.
```

Also check scalar type matches. For non-inplace variants, output is a bool tensor. For in-place variants, an int tensor (same as input).

Test Plan:
New tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*gt*"
Building: finished in 0.2 sec (100%) 265/265 jobs, 0/265 updated
  Total time: 0.2 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *gt*
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.gt
[       OK ] VulkanAPITest.gt (67 ms)
[ RUN      ] VulkanAPITest.gt_broadcast
[       OK ] VulkanAPITest.gt_broadcast (1 ms)
[ RUN      ] VulkanAPITest.gt_broadcast_invalid
[       OK ] VulkanAPITest.gt_broadcast_invalid (0 ms)
[ RUN      ] VulkanAPITest.gt_
[       OK ] VulkanAPITest.gt_ (3 ms)
[ RUN      ] VulkanAPITest.gt_broadcast_
[       OK ] VulkanAPITest.gt_broadcast_ (0 ms)
[ RUN      ] VulkanAPITest.gt_scalar
[       OK ] VulkanAPITest.gt_scalar (2 ms)
[ RUN      ] VulkanAPITest.gt_scalar_
[       OK ] VulkanAPITest.gt_scalar_ (1 ms)
[----------] 7 tests from VulkanAPITest (77 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (77 ms total)
[  PASSED  ] 7 tests
```

All tests: https://www.internalfb.com/phabricator/paste/view/P797564233

```
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:6751: Skipped
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 324 tests from VulkanAPITest (6024 ms total)

[----------] Global test environment tear-down
[==========] 324 tests from 1 test suite ran. (6024 ms total)
[  PASSED  ] 323 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```

clang-format on `BinaryOp.cpp`

Reviewed By: SS-JIA

Differential Revision: D47767546

