### PR TITLE
Make RNGStateTracker support cuda-like device

### DIFF
--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -429,7 +429,7 @@ def distribute_tensor(
     # TODO: the value assignment to global variable is not the ideal solution
     # we can replace it in future.
     if is_rng_supported_mesh(device_mesh) and not random._rng_tracker:
-        random._rng_tracker = OffsetBasedRNGTracker()
+        random._rng_tracker = OffsetBasedRNGTracker(device_mesh.device_type)
 
     if not tensor.is_leaf:
         raise RuntimeError(

--- a/torch/distributed/_tensor/random.py
+++ b/torch/distributed/_tensor/random.py
@@ -11,7 +11,7 @@ from torch.distributed._tensor.device_mesh import _get_device_handle, DeviceMesh
 from torch.distributed._tensor.placement_types import DTensorSpec, Shard
 
 
-_rng_tracker: Optional["CudaRNGStateTracker"] = None
+_rng_tracker: Optional["RNGStateTracker"] = None
 
 
 def is_rng_supported_mesh(device_mesh: DeviceMesh) -> bool:
@@ -78,7 +78,7 @@ def manual_seed(seed: int, device_mesh: DeviceMesh, tp_dim: int = 0) -> None:
     # OffsetBasedRNGTracker to perform random operators.
     global _rng_tracker
     if not _rng_tracker:
-        _rng_tracker = OffsetBasedRNGTracker()
+        _rng_tracker = OffsetBasedRNGTracker(device_mesh.device_type)
 
     # the current rank is in mesh
     if device_mesh.get_coordinate() is not None:
@@ -92,23 +92,25 @@ def manual_seed(seed: int, device_mesh: DeviceMesh, tp_dim: int = 0) -> None:
             )
 
 
-class CudaRNGStateTracker:
+class RNGStateTracker:
     """
-    CudaRNGStateTracker stores Random Number Generator (RNG) state (a ByteTensor object)
+    RNGStateTracker stores Random Number Generator (RNG) state (a ByteTensor object)
     in a dict, mapping from a corresponding tag to each state tensor. It also provides
     a set of convenient utility methods to help access/modify the state tensors. The most
     important interface is _distribute_region which will be used when DTensor executes
     a random op (an operator that calls RNG).
     """
 
-    def __init__(self):
-        if not torch.cuda.is_available():
+    def __init__(self, device_type: str = "cuda"):
+        self._device_type = device_type
+        self._device_handle = _get_device_handle(device_type)
+        if not (self._device_handle and self._device_handle.is_available()):
             raise RuntimeError(
-                f"{self.__class__.__name__} instantiation requires the presence of CUDA device"
+                f"{self.__class__.__name__} instantiation requires the presence of CUDA/CUDA-like device"
             )
 
         self._states = {}
-        self._devices = [torch.cuda.current_device()]
+        self._devices = [self._device_handle.current_device()]
         self._use_distribute_region = True
 
     @property
@@ -144,17 +146,17 @@ class CudaRNGStateTracker:
         pass
 
 
-class OffsetBasedRNGTracker(CudaRNGStateTracker):
+class OffsetBasedRNGTracker(RNGStateTracker):
     """
-    This subclass of `CudaRNGStateTracker` defines the default policy of how RNG states
+    This subclass of `RNGStateTracker` defines the default policy of how RNG states
     should be shared and synchronized among all ranks to respect the semantics of DTensor
     random operators.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, device_type: str = "cuda"):
+        super().__init__(device_type)
         # synchronize RNG state using rank 0's current one
-        rng_state = torch.cuda.get_rng_state().to("cuda")
+        rng_state = self._device_handle.get_rng_state().to(device_type)
         dist.broadcast(rng_state, 0)
         self.rng_states["parallel-rng"] = rng_state.to("cpu")
 
@@ -173,8 +175,8 @@ class OffsetBasedRNGTracker(CudaRNGStateTracker):
         if self.distribute_region_enabled:
             old_offset = self.get_offset("parallel-rng")
             self._set_pre_op_offset(spec)
-            with torch.random.fork_rng(self._devices):
-                torch.cuda.set_rng_state(self.rng_states["parallel-rng"])
+            with torch.random.fork_rng(self._devices, device_type=self._device_type):
+                self._device_handle.set_rng_state(self.rng_states["parallel-rng"])
                 try:
                     yield  # execute the region code
                 finally:
@@ -330,11 +332,11 @@ class OffsetBasedRNGTracker(CudaRNGStateTracker):
         return shard_linear_idx
 
 
-class TensorParallelRNGTracker(CudaRNGStateTracker):
-    def __init__(self):
-        super().__init__()
+class TensorParallelRNGTracker(RNGStateTracker):
+    def __init__(self, device_type: str = "cuda"):
+        super().__init__(device_type)
         # copy the default RNG state
-        self.rng_states["tensor-parallel-rng"] = torch.cuda.get_rng_state()
+        self.rng_states["tensor-parallel-rng"] = self._device_handle.get_rng_state()
 
     def _manual_seed(
         self,
@@ -361,11 +363,11 @@ class TensorParallelRNGTracker(CudaRNGStateTracker):
             )
 
         if self.distribute_region_enabled:
-            with torch.random.fork_rng(self._devices):
-                torch.cuda.set_rng_state(self.rng_states["tensor-parallel-rng"])
+            with torch.random.fork_rng(self._devices, device_type=self._device_type):
+                self._device_handle.set_rng_state(self.rng_states["tensor-parallel-rng"])
                 try:
                     yield
                 finally:
-                    self.rng_states["tensor-parallel-rng"] = torch.cuda.get_rng_state()
+                    self.rng_states["tensor-parallel-rng"] = self._device_handle.get_rng_state()
         else:
             yield

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -89,7 +89,7 @@ def parallelize_module(  # type: ignore[return]
         is_rng_supported_mesh(device_mesh) and
         not isinstance(random._rng_tracker, TensorParallelRNGTracker)
     ):
-        random._rng_tracker = TensorParallelRNGTracker()
+        random._rng_tracker = TensorParallelRNGTracker(device_mesh.device_type)
         # TODO: we should allow user to pass in the default seed from a config
         random._rng_tracker._manual_seed(device_mesh, base_seed=1234, tp_dim=tp_mesh_dim)
         # By default we execute random ops in non-tensor-parallel region. If users want


### PR DESCRIPTION
replace CudaRNGStateTracker with RNGStateTracker by using device_handle to rewrite some Cuda-binding code
