### PR TITLE
[CI] Fix sccaching of nvcc builds

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -68,6 +68,7 @@ if(USE_CUDA)
     else()
       caffe2_update_option(USE_TENSORRT OFF)
     endif()
+    find_program(SCCACHE_EXECUTABLE sccache)
     if(SCCACHE_EXECUTABLE)
       # Using RSP/--options-file renders output noncacheable by sccache
       # as they fall under `multiple input files` non-cacheable rule

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -68,6 +68,13 @@ if(USE_CUDA)
     else()
       caffe2_update_option(USE_TENSORRT OFF)
     endif()
+    if(SCCACHE_EXECUTABLE)
+      # Using RSP/--options-file renders output noncacheable by sccache
+      # as they fall under `multiple input files` non-cacheable rule
+      set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_INCLUDES 0)
+      set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_LIBRARIES 0)
+      set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_OBJECTS 0)
+    endif()
   else()
     message(WARNING
       "Not compiling with CUDA. Suppress this warning with "


### PR DESCRIPTION
In cmake-3.26 or newer, `--options-file` is used, which renders nvcc outputs uncacheable by `sccache`, which were enable for CUDA-11 or newer builds by default by https://github.com/Kitware/CMake/commit/6377a43814bb6f3087b731644bb61302a3fc3c55

Fix it by disabling RESPONSE_FILE use for CUDA compilation.
Test Plan: Check that `multiple input files` stats in `PyTorch Build Statistics` is down to 13 files again, see https://github.com/pytorch/pytorch/actions/runs/5801865789/job/15727069855?pr=106811#step:10:42423

Fixes https://github.com/pytorch/pytorch/issues/105004
