### PR TITLE
Update opset version warning text

### DIFF
--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -110,8 +110,8 @@ class OnnxRegistry:
         # TODO: get opset version from torchlib
         self._opset_version = _DEFAULT_OPSET_VERSION
         warnings.warn(
-            f"Torchlib only supports opset version {self._opset_version} for now. If you need to use a \
-            different opset version, please register them with register_custom_op."
+            f"torch.onnx.dynamo_export only implements opset version {self._opset_version} for now. If you need to use a "
+            "different opset version, please register them with register_custom_op."
         )
 
         # Initialize registry from torchlib


### PR DESCRIPTION
Fix the line break. Remove mentioning of "Torchlib" and instead mention `torch.onnx.dynamo_export` because `Torchlib` seems like a foreign concept in torch. Suggestions welcome.
