### PR TITLE
[PG NCCL][RFC] Pause before throwing exception

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -454,6 +454,7 @@ bool ProcessGroupNCCL::WorkNCCL::checkTimeout(
       " milliseconds before timing out.");
 
   LOG(ERROR) << exceptionMsg;
+  std::this_thread::sleep_for(std::chrono::milliseconds(10 * kWatchdogThreadSleepMillis));
   std::exception_ptr exception_ptr =
       std::make_exception_ptr(std::runtime_error(exceptionMsg));
   setException(exception_ptr);


### PR DESCRIPTION
Summary:
When this exception is thrown, torchx will kick in and take down the
remaining processes. Adding a bit of time before throwing it so that other
processes can also have their watchdogs fire, which can better contribute to
log understanding in terms of potential collective mismatches, shape
misalignment, etc.

Tested by running some jobs and ensuring all the watchdogs fire and report
errors in logs when collectives are misaligned, instead of just one.

Test Plan: CI

Differential Revision: D47975982

