### PR TITLE
[Pytorch][Vulkan] Set global and local sizes for image->bool copy

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized_mul4.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized_mul4.glsl
@@ -23,6 +23,9 @@ layout(set = 0, binding = 2) uniform PRECISION restrict Block {
   // xyz contain the extents of the input texture, w contains HxW to help
   // calculate buffer offsets
   ivec4 in_extents;
+  // x: number of texels spanned by one batch: ceil(c_info.y/4)
+  // y: number of channels
+  ivec2 c_info;
 }
 uBlock;
 
@@ -33,39 +36,54 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
-    // each instance of the shader writes out four elements of the output
-    // by processing 4 consecutive texels at the same depth.
-    // global size = {HxW / 4, 1u, z_extent}.
-    // this shader requires HxW to be a multiple of 4, so that multiple
-    // planes can be processed in parallel
+  // each instance of the shader writes out four elements of the output
+  // by processing 4 consecutive texels at the same depth.
+  // global size = {HxW / 4, 1u, z_extent}.
+  // this shader requires HxW to be a multiple of 4, so that multiple
+  // planes can be processed in parallel
 
-  if (4 * pos.x >= uBlock.in_extents.w ||
-      pos.y > 0 ||
+  if (4 * pos.x >= uBlock.in_extents.w || pos.y > 0 ||
       pos.z >= uBlock.in_extents.z) {
     return;
   }
 
   ivec4 xy_pos = ivec4(0, 1, 2, 3) + 4 * pos.x;
-    // each output element is a uint32 made up four consecutive uint8 from the
-    // input in nchw format. xy_pos contains the positions of these four
-    // elements from the input in the flatten out HxW plane.
+  // each output element is a uint32 made up four consecutive uint8 from the
+  // input in nchw format. xy_pos contains the positions of these four
+  // elements from the input in the flatten out HxW plane.
 
   ivec4 x_pos = xy_pos % uBlock.in_extents.x;
   ivec4 y_pos = xy_pos / uBlock.in_extents.x;
-    // we divide this "flatten out position" by H, to find the positions along
-    // the y-axis (height) and we compute its reminder mod H, to find the
-    // position along the x-axis (width).
+  // we divide this "flatten out position" by H, to find the positions along
+  // the y-axis (height) and we compute its reminder mod H, to find the
+  // position along the x-axis (width).
 
   const ivec4 intex0 = texelFetch(uImage, ivec3(x_pos[0], y_pos[0], pos.z), 0);
   const ivec4 intex1 = texelFetch(uImage, ivec3(x_pos[1], y_pos[1], pos.z), 0);
   const ivec4 intex2 = texelFetch(uImage, ivec3(x_pos[2], y_pos[2], pos.z), 0);
   const ivec4 intex3 = texelFetch(uImage, ivec3(x_pos[3], y_pos[3], pos.z), 0);
 
-  const int base_index = 4 * pos.x + 4 * uBlock.in_extents.w * pos.z;
+  int channel_end = 4;
+  if (uBlock.c_info.y % 4 != 0 &&
+      pos.z % uBlock.c_info.x == uBlock.c_info.x - 1) {
+    channel_end = uBlock.c_info.y % 4;
+  }
+  // when channel%4 != 0, the texture is not densely filled
+  // only copy valid texels as the 1D buffer is dense
+
+  const int base_index = 4 * pos.x +
+      uBlock.in_extents.w *
+          ((pos.z / uBlock.c_info.x) * uBlock.c_info.y +
+           (pos.z % uBlock.c_info.x) * 4);
+  // account for case when channel%4 != 0
+  // base: (pos.z / [C/4]) * C
+  // offset: (pos.z % [C/4]) * 4)
+  // when channel%4 == 0, this is equivalent to pos.z * 4
+
   const ivec4 buf_indices =
       base_index + ivec4(0, 1, 2, 3) * uBlock.in_extents.w;
 
-  for (int i = 0; i < 4; i += 1) {
+  for (int i = 0; i < channel_end; i += 1) {
     uint ui32 = (uint(intex3[i] & 0xFF) << 24)
               | (uint(intex2[i] & 0xFF) << 16)
               | (uint(intex1[i] & 0xFF) << 8)


### PR DESCRIPTION
Summary:
1. Add bool to quantized flow
2. Add support for cases where channel is *not* a multiple of 4 to the shader `image_to_nchw_quantized_mul4.glsl`. Note that the `mul4` in the shader name refers to height * width % 4 == 0.

Add test cases.

See: D48082479

Test Plan:
New tests:
```
lfq@lfq-mbp fbsource % buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 -- --gtest_filter="*copy_to_texture_bool*"

Downloaded 1/3 artifacts, 1.74 Mbytes, 50.0% cache miss (for updated rules)
Building: finished in 14.4 sec (100%) 474/474 jobs, 3/474 updated
  Total time: 14.4 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *copy_to_texture_bool*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.copy_to_texture_bool_mul4_hw
VUID-VkDeviceCreateInfo-pProperties-04451(ERROR / SPEC): msgNum: 976972960 - Validation Error: [ VUID-VkDeviceCreateInfo-pProperties-04451 ] Object 0: handle = 0x10bf61020, type = VK_OBJECT_TYPE_PHYSICAL_DEVICE; | MessageID = 0x3a3b6ca0 | vkCreateDevice: VK_KHR_portability_subset must be enabled because physical device VkPhysicalDevice 0x10bf61020[] supports it The Vulkan spec states: If the [VK_KHR_portability_subset] extension is included in pProperties of vkEnumerateDeviceExtensionProperties, ppEnabledExtensions must include "VK_KHR_portability_subset". (https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pProperties-04451)
    Objects: 1
        [0] 0x10bf61020, type: 2, name: NULL
[       OK ] VulkanAPITest.copy_to_texture_bool_mul4_hw (114 ms)
[ RUN      ] VulkanAPITest.copy_to_texture_bool_mul4_chw
[       OK ] VulkanAPITest.copy_to_texture_bool_mul4_chw (4 ms)
[ RUN      ] VulkanAPITest.copy_to_texture_bool
[       OK ] VulkanAPITest.copy_to_texture_bool (7 ms)
[----------] 3 tests from VulkanAPITest (126 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (127 ms total)
[  PASSED  ] 3 tests.

```

All tests:
```
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 331 tests from VulkanAPITest (7327 ms total)

[----------] Global test environment tear-down
[==========] 331 tests from 1 test suite ran. (7327 ms total)
[  PASSED  ] 330 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```
Quantized tests:
```
[----------] 63 tests from VulkanAPITest (2009 ms total)

[----------] Global test environment tear-down
[==========] 63 tests from 1 test suite ran. (2009 ms total)
[  PASSED  ] 63 tests.

  YOU HAVE 8 DISABLED TESTS
```

Differential Revision: D48086455

