### PR TITLE
Add missing quantize per tensor vulkan backend function

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/QuantizedFunctions.h
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedFunctions.h
@@ -11,6 +11,12 @@ Tensor quantize_per_tensor(
     const int64_t zero_point,
     const c10::ScalarType dtype);
 
+Tensor quantize_per_tensor_tensor_qparams(
+    const at::Tensor& input_arg,
+    const at::Tensor& scale,
+    const at::Tensor& zero_point,
+    const c10::ScalarType dtype);
+
 Tensor dequantize_helper(
     const at::Tensor& input_arg,
     const double scale,

--- a/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
@@ -83,6 +83,18 @@ Tensor quantize_per_tensor(
   return convert_quantized(v_output);
 }
 
+Tensor quantize_per_tensor_tensor_qparams(
+    const at::Tensor& input_arg,
+    const at::Tensor& scale,
+    const at::Tensor& zero_point,
+    const c10::ScalarType dtype) {
+  TORCH_CHECK(
+      (scale.numel() == 1 && zero_point.numel() == 1),
+      "Only 1 element expected in scale and zero_point");
+  return quantize_per_tensor(
+      input_arg, scale.item().toDouble(), zero_point.item().toLong(), dtype);
+}
+
 // helper for dequantize function to use scale and zero_point
 Tensor dequantize_helper(
     const at::Tensor& input_arg,
@@ -154,6 +166,9 @@ Tensor dequantize(const Tensor& self) {
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("aten::quantize_per_tensor"), quantize_per_tensor);
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::quantize_per_tensor.tensor_qparams"),
+      quantize_per_tensor_tensor_qparams);
   m.impl(TORCH_SELECTIVE_NAME("aten::dequantize.self"), dequantize);
 }
 


### PR DESCRIPTION
Summary: Add missing function for vulkan namespace for quantization

Test Plan:
Check that a quantized model runs on Vulkan.
Notebook tested: https://www.internalfb.com/intern/anp/view/?id=4045081

Differential Revision: D48047516

