### PR TITLE
[inductor] don't cache non-static content

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -26,7 +26,11 @@ import torch.nn as nn
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.testing import expectedFailureCodegenDynamic, rand_strided, same
 from torch._inductor.codegen.common import DataTypePropagation, OptimizationContext
-from torch._inductor.utils import run_and_get_code, run_and_get_triton_code
+from torch._inductor.utils import (
+    add_scheduler_init_hook,
+    run_and_get_code,
+    run_and_get_triton_code,
+)
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn import functional as F
 from torch.testing import FileCheck, make_tensor
@@ -6770,6 +6774,35 @@ class CommonTemplate:
         self.assertEqual(U, U_e)
         self.assertEqual(rot.grad, rot_e.grad)
         self.assertEqual(trans.grad, trans_e.grad)
+
+    def test_inner_fn_str_and_stride(self):
+        def f(x):
+            x = x + 1
+            x = test_operators.realize(x)
+            x = x * 2
+            x = test_operators.realize(x)
+            return x
+
+        x = torch.rand(3, 2, device=self.device).t()
+        ref = f(x)
+        called = False
+
+        def hook_fn(scheduler, nodes):
+            nonlocal called
+            called = True
+
+            if self.device != "cpu":
+                self.assertEqual(len(nodes), 3)
+                _, mul_buf, _ = nodes
+                self.assertTrue(all(buf.get_stride() == [1, 2] for buf in nodes))
+                # before the fix, the wrong index expression
+                # 'i1 + 3 * i0' is cached.
+                self.assertTrue("i0 + 2 * i1" in mul_buf.data.inner_fn_str())
+
+        with add_scheduler_init_hook(hook_fn):
+            actual = torch.compile(f)(x)
+        self.assertEqual(ref, actual)
+        self.assertTrue(called)
 
 
 @dataclasses.dataclass

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6800,7 +6800,7 @@ class CommonTemplate:
                 self.assertTrue("i0 + 2 * i1" in mul_buf.data.inner_fn_str())
 
         with add_scheduler_init_hook(hook_fn):
-            actual = torch.compile(f)(x)
+            actual = torch.compile(f, fullgraph=True)(x)
         self.assertEqual(ref, actual)
         self.assertTrue(called)
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -45,7 +45,6 @@ from .lowering import (
 from .sizevars import SizeVarAllocator
 from .utils import (
     convert_shape_to_inductor,
-    delete_cache_on_self,
     gather_origins,
     get_dtype_size,
     get_sympy_Expr_dtype,
@@ -643,9 +642,6 @@ class GraphLowering(torch.fx.Interpreter):
 
     def finalize(self):
         for buf in self.buffers:
-            delete_cache_on_self(buf)
-            if isinstance(buf, ir.ComputedBuffer):
-                delete_cache_on_self(buf.data)
             buf.decide_layout()
 
     def run_node(self, n: torch.fx.Node):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -45,6 +45,7 @@ from .lowering import (
 from .sizevars import SizeVarAllocator
 from .utils import (
     convert_shape_to_inductor,
+    delete_cache_on_self,
     gather_origins,
     get_dtype_size,
     get_sympy_Expr_dtype,
@@ -642,6 +643,9 @@ class GraphLowering(torch.fx.Interpreter):
 
     def finalize(self):
         for buf in self.buffers:
+            delete_cache_on_self(buf)
+            if isinstance(buf, ir.ComputedBuffer):
+                delete_cache_on_self(buf.data)
             buf.decide_layout()
 
     def run_node(self, n: torch.fx.Node):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -374,7 +374,6 @@ class Loops(IRNode):
             for n, s in enumerate(ranges)
         ]
 
-    @cache_on_self
     def inner_fn_str(self):
         index = self._index(self.ranges)
         return V.KernelFormatterHandler.ir_to_string(self.inner_fn, index)
@@ -382,7 +381,6 @@ class Loops(IRNode):
     def is_zero_elements(self):
         return any(r == 0 for r in self.ranges)
 
-    @cache_on_self
     def get_reads(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.get_reduction_type():
@@ -551,7 +549,6 @@ class Reduction(Loops):
     def index_length(self):
         return len(self.ranges) + len(self.reduction_ranges)
 
-    @cache_on_self
     def inner_fn_str(self):
         index = self._index(self.ranges)
         rindex = self._index(self.reduction_ranges, "r")
@@ -1189,7 +1186,6 @@ class BaseView(IRNode):
     def is_extern(self):
         return self.data.is_extern()
 
-    @cache_on_self
     def get_reads(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             return extract_read_writes(
@@ -2119,7 +2115,6 @@ class Buffer(IRNode):
             return [self.layout.target.get_name()]
         return ()
 
-    @cache_on_self
     def get_read_writes(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             return extract_read_writes(
@@ -2177,7 +2172,6 @@ class ShapeAsConstantBuffer(IRNode):
 class ComputedBuffer(Buffer):
     data: Loops
 
-    @cache_on_self
     def get_read_writes(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.data.get_reduction_type():
@@ -2428,7 +2422,6 @@ class TemplateBuffer(Buffer):
     def get_read_writes(self):
         return self.normalized_read_writes()
 
-    @cache_on_self
     def normalized_read_writes(self):
         name = self.get_name()
         indexer = self.layout.make_indexer()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -374,6 +374,10 @@ class Loops(IRNode):
             for n, s in enumerate(ranges)
         ]
 
+    @cache_on_self
+    def inner_fn_str_len(self):
+        return len(self.inner_fn_str())
+
     def inner_fn_str(self):
         index = self._index(self.ranges)
         return V.KernelFormatterHandler.ir_to_string(self.inner_fn, index)
@@ -2172,6 +2176,10 @@ class ShapeAsConstantBuffer(IRNode):
 class ComputedBuffer(Buffer):
     data: Loops
 
+    @cache_on_self
+    def num_reads(self):
+        return len(self.get_read_writes().reads)
+
     def get_read_writes(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.data.get_reduction_type():
@@ -2191,7 +2199,7 @@ class ComputedBuffer(Buffer):
         can_inline = (
             hasattr(self.data, "make_loader")
             and self.name not in V.graph.mutated_buffers
-            and len(self.get_read_writes().reads) == 0
+            and self.num_reads() == 0
         )
         if can_inline:
             return self.data.make_loader()
@@ -4363,7 +4371,7 @@ class StorageBox(MutableBox):
     def has_exceeded_max_reads(self):
         return isinstance(self.data, Pointwise) and (
             self.num_reads() > config.realize_acc_reads_threshold
-            or len(self.inner_fn_str()) > config.realize_bytes_threshold
+            or self.inner_fn_str_len() > config.realize_bytes_threshold
         )
 
     def mark_reuse(self, users):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -7,7 +7,6 @@ import logging
 import math
 import operator
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -275,12 +274,6 @@ def cache_on_self(fn):
         return getattr(self, key)
 
     return wrapper
-
-
-def delete_cache_on_self(self):
-    for k in list(self.__dict__.keys()):
-        if re.match("__(.*)_cache", k):
-            delattr(self, k)
 
 
 def aggregate_origins(node_schedule):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -7,11 +7,13 @@ import logging
 import math
 import operator
 import os
+import re
 import shutil
 import sys
 import tempfile
 import textwrap
 import time
+import unittest
 from io import StringIO
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 from unittest import mock
@@ -273,6 +275,12 @@ def cache_on_self(fn):
         return getattr(self, key)
 
     return wrapper
+
+
+def delete_cache_on_self(self):
+    for k in list(self.__dict__.keys()):
+        if re.match("__(.*)_cache", k):
+            delattr(self, k)
 
 
 def aggregate_origins(node_schedule):
@@ -741,6 +749,25 @@ def override_lowering(aten_op, override_fn):
         yield
     finally:
         lowering.lowerings[aten_op] = orig_fn
+
+
+def add_scheduler_init_hook(pre_fn, post_fn=None):
+    """
+    Add hook functions to be called at the beginning and end of Scheduler.__init__.
+    Used for unit tests.
+    """
+    from torch._inductor.scheduler import Scheduler
+
+    orig_fn = Scheduler.__init__
+
+    def wrapper(scheduler, nodes):
+        pre_fn(scheduler, nodes)
+        out = orig_fn(scheduler, nodes)
+        if post_fn:
+            post_fn(scheduler, nodes)
+        return out
+
+    return unittest.mock.patch.object(Scheduler, "__init__", wrapper)
 
 
 def developer_warning(msg):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #100331
* __->__ #106502

I happened to find that inductor may cache stale inner_fn_str and ReadWrites object in a ComputedBuffer when I work on looping ordering.

Let's say we have producer buffer buf0 and consumer buffer buf1. Before we call GraphLowering.finalize, the layout for buf0 may be a FlexibleLayout. At that moment, the inner_fn_str or ReadWrites object computed for buf1 will be based on the layout of buf0 which most likely is a contiguous FlexibleLayout. And they will be cached on buf1 object (or buf1.data).

However after we call GraphLowering.finalize, we may realize it's better to give a non-contiguous layout for buf0 (e.g., if its input has non-contiguous layout or whatever reason). The layout change of buf0 should affect the inner_fn_str and ReadWrites object for buf1. But we may have cached those on buf1. The stale ReadWrites objects for buf1 may result in sub-optimal strides for buf1.

This may affect perf and I'll check the nightly runs.

Here is a dump of `nodes` in `Scheduler.__init__` before the fix as a reference: https://gist.github.com/shunting314/ed2152a08e268f5563fd55398b1392c7 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov