### PR TITLE
Add _unsafe_index decomp

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -549,7 +549,6 @@ aten::_unique
 aten::_unique.out
 aten::_unique2
 aten::_unique2.out
-aten::_unsafe_index.Tensor
 aten::_unsafe_index_put
 aten::_upsample_bicubic2d_aa
 aten::_upsample_bicubic2d_aa.out

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -338,6 +338,7 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.triu_,
             aten.unfold_backward,
             aten.unfold_copy,
+            aten._unsafe_index,
             aten.upsample_bilinear2d,
             aten.upsample_nearest2d_backward,
             aten.xlogy,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2995,6 +2995,11 @@ def _reshape_alias(x, shape, *args):
     return aten.view(x, shape)
 
 
+@register_decomposition([aten._unsafe_index])
+def _index(x, indices):
+    return aten.index(x, indices)
+
+
 def _nll_loss_forward(
     self: Tensor,
     target: Tensor,


### PR DESCRIPTION
Summary:
Redirect `aten._unsafe_index` to `aten.index` through a decomposition.

Also add it to the list of core decompositions.

Test Plan: contbuild and OSS CI (similar to D40075277)

Differential Revision: D48163393

