### PR TITLE
Add test support for dynamic shapes for torch.onnx.dynamo_export

### DIFF
--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -82,17 +82,14 @@ def run_model_test(test_suite: _TestONNXRuntime, *args, **kwargs):
     return verification.verify(*args, options=options, **kwargs)
 
 
-def assert_dynamic_shapes(
-    export_output: torch.onnx.ExportOutput, dynamic_shapes: Optional[bool]
-):
+def assert_dynamic_shapes(export_output: torch.onnx.ExportOutput, dynamic_shapes: bool):
     """Assert whether the exported model has dynamic shapes or not.
 
     Args:
         export_output (torch.onnx.ExportOutput): The output of torch.onnx.dynamo_export.
-        dynamic_shapes (Optional[bool], optional): Whether the exported model has dynamic shapes or not.
+        dynamic_shapes (bool): Whether the exported model has dynamic shapes or not.
             When True, raises if graph inputs don't have at least one dynamic dimension
             When False, raises if graph inputs have at least one dynamic dimension.
-            When None, no check is performed. Defaults to None.
 
     Raises:
         AssertionError: If the exported model has dynamic shapes and dynamic_shapes is False and vice-versa.
@@ -224,7 +221,7 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
                 ]
             ]
         ] = None,
-        skip_dynamic_shapes_check: Optional[bool] = False,
+        skip_dynamic_shapes_check: bool = False,
     ):
         """Compare the results of PyTorch model with exported ONNX model
 
@@ -248,6 +245,8 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
                 For example,
                 additional_test_inputs = [((args1, args2), {"kwargs":1}), ((args1,),), ((), {"kwargs":1})]
             skip_dynamic_shapes_check: Whether to skip dynamic shape check. Defaults to False.
+                Must be used when tests do not produce dynamic shapes even when dynamic shape feature is enabled.
+                This is needed because Torch Dynamo uses the dynamic_shapes flag as a hint, only.
 
         """
 

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -210,7 +210,6 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         model: _ModelType,
         input_args: Sequence[_InputArgsType],
         *,
-        dynamic_shapes: Optional[bool],
         input_kwargs: Optional[Mapping[str, _InputArgsType]] = None,
         rtol: Optional[float] = 1e-3,
         atol: Optional[float] = 1e-7,
@@ -225,13 +224,13 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
                 ]
             ]
         ] = None,
+        skip_dynamic_shapes_check: Optional[bool] = False,
     ):
         """Compare the results of PyTorch model with exported ONNX model
 
         Args:
             model (_ModelType): PyTorch model
             input_args (Sequence[_InputArgsType]): torch input arguments
-            dynamic_shapes (bool): Whether the model has dynamic shapes.
             input_kwargs (Mapping[str, _InputArgsType]): torch input kwargs
             rtol (float, optional): relative tolerance. Defaults to 1e-3.
             atol (float, optional): absolute tolerance. Defaults to 1e-7.
@@ -248,6 +247,7 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
                 even if the following element is not provided.
                 For example,
                 additional_test_inputs = [((args1, args2), {"kwargs":1}), ((args1,),), ((), {"kwargs":1})]
+            skip_dynamic_shapes_check: Whether to skip dynamic shape check. Defaults to False.
 
         """
 
@@ -279,7 +279,8 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
             ),
         )
 
-        assert_dynamic_shapes(export_output, dynamic_shapes)
+        if not skip_dynamic_shapes_check:
+            assert_dynamic_shapes(export_output, self.dynamic_shapes)
 
         if verbose:
             export_output.diagnostic_context.dump(

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -625,6 +625,7 @@ def _run_test_output_match(
     device: str,
     dtype: torch.dtype,
     op: opinfo_core.OpInfo,
+    dynamic_shapes: bool,
 ):
     # device is provided by instantiate_device_type_tests, but we only want to run in cpu.
     assert device == "cpu"
@@ -661,7 +662,7 @@ def _run_test_output_match(
                     atol = None
                 # Run the test
                 test_suite.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-                    model, inputs, rtol=rtol, atol=atol
+                    model, inputs, dynamic_shapes=dynamic_shapes, rtol=rtol, atol=atol
                 )
 
 
@@ -697,7 +698,7 @@ class TestOnnxModelOutputConsistency(onnx_test_common._TestONNXRuntime):
     )
     def test_output_match(self, device: str, dtype: torch.dtype, op):
         """Test the ONNX exporter."""
-        _run_test_output_match(self, device, dtype, op)
+        _run_test_output_match(self, device, dtype, op, self.dynamic_shapes)
 
     @common_device_type.ops(
         [op for op in OPS_DB if op.name in COMPLEX_TESTED_OPS],
@@ -705,7 +706,7 @@ class TestOnnxModelOutputConsistency(onnx_test_common._TestONNXRuntime):
     )
     def test_output_match_complex(self, device: str, dtype: torch.dtype, op):
         """Test the ONNX exporter with complex dtype."""
-        _run_test_output_match(self, device, dtype, op)
+        _run_test_output_match(self, device, dtype, op, self.dynamic_shapes)
 
 
 for opset in onnx_test_common.FX_TESTED_OPSETS:

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -625,7 +625,6 @@ def _run_test_output_match(
     device: str,
     dtype: torch.dtype,
     op: opinfo_core.OpInfo,
-    dynamic_shapes: bool,
 ):
     # device is provided by instantiate_device_type_tests, but we only want to run in cpu.
     assert device == "cpu"
@@ -662,7 +661,7 @@ def _run_test_output_match(
                     atol = None
                 # Run the test
                 test_suite.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-                    model, inputs, dynamic_shapes=dynamic_shapes, rtol=rtol, atol=atol
+                    model, inputs, rtol=rtol, atol=atol
                 )
 
 
@@ -698,7 +697,7 @@ class TestOnnxModelOutputConsistency(onnx_test_common._TestONNXRuntime):
     )
     def test_output_match(self, device: str, dtype: torch.dtype, op):
         """Test the ONNX exporter."""
-        _run_test_output_match(self, device, dtype, op, self.dynamic_shapes)
+        _run_test_output_match(self, device, dtype, op)
 
     @common_device_type.ops(
         [op for op in OPS_DB if op.name in COMPLEX_TESTED_OPS],
@@ -706,7 +705,7 @@ class TestOnnxModelOutputConsistency(onnx_test_common._TestONNXRuntime):
     )
     def test_output_match_complex(self, device: str, dtype: torch.dtype, op):
         """Test the ONNX exporter with complex dtype."""
-        _run_test_output_match(self, device, dtype, op, self.dynamic_shapes)
+        _run_test_output_match(self, device, dtype, op)
 
 
 for opset in onnx_test_common.FX_TESTED_OPSETS:

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -88,10 +88,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         tensor_x = torch.randn(1, 1, 2, dtype=torch.float32)
 
-        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (tensor_x,),
-        )
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(func, (tensor_x,))
 
     @pytorch_test_common.xfail(
         "AssertionError: Dynamo input/output is not consistent with traced input/output. "
@@ -125,20 +122,14 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         tensor_x = torch.randn(1, 2, 3, dtype=torch.float32)
 
         # Test without providing optional kwarg.
-        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (tensor_x,),
-        )
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(func, (tensor_x,))
         # Test with only positional args.
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (tensor_x, torch.tensor(8.0)),
+            func, (tensor_x, torch.tensor(8.0))
         )
         # Test while specifying optional kwarg.
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (tensor_x,),
-            input_kwargs={"b": torch.tensor(5.0)},
+            func, (tensor_x,), input_kwargs={"b": torch.tensor(5.0)}
         )
 
     @pytorch_test_common.xfail(
@@ -205,8 +196,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             [torch.randn(3), torch.randn(3), torch.randn(3)],
         ]
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (x_dict, y_tuple, z_list),
+            func, (x_dict, y_tuple, z_list)
         )
 
     def test_func_with_nested_output_structure(self):
@@ -222,10 +212,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.randn(3)
         y = torch.randn(3)
         z = torch.randn(3)
-        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (x, y, z),
-        )
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(func, (x, y, z))
 
     def test_mnist(self):
         class MNISTModel(nn.Module):
@@ -251,8 +238,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            MNISTModel(),
-            (tensor_x,),
+            MNISTModel(), (tensor_x,)
         )
 
     def test_log_sigmoid(self):
@@ -267,10 +253,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 return self.m(x)
 
         input = torch.randn(2)
-        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            Model(),
-            (input,),
-        )
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(Model(), (input,))
 
     @skip_if_no_torchvision
     def test_resnet18(self):
@@ -342,9 +325,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         input_y = torch.randn(1, 4)
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            DynamicAdd(),
-            (x, y),
-            additional_test_inputs=[((input_x, input_y),)],
+            DynamicAdd(), (x, y), additional_test_inputs=[((input_x, input_y),)]
         )
 
     def test_matmul(self):
@@ -358,9 +339,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         input_y = torch.randn(2, 4, 4)
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            DynamicMatMul(),
-            (x, y),
-            additional_test_inputs=[((input_x, input_y),)],
+            DynamicMatMul(), (x, y), additional_test_inputs=[((input_x, input_y),)]
         )
 
     @pytorch_test_common.skip_dynamic_fx_test(
@@ -410,14 +389,10 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         d3 = torch.tensor([3])
         d4 = torch.tensor([4])
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            Squeeze(),
-            (d1, d4),
-            additional_test_inputs=[((d3, d4),)],
+            Squeeze(), (d1, d4), additional_test_inputs=[((d3, d4),)]
         )
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            Squeeze(),
-            (d3, d4),
-            additional_test_inputs=[((d1, d3),)],
+            Squeeze(), (d3, d4), additional_test_inputs=[((d1, d3),)]
         )
 
     def test_slice(self):
@@ -443,9 +418,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 return x
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            MutationModel(),
-            (torch.randn(12),),
-            has_mutation=True,
+            MutationModel(), (torch.randn(12),), has_mutation=True
         )
 
     def test_arange(self):
@@ -532,7 +505,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             ViewModel(),
             (x,),
             # additional_test_inputs=[((y,),)],  # TODO: Without `additional_test_inputs` arg, dynamic shape cannot be verified
-            skip_dynamic_shapes_check=True,
+            skip_dynamic_shapes_check=True,  # Has static shape for dynamic_shapes=True due to 0/1 specialization
         )
 
     def test_flatten_dynamic_axes(self):
@@ -545,9 +518,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         y = torch.randn(5, 5, 4, 5)
         model = MyModule()
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            model,
-            (x,),
-            additional_test_inputs=[((y,),)],
+            model, (x,), additional_test_inputs=[((y,),)]
         )
 
     def test_none_input(self):
@@ -560,8 +531,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 return x + y + z
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            NoneInputModel(),
-            (torch.randn(1, 2), None, torch.randn(1, 2)),
+            NoneInputModel(), (torch.randn(1, 2), None, torch.randn(1, 2))
         )
 
     def test_operator_with_data_dependent_output(self):
@@ -570,8 +540,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             return x + torch.full(x.shape, torch.tensor(torch.finfo(x.dtype).min))
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (torch.randn(3, 4),),
+            func, (torch.randn(3, 4),)
         )
 
     def test_operator_with_scalar_output(self):
@@ -579,8 +548,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             return x.item() + y
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (torch.tensor([1]), torch.randn(3, 4)),
+            func, (torch.tensor([1]), torch.randn(3, 4))
         )
 
     def test_operator_with_dynamic_output_shape(self):
@@ -588,8 +556,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             return x.nonzero()
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func,
-            (torch.randn(3, 4),),
+            func, (torch.randn(3, 4),)
         )
 
     def test_gpt2_tiny(self):
@@ -614,8 +581,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 return x
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            CustomModule(),
-            (torch.randn(1, 2, 3),),
+            CustomModule(), (torch.randn(1, 2, 3),)
         )
 
     @_beartype.beartype

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -570,7 +570,10 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         another_inputs = tokenizer("Another Hello world!", return_tensors="pt")
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            model, [], inputs, additional_test_inputs=[((), another_inputs)]
+            model,
+            [],
+            input_kwargs=inputs,
+            additional_test_inputs=[((), another_inputs)],
         )
 
     def test_prims_device_put(self):
@@ -591,7 +594,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         create_model: Callable,
         create_args: Callable,
         create_pytorch_only_kwargs: Callable,
-        skip_dynamic_shapes_check: Optional[bool] = False,
     ):
         """Test helper for large-scale exporter.
 
@@ -600,7 +602,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model: A function that creates a model. It should always create the same model.
             create_args: A function that creates random input arguments for the model.
             create_pytorch_only_kwargs: A function that creates kwargs for calling PyTorch model with real tensors.
-            skip_dynamic_shapes_check: Whether to skip dynamic shape check. Default is False
 
         This test contains several steps.
 
@@ -664,10 +665,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
                 onnx_model = export_output.model_proto
 
-            if not skip_dynamic_shapes_check:
-                onnx_test_common.assert_dynamic_shapes(
-                    export_output, self.dynamic_shapes
-                )
+            onnx_test_common.assert_dynamic_shapes(export_output, self.dynamic_shapes)
 
             # Tasks done by the following block.
             #  1. Iterate through all tensors stored in ctx.paths (the file content is loaded torch.load)
@@ -751,7 +749,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,
-            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     @pytorch_test_common.skip_dynamic_fx_test(
@@ -778,7 +775,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,
-            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
 
@@ -827,7 +823,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         create_kwargs: Callable,
         load_checkpoint_during_init: bool,
         export_within_fake_mode: bool,
-        skip_dynamic_shapes_check: Optional[bool] = False,
     ):
         """Test helper for FakeTensorMode-enabled exporter.
 
@@ -839,7 +834,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             load_checkpoint_during_init: Whether to load a checkpoint during model initialization.
                 (after or during model creation, but before exporting starts)
             export_within_fake_mode: Whether to call torch.onnx._dynamo_export within torch._subclasses.FakeTensorMode
-            skip_dynamic_shapes_check: Whether to skip dynamic shapes check. Default is False
 
         This test contains several steps.
 
@@ -892,10 +886,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                     fake_model, *fake_args, **fake_kwargs, export_options=export_options
                 )
 
-            if not skip_dynamic_shapes_check:
-                onnx_test_common.assert_dynamic_shapes(
-                    export_output, self.dynamic_shapes
-                )
+            onnx_test_common.assert_dynamic_shapes(export_output, self.dynamic_shapes)
 
             with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
                 export_output.save(
@@ -950,7 +941,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     def test_large_scale_exporter_with_tiny_gpt2(self):
@@ -976,7 +966,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     def test_large_scale_exporter_with_toy_mlp(self):
@@ -1014,7 +1003,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
 

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -89,7 +89,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         tensor_x = torch.randn(1, 1, 2, dtype=torch.float32)
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (tensor_x,), dynamic_shapes=self.dynamic_shapes
+            func,
+            (tensor_x,),
         )
 
     @pytorch_test_common.xfail(
@@ -125,18 +126,19 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         # Test without providing optional kwarg.
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (tensor_x,), dynamic_shapes=self.dynamic_shapes
+            func,
+            (tensor_x,),
         )
         # Test with only positional args.
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (tensor_x, torch.tensor(8.0)), dynamic_shapes=self.dynamic_shapes
+            func,
+            (tensor_x, torch.tensor(8.0)),
         )
         # Test while specifying optional kwarg.
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             func,
             (tensor_x,),
             input_kwargs={"b": torch.tensor(5.0)},
-            dynamic_shapes=self.dynamic_shapes,
         )
 
     @pytorch_test_common.xfail(
@@ -203,7 +205,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             [torch.randn(3), torch.randn(3), torch.randn(3)],
         ]
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (x_dict, y_tuple, z_list), dynamic_shapes=self.dynamic_shapes
+            func,
+            (x_dict, y_tuple, z_list),
         )
 
     def test_func_with_nested_output_structure(self):
@@ -220,7 +223,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         y = torch.randn(3)
         z = torch.randn(3)
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (x, y, z), dynamic_shapes=self.dynamic_shapes
+            func,
+            (x, y, z),
         )
 
     def test_mnist(self):
@@ -247,7 +251,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            MNISTModel(), (tensor_x,), dynamic_shapes=self.dynamic_shapes
+            MNISTModel(),
+            (tensor_x,),
         )
 
     def test_log_sigmoid(self):
@@ -263,7 +268,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         input = torch.randn(2)
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            Model(), (input,), dynamic_shapes=self.dynamic_shapes
+            Model(),
+            (input,),
         )
 
     @skip_if_no_torchvision
@@ -280,7 +286,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         dummy_input = torch.randn(1, 3, 224, 224)
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            model, (dummy_input,), dynamic_shapes=self.dynamic_shapes
+            model,
+            (dummy_input,),
         )
 
     @pytorch_test_common.xfail(
@@ -296,7 +303,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             model,
             (dummy_input,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((test_inputs,),)],
             rtol=1e-3,
             atol=1e-5,
@@ -315,7 +321,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             DynamicAdd(),
             (x, y),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((another_x, another_y),)],
         )
 
@@ -339,7 +344,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             DynamicAdd(),
             (x, y),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((input_x, input_y),)],
         )
 
@@ -356,7 +360,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             DynamicMatMul(),
             (x, y),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((input_x, input_y),)],
         )
 
@@ -375,7 +378,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             test(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((y,),)],
         )
 
@@ -394,7 +396,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             TransposeModule(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((y,),)],
         )
 
@@ -411,13 +412,11 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             Squeeze(),
             (d1, d4),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((d3, d4),)],
         )
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             Squeeze(),
             (d3, d4),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((d1, d3),)],
         )
 
@@ -434,7 +433,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             DynamicSliceExportMod(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((y,),)],
         )
 
@@ -447,7 +445,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             MutationModel(),
             (torch.randn(12),),
-            dynamic_shapes=self.dynamic_shapes,
             has_mutation=True,
         )
 
@@ -465,7 +462,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             ArangeModel(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((y,),)],
         )
 
@@ -484,7 +480,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             Model(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((x2,),)],
         )
 
@@ -502,7 +497,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             Model(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((x2,),)],
         )
 
@@ -520,7 +514,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             Model(),
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((x2,),)],
         )
 
@@ -538,8 +531,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             ViewModel(),
             (x,),
-            dynamic_shapes=None,  # This test always generate static shape
             # additional_test_inputs=[((y,),)],  # TODO: Without `additional_test_inputs` arg, dynamic shape cannot be verified
+            skip_dynamic_shapes_check=True,
         )
 
     def test_flatten_dynamic_axes(self):
@@ -554,7 +547,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             model,
             (x,),
-            dynamic_shapes=self.dynamic_shapes,
             additional_test_inputs=[((y,),)],
         )
 
@@ -570,7 +562,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             NoneInputModel(),
             (torch.randn(1, 2), None, torch.randn(1, 2)),
-            dynamic_shapes=self.dynamic_shapes,
         )
 
     def test_operator_with_data_dependent_output(self):
@@ -579,7 +570,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             return x + torch.full(x.shape, torch.tensor(torch.finfo(x.dtype).min))
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (torch.randn(3, 4),), dynamic_shapes=self.dynamic_shapes
+            func,
+            (torch.randn(3, 4),),
         )
 
     def test_operator_with_scalar_output(self):
@@ -589,7 +581,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
             func,
             (torch.tensor([1]), torch.randn(3, 4)),
-            dynamic_shapes=self.dynamic_shapes,
         )
 
     def test_operator_with_dynamic_output_shape(self):
@@ -597,7 +588,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             return x.nonzero()
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            func, (torch.randn(3, 4),), dynamic_shapes=self.dynamic_shapes
+            func,
+            (torch.randn(3, 4),),
         )
 
     def test_gpt2_tiny(self):
@@ -611,11 +603,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         another_inputs = tokenizer("Another Hello world!", return_tensors="pt")
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            model,
-            [],
-            input_kwargs=inputs,
-            dynamic_shapes=self.dynamic_shapes,
-            additional_test_inputs=[((), another_inputs)],
+            model, [], inputs, additional_test_inputs=[((), another_inputs)]
         )
 
     def test_prims_device_put(self):
@@ -626,7 +614,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 return x
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
-            CustomModule(), (torch.randn(1, 2, 3),), dynamic_shapes=self.dynamic_shapes
+            CustomModule(),
+            (torch.randn(1, 2, 3),),
         )
 
     @_beartype.beartype
@@ -636,7 +625,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         create_model: Callable,
         create_args: Callable,
         create_pytorch_only_kwargs: Callable,
-        dynamic_shapes: bool,
+        skip_dynamic_shapes_check: Optional[bool] = False,
     ):
         """Test helper for large-scale exporter.
 
@@ -645,7 +634,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model: A function that creates a model. It should always create the same model.
             create_args: A function that creates random input arguments for the model.
             create_pytorch_only_kwargs: A function that creates kwargs for calling PyTorch model with real tensors.
-            dynamic_shapes: Whether dynamic shapes is enabled or not.
+            skip_dynamic_shapes_check: Whether to skip dynamic shape check. Default is False
 
         This test contains several steps.
 
@@ -709,7 +698,10 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
                 onnx_model = export_output.model_proto
 
-            onnx_test_common.assert_dynamic_shapes(export_output, dynamic_shapes)
+            if not skip_dynamic_shapes_check:
+                onnx_test_common.assert_dynamic_shapes(
+                    export_output, self.dynamic_shapes
+                )
 
             # Tasks done by the following block.
             #  1. Iterate through all tensors stored in ctx.paths (the file content is loaded torch.load)
@@ -793,7 +785,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,
-            dynamic_shapes=self.dynamic_shapes,
+            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     @pytorch_test_common.skip_dynamic_fx_test(
@@ -820,7 +812,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,
-            dynamic_shapes=self.dynamic_shapes,
+            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
 
@@ -869,7 +861,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         create_kwargs: Callable,
         load_checkpoint_during_init: bool,
         export_within_fake_mode: bool,
-        dynamic_shapes: bool,
+        skip_dynamic_shapes_check: Optional[bool] = False,
     ):
         """Test helper for FakeTensorMode-enabled exporter.
 
@@ -881,7 +873,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             load_checkpoint_during_init: Whether to load a checkpoint during model initialization.
                 (after or during model creation, but before exporting starts)
             export_within_fake_mode: Whether to call torch.onnx._dynamo_export within torch._subclasses.FakeTensorMode
-            dynamic_shapes: Whether dynamic shapes is enabled or not.
+            skip_dynamic_shapes_check: Whether to skip dynamic shapes check. Default is False
 
         This test contains several steps.
 
@@ -934,7 +926,10 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                     fake_model, *fake_args, **fake_kwargs, export_options=export_options
                 )
 
-            onnx_test_common.assert_dynamic_shapes(export_output, dynamic_shapes)
+            if not skip_dynamic_shapes_check:
+                onnx_test_common.assert_dynamic_shapes(
+                    export_output, self.dynamic_shapes
+                )
 
             with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
                 export_output.save(
@@ -989,7 +984,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            dynamic_shapes=self.dynamic_shapes,
+            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     def test_large_scale_exporter_with_tiny_gpt2(self):
@@ -1015,7 +1010,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            dynamic_shapes=self.dynamic_shapes,
+            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
     def test_large_scale_exporter_with_toy_mlp(self):
@@ -1053,7 +1048,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_kwargs,
             load_checkpoint_during_init=self.load_checkpoint_during_init,
             export_within_fake_mode=self.export_within_fake_mode,
-            dynamic_shapes=self.dynamic_shapes,
+            skip_dynamic_shapes_check=True,  # TODO: Fix Fake Mode + Dynamic shape support
         )
 
 


### PR DESCRIPTION
This PR adds the ability to check whether the resulting ONNX graph has dynamic shape when the dynamic shape is enabled

Only test/onnx/test_fx_to_onnx.py and test/onnx/test_fx_op_consistency.py were covered because test/onnx/test_fx_to_onnx.py does not use any common "run_test" helper to wrap `dynamo_export` call. Maybe that could be a refactor