### PR TITLE
[MPS] Make several ops unranked to avoid graph recompilation

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -72,7 +72,8 @@ public:
   void copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                      size_t length, size_t srcOffset, size_t dstOffset,
                      bool non_blocking, uint64_t profileId);
-  void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
+  void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results,
+                       SyncType syncType = SyncType::NONE, MPSGraphExecutable* executable = nullptr);
   void addCompletedHandler(MTLCommandBufferHandler block);
 
   /// Get the MPS device index that this stream is associated with.
@@ -92,6 +93,7 @@ private:
   MPSCommandBuffer* _prevCommandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
+  MPSGraphExecutableExecutionDescriptor *_executableExecutionDescriptor = nil;
   MPSGraphCompilationDescriptor *_compilationDescriptor = nil;
   dispatch_queue_t _serialQueue = nullptr;
   // CommitAndContinue is enabled by default

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -51,6 +51,17 @@ void runMPSGraph(
     NSDictionary* feeds,
     NSDictionary* results);
 
+struct MPSCachedGraph;
+
+void runMPSGraph(
+  MPSStream *mpsStream,
+  MPSCachedGraph* cachedGraph,
+  NSDictionary *feeds,
+  NSDictionary *results,
+  bool disableTypeInference = false,
+  SyncType syncType = SyncType::COMMIT_ADAPTIVE);
+
+
 MPSDataType getMPSDataType(ScalarType scalar_type);
 static inline MPSDataType getMPSDataType(const Tensor& t) {
   return getMPSDataType(t.scalar_type());
@@ -68,7 +79,7 @@ std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t);
 NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);
 std::string getMPSShapeString(MPSShape* shape);
-std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = true);
+std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = true, bool exclude_shape = false);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
@@ -148,8 +159,11 @@ struct MPSCachedGraph
 
   MPSGraph *graph() const { return (MPSGraph *)_object; }
   NSObject *object() const { return _object; }
+  MPSGraphExecutable *getExecultable() const { return _executable; }
+  void setExecultable(MPSGraphExecutable *executable) { _executable = executable; }
 private:
   NSObject *_object = nullptr;
+  MPSGraphExecutable* _executable = nullptr;
 };
 
 struct MPSUnaryCachedGraph : public MPSCachedGraph

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -702,10 +702,11 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
   }
 
   @autoreleasepool {
-    string key = "index_select_out_mps" + getTensorsStringKey({self, index}) + ":" + std::to_string(dim);
+    string key = "index_select_out_mps" + getTensorsStringKey({self, index}, true, /*exclude_shape*/ true) + ":" +
+        std::to_string(dim);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self));
-      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
+      MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, inputType);
+      MPSGraphTensor* indexTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(index.scalar_type()));
 
       MPSGraphTensor* outputTensor = [mpsGraph gatherWithUpdatesTensor:inputTensor
                                                          indicesTensor:indexTensor
@@ -737,7 +738,7 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph, feeds, results, /*disable_type_inference=*/true);
   }
 
   return output;

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -445,15 +445,39 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     MPSGraphTensor* outputTensor_ = nil;
   };
 
+  MPSShape* shape = nil;
+  bool doTranspose = false;
+
+  // Handle transposes for the second batch of matrices.
+  if (batch2.is_view() && !batch2.is_contiguous()) {
+    if (batch2.numel() == batch2._base().numel()) {
+      const IntArrayRef& viewSizes = batch2.sizes();
+
+      // Handle 3D and 4D tensors.
+      // For 4D tensors, first it must have been reshaped from 4D to 3D and then transposed.
+      int32_t baseTransposeStrideDim = batch2._base().dim() == 4 ? -3 : -2;
+      if (batch2.size(0) == batch2.size(0) && batch2._base().stride(0) == batch2.stride(0) &&
+          batch2._base().stride(baseTransposeStrideDim) == batch2.stride(-1)) {
+        shape = @[ @(viewSizes[0]), @(viewSizes[2]), @(viewSizes[1]) ];
+        doTranspose = true;
+      }
+    }
+  }
+
   @autoreleasepool {
-    string key = "bmm_out_mps_impl" + getTensorsStringKey({batch1, batch2});
+    string key = "bmm_out_mps_impl" + getTensorsStringKey({batch1, batch2}, true, /*exclude_shape*/ true) +
+        std::to_string(doTranspose);
 
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* batch1Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch1);
-      MPSGraphTensor* batch2Tensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, batch2);
+      MPSGraphTensor* batch1Tensor = mps::mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batch1.scalar_type()));
+      MPSGraphTensor* batch2Tensor = mps::mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(batch2.scalar_type()));
+      MPSGraphTensor* batch2TensorTranspose = batch2Tensor;
 
+      if (doTranspose) {
+        batch2TensorTranspose = [mpsGraph transposeTensor:batch2Tensor dimension:-1 withDimension:-2 name:nil];
+      }
       MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
-                                                                      secondaryTensor:batch2Tensor
+                                                                      secondaryTensor:batch2TensorTranspose
                                                                                  name:@"MM/(batch1@batch2)"];
 
       newCachedGraph->batch1Tensor_ = batch1Tensor;
@@ -461,7 +485,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
       newCachedGraph->outputTensor_ = productTensor;
     });
     Placeholder batch1Placeholder = Placeholder(cachedGraph->batch1Tensor_, batch1);
-    Placeholder batch2Placeholder = Placeholder(cachedGraph->batch2Tensor_, batch2);
+    Placeholder batch2Placeholder = Placeholder(cachedGraph->batch2Tensor_, batch2, shape, !doTranspose);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
@@ -472,7 +496,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results =
         @{outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()};
 
-    mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    mps::runMPSGraph(stream, cachedGraph, feeds, results, /*disable_type_inference*/ true);
   }
 
   return result;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -147,7 +147,6 @@ def mps_ops_grad_modifier(ops):
 
     MACOS_BEFORE_13_3_XFAILLIST_GRAD = {
         # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
-        'masked.softmin': [torch.float32],
         'masked.log_softmax': [torch.float32],
 
         # Unsupported Border padding mode, forward pass success as fallback to cpu

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -148,6 +148,7 @@ def mps_ops_grad_modifier(ops):
     MACOS_BEFORE_13_3_XFAILLIST_GRAD = {
         # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
         'masked.softmin': [torch.float32],
+        'masked.log_softmax': [torch.float32],
 
         # Unsupported Border padding mode, forward pass success as fallback to cpu
         'grid_sampler_2d': [torch.float32],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7905,6 +7905,8 @@ class TestNLLLoss(TestCaseMPS):
             helper((2, 8, 4, 5), 1.0, op_name, inplace)
             helper((2, 8, 3, 5), 0.1, op_name, inplace)
             helper((2, 8, 3, 5), 0.2, op_name, inplace)
+            helper((3, 4, 5, 6, 2), 0.2, op_name, inplace)
+            helper((2), 0.2, op_name, inplace)
 
     # Test add
     def test_add_scalars(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -148,8 +148,6 @@ def mps_ops_grad_modifier(ops):
     MACOS_BEFORE_13_3_XFAILLIST_GRAD = {
         # Failures due to precision issues (due to fast-math). These has been fixed in MacOS 13.3+
         'masked.softmin': [torch.float32],
-        'masked.softmax': [torch.float32],
-        'masked.log_softmax': [torch.float32],
 
         # Unsupported Border padding mode, forward pass success as fallback to cpu
         'grid_sampler_2d': [torch.float32],


### PR DESCRIPTION
- Made `bmm`, `cat`, `softmax`, `copy_cast` and `index_select` unranked. This improves the performance of LLMs and other networks, because these graphs would be invariant to shape changes, and therefore, they won't recompile. 
- Binary ops: Flatten tensors bigger than 4D to 1D, and reuse existing buffer for in-place operations (for offset 0).
- Cache the `MPSGraphExecutable` in `MPSCachedGraph`. These executables have the typeInference disabled which should help with recompilation issues on MPSGraph.
- Handle transposes in second batch of matrices in `bmm`. This helps with performance in case the second batch (i.e., `other` argument) was transposed (like the case with `QxK.t()` in Transformers).


cc @kulinseth @albanD @malfet @DenisVieriu97 @abhudev