### PR TITLE
[TGIF][Inplace][Perf] Copy tensor to device with pinned memory & move copy weight sleep to getRecord

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -110,6 +110,7 @@ class TORCH_API PyTorchStreamReader final {
       void* dst,
       size_t n,
       size_t chunk_size,
+      void* buf,
       const std::function<void(void*, const void*, size_t)>& memcpy_func);
   size_t getRecordOffset(const std::string& name);
   bool hasRecord(const std::string& name);

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -23,6 +23,8 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoad) {
   });
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 127> data1;
+  // Inplace memory buffer
+  std::vector<uint8_t> buf(data1.size());
 
   for (auto i : c10::irange(data1.size())) {
     data1[i] = data1.size() - i;
@@ -74,7 +76,7 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoad) {
   ASSERT_EQ(memcmp(dst.data(), data1.data(), size), 0);
   // chunked getRecord() test
   ret = reader.getRecord(
-      "key1", dst.data(), size, 3, [](void* dst, const void* src, size_t n) {
+      "key1", dst.data(), size, 3, buf.data(), [](void* dst, const void* src, size_t n) {
         memcpy(dst, src, n);
       });
   ASSERT_EQ(ret, size);
@@ -94,7 +96,7 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoad) {
   ASSERT_EQ(memcmp(dst.data(), data2.data(), size), 0);
   // chunked getRecord() test
   ret = reader.getRecord(
-      "key2", dst.data(), size, 3, [](void* dst, const void* src, size_t n) {
+      "key2", dst.data(), size, 3, buf.data(), [](void* dst, const void* src, size_t n) {
         memcpy(dst, src, n);
       });
   ASSERT_EQ(ret, size);
@@ -112,6 +114,9 @@ TEST(PytorchStreamWriterAndReader, GetNonexistentRecordThrows) {
   });
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 127> data1;
+
+  // Inplace memory buffer
+  std::vector<uint8_t> buf;
 
   for (auto i : c10::irange(data1.size())) {
     data1[i] = data1.size() - i;
@@ -154,6 +159,7 @@ TEST(PytorchStreamWriterAndReader, GetNonexistentRecordThrows) {
           dst.data(),
           data1.size(),
           3,
+          buf.data(),
           [](void* dst, const void* src, size_t n) { memcpy(dst, src, n); }),
       c10::Error);
 
@@ -171,6 +177,8 @@ TEST(PytorchStreamWriterAndReader, SkipDebugRecords) {
   });
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 127> data1;
+  // Inplace memory buffer
+  std::vector<uint8_t> buf(data1.size());
 
   for (auto i : c10::irange(data1.size())) {
     data1[i] = data1.size() - i;
@@ -218,6 +226,7 @@ TEST(PytorchStreamWriterAndReader, SkipDebugRecords) {
       dst.data(),
       data1.size(),
       3,
+      buf.data(),
       [](void* dst, const void* src, size_t n) { memcpy(dst, src, n); });
   EXPECT_EQ(ret, 0);
   // clean up


### PR DESCRIPTION
Summary:
There are 2 changes in the diff that helps optimize perf during inplace update:
1. Read data with pinned memory
2. move the copy weight sleep from between copying the whole Tensor to between copying chunks

Test Plan:
**Local Test**
```
./ai_infra/inference_platform/test_platform/script/run_sigrid_4card.sh --port 7451 --local_model_dir /home/lujia/script --cuda_devices 6 --bind_node 3 --model_id 962549778_514 --gflag_config_path sigrid/predictor/predictor_x_gflags_mrs_prospector_gpu_torchscript_fusedsolution_1card_opt_fm -- --enable_thrift_warmup=false --tgif_replicate_merge_by_tempfile=false --enable_inplace_snapshot_transition --model_version_config_path sigrid/predictor/models_version/lujia_test --inplace_update_max_retries 0 --submod_to_device="merge|cuda0"
```

**Load test on job  tsp_eag/smart/inference_platform_sp__sigrid_predictor_gpu_adhoc_realtimetest_m962549778_latest.s3**

Before:
(p99 latency)
{F1066957232}

(SR error rate)
 {F1066957650}

After:
(p99 latency)
 {F1066957141}

(SR error rate)
{F1066957376}

Differential Revision: D48182533

