### PR TITLE
Enable Mypy Checking in torch/_inductor/fx_passes/pad_mm.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -189,13 +189,6 @@ include_patterns = [
     'torch/_dynamo/debug_utils.py',
     'torch/_dynamo/repro/**/*.py',
     'torch/_inductor/**/*.py',
-    'torch/_inductor/autotune_process.py',
-    'torch/_inductor/graph.py',
-    'torch/_inductor/codegen/wrapper.py',
-    'torch/_inductor/cudagraph_trees.py',
-    'torch/_inductor/lowering.py',
-    'torch/_inductor/metrics.py',
-    'torch/_inductor/fx_passes/pad_mm.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]
@@ -226,7 +219,6 @@ exclude_patterns = [
     'torch/_inductor/fx_passes/binary_folding.py',
     'torch/_inductor/fx_passes/replace_random.py',
     'torch/_inductor/fx_passes/joint_graph.py',
-    'torch/_inductor/fx_passes/pad_mm.py',
     'torch/_inductor/fx_passes/__init__.py',
     'torch/_inductor/fx_passes/group_batch_fusion.py',
     'torch/_inductor/fx_passes/pre_grad.py',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -189,6 +189,13 @@ include_patterns = [
     'torch/_dynamo/debug_utils.py',
     'torch/_dynamo/repro/**/*.py',
     'torch/_inductor/**/*.py',
+    'torch/_inductor/autotune_process.py',
+    'torch/_inductor/graph.py',
+    'torch/_inductor/codegen/wrapper.py',
+    'torch/_inductor/cudagraph_trees.py',
+    'torch/_inductor/lowering.py',
+    'torch/_inductor/metrics.py',
+    'torch/_inductor/fx_passes/pad_mm.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -3,7 +3,6 @@ from itertools import chain
 from typing import Optional
 
 import torch
-import triton
 from torch import Tensor
 from torch._inductor import utils
 from torch.utils._mode_utils import no_dispatch

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -425,7 +425,7 @@ def _pad_mm_init():
             should_pad_addmm,
         ),
     ]:
-        args = [*args, *workaround.values()] # type: ignore[attr-defined]
+        args = [*args, *workaround.values()]  # type: ignore[attr-defined]
         register_replacement(
             pattern,
             replacement,

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -3,6 +3,7 @@ from itertools import chain
 from typing import Optional
 
 import torch
+import triton
 from torch import Tensor
 from torch._inductor import utils
 from torch.utils._mode_utils import no_dispatch

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -424,7 +424,7 @@ def _pad_mm_init():
             should_pad_addmm,
         ),
     ]:
-        args = [*args, *workaround.values()]
+        args = [*args, *workaround.values()] # type: ignore[attr-defined]
         register_replacement(
             pattern,
             replacement,


### PR DESCRIPTION
Fixes #105230

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/fx_passes/pad_mm.py

After Fix:

mypy --follow-imports=skip torch/_inductor/fx_passes/pad_mm.py Success: no issues found in 1 source file


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel