### PR TITLE
[ONNX] Bump kMainOpsetVersion to opset19

### DIFF
--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -61,7 +61,7 @@ namespace onnx_torch = ::torch::onnx;
 namespace onnx = ::ONNX_NAMESPACE;
 
 const static int kInvalidOpsetVersion = -1;
-const static int kMainOpsetVersion = 18;
+const static int kMainOpsetVersion = 19;
 // Based on OP_SET_ID_VERSION_MAP in
 // https://github.com/onnx/onnx/blob/master/onnx/helper.py.
 constexpr static std::array<int64_t, kMainOpsetVersion + 1>
@@ -85,6 +85,7 @@ constexpr static std::array<int64_t, kMainOpsetVersion + 1>
         8, // opset 16
         8, // opset 17
         8, // opset 18
+        9, // opset 19
 };
 
 std::string getNodeStackTraceString(const Node* n) {


### PR DESCRIPTION
Torch has the ONNX submodule 1.14. The change bumps `kMainOpsetVersion` to opset19 so that torchscript can export to the latest opset version.