### PR TITLE
Fix guarding issues w/ numpy

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -32,6 +32,7 @@ from torch._dynamo.exc import Unsupported
 from torch._dynamo.source import GetItemSource, LocalSource
 from torch._dynamo.testing import (
     CompileCounter,
+    CompileCounterWithBackend,
     expectedFailureDynamic,
     same,
     skipIfNotPy311,
@@ -1240,7 +1241,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             ref = fn(x)
             res = opt_fn(x)
             self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.frame_count, ifdynstaticdefault(2, 1))
 
     def test_numpy_ndarray_graph_break_with_multiple_outputs(self):
         def fn(x, y):
@@ -1256,7 +1257,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             y = torch.randn([1, 3])
             ref = fn(x, y)
             res = opt_fn(x, y)
-            self.assertTrue(same(ref, res))
+            self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 2)
 
     def test_tensor_interacts_with_numpy_ndarray(self):
@@ -1275,7 +1276,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             y = torch.randn([1, 3])
             ref = fn(x, y)
             res = opt_fn(x, y)
-            self.assertTrue(same(ref, res))
+            self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 2)
 
     def test_numpy_ndarray_works_with_builtin_function(self):
@@ -1289,8 +1290,33 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             x = np.random.randn(2, 3)
             ref = fn(x)
             res = opt_fn(x)
-            self.assertTrue(same(ref, res))
+            self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
+
+    def test_numpy_no_raise(self):
+        def _inf_nan_preprocess(t, t_np):
+            t_np = np.nan_to_num(t_np)
+            return t, t_np
+
+        def fn():
+            # shape, dims format
+            test_cases = (
+                (3, 3),
+                (4, 4),
+                (5, 5),
+            )
+
+            for shape in test_cases:
+                t = torch.randn(shape, dtype=torch.complex64)
+                t_np = np.random.randn(*shape).astype(np.complex64)
+
+                _, t_np = _inf_nan_preprocess(t, t_np)
+                print(t, t_np)  # Just a side effect so that compilation kicks in
+
+        cnt = CompileCounterWithBackend("inductor")
+        fn = torch._dynamo.optimize(cnt)(fn)
+        fn()
+        self.assertEqual(cnt.frame_count, ifdynstaticdefault(2, 1))
 
     def test_mandelbrot_numpy(self):
         def mandelbrot_numpy(max_iter):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1241,7 +1241,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             ref = fn(x)
             res = opt_fn(x)
             self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, ifdynstaticdefault(2, 1))
+        self.assertEqual(cnts.frame_count, 2)
 
     def test_numpy_ndarray_graph_break_with_multiple_outputs(self):
         def fn(x, y):

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -157,7 +157,7 @@ class PyCodegen:
         self.top_of_stack = value
 
     def add_graph_output(self, value):
-        graph_outputs_key = id(value.proxy)
+        graph_outputs_key = id(value.as_proxy())
         if graph_outputs_key not in self.graph_outputs:
             self.graph_outputs[graph_outputs_key] = GraphOutputEntry(
                 len(self.graph_outputs), value

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -98,7 +98,7 @@ traceable_tensor_subclasses = set()
 # This is a good way to get your model to work one way or another, but you may
 # lose optimization opportunities this way.  Devs, if your benchmark model is failing
 # this way, you should figure out why instead of suppressing it.
-suppress_errors = os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", "1") == "1"
+suppress_errors = False
 
 # Record and write an execution record of the current frame to a file
 # if an exception is encountered

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -85,7 +85,7 @@ CLOSURE_VARS = collections.OrderedDict(
         ("__load_module", lambda name: importlib.import_module(name)),
         ("utils_device", torch.utils._device),
         ("device", torch.device),
-        ("__numpy_to_tensor", torch._dynamo.utils.numpy_to_tensor),
+        ("__as_tensor", torch.as_tensor),
     ]
 )
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -85,6 +85,7 @@ CLOSURE_VARS = collections.OrderedDict(
         ("__load_module", lambda name: importlib.import_module(name)),
         ("utils_device", torch.utils._device),
         ("device", torch.device),
+        ("__numpy_to_tensor", torch._dynamo.utils.numpy_to_tensor),
     ]
 )
 
@@ -569,11 +570,11 @@ class GuardBuilder(GuardBuilderBase):
         for shape_guard in guards:
             self._produce_guard_code(guard, [shape_guard], shape_env=True)
 
-    def TENSOR_MATCH(self, guard: Guard):
+    def TENSOR_MATCH(self, guard: Guard, value=None):
         if guard.is_nn_module():
             self.ID_MATCH(guard)
         else:
-            value = self.get(guard.name)
+            value = value if value is not None else self.get(guard.name)
             assert isinstance(value, torch.Tensor)
             tensor_name = self.arg_ref(guard)
             # [Note - On Export Tensor Guards]

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -39,7 +39,7 @@ from torch.fx.experimental.symbolic_shapes import (
     SYMPY_INTERP,
 )
 
-from torch.utils.weak import WeakIdRef
+from torch.utils.weak import TensorWeakRef, WeakIdRef
 
 from . import config, convert_frame, mutation_guard
 from .eval_frame import set_guard_error_hook, set_guard_fail_hook
@@ -574,8 +574,12 @@ class GuardBuilder(GuardBuilderBase):
         if guard.is_nn_module():
             self.ID_MATCH(guard)
         else:
+            if isinstance(value, TensorWeakRef):
+                value = value()
+
             value = value if value is not None else self.get(guard.name)
             assert isinstance(value, torch.Tensor)
+
             tensor_name = self.arg_ref(guard)
             # [Note - On Export Tensor Guards]
             #

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -326,7 +326,6 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.random_values_var = None
         self.unspec_variable_map: Dict[str, UnspecializedPythonVariable] = {}
         self.torch_function_enabled = torch._C._is_torch_function_enabled()
-
         # We save the global torch state here to be restored in case of graph
         # breaks. The relevant issue is seen here
         # https://github.com/pytorch/pytorch/pull/100570#issuecomment-1543427086

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -475,6 +475,19 @@ class ConstantSource(Source):
         raise NotImplementedError()
 
 
+@dataclasses.dataclass(frozen=True)
+class NumpyTensorSource(ChainedSource):
+    def name(self) -> str:
+        return f"__numpy_to_tensor({self.base.name()})"
+
+    def guard_source(self):
+        return self.base.guard_source()
+
+    def reconstruct(self, codegen):
+        codegen.load_import_from("torch._dynamo.utils", "numpy_to_tensor")
+        return self.base.reconstruct(codegen) + create_call_function(1, True)
+
+
 # This is a synthetic source that is associated with the singleton
 # shape env guard we always register for all frames.  We get the actual
 # guard contents from the ambient ShapeEnv

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -478,13 +478,13 @@ class ConstantSource(Source):
 @dataclasses.dataclass(frozen=True)
 class NumpyTensorSource(ChainedSource):
     def name(self) -> str:
-        return f"__numpy_to_tensor({self.base.name()})"
+        return f"__as_tensor({self.base.name()})"
 
     def guard_source(self):
         return self.base.guard_source()
 
     def reconstruct(self, codegen):
-        codegen.load_import_from("torch._dynamo.utils", "numpy_to_tensor")
+        codegen.load_import_from("torch", "as_tensor")
         return self.base.reconstruct(codegen) + create_call_function(1, True)
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1645,6 +1645,8 @@ def to_numpy_helper(value):
 
 def numpy_to_tensor(value):
     """Convert tnp.ndarray to tensor, leave other types intact. If a list/tuple, loop through it to convert."""
+    if isinstance(value, np.ndarray):
+        return numpy_to_tensor(tnp.array(value, dtype=str(value.dtype)))
     if isinstance(value, tnp.ndarray):
         return value.tensor
     elif isinstance(value, (tuple, list)):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1646,7 +1646,7 @@ def to_numpy_helper(value):
 def numpy_to_tensor(value):
     """Convert tnp.ndarray to tensor, leave other types intact. If a list/tuple, loop through it to convert."""
     if isinstance(value, np.ndarray):
-        return numpy_to_tensor(tnp.array(value, dtype=str(value.dtype)))
+        return torch.as_tensor(value)
     if isinstance(value, tnp.ndarray):
         return value.tensor
     elif isinstance(value, (tuple, list)):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -164,10 +164,6 @@ class GraphArg:
 
     def __post_init__(self):
         if isinstance(self._example, torch.Tensor):
-            # A hack for intermediary variables, see example_strong_ref
-            if hasattr(self._example, "__dynamo_retain"):
-                self.example_strong_ref = self._example
-
             self._example = TensorWeakRef(self._example)
             assert is_fake(self.fake_tensor)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -820,7 +820,6 @@ class NumpyVariable(VariableTracker):
     ) -> "VariableTracker":
         from ..utils import numpy_to_tensor_wrapper
 
-        from .builder import wrap_fx_proxy_cls
         from .tensor import NumpyNdarrayVariable
 
         options = VariableTracker.propagate([[self]], [args], [list(kwargs.values())])
@@ -839,17 +838,12 @@ class NumpyVariable(VariableTracker):
 
             # TODO(larryliu0820): currently assuming all numpy.* functions are returning a ndarray that can be
             #  wrapped by NumpyNdarrayVariable which is wrong!
-            return wrap_fx_proxy_cls(
-                target_cls=NumpyNdarrayVariable,
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_function",
-                    numpy_to_tensor_wrapper(func),
-                    *proxy_args_kwargs(args, kwargs),
-                ),
-                example_value=None,
-                **options,
+            proxy = tx.output.create_proxy(
+                "call_function",
+                numpy_to_tensor_wrapper(func),
+                *proxy_args_kwargs(args, kwargs),
             )
+            return NumpyNdarrayVariable.create(tx, proxy, **options)
 
     def call_method(
         self,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -876,14 +876,6 @@ class NumpyNdarrayVariable(TensorVariable):
             **options,
         )
 
-    def __init__(
-        self,
-        proxy,
-        **kwargs,
-    ):
-        super().__init__(proxy, **kwargs)
-        self.proxy = proxy
-
     def var_getattr(self, tx, name):
         # NB: This INTENTIONALLY does not call super(), because there is
         # no intrinsic reason ndarray properties are related to Tensor

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -479,23 +479,17 @@ class TensorVariable(VariableTracker):
                 )
             return constant_result
         elif name == "numpy":
-            from .builder import wrap_fx_proxy_cls
-
             assert not args, "Tensor.numpy() doesn't take args."
             # TODO: support force
             if kwargs and "force" in kwargs:
                 unimplemented(f"Tensor.numpy(force={kwargs['force']})")
-            return wrap_fx_proxy_cls(
-                target_cls=NumpyNdarrayVariable,
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_function",
-                    torch.detach,
-                    *proxy_args_kwargs([self], {}),
-                ),
-                example_value=None,
-                **options,
+            proxy = tx.output.create_proxy(
+                "call_function",
+                torch.detach,
+                *proxy_args_kwargs([self], {}),
             )
+            return NumpyNdarrayVariable.create(tx, proxy, **options)
+
         elif name == "tolist":
             from .builder import SourcelessBuilder
 
@@ -871,12 +865,24 @@ class NumpyNdarrayVariable(TensorVariable):
     Use this for Tensor.numpy() call.
     """
 
+    @staticmethod
+    def create(tx, proxy, **options):
+        from .builder import wrap_fx_proxy_cls
+
+        return wrap_fx_proxy_cls(
+            target_cls=NumpyNdarrayVariable,
+            tx=tx,
+            proxy=proxy,
+            **options,
+        )
+
     def __init__(
         self,
-        proxy: torch.fx.Proxy,
+        proxy,
         **kwargs,
     ):
         super().__init__(proxy, **kwargs)
+        self.proxy = proxy
 
     def var_getattr(self, tx, name):
         # NB: This INTENTIONALLY does not call super(), because there is
@@ -884,12 +890,12 @@ class NumpyNdarrayVariable(TensorVariable):
         # properties.  The inheritance here is for implementation sharing.
 
         from ..utils import numpy_attr_wrapper
-        from .builder import wrap_fx_proxy, wrap_fx_proxy_cls
+        from .builder import wrap_fx_proxy
 
         result = None
         options = VariableTracker.propagate(self)
 
-        example_value = self.proxy.node.meta["example_value"]
+        example_value = self.as_proxy().node.meta["example_value"]
         example_ndarray = tnp.ndarray(example_value)
 
         def insert_into_graph():
@@ -902,17 +908,14 @@ class NumpyNdarrayVariable(TensorVariable):
             )
 
         if name in ["T", "real", "imag"]:
-            result = wrap_fx_proxy_cls(
-                target_cls=NumpyNdarrayVariable,
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_function",
-                    numpy_attr_wrapper,
-                    (self.as_proxy(), name),
-                    {},
-                ),
-                **options,
+            proxy = tx.output.create_proxy(
+                "call_function",
+                numpy_attr_wrapper,
+                (self.as_proxy(), name),
+                {},
             )
+            result = NumpyNdarrayVariable.create(tx, proxy, **options)
+
         # These are awkward to implement.  The standard playbook for torch._numpy
         # interop is to trace a call into the torch._numpy wrapper which works for
         # Tensor operations.  However, we don't want to do this for calls
@@ -950,25 +953,17 @@ class NumpyNdarrayVariable(TensorVariable):
         kwargs: "Dict[str, VariableTracker]",
     ) -> "VariableTracker":
         options = VariableTracker.propagate([[self]], [args], [list(kwargs.values())])
-        from torch._dynamo.variables.builder import wrap_fx_proxy_cls
         from ..utils import numpy_method_wrapper
 
         if name in ["__len__", "size"]:
             # delegate back to TensorVariable
             return super().call_method(tx, name, args, kwargs)
-        result = wrap_fx_proxy_cls(
-            target_cls=NumpyNdarrayVariable,
-            tx=tx,
-            proxy=tx.output.create_proxy(
-                "call_function",
-                numpy_method_wrapper(name),
-                *proxy_args_kwargs([self] + list(args), kwargs),
-            ),
-            example_value=None,
-            **options,
+        proxy = tx.output.create_proxy(
+            "call_function",
+            numpy_method_wrapper(name),
+            *proxy_args_kwargs([self] + list(args), kwargs),
         )
-
-        return result
+        return NumpyNdarrayVariable.create(tx, proxy, **options)
 
     def python_type(self):
         return np.ndarray


### PR DESCRIPTION
```
import torch
import numpy as np


def _inf_nan_preprocess(t, t_np):
    t_np = np.nan_to_num(t_np)
    return t, t_np


@torch.compile()
def fn():
    # shape, dims format
    test_cases = (
        (3, 3),
        (4, 4),
        (5, 5),
    )

    for shape in test_cases:
        t = torch.randn(shape, dtype=torch.complex64)
        t_np = np.random.randn(*shape).astype(np.complex64)

        _, t_np = _inf_nan_preprocess(t, t_np)
        print(t, t_np)  # Just a side effect so that compilation kicks in


fn()
```

cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305