### PR TITLE
Disallow torch.onnx.dynamo_export(dynamic_shapes=True, fake_context=...)

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -906,6 +906,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 for ref_output, ort_output in zip(ref_outputs, ort_outputs):
                     torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
+    @pytorch_test_common.skip_dynamic_fx_test(
+        "fx graph does not capture symbolic value for aten::scalar_tensor."
+    )
     def test_fake_tensor_mode_simple(self):
         def create_model() -> nn.Module:
             class Model(torch.nn.Module):
@@ -934,6 +937,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             export_within_fake_mode=self.export_within_fake_mode,
         )
 
+    @pytorch_test_common.skip_dynamic_fx_test(
+        "fx graph does not capture symbolic value for aten::scalar_tensor."
+    )
     def test_large_scale_exporter_with_tiny_gpt2(self):
         model_name = "sshleifer/tiny-gpt2"
 
@@ -959,6 +965,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             export_within_fake_mode=self.export_within_fake_mode,
         )
 
+    @pytorch_test_common.skip_dynamic_fx_test(
+        "fx graph does not capture symbolic value for aten::scalar_tensor."
+    )
     def test_large_scale_exporter_with_toy_mlp(self):
         class MLPModel(nn.Module):
             def __init__(self):

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -220,6 +220,11 @@ class ResolvedExportOptions(ExportOptions):
                 if not key.startswith("_"):  # skip private attributes
                     assert hasattr(self, key), f"Unresolved option '{key}'"
 
+        if self.dynamic_shapes and self.fake_context:
+            raise RuntimeError(
+                "Cannot enable both dynamic shapes and fake mode at the same time."
+            )
+
 
 @contextlib.contextmanager
 def enable_fake_mode():


### PR DESCRIPTION
Currently, the ONNX exporter does not support dynamic shapes when fake mode is enabled.

The result is a possibly successful export with STATIC shapes.
This PR raises an exception when this invalid combination is specified by the user