### PR TITLE
Remove deepcopy override from ExportedProgram

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -358,21 +358,6 @@ class ExportedProgram:
         )
         return string
 
-    def __deepcopy__(
-        self, memo: Optional[Dict[int, Any]] = None
-    ) -> "ExportedProgram":
-        gm = copy.deepcopy(self.graph_module, memo)
-        new_ep = ExportedProgram(
-            gm,
-            gm.graph,
-            copy.deepcopy(self.graph_signature, memo),
-            copy.deepcopy(self.call_spec, memo),
-            copy.deepcopy(self.state_dict, memo),
-            copy.deepcopy(self.range_constraints, memo),
-            copy.deepcopy(self.equality_constraints, memo),
-        )
-        return new_ep
-
     def module(self) -> torch.nn.Module:
         """
         Returns a self contained GraphModule with all the states


### PR DESCRIPTION
Summary: When we do a deep copy of the ExportedProgram because of the custom deep copy override the graph metadata (graph.meta) is failing to be copied over. This can be fixed but overall i don't see a need for a custom deepcopy in ExportedProgram and thus trying to get rid of it.

Test Plan: CI

Differential Revision: D48043723

