### PR TITLE
Expose intended public constraints. Fixes #106386

### DIFF
--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -14,6 +14,7 @@ The following constraints are implemented:
 - ``constraints.lower_cholesky``
 - ``constraints.lower_triangular``
 - ``constraints.multinomial``
+- ``constraints.nonnegative``
 - ``constraints.nonnegative_integer``
 - ``constraints.one_hot``
 - ``constraints.positive_integer``
@@ -50,7 +51,9 @@ __all__ = [
     "lower_cholesky",
     "lower_triangular",
     "multinomial",
+    "nonnegative",
     "nonnegative_integer",
+    "one_hot",
     "positive",
     "positive_semidefinite",
     "positive_definite",


### PR DESCRIPTION
Fixes #106386

Straightforward change, just exposes the `one_hot` and `nonnegative` distribution constraints that are intended to be public. This fixes downstream pyro usage of these constraints.
