### PR TITLE
Remove dynamic_shapes from torch.onnx.dynamo_export public API

### DIFF
--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -40,8 +40,6 @@ class TestExportOptionsAPI(common_utils.TestCase):
         with self.assertRaises(expected_exception_type):
             ExportOptions(opset_version="3000")  # type: ignore[arg-type]
         with self.assertRaises(expected_exception_type):
-            ExportOptions(dynamic_shapes=2)  # type: ignore[arg-type]
-        with self.assertRaises(expected_exception_type):
             ExportOptions(logger="DEBUG")  # type: ignore[arg-type]
         with self.assertRaises(expected_exception_type):
             ResolvedExportOptions(options=12)  # type: ignore[arg-type]
@@ -51,11 +49,14 @@ class TestExportOptionsAPI(common_utils.TestCase):
         self.assertFalse(options.dynamic_shapes)
 
     def test_dynamic_shapes_explicit(self):
-        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=None))
+        options = ResolvedExportOptions(ExportOptions())
+        options.dynamic_shapes = None
         self.assertFalse(options.dynamic_shapes)
-        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=True))
+        options = ResolvedExportOptions(ExportOptions())
+        options.dynamic_shapes = True
         self.assertTrue(options.dynamic_shapes)
-        options = ResolvedExportOptions(ExportOptions(dynamic_shapes=False))
+        options = ResolvedExportOptions(ExportOptions())
+        options.dynamic_shapes = False
         self.assertFalse(options.dynamic_shapes)
 
     def test_logger_default(self):
@@ -82,7 +83,6 @@ class TestDynamoExportAPI(common_utils.TestCase):
                 export_options=ExportOptions(
                     opset_version=17,
                     logger=logging.getLogger(),
-                    dynamic_shapes=True,
                 ),
             ),
             ExportOutput,

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -232,15 +232,20 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         # Feed args and kwargs into exporter.
         # Note that exporter should flatten kwargs into positional args the exported model;
         # since ONNX doesn't represent kwargs.
+        export_options = torch.onnx.ExportOptions(
+            opset_version=opset_version,
+            op_level_debug=self.op_level_debug,
+        )
+        # TODO: Remove ResolvedExportOptions when dynamic shape API is public
+        export_options = torch.onnx._internal.exporter.ResolvedExportOptions(
+            export_options
+        )
+        export_options.dynamic_shapes = self.dynamic_shapes
         export_output = torch.onnx.dynamo_export(
             ref_model,
             *ref_input_args,
             **ref_input_kwargs,
-            export_options=torch.onnx.ExportOptions(
-                opset_version=opset_version,
-                op_level_debug=self.op_level_debug,
-                dynamic_shapes=self.dynamic_shapes,
-            ),
+            export_options=export_options,
         )
 
         if verbose:


### PR DESCRIPTION
On PyTorch Dynamo core, Dynamic Shape API has been changing not only the public API, but also the default behavior very often, which is hard to follow on the ONNX exporter side

Moreover, The Fake Mode support added to `dynamo_export` API is closely related to dynamic shape (`FakeTensorMode` takes a `ShapeEnv` object to handle shape dynamism)

This PR temporarily removes `dynamic_shapes` flag from the public API while we figure out how to properly expose it to the user. It is still possible to change dynamic_shapes through hidden APIs as can be seen at test/onnx/test_fx_to_onnx_with_onnxruntime.py

Fixes #ISSUE_NUMBER
