### PR TITLE
[jit] Skip NNAPI tests if test_nnapi.py cannot be found

### DIFF
--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -7,7 +7,13 @@ import unittest
 import torch
 import torch._C
 from pathlib import Path
-from test_nnapi import TestNNAPI
+try:
+    from test_nnapi import TestNNAPI
+    HAS_TEST_NNAPI = True
+except ImportError:
+    from torch.testing._internal.common_utils import TestCase as TestNNAPI
+    HAS_TEST_NNAPI = False
+
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -30,6 +36,7 @@ torch_root = Path(__file__).resolve().parent.parent.parent
 lib_path = torch_root / 'build' / 'lib' / 'libnnapi_backend.so'
 @unittest.skipIf(not os.path.exists(lib_path),
                  "Skipping the test as libnnapi_backend.so was not found")
+@unittest.skipIf(not HAS_TEST_NNAPI, "test_nnapi.py not found")
 class TestNnapiBackend(TestNNAPI):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Summary: Internal test infra can't find test_nnapi.py. Easiest solution is to just skip these tests if test_nnapi.py can't be found

Differential Revision: D48041615

