### PR TITLE
Enable Mypy Check in torch/_inductor/select_algorithm.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -189,6 +189,7 @@ include_patterns = [
     'torch/_inductor/cudagraph_trees.py',
     'torch/_inductor/lowering.py',
     'torch/_inductor/metrics.py',
+    'torch/_inductor/select_algorithm.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -174,8 +174,8 @@ class BenchmarkRequest:
     num_stages: int
     num_warps: int
 
-    input_tensors: List[TensorMeta]
-    output_tensor: TensorMeta
+    input_tensors: Union["TensorMeta", List["TensorMeta"]]
+    output_tensor: Union["TensorMeta", List["TensorMeta"]]
 
     def benchmark(
         self, *input_tensors: torch.Tensor, output_tensor: Optional[torch.Tensor] = None
@@ -198,7 +198,11 @@ class BenchmarkRequest:
         # create args and out tensor
         if output_tensor is None:
             assert len(input_tensors) == 0
-            input_tensors = tuple(x.to_tensor() for x in self.input_tensors)
+            if isinstance(self.input_tensors, List):
+                input_tensors = tuple(x.to_tensor() for x in self.input_tensors)
+            if isinstance(self.input_tensors, TensorMeta):
+                input_tensors = tuple(self.input_tensors.to_tensor())
+            assert isinstance(self.output_tensor, TensorMeta)
             output_tensor = self.output_tensor.to_tensor()
 
         if DEBUG:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -8,7 +8,7 @@ import textwrap
 import time
 from io import StringIO
 
-from typing import Any, List
+from typing import Any, Dict, List, Type, Union
 from unittest.mock import patch
 
 import sympy
@@ -32,7 +32,7 @@ from .virtualized import V
 log = logging.getLogger(__name__)
 
 # correctness checks struggle with fp16/tf32
-VERIFY = False  # dict(atol=1, rtol=0.05)
+VERIFY: Dict[str, Any] = dict()
 PRINT_AUTOTUNE = True
 DEBUG = False
 
@@ -257,7 +257,7 @@ class TritonTemplateKernel(TritonKernel):
             input_node.freeze_layout()
             epilogue_args.append(input_node.make_loader()(index_symbols))
 
-        V.ops.store(
+        V.ops.store(  # type: ignore[attr-defined]
             self.output_node.get_name(),
             output_index,
             self.epilogue_fn(*epilogue_args),
@@ -316,6 +316,7 @@ class TritonTemplateKernel(TritonKernel):
         *,
         copy_shape=None,
         dense_indexing=False,
+        override_mask=None,
     ):
         """
         Override the default indexing to use our custom mask and force
@@ -383,7 +384,7 @@ def _jinja2_env():
 
 class TritonTemplate:
     index_counter = itertools.count()
-    all_templates = dict()
+    all_templates: Dict[str, "TritonTemplate"] = dict()
 
     @staticmethod
     def _template_from_string(source):
@@ -691,7 +692,7 @@ class ExternKernelCaller(ChoiceCaller):
         else:
             algo = self.to_callable()
             out_new = algo(*args)
-            torch._C._dynamo.guards.assert_size_stride(
+            torch._C._dynamo.guards.assert_size_stride(  # type: ignore[attr-defined]
                 out_new, tuple(out.size()), tuple(out.stride())
             )
             out.copy_(out_new)  # for correctness checking
@@ -717,6 +718,7 @@ class ExternKernelCaller(ChoiceCaller):
         )
 
     def output_node(self):
+        cls: Union[Type[ir.ExternKernelOut], Type[ir.ExternKernelAlloc]]
         if self.has_out_variant:
             cls = ir.ExternKernelOut
         else:
@@ -887,7 +889,7 @@ class AlgorithmSelectorCache(PersistentCache):
             lines += ["]", f"out = {tensor_repr(out)}", ""]
             return "\n".join(lines)
 
-        benchmark.debug_str = debug_str
+        benchmark.debug_str = debug_str  # type: ignore[attr-defined]
         return benchmark
 
     @staticmethod


### PR DESCRIPTION
Fixes #105230 to enable mypy check.

```
$ mypy  torch/_inductor/select_algorithm.py
Success: no issues found in 1 source file
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov