### PR TITLE
[functorch] test_eager_transform not using deprecated apis

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -32,13 +32,13 @@ from functorch.experimental import replace_all_batch_norm_modules_
 from torch._C import _ExcludeDispatchKeyGuard, DispatchKeySet, DispatchKey
 
 import functorch
-from functorch import (
-    grad, vjp, vmap, jacrev, jacfwd, grad_and_value, hessian,
-    jvp, make_functional, make_functional_with_buffers,
-    combine_state_for_ensemble, make_fx
+from torch.func import (
+    grad, vjp, vmap, jacrev, jacfwd, grad_and_value, hessian, jvp
 )
+from torch.fx.experimental.proxy_tensor import make_fx
+
 from torch._functorch.make_functional import (
-    functional_init, functional_init_with_buffers,
+    make_functional, make_functional_with_buffers, combine_state_for_ensemble, functional_init, functional_init_with_buffers,
 )
 from torch._functorch.eager_transforms import _slice_argnums
 from functorch.experimental import functionalize
@@ -3064,9 +3064,10 @@ class TestComposability(TestCase):
     def test_deprecation_vmap(self, device):
         x = torch.randn(3, device=device)
 
+        deprecated_vmap = functorch.vmap
         # functorch version of the API is deprecated
         with self.assertWarnsRegex(UserWarning, "Please use torch.vmap"):
-            vmap(torch.sin)
+            deprecated_vmap(torch.sin)
 
         # the non-functorch version is not deprecated
         with warnings.catch_warnings():


### PR DESCRIPTION
When developing https://github.com/pytorch/pytorch/pull/105679, a unit test fails in test_eager_transform "PYTORCH_TEST_WITH_DYNAMO=1 python test/functorch/test_eager_transforms.py -k test_argnums_cpu". After solving https://github.com/pytorch/pytorch/pull/106425 accidentally, I finally pin down the root cause is a single line of change in _dynamo/skipfiles.py: where I added an "import functorch".  The purpose is that dynamo won't skip _cond.py. 

It seems to me the error is related to how dynamo decides to skip functorch.deprecated.py or not, after switching all tests in test_eager_transform.py to use the new apis in torch.func, the error is gone.

Test Plan:
existing tests.