### PR TITLE
Disable TV if Z3 is not found.

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -1,8 +1,10 @@
 # Owner(s): ["module: dynamo"]
 import unittest
+import warnings
 
 from torch._dynamo import config
 from torch._dynamo.testing import make_test_cls_with_patches
+from torch.testing._internal.common_utils import TEST_Z3
 
 try:
     from . import (
@@ -42,7 +44,7 @@ def make_dynamic_cls(cls):
         suffix,
         (config, "assume_static_by_default", False),
         (config, "specialize_int", False),
-        (config, "translation_validation", True),
+        (config, "translation_validation", TEST_Z3),
         xfail_prop="_expected_failure_dynamic",
     )
 
@@ -74,5 +76,11 @@ unittest.expectedFailure(
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
+
+    if not TEST_Z3:
+        warnings.warn(
+            "translation validation is off. "
+            "Testing with translation validation requires Z3."
+        )
 
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106399

Fix: #106276

This PR disables translation validation when running _test/dynamo/test_dynamic_shapes.py_
if Z3 is not installed.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov