### PR TITLE
Allow bad register_buffer for Module

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -380,9 +380,8 @@ class TestNN(NNTestCase):
                 super().__init__(2, 2)
                 self.bar = Buffer(torch.rand(2, 2))
 
-
-            # persistent is explicitly missing!
             def register_buffer(self, name, value):
+                # persistent is explicitly missing!
                 super().register_buffer(name, value, True)
 
         foo = MyBadModule()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -374,6 +374,20 @@ class TestNN(NNTestCase):
         self.assertEqual(names(m.named_buffers(remove_duplicate=False)),
                          ["buffer1", "buffer2"])
 
+    def test_buffer_bad_subclass(self):
+        class MyBadModule(nn.Linear):
+            def __init__(self):
+                super().__init__(2, 2)
+                self.bar = Buffer(torch.rand(2, 2))
+
+
+            # persistent is explicitly missing!
+            def register_buffer(self, name, value):
+                super().register_buffer(name, value, True)
+
+        foo = MyBadModule()
+        self.assertIsNotNone(foo.bar)
+
     def test_call_supports_python_dict_output(self):
         class Net(nn.Module):
             def __init__(self):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1750,7 +1750,7 @@ class Module:
                         persistent = value.persistent
                     else:
                         persistent = name not in self._non_persistent_buffers_set
-                    ### HACK
+                    # === HACK ===
                     # This whole block below should just be:
                     # self.register_buffer(name, value, persistent)
 
@@ -1773,7 +1773,7 @@ class Module:
                             # Assume that the implementation without the argument has the
                             # behavior from before the argument was added: persistent=True
                             self.register_buffer(name, value)
-                    ### HACK END
+                    # === HACK END ===
                 else:
                     super().__setattr__(name, value)
 


### PR DESCRIPTION
To avoid having to land https://github.com/pytorch/pytorch/pull/106743 and revert this PR again without any plan to be able to re-land it.

This can also be added to the OG PR post revert if we need to reland this in a way that doesn't break such bad subclass.