### PR TITLE
[ONNX] Do not filter memory_format as it's kwargs in aten.clone

### DIFF
--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -179,7 +179,6 @@ def filter_incompatible_and_dtype_convert_kwargs(kwargs):
             "device",
             "requires_grad",
             "pin_memory",
-            "memory_format",
             "implicit",
         }:
             continue
@@ -190,6 +189,9 @@ def filter_incompatible_and_dtype_convert_kwargs(kwargs):
                 continue
             else:
                 value = int(jit_type_utils.JitScalarType.from_dtype(value).onnx_type())
+        if key == "memory_format":
+            # memory_format is not supported by onnxscript.
+            value = str(value)
         filtered[key] = value
     return filtered
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106411
* #106410

Partially fix #106057 

`memory_format` doesn't do anything in onnx-script, and it was filtered in early stage. However, some ops (ex: aten_clone) actually keeps this as an attribute, which further causes non-perfect match when it's actually nothing to worry about. This PR allows the kwargs. (CI could break if some ops has `memory_format` in torch, but doesn't have it on onnx-script signature. I think we had those breaking cases when I tried to include device in kwargs..)

NOTE: Need suggestion on what kwargs are allowed, and why. Trying to find a pattern.