### PR TITLE
[inductor][fx passes] add tensor size limit for group fusion and enable batch fusion

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -52,7 +52,7 @@ split_cat_fx_passes = True
 group_fusion = False
 
 # enable pattern match with batch fusion (using torch op)
-batch_fusion = False
+batch_fusion = True
 
 # enable reordering pass
 reordering = True

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -26,8 +26,10 @@ aten = torch.ops.aten
 log = logging.getLogger(__name__)
 
 MIN_FUSE_SET_SIZE = 5
-MAX_FUSE_SET_SIZE = 100
+MAX_FUSE_SET_SIZE = 300
 MAX_FUSE_SEARCH_DEPTH = 5
+# The maximum tensor size that can go into the fusion group
+MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR = 4096
 
 
 class GroupBatchFusionBase:
@@ -64,6 +66,8 @@ class GroupLinearFusion(GroupFusion):
             and len(input_shape) == 2
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
+            and shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+            for shape in input_shape + weight_shape
         )
 
     def _mm_node_can_be_fused(self, node):
@@ -73,6 +77,8 @@ class GroupLinearFusion(GroupFusion):
             len(input_shape) == 2
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
+            and shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+            for shape in input_shape + weight_shape
         )
 
     def match(self, node):


### PR DESCRIPTION
Summary:
Add threshhold for max size. if tensor size> threshold, we will not fuse them.

Enable batch_fusion by default since we have found consistent qps gain and ne neutral.

Test Plan:
Some local test result in: https://docs.google.com/document/d/1-qNuvGejhGgwKmRVTbz98_-SVu_fMoKgFcxyxrNMH_M/edit
4096 should be a better threshold for ads cmf model.
f465511761
f465519705
4.8% qps gain
 {F1064213077}
ne neutral
 {F1064214423}

Reviewed By: yanboliang

Differential Revision: D48042826



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov