### PR TITLE
Update mobile build docker image to pytorch-linux-jammy-py3-clang12-asan

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -174,15 +174,6 @@ case "$image" in
     CONDA_CMAKE=yes
     TRITON=yes
     ;;
-  pytorch-linux-focal-py3-clang7-asan)
-    ANACONDA_PYTHON_VERSION=3.9
-    CLANG_VERSION=7
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    CONDA_CMAKE=yes
-    TRITON=yes
-    ;;
   pytorch-linux-focal-py3-clang10-onnx)
     ANACONDA_PYTHON_VERSION=3.8
     CLANG_VERSION=10

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -229,7 +229,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-focal-py3-clang7-mobile-build
-      docker-image-name: pytorch-linux-focal-py3-clang7-asan
+      docker-image-name: pytorch-linux-jammy-py3-clang12-asan
       build-generates-artifacts: false
       test-matrix: |
         { include: [

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -224,11 +224,11 @@ jobs:
       docker-image: ${{ needs.linux-bionic-cuda12_1-py3_10-gcc9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda12_1-py3_10-gcc9-build.outputs.test-matrix }}
 
-  linux-focal-py3-clang7-mobile-build:
-    name: linux-focal-py3-clang7-mobile-build
+  linux-jammy-py3-clang12-mobile-build:
+    name: linux-jammy-py3-clang12-mobile-build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-py3-clang7-mobile-build
+      build-environment: linux-jammy-py3-clang12-mobile-build
       docker-image-name: pytorch-linux-jammy-py3-clang12-asan
       build-generates-artifacts: false
       test-matrix: |


### PR DESCRIPTION
`pytorch-linux-focal-py3-clang7-asan` has been removed by https://github.com/pytorch/pytorch/pull/106355