### PR TITLE
Remove skipIfROCm from test_cuda_repro.py

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -921,7 +921,6 @@ class CudaReproTests(TestCase):
         ref = compiled(list(args))
         assert same(ref, correct)
 
-    @skipIfRocm
     @config.patch({"triton.cudagraphs": True})
     def test_index_put_inplace_cudagraph(self):
         def fn(x, y, z):
@@ -942,7 +941,6 @@ class CudaReproTests(TestCase):
 
         self.assertEqual(ref, res)
 
-    @skipIfRocm
     @config.patch({"triton.cudagraphs": True})
     def test_index_put_cudagraph(self):
         def fn(x, y, z):
@@ -963,7 +961,6 @@ class CudaReproTests(TestCase):
 
         self.assertEqual(ref, res)
 
-    @skipIfRocm
     @config.patch({"triton.cudagraphs": True})
     def test_index_put_no_fallback_cudagraph(self):
         def fn(x, y, z):


### PR DESCRIPTION
This is to fix tests failures after land race of https://github.com/pytorch/pytorch/pull/105662


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov