### PR TITLE
Add quantization support to reshape and size for the ONNX exporter

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -315,8 +315,10 @@ def quantized_args(
     *arg_q_descriptors: bool,
     scale: Optional[float] = None,
     zero_point: Optional[int] = None,
+    quantize_output: bool = True,
 ):
     """A decorator which extends support for quantized version of the base operator.
+
     Quantization is detected by examining the arguments that are annotated by
     `arg_q_descriptors`.
 
@@ -353,6 +355,7 @@ def quantized_args(
           the first quantized input scale.
         zero_point: Quantized output zero point. If None,
           derive from the first quantized input zero point.
+        quantize_output: If True, quantize the output of the base operator. Default is True
     """
 
     def decorator(fn):
@@ -435,7 +438,9 @@ def quantized_args(
                 _zero_point is not None
             ), "Bug: Zero point must be set for quantized operator"
 
-            return quantize_helper(g, output, _scale, _zero_point)
+            if quantize_output:
+                return quantize_helper(g, output, _scale, _zero_point)
+            return output
 
         return wrapper
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -900,6 +900,7 @@ def _dim_arange(g: jit_utils.GraphContext, like, dim):
 
 
 @_onnx_symbolic("aten::size")
+@symbolic_helper.quantized_args(True, quantize_output=False)
 @_beartype.beartype
 def size(g: jit_utils.GraphContext, self, dim=None):
     if dim is None:

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -57,6 +57,7 @@ def triu(g: jit_utils.GraphContext, self, diagonal, out=None):
 
 
 @_onnx_symbolic("aten::reshape")
+@symbolic_helper.quantized_args(True)
 @symbolic_helper.parse_args("v", "v")
 @_beartype.beartype
 def reshape(g: jit_utils.GraphContext, self, shape):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1076,6 +1076,7 @@ def embedding_bag(
 
 
 @_onnx_symbolic("aten::size")
+@symbolic_helper.quantized_args(True, quantize_output=False)
 @_beartype.beartype
 def size(g: jit_utils.GraphContext, self, dim=None):
     if dim is None:


### PR DESCRIPTION
Fixes https://github.com/microsoft/onnx-converters-private/issues/175

Add quantization support for Reshape-14, Size-9 and Size-11
For Size operators, we don't requantize outputs because we want the original scalar in the graph