### PR TITLE
[FSDP] Fix train -> EMA -> eval with mixed precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -25,6 +25,7 @@ from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, size_based_auto_wrap_policy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
+from torch.optim.swa_utils import AveragedModel
 from torch.testing._internal.common_distributed import (
     SaveForwardInputsModel,
     skip_if_lt_x_gpu,
@@ -1277,6 +1278,89 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         self.assertEqual(forward_inputs["model_input_x"].dtype, torch.float16)
         self.assertEqual(forward_inputs["l2_input_x"].dtype, torch.float16)
         self.assertEqual(forward_inputs["l2_input_y"].dtype, torch.float32)
+
+
+class TestFSDPTrainEval(FSDPTest):
+    @property
+    def world_size(self):
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_train_ema_eval_flow(self):
+        """
+        Tests a train -> EMA update -> eval flow with mixed precision enabled.
+        """
+        self.run_subtests(
+            {
+                "sharding_strategy": [
+                    # We mainly want to test `SHARD_GRAD_OP` since it surfaced
+                    # the original bug of not using the right EMA parameters
+                    # for eval, but we also test the others for completeness
+                    ShardingStrategy.SHARD_GRAD_OP,
+                    ShardingStrategy.FULL_SHARD,
+                    ShardingStrategy.NO_SHARD,
+                ]
+            },
+            self._test_train_ema_eval_flow,
+        )
+
+    def _test_train_ema_eval_flow(self, sharding_strategy: ShardingStrategy):
+        class TransformerWithEMA(nn.Module):
+            def __init__(self, device: torch.device):
+                super().__init__()
+                self.module = nn.Transformer(device=device)
+                self.ema_module = AveragedModel(
+                    nn.Transformer(device=device),
+                    multi_avg_fn=torch.optim.swa_utils.get_ema_multi_avg_fn(),
+                    use_buffers=True,
+                )
+
+            def forward(self, *args, **kwargs):
+                # Use main copy for training and EMA copy for eval
+                if self.training:
+                    return self.module(*args, **kwargs)
+                return self.ema_module(*args, **kwargs)
+
+        device = torch.device("cuda")
+        model = TransformerWithEMA(device=device)
+        policy = ModuleWrapPolicy(
+            {nn.Transformer, nn.TransformerEncoderLayer, nn.TransformerDecoderLayer}
+        )
+        mixed_precision = MixedPrecision(param_dtype=torch.float16)
+        fsdp_model = FSDP(
+            model,
+            auto_wrap_policy=policy,
+            mixed_precision=mixed_precision,
+            sharding_strategy=sharding_strategy,
+        )
+        optim = torch.optim.Adam(fsdp_model.module.parameters(), lr=1e-2)
+        if self.rank == 0:
+            print(fsdp_model)
+        torch.manual_seed(1 + self.rank)
+        eval_src = torch.randn((8, 1, 512), device=device)
+        eval_tgt = torch.randn((16, 1, 512), device=device)
+        eval_out_sums: List[torch.Tensor] = []
+        # An iteration consists of training forward/backward/optimizer,
+        # updating the EMA copy with the main copy, and eval forward
+        for _ in range(3):
+            fsdp_model.train()
+            train_src = torch.randn((8, 4, 512), device=device)
+            train_tgt = torch.randn((16, 4, 512), device=device)
+            train_out = fsdp_model(train_src, train_tgt)
+            train_out.sum().backward()
+            optim.step()
+            optim.zero_grad()
+            with FSDP.summon_full_params(fsdp_model):
+                fsdp_model.ema_module.update_parameters(fsdp_model.module)
+            fsdp_model.eval()
+            with torch.no_grad():
+                eval_out = fsdp_model(eval_src, eval_tgt)
+            eval_out_sums.append(eval_out.sum())
+        # Check that the eval outputs differ from iteration to iteration as a
+        # proxy for eval using the correct EMA parameters
+        for i in range(len(eval_out_sums) - 1):
+            self.assertNotEqual(eval_out_sums[i], eval_out_sums[i + 1])
+        self.assertNotEqual(eval_out_sums[0], eval_out_sums[-1])
 
 
 if __name__ == "__main__":

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -258,6 +258,11 @@ class TestUnshardParams(TestUnshardParamsBase):
         """
         Tests that unsharding parameters respects the expected reshard behavior
         between forward and backward as well as after backward.
+
+        For mixed precision, we should *not* respect the reshard behavior
+        because the ``summon_full_params()`` forces full precision, which uses
+        a different all-gather tensor than the one already in memory and will
+        not persist any modifications correctly.
         """
         self.run_subtests(
             {
@@ -321,6 +326,12 @@ class TestUnshardParams(TestUnshardParamsBase):
             offload_to_cpu=offload_to_cpu,
         ):
             pass
+        if mixed_precision is not None:
+            # After forcing full precision, we must invalidate the existing
+            # unsharded low-precision flat parameter since it will not persist
+            # changes from the `summon_full_params()` context, so we cannot
+            # respect the reshard behavior
+            expected_outer_flat_param_unsharded_numel = 0
         self.assertEqual(
             expected_outer_flat_param_unsharded_numel,
             _get_unsharded_storage_size(outer_flat_param),

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1293,6 +1293,14 @@ class FlatParamHandle:
                 unsharded_flat_param.dtype != self._fwd_bwd_param_dtype,
                 f"Expects full precision but got {self._fwd_bwd_param_dtype}",
             )
+            # For no-reshard-after-forward strategies, `_full_param_padded` may
+            # still be allocated from a previous forward. As we are forcing
+            # full precision here, the full-precision unsharded copy may be
+            # modified, invalidating the existing low-precision unsharded copy,
+            # so we should free it here to ensure a new all-gather for the next
+            # forward/backward computation to persist the modifications.
+            if flat_param._full_param_padded.untyped_storage().size() > 0:
+                _free_storage(flat_param._full_param_padded)
         else:
             unsharded_flat_param = flat_param._full_param_padded  # type: ignore[attr-defined]
         return unsharded_flat_param


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106858
* #106857

This fixes a pretty vicious bug relating to `SHARD_GRAD_OP`, mixed precision, EMA, and eval.

**Bug Explanation**
The model has a main module and an EMA module, where the main module is used for training and the EMA module is used for eval. The model has FSDP's fp16 mixed precision enabled. The flow consists of (1) training forward/backward/optimizer -> (2) EMA update (copy main module to EMA module) -> eval forward in `torch.no_grad()`, where this repeats for many iterations.

Consider the _second_ iteration.
- From the first iteration's eval forward, the EMA module has the fp16 unsharded parameters in memory (not freed due to `SHARD_GRAD_OP`).
- In this second iteration's step (2), we perform the EMA update under the `summon_full_params()` context, where FSDP specially forces full precision.  This means that the EMA module now uses fp32 unsharded parameters, distinct from the fp16 unsharded parameters still in memory. The EMA update modifies those fp32 parameters, and upon exiting the context, FSDP correctly writes the modifications back to the fp32 sharded parameters.
- In the second iteration's step (3) (eval forward), FSDP checks whether it needs to run the unshard op (including all-gather) but sees it does not since the fp16 unsharded parameters are still in memory. Thus, FSDP uses those fp16 unsharded parameters directly without all-gather. However, these fp16 unsharded parameters are stale and do not include the EMA update!
- In other words, at this point, the fp32 sharded parameters are correct, the fp16 unsharded parameters are stale, and FSDP chooses _not_ to re-all-gather since the fp16 unsharded parameters are in memory.

**Fix Explanation**
This PR fixes this by freeing the fp16 unsharded parameters if they are still allocated when forcing full precision, i.e. using fp32 unsharded parameters in `summon_full_params()`. This ensures that any modifications written back to the fp32 sharded parameters will be persisted via the next all-gather.