### PR TITLE
Add FP8 support to `torch.mm`

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -125,6 +125,8 @@ template <>
 void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half));
 template <>
 void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16));
+template <>
+void bgemm<at::Float8_e5m2>(CUDABLAS_BGEMM_ARGTYPES(at::Float8_e5m2));
 
 #if defined(USE_ROCM) && ROCM_VERSION <= 55000
 // ROCm 5.6 hipblas matches the const Dtype *A API, but prior hipblas does not.

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -162,9 +162,9 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   IntArrayRef mat1_sizes = mat1.sizes();
   IntArrayRef mat2_sizes = mat2.sizes();
   IntArrayRef self__sizes;
-  bool useLtInterface = false;
   static bool disable_addmm_cuda_lt = getDisableAddmmCudaLt();
   at::ScalarType scalar_type = self.scalar_type();
+  bool useLtInterface = scalar_type == at::ScalarType::Float8_e5m2 || scalar_type == at::ScalarType::Float8_e4m3fn;
   c10::MaybeOwned<Tensor> self_;
   if (&result != &self) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11040 && !defined(_MSC_VER)
@@ -267,9 +267,11 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
 
 #if !defined(USE_ROCM) && !defined(_MSC_VER)
   if (useLtInterface) {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
+    AT_DISPATCH_FLOATING_TYPES_AND4(
         at::ScalarType::Half,
         at::ScalarType::BFloat16,
+        at::ScalarType::Float8_e5m2,
+        at::ScalarType::Float8_e4m3fn,
         scalar_type,
         "addmm_cuda_lt",
         [&] {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106710
* #106709
* #106708

Though the implementation in cublasLt is very spotty at the moment
I.e. it looks like it accepts only `torch.mm(transposed, nontransposed)`
matrices at the moment and bias can not be float8 as well

Test plan:
/usr/bin/python3.8 -c 'import torch;print(torch.mm(torch.rand((16, 16), device="cuda").to(dtype=torch.float8_e4m3fn), torch.rand((16, 16), device="cuda").to(dtype=torch.float8_e4m3fn).t()))'