### PR TITLE
[WIP] FSDP rate limiter

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -57,6 +57,11 @@ FSDP_FLATTENED = "_fsdp_flattened"
 _MODULE_TO_INP_DTYPE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
+class AllGatherLimitStrategy(Enum):
+    CPU_SYNC = 1
+    STREAM_WAIT = 2
+
+
 class _FSDPDeviceHandle:
     """
     This is a simple abstraction for FSDP computing devices,
@@ -136,9 +141,10 @@ class _FSDPState(_State):
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
         self._device_mesh: Optional[DeviceMesh] = None
 
-        # Used by stream-based rate limiter
+        # Used by rate limiter
+        self.limit_all_gathers: int = 0
+        self._allgather_limit_strategy: Optional[AllGatherLimitStrategy] = None
         self._ping_pong_buffers: List[Tensor] = []
-        self._num_ping_pong_buffers: int = 2
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -26,6 +26,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.fsdp.flat_param as flat_param_file
 import torch.nn as nn
+from torch import Tensor
 from torch.distributed._composable_state import _get_module_state, _State
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -134,6 +135,10 @@ class _FSDPState(_State):
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
         self._device_mesh: Optional[DeviceMesh] = None
+
+        # Used by stream-based rate limiter
+        self._ping_pong_buffers: List[Tensor] = []
+        self._num_ping_pong_buffers: int = 2
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -399,7 +399,7 @@ def _init_core_state(
         os.environ.get(_FSDP_USE_FULL_PREC_IN_EVAL, "") == "1"
     )
     state.cpu_offload = cpu_offload or CPUOffload()
-    if isinstance(limit_all_gathers, int):
+    if type(limit_all_gathers) is int:
         # If user specifies an int, we use `limit_all_gathers` number of
         # ping-pong buffers and the stream-wait based strategy
         state._allgather_limit_strategy = AllGatherLimitStrategy.STREAM_WAIT
@@ -409,6 +409,7 @@ def _init_core_state(
         # a max of 2 outstanding all-gathers
         state._allgather_limit_strategy = AllGatherLimitStrategy.CPU_SYNC
         state.limit_all_gathers = 2
+    print(f"KW: limit_all_gathers: {state.limit_all_gathers}, strategy: {state._allgather_limit_strategy}")
     state._use_orig_params = use_orig_params
     state.training_state = TrainingState.IDLE
     state._is_root = None

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -436,8 +436,13 @@ def _reshard(
     """
     Reshards the handle. ``free_unsharded_flat_param`` indicates whether to
     free the handle's padded unsharded flat parameter.
+    Note that we don't free all-gather buffer in the stream-wait strategy
     """
-    handle.reshard(free_unsharded_flat_param)
+    free_storage = (
+        free_unsharded_flat_param
+        and state._allgather_limit_strategy == AllGatherLimitStrategy.CPU_SYNC
+    )
+    handle.reshard(free_storage)
     if state.limit_all_gathers > 0 and free_unsharded_flat_param:
         free_event = state._device_handle.Event()
         free_event.record()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -170,6 +170,7 @@ def _find_max_unsharded_numel(
 
 
 @no_type_check
+@torch.no_grad()
 def _create_ping_pong_buffers(
     root_state: _FSDPState,
 ):

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1630,10 +1630,8 @@ class FlatParamHandle:
         # `use_orig_params=True`, the `param` does not point to valid memory
         # when setting `param.data = ...` in `_use_sharded_views()`.
         self._use_sharded_flat_param()
-        """
         if free_unsharded_flat_param:
             self._free_unsharded_flat_param()
-        """
 
     def post_reshard(self):
         """

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -400,7 +400,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         device_id: Optional[Union[int, torch.device]] = None,
         sync_module_states: bool = False,
         forward_prefetch: bool = False,
-        limit_all_gathers: bool = True,
+        limit_all_gathers: Union[bool, int] = True,
         use_orig_params: bool = False,
         ignored_states: Union[
             Optional[Iterable[torch.nn.Parameter]], Optional[Iterable[torch.nn.Module]]


### PR DESCRIPTION
Use streams wait to hold all-gather execution instead of using CPU synchronization.

The basic implementation relies on using ping-pong buffers (for maximally two outstanding all-gathers). Each buffer would have size of the largest FSDP instance.