### PR TITLE
Fix bug: not creating empty tensor with correct sizes and device.

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1393,7 +1393,7 @@ Tensor& comparison_op_out(Tensor& result, const Tensor& self, const Tensor& othe
 
 template <typename OutImpl>
 Tensor comparison_op(const Tensor& self, const Tensor& other, OutImpl& out_impl) {
-  Tensor result = at::empty({0}, self.options().dtype(kBool));
+  Tensor result = at::empty(self.sizes(), self.options().dtype(kBool).device(self.device()));
   return out_impl(result, self, other);
 }
 


### PR DESCRIPTION
Summary:
logical_add and logical_add_ are reusing implementation of logical_add_out. But the `comparison_op` doesn't create an empty tensor with correct sizes and device type.
```
Tensor& logical_and_out(const Tensor& self, const Tensor& other, Tensor& result) { return comparison_op_out(result, self, other, logical_and_stub); }
Tensor logical_and(const Tensor& self, const Tensor& other) { return comparison_op(self, other, static_cast<OutFunc>(at::logical_and_out)); }
Tensor& logical_and_(Tensor& self, const Tensor& other) { return comparison_op_(self, other, static_cast<OutFunc>(at::logical_and_out)); }
```

Test Plan: CI tests.

Differential Revision: D48134169

