### PR TITLE
[Dynamo] Revert 'Enable torch._dynamo.config.suppress_errors by default'

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -4738,8 +4738,6 @@ class TestCompileTransforms(TestCase):
     # torch.compile is not supported on Windows
     # Triton only supports GPU with SM70 or later.
     @expectedFailureIf(IS_WINDOWS or (TEST_CUDA and not SM70OrLater))
-    @torch._dynamo.config.patch(suppress_errors=False)
-    @skipIfTorchDynamo("Do not test torch.compile on top of torch.compile")
     def test_compile_vmap_hessian(self, device):
         # The model and inputs are a smaller version
         # of code at benchmark repo:

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2101,6 +2101,15 @@ class CPUReproTests(TestCase):
         self.assertTrue(same(fn(x), opt_fn(x)))
         assert metrics.generated_cpp_vec_kernel_count == 2
 
+    def test_invalid_index_of_empty_tensor(self):
+        def fn(a):
+            b = a[[0]]
+            return b
+
+        a = torch.tensor([])
+        with self.assertRaises(RuntimeError):
+            torch.compile(fn)(a)
+
     def test_ir_node_str(self):
         @torch.compile
         def fn(x: torch.Tensor) -> torch.Tensor:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2396,6 +2396,7 @@ class CommonTemplate:
         )
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
 
+    @unittest.skipIf(config.is_fbcode(), "fbcode triton error, needs debugging")
     def test_adaptive_avg_pool2d_low_prec(self):
         class Model(torch.nn.Module):
             def __init__(self):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -98,7 +98,7 @@ traceable_tensor_subclasses = set()
 # This is a good way to get your model to work one way or another, but you may
 # lose optimization opportunities this way.  Devs, if your benchmark model is failing
 # this way, you should figure out why instead of suppressing it.
-suppress_errors = os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", "1") == "1"
+suppress_errors = bool(os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", False))
 
 # Record and write an execution record of the current frame to a file
 # if an exception is encountered

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -33,7 +33,6 @@ from .exc import (
     augment_exc_message,
     BackendCompilerFailed,
     format_error_msg,
-    format_error_msg_verbose,
     InternalTorchDynamoError,
     TorchRuntimeError,
     unimplemented,
@@ -566,17 +565,7 @@ def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):
             # possible to accidentally not log at all.
             record_filename = getattr(e, "record_filename", None)
             code = frame.f_code
-            if config.is_fbcode():
-                from torch._dynamo.fb.logging import (  # type: ignore[import]
-                    log_dynamo_suppress_errors,
-                )
-
-                error_msg = format_error_msg_verbose(e, code, record_filename, frame)
-                log_dynamo_suppress_errors(
-                    code.co_name, code.co_filename, code.co_firstlineno, error_msg
-                )
-            else:
-                error_msg = format_error_msg(e, code, record_filename, frame)
+            error_msg = format_error_msg(e, code, record_filename, frame)
 
             if soft_fail:
                 log.info(error_msg, exc_info=True)


### PR DESCRIPTION
D47969512 was the original diff to revert this, but the diff train doesn't work well, so I have to split it into two part: this OSS PR and another separate diff to revert the fbcode change.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305