### PR TITLE
[caffe2] Add enforce inside ScatterAssignOp

### DIFF
--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -625,13 +625,28 @@ class ScatterWeightedSumOp : public Operator<Context> {
  * @brief Update slices of the tensor in-place by overriding.
  *
  * Input:
- *   DATA - tensor to be updated
+ *   DATA - tensor to be updated (also referred to here as X_0)
  *   INDICES - 1-D list of indices on the first dimension of X_0 that need to be
  *             updated
  *   SLICES - update slices, has to have shape of len(INDICES) + shape(X_0)[1:]
  *
  * Output:
  *   DATA - has to be exactly the same tensor as the input 0
+ *
+ * Example: For the inputs
+ *
+ *    DATA = [[1, 2], [3, 4], [5, 6]]
+ *    INDICES = [2, 0]
+ *    SLICES = [[0, 9], [7, 8]]
+ *
+ * ScatterAssignOp will modify DATA in place to insert the entries at
+ * INDICES with the values in SLICES, so DATA[INDICES[i]] = SLICES[INDICES[i]].
+ * So the final output will then be
+ *
+ *    DATA = [[7, 8], [3, 4], [0, 9]]
+ *
+ * Note: If DATA is empty, INDICES and SLICES must be empty as well, and this is
+ * a no-op.
  *
  * Note: The op pretty much ignores the exact shapes of the input arguments and
  * cares only about sizes. It's done for performance consideration to avoid
@@ -724,10 +739,17 @@ class ScatterAssignOp : public Operator<Context> {
     auto* output = Output(0);
     CAFFE_ENFORCE_EQ(&input, output, "In place operation is required");
 
-    CAFFE_ENFORCE_GT(input.dim(), 0, "X0 has to be at least the vector");
+    CAFFE_ENFORCE_GT(input.dim(), 0, "Input has to be at least a vector");
     int64_t M = input.numel();
     int64_t N = input.size(0);
     int64_t K = indices.numel();
+
+    if (M == 0) {
+      CAFFE_ENFORCE_EQ(K, 0, "Indices must be empty when input is empty");
+      CAFFE_ENFORCE_EQ(slices.numel(), 0, "Slices must be empty when input is empty");
+      return;
+    }
+
     int64_t block_size = M / N;
     CAFFE_ENFORCE_EQ(slices.numel(), block_size * K);
     // TODO(dzhulgakov): it can be made to work with arbitrary data type by


### PR DESCRIPTION
Summary: Adding an enforce gives better error information than raising SIGFPE when division by zero happens. We'll get the actual BlobRef names as well as the error categories.

Test Plan:
Ran a local worker and client using DPP session with empty tensors and checked the error:

`../buck-out/v2/gen/fbcode/data_preproc/perf_test/client --sr2_event_base_pool_size=24`

`../buck-out/v2/gen/fbcode/data_preproc/perf_test/worker --dpp_session_id=5D49F56C98CC95BD97027BC0DDB38D8F`

```{dpp_internal_errorcategory : user_error,
ONCALL : MLDP_CONTROL,
CATEGORY : INPUT_ERROR,
errorsubsystemtags : [DPP_WORKER],
errorcause : USER_ERROR,
RETRYABILITY : 0}F0806 17:47:52.607200 2280375 SchedRuntimeEnv.cpp:385] facebook::data_preproc::NonRetryableGenericUser
Error: User preprocessing error c10::Error: [enforce fail at utility_ops.h:730] input.numel() > 0. 0 vs 0. tensor has t
o be nonempty (Error from operator:
input: "preproc_data_pipeline/preproc/features/default_feature_preproc/normalization/dper_feature_normalization/sparse_
features_processor_1/sparse_feature_transform/F3_ADFINDER_USER_ADS_COFFEE_LSF_FLEXIBLE_BATCH_USER_FB_UIP_FEATURE_IDSCOR
ELIST_ENCODED_FB_UIP_TOP100_IDSCORELIST_ENCODED_1/sequential_1019/id_score_list_quantization_decode_1/Concat:0" input:
"preproc_data_pipeline/preproc/features/default_feature_preproc/normalization/dper_feature_normalization/sparse_feature
s_processor_1/sparse_feature_transform/F3_ADFINDER_USER_ADS_COFFEE_LSF_FLEXIBLE_BATCH_USER_FB_UIP_FEATURE_IDSCORELIST_E
NCODED_FB_UIP_TOP100_IDSCORELIST_ENCODED_1/sequential_1019/id_score_list_quantization_decode_1/Mul_2" input: "preproc_d
ata_pipeline/preproc/features/default_feature_preproc/normalization/dper_feature_normalization/sparse_features_processo
r_1/sparse_feature_transform/F3_ADFINDER_USER_ADS_COFFEE_LSF_FLEXIBLE_BATCH_USER_FB_UIP_FEATURE_IDSCORELIST_ENCODED_FB_UIP_TOP100_IDSCORELIST_ENCODED_1/sequential_1019/id_score_list_quantization_decode_1/encoded_id_lengths" output: "preproc_data_pipeline/preproc/features/default_feature_preproc/normalization/dper_feature_normalization/sparse_features_processor_1/sparse_feature_transform/F3_ADFINDER_USER_ADS_COFFEE_LSF_FLEXIBLE_BATCH_USER_FB_UIP_FEATURE_IDSCORELIST_ENCODED_FB_UIP_TOP100_IDSCORELIST```

Differential Revision: D48104430

