### PR TITLE
Change AOTAutograd tests to accept Tensors that don't require grad

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -9,6 +9,7 @@ import re
 import typing
 
 import torch._custom_ops as custom_ops
+import torch.testing._internal.optests as optests
 
 import torch.testing._internal.custom_op_db
 from functorch import make_fx
@@ -50,6 +51,23 @@ class TestCustomOpTesting(TestCase):
     def get_op(self, qualname):
         ns, name = qualname.split("::")
         return getattr(getattr(torch.ops, ns), name).default
+
+    def test_aot_autograd_check_degenerate_cases(self, device):
+        def f(x):
+            return x.clone()
+
+        # Should not raise
+        x = torch.randn(3, device=device)
+        optests.aot_autograd_check(f, (x,), {}, dynamic=True)
+        optests.aot_autograd_check(f, (x,), {}, dynamic=False)
+
+        def g(x):
+            return x.detach()
+
+        # Should not raise
+        y = torch.randn(3, device=device, requires_grad=True)
+        optests.aot_autograd_check(g, (y,), {}, dynamic=True)
+        optests.aot_autograd_check(g, (y,), {}, dynamic=False)
 
     def test_incorrect_schema_mutation(self, device):
         lib = self.lib()


### PR DESCRIPTION
Summary:
Motivations:

- This makes it easier to blindly apply the AOTAutograd test

Test Plan: - new tests

Differential Revision: D48007932

