### PR TITLE
[prototype only] Add cutlass as an alternative backend to inductor

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1,6 +1,9 @@
 # Owner(s): ["module: inductor"]
 
+from typing import List
+
 import torch
+
 from torch import multiprocessing as mp
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._inductor import config
@@ -147,14 +150,109 @@ class TestDoBench(TestCase):
         a = torch.randn(100, 10).cuda()
         b = torch.randn(10, 100).cuda()
 
-        with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": True,
+            }
+        ):
             torch.compile(mm, dynamic=dynamic)(a, b)
+
+    @parametrize("dynamic", (False,))
+    @parametrize("max_autotune_gemm_backends", ("Aten,Triton,Cutlass",))
+    def test_max_autotune_multi_backends_regular_mm(
+        self, dynamic: bool, max_autotune_gemm_backends: str
+    ):
+        """
+        Make sure autotuning mm in sub processes work without crashes.
+        """
+        print("enter")
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def mm(a, b):
+            return a @ b
+
+        a = torch.randn(1000, 16).cuda().half()
+        b = torch.randn(16, 1000).cuda().half()
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": False,
+                "max_autotune_gemm_backends": max_autotune_gemm_backends,
+            }
+        ):
+            Y_compiled = torch.compile(mm, dynamic=dynamic)(a, b)
+            Y = mm(a, b)
+            torch.testing.assert_close(Y_compiled, Y)
+
+
+    @parametrize("dynamic", (False,))
+    @parametrize("max_autotune_gemm_backends", ("Aten,Triton,Cutlass",))
+    def test_max_autotune_multi_backends_regular_mm_align_8(
+        self, dynamic: bool, max_autotune_gemm_backends: str
+    ):
+        """
+        Make sure autotuning mm in sub processes work without crashes.
+        """
+        print("enter")
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def mm(a, b):
+            return torch.nn.functional.linear(a, b)
+
+        a = torch.randn(1000, 16).cuda().half()
+        b = torch.randn(1000, 16).cuda().half()
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": False,
+                "max_autotune_gemm_backends": max_autotune_gemm_backends,
+            }
+        ):
+            Y_compiled = torch.compile(mm, dynamic=dynamic)(a, b)
+            Y = mm(a, b)
+            torch.testing.assert_close(Y_compiled, Y)
+
+
+    @parametrize("dynamic", (False,))
+    @parametrize("max_autotune_gemm_backends", ("Aten,Triton,Cutlass",))
+    def test_max_autotune_multi_backends_mm_bias(
+        self, dynamic: bool, max_autotune_gemm_backends: str
+    ):
+        """
+        Make sure autotuning mm in sub processes work without crashes.
+        """
+
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def mm(a, b, bias):
+            return torch.nn.functional.linear(a, b, bias)
+
+        a = torch.randn(2048, 51456).cuda().half()
+        b = torch.randn(4096, 51456).cuda().half()
+        bias = torch.randn(4096).cuda().half()
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": False,
+                "max_autotune_gemm_backends": max_autotune_gemm_backends,
+            }
+        ):
+            Y = mm(a, b, bias)
+            Y_compiled = torch.compile(mm, dynamic=dynamic)(a, b, bias)
+            torch.testing.assert_close(Y_compiled, Y)
+
 
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm(self, dynamic):
         """
-        Make sure autotuning addmm in sub processes work without crashes.
+        Make sure autotuning mm in sub processes work without crashes.
         """
+
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
 
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
@@ -163,7 +261,44 @@ class TestDoBench(TestCase):
         a = torch.randn(100, 10).cuda()
         b = torch.randn(10, 100).cuda()
         with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
-            torch.compile(addmm, dynamic=dynamic)(x, a, b)
+            Y_compiled = torch.compile(addmm, dynamic=dynamic)(x, a, b)
+            Y = addmm(x, a, b)
+            torch.testing.assert_close(Y_compiled, Y)
+
+
+    @parametrize("max_autotune_gemm_backends", ("Aten,Triton,Cutlass",))
+    def test_max_autotune_addmm_multi_backends(self, max_autotune_gemm_backends):
+        """
+        Make sure autotuning addmm in sub processes work without crashes.
+        """
+
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def addmm(x, a, b, alpha, beta):
+            return torch.addmm(x, a, b, alpha=alpha, beta=beta)
+
+        def compare_results(m: int, k: int, n: int, alpha: float, beta: float, x_shape: List[int]) -> None:
+            x = torch.randn(x_shape).cuda().half()
+            a = torch.randn(m, k).cuda().half()
+            b = torch.randn(k, n).cuda().half()
+            y_expected = addmm(x, a, b, alpha, beta)
+
+            compiled_fn = torch.compile(addmm, dynamic=False)
+            y = compiled_fn(x, a, b, alpha, beta)
+            torch.testing.assert_close(y, y_expected)
+
+        with config.patch({
+            "max_autotune": True,
+            "autotune_in_subproc": False,
+            "max_autotune_gemm_backends": max_autotune_gemm_backends,
+        }):
+            # No broadcast
+            compare_results(4096, 25728, 2048, 2.0, 0.4, [4096, 2048])
+            # Broadcast first dim.
+            compare_results(4096, 25728, 2048, 2.0, 0.4, [2048])
+            # Broadcast last dim.
+            compare_results(4096, 25728, 2048, 2.0, 0.4, [4096, 1])
+
 
     def test_cat_addmm(self):
         def fn(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1,25 +1,28 @@
 import dataclasses
+import functools
 import queue
 import time
 import warnings
+from ctypes import byref, c_size_t, c_void_p
 from multiprocessing.process import BaseProcess
 from multiprocessing.queues import Queue
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch import multiprocessing
 from torch._dynamo.testing import rand_strided
 
 from torch._inductor import ir
-from torch._inductor.codecache import PyCodeCache
+from torch._inductor.codecache import CUDACodeCache, DLLWrapper, PyCodeCache
 
 if TYPE_CHECKING:
     from torch._inductor.select_algorithm import TritonTemplateCaller
 
-from .utils import do_bench
+from .utils import do_bench, do_bench_using_profiling
 from .virtualized import V
 
-DEBUG = False
+
+DEBUG = True
 EXIT_HANDLER_REGISTERED = False
 
 
@@ -43,7 +46,6 @@ class TuningProcess:
         request_queue: "Queue[Any]",
         response_queue: "Queue[Any]",
     ) -> None:
-        print("enter child process main")
         while True:
             obj = request_queue.get()
 
@@ -166,30 +168,27 @@ class BenchmarkRequest:
     can be done inside the same process since they usually don't cause crash.
     """
 
-    module_path: str  # the path of the module defining the triton kernel
-    module_cache_key: str
-    kernel_name: str  # the kernel name defined in the module
-    grid: List[int]
+    # the kernel name defined in the module
+    kernel_name: str
+    input_tensor_meta: List[TensorMeta]
+    output_tensor_meta: TensorMeta
     extra_args: Dict[str, Any]
-    num_stages: int
-    num_warps: int
 
-    input_tensors: List[TensorMeta]
-    output_tensor: TensorMeta
+    def make_run_fn(
+        self, *input_tensors: torch.Tensor, output_tensor: torch.Tensor
+    ) -> Callable[[], None]:
+        raise NotImplementedError()
+
+    def cleanup_run_fn(self) -> None:
+        pass
 
     def benchmark(
-        self, *input_tensors: torch.Tensor, output_tensor: Optional[torch.Tensor] = None
+        self,
+        *input_tensors: torch.Tensor,
+        output_tensor: Optional[torch.Tensor] = None,
     ) -> float:
         if DEBUG:
             start_ts = time.time()
-
-        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
-        if DEBUG:
-            print(
-                f"benchmark module key: {self.module_cache_key}, path: {self.module_path}"
-            )
-
-        run = getattr(mod, self.kernel_name).run
 
         if DEBUG:
             load_elapse = time.time() - start_ts
@@ -198,33 +197,145 @@ class BenchmarkRequest:
         # create args and out tensor
         if output_tensor is None:
             assert len(input_tensors) == 0
-            input_tensors = tuple(x.to_tensor() for x in self.input_tensors)
-            output_tensor = self.output_tensor.to_tensor()
+            input_tensors = tuple(x.to_tensor() for x in self.input_tensor_meta)
+            output_tensor = self.output_tensor_meta.to_tensor()
 
         if DEBUG:
             create_tensor_elapse = time.time() - start_ts
             start_ts = time.time()
 
-        def worker() -> float:
-            return run(
-                *input_tensors,
-                output_tensor,
-                *self.extra_args,
-                grid=self.grid,
-                num_stages=self.num_stages,
-                num_warps=self.num_warps,
-            )
-
-        out = do_bench(worker)
+        out = do_bench_using_profiling(
+            self.make_run_fn(*input_tensors, output_tensor=output_tensor)
+        )
         torch.cuda.synchronize()  # shake out any CUDA errors
 
         if DEBUG:
             bench_elapse = time.time() - start_ts
             print(
-                f"InChidProcess {self.module_cache_key}: load {load_elapse}, "
-                + f"create tensor {create_tensor_elapse}, bench {bench_elapse}"
+                f"InChidProcess {str(self)}: load {load_elapse}, "
+                + f"create tensor {create_tensor_elapse}, bench {bench_elapse}, "
+                + f"collected time {out}"
             )
+        self.cleanup_run_fn()
         return out
+
+
+class TritonBenchmarkRequest(BenchmarkRequest):
+    def __init__(
+        self,
+        kernel_name: str,
+        input_tensor_meta: List[TensorMeta],
+        output_tensor_meta: TensorMeta,
+        extra_args: Dict[str, Any],
+        module_path: str,  # the path of the module defining the triton kernel
+        module_cache_key: str,
+        grid: List[int],
+        num_stages: int,
+        num_warps: int,
+    ):
+        super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
+        self.module_path = module_path
+        self.module_cache_key = module_cache_key
+        self.grid = grid
+        self.num_stages = num_stages
+        self.num_warps = num_warps
+
+    def make_run_fn(
+        self, *input_tensors: torch.Tensor, output_tensor: torch.Tensor
+    ) -> Callable[[], None]:
+        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
+        if DEBUG:
+            print(
+                f"benchmark module key: {self.module_cache_key}, path: {self.module_path}"
+            )
+
+        run_method = getattr(mod, self.kernel_name).run
+
+        return functools.partial(
+            run_method,
+            *input_tensors,
+            output_tensor,
+            *self.extra_args,
+            grid=self.grid,
+            num_stages=self.num_stages,
+            num_warps=self.num_warps,
+            stream=torch.cuda.current_stream().cuda_stream,
+        )
+
+    def __str__(self) -> str:
+        return f"{self.kernel_name=}, {self.module_path=}, {self.module_cache_key=}"
+
+
+class CUDABenchmarkRequest(BenchmarkRequest):
+    def __init__(
+        self,
+        kernel_name: str,
+        input_tensor_meta: List[TensorMeta],
+        output_tensor_meta: TensorMeta,
+        extra_args: Dict[str, Any],
+        source_code: str,
+    ):
+        super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
+        self.source_code = source_code
+        self.workspace_size: int = 0
+        self.workspace: Optional[Tensor] = None
+        self.DLL: Optional[DLLWrapper] = None
+        self.hash_key: str = ""
+        self.source_file: str = ""
+        self.hash_key, self.source_file = CUDACodeCache.write_source_code(
+            self.source_code, "so"
+        )
+
+    def make_run_fn(
+        self, *input_tensors: torch.Tensor, output_tensor: torch.Tensor
+    ) -> Callable[[], None]:
+        self.DLL, self.hash_key, self.source_file = CUDACodeCache.load(
+            self.source_code, "so"
+        )
+        args = [
+            c_void_p(tensor.data_ptr())
+            for tensor in list(input_tensors) + [output_tensor]
+        ]
+        print(
+            f"{self.kernel_name=}, {self.source_file=}, {self.hash_key=}, {self.DLL=}"
+        )
+        print(f"{args=}, {self.extra_args=}", flush=True)
+        run_method = getattr(self.DLL, self.kernel_name)
+        stream_ptr = c_void_p(torch.cuda.current_stream().cuda_stream)
+
+        # Retrieve workspace_size and initialize workspace.
+        c_workspace_size = c_size_t()
+        run_method(
+            *args,  # input ptrs and output ptrs
+            *self.extra_args,
+            byref(
+                c_workspace_size
+            ),  # set workspace size ptr to retrieve workspace size
+            None,  # null workspace ptr
+            stream_ptr,
+        )
+        self.workspace_size = c_workspace_size.value
+        assert (
+            self.workspace_size == 0
+        ), "Autotune cache needs to be updated to support non-zero workspace_size!"
+        self.workspace = torch.empty(self.workspace_size, dtype=torch.uint8, device="cuda")
+
+        # Generate partial function.
+        return functools.partial(
+            run_method,
+            *args,
+            *self.extra_args,
+            None,  # null workspace size ptr
+            c_void_p(self.workspace.data_ptr()),  # set workspace ptr
+            stream_ptr,
+        )
+
+    def cleanup_run_fn(self) -> None:
+        self.DLL.close()
+        self.workspace = None
+
+    def __str__(self) -> str:
+        return f"{self.kernel_name=}, {self.source_file=}, {self.hash_key=}"
 
 
 def benchmark_in_sub_process(
@@ -266,4 +377,5 @@ def benchmark_in_sub_process(
             # return INF so this choice will be ignored
             return float("inf")
 
+        print(f"benchmark successful! {timing=}")
         return timing

--- a/torch/_inductor/codegen/cuda/__init__.py
+++ b/torch/_inductor/codegen/cuda/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+THIRD_PARTY_PATH = "../../../../third_party/"
+CUTLASS_PY_PATH = "cutlass/tools/library/scripts/"
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), THIRD_PARTY_PATH, CUTLASS_PY_PATH)))

--- a/torch/_inductor/codegen/cuda/cuda_env.py
+++ b/torch/_inductor/codegen/cuda/cuda_env.py
@@ -1,0 +1,46 @@
+import functools
+import logging
+import torch
+from subprocess import PIPE, Popen
+
+from ... import config
+
+
+def _detect_cuda_arch() -> str:
+    # Get Compute Capability of the first Visible device
+    major, minor = torch.cuda.get_device_capability(0)
+    comp_cap = major * 10 + minor
+    if comp_cap >= 90:
+        return "90"
+    elif comp_cap >= 80:
+        return "80"
+    elif comp_cap >= 75:
+        return "75"
+    elif comp_cap >= 70:
+        return "70"
+    else:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_cuda_arch() -> str:
+    try:
+        cuda_arch = config.cuda.arch
+        if cuda_arch is None:
+            cuda_arch = _detect_cuda_arch()
+        return cuda_arch
+    except Exception as e:
+        logging.error(f"Error getting cuda arch: {e=}")
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_cuda_version() -> str:
+    try:
+        cuda_version = config.cuda.version
+        if cuda_version is None:
+            cuda_version = torch.version.cuda
+        return cuda_version
+    except Exception as e:
+        logging.error(f"Error getting cuda version: {e=}")
+        return None

--- a/torch/_inductor/codegen/cuda/cuda_kernel.py
+++ b/torch/_inductor/codegen/cuda/cuda_kernel.py
@@ -1,0 +1,287 @@
+from typing import List, Optional
+
+import sympy
+
+from ...autotune_process import CUDABenchmarkRequest
+from ...ir import Callable, CUDATemplateBuffer, IRNode, Layout, TensorBox
+from ...select_algorithm import ChoiceCaller
+from ...utils import sympy_product
+from ...virtualized import V
+
+from ..common import IndentedBuffer, Kernel, OpOverrides
+from ..cpp import CppPrinter, DTYPE_TO_CPP
+
+
+cexpr = CppPrinter().doprint
+
+
+def _normalize_idx(index: int, total_length: int) -> int:
+    return index if index >= 0 else index + total_length
+
+
+class CUDAKernel(Kernel):
+    overrides = OpOverrides
+
+
+class CUDATemplateKernel(CUDAKernel):
+    EXTRA_CPP_ARGS = "size_t* workspace_size, uint8_t* workspace, cudaStream_t stream"
+
+    def __init__(
+        self,
+        kernel_name,
+    ):
+        super().__init__()
+        self.kernel_name = kernel_name
+        self.named_nodes = {}
+
+    def arg_name(self, node: IRNode) -> Optional[str]:
+        if node is None:
+            return None
+        return {**self.args.input_buffers, **self.args.output_buffers}.get(
+            node.get_name(), None
+        )
+
+    def check_not_null(self, node: IRNode) -> str:
+        if node is None:
+            return ""
+
+        size_str = self.size(node, 0, -1)
+        name_str = self.arg_name(node)
+        if name_str is None:
+            return ""
+
+        res = IndentedBuffer(initial_indent=2)
+        res.tabwidth = 1
+        res.splice(
+            """
+            {{
+              if (!{name_str}) {{
+                int64_t {name_str}_size = {size_str};
+                if ({name_str}_size > 0) {{
+                  throw std::runtime_error("input {name_str} is null!");
+                }}
+              }}
+            }}
+            """.format(
+                name_str=name_str, size_str=size_str
+            )
+        )
+        return res.getvalue()
+
+    def def_kernel(
+        self,
+        inputs: List[IRNode],
+        outputs: List[IRNode],
+        names_str: str = "",
+        input_reorder: List[int] = None,
+    ) -> str:
+        """
+        Hook called from template code to generate function def and
+        needed args.
+        """
+        print(f"{input_reorder=}")
+
+        names = [x.strip() for x in names_str.strip().split(",")]
+        if len(inputs) + len(outputs) != len(names):
+            raise RuntimeError(
+                f"{len(inputs) + len(outputs)=} != {len(names)=}, {inputs=}, {outputs=}, {names=}"
+            )
+
+        if input_reorder is not None:
+            assert len(inputs) == len(input_reorder)
+        else:
+            input_reorder = list(range(len(inputs)))
+
+        for idx in input_reorder:
+            name = names[idx]
+            node = inputs[idx]
+            if node is not None:
+                print(f"before: {self.args.input_buffers=}")
+                self.named_nodes[name] = node
+                self.args.input_buffers[node.get_name()] = name
+                print(f"after: {self.args.input_buffers=}")
+
+        for name, node in zip(names[len(inputs) : len(inputs) + len(outputs)], outputs):
+            if node is not None:
+                print(f"before: {self.args.output_buffers=}")
+                self.named_nodes[name] = node
+                self.args.output_buffers[node.get_name()] = name
+                print(f"after: {self.args.output_buffers=}")
+
+        arg_defs, *_ = self.args.cpp_argdefs()
+        return f"PT_EXPORT int {self.kernel_name}({', '.join(arg_defs)}, {self.EXTRA_CPP_ARGS})"
+
+    def declare_kernel(self) -> str:
+        """
+        Declares extern C API. This function must be called after self.def_kernel().
+        """
+
+        arg_defs, *_ = self.args.cpp_argdefs()
+        args = ", ".join(arg_defs + [self.EXTRA_CPP_ARGS])
+
+        res = IndentedBuffer(initial_indent=2)
+        res.tabwidth = 1
+        res.splice(
+            """
+            extern "C" {{
+                PT_EXPORT void {kernel_name}({args});
+            }}
+            """.format(
+                kernel_name=self.kernel_name, args=args
+            )
+        )
+        return res.getvalue()
+
+    def call_kernel(self, name: str, node: CUDATemplateBuffer) -> None:
+        wrapper = V.graph.wrapper_code
+        _, call_args, _ = self.args.python_argdefs()
+        # dynamo wraps unspec variable as 0d CPU tensor, need convert to scalar
+        for i in range(len(call_args)):
+            if V.graph.is_unspec_arg(call_args[i]):
+                call_args[i] = call_args[i] + ".item()"
+            else:
+                call_args[i] = f"c_void_p({call_args[i]}.data_ptr())"
+
+        call_args.append("None")
+        print(f"{type(node)=}, {node.get_workspace_size()=}")
+        if node.get_workspace_size() > 0:
+            call_args.append(f"c_void_p({node.get_name()}_workspace.data_ptr())")
+        else:
+            call_args.append("None")
+
+        wrapper.generate_kernel_call(
+            name,
+            call_args,
+            V.graph.scheduler.current_device.index,
+            cuda=True,
+            triton=False,
+        )
+
+    def dtype(self, node: IRNode) -> str:
+        if node is None:
+            return "void"
+        return DTYPE_TO_CPP.get(node.get_layout().dtype)
+
+    def offset(self, node: IRNode) -> str:
+        if node is None:
+            return "0"
+        return str(node.get_layout().offset)
+
+    def ptr(self, node: IRNode, default_node: IRNode = None) -> str:
+        if node is None:
+            if default_node is not None:
+                node = default_node
+            else:
+                return "nullptr"
+        arg_name = self.arg_name(node)
+        if arg_name is None:
+            return "nullptr"
+        offset = self.offset(node)
+        return arg_name if offset == "0" else f"{arg_name} + {offset}"
+
+    def size(
+        self,
+        node: IRNode,
+        start_index: int,
+        end_index: Optional[int] = None,
+        default_value: int = 0,
+    ) -> str:
+        """
+        Hook called from template code to get the size of an arg.
+        Will add needed args to pass it in if it is dynamic.
+        """
+
+        if node is None:
+            return str(default_value)
+
+        start_index = _normalize_idx(start_index, len(node.get_size()))
+        if end_index is None:
+            end_index = start_index
+        end_index = _normalize_idx(end_index, len(node.get_size()))
+
+        sizes = node.get_size()[start_index : end_index + 1]
+        if len(sizes) == 0:
+            return str(default_value)
+
+        val = sympy_product(sizes)
+        return cexpr(self.rename_indexing(val))
+
+    def stride(self, node: IRNode, index: int, default_value: int = 0) -> str:
+        """
+        Hook called from template code to get the stride of an arg.
+        Will add needed args to pass it in if it is dynamic.
+        """
+
+        if node is None:
+            return str(default_value)
+
+        index = _normalize_idx(index, len(node.get_size()))
+        if index < 0:
+            return str(default_value)
+
+        stride = node.get_stride()[index]
+        return cexpr(self.rename_indexing(stride))
+
+    def row_stride(self, node: IRNode, default_value: int = 0) -> str:
+        """
+        Hook called from template code to get the stride of an arg.
+        Will add needed args to pass it in if it is dynamic.
+        """
+
+        if node is None or len(node.get_stride()) < 2:
+            return str(default_value)
+
+        stride0 = node.get_stride()[-1]
+        stride1 = node.get_stride()[-2]
+        if stride0 == 1:
+            return cexpr(self.rename_indexing(stride1))
+        elif stride1 == 1:
+            return cexpr(self.rename_indexing(stride0))
+        else:
+            raise RuntimeError(
+                f"At least 1 stride should be 1. Strides: {node.get_stride()=}"
+            )
+
+
+class CUDATemplateCaller(ChoiceCaller):
+    def __init__(
+        self,
+        name: str,
+        category: str,
+        input_nodes: List[IRNode],
+        layout: Layout,
+        make_kernel_render: Callable[[str], str],
+        bmreq: CUDABenchmarkRequest,
+    ):
+        super().__init__(name, input_nodes, layout)
+        self.category = category
+        self.make_kernel_render = make_kernel_render
+        self.bmreq = bmreq
+
+    def benchmark(self, *args, out):
+        assert self.bmreq is not None
+        return self.bmreq.benchmark(*args, output_tensor=out)
+
+    def __str__(self):
+        return f"CUDATemplateCaller(source_file={self.bmreq.source_file})"
+
+    def call_name(self) -> str:
+        return f"cuda_template_kernels.{self.name}"
+
+    def hash_key(self):
+        return "-".join(
+            [
+                self.category,
+                self.bmreq.hash_key,
+            ]
+        )
+
+    def output_node(self):
+        return TensorBox.create(
+            CUDATemplateBuffer(
+                layout=self.layout,
+                inputs=self.input_nodes,
+                make_kernel_render=self.make_kernel_render,
+                workspace_size=self.bmreq.workspace_size,
+            )
+        )

--- a/torch/_inductor/codegen/cuda/cuda_scheduling.py
+++ b/torch/_inductor/codegen/cuda/cuda_scheduling.py
@@ -1,0 +1,42 @@
+from typing import List
+
+from ... import config
+from ...codecache import code_hash, get_path
+from ...scheduler import BaseSchedulerNode
+from ...utils import get_fused_kernel_name, get_kernel_metadata
+from ...virtualized import V
+
+from ..common import IndentedBuffer
+from ..triton import TritonScheduling
+
+
+class CUDAScheduling(TritonScheduling):
+    def define_kernel(self, src_code, node_schedule):
+        wrapper = V.graph.wrapper_code
+        if src_code in wrapper.src_to_kernel:
+            kernel_name = wrapper.src_to_kernel[src_code]
+        else:
+            fused_name = (
+                get_fused_kernel_name(node_schedule, config.triton.descriptive_names)
+                if config.triton.descriptive_names
+                else ""
+            )
+            kernel_name = "_".join(["cuda", fused_name, wrapper.next_kernel_suffix()])
+            # use the original src_code as the key
+            wrapper.src_to_kernel[src_code] = kernel_name
+            src_code = src_code.replace("KERNEL_NAME", kernel_name)
+
+            basename, _, kernel_path = get_path(code_hash(src_code), "py")
+
+            compile_wrapper = IndentedBuffer()
+            compile_wrapper.writeline(f"async_compile.cuda('so', r'''")
+            compile_wrapper.splice(src_code, strip=True)
+            compile_wrapper.writeline("''')")
+
+            metadata_comment = f"# kernel path: {kernel_path}"
+            origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+            metadata_comment += "\n" + origins + "\n" + detailed_origins
+            wrapper.define_kernel(
+                kernel_name, compile_wrapper.getvalue(), metadata_comment
+            )
+        return kernel_name

--- a/torch/_inductor/codegen/cuda/cuda_template.py
+++ b/torch/_inductor/codegen/cuda/cuda_template.py
@@ -1,0 +1,212 @@
+import functools
+import itertools
+from copy import copy
+from typing import List
+from unittest.mock import patch
+
+import sympy
+import torch
+
+# import cutlass libs
+import scripts as cutlass_lib
+
+from ...autotune_process import CUDABenchmarkRequest, TensorMeta
+from ...ir import Buffer, IRNode, Layout
+from ...utils import IndentedBuffer, unique
+from ...virtualized import V
+from ..common import jinja2_env
+
+from . import cutlass_utils
+from .cuda_kernel import CUDATemplateCaller, CUDATemplateKernel
+
+
+class CUDATemplate:
+    index_counter = itertools.count()
+
+    def __init__(
+        self, name: str, input_nodes: List[IRNode], layout: Layout,
+        input_reorder: List[int]=None,
+    ):
+        super().__init__()
+        self.name = name
+        self.input_nodes = input_nodes
+        self.output_node = Buffer("buf_out", layout)
+        self.input_reorder = input_reorder
+
+    @staticmethod
+    def _template_from_string(source):
+        env = jinja2_env()
+        if env is not None:
+            return env.from_string(source)
+        return None
+
+    def maybe_append_choice(self, choices, **kwargs):
+        choices.append(self.generate(**kwargs))
+
+    @staticmethod
+    def _fake_get_dtype(fake_out):
+        _get_dtype_real = V.graph.get_dtype
+
+        def get_dtype(name):
+            if name == fake_out.get_name():
+                return fake_out.get_dtype()
+            return _get_dtype_real(name)
+
+        return get_dtype
+
+    def generate(self, **kwargs) -> CUDATemplateCaller:
+        kernel_name = f"cuda_{self.name}"
+        with patch.object(
+            V.graph, "get_dtype", self._fake_get_dtype(self.output_node)
+        ), CUDATemplateKernel(
+            kernel_name=kernel_name,
+        ) as kernel:
+            # need to do call render twice to get all the needed args right
+            # self.render(kernel=kernel, **kwargs)
+            code = self.render(kernel=kernel, **kwargs)
+            _, call_args, _ = kernel.args.python_argdefs()
+            print("Generated Code:\n", code)
+            print(f"args: {kernel.args.cpp_argdefs()}, {kernel.args.python_argdefs()}")
+
+        input_reorder = self.input_reorder if self.input_reorder is not None else list(range(len(self.input_nodes)))
+        expected_args = list(unique(self.input_nodes[idx].get_name() for idx in input_reorder))
+        expected_args.extend([self.output_node.get_name()])
+        assert list(call_args)[: len(expected_args)] == expected_args, (
+            call_args,
+            expected_args,
+        )
+        extra_args = V.graph.sizevars.size_hints(
+            map(sympy.expand, call_args[len(expected_args) :])
+        )
+
+        kernel_hash_name = f"cuda_{self.name}_{next(self.index_counter)}"
+
+        # create the BenchmarkRequest
+        bmreq = CUDABenchmarkRequest(
+            kernel_name=kernel_name,
+            input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
+            output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
+            extra_args=extra_args,
+            source_code=code,
+        )
+
+        def make_kernel_render(output_node):
+            kernel = CUDATemplateKernel(
+                kernel_name="KERNEL_NAME",
+            )
+            render = functools.partial(
+                self.render,
+                kernel=kernel,
+                output_node=output_node,
+                **kwargs,
+            )
+            return kernel, render
+
+        return CUDATemplateCaller(
+            kernel_hash_name,
+            self.name,
+            self.input_nodes,
+            self.output_node.get_layout(),
+            make_kernel_render,
+            bmreq,
+        )
+
+    def header(self) -> IndentedBuffer:
+        res = IndentedBuffer()
+        res.splice(
+            """
+                #include <exception>
+                #include <iostream>
+                #include <memory>
+                #include <random>
+                #include <vector>
+            """
+        )
+        return res
+
+    def globals(self) -> IndentedBuffer:
+        res = IndentedBuffer()
+        res.splice(
+            """
+                // We compile all models with -fvisibility=hidden. Any symbols that need to be
+                // exposed in the final shared library must be declared with PT_EXPORT to make
+                // them visible.
+                #ifdef __GNUC__ // Applies to any compiler with GNU extensions (clang and g++)
+                #define PT_EXPORT __attribute__((__visibility__("default")))
+                #else
+                #ifdef _WIN32
+                #define PT_EXPORT __declspec(dllexport)
+                #else
+                #define PT_EXPORT
+                #endif
+                #endif
+
+                using bfloat16 = nv_bfloat16;
+            """
+        )
+        return res
+
+
+    _DTYPE_TO_CUTLASS = {
+        torch.float32: "float",
+        torch.float64: "double",
+        torch.float16: "cutlass::half_t",
+        torch.int32: "int",
+        torch.int8: "int8_t",
+        torch.uint8: "uint8_t",
+        torch.bool: "bool",
+        torch.bfloat16: "cutlass::bfloat16_t",
+    }
+
+    def cutlass_type_cast(self, node: IRNode, ptr: str) -> str:
+        if node is None:
+            return ptr
+        else:
+            return f"({self._DTYPE_TO_CUTLASS.get(node.get_dtype())}*)({ptr})"
+
+
+    def render(self, **kwargs) -> str:
+        raise NotImplementedError
+
+
+class CutlassTemplate(CUDATemplate):
+    def header(self) -> IndentedBuffer:
+        res = super().header()
+        res.splice(
+            """
+                #include "cutlass/cutlass.h"
+                #include "cutlass/numeric_types.h"
+                #include "cutlass/util/host_tensor.h"
+                #include "cutlass/util/reference/host/tensor_fill.h"
+                #include "cutlass/util/reference/device/tensor_fill.h"
+                #include "cutlass/util/device_memory.h"
+            """
+        )
+        return res
+
+    def globals(self) -> IndentedBuffer:
+        res = super().globals()
+        res.splice(
+            """
+                #define CUTLASS_CHECK(status)                                                      \\
+                {                                                                                  \\
+                  cutlass::Status error = status;                                                  \\
+                  if (error != cutlass::Status::kSuccess) {                                        \\
+                    auto msg = std::string("[") + __FILE__ + "] Got cutlass error: " +             \\
+                        cutlassGetStatusString(error) + " at: " + std::to_string(__LINE__);        \\
+                    throw std::runtime_error(msg);                                                 \\
+                  }                                                                                \\
+                }
+            """
+        )
+        return res
+
+    def cute_int(self, int_str: str, var_name: str) -> str:
+        res = ""
+        if int_str in {"1", "1L"}:
+            res = "cute::Int<1>{}"
+        else:
+            res = int_str
+
+        return f"{res} /* {var_name} */"
+

--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -1,0 +1,125 @@
+import functools
+from typing import Any, List
+
+import sympy
+
+import torch
+
+# Import cutlass python scripts.
+import generator as cutlass_generator
+import library as cutlass_lib
+import manifest as cutlass_manifest
+
+from .cuda_env import get_cuda_arch, get_cuda_version
+
+
+class Args:
+    def __init__(self, cuda_arch, cuda_version):
+        self.operations = "all"
+        self.build_dir = ""
+        self.curr_build_dir = ""
+        self.generator_target = ""
+        self.architectures = cuda_arch
+        self.kernels = "all"
+        self.ignore_kernels = ""
+        self.cuda_version = cuda_version
+        self.kernel_filter_file = None
+        self.selected_kernel_list = None
+        self.interface_dir = None
+        self.filter_by_cc = True
+        self.disable_full_archs_compilation = False
+
+
+@functools.lru_cache(maxsize=1)
+def gen_ops() -> List[Any]:
+    arch = get_cuda_arch()
+    version = get_cuda_version()
+    args = Args(arch, version)
+    manifest = cutlass_manifest.Manifest(args)
+
+    if arch == "90":
+        print(f"{args.cuda_version=}")
+        cutlass_generator.GenerateSM90(manifest, args.cuda_version)
+        print(f"SM90: {len(manifest.operations)=}")
+        cutlass_generator.GenerateSM80(manifest, args.cuda_version)
+        print(f"SM80 + SM90: {len(manifest.operations)=}")
+    else:
+        try:
+            func = getattr(cutlass_generator, "GenerateSM" + arch)
+            func(manifest, args.cuda_version)
+        except AttributeError as e:
+            raise NotImplementedError(
+                "Arch " + arch + " is not supported by current cutlass lib."
+            ) from e
+
+    return manifest.operations
+
+
+def torch_dtype_match(torch_dtype0, torch_dtype1) -> bool:
+    _MATCHED_DTYPES = [
+        {torch.float, torch.float32},
+        {torch.float16, torch.half},
+    ]
+
+    if torch_dtype0 == torch_dtype1:
+        return True
+    for matched_dtypes in _MATHED_DTYPES:
+        if torch_dtype0 in matched_dtypes and torch_dtype1 in matched_dtypes:
+            return True
+    return False
+
+def dtype_match(torch_dtype, cutlass_dtype) -> bool:
+    if torch_dtype == torch.float or torch_dtype == torch.float32:
+        return (
+            cutlass_dtype == cutlass_lib.DataType.f32
+            or cutlass_dtype == cutlass_lib.DataType.tf32
+        )
+    elif torch_dtype == torch.float16 or torch_dtype == torch.half:
+        return cutlass_dtype == cutlass_lib.DataType.f16
+    elif torch_dtype == torch.bfloat16:
+        return cutlass_dtype == cutlass_lib.DataType.bf16
+    else:
+        return False
+
+
+def get_accumulator_dtype(input_torch_dtypes) -> torch.dtype:
+    if len(input_torch_dtypes) == 0:
+        return None
+    torch_dtype = input_torch_dtypes[0]
+    for dtype in input_torch_dtypes[1:]:
+        if not torch_dtype_match(torch_dtype, dtype):
+            raise RuntimeError(f"Unmatched input dtypes: {torch_dtype=}, {dtype=}")
+    if torch_dtype in {torch.float16, torch.half}:
+        if torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction:
+            return torch_dtype
+        else:
+            return torch.float
+    if torch_dtype in {torch.bfloat16, torch.float, torch.float32}:
+        return torch.float
+    raise NotimplementedError(f"Unsupported data type: {input_torch_dtypes=}")
+
+
+def get_alignments(torch_dtype) -> List[int]:
+    if torch_dtype in (torch.float16, torch.half, torch.bfloat16):
+        return [8, 4, 2, 1]
+    elif torch_dtype in (torch.float, torch.float32):
+        return [4, 2, 1]
+    else:
+        raise NotImplementedError(f"unsupported {torch_dtype=} for alignments")
+
+
+def get_alignment(torch_layout) -> int:
+    dtype = torch_layout.dtype
+    size = torch_layout.size
+    offset = torch_layout.offset
+
+    def is_static_int(number):
+        return isinstance(number, int) or isinstance(number, sympy.Integer)
+
+    if is_static_int(size[-1]) and is_static_int(offset):
+        alignments = get_alignments(dtype)
+        for alignment in alignments:
+            if int(size[-1]) % alignment == 0 and int(offset) % alignment == 0:
+                return alignment
+
+    return 1

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1,0 +1,489 @@
+import copy
+import re
+from typing import List, Optional
+
+import torch
+
+# import cutlass libs
+import gemm_operation as cutlass_gemm_op
+import library as cutlass_lib
+
+from ...ir import Buffer, FixedLayout, IRNode, Layout
+from ..common import IndentedBuffer
+
+from . import cutlass_utils
+from .cuda_kernel import CUDATemplateKernel
+from .cuda_template import CutlassTemplate
+
+# Only supports alpha * A@B + beta * C now.
+# TODO: Support arbitrary epilogue after epilogue visitor is released in cutlass 3.2.
+GEMM_TEMPLATE = r"""
+{{template.header().getvalue()}}
+
+{{template.globals().getvalue()}}
+
+{{instance_definition}}
+
+// When workspace_size is not a nullptr, populates requested workspace_size and returns.
+// Otherwise, compuates the Gemm kernel using the given workspace ptr.
+extern "C" {
+{{kernel.def_kernel(inputs=[X, W, Bias], outputs=[Y], names_str="X, W, Bias, Y", input_reorder=input_reorder)}} {
+  try {
+  // printf("X: %p\n", (void*)(X));
+  // printf("W: %p\n", (void*)(W));
+  // printf("Bias: %p\n", (void*)(Bias));
+  // printf("Y: %p\n", (void*)(Y));
+  // printf("workspace size: %p\n", (void*)(workspace_size));
+  // printf("workspace: %p\n", (void*)(workspace));
+  // printf("stream: %p\n", (void*)(stream));
+
+  {{kernel.check_not_null(X)}}
+  {{kernel.check_not_null(W)}}
+  {{kernel.check_not_null(Bias)}}
+  {{kernel.check_not_null(Y)}}
+
+  int64_t B = {{kernel.size(Y, 0, -3, default_value=1)}};
+  int64_t M = {{kernel.size(X, -2)}};
+  int64_t K = {{kernel.size(X, -1)}};
+  int64_t N = {{kernel.size(W, -1)}};
+
+  using ElementComputeEpilogue = {{instance_type}}::ElementAccumulator;
+  using coord_t = cutlass::gemm::GemmCoord::Index;
+  {{instance_type}}::Arguments arguments;
+
+  {{template.render_gemm_arguments(argument_template, epilogue_template, should_swap_xw, X, W, Bias, Y, alpha, beta, kernel)}}
+
+  {{instance_type}} gemm_op;
+
+  if (workspace_size) {
+    *workspace_size = gemm_op.get_workspace_size(arguments);
+    return 0;
+  }
+
+  {
+    auto status = gemm_op.can_implement(arguments);
+    CUTLASS_CHECK(status);
+  }
+  {
+    auto status = gemm_op.initialize(arguments, workspace, stream);
+    CUTLASS_CHECK(status);
+  }
+  {
+    auto status = gemm_op(stream);
+    CUTLASS_CHECK(status);
+  }
+  }
+  catch (std::exception& e) {
+    std::cerr << "Runtime error: " << e.what() << std::endl;
+    return -1;
+  }
+  catch (...) {
+    return -1;
+  }
+
+  return 0;
+}
+}
+
+"""
+
+
+GEMM_ARGS_CUTLASS_2X = r"""
+  int64_t batch_stride_x = {{kernel.stride(X, -3)}};
+  int64_t row_stride_x = {{kernel.row_stride(X)}};
+
+  int64_t batch_stride_w = {{kernel.stride(W, -3)}};
+  int64_t row_stride_w = {{kernel.row_stride(W)}};
+
+  int64_t batch_stride_bias = {{kernel.stride(Bias, -3)}};
+  int64_t row_stride_bias = {{kernel.row_stride(Bias)}};
+
+  int64_t batch_stride_y = {{kernel.stride(Y, -3)}};
+  int64_t row_stride_y = {{kernel.row_stride(Y)}};
+
+  // Initialize GemmUniversalInstance arguments.
+  arguments = {
+    {{template.gemm_mode()}},  // GemmUniversalMode mode
+    {
+      static_cast<coord_t>(M),
+      static_cast<coord_t>(N),
+      static_cast<coord_t>(K)
+    },  // GemmCoord problem_size
+    {{split_k if split_k > 1 else 'B'}},  // int batch_count
+    {ElementComputeEpilogue({{alpha}}), ElementComputeEpilogue({{beta}})},  // typename EpilogueOutputOp::Params epilogue
+    {{template.cutlass_type_cast(X, kernel.ptr(X))}},  // void const * ptr_A
+    {{template.cutlass_type_cast(W, kernel.ptr(W))}},  // void const * ptr_B
+    {{template.cutlass_type_cast(Bias, kernel.ptr(Bias))}},  // void const * ptr_C
+    {{template.cutlass_type_cast(Y, kernel.ptr(Y))}},  // void * ptr_D
+    batch_stride_x,  // int64_t batch_stride_A
+    batch_stride_w,  // int64_t batch_stride_B
+    batch_stride_bias,  // int64_t batch_stride_C
+    batch_stride_y,  // int64_t batch_stride_D
+    row_stride_x,  // typename LayoutA::Stride::LongIndex lda
+    row_stride_w,  // typename LayoutB::Stride::LongIndex ldb
+    row_stride_bias,  // typename LayoutC::Stride::LongIndex ldc
+    row_stride_y,  // typename LayoutC::Stride::LongIndex ldd
+  };
+"""
+
+
+GEMM_ARGS_CUTLASS_3X = r"""
+  // Initialize GemmUniversal3xInstance arguments.
+  arguments = {
+    {{template.gemm_mode()}},  // GemmUniversalMode mode
+    {
+      static_cast<coord_t>({{M}}),
+      static_cast<coord_t>({{N}}),
+      static_cast<coord_t>(K),
+      static_cast<coord_t>(B)
+    }, // ProblemShape problem_shape
+    {
+      {{template.cutlass_type_cast(X, kernel.ptr(X))}},  // ElementA const* ptr_A
+      { {{template.cute_int(kernel.stride(X, -2), "stride_x0")}}, {{template.cute_int(kernel.stride(X, -1), "stride_x1")}}, {{template.cute_int(kernel.stride(X, -3), "batch_stride_x")}}},  // StrideA dA
+      {{template.cutlass_type_cast(W, kernel.ptr(W))}},  // ElementB const* ptr_B
+      { {{template.cute_int(kernel.stride(W, -1), "stride_w1")}}, {{template.cute_int(kernel.stride(W, -2), "stride_w0")}}, {{template.cute_int(kernel.stride(W, -3), "batch_stride_w")}}},  // StrideB dB
+    },  // MainloopArguments mainloop
+    {{epilogue_arguments}}
+  };
+"""
+
+
+GEMM_ARGS_CUTLASS_3X_EPILOGUE = r"""
+    {
+      {ElementComputeEpilogue({{alpha}}), ElementComputeEpilogue({{beta}})},  // typename ThreadEpilogueOp::Params thread
+      {{template.cutlass_type_cast(Bias, kernel.ptr(Bias))}},  // ElementC const* ptr_C
+      { {{template.cute_int(kernel.stride(Bias, -2, 1), "stride_bias0")}}, {{template.cute_int(kernel.stride(Bias, -1, 1), "stride_bias1")}}, {{template.cute_int(kernel.stride(Bias, -3), "batch_stride_bias")}}},  // StrideC dC
+      {{template.cutlass_type_cast(Y, kernel.ptr(Y))}},  // ElementD const* ptr_D
+      { {{template.cute_int(kernel.stride(Y, -2), "stride_y0")}}, {{template.cute_int(kernel.stride(Y, -1), "stride_y1")}}, {{template.cute_int(kernel.stride(Y, -3), "batch_stride_y")}}},  // StrideD dD
+    },  // EpilogueArguments epilogue
+"""
+
+
+class CutlassGemmTemplate(CutlassTemplate):
+    # Calculates alpha * X@W + beta * Bias
+
+    def __init__(
+        self,
+        input_nodes: List[IRNode],
+        layout: Layout,
+        alpha: float,
+        beta: float,
+        input_reorder: List[int]=None,
+    ):
+        super().__init__("cutlass_gemm", input_nodes, layout, input_reorder)
+        self.alpha = alpha
+        self.beta = beta
+
+    def header(self) -> IndentedBuffer:
+        res = super().header()
+        res.splice(
+            """
+                #include "cutlass/gemm/gemm.h"
+                #include "cutlass/gemm/device/gemm_universal.h"
+                #include "cutlass/gemm/device/gemm_universal_adapter.h"
+
+                #include "cutlass/gemm/kernel/gemm_universal.hpp"
+                #include "cutlass/gemm/collective/collective_builder.hpp"
+                #include "cutlass/epilogue/collective/collective_builder.hpp"
+            """
+        )
+        return res
+
+    @staticmethod
+    def cutlass_layout(torch_layout) -> Optional[cutlass_lib.LayoutType]:
+        if torch_layout.stride[-1] == 1:
+            return cutlass_lib.LayoutType.RowMajor
+        elif torch_layout.stride[-2] == 1:
+            return cutlass_lib.LayoutType.ColumnMajor
+        else:
+            return None
+
+    @staticmethod
+    def flip_cutlass_layout(
+        cutlass_layout: cutlass_lib.LayoutType,
+    ) -> cutlass_lib.LayoutType:
+        if cutlass_layout == cutlass_lib.LayoutType.RowMajor:
+            return cutlass_lib.LayoutType.ColumnMajor
+        else:
+            return cutlass_lib.LayoutType.RowMajor
+
+    @staticmethod
+    def layout_match(torch_layout, cutlass_layout) -> bool:
+        return CutlassGemmTemplate.cutlass_layout(torch_layout) == cutlass_layout
+
+    @staticmethod
+    def set_alignment(torch_layout, op_element) -> bool:
+        alignment = cutlass_utils.get_alignment(torch_layout)
+        if alignment < op_element.alignment:
+            return False
+        else:
+            op_element.alignment = alignment
+            return True
+
+    @staticmethod
+    def has_tma_epilogue(op) -> bool:
+        result = False
+        if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+            epilogue_schedule_str = str(op.epilogue_schedule).split(".")[-1]
+            result = epilogue_schedule_str.lower().startswith("tma")
+        return result
+
+    @staticmethod
+    def define_gemm_instance(
+        op: cutlass_gemm_op.GemmOperation,
+    ) -> str:
+        if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+            emitter = cutlass_gemm_op.EmitGemmUniversal3xInstance()
+            op_def = emitter.emit(op)
+            pattern = re.compile(r"\s*struct\s(.*?)\s:")
+            decl = [line for line in op_def.split("\n") if "struct " in line][-1]
+        else:
+            emitter = cutlass_gemm_op.EmitGemmInstance()
+            op_def = emitter.emit(op)
+            op_def = op_def.replace(
+                "cutlass::gemm::device::Gemm", "cutlass::gemm::device::GemmUniversal"
+            )
+            op_def = op_def.replace("false,", "")
+            pattern = re.compile(r"\s*using\s(.*?)\s=")
+            decl = op_def.split("\n")[2]
+        match = pattern.match(decl)
+        if match is None:
+            raise RuntimeError("Invalid Gemm config: \n" + op_def)
+        op_type = match.groups()[0]
+        if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+            op_def += f"\n  using {op_type}_device_type = cutlass::gemm::device::GemmUniversalAdapter<{op_type}>;\n"
+            op_type = f"{op_type}_device_type"
+        return op_def, op_type
+
+    @staticmethod
+    def should_swap_XW(
+        bias: IRNode,
+        beta: float,
+    ) -> bool:
+        return True
+
+        # TODO(ipiszy): Check whether it's necessary to swap X/W.
+        # strides = bias.get_stride()
+        # if strides[-1] != 1:
+        #     return True
+        # for stride in strides[:-1]:
+        #     if stride != 0:
+        #         return True
+        # return False
+
+    @staticmethod
+    def swap_XW(op: cutlass_gemm_op.GemmOperation) -> cutlass_gemm_op.GemmOperation:
+        # Swap X and W in GemmOperation.
+        new_op = copy.deepcopy(op)
+        new_op.A.layout = CutlassGemmTemplate.flip_cutlass_layout(new_op.A.layout)
+        new_op.B.layout = CutlassGemmTemplate.flip_cutlass_layout(new_op.B.layout)
+        new_op.A, new_op.B = new_op.B, new_op.A
+        new_op.C.layout = CutlassGemmTemplate.flip_cutlass_layout(new_op.C.layout)
+        new_op.D.layout = CutlassGemmTemplate.flip_cutlass_layout(new_op.D.layout)
+        return new_op
+
+    def filter_op(
+        self,
+        op: cutlass_gemm_op.GemmOperation,
+    ) -> cutlass_gemm_op.GemmOperation:
+        # Skip GroupedGemmOperation.
+        if isinstance(op, cutlass_gemm_op.GroupedGemmOperation):
+            return None
+
+        # Skip simt kernels
+        if (
+            op.tile_description.math_instruction.opcode_class
+            == cutlass_lib.OpcodeClass.Simt
+        ):
+            return None
+
+        # Skip sparse kernels
+        if op.gemm_kind == cutlass_lib.GemmKind.Sparse:
+            return None
+
+        # Filter ops by dtypes.
+        X = self.input_nodes[0]
+        W = self.input_nodes[1]
+        accumulator_torch_dtype = cutlass_utils.get_accumulator_dtype(
+            [X.get_dtype(), W.get_dtype()],
+        )
+        if not (
+            cutlass_utils.dtype_match(X.get_dtype(), op.A.element)
+            and cutlass_utils.dtype_match(W.get_dtype(), op.B.element)
+            and cutlass_utils.dtype_match(self.output_node.get_layout().dtype, op.C.element)
+            and cutlass_utils.dtype_match(accumulator_torch_dtype, op.accumulator_type())
+        ):
+            return None
+
+        # Filter ops by input layouts.
+        if not (
+            self.layout_match(X.get_layout(), op.A.layout)
+            and self.layout_match(W.get_layout(), op.B.layout)
+        ):
+            return None
+
+        # Update op.
+        op = copy.deepcopy(op)
+
+        # Set output layout.
+        op.D.layout = CutlassGemmTemplate.cutlass_layout(self.output_node.get_layout())
+
+        # Filter ops by alignments and set alignments.
+        if not (
+            self.set_alignment(X.get_layout(), op.A)
+            and self.set_alignment(W.get_layout(), op.B)
+            and self.set_alignment(self.output_node.get_layout(), op.D)
+        ):
+            return None
+
+        # Set epilogue.
+        # TODO: update epilogue functor according to epilogues.
+        op.element_epilogue = op.accumulator_type()
+
+        # Set bias layout and alignment.
+        if len(self.input_nodes) >= 3 and self.input_nodes[2] is not None:
+            Bias = self.input_nodes[2]
+            op.C.layout = CutlassGemmTemplate.cutlass_layout(Bias.get_layout())
+            if not self.set_alignment(Bias.get_layout(), op.C):
+                return None
+        else:
+            if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+                op.C.element = cutlass_lib.DataType.void
+            else:
+                op.C.layout = op.D.layout
+
+        return op
+
+    def gen_ops(self) -> List[cutlass_gemm_op.GemmOperation]:
+        ops = cutlass_utils.gen_ops()[cutlass_lib.OperationKind.Gemm]
+        res = set()
+        num_3x_ops = 0
+        num_2x_ops = 0
+        for key, op_list in ops.items():
+            for op in op_list:
+                filter_res = self.filter_op(op)
+                if filter_res is not None:
+                    res.add(filter_res)
+        for op in res:
+            if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+                num_3x_ops += 1
+            else:
+                num_2x_ops += 1
+        print(f"Got cutlass configs: {len(res)=}, {num_3x_ops=}, {num_2x_ops=}")
+        return list(res)
+
+    def gemm_mode(self) -> str:
+        sizes = self.output_node.get_size()
+        if len(sizes) > 2:
+            return "cutlass::gemm::GemmUniversalMode::kBatched"
+        else:
+            return "cutlass::gemm::GemmUniversalMode::kGemm"
+
+    def render_gemm_arguments(
+        self,
+        argument_template: str,
+        epilogue_template: str,
+        should_swap_xw: bool,
+        X: IRNode,
+        W: IRNode,
+        Bias: IRNode,
+        Y: IRNode,
+        alpha: float,
+        beta: float,
+        kernel: CUDATemplateKernel,
+    ) -> str:
+        options = dict(
+            alpha=self.alpha,
+            beta=self.beta,
+            X=X,
+            W=W,
+            Y=Y,
+            Bias=Bias,
+            template=self,
+            kernel=kernel,
+            M="M",
+            N="N",
+        )
+
+        if epilogue_template is not None:
+            if should_swap_xw:
+                # Swap
+                def clone_with_transposed_stride(node: IRNode) -> IRNode:
+                    old_layout = node.get_layout()
+                    new_stride = list(old_layout.stride)
+                    new_stride[-2], new_stride[-1] = new_stride[-1], new_stride[-2]
+                    new_layout = FixedLayout(
+                        old_layout.device,
+                        old_layout.dtype,
+                        list(old_layout.size),
+                        new_stride,
+                        old_layout.offset,
+                    )
+                    return Buffer(node.get_name(), new_layout)
+
+                new_X = clone_with_transposed_stride(X)
+                new_W = clone_with_transposed_stride(W)
+                new_Bias = clone_with_transposed_stride(Bias)
+                new_Y = clone_with_transposed_stride(Y)
+                options['X'], options['W'], options['Bias'], options['Y'] = new_W, new_X, new_Bias, new_Y
+                options['M'], options['N'] = "N", "M"
+
+            epilogue_arguments = self._template_from_string(epilogue_template).render(**options)
+            arguments = self._template_from_string(argument_template).render(
+                epilogue_arguments=epilogue_arguments, **options
+            )
+        else:
+            arguments = self._template_from_string(GEMM_ARGS_CUTLASS_2X).render(
+                split_k=1, **options
+            )
+        return arguments
+
+    def render(
+        self,
+        kernel: CUDATemplateKernel,
+        op: cutlass_gemm_op.GemmOperation,
+        output_node: IRNode = None,
+    ) -> str:
+        if output_node is not None:
+            self.output_node = output_node
+        assert len(self.input_nodes) >= 2 and self.output_node is not None
+        X, W = self.input_nodes[0], self.input_nodes[1]
+        Y = self.output_node
+        Bias = None if len(self.input_nodes) == 2 or self.input_nodes[2] is None else self.input_nodes[2]
+
+        epilogue_template: Optional[str] = None
+        argument_template: Optional[str] = None
+        should_swap_xw: bool = False
+
+        if op.gemm_kind == cutlass_lib.GemmKind.Universal3x:
+            if Bias is not None and self.has_tma_epilogue(op):
+                if self.should_swap_XW(Bias, self.beta):
+                    # TMA epilogue requires bias vector in column major to get best perf.
+                    op = self.swap_XW(op)
+                    should_swap_xw = True
+            epilogue_template = GEMM_ARGS_CUTLASS_3X_EPILOGUE
+            argument_template = GEMM_ARGS_CUTLASS_3X
+        else:
+            # TODO: Support split_k.
+            argument_template = GEMM_ARGS_CUTLASS_2X
+
+        instance_definition, instance_type = self.define_gemm_instance(op)
+        options = dict(
+            alpha=self.alpha,
+            beta=self.beta,
+            X=X,
+            W=W,
+            Y=Y,
+            Bias=Bias,
+            epilogue_template=epilogue_template,
+            argument_template=argument_template,
+            should_swap_xw=should_swap_xw,
+            template=self,
+            kernel=kernel,
+            instance_definition=instance_definition,
+            instance_type=instance_type,
+            input_reorder=self.input_reorder,
+        )
+
+        res = self._template_from_string(GEMM_TEMPLATE).render(**options)
+        return res

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -73,9 +73,10 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton.
+# Possible choices are combinations of: ATen, Triton, Cutlass.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor.
+# Cutlass: Cutlass templates and kernels.
 max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON"
 ).upper()
@@ -384,6 +385,36 @@ class triton:
     # extraction and minification functionality.
     # Valid values: "compile_error", "runtime_error", "accuracy"
     inject_relu_bug_TESTING_ONLY = None
+
+
+class cuda:
+    # Whether to enable custom CUDA kernels.
+    # If True, both Triton and custom CUDA kernel codegen are enabled.
+    # If False, only Triton codegen is enabled.
+    enabled = False
+
+    # CUDA arch to use for CUDA template kernel compilation.
+    # Available options: "70", "75", "80", "90"
+    # When arch is None, the Inductor tries to detect CUDA arch by querying
+    # CUDA Python lib or "nvidia-smi" commandline.
+    arch = None
+
+    # CUDA version to use for CUDA template kernel compilation.
+    # e.g. "11.4", "12.1", etc.
+    # When version is None, the Inductor tries to detech CUDA version by
+    # querying CUDA Python lib for "nvidia-smi" commandline.
+    version = "12.1"
+
+    # Optimization level for the host compiler.
+    compile_opt_level = "-O1"
+
+    enable_cuda_lto = False
+
+    enable_ptxas_info = False
+
+    enable_debug_info = False
+
+    use_fast_math = False
 
 
 # create a directory containing lots of debug information

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -85,3 +85,6 @@ class CppCompileError(RuntimeError):
             .strip()
             .format(cmd=" ".join(cmd), output=output)
         )
+
+class CUDACompileError(CppCompileError):
+    pass

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -959,6 +959,7 @@ class GraphLowering(torch.fx.Interpreter):
         linemap = [(line_no, node.stack_trace) for line_no, node in linemap]
         key, path = PyCodeCache.write(code)
         mod = PyCodeCache.load_by_key_path(key, path, linemap=linemap)
+        print(f"pycodecache: {path=}, {mod=}")
         self.cache_key = key
         self.cache_path = path
         self.cache_linemap = linemap

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1532,7 +1532,12 @@ class Scheduler:
 
             if node.is_template():
                 node, *epilogue = node.get_nodes()
-                self.get_backend(device).codegen_template(node, epilogue)
+                if isinstance(node.node, ir.CUDATemplateBuffer):
+                    from .codegen.cuda.cuda_scheduling import CUDAScheduling
+                    CUDAScheduling(self).codegen_template(node, epilogue)
+                else:
+                    self.get_backend(device).codegen_template(node, epilogue)
+
             elif node.is_extern():
                 self.codegen_extern_call(node)
             elif node.is_foreach():


### PR DESCRIPTION
**NOTE: This PR is a prototype to collect early feedback. I'll follow up on splitting it into small PRs and add proper unittests.**

This PR adds cutlass support for simple gemm cases (matmul and linear), without arbitrary epilogue fusions. More support for epilogue fusion will be implemented on top of cutlass epilogue visitor, which is to be released in cutlass 3.2.

### Key changes:
* API:
Introduce "Cutlass" as an alternative backend in `max_autotune_gemm_backends` in torch/_inductor/config.py.
This option is exposed via `torch.compile()` API `options` arg.

* CUDA env:
Add a file torch/_inductor/codegen/cuda/cuda_env.py to get cuda version / arch. Not sure whether there are better ways to do this in Pytorch.

* CUDA / CutlassGemm template:
  * IR: Create `TritonTemplateBuffer` and `CUDATemplateBuffer` subclasses. CUDATemplateBuffer keeps workspace_size which is required by cutlass kernels. Remembering the workspace_size is useful for memory planning.
  * Templates: Create `CUDATemplate` and `CutlassGemmTemplate` for code rendering.
  * Kernel: Create `CUDAKernel` and `CUDATemplateKernel` for code rendering.
  * Scheduling: Create `CUDAScheduling`, which simply inherit from `TritonScheduling`, since it's only used by template codegen instead of more general node fusions. Accordingly, rely on "triton.py" for `codegen_template()` and `can_fuse()` and add simple `if / else` branches for CUDAScheduling. This looks a bit hacky, please suggest better ways.
  * Wrapper: Add changes to support calling from Python to methods defined in .so. Also update memory_planning part to take "workspace_size" into consideration.
 
* CUDA codecache / autotuning
  * Compilation: Add `CUDACodeCache` for CUDA compilation. Currently it relies on nvcc. More follow-ups are needed, e.g. nvrtc, add support for non-linux platform, and add support for internal production environment.
  * Max autotune: Add `TritonBenchmarkRequest` and `CUDABenchmarkRequest` subclasses to handle benchmarking.

* Profiling util
  * I found that current profiling time is very inaccurate as CPU-side overhead is dominant. This PR tries to rely on `torch.profile()` to get accurate timing info. However, one caveat is that it may exclude `vectorized_elementwise_kernel` kernel incorrectly which is used to clear L2 cache.

### Tests:
* Gemm bias / Gemm + matrix tests * A100 / H100 tests all done.
Static shape only. 


### Things to fix in this PR:
* Update max autotune cache file format to also record "workspace_size" for each CUDA kernel. Otherwise if workspace_size > 0 and cache hits, current logic will break.


### Things to fix in follow-up PRs:
* Support AOTInductor.
* Support dynamic shapes.
* Make cutlass profiling more robust. It's possible that selected cutlass configs don't compile. We should either select configs more smartly, or avoid crashing the current process when compilation fails.
* Dedup cutlass configs. It's way too many now.
* Parallel compilation to improve compilation speed. Now it's super slow.
* Parallel benchmarking using multi-GPUs.

### Things to add:
* fp8
* epilogue visitor, general epilogue fusion
* conv kernels

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov