### PR TITLE
`torch::nn::MultiheadAttention`, `F::multi_head_attention_forward`: check embed_dim and num_heads

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -674,6 +674,13 @@ inline std::tuple<Tensor, Tensor> multi_head_attention_forward(
   TORCH_INTERNAL_ASSERT(embed_dim == embed_dim_to_check);
   TORCH_INTERNAL_ASSERT(key.sizes() == value.sizes());
 
+  TORCH_CHECK(
+      embed_dim > 0 && num_heads > 0,
+      "embed_dim and num_heads must be greater than 0, got embed_dim=",
+      embed_dim,
+      " and num_heads=",
+      num_heads,
+      " instead");
   const auto head_dim = embed_dim / num_heads;
   TORCH_CHECK(
       head_dim * num_heads == embed_dim,

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -495,6 +495,13 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
 }
 
 void MultiheadAttentionImpl::reset() {
+  TORCH_CHECK(
+      options.embed_dim() > 0 && options.num_heads() > 0,
+      "embed_dim and num_heads must be greater than 0, got embed_dim=",
+      options.embed_dim(),
+      " and num_heads=",
+      options.num_heads(),
+      " instead");
   _qkv_same_embed_dim = options.kdim() == options.embed_dim() &&
       options.vdim() == options.embed_dim();
   head_dim = options.embed_dim() / options.num_heads();


### PR DESCRIPTION
Fixes #106700

Referred [check of python API](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/activation.py#L967-L971).

cc @jbschlosser @malfet