### PR TITLE
Fix the Test of duplicate registration on genarator

### DIFF
--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -380,7 +380,11 @@ at::Generator make_generator_privateuse1(c10::DeviceIndex device_index) {
   return at::make_generator<PrivateGeneratorImpl>(device_index);
 }
 
-void register_generator() {
+void register_generator_first() {
+  REGISTER_GENERATOR_PRIVATEUSE1(make_generator_privateuse1)
+}
+
+void register_generator_second() {
   REGISTER_GENERATOR_PRIVATEUSE1(make_generator_privateuse1)
 }
 
@@ -462,7 +466,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("custom_device", &get_custom_device, "get custom device object");
     m.def("custom_add_called", &custom_add_called, "check if our custom add function was called");
     m.def("custom_abs_called", &custom_abs_called, "check if our custom abs function was called");
-    m.def("register_generator", &register_generator, "register generator for custom device");
+    m.def("register_generator_first", &register_generator_first, "register generator for custom device firstly");
+    m.def("register_generator_second", &register_generator_second, "register generator for custom device secondly");
     m.def("set_custom_device_index", &set_custom_device_index, "set custom device index");
     m.def("custom_storage_registry", &custom_storage_registry, "set custom storageImpl creat method");
     m.def("custom_storageImpl_called", &custom_storageImpl_called, "check if our custom abs function was called");

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -164,13 +164,13 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             with self.assertRaisesRegex(RuntimeError,
                                         "Please register a generator to the PrivateUse1 dispatch key"):
                 gen_ = torch.Generator(device=device)
-            self.module.register_generator()
+            self.module.register_generator_first()
             gen = torch.Generator(device=device)
             self.assertTrue(gen.device == device)
             # generator can be registered only once
             with self.assertRaisesRegex(RuntimeError,
                                         "Only can register a generator to the PrivateUse1 dispatch key once"):
-                self.module.register_generator()
+                self.module.register_generator_second()
             self.module.register_hook()
             default_gen = self.module.default_generator(0)
             self.assertTrue(default_gen.device.type == torch._C._get_privateuse1_backend_name())


### PR DESCRIPTION
The duplicate registration test case shown in the figure below has always failed.
https://github.com/pytorch/pytorch/blob/3d165dc3f3e1ba42c7512200b1b9c14d4556ec61/test/test_cpp_extensions_open_device_registration.py#L171-L173

https://github.com/pytorch/pytorch/blob/3d165dc3f3e1ba42c7512200b1b9c14d4556ec61/aten/src/ATen/core/GeneratorForPrivateuseone.h#L36-L37

Because there is a static variable in the ```self.module.register_generator()``` function, it will only be initialized once.

