### PR TITLE
[FSDP][Easy] `zeros` -> `empty` for immediately freed tensors

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1137,7 +1137,7 @@ class FlatParamHandle:
             # sharded tensor on the compute device to be all-gathered (for
             # sharded strategies) or directly used (for `NO_SHARD`) for
             # computation.
-            flat_param._mp_shard = torch.zeros_like(
+            flat_param._mp_shard = torch.empty_like(
                 flat_param._local_shard,
                 device=self.device,
                 dtype=self._fwd_bwd_param_dtype,
@@ -1152,7 +1152,7 @@ class FlatParamHandle:
                 else flat_param.dtype
             )  # use low precision if parameter mixed precision is enabled
             padded_unsharded_numel = flat_param.numel() * self.world_size
-            flat_param._full_param_padded = torch.zeros(
+            flat_param._full_param_padded = torch.empty(
                 padded_unsharded_numel,
                 device=self.device,
                 dtype=unsharded_param_dtype,
@@ -1163,7 +1163,7 @@ class FlatParamHandle:
             if self._uses_param_mixed_precision:
                 # For parameter mixed precision, we maintain a full precision
                 # padded unsharded tensor for when we force full precision.
-                flat_param._full_prec_full_param_padded = torch.zeros(
+                flat_param._full_prec_full_param_padded = torch.empty(
                     padded_unsharded_numel,
                     device=self.device,
                     dtype=flat_param.dtype,  # full precision


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106858
* __->__ #106857

Since we immediately free these tensors' storage (via `_free_storage()`), there is no reason to zero them after allocation:
https://github.com/pytorch/pytorch/blob/92e5b124c8feae01450ba020ed95a5ce8a327fa8/torch/distributed/fsdp/flat_param.py#L1140-L1145
https://github.com/pytorch/pytorch/blob/92e5b124c8feae01450ba020ed95a5ce8a327fa8/torch/distributed/fsdp/flat_param.py#L1155-L1161
https://github.com/pytorch/pytorch/blob/92e5b124c8feae01450ba020ed95a5ce8a327fa8/torch/distributed/fsdp/flat_param.py#L1166-L1171