### PR TITLE
Change dropout of device Privateuse1 to fused kernel

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -43,7 +43,7 @@ Tensor make_feature_noise(const Tensor& input) {
 }
 
 bool is_fused_kernel_acceptable(const Tensor& input, double p) {
-  return (input.is_cuda() || input.is_xpu() || input.is_lazy()) && p > 0 && p < 1 && input.sym_numel() > 0;
+  return (input.is_cuda() || input.is_xpu() || input.is_lazy() || input.device().is_privateuseone()) && p > 0 && p < 1 && input.sym_numel() > 0;
 }
 
 // NB: sure, we could have used different overloads here, but I would feel insecure


### PR DESCRIPTION
Similar to issue in  #97894, dropout is dispatched to fused kernel(native_dropout) only with some devices like cuda, etc.. It is hard  to optimize performance when using AOT with custom device, as dropout is finally decomposed to bernoulli and mul.  This PR changes this behavior.


cc @ezyang @msaroufim @wconstab @bdhirsh @anijain2305