### PR TITLE
fixing named tensor unflatten example

### DIFF
--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -204,9 +204,9 @@ and :meth:`~Tensor.reshape`, but have more semantic meaning to someone reading t
     >>> named_flat_imgs.names
     ('N', 'features')
 
-    >>> unflattened_imgs = imgs.view(32, 3, 128, 128)
-    >>> unflattened_named_imgs = named_flat_imgs.unflatten(
-            'features', [('C', 3), ('H', 128), ('W', 128)])
+    >>> unflattened_named_imgs = named_flat_imgs.unflatten('features', [('C', 3), ('H', 128), ('W', 128)])
+    >>> unflattened_named_imgs.names
+    ('N', 'C', 'H', 'W')
 
 .. _named_tensors_autograd-doc:
 


### PR DESCRIPTION
Fixes an example from the documentation [here](https://pytorch.org/docs/stable/named_tensor.html#manipulating-dimensions).