### PR TITLE
[export] refactor and add same_signature flag to dynamo.export

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -849,6 +849,201 @@ class ExportResult(NamedTuple):
     # destructuring so it is BC-breaking
 
 
+def check_signature_rewritable(graph):
+    input_errors = []
+    for node in graph.graph.nodes:
+        if node.op == "placeholder":
+            assert hasattr(node, "_dynamo_source")
+            source = node._dynamo_source
+            user_stacks = graph._source_to_user_stacks.get(source)
+            if user_stacks is None:
+                continue
+            assert len(user_stacks) > 0
+            # In some cases we may not have a useful stack.  Look for a
+            # useful stack
+            stack = None
+            for s in user_stacks:
+                if len(s) == 0:
+                    continue
+                stack = s
+                break
+            if stack is None:
+                msg = f"{source.name()}, a closed over free variable"
+            else:
+                tb = "".join(traceback.format_list(stack))
+                extra = ""
+                if len(user_stacks) > 1:
+                    extra = f"(elided {len(user_stacks)-1} more accesses)"
+                msg = f"{source.name()}, accessed at:\n{tb}{extra}"
+            # TODO: option to print ALL of the stack traces at once
+            input_errors.append(msg)
+
+    if input_errors:
+        raise UserError(
+            UserErrorType.INVALID_INPUT,
+            "Cannot export model which references tensors that are neither "
+            "buffers/parameters/constants nor are direct inputs.  For each tensor, if you'd "
+            "like this tensor to be an explicit input, add it as a dummy argument "
+            "to the top-level model definition you are exporting; if you would "
+            "like its value to be embedded as an exported constant, wrap its access "
+            "in a function marked with @assume_constant_result.\n\n"
+            + "\n\n".join(input_errors),
+        )
+
+
+def rewrite_signature(
+    f_sig,
+    graph,
+    fake_mode,
+    flat_args,
+    in_spec,
+    example_fake_inputs,
+    graph_captured_input,
+    graph_captured_output,
+    dynamo_traced_result,
+):
+    orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
+
+    def produce_matching(source_args, candidate_args):
+        matched_elements_positions = []
+        dict_of_source_args = dict()
+        for i in range(0, len(source_args)):
+            element_id = id(source_args[i])
+            dict_of_source_args[element_id] = i
+
+        for i in range(0, len(candidate_args)):
+            arg = candidate_args[i]
+            # 1-element tensor arg can be unspec int/float
+            if isinstance(arg, torch.Tensor) and torch.numel(arg) == 1:
+                if id(arg) in dict_of_source_args:
+                    matched_elements_positions.append(dict_of_source_args[id(arg)])
+                elif id(arg.item()) in dict_of_source_args:
+                    matched_elements_positions.append(
+                        dict_of_source_args[id(arg.item())]
+                    )
+                else:
+                    raise AssertionError(
+                        "Dynamo input/output is not consistent with traced input/output"
+                    )
+            else:
+                assert (
+                    id(arg) in dict_of_source_args
+                ), "Dynamo input and output is a strict subset of traced input/output"
+                matched_elements_positions.append(dict_of_source_args[id(arg)])
+
+        return matched_elements_positions
+
+    matched_input_elements_positions = produce_matching(flat_args, graph_captured_input)
+
+    flat_results_traced, out_spec_traced = pytree.tree_flatten(dynamo_traced_result)
+
+    assert graph_captured_output is not None
+    flat_both = list(graph_captured_output) + flat_args
+    matched_output_elements_positions = produce_matching(flat_both, flat_results_traced)
+
+    new_graph = FlattenInputOutputSignature(
+        graph,
+        flat_args,
+        matched_input_elements_positions,
+        matched_output_elements_positions,
+        example_fake_inputs,
+        fake_mode,
+    ).transform()
+
+    # Make dynamo graph to have same input/output spec as user code
+    def argument_names(f_sig, args, kwargs) -> List[str]:
+        def signature_to_fullargspec(sig: inspect.Signature):
+            # Get a list of Parameter objects from the Signature object
+            params = list(sig.parameters.values())
+            # Separate positional arguments, keyword-only arguments and varargs/varkw
+            args = [
+                p.name
+                for p in params
+                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            ]
+            kwonlyargs = [
+                p.name for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY
+            ]
+            varargs = next(
+                (p.name for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL),
+                None,
+            )
+            varkw = next(
+                (p.name for p in params if p.kind == inspect.Parameter.VAR_KEYWORD),
+                None,
+            )
+            # Get default values for positional arguments and keyword-only arguments
+            defaults = tuple(
+                p.default
+                for p in params
+                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+                and p.default is not inspect.Parameter.empty
+            )
+            kwonlydefaults = {
+                p.name: p.default
+                for p in params
+                if p.kind == inspect.Parameter.KEYWORD_ONLY
+                and p.default is not inspect.Parameter.empty
+            }
+            # Get annotations for parameters and return value
+            annotations = {}
+            if sig.return_annotation:
+                annotations = {"return": sig.return_annotation}
+            for parameter in params:
+                annotations[parameter.name] = parameter.annotation
+            # Return a FullArgSpec object with the extracted attributes
+            return inspect.FullArgSpec(
+                args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations
+            )
+
+        fullargspec = signature_to_fullargspec(f_sig)
+
+        # 1. Map `args` 1-to-1 to positional arguments in original signature.
+        input_strs = fullargspec.args[: len(args)]
+
+        if len(args) > len(fullargspec.args):
+            # 2. If there are more arguments left in `args`, they map to varargs in original
+            # signature. Assign names as {varargs}_0, {varargs}_1, ...
+            assert fullargspec.varargs is not None, "More arguments than expected"
+            input_strs += [
+                f"{fullargspec.varargs}_{i}"
+                for i in range(0, len(args) - len(input_strs))
+            ]
+        elif len(args) < len(fullargspec.args):
+            # 3. If there are fewer arguments in `args` than `fullargspec.args`,
+            # it implies these are arguments either with default values, or provided in
+            # `kwargs`. The former can be safely ignored. Because Dynamo.export does not
+            # export them as part of the function signature. The latter will be handled
+            # in the next step.
+            for unprovided_arg in fullargspec.args[
+                len(args) : -len(fullargspec.defaults or [])
+            ]:
+                assert unprovided_arg in kwargs, f"Missing argument {unprovided_arg}"
+
+        # 4. Keyword arguments provided in `kwargs`.
+        input_strs += list(kwargs.keys())
+
+        # 5. Keyword-only arguments with default values if not provided are not exported
+        # as part of the function signature.
+        for kwonly_arg in fullargspec.kwonlyargs:
+            kwonlydefaults = fullargspec.kwonlydefaults or {}
+            assert (
+                kwonly_arg in kwargs or kwonly_arg in kwonlydefaults
+            ), f"Missing keyword only argument {kwonly_arg}"
+
+        return input_strs
+
+    new_graph.graph._codegen = _PyTreeCodeGen(
+        _PyTreeInfo(
+            argument_names(f_sig, orig_args, orig_kwargs),
+            in_spec,
+            out_spec_traced,
+        )
+    )
+    new_graph.recompile()
+    return new_graph
+
+
 def export(
     f: Callable[..., Any],
     *extra_args,
@@ -860,6 +1055,7 @@ def export(
     tracing_mode: str = "symbolic",
     constraints: Optional[List[Constraint]] = None,
     assume_static_by_default: bool = False,
+    same_signature: bool = True,
     **extra_kwargs,
 ) -> Callable[..., ExportResult]:
     """
@@ -882,6 +1078,8 @@ def export(
         Required if aten_graph or tracing_mode is specified. Default is None.
 
         tracing_mode (str): If "symbolic", turn on dynamic shapes support. Default is "symbolic".
+
+        same_signature (bool): If True, rewrite the returned graph's signature to be the same as f.
 
     Returns:
         A function that given args and kwargs, returns a tuple of (graph, guards)
@@ -923,35 +1121,6 @@ def export(
             fake_mode is not None
         )  # Allow fake constants during symbolic tracing
 
-        def produce_matching(source_args, candidate_args):
-            matched_elements_positions = []
-            dict_of_source_args = dict()
-            for i in range(0, len(source_args)):
-                element_id = id(source_args[i])
-                dict_of_source_args[element_id] = i
-
-            for i in range(0, len(candidate_args)):
-                arg = candidate_args[i]
-                # 1-element tensor arg can be unspec int/float
-                if isinstance(arg, torch.Tensor) and torch.numel(arg) == 1:
-                    if id(arg) in dict_of_source_args:
-                        matched_elements_positions.append(dict_of_source_args[id(arg)])
-                    elif id(arg.item()) in dict_of_source_args:
-                        matched_elements_positions.append(
-                            dict_of_source_args[id(arg.item())]
-                        )
-                    else:
-                        raise AssertionError(
-                            "Dynamo input/output is not consistent with traced input/output"
-                        )
-                else:
-                    assert (
-                        id(arg) in dict_of_source_args
-                    ), "Dynamo input and output is a strict subset of traced input/output"
-                    matched_elements_positions.append(dict_of_source_args[id(arg)])
-
-            return matched_elements_positions
-
         def guard_export_print(guards: Set[_guards.Guard]):
             nonlocal out_guards
             assert (
@@ -985,6 +1154,8 @@ def export(
 
             return result_capturing_wrapper
 
+        # Note: This is needed by rewrite_signature. We need to put it before
+        # optimize_assert since user program may mutate the inputs.
         flat_args, in_spec = pytree.tree_flatten((args, kwargs))
 
         remove_from_cache(f)
@@ -1060,59 +1231,13 @@ def export(
         assert out_guards is not None, "Failed to produce guards during tracing"
         assert fake_mode is not None
 
-        input_errors = []
-        for node in graph.graph.nodes:
-            if node.op == "placeholder":
-                assert hasattr(node, "_dynamo_source")
-                source = node._dynamo_source
-                user_stacks = graph._source_to_user_stacks.get(source)
-                if user_stacks is None:
-                    continue
-                assert len(user_stacks) > 0
-                # In some cases we may not have a useful stack.  Look for a
-                # useful stack
-                stack = None
-                for s in user_stacks:
-                    if len(s) == 0:
-                        continue
-                    stack = s
-                    break
-                if stack is None:
-                    msg = f"{source.name()}, a closed over free variable"
-                else:
-                    tb = "".join(traceback.format_list(stack))
-                    extra = ""
-                    if len(user_stacks) > 1:
-                        extra = f"(elided {len(user_stacks)-1} more accesses)"
-                    msg = f"{source.name()}, accessed at:\n{tb}{extra}"
-                # TODO: option to print ALL of the stack traces at once
-                input_errors.append(msg)
-
-        if input_errors:
-            raise UserError(
-                UserErrorType.INVALID_INPUT,
-                "Cannot export model which references tensors that are neither "
-                "buffers/parameters/constants nor are direct inputs.  For each tensor, if you'd "
-                "like this tensor to be an explicit input, add it as a dummy argument "
-                "to the top-level model definition you are exporting; if you would "
-                "like its value to be embedded as an exported constant, wrap its access "
-                "in a function marked with @assume_constant_result.\n\n"
-                + "\n\n".join(input_errors),
-            )
-
-        matched_input_elements_positions = produce_matching(
-            flat_args, graph_captured_input
-        )
+        # This check need to happend before aten_graph
+        # because placeholder's _source_node attribute is not preserved by make_fx
+        if same_signature:
+            check_signature_rewritable(graph)
 
         # NB: This is mostly hitting the cache; Dynamo already converted these
         example_fake_inputs = [fake_mode.from_tensor(t) for t in example_inputs]
-        flat_results_traced, out_spec_traced = pytree.tree_flatten(result_traced)
-
-        assert graph_captured_result is not None
-        flat_both = list(graph_captured_result) + flat_args
-        matched_output_elements_positions = produce_matching(
-            flat_both, flat_results_traced
-        )
 
         if aten_graph:
             # Running graph with interpreter is needed for propagating the stack_trace
@@ -1134,117 +1259,26 @@ def export(
                     # Wrap the internal error to the user-facing error
                     raise UserError(UserErrorType.DYNAMIC_CONTROL_FLOW, str(e))
 
-        new_graph = FlattenInputOutputSignature(
-            graph,
-            flat_args,
-            matched_input_elements_positions,
-            matched_output_elements_positions,
-            example_fake_inputs,
-            fake_mode,
-        ).transform()
-
+        if same_signature:
+            graph = rewrite_signature(
+                original_signature,
+                graph,
+                fake_mode,
+                flat_args,
+                in_spec,
+                example_fake_inputs,
+                graph_captured_input,
+                graph_captured_result,
+                result_traced,
+            )
         # Store constraints and inputs as metadata for user passes, e.g. turn constraints to runtime check
-        new_graph.meta["input_shape_constraints"] = (
+        graph.meta["input_shape_constraints"] = (
             [constraint.serializable_spec for constraint in constraints]
             if constraints
             else []
         )
 
-        def signature_to_fullargspec(sig: inspect.Signature):
-            # Get a list of Parameter objects from the Signature object
-            params = list(sig.parameters.values())
-            # Separate positional arguments, keyword-only arguments and varargs/varkw
-            args = [
-                p.name
-                for p in params
-                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-            ]
-            kwonlyargs = [
-                p.name for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY
-            ]
-            varargs = next(
-                (p.name for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL),
-                None,
-            )
-            varkw = next(
-                (p.name for p in params if p.kind == inspect.Parameter.VAR_KEYWORD),
-                None,
-            )
-            # Get default values for positional arguments and keyword-only arguments
-            defaults = tuple(
-                p.default
-                for p in params
-                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-                and p.default is not inspect.Parameter.empty
-            )
-            kwonlydefaults = {
-                p.name: p.default
-                for p in params
-                if p.kind == inspect.Parameter.KEYWORD_ONLY
-                and p.default is not inspect.Parameter.empty
-            }
-            # Get annotations for parameters and return value
-            annotations = {}
-            if sig.return_annotation:
-                annotations = {"return": sig.return_annotation}
-            for parameter in params:
-                annotations[parameter.name] = parameter.annotation
-            # Return a FullArgSpec object with the extracted attributes
-            return inspect.FullArgSpec(
-                args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations
-            )
-
-        # Make dynamo graph to have same input/output spec as user code
-        def argument_names(f: Callable[..., Any], *args, **kwargs) -> List[str]:
-            fullargspec = signature_to_fullargspec(original_signature)
-
-            # 1. Map `args` 1-to-1 to positional arguments in original signature.
-            input_strs = fullargspec.args[: len(args)]
-
-            if len(args) > len(fullargspec.args):
-                # 2. If there are more arguments left in `args`, they map to varargs in original
-                # signature. Assign names as {varargs}_0, {varargs}_1, ...
-                assert fullargspec.varargs is not None, "More arguments than expected"
-                input_strs += [
-                    f"{fullargspec.varargs}_{i}"
-                    for i in range(0, len(args) - len(input_strs))
-                ]
-            elif len(args) < len(fullargspec.args):
-                # 3. If there are fewer arguments in `args` than `fullargspec.args`,
-                # it implies these are arguments either with default values, or provided in
-                # `kwargs`. The former can be safely ignored. Because Dynamo.export does not
-                # export them as part of the function signature. The latter will be handled
-                # in the next step.
-                for unprovided_arg in fullargspec.args[
-                    len(args) : -len(fullargspec.defaults or [])
-                ]:
-                    assert (
-                        unprovided_arg in kwargs
-                    ), f"Missing argument {unprovided_arg}"
-
-            # 4. Keyword arguments provided in `kwargs`.
-            input_strs += list(kwargs.keys())
-
-            # 5. Keyword-only arguments with default values if not provided are not exported
-            # as part of the function signature.
-            for kwonly_arg in fullargspec.kwonlyargs:
-                kwonlydefaults = fullargspec.kwonlydefaults or {}
-                assert (
-                    kwonly_arg in kwargs or kwonly_arg in kwonlydefaults
-                ), f"Missing keyword only argument {kwonly_arg}"
-
-            return input_strs
-
-        new_graph.graph._codegen = _PyTreeCodeGen(
-            _PyTreeInfo(
-                argument_names(f, *args, **kwargs),
-                in_spec,
-                out_spec_traced,
-            )
-        )
-
-        new_graph.recompile()
-        return ExportResult(new_graph, out_guards)
+        return ExportResult(graph, out_guards)
 
     if extra_args or extra_kwargs:
         warnings.warn(


### PR DESCRIPTION
This PR adds a **same_signature** flag to dynamo.export. 

**Motivation:**
In https://github.com/pytorch/pytorch/pull/105679, we experimented on **using dynamo to inspect the UDFs** for cond in eager mode (without torch.compile). This helps us to normalize the inputs (e.g. lifting closure to inputs) and makes higher order operator more robust (e.g. forbid python side effects) and less error-prone in general.

We decided to use dynamo.export (instead of torch.compile) to do the inspection (pointed out by @voznesenskym @zou3519):
- We'd like a **whole-graph capture** for the UDF.
- We'd like the dynamo inspection to be **stateless**. Using torch.compile would require resetting dynamo context before and after the inspection because the compile flags may be different from users' torch.compile. This will clear all dynamo cache.
- We can still implement some **caching** based on the guards.

However, this requires export to be able to handle the case where it cannot always rewrite signature: e.g. closure lifted as input.

This PR makes the rewrite optional.

**Implementation:**
We just put all the code that are related to signature rewriting into a function called rewrite_signature and use a same_signature flag to optionally to the transformation.

**Test Plan:**
existing tests.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov