### PR TITLE
[Pytorch][Vulkan] aten::flip

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/flip.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/flip.glsl
@@ -1,0 +1,77 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // x=width, y=height, z=channel, w=batch
+  uvec4 extents;
+  // x=width, y=height, z=channel, w=batch
+  // 1=flip, 0=noflip
+  ivec4 dims;
+}
+uBlock;
+
+/*
+ * Local Work Group Size
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Returns a new tensor with values flipped along dimension dim
+ */
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  int flattened_channels = int(ceil(uBlock.extents.z / 4.0));
+  vec4 out_texel = vec4(0, 0, 0, 0);
+  uint src_x = pos.x;
+  uint src_y = pos.y;
+  uint src_z = pos.z;
+
+  // Width
+  if (uBlock.dims.x == 1) {
+    src_x = uBlock.extents.x - 1 - pos.x;
+  }
+
+  // Height
+  if (uBlock.dims.y == 1) {
+    src_y = uBlock.extents.y - 1 - pos.y;
+  }
+
+  // Batch
+  if (uBlock.dims.w == 1) {
+    uint n = pos.z / flattened_channels;
+    uint src_n = uBlock.extents.w - 1 - n;
+    uint c_div4 = pos.z - n * flattened_channels;
+    src_z = src_n * flattened_channels + c_div4;
+  }
+
+  uint prev_src_z = src_z; // save this
+  for (int p = 0; p < 4; p++) {
+    uint src_p = p;
+
+    // Channel
+    if (uBlock.dims.z == 1) {
+      // n * [C/4]
+      uint nc = (pos.z / flattened_channels) * flattened_channels;
+      // i / 4
+      uint c_div4 = pos.z - nc;
+      uint c = c_div4 * 4 + p;
+      uint src_c = uBlock.extents.z - 1 - c;
+
+      src_z = (uBlock.dims.w == 1)
+          ? prev_src_z - c_div4 + src_c / 4 // Batch and Channel
+          : nc + src_c / 4; // Channel only
+      src_p = src_c % 4;
+    }
+
+    vec4 v = texelFetch(uInput, ivec3(src_x, src_y, src_z), 0);
+    out_texel[p] = v[src_p];
+    imageStore(uOutput, pos, out_texel);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Flip.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Flip.cpp
@@ -1,0 +1,104 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor flip(const at::Tensor& self, const IntArrayRef dim_list) {
+  TORCH_CHECK(
+      self.dim() >= 1 || self.dim() <= 4,
+      "Vulkan flip supports up to 4d tensors as input!");
+
+  // Get the global Vulkan context
+  api::Context* const context = api::context();
+
+  // Cast the input Tensor to a vTensor
+  const Tensor input = self.is_vulkan() ? self : self.vulkan();
+  const vTensor& v_input = convert(input);
+
+  // Create the output texture
+  vTensor v_output{
+      context,
+      self.sizes().vec(),
+      self.scalar_type(),
+  };
+
+  // Required to determine how to insert memory barriers in the command buffer
+  api::PipelineBarrier pipeline_barrier{};
+
+  // Create dim args
+  std::vector<int32_t> dim_args = {0, 0, 0, 0};
+  for (const auto dim : dim_list) {
+    TORCH_CHECK(
+        dim >= -self.dim() - 1 && dim <= self.dim(),
+        "Vulkan flip dimension out of range expected to be in range of [",
+        -self.dim() - 1,
+        ",",
+        self.dim(),
+        "], but got ",
+        dim);
+    // Normalize
+    int normalized_dim = utils::normalize(dim, self.dim());
+
+    // Shift into 4d range
+    if (self.dim() < 4) {
+      normalized_dim += (4 - self.dim());
+    }
+    dim_args[normalized_dim] = 1;
+  }
+
+  // Create the params buffer
+  const struct Block final {
+    uvec4 extents;
+    ivec4 dims;
+  } block{
+      {get_dim<Dim4D::Width>(v_output),
+       get_dim<Dim4D::Height>(v_output),
+       get_dim<Dim4D::Channel>(v_output),
+       get_dim<Dim4D::Batch>(v_output)},
+      {dim_args[3], dim_args[2], dim_args[1], dim_args[0]},
+  };
+
+  api::UniformParamsBuffer params(context, block);
+
+  context->submit_compute_job(
+      // shader descriptor
+      VK_KERNEL(flip),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      // params buffer
+      params.buffer());
+  return convert(v_output);
+};
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::flip"), TORCH_FN(flip));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1808,6 +1808,69 @@ TEST_F(VulkanAPITest, expand_as) {
   ASSERT_TRUE(check);
 }
 
+void test_flip(const at::IntArrayRef input_shape, const at::IntArrayRef dim_list) {
+  c10::InferenceMode mode;
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  const auto out_cpu = at::flip(in_cpu, dim_list);
+  const auto out_vulkan = at::flip(in_vulkan, dim_list);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+    std::cout << "test flip failed with input_shape: " << input_shape
+              << " and dim_list: " << dim_list << std::endl;
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, flip_1d) {
+  test_flip({5}, {0});
+  test_flip({5}, {-1});
+}
+
+TEST_F(VulkanAPITest, flip_2d) {
+  test_flip({5, 5}, {-1});
+  test_flip({2, 7}, {-2});
+
+  test_flip({5, 5}, {0, 1});
+}
+
+TEST_F(VulkanAPITest, flip_3d) {
+  test_flip({5, 7, 5}, {-1});
+  test_flip({2, 9, 7}, {-2});
+  test_flip({9, 7, 5}, {-3});
+
+  test_flip({10, 7, 5}, {0, 1});
+  test_flip({10, 7, 5}, {0, 2});
+  test_flip({10, 7, 5}, {1, 2});
+
+  test_flip({10, 7, 5}, {2, 1, 0});
+}
+
+TEST_F(VulkanAPITest, flip_4d) {
+  test_flip({2, 9, 1, 1}, {-1});
+  test_flip({7, 5, 9, 3}, {-2});
+  test_flip({3, 8, 5, 2}, {-3});
+  test_flip({7, 9, 5, 3}, {-4});
+
+  test_flip({10, 7, 5, 6}, {0, 1});
+  test_flip({10, 7, 5, 6}, {0, 2});
+  test_flip({10, 7, 5, 6}, {0, 3});
+  test_flip({10, 7, 5, 6}, {1, 2});
+  test_flip({10, 7, 5, 6}, {1, 3});
+  test_flip({10, 7, 5, 6}, {2, 3});
+
+  test_flip({10, 7, 5, 6}, {0, 1, 2});
+  test_flip({10, 7, 5, 6}, {0, 1, 3});
+  test_flip({10, 7, 5, 6}, {0, 2, 3});
+  test_flip({10, 7, 5, 6}, {3, 2, 1});
+
+  test_flip({10, 7, 5, 6}, {3, 2, 1, 0});
+}
+
 TEST_F(VulkanAPITest, gelu) {
   const auto in_cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_vulkan = in_cpu.vulkan();


### PR DESCRIPTION
Summary:
https://pytorch.org/docs/stable/generated/torch.flip.html

Implement flip for vulkan.

For batch and channel cases:
- Calculate the logical tensor values of N and C from pos.xyz
- Flip the logical tensor value of N, C or both
- Use `n*[C/4] + i/4, i%4` to get the new tensor value

Test Plan:
New tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*flip*"
Recommended: Free up disk space to speed up builds.

  Only 17GB is available on disk. Buck is slow when free disk space is under
  50GB.

  Consider running this command (from your home directory) to reclaim purgeable
  space:

  sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -P *

Downloaded 0/53 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 35.3 sec (100%) 536/536 jobs, 6/536 updated
  Total time: 35.3 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *flip*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.flip_1d
[       OK ] VulkanAPITest.flip_1d (117 ms)
[ RUN      ] VulkanAPITest.flip_2d
[       OK ] VulkanAPITest.flip_2d (1 ms)
[ RUN      ] VulkanAPITest.flip_3d
[       OK ] VulkanAPITest.flip_3d (2 ms)
[ RUN      ] VulkanAPITest.flip_4d
[       OK ] VulkanAPITest.flip_4d (10 ms)
[----------] 4 tests from VulkanAPITest (132 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (132 ms total)
[  PASSED  ] 4 tests.
lfq@lfq-mbp fbsource %
```

clang-format on `Flip.cpp` and `flip.glsl`

Reviewed By: SS-JIA

Differential Revision: D47921025

