### PR TITLE
[export] Support preserving calling convention to some modules.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -111,6 +111,55 @@ class TestExport(TestCase):
         inp = ([torch.ones(1, 3)], torch.ones(1, 3))
         self._test_export_same_as_eager(f, inp)
 
+    def test_export_preserve_signature(self):
+        class NestedChild(torch.nn.Module):
+            def forward(self, zx, y):
+                return {"x": y["key"] + zx[1], "w": y["key"] * zx[1]}
+
+        class Child1(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nested = NestedChild()
+
+            def forward(self, x, y):
+                z = torch.ones_like(x)
+                xw = self.nested((z, x), y={"key": y})
+                return xw["w"] + z - xw["x"]
+
+        class Child2(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x - 1
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo = Child1()
+                self.bar = Child2()
+
+            def forward(self, x, y):
+                x = self.foo(x, y)
+                x = self.bar(x)
+                return x
+
+        orig_eager = MyModule()
+        inps = torch.rand(2, 3), torch.rand(2, 3)
+        ep = export(
+            orig_eager,
+            inps,
+            {},
+            preserve_module_call_signature=("foo.nested", "foo"),
+        )
+        ep.validate()
+        self.assertEqual(len(ep.module_call_graph), 2)
+        # TODO(zhxchen17) unflattener
+        # unflattened = unflatten(export_module)
+        # self.compare_outputs(export_module, unflattened, inps)
+        # unflattened.foo.nested = NestedChild()
+        # self.compare_outputs(export_module, unflattened, inps)
+
     def test_raise_user_error_when_guard_on_data_dependent_operation(self):
         def fn_ddo(x):
             y = x.nonzero()

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -145,10 +145,11 @@ FILENAME_ALLOWLIST |= {
     _module_dir(torch) + "ao/quantization/pt2e/utils.py",
 }
 
-# TODO (zhxchen17) Make exportdb importable here.
 FILENAME_ALLOWLIST |= set(
     glob.glob(_module_dir(torch) + "_export/db/examples/*.py"),
-)
+) | {
+    _module_dir(torch) + "_export/wrappers.py",
+}
 
 # torch.func: need to allow this file to be able to look at functorch transforms
 FILENAME_ALLOWLIST |= {

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -269,6 +269,8 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
             "tag_activation_checkpoint",
         ):
             return CheckpointHigherOrderVariable(value, source, **kwargs)
+        elif value.__name__ == "_export_tracepoint":
+            return ExportTracepointHigherOrderVariable(value, source, **kwargs)
         else:
             unimplemented(f"HigherOrderOperator {value.__name__}")
 
@@ -1096,4 +1098,24 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
                 kwargs=checkpoint_kwargs,
             ),
             example_value=example_value,
+        )
+
+
+class ExportTracepointHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        from .builder import wrap_fx_proxy
+
+        p_args = tuple(arg.as_proxy() for arg in args)
+        p_kwargs = {key: arg.as_proxy() for key, arg in kwargs.items()}
+        return wrap_fx_proxy(
+            tx=tx,
+            proxy=tx.output.create_proxy(
+                "call_function",
+                self.value,
+                args=p_args,
+                kwargs=p_kwargs,
+            ),
+            example_value=None,
         )

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -3,8 +3,9 @@ import inspect
 import re
 import weakref
 from collections import OrderedDict
-from unittest.mock import patch
+from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from unittest.mock import patch
 
 import sympy
 
@@ -12,19 +13,21 @@ import torch
 import torch._dynamo
 import torch.fx
 import torch.fx._pytree as fx_pytree
-from torch.fx._compatibility import compatibility
 
 import torch.utils._pytree as pytree
 from torch._decomp import core_aten_decompositions, get_decompositions
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.eval_frame import Constraint
 from torch._dynamo.exc import UserError, UserErrorType
+from torch._export.exported_program import ModuleCallEntry, ModuleCallSignature
+from torch._export.passes.collect_tracepoints_pass import CollectTracepointsPass
 from torch._functorch.aot_autograd import aot_export_module
 from torch._functorch.eager_transforms import functionalize
 from torch._guards import detect_fake_mode
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx import traceback as fx_traceback
+from torch.fx._compatibility import compatibility
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
@@ -50,6 +53,7 @@ from .passes.replace_sym_size_ops_pass import _ReplaceSymSizeOpPass
 from .passes.replace_view_ops_with_view_copy_ops_pass import (
     ReplaceViewOpsWithViewCopyOpsPass,
 )
+from .wrappers import _wrap_submodules
 
 # Note - [On Export Dynamic Dimension UX]
 #
@@ -170,6 +174,8 @@ def export(
     args: Tuple[Any],
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
+    *,
+    preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
     Traces either an nn.Module's forward function or just a callable with PyTorch
@@ -185,6 +191,9 @@ def export(
         constraints: A optional list of constraints on the dynamic arguments specifying
             their possible range of their shapes
 
+        preserve_module_call_signature: A list of submodule paths for which the original
+            calling conventions are preserved as metadata.
+
     Returns:
         An ExportedProgram containing the traced method.
     """
@@ -197,6 +206,7 @@ def export(
 
     with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
         try:
+            module_call_signatures: Dict[str, ModuleCallSignature] = {}
             # TODO horrible hack to skip dynamo when retracing
 
             def _safe_to_skip(gm: torch.fx.GraphModule):
@@ -208,15 +218,16 @@ def export(
             if isinstance(f, torch.fx.GraphModule) and _safe_to_skip(f):
                 gm_torch_level = f
             else:
-                gm_torch_level, _ = torch._dynamo.export(
-                    f,
-                    constraints=constraints,
-                    assume_static_by_default=True,
-                    tracing_mode="symbolic",
-                )(
-                    *args,
-                    **kwargs,
-                )
+                with _wrap_submodules(f, preserve_module_call_signature, module_call_signatures):
+                    gm_torch_level, _ = torch._dynamo.export(
+                        f,
+                        constraints=constraints,
+                        assume_static_by_default=True,
+                        tracing_mode="symbolic",
+                    )(
+                        *args,
+                        **kwargs,
+                    )
 
             params_buffers: OrderedDict[str, Union[torch.Tensor, torch.nn.Parameter]] = OrderedDict()
             for name, param in gm_torch_level.named_parameters(recurse=True, remove_duplicate=False):
@@ -389,11 +400,14 @@ def export(
                 params_buffers,
                 range_constraints,
                 equality_constraints,
+                [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
             )
 
             exported_program = exported_program.transform(
                 _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
             )
+            if len(preserve_module_call_signature) > 0:
+                exported_program = exported_program.transform(CollectTracepointsPass(module_call_signatures))
             return exported_program.transform(_ReplaceSymSizeOpPass())
 
         except (ConstraintViolationError, ValueRangeError) as e:

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -1,0 +1,52 @@
+import operator
+
+import torch
+
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+__all__ = ["CollectTracepointsPass"]
+
+
+class CollectTracepointsPass(PassBase):
+    """
+    Performs constant folding and constant propagation.
+    """
+
+    def __init__(self, specs) -> None:
+        super().__init__()
+        self.specs = specs
+
+    def call(self, gm):
+        for module in gm.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if node.target == torch.ops.higher_order._export_tracepoint:
+                    for i, arg in enumerate(node.args):
+                        kind = node.kwargs["kind"]
+                        if kind == "module_call_inputs":
+                            self.specs[node.kwargs["path"]].inputs.append(arg.name)
+                        elif kind == "module_call_outputs":
+                            self.specs[node.kwargs["path"]].outputs.append(arg.name)
+                        else:
+                            raise AssertionError(f"Unknown tracepoint kind: {kind}")
+                        for user in node.users:
+                            assert user.op == "call_function"
+                            assert user.target == operator.getitem
+                            assert isinstance(user.args[1], int)
+                            if user.args[1] == i:
+                                break
+                        else:
+                            raise AssertionError(
+                                f"Corresponding user node not found for argument: {arg}, index: {i}"
+                            )
+                        user.replace_all_uses_with(arg)
+                    users = list(node.users)
+                    for user in users:
+                        assert len(user.users) == 0
+                        gm.graph.erase_node(user)
+                    gm.graph.erase_node(node)
+            return PassResult(gm, True)

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -212,10 +212,26 @@ class RangeConstraint:
 
 
 @dataclass
+class ModuleCallSignature:
+    inputs: List[Argument]
+    outputs: List[Argument]
+    in_spec: str
+    out_spec: str
+
+
+@dataclass
+class ModuleCallEntry:
+    fqn: str
+    signature: Optional[ModuleCallSignature] = None
+
+
+@dataclass
 class GraphModule:
     graph: Graph
     signature: GraphSignature
+    # TODO(zhxchen17) Merge call_spec into call graph.
     call_spec: CallSpec
+    module_call_graph: List[ModuleCallEntry]
 
 
 @dataclass

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -9,7 +9,7 @@ import typing
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import cast, Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union
 
 import sympy
 
@@ -32,6 +32,8 @@ from .schema import (  # type: ignore[attr-defined]
     GraphSignature,
     Layout,
     MemoryFormat,
+    ModuleCallEntry,
+    ModuleCallSignature,
     NamedArgument,
     Node,
     OptionalTensorArgument,
@@ -328,10 +330,16 @@ class GraphState:
 
 
 class GraphModuleSerializer:
-    def __init__(self, graph_signature: ep.ExportGraphSignature, call_spec: ep.CallSpec):
+    def __init__(
+        self,
+        graph_signature: ep.ExportGraphSignature,
+        call_spec: ep.CallSpec,
+        module_call_graph: List[ep.ModuleCallEntry]
+    ):
         self.graph_state = GraphState()
         self.graph_signature = graph_signature
         self.call_spec = call_spec
+        self.module_call_graph = module_call_graph
 
     @contextmanager
     def save_graph_state(self):
@@ -588,6 +596,30 @@ class GraphModuleSerializer:
         self.graph_state.sym_bool_values[name] = serialize_sym_bool(meta_val)
         return SymBoolArgument.create(as_name=name)
 
+    def serialize_module_call_signature(self, module_call_signature: ep.ModuleCallSignature) -> ModuleCallSignature:
+        def serialize_argument(x: ep.ArgumentSpec) -> Argument:
+            if x.kind == ep.ArgumentKind.Tensor:
+                return Argument.create(as_tensor=TensorArgument(name=x.value))
+            elif x.kind == ep.ArgumentKind.SymInt:
+                return Argument.create(as_sym_int=SymIntArgument.create(as_name=x.value))
+            else:
+                assert x.kind == ep.ArgumentKind.Constant
+                return self.serialize_input(x.value)
+        return ModuleCallSignature(
+            inputs=[serialize_argument(x) for x in module_call_signature.inputs],
+            outputs=[serialize_argument(x) for x in module_call_signature.outputs],
+            in_spec=pytree_to_str(module_call_signature.in_spec),
+            out_spec=pytree_to_str(module_call_signature.out_spec),
+        )
+
+    def serialize_module_call_graph(self, module_call_graph: List[ep.ModuleCallEntry]) -> List[ModuleCallEntry]:
+        return [
+            ModuleCallEntry(
+                fqn=entry.fqn,
+                signature=self.serialize_module_call_signature(entry.signature) if entry.signature else None,
+            ) for entry in module_call_graph
+        ]
+
     def serialize_outputs(self, node: torch.fx.Node) -> List[Argument]:
         """For a given node, return the dataclass representing its output values.
 
@@ -688,6 +720,7 @@ class GraphModuleSerializer:
             graph=graph,
             signature=serialize_signature(self.graph_signature),
             call_spec=serialize_call_spec(self.call_spec),
+            module_call_graph=self.serialize_module_call_graph(self.module_call_graph),
         )
 
 
@@ -703,7 +736,8 @@ class ExportedProgramSerializer:
         serialized_graph_module = (
             GraphModuleSerializer(
                 exported_program.graph_signature,
-                exported_program.call_spec
+                exported_program.call_spec,
+                exported_program.module_call_graph
             ).serialize(exported_program.graph_module)
         )
         serialized_range_constraints = serialize_range_constraints(exported_program.range_constraints)
@@ -890,7 +924,7 @@ class GraphModuleDeserializer:
         self,
         serialized_graph_module: GraphModule,
         symbol_name_to_range: Optional[Dict[str, symbolic_shapes.ValueRanges]] = None,
-    ) -> Tuple[torch.fx.GraphModule, ep.ExportGraphSignature, ep.CallSpec, Dict[str, sympy.Symbol]]:
+    ) -> Tuple[torch.fx.GraphModule, ep.ExportGraphSignature, ep.CallSpec, List[ep.ModuleCallEntry], Dict[str, sympy.Symbol]]:
         self.shape_env = symbolic_shapes.ShapeEnv()
         self.fake_tensor_mode = FakeTensorMode(shape_env=self.shape_env)
         self.symbol_name_to_symbol: Dict[str, sympy.Symbol] = {}
@@ -900,7 +934,8 @@ class GraphModuleDeserializer:
 
         sig = deserialize_signature(serialized_graph_module.signature)
         call_spec = deserialize_call_spec(serialized_graph_module.call_spec)
-        return torch.fx.GraphModule(self.module, self.graph), sig, call_spec, self.symbol_name_to_symbol
+        module_call_graph = self.deserialize_module_call_graph(serialized_graph_module.module_call_graph)
+        return torch.fx.GraphModule(self.module, self.graph), sig, call_spec, module_call_graph, self.symbol_name_to_symbol
 
     def sync_fx_node(self, name: str, fx_node: torch.fx.Node):
         if name in self.serialized_name_to_node:
@@ -1104,6 +1139,32 @@ class GraphModuleDeserializer:
 
         return ret
 
+    def deserialize_module_call_signature(self, module_call_signature: ModuleCallSignature) -> ep.ModuleCallSignature:
+        def deserialize_argument(x: Argument) -> ep.ArgumentSpec:
+            if x.as_tensor is not None:
+                return ep.ArgumentSpec(kind=ep.ArgumentKind.Tensor, value=x.as_tensor.name)
+            elif x.as_symint is not None:
+                return ep.ArgumentSpec(kind=ep.ArgumentKind.SymInt, value=x.as_symint.as_name)
+            else:
+                return ep.ArgumentSpec(
+                    kind=ep.ArgumentKind.Constant, value=self.deserialize_input(x)
+                )
+
+        return ep.ModuleCallSignature(
+            inputs=[deserialize_argument(x) for x in module_call_signature.inputs],
+            outputs=[deserialize_argument(x) for x in module_call_signature.outputs],
+            in_spec=str_to_pytree(module_call_signature.in_spec),
+            out_spec=str_to_pytree(module_call_signature.out_spec),
+        )
+
+    def deserialize_module_call_graph(self, module_call_graph: List[ModuleCallEntry]) -> List[ep.ModuleCallEntry]:
+        return [
+            ep.ModuleCallEntry(
+                fqn=entry.fqn,
+                signature=self.deserialize_module_call_signature(entry.signature) if entry.signature else None,
+            ) for entry in module_call_graph
+        ]
+
 
 class ExportedProgramDeserializer:
     def __init__(self, expected_opset_version: Optional[Dict[str, int]] = None):
@@ -1134,7 +1195,7 @@ class ExportedProgramDeserializer:
             for k, v in serialized_exported_program.range_constraints.items()
         }
 
-        graph_module, sig, call_spec, symbol_name_to_symbol = (
+        graph_module, sig, call_spec, module_call_graph, symbol_name_to_symbol = (
             GraphModuleDeserializer()
             .deserialize(
                 serialized_exported_program.graph_module,
@@ -1160,6 +1221,7 @@ class ExportedProgramDeserializer:
             state_dict,
             range_constraints,
             equality_constraints,
+            module_call_graph,
         )
         return upgrader.upgrade(exported_program)
 

--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -1,0 +1,134 @@
+from contextlib import contextmanager
+
+import torch
+import torch._custom_ops
+from torch._C import _ExcludeDispatchKeyGuard, DispatchKey, DispatchKeySet
+from torch._export.exported_program import ModuleCallSignature
+from torch._functorch.eager_transforms import _unwrap_all_tensors_from_functional
+from torch._higher_order_ops.wrap import wrap
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+from torch.utils import _pytree as pytree
+from torch.utils._python_dispatch import (
+    _get_current_dispatch_mode,
+    _pop_mode_temporarily,
+)
+
+
+_export_tracepoint = HigherOrderOperator("_export_tracepoint")
+
+
+_export_tracepoint.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
+_export_tracepoint.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
+_export_tracepoint.fallthrough(DispatchKey.ADInplaceOrView)
+_export_tracepoint.fallthrough(DispatchKey.BackendSelect)
+_export_tracepoint.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
+_export_tracepoint.fallthrough(DispatchKey.AutogradCPU)
+
+
+@_export_tracepoint.py_impl(ProxyTorchDispatchMode)
+def export_tracepoint_dispatch_mode(*args, **kwargs):
+    mode = _get_current_dispatch_mode()
+    assert mode is not None, "Mode should always be enabled for python fallback key"
+    with _pop_mode_temporarily() as mode:
+        if not mode.enable_tracing:
+            return _export_tracepoint(*args, **kwargs)
+        p_args, p_kwargs = pytree.tree_map(mode.tracer.unwrap_proxy, (args, kwargs))
+        proxy = mode.tracer.create_proxy(
+            "call_function", _export_tracepoint, p_args, p_kwargs
+        )
+        return track_tensor_tree(args, proxy, constant=None, tracer=mode.tracer)
+
+
+@_export_tracepoint.py_impl(FakeTensorMode)
+def export_tracepoint_fake_tensor_mode(*args, **kwargs):
+    return args
+
+
+@_export_tracepoint.py_impl(DispatchKey.Functionalize)
+def export_tracepoint_functionalize(*args, **kwargs):
+    reapply_views = torch._C._functionalization_reapply_views_tls()
+    unwrapped_args = _unwrap_all_tensors_from_functional(
+        args, reapply_views=reapply_views
+    )
+    unwrapped_kwargs = _unwrap_all_tensors_from_functional(
+        kwargs, reapply_views=reapply_views
+    )
+    with _ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.Functionalize)):
+        return _export_tracepoint(*unwrapped_args, **unwrapped_kwargs)
+
+
+@_export_tracepoint.py_impl(DispatchKey.CPU)
+def export_tracepoint_cpu(*args, **kwargs):
+    return args
+
+
+def _wrap_submodule(mod, path, module_call_signatures):
+    assert isinstance(mod, torch.nn.Module)
+    assert path != ""
+    parent = None
+    submodule = mod
+    for name in path.split("."):
+        parent = submodule
+        if not hasattr(submodule, name):
+            raise RuntimeError(f"Couldn't find submodule at path {path}")
+        submodule = getattr(submodule, name)
+
+    from torch._dynamo import assume_constant_result
+
+    # TODO(zhxchen17) Use pytree output from higher order op directly.
+    @assume_constant_result
+    def update_module_call_signatures(path, in_spec, out_spec):
+        assert path not in module_call_signatures
+        module_call_signatures[path] = ModuleCallSignature(
+            inputs=[], outputs=[], in_spec=in_spec, out_spec=out_spec
+        )
+
+    class WrappedModule:
+        def __init__(self):
+            self.__class__ = type(
+                submodule.__class__.__name__,
+                (self.__class__, submodule.__class__),
+                {},
+            )
+            self.__dict__ = submodule.__dict__
+            assert not hasattr(self, "module_call_signatures")
+            self.module_call_signatures = module_call_signatures
+
+        def forward(self, *args, **kwargs):
+            flat_args, in_spec = pytree.tree_flatten((args, kwargs))
+
+            def flat_gm(*flat_args):
+                flat_args = _export_tracepoint(
+                    *flat_args, kind="module_call_inputs", path=path
+                )
+                args, kwargs = pytree.tree_unflatten(flat_args, in_spec)
+                res = submodule(*args, **kwargs)
+                flat_res, out_spec = pytree.tree_flatten(res)
+                flat_res = _export_tracepoint(
+                    *flat_res, kind="module_call_outputs", path=path
+                )
+                update_module_call_signatures(path, in_spec, out_spec)
+                return flat_res
+
+            flat_res = wrap(flat_gm, *flat_args)
+            return pytree.tree_unflatten(
+                flat_res, self.module_call_signatures[path].out_spec
+            )
+
+    setattr(parent, name, WrappedModule())
+    return parent, name, submodule
+
+
+@contextmanager
+def _wrap_submodules(f, preserve_signature, module_call_signatures):
+    tasks = []
+
+    try:
+        for path in preserve_signature:
+            tasks.append(_wrap_submodule(f, path, module_call_signatures))
+        yield
+    finally:
+        for parent, name, submodule in tasks:
+            setattr(parent, name, submodule)


### PR DESCRIPTION
Summary: APS use this feature to swap out some submodules after unflattening.

Test Plan: test_export_preserve_signature

Differential Revision: D48154341



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov