### PR TITLE
[pytorch] Disable CUDA sync events by default

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1471,7 +1471,7 @@ void set_fwd_bwd_enabled_val(bool val) {
 
 namespace {
 std::function<bool()>& cuda_sync_enabled_fn() {
-  static std::function<bool()> fn = []() { return true; };
+  static std::function<bool()> fn = []() { return false; };
   return fn;
 }
 } // namespace


### PR DESCRIPTION
Summary:
As above, this was missed in a previous diff accidentally setting defaul to true.
Internal to MEta this is disabled but it is enabled in open source PyTorch.

Test Plan: CI

Differential Revision: D48124636

