### PR TITLE
Update XLA dyanmo backend name

### DIFF
--- a/torch/_dynamo/backends/torchxla.py
+++ b/torch/_dynamo/backends/torchxla.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from ..backends.common import aot_autograd
 from ..backends.registry import register_experimental_backend as register_backend
@@ -13,6 +14,18 @@ def torchxla_trivial(gm, fake_tensor_inputs):
 
 @register_backend
 def torchxla_trace_once(model, fake_tensor_inputs):
+    warnings.warn(
+        "This backend will be deprecated in 2.2, please use `openxla` backend instead"
+    )
+
+    return xla_backend_helper(model, fake_tensor_inputs)
+
+
+def openxla_eval(model, fake_tensor_inputs):
+    return xla_backend_helper(model, fake_tensor_inputs)
+
+
+def xla_backend_helper(model, fake_tensor_inputs):
     import torch_xla.core.dynamo_bridge as bridge  # type: ignore[import]
 
     compiled_graph = None
@@ -37,3 +50,8 @@ aot_torchxla_trace_once = aot_autograd(
     fw_compiler=torchxla_trace_once,
 )
 register_backend(name="aot_torchxla_trace_once", compiler_fn=aot_torchxla_trace_once)
+
+openxla = aot_autograd(
+    fw_compiler=openxla_eval,
+)
+register_backend(name="openxla", compiler_fn=openxla)


### PR DESCRIPTION
This is to deprecate the old XLA dyanmo backend and rename it `openxla`.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov