### PR TITLE
[ROCm] enable test_api (test_libtorch) cpp unit tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -569,10 +569,11 @@ test_libtorch() {
 
   # The slow test config corresponds to a default test config that should run
   # the libtorch tests instead.
-  if [[ "$BUILD_ENVIRONMENT" != *rocm* && "$TEST_CONFIG" != "slow" ]]; then
+  if [[ "$TEST_CONFIG" != "slow" ]]; then
     echo "Testing libtorch"
     ln -sf "$TORCH_LIB_DIR"/libbackend_with_compiler.so "$TORCH_BIN_DIR"
     ln -sf "$TORCH_LIB_DIR"/libjitbackend_test.so "$TORCH_BIN_DIR"
+    ln -sf "$TORCH_LIB_DIR"/libcaffe2_nvrtc.so "$TORCH_BIN_DIR"
     ln -sf "$TORCH_LIB_DIR"/libc10* "$TORCH_BIN_DIR"
     ln -sf "$TORCH_LIB_DIR"/libshm* "$TORCH_BIN_DIR"
     ln -sf "$TORCH_LIB_DIR"/libtorch* "$TORCH_BIN_DIR"
@@ -585,7 +586,8 @@ test_libtorch() {
       test_libtorch_api
     fi
 
-    if [[ -z "${SHARD}" || "${SHARD}" == "2" ]]; then
+    # still disable rocm
+    if [[ "$BUILD_ENVIRONMENT" != *rocm* && (-z "${SHARD}" || "${SHARD}" == "2") ]]; then
       test_libtorch_jit
     fi
 

--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -8,8 +8,6 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/expanding-array.cpp
   ${TORCH_API_TEST_DIR}/fft.cpp
   ${TORCH_API_TEST_DIR}/functional.cpp
-  ${TORCH_API_TEST_DIR}/integration.cpp
-  ${TORCH_API_TEST_DIR}/init.cpp
   ${TORCH_API_TEST_DIR}/jit.cpp
   ${TORCH_API_TEST_DIR}/memory.cpp
   ${TORCH_API_TEST_DIR}/meta_tensor.cpp
@@ -44,6 +42,11 @@ set(TORCH_API_TEST_SOURCES
 )
 if(USE_CUDA)
   list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/parallel.cpp)
+endif()
+
+if(NOT USE_ROCM)
+  list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/init.cpp)
+  list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/integration.cpp)
 endif()
 
 add_executable(test_api ${TORCH_API_TEST_SOURCES})


### PR DESCRIPTION
This is part of effort to enable missed cpp tests for ROCm platform.
In this change,  
- enabled test_libtorch cpp tests (more than 3107 tests)
- fixed missing dependency: libcaffe2_nvrtc.so required by FunctionalTest.Conv1d
- test_api binary is changed to exclude failed tests InitTest and IntegrationTest - to revisit later 



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo