### PR TITLE
[ROCm] Enable hipsolver unit tests for batched linalg drivers

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1620,7 +1620,7 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
     // Now, batched_cublas does not handle rectangular matrices, so we still dispatch to
     // looped_cusolver even if m != n.
 #ifdef USE_ROCM
-    bool looped_correct = true;
+    constexpr bool looped_correct = true;
 #else
     constexpr bool looped_correct = CUSOLVER_VERSION >= 11100;
 #endif

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1620,7 +1620,7 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
     // Now, batched_cublas does not handle rectangular matrices, so we still dispatch to
     // looped_cusolver even if m != n.
 #ifdef USE_ROCM
-	bool looped_correct = true;
+    bool looped_correct = true;
 #else
     constexpr bool looped_correct = CUSOLVER_VERSION >= 11100;
 #endif

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1613,13 +1613,17 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
   };
 
   const auto preferred_backend = at::globalContext().linalgPreferredBackend();
-#if defined(USE_LINALG_SOLVER) && !defined(USE_ROCM)
+#if defined(USE_LINALG_SOLVER)
   const auto lu_factor_cusolver = [batch_size, m, n](const Tensor& input, const Tensor& pivots, const Tensor& infos, bool compute_pivots) {
     // In CUDA 10.2, lu_factor_looped_cusolver does not finish the computations when the input
     // matrix is exactly singular. The returned pivots contain garbage. This breaks linalg.det
     // Now, batched_cublas does not handle rectangular matrices, so we still dispatch to
     // looped_cusolver even if m != n.
+#ifdef USE_ROCM
+	bool looped_correct = true;
+#else
     constexpr bool looped_correct = CUSOLVER_VERSION >= 11100;
+#endif
     if (m != n || (looped_correct && (batch_size == 1 || m >= 512))) {
       lu_factor_looped_cusolver(input, pivots, infos, compute_pivots);
     } else {
@@ -1630,26 +1634,32 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
   if (preferred_backend == at::LinalgBackend::Cusolver) {
     lu_factor_cusolver(input, pivots, infos, compute_pivots);
   } else
-#endif // ifdef USE_LINALG_SOLVER && !USE_ROCM
+#endif // ifdef USE_LINALG_SOLVER
   if (preferred_backend == at::LinalgBackend::Magma) {
     lu_factor_magma(input, pivots, infos, compute_pivots);
   } else {  // preferred backend == default
-#if defined(USE_LINALG_SOLVER) && !defined(USE_ROCM)
+#if defined(USE_LINALG_SOLVER)
 #if AT_MAGMA_ENABLED()
     // If magma batched is buggy, we use cusolver
     // otherwise, lu_factor just works for square matrices, for non-square matrices magma batched is the fastest
     // otherwise (i.e. for square matrices), we choose between cusolver and magma using a heuristic
+    // ROCm: magma_batched is buggy on rocm also. If we are here, we have access to hipSOLVER so always use
+    // it instead of magma
+#if defined(USE_ROCM)
+    lu_factor_cusolver(input, pivots, infos, compute_pivots);
+#else
     if (m == n && (batch_size == 1 || m <= 16 || (m <= 128 && batch_size <= 16))) {
       lu_factor_cusolver(input, pivots, infos, compute_pivots);
     } else {
       lu_factor_batched_magma(input, pivots, infos, compute_pivots);
     }
-#else // USE_LINALG_SOLVER && !AT_MAGMA_ENABLED
+#endif // USE_ROCM
+#else // !AT_MAGMA_ENABLED
     lu_factor_cusolver(input, pivots, infos, compute_pivots);
-#endif
+#endif // AT_MAGMA_ENABLED
 #else // !USE_LINALG_SOLVER
     lu_factor_magma(input, pivots, infos, compute_pivots);
-#endif
+#endif // USE_LINALG_SOLVER
   }
 
   // We return the trivial permutation of pivots starting with 1 (FORTRAN indexing)
@@ -1834,9 +1844,9 @@ void geqrf_magma(const Tensor& input, const Tensor& tau) {
 }
 
 void geqrf_kernel(const Tensor& input, const Tensor& tau) {
-#ifdef CUDART_VERSION
+#if defined(CUDART_VERSION) || defined(USE_ROCM)
   auto geqrf_cusolver_backend = [](const Tensor& input, const Tensor& tau) {
-    #if defined(USE_LINALG_SOLVER) && !defined(USE_ROCM)
+#if defined(USE_LINALG_SOLVER)
       // For the benchmarks see
       // https://github.com/pytorch/pytorch/pull/56253#discussion_r622851107
       if (input.size(-2) <= 256 && batchCount(input) >= std::max<int64_t>(2, input.size(-2) / 16)) {
@@ -1844,7 +1854,7 @@ void geqrf_kernel(const Tensor& input, const Tensor& tau) {
       } else {
         return geqrf_cusolver(input, tau);
       }
-    #endif
+#endif
       return geqrf_batched_cublas(input, tau);
   };
 
@@ -2463,7 +2473,7 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
     }
   };
 
-#ifdef CUDART_VERSION
+#if defined(USE_LINALG_SOLVER)
   auto lu_solve_batched_cublas_fn = [](const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
     auto LU_ = maybe_expand_lu(B, LU);
     auto pivots_ = maybe_expand_pivots(B, pivots);
@@ -2480,7 +2490,7 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
 
   // Preferred Backend
   auto preferred_backend = at::globalContext().linalgPreferredBackend();
-#if defined(USE_LINALG_SOLVER) && !defined(USE_ROCM)
+#if defined(USE_LINALG_SOLVER)
   if (preferred_backend == at::LinalgBackend::Cusolver) {
     if (b <= 2 && n >= 64) {
       lu_solve_looped_cusolver(LU, pivots, B, trans);
@@ -2489,7 +2499,7 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
     }
     return;
   } else
-#endif // ifdef USE_LINALG_SOLVER && !USE_ROCM
+#endif // ifdef USE_LINALG_SOLVER
   if (preferred_backend == at::LinalgBackend::Magma) {
     // Looped magma is very slow, but batched magma is buggy in these two cases
     if (!over_batched_magma_dim_limit && trans == TransposeType::NoTranspose) {
@@ -2526,21 +2536,19 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
   //}
   //}
 
+
+#if defined(USE_LINALG_SOLVER)
   // Particular case when multiplying A^{-1}B where B is square
   // In this case doing two triangular solves is almost always fastest
   if (n == k) {
-#ifdef CUDART_VERSION
     if (n <= 16) {
       lu_solve_batched_cublas_fn(LU, pivots, B, trans);
       return;
     }
-#endif
     lu_solve_triangular(LU, pivots, B, trans);
     return;
   }
 
-#ifdef CUDART_VERSION
-#if defined(USE_LINALG_SOLVER) && !defined(USE_ROCM)
 if (n <= 8) {
   if (use_magma_ && !over_batched_magma_dim_limit && trans == TransposeType::NoTranspose && k >= 256) {
     lu_solve_batched_magma_fn(LU, pivots, B, trans);
@@ -2566,11 +2574,11 @@ if (n <= 8) {
 } else { // n > 128
   lu_solve_triangular(LU, pivots, B, trans);
 }
-#endif // ifdef USE_LINALG_SOLVER && !USE_ROCM
-#else  // No cublas or cusolver
+#else
+  // No cublas or cusolver
   // lu_solve_triangular is almost always best
   lu_solve_triangular(LU, pivots, B, trans);
-#endif // ifdef CUDART_VERSION
+#endif // ifdef USE_LINALG_SOLVER
 }
 
 REGISTER_CUDA_DISPATCH(lu_solve_stub, &lu_solve_kernel);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2729,7 +2729,6 @@ class TestLinalg(TestCase):
     @slowTest
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
-    @skipCUDAIfRocm
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 2e-3, torch.complex64: 2e-3,
                         torch.float64: 1e-5, torch.complex128: 1e-5})
@@ -2772,7 +2771,6 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
     @onlyNativeDeviceTypes   # TODO: XLA doesn't raise exception
-    @skipCUDAIfRocm
     @dtypes(*floating_and_complex_types())
     def test_inverse_errors_large(self, device, dtype):
         # Test batched inverse of singular matrices reports errors without crashing (gh-51930)
@@ -4057,7 +4055,6 @@ class TestLinalg(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Test fails for float64 on GPU (P100, V100) on Meta infra")
     @onlyCUDA
     @skipCUDAIfNoMagma  # Magma needed for the PLU decomposition
-    @skipCUDAIfRocm  # There is a memory access bug in rocBLAS in the (non-batched) solve_triangular
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
@@ -7157,7 +7154,6 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         if self.device_type == 'cuda':
             sub_test(False)
 
-    @skipCUDAIfRocm  # ROCm: test was exceptionally slow, even for slow tests. Skip until triage.
     @slowTest
     @skipCPUIfNoLapack
     @skipCUDAIfNoMagmaAndNoCusolver


### PR DESCRIPTION
This is a follow up to https://github.com/pytorch/pytorch/pull/105881 and replaces https://github.com/pytorch/pytorch/pull/103203

The batched linalg drivers from 103203 were brought in as part of the first PR. This change enables the ROCm unit tests that were enabled as a result of that change. Along with a fix to prioritize hipsolver over magma when the preferred linalg backend is set to `default`
The following 16 unit tests will be enabled for rocm in this change:
- test_inverse_many_batches_cuda*
- test_inverse_errors_large_cuda*
- test_linalg_solve_triangular_large_cuda*
- test_lu_solve_batched_many_batches_cuda*


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang