### PR TITLE
Dynamo debug decorator

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -5,6 +5,7 @@ from .convert_frame import replay
 from .decorators import (
     allow_in_graph,
     assume_constant_result,
+    debug,
     disable,
     disallow_in_graph,
     forbid_in_graph,
@@ -53,6 +54,7 @@ __all__ = [
     "is_compiling",
     "register_backend",
     "list_backends",
+    "debug",
 ]
 
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -180,6 +180,7 @@ def has_tensor_in_frame(frame):
             seen_ids[obj_id] = False
             return seen_ids[obj_id]
         elif is_namedtuple(obj):
+            # print(obj)
             seen_ids[obj_id] = any(has_tensor(getattr(obj, v)) for v in obj._fields)
             return seen_ids[obj_id]
         else:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -180,7 +180,6 @@ def has_tensor_in_frame(frame):
             seen_ids[obj_id] = False
             return seen_ids[obj_id]
         elif is_namedtuple(obj):
-            # print(obj)
             seen_ids[obj_id] = any(has_tensor(getattr(obj, v)) for v in obj._fields)
             return seen_ids[obj_id]
         else:

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -52,6 +52,12 @@ class DebugFlags:
 # under the hood for this fn.Nothing in the implementation of the decorator or the internal
 # logic is overly opinionated on it being a function. It should be very easy to extend this
 # to globals, modules, methods, etc as needed (some of these might already just work?).
+#
+# Future ways to extend this:
+# - Cover entrance frame fn
+# - Extend to guards (debug guard fn, but also to debug the associated guard of a decorated fn)
+# - More objects
+# - More flags (stacktraces, etc)
 def debug(fn, flags=DebugFlags()):
     assert callable(fn)
     fn._dynamo_debug_flagged = flags

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -210,6 +210,10 @@ class VariableBuilder:
             vt = self.tx.output.side_effects.track_object_existing(
                 self.source, value, vt
             )
+        if hasattr(value, "_dynamo_debug_flagged"):
+            # Note(voz): This should cover *most* things, certainly all inputs, user defined
+            # functions. See note - On Extending Debug
+            vt.set_debug_flags(value._dynamo_debug_flagged)
         return vt
 
     def _can_lift_attrs_to_inputs(self, vt):

--- a/torch/testing/_internal/logging_utils.py
+++ b/torch/testing/_internal/logging_utils.py
@@ -7,15 +7,7 @@ import torch._logging._internal
 from torch._dynamo.utils import LazyString
 import logging
 
-@contextlib.contextmanager
-def preserve_log_state():
-    prev_state = torch._logging._internal._get_log_state()
-    torch._logging._internal._set_log_state(torch._logging._internal.LogState())
-    try:
-        yield
-    finally:
-        torch._logging._internal._set_log_state(prev_state)
-        torch._logging._internal._init_logs()
+preserve_log_state = torch._dynamo.utils.preserve_log_state
 
 def log_settings(settings):
     exit_stack = contextlib.ExitStack()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106625

Dynamo debug decorator

```
@torch._dynamo.debug
def inner_foo(x):
    return x * x

def fn(x, y):
    x2 = inner_foo(x)
    return x2 * y


x = torch.rand([4, 10])
y = torch.rand([4, 10])

torch._dynamo.optimize("eager")(fn)(x, y)
```
Output:
```
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG] INLINING <code object inner_foo at 0x7fd962616e40, file "/scratch/voz/work/pytorch/x.py", line 7>
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG]   9           0 LOAD_FAST                0 (x)
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG]               2 LOAD_FAST                0 (x)
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG]               4 BINARY_MULTIPLY
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG]               6 RETURN_VALUE
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG] 
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert.__trace_source: [DEBUG] TRACE starts_line inner_foo /scratch/voz/work/pytorch/x.py:7 (inline depth: 1)
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert.__trace_source: [DEBUG]     @torch._dynamo.debug
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert.__trace_source: [DEBUG] TRACE starts_line inner_foo /scratch/voz/work/pytorch/x.py:9 (inline depth: 1)
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert.__trace_source: [DEBUG]         return x * x
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG] TRACE LOAD_FAST x []
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG] TRACE LOAD_FAST x [TensorVariable()]
[2023-08-04 17:48:38,550] torch._dynamo.symbolic_convert: [DEBUG] TRACE BINARY_MULTIPLY None [TensorVariable(), TensorVariable()]
[2023-08-04 17:48:38,555] torch._dynamo.symbolic_convert: [DEBUG] TRACE RETURN_VALUE None [TensorVariable()]
[2023-08-04 17:48:38,555] torch._dynamo.symbolic_convert: [DEBUG] DONE INLINING <code object inner_foo at 0x7fd962616e40, file "/scratch/voz/work/pytorch/x.py", line 7>
```
And drops a breakpoint in.

cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @ipiszy