### PR TITLE
Enable mypy check in torch/_inductor/kernel/mm_common.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -197,6 +197,7 @@ include_patterns = [
     'torch/_inductor/metrics.py',
     'torch/_inductor/select_algorithm.py',
     'torch/_inductor/wrapper_benchmark.py',
+    'torch/_inductor/kernel/mm_common.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]

--- a/mypy-nofollow.ini
+++ b/mypy-nofollow.ini
@@ -34,3 +34,9 @@ ignore_errors = True
 
 [mypy-torch._C.*]
 ignore_errors = True
+
+[mypy-triton]
+ignore_missing_imports = True
+
+[mypy-triton.*]
+ignore_missing_imports = True

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -153,9 +153,9 @@ def mm_args(mat1, mat2, *others, layout=None, out_dtype=None, use_4x2_dim=False)
 def addmm_epilogue(dtype, alpha, beta):
     def epilogue(acc, bias):
         if alpha != 1:
-            acc = V.ops.mul(acc, V.ops.constant(alpha, dtype))
+            acc = V.ops.mul(acc, V.ops.constant(alpha, dtype))  # type: ignore[attr-defined]
         if beta != 1:
-            bias = V.ops.mul(bias, V.ops.constant(beta, dtype))
-        return V.ops.add(acc, bias)
+            bias = V.ops.mul(bias, V.ops.constant(beta, dtype))  # type: ignore[attr-defined]
+        return V.ops.add(acc, bias)  # type: ignore[attr-defined]
 
     return epilogue


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner init && lintrunner -a torch/_inductor/kernel/mm_common.py
...
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/kernel/mm_common.py
Success: no issues found in 1 source file
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov