### PR TITLE
add a debug api to extract cache entry from code

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -101,6 +101,11 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         entries = _debug_get_cache_entry_list(g.__code__)
         self.assertTrue(len(entries) == 0)
 
+        try:
+            _debug_get_cache_entry_list(1)
+        except TypeError as e:
+            self.assertIn("expected a code object!", str(e))
+
     def test_boolarg(self):
         def boolarg(aa, bb, flag):
             if flag:

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -39,7 +39,7 @@ from torch._dynamo.testing import (
 )
 
 from torch._dynamo.utils import CompileProfiler, ifdynstaticdefault
-from torch._dynamo.utils import _debug_get_cache_entry_list
+from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -27,6 +27,7 @@ import torch._dynamo.testing
 import torch.onnx.operators
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph, bytecode_analysis, bytecode_transformation
+from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch._dynamo.exc import Unsupported
 from torch._dynamo.source import GetItemSource, LocalSource
 from torch._dynamo.testing import (
@@ -39,7 +40,6 @@ from torch._dynamo.testing import (
 )
 
 from torch._dynamo.utils import CompileProfiler, ifdynstaticdefault
-from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig
@@ -90,11 +90,14 @@ class MiscTests(torch._dynamo.test_case.TestCase):
     def test_get_cache_entry(self):
         def f(x):
             return x + 1
+
         torch.compile(f)(torch.randn(5, 5, 5))
         entries = _debug_get_cache_entry_list(f.__code__)
         self.assertTrue(len(entries) > 0)
+
         def g(x):
             return x + 2
+
         entries = _debug_get_cache_entry_list(g.__code__)
         self.assertTrue(len(entries) == 0)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -39,6 +39,7 @@ from torch._dynamo.testing import (
 )
 
 from torch._dynamo.utils import CompileProfiler, ifdynstaticdefault
+from torch._dynamo.utils import _debug_get_cache_entry_list
 from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig
@@ -86,6 +87,17 @@ qconfig_dict = {"object_type": [(torch.nn.Linear, uniform_qconfig_8bit)]}
 
 
 class MiscTests(torch._dynamo.test_case.TestCase):
+    def test_get_cache_entry(self):
+        def f(x):
+            return x + 1
+        torch.compile(f)(torch.randn(5, 5, 5))
+        entries = _debug_get_cache_entry_list(f.__code__)
+        self.assertTrue(len(entries) > 0)
+        def g(x):
+            return x + 2
+        entries = _debug_get_cache_entry_list(g.__code__)
+        self.assertTrue(len(entries) == 0)
+
     def test_boolarg(self):
         def boolarg(aa, bb, flag):
             if flag:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -14,6 +14,7 @@ import traceback
 import types
 import warnings
 import weakref
+from collections import namedtuple
 from enum import Enum
 from os.path import dirname, join
 from typing import (
@@ -29,7 +30,6 @@ from typing import (
     Union,
 )
 from unittest.mock import patch
-from collections import namedtuple
 
 import torch
 import torch.fx
@@ -98,7 +98,6 @@ DONT_WRAP_FILES = {
     inspect.getsourcefile(GraphModule),
     join(dirname(dirname(__file__)), "onnx/_internal/fx/dynamo_graph_extractor.py"),
 }
-
 
 
 CacheEntry = namedtuple("CacheEntry", "check_fn, code")

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -106,7 +106,7 @@ CacheEntry = namedtuple("CacheEntry", "check_fn, code")
 
 def _debug_get_cache_entry_list(code):
     cache_list = torch._C._dynamo.eval_frame._debug_get_cache_entry_list(code)
-    return map(CacheEntry._make, cache_list)
+    return list(map(CacheEntry._make, cache_list))
 
 
 class OptimizedModule(torch.nn.Module):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -29,6 +29,7 @@ from typing import (
     Union,
 )
 from unittest.mock import patch
+from collections import namedtuple
 
 import torch
 import torch.fx
@@ -99,7 +100,6 @@ DONT_WRAP_FILES = {
 }
 
 
-from collections import namedtuple
 
 CacheEntry = namedtuple("CacheEntry", "check_fn, code")
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -103,7 +103,10 @@ DONT_WRAP_FILES = {
 CacheEntry = namedtuple("CacheEntry", "check_fn, code")
 
 
-def _debug_get_cache_entry_list(code):
+def _debug_get_cache_entry_list(code: types.CodeType) -> List[CacheEntry]:
+    """
+    Given a code object, retrieve the cache entries stored in this code.
+    """
     cache_list = torch._C._dynamo.eval_frame._debug_get_cache_entry_list(code)
     return list(map(CacheEntry._make, cache_list))
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -99,6 +99,16 @@ DONT_WRAP_FILES = {
 }
 
 
+from collections import namedtuple
+
+CacheEntry = namedtuple("CacheEntry", "check_fn, code")
+
+
+def _debug_get_cache_entry_list(code):
+    cache_list = torch._C._dynamo.eval_frame._debug_get_cache_entry_list(code)
+    return map(CacheEntry._make, cache_list)
+
+
 class OptimizedModule(torch.nn.Module):
     """
     Wraps the original nn.Module object and later patches its

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2047,10 +2047,14 @@ def is_guard_failure_reporting_enabled():
         or torch._logging._internal.log_state.is_artifact_enabled("recompiles")
     )
 
+
 from collections import namedtuple
-CacheEntry = namedtuple('CacheEntry', 'check_fn, code')
+
+CacheEntry = namedtuple("CacheEntry", "check_fn, code")
+
 
 def _debug_get_cache_entry_list(code):
     from torch._C._dynamo.eval_frame import _debug_get_cache_entry_list
+
     cache_list = _debug_get_cache_entry_list(code)
     return map(CacheEntry._make, cache_list)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2046,15 +2046,3 @@ def is_guard_failure_reporting_enabled():
         config.report_guard_failures
         or torch._logging._internal.log_state.is_artifact_enabled("recompiles")
     )
-
-
-from collections import namedtuple
-
-CacheEntry = namedtuple("CacheEntry", "check_fn, code")
-
-
-def _debug_get_cache_entry_list(code):
-    from torch._C._dynamo.eval_frame import _debug_get_cache_entry_list
-
-    cache_list = _debug_get_cache_entry_list(code)
-    return map(CacheEntry._make, cache_list)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2046,3 +2046,11 @@ def is_guard_failure_reporting_enabled():
         config.report_guard_failures
         or torch._logging._internal.log_state.is_artifact_enabled("recompiles")
     )
+
+from collections import namedtuple
+CacheEntry = namedtuple('CacheEntry', 'check_fn, code')
+
+def _debug_get_cache_entry_list(code):
+    from torch._C._dynamo.eval_frame import _debug_get_cache_entry_list
+    cache_list = _debug_get_cache_entry_list(code)
+    return map(CacheEntry._make, cache_list)

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -337,25 +337,8 @@ PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
     return NULL;  // Return NULL if failed to create list
   }
   while (current_node != NULL) {
-    // Creating a new Python list for the check_fn and code of current CacheEntry
-    PyObject* inner_list = PyList_New(0);
-    if (!inner_list) {
-      Py_DECREF(outer_list);  // Clean up if failed to create list
-      return NULL;
-    }
-
-    // Add the check_fn and code to the inner list
-    if (PyList_Append(inner_list, current_node->check_fn) < 0) {
-      Py_DECREF(outer_list);
-      Py_DECREF(inner_list);  // Clean up if failed to append
-      return NULL;
-    }
-    if (PyList_Append(inner_list, (PyObject*)current_node->code) < 0) {
-      Py_DECREF(outer_list);
-      Py_DECREF(inner_list);  // Clean up if failed to append
-      return NULL;
-    }
-
+    // Creating a new Python tuple for the check_fn and code of current CacheEntry
+    PyObject* inner_list = PyTuple_Pack(2, current_node->check_fn, current_node->code);
     // Add the inner list to the outer list
     if (PyList_Append(outer_list, inner_list) < 0) {
       Py_DECREF(outer_list);

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -321,11 +321,14 @@ inline static CacheEntry* get_cache_entry(PyCodeObject* code) {
 }
 
 PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
-  PyObject* my_object;
-  if (!PyArg_ParseTuple(args, "O", &my_object)) {
+  PyObject* object;
+  if (!PyArg_ParseTuple(args, "O", &object)) {
     return NULL;
   }
-  PyCodeObject* code = (PyCodeObject*)my_object;
+  if (!PyCode_Check(object)) {
+    PyErr_SetString(PyExc_TypeError, "expected a code object!");
+  }
+  PyCodeObject* code = (PyCodeObject*)object;
 
   CacheEntry* current_node = get_cache_entry(code);
 

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -339,10 +339,10 @@ PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
   while (current_node != NULL && current_node != SKIP_CODE) {
     // Creating a new Python tuple for the check_fn and code of current CacheEntry
     PyObject* inner_list = PyTuple_Pack(2, current_node->check_fn, current_node->code);
-    // Add the inner list to the outer list
-    if (PyList_Append(outer_list, inner_list) < 0) {
-      Py_DECREF(outer_list);
-      Py_DECREF(inner_list);  // Clean up if failed to append
+    int flag = PyList_Append(outer_list, inner_list);  // Add the inner list to the outer list
+    Py_DECREF(inner_list);  // Decrement our own reference
+    if (flag < 0) {
+      Py_DECREF(outer_list);  // Clean up if failed to append
       return NULL;
     }
 

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -327,6 +327,7 @@ PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
   }
   if (!PyCode_Check(object)) {
     PyErr_SetString(PyExc_TypeError, "expected a code object!");
+    return NULL;
   }
   PyCodeObject* code = (PyCodeObject*)object;
 

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -336,7 +336,7 @@ PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
   if (!outer_list) {
     return NULL;  // Return NULL if failed to create list
   }
-  while (current_node != NULL) {
+  while (current_node != NULL && current_node != SKIP_CODE) {
     // Creating a new Python tuple for the check_fn and code of current CacheEntry
     PyObject* inner_list = PyTuple_Pack(2, current_node->check_fn, current_node->code);
     // Add the inner list to the outer list

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -329,11 +329,6 @@ PyObject* _debug_get_cache_entry_list(PyObject* self, PyObject* args) {
 
   CacheEntry* current_node = get_cache_entry(code);
 
-  if(current_node == NULL)
-  {
-  return NULL;
-  }
-
   PyObject* outer_list = PyList_New(0);
   if (!outer_list) {
     return NULL;  // Return NULL if failed to create list


### PR DESCRIPTION
Per the discussion with @jansel  in https://dev-discuss.pytorch.org/t/how-are-guards-installed-on-frames-that-are-transient-objects/1415/7 , guards and compiled code live in `co_extra` field in pycodeobject, which cannot be accessed in a trivial way. This PR tries to add a debug API to extract the data from that field, which can make debugging torchdynamo much easier.

The API is intended to be used for debug only, and should have no compatibility issues with the current system.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov