### PR TITLE
[Compiled Autograd] Fix bug with multithreading check

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest import mock
 
 import torch
+import torch.nn as nn
 from torch import _inductor as inductor
 from torch._dynamo import compiled_autograd
 from torch._dynamo.test_case import run_tests, TestCase
@@ -268,6 +269,77 @@ class TestCompiledAutograd(TestCase):
                 yield b_grad.clone()
 
         self.check_output_and_recompiles(fn, count=1)
+
+    @unittest.skipIf(not HAS_CUDA, "requires cuda")
+    def test_issue106555(self):
+        DEVICE = torch.device("cuda:0")
+        NUM_FEATURES = 256
+
+        def bias_sigmoid_mul(x1, x2, bias):
+            x2 = torch.sigmoid(x2 + bias)
+            y = x1 * x2
+            return y
+
+        bias_sigmoid_mul_jit = torch.compile(bias_sigmoid_mul)
+
+        class ModuleWithJit(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear_1 = nn.Linear(NUM_FEATURES, NUM_FEATURES, bias=True)
+                self.linear_2 = nn.Linear(NUM_FEATURES, NUM_FEATURES, bias=False)
+                self.linear_2_bias = nn.Parameter(torch.zeros(NUM_FEATURES))
+
+            def forward(self, input_tensor):
+                x1 = self.linear_1(input_tensor)
+                x2 = self.linear_2(input_tensor)
+                output = bias_sigmoid_mul_jit(x1, x2, self.linear_2_bias)
+                return output
+
+            class Model(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.module_with_jit_1 = ModuleWithJit()
+                    self.module_with_jit_2 = ModuleWithJit()
+
+                def forward(self, x, gradient_checkpointing: bool):
+                    if gradient_checkpointing:
+                        y = torch.utils.checkpoint.checkpoint(
+                            self._forward, x, use_reentrant=True
+                        )
+                    else:
+                        y = self._forward(x)
+                    return y
+
+                def _forward(self, x):
+                    x = x + self.module_with_jit_1(x)
+                    x = x + self.module_with_jit_2(x.transpose(-2, -3)).transpose(
+                        -2, -3
+                    )
+                    return x
+
+            torch.cuda.set_device(device=DEVICE)
+            torch.manual_seed(1234567890)
+            model = Model()
+            model.train()
+            model.to(device=DEVICE)
+            model_parameters = list(model.parameters())
+
+            torch.manual_seed(1234567890)
+            input_tensor = torch.randn(1, 128, 256, NUM_FEATURES).to(device=DEVICE)
+            input_tensor.requires_grad = True
+            target_tensor = torch.randn(1, 128, 256, NUM_FEATURES).to(
+                dtype=input_tensor.dtype, device=DEVICE
+            )
+
+            for iteration in range(10):
+                for param in model_parameters:
+                    param.grad = None
+                output_tensor = model(
+                    x=input_tensor.clone(),
+                    gradient_checkpointing=True,
+                )
+                loss = torch.mean(torch.abs(target_tensor - output_tensor))
+                loss.backward()
 
 
 def load_test_module(name):

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -166,7 +166,8 @@ def enable(compiler_fn):
     prior = torch._C._dynamo.compiled_autograd.set_autograd_compiler(
         functools.partial(AutogradCompilerInstance, compiler_fn)
     )
-    yield
+    with torch.autograd.set_multithreading_enabled(False):
+        yield
     torch._C._dynamo.compiled_autograd.set_autograd_compiler(prior)
 
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1369,6 +1369,9 @@ Engine& Engine::get_default_engine() {
 }
 
 void Engine::set_compiled_autograd(Engine::compiled_autograd_fn fn) {
+  if (the_compiled_autograd.load() == fn) {
+    return;
+  }
   auto prior = the_compiled_autograd.exchange(COMPILED_AUTOGRAD_POISON);
   TORCH_CHECK(
       num_threads_in_backwards.load() == 0 && prior != COMPILED_AUTOGRAD_POISON,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106621

Fixes #106555

There was bug where the multithreading check would fire because of the
`compiled_autograd.disable()` calls in AotAutograd, even though compiled
autograd was already disabled, so that call was doing nothing.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305