### PR TITLE
[ONNX] Preserve extra kwargs when aten name fallback is triggered

### DIFF
--- a/torch/onnx/_internal/fx/diagnostics.py
+++ b/torch/onnx/_internal/fx/diagnostics.py
@@ -125,6 +125,11 @@ def _bool(obj: bool) -> str:
 
 
 @_format_argument.register
+def _string(obj: str) -> str:
+    return obj
+
+
+@_format_argument.register
 def _registration_symbolic_function(obj: registration.SymbolicFunction) -> str:
     # TODO: Compact display of `param_schema`.
     return f"registration.SymbolicFunction({obj.op_full_name}, is_custom={obj.is_custom}, is_complex={obj.is_complex})"

--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -725,6 +725,11 @@ class _OnnxSchemaChecker:
                 if fill_defaults:
                     onnx_attributes[param.name] = param.default
 
+        # pick up extra kwargs
+        extra_kwargs = set(kwargs).difference({param.name for param in param_schemas})
+        for extra_kwarg in extra_kwargs:
+            onnx_attributes[extra_kwarg] = kwargs[extra_kwarg]
+
         return onnx_inputs, onnx_attributes
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106411
* __->__ #106410

Partially fix #106057 

When we applied `param_schema` on to onnx_args/onnx_kwargs, the extra kwargs are not kept because it's assumed they are matched, which creates a bug when an aten overload falls back, the opschema is perfect match in a way the the extra kwargs is ignore. In aten name fallback, usually there is different between the schemas, and we should keep that difference, and warns the users when it's a nearest match.