### PR TITLE
`torch::nn::AdaptiveLogSoftmaxWithLoss`: check length of `cutoffs`

### DIFF
--- a/torch/csrc/api/src/nn/modules/adaptive.cpp
+++ b/torch/csrc/api/src/nn/modules/adaptive.cpp
@@ -25,6 +25,9 @@ AdaptiveLogSoftmaxWithLossImpl::AdaptiveLogSoftmaxWithLossImpl(
 
 void AdaptiveLogSoftmaxWithLossImpl::reset() {
   TORCH_CHECK(
+      options.cutoffs().size() > 0,
+      "cutoffs should be a sequence of length larger than 0");
+  TORCH_CHECK(
       std::is_sorted(options.cutoffs().begin(), options.cutoffs().end()) &&
           *std::min_element(
               options.cutoffs().begin(), options.cutoffs().end()) > 0 &&

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -124,6 +124,9 @@ class AdaptiveLogSoftmaxWithLoss(Module):
 
         cutoffs = list(cutoffs)
 
+        if (len(cutoffs) == 0):
+            raise ValueError("cutoffs should be a sequence of length larger than 0")
+
         if (cutoffs != sorted(cutoffs)) \
                 or (min(cutoffs) <= 0) \
                 or (max(cutoffs) > (n_classes - 1)) \


### PR DESCRIPTION
Fixes #106698

Also added a check for python API, because current error message
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sehoon/pytorch-latest/torch/nn/modules/adaptive.py", line 128, in __init__
    or (min(cutoffs) <= 0) \
ValueError: min() arg is an empty sequence
```
is not very comprehensible.
