### PR TITLE
expandable_segments fix possible assert

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2353,8 +2353,8 @@ class DeviceCachingAllocator {
           block->requested_size,
           block->stream,
           block->context_when_allocated);
-      block->context_when_allocated = nullptr;
     }
+    block->context_when_allocated = nullptr;
     size_t original_block_size = block->size;
     size_t requested_size = block->requested_size;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106818

If record_history is enabled, then a block is allocated, record_history
is disabled, and then the block is freed and later unnmapped, we can hit
the `to_map->context_when_allocated == nullptr` assertion.

This change universally clears context_when_allocated on free, which should
prevent this sequence of events from  happening.