### PR TITLE
add register backend for custom device

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -50,6 +50,12 @@ class DummyModule:
     def current_device():
         return 0
 
+class DummyBackendModule():
+
+    @staticmethod
+    def is_built():
+        return True
+
 @unittest.skipIf(IS_ARM64, "Does not work on arm")
 class TestCppExtensionOpenRgistration(common.TestCase):
     """Tests Open Device Registration with C++ extensions.
@@ -476,6 +482,15 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             self.assertEqual(z_cpu, z[0])
             self.assertEqual(z_cpu, z[1])
 
+        def test_open_device_backend_register():
+            with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
+                torch.backends._register_backend_module('ooo', DummyBackendModule)
+            torch.utils.rename_privateuse1_backend('foo')
+            torch.backends._register_backend_module('foo', DummyBackendModule)
+            with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
+                torch.backends._register_backend_module('foo', DummyBackendModule)
+            self.assertTrue(torch.backends.foo.is_built())
+
         test_base_device_registration()
         test_before_common_registration()
         test_common_registration()
@@ -497,6 +512,7 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         test_open_device_tensor_type_fallback()
         test_open_device_tensorlist_type_fallback()
+        test_open_device_backend_register()
 
 
 if __name__ == "__main__":

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -50,7 +50,7 @@ class DummyModule:
     def current_device():
         return 0
 
-class DummyBackendModule():
+class DummyBackendModule:
 
     @staticmethod
     def is_built():

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -1,7 +1,8 @@
 import sys
 import types
-import torch
 from contextlib import contextmanager
+
+import torch
 
 # The idea for this parameter is that we forbid bare assignment
 # to torch.backends.<cudnn|mkldnn>.enabled and friends when running our
@@ -69,6 +70,7 @@ from torch.backends import (
     quantized as quantized,
 )
 
+
 def _register_backend_module(device_type, module):
     r"""Register an external runtime module of the specific :attr:`device_type`
     supported by torch.
@@ -80,8 +82,10 @@ def _register_backend_module(device_type, module):
     device_type = torch.device(device_type).type
     m = sys.modules[__name__]
     if hasattr(m, device_type):
-        raise RuntimeError("The runtime module of '{}' has already "
-                           "been registered with '{}'".format(device_type, getattr(m, device_type)))
+        raise RuntimeError(
+            "The runtime module of '{}' has already "
+            "been registered with '{}'".format(device_type, getattr(m, device_type))
+        )
     setattr(m, device_type, module)
-    torch_module_name = '.'.join([__name__, device_type])
+    torch_module_name = ".".join([__name__, device_type])
     sys.modules[torch_module_name] = module


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
as title, add register backend func for custom device, then we could call func by torch.backends.foo for `foo` custom device. 