### PR TITLE
[dynamo] Support dict.get with no default specified, and dict.copy

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2919,7 +2919,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         def forward_with_cond_scale(x, t, cond_scale, self_cond, other1, other2):
             return x.sin() + t + cond_scale + self_cond + other1 + other2
 
-        @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             d1 = dict(other1=5)
             d2 = dict(other2=4)
@@ -2929,7 +2928,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                 "addition": d2.get("other2") + d1.get("does_not_exist", 1)
             }
 
-        self.assertTrue(same(fn(torch.ones(4)), torch.ones(4).sin() + 15))
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        self.assertTrue(same(fn(torch.ones(4)), compiled_fn(torch.ones(4))))
 
     def test_graph_break_unsupported_fake(self):
         counter = torch._dynamo.testing.CompileCounter()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2924,7 +2924,10 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             d1 = dict(other1=5)
             d2 = dict(other2=4)
             text_cond = {**d1, **d2}
-            return forward_with_cond_scale(x, 1, cond_scale=2, self_cond=3, **text_cond)
+            return {
+                "forward": forward_with_cond_scale(x, 1, cond_scale=2, self_cond=3, **text_cond),
+                "addition": d2.get("other2") + d1.get("does_not_exist", 1)
+            }
 
         self.assertTrue(same(fn(torch.ones(4)), torch.ones(4).sin() + 15))
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2924,8 +2924,10 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             d2 = dict(other2=4)
             text_cond = {**d1, **d2}
             return {
-                "forward": forward_with_cond_scale(x, 1, cond_scale=2, self_cond=3, **text_cond),
-                "addition": d2.get("other2") + d1.get("does_not_exist", 1)
+                "forward": forward_with_cond_scale(
+                    x, 1, cond_scale=2, self_cond=3, **text_cond
+                ),
+                "addition": d2.get("other2") + d1.get("does_not_exist", 1),
             }
 
         compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -153,10 +153,14 @@ class ConstDictVariable(VariableTracker):
             and args
             and ConstDictVariable.is_valid_key(args[0])
             and ConstDictVariable.get_key(args[0]) not in self.items
-            and len(args) == 2
+            and len(args) in (1, 2)
         ):
-            # missing item, return the default value
-            return args[1].add_options(options)
+            if len(args) == 2:
+                # missing item, return the supplied default value
+                return args[1].add_options(options)
+            else:
+                # missing item, no default value, return None
+                return ConstantVariable(None)
         elif (
             name == "pop"
             and args

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -206,7 +206,7 @@ class ConstDictVariable(VariableTracker):
         elif name == "copy":
             assert not (args or kwargs)
             return ConstDictVariable(
-                {k: v for k, v in val.items()},
+                dict(val),
                 dict,
                 **options,
             )

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -200,6 +200,13 @@ class ConstDictVariable(VariableTracker):
             return ConstantVariable(
                 ConstDictVariable.get_key(args[0]) in self.items, **options
             )
+        elif name == "copy":
+            assert not (args or kwargs)
+            return ConstDictVariable(
+                {k: v for k, v in val.items()},
+                dict,
+                **options,
+            )
         else:
             return super().call_method(tx, name, args, kwargs)
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -159,8 +159,11 @@ class ConstDictVariable(VariableTracker):
                 # missing item, return the supplied default value
                 return args[1].add_options(options)
             else:
-                # missing item, no default value, return None
-                return ConstantVariable(None)
+                if name == "get":
+                    # missing item, no default value, return None
+                    return ConstantVariable(None)
+                else:
+                    unimplemented(f"pop missing key {args[0]}")
         elif (
             name == "pop"
             and args


### PR DESCRIPTION
Previously, `.get(key, default)` was supported, but `.get(key)` was not.

Also adds `.copy`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @Xia-Weiwen @ipiszy