### PR TITLE
Enable mypy check in torch/_inductor/fx_passes/post_grad.py

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -2,6 +2,9 @@ import functools
 import itertools
 import logging
 import operator
+from typing import List, Optional, Union
+
+from sympy import Expr
 
 import torch
 import torch._inductor as inductor
@@ -149,7 +152,7 @@ def register_lowering_pattern(pattern, extra_check=_return_true, pass_number=1):
     )
 )
 def mm_plus_mm(match: Match, mat1, mat2, mat3, mat4):
-    return inductor.kernel.mm_plus_mm.tuned_mm_plus_mm(mat1, mat2, mat3, mat4)
+    return inductor.kernel.mm_plus_mm.tuned_mm_plus_mm(mat1, mat2, mat3, mat4)  # type: ignore[attr-defined]
 
 
 @register_graph_pattern(
@@ -225,7 +228,7 @@ def cat_tuned_op(match, inputs, dim, *, op, shape_of):
     assert dim in (0, 1)
     notdim = 1 - dim
 
-    new_size = None
+    new_size: Optional[Union[List[Expr], List[int]]] = None
     offsets_start = []
     offsets_end = []
 
@@ -242,6 +245,7 @@ def cat_tuned_op(match, inputs, dim, *, op, shape_of):
         offsets_start.append(new_size[dim] - shape[dim])
         offsets_end.append(new_size[dim])
 
+    assert new_size is not None
     dtype = functools.reduce(
         torch.promote_types, [x.get_dtype() for x in itertools.chain(*inputs)]
     )


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner -a torch/_inductor/fx_passes/post_grad.py
  FLAKE8 success!
  CLANGFORMAT success!
  MYPYNOFOLLOW success!
  MYPY success!
  MYPYSTRICT success!
  CLANGTIDY success!
  TYPEIGNORE success!
  NOQA success!
  CIRCLECI success!
  SPACES success!
  NEWLINE success!
  CONSTEXPR success!
  NATIVEFUNCTIONS success!
  INCLUDE success!
  TABS success!
  PYBIND11_INCLUDE success!
  ERROR_PRONE_ISINSTANCE success!
  PYBIND11_SPECIALIZATION success!
  PYPIDEP success!
  RAWCUDA success!
  CUBINCLUDE success!
  EXEC success!
  RAWCUDADEVICE success!
  ROOT_LOGGING success!
  DEPLOY_DETECTION success!
  ACTIONLINT success!
  CALL_ONCE success!
  TESTOWNERS success!
  WORKFLOWSYNC success!
  CMAKE success!
  COPYRIGHT success!
  BAZEL_LINTER success!
  SHELLCHECK success!
  LINTRUNNER_VERSION success!
  UFMT success!
  ONCE_FLAG success!
  RUFF success!
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/fx_passes/post_grad.py
Success: no issues found in 1 source file
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov