### PR TITLE
InductorCpp: Fix "call to constructor is ambiguous" error

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1215,7 +1215,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
     def generate_profiler_mark_wrapper_call(self, stack):
         self.wrapper_call.writeline(
-            'RECORD_FUNCTION("inductor_wrapper_call", c10::ArrayRef<c10::IValue>({{}}));'
+            'RECORD_FUNCTION("inductor_wrapper_call", c10::ArrayRef<c10::IValue>());'
         )
 
     def codegen_device(self, device):


### PR DESCRIPTION
Not sure why `{{}}` is better that just calling a default constructor, but removing it fixes:
```
% python test_cpp_wrapper.py -v -k test_profiler_mark_wrapper_call_cpu_cpp_wrapper
....
clang++ -MMD -MF main.o.d -DTORCH_EXTENSION_NAME=inline_extension_cwnqbbq5lr6hsaktauqhm5hulaxgvvwxphzkz3docrqablnmbd4v -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_clang\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1002\" -I/var/lib/jenkins/workspace/test/inductor/-I/var/lib/jenkins/workspace/torch/include -I/var/lib/jenkins/workspace/torch/include/torch/csrc/api/include -I/var/lib/jenkins/workspace/torch/include/TH -I/var/lib/jenkins/workspace/torch/include/THC -I/opt/conda/envs/py_3.9/include/python3.9 -isystem /var/lib/jenkins/workspace/torch/include -isystem /var/lib/jenkins/workspace/torch/include/torch/csrc/api/include -isystem /var/lib/jenkins/workspace/torch/include/TH -isystem /var/lib/jenkins/workspace/torch/include/THC -isystem /opt/conda/envs/py_3.9/include/python3.9 -D_GLIBCXX_USE_CXX11_ABI=1 -fPIC -std=c++17 -std=c++17 -Wno-unused-variable -O3 -ffast-math -fno-finite-math-only -march=native -fopenmp -Wall -DCPU_CAPABILITY_AVX512 -D C10_USING_CUSTOM_GENERATED_MACROS -c /tmp/torchinductor_jenkins/py39_cpu/inline_extension_cwnqbbq5lr6hsaktauqhm5hulaxgvvwxphzkz3docrqablnmbd4v/main.cpp -o main.o 
/tmp/torchinductor_jenkins/py39_cpu/inline_extension_cwnqbbq5lr6hsaktauqhm5hulaxgvvwxphzkz3docrqablnmbd4v/main.cpp:41:50: error: call to constructor of 'c10::ArrayRef<c10::IValue>' is ambiguous
        RECORD_FUNCTION("inductor_wrapper_call", c10::ArrayRef<c10::IValue>({{}}));
                                                 ^                          ~~~~
/var/lib/jenkins/workspace/torch/include/ATen/record_function.h:580:38: note: expanded from macro 'RECORD_FUNCTION'
      at::RecordScope::FUNCTION, fn, inputs, ##__VA_ARGS__)
                                     ^~~~~~
/var/lib/jenkins/workspace/torch/include/ATen/record_function.h:561:20: note: expanded from macro 'RECORD_FUNCTION_WITH_SCOPE'
        guard, fn, inputs, ##__VA_ARGS__);                 \
                   ^~~~~~
/var/lib/jenkins/workspace/torch/include/c10/util/ArrayRef.h:40:7: note: candidate constructor (the implicit move constructor)
class ArrayRef final {
      ^
/var/lib/jenkins/workspace/torch/include/c10/util/ArrayRef.h:40:7: note: candidate constructor (the implicit copy constructor)
/var/lib/jenkins/workspace/torch/include/c10/util/ArrayRef.h:71:13: note: candidate constructor
  constexpr ArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
            ^
/var/lib/jenkins/workspace/torch/include/c10/util/ArrayRef.h:126:28: note: candidate constructor
  /* implicit */ constexpr ArrayRef(const std::initializer_list<T>& Vec)
                           ^
1 error generated.
```
if clang12 is used as the host compiler



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov