### PR TITLE
Enable mypy check in torch/_inductor/wrapper_benchmark.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -195,6 +195,7 @@ include_patterns = [
     'torch/_inductor/lowering.py',
     'torch/_inductor/metrics.py',
     'torch/_inductor/select_algorithm.py',
+    'torch/_inductor/wrapper_benchmark.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -96,7 +96,6 @@ def benchmark_all_kernels(benchmark_name, benchmark_all_configs):
                 ms, num_gb, gb_per_s, prefix=prefix, suffix=kernel_detail_str
             )
 
-        bench_result = []
         kernel_desc = (
             f"{benchmark_name:20} {kernel_category[:3].upper()} {kernel_key[:10]}"
         )


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner init && lintrunner -a torch/_inductor/wrapper_benchmark.py
...
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/wrapper_benchmark.py
Success: no issues found in 1 source file 
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov