### PR TITLE
[ignore] Hacks to get NestedTensor subclass to compile via desugaring

### DIFF
--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -72,7 +72,7 @@ static c10::SymInt get_nbytes(const Tensor& value) {
   // for these tensors (which is wrong), but we don't give them any space.
   // A more proper fix would be to have a SparseFunctionalTensorWrapper that
   // models sparse correctly.
-  if (value.is_sparse()) {
+  if (value.is_sparse() || value.unsafeGetTensorImpl()->key_set().has(DispatchKey::AutogradNestedTensor)) {
     return 0;
   }
   if (value.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -75,12 +75,6 @@ class TORCH_API TensorMaker {
     return *this;
   }
 
-  TensorMaker& is_fake(bool value) noexcept {
-    is_fake_ = value;
-
-    return *this;
-  }
-
   Tensor make_tensor();
 
  private:
@@ -105,7 +99,6 @@ class TORCH_API TensorMaker {
   TensorOptions opts_{};
   bool resizeable_{}; // Allows the storage of this tensor to be resized
   bool is_nested_{};
-  bool is_fake_{};
 };
 
 inline TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept {

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -69,6 +69,18 @@ class TORCH_API TensorMaker {
     return *this;
   }
 
+  TensorMaker& is_nested(bool value) noexcept {
+    is_nested_ = value;
+
+    return *this;
+  }
+
+  TensorMaker& is_fake(bool value) noexcept {
+    is_fake_ = value;
+
+    return *this;
+  }
+
   Tensor make_tensor();
 
  private:
@@ -92,6 +104,8 @@ class TORCH_API TensorMaker {
   c10::optional<Device> device_{};
   TensorOptions opts_{};
   bool resizeable_{}; // Allows the storage of this tensor to be resized
+  bool is_nested_{};
+  bool is_fake_{};
 };
 
 inline TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept {

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -41,10 +41,8 @@ Tensor TensorMaker::make_tensor() {
 
    auto keys = c10::DispatchKeySet({opts_.computeDispatchKey()});
    if (is_nested_) {
-    if (!is_fake_) {
       keys = keys.add(c10::DispatchKey::NestedTensor);
-    }
-    keys = keys.add(c10::DispatchKey::AutogradNestedTensor);
+      keys = keys.add(c10::DispatchKey::AutogradNestedTensor);
    }
    Tensor tensor = detail::make_tensor<TensorImpl>(
        std::move(storage), keys, opts_.dtype());

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -39,8 +39,15 @@ Tensor TensorMaker::make_tensor() {
 
    Storage storage{Storage::use_byte_size_t{}, size_bytes, std::move(data_ptr), /*allocator=*/c10::GetAllocator(c10::kMeta), /*resizeable=*/resizeable_};
 
+   auto keys = c10::DispatchKeySet({opts_.computeDispatchKey()});
+   if (is_nested_) {
+    if (!is_fake_) {
+      keys = keys.add(c10::DispatchKey::NestedTensor);
+    }
+    keys = keys.add(c10::DispatchKey::AutogradNestedTensor);
+   }
    Tensor tensor = detail::make_tensor<TensorImpl>(
-       std::move(storage), opts_.computeDispatchKey(), opts_.dtype());
+       std::move(storage), keys, opts_.dtype());
 
   TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
   if (strides_) {

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -159,7 +159,7 @@ _SKIP_PYTHON_BINDINGS = [
     "fill.Scalar",  # only used by the functionalization pass
     "lift.*",
     "normal_functional",  # only used by the functionalization pas
-    "_nested_view_from_buffer",  # View only version of _nested_from_buffer. This will force users to only use the "safe" version.
+    # "_nested_view_from_buffer",  # View only version of _nested_from_buffer. This will force users to only use the "safe" version.
     "_nested_view_from_buffer_copy",
     "_nested_view_from_buffer_copy_out",
     "nbytes",

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -53,7 +53,7 @@ import torch._functorch.config
 import torch.fx.experimental.symbolic_shapes
 from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
-from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensor, is_fake_tensor
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._pytree import tree_map
 
@@ -1267,7 +1267,7 @@ def get_fake_value(node, tx):
 
     def fake_wrapper(e):
         if isinstance(e, torch.Tensor):
-            assert isinstance(e, FakeTensor)
+            assert is_fake_tensor(e)
         return e
 
     def visit(n: torch.fx.Node):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -15,13 +15,14 @@ import torch
 from torch import SymInt
 from torch._guards import GuardSource, TracingContext
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensor, is_fake_tensor
 from torch.fx.experimental.symbolic_shapes import (
     DimConstraint,
     DimDynamic,
     RelaxedUnspecConstraint,
 )
 from torch.fx.immutable_collections import immutable_list
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch.utils.weak import TensorWeakRef, WeakIdRef
 
 from .. import config, mutation_guard, replay_record, skipfiles
@@ -160,9 +161,7 @@ class GraphArg:
     def __post_init__(self):
         if isinstance(self._example, torch.Tensor):
             self._example = TensorWeakRef(self._example)
-            assert isinstance(
-                self.fake_tensor, torch._subclasses.fake_tensor.FakeTensor
-            )
+            assert is_fake_tensor(self.fake_tensor)
 
     def load(self, tx):
         return self.source.reconstruct(tx)
@@ -382,7 +381,9 @@ class VariableBuilder:
         value = inspect.getattr_static(value, "_torchdynamo_inline", value)
 
         # Everything else (NB: order matters!)
-        if istype(value, config.traceable_tensor_subclasses):
+        if is_traceable_wrapper_subclass(value) or istype(
+            value, config.traceable_tensor_subclasses
+        ):
             return self.wrap_tensor(value)
         elif is_namedtuple(value):
             return self.wrap_listlike(value)
@@ -884,7 +885,7 @@ class VariableBuilder:
                 torch.Tensor,
                 torch.nn.Parameter,
                 torch._subclasses.fake_tensor.FakeTensor,
-            ), type(value)
+            ) or is_traceable_wrapper_subclass(value), type(value)
             ignore_subclass = False
 
         is_duplicate_tensor = source in self.tx.output.input_source_to_var
@@ -919,7 +920,7 @@ class VariableBuilder:
         # ignore_subclass changes
         fake_tensor_value = None
         example_value = tensor_variable.proxy.node.meta["example_value"]
-        if isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor):
+        if is_fake_tensor(example_value):
             fake_tensor_value = example_value
 
         grapharg = GraphArg(source, value, False, fake_tensor_value)
@@ -1078,7 +1079,7 @@ class VariableBuilder:
                     example_value = unspec_var.value
                 else:
                     example_value = unspec_var.proxy.node.meta["example_value"]
-                if isinstance(example_value, torch._subclasses.fake_tensor.FakeTensor):
+                if is_fake_tensor(example_value):
                     fake_tensor_value = example_value
                 proxy.node.meta["grapharg"] = GraphArg(
                     self.get_source(),
@@ -1176,7 +1177,7 @@ def wrap_fx_proxy_cls(
     def _clone_input(value):
         if isinstance(value, torch.Tensor):
             # tensor subclasses will not be converted to FakeTensors and need to be cloned
-            if not isinstance(value, torch._subclasses.fake_tensor.FakeTensor):
+            if not is_fake_tensor(value):
                 # NB: ensure strides are preserved
                 value = clone_input(value)
 
@@ -1463,22 +1464,27 @@ def _automatic_dynamic(e, tx, name, static_shapes):
 def wrap_to_fake_tensor_and_record(
     e, tx, ignore_subclass=False, *, source: Optional[Source], is_tensor: bool
 ):
-    if type(e) in (torch.Tensor, torch.nn.Parameter) or (
-        ignore_subclass and isinstance(e, torch.Tensor)
+    if (
+        type(e) in (torch.Tensor, torch.nn.Parameter)
+        or (ignore_subclass and isinstance(e, torch.Tensor))
+        or is_traceable_wrapper_subclass(e)
     ):
         assert source is not None
         static_shapes, reason = tensor_always_has_static_shape(
             e, is_tensor, guard_source=source.guard_source()
         )
 
-        dynamic_dims, constraint_dims = _automatic_dynamic(
-            e, tx, source.name(), static_shapes
-        )
+        if not e.is_nested:
+            dynamic_dims, constraint_dims = _automatic_dynamic(
+                e, tx, source.name(), static_shapes
+            )
+        else:
+            dynamic_dims, constraint_dims = None, None
 
         log.debug(
             "wrap_to_fake %s %s %s %s",
             source.name(),
-            tuple(e.shape),
+            tuple(e.shape) if not e.is_nested else "(nested)",
             dynamic_dims,
             constraint_dims,
         )

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -17,7 +17,7 @@ VariableInfo::VariableInfo(const Variable& var)
     : layout(var.layout()),
       device(var.device()),
       scalar_type(var.scalar_type()),
-      size(var.is_nested()
+      size((var.is_nested() && !var.unsafeGetTensorImpl()->key_set().has(at::DispatchKey::Python))
         ? VariableInfoSizeType(
           NestedSizeInfo(
             var.sym_numel(),

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -6,6 +6,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <c10/util/variant.h>
 #include <vector>
 
 namespace torch {
@@ -156,6 +157,15 @@ struct TORCH_API AutogradContext {
   friend struct CppNode;
 };
 
+struct TORCH_API NestedSizeInfo {
+  explicit NestedSizeInfo(c10::SymInt numel_, const Variable& nested_size_);
+
+  c10::SymInt numel;
+  Variable nested_size;
+};
+
+using VariableInfoSizeType = c10::variant<std::vector<c10::SymInt>, NestedSizeInfo>;
+
 struct TORCH_API VariableInfo {
   explicit VariableInfo();
   explicit VariableInfo(const Variable& var);
@@ -165,7 +175,7 @@ struct TORCH_API VariableInfo {
   at::Layout layout = at::Layout::Strided;
   at::Device device = at::kCPU;
   at::ScalarType scalar_type = at::kFloat;
-  std::vector<c10::SymInt> size;
+  VariableInfoSizeType size;
   bool requires_grad;
   bool is_empty;
 };

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -94,7 +94,7 @@ struct InputMetadata {
         grad.is_nested() == is_nested_tensor(),
         "Both grad and InputMetadata need to be either nested or non nested tensors.")
     if (grad.is_nested()) {
-      return at::native::get_nested_sizes(grad).is_same_size(shape_as_tensor());
+      return grad._nested_tensor_size().is_same_size(shape_as_tensor());
     }
     return grad.sym_sizes().equals(shape_as_dim_vector());
   }
@@ -123,7 +123,7 @@ struct InputMetadata {
     std::stringstream ss;
     ss << "invalid gradient at index " << index << " - got ";
     if (grad.is_nested()) {
-      ss << at::native::get_nested_sizes(grad);
+      ss << grad._nested_tensor_size();
     } else {
       ss << grad.sym_sizes();
     }
@@ -146,7 +146,7 @@ struct InputMetadata {
   }
   MetadataShape compute_variant_shape(const at::Tensor& input) {
     if (input.is_nested()) {
-      auto nested_size = at::native::get_nested_sizes(input);
+      auto nested_size = input._nested_tensor_size();
       return MetadataShape{c10::in_place_type<at::Tensor>, nested_size};
     }
     return MetadataShape{c10::in_place_type<SymIntSmallVec>, input.sym_sizes()};

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -630,12 +630,12 @@ static PyObject* THPVariable_make_wrapper_subclass(
       "int64_t? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
       "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
-      "bool is_nested=False, bool is_fake=False)",
+      "bool is_nested=False)",
       "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef strides=None, "
       "SymInt? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
       "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
-      "bool is_nested=False, bool is_fake=False)",
+      "bool is_nested=False)",
   });
   ParsedArgs<15> parsed_args{};
   auto r = parser.parse(args, kwargs, parsed_args);
@@ -687,7 +687,6 @@ static PyObject* THPVariable_make_wrapper_subclass(
                  .options(options)
                  .resizeable_storage()
                  .is_nested(r.toBool(13))
-                 .is_fake(r.toBool(14))
                  .make_tensor();
 
     const auto sizes_strides_policy = r.stringViewOptional(10);
@@ -710,12 +709,7 @@ static PyObject* THPVariable_make_wrapper_subclass(
 
     auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
     if (r.toBool(13)) {
-      // HACK: don't include the NestedTensor key if this is subclass holds
-      // fake tensors so that we go through the .sizes() path instead of
-      // _nested_tensor_sizes path.
-      if (!r.toBool(14)) {
-        keys = keys.add(c10::DispatchKey::NestedTensor);
-      }
+      keys = keys.add(c10::DispatchKey::NestedTensor);
       keys = keys.add(c10::DispatchKey::AutogradNestedTensor);
     }
     tensor = at::detail::make_tensor<TensorImpl>(

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -146,14 +146,14 @@ def is_traceable_wrapper_subclass(t):
     tensor_like = isinstance(t, torch.Tensor) and type(t) != torch.Tensor
     return tensor_like and hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__")
 
-def transform_subclass(t, callback):
+def transform_subclass(t, callback, source=None):
     assert is_traceable_wrapper_subclass(t)
     # convert the tensor subclass into its constituent dense tensors,
     # and apply a transformation to each dense tensor.
     from torch.utils._pytree import tree_map_only
     flattened_tensors, ctx = type(t).__tensor_flatten__(t)
     transformed_tensors = tree_map_only(torch.Tensor, callback, flattened_tensors)
-    return type(t).__tensor_unflatten__(transformed_tensors, ctx)
+    return type(t).__tensor_unflatten__(transformed_tensors, ctx, source=source)
 
 # TODO: this.
 #def set_subclass_output_aliasing(func, outputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107793
* #107089
* __->__ #106722
* #106721

Contents: borrow some changes from https://www.internalfb.com/diff/D45923484 and https://github.com/pytorch/pytorch/pull/105308 + some more hacks

Note to self: Rebasing onto this stack should allow you to run the NestedTensor examples in the linked gist successfully https://gist.github.com/soulitzer/9ae591a996fa8e63c55db6e514383b13

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov