### PR TITLE
Pin conda to 23.5.2 for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ ARG CUDA_VERSION=11.7
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
 # Automatically set by buildx
-RUN /opt/conda/bin/conda update -y conda
-RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -y python=${PYTHON_VERSION}
+# Note conda needs to be pinned to 23.5.2 see: https://github.com/pytorch/pytorch/issues/106470
+RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -y python=${PYTHON_VERSION} conda=23.5.2
 ARG TARGETPLATFORM
 
 # On arm64 we can only install wheel packages.


### PR DESCRIPTION
Fixes #106470

Since conda released version 23.7.2 - https://github.com/conda/conda/releases our nightly Docker build started to fail 
```
#28 12.53 ResolvePackageNotFound: 
#28 12.53   - conda==23.5.2
```

This PR pins conda Docker install to 23.5.2 to fix nightly Docker release

