### PR TITLE
Fix OGBG compilation failure

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -492,7 +492,7 @@ def make_cell(val=None):
 
 def proxy_args_kwargs(args, kwargs):
     try:
-        proxy_args = tuple(arg.as_proxy() for arg in args)
+        proxy_args = ([arg.as_proxy() for arg in args],)
         proxy_kwargs = {key: arg.as_proxy() for key, arg in kwargs.items()}
         return proxy_args, proxy_kwargs
     except NotImplementedError as e:


### PR DESCRIPTION
## Repro

Setup instructions here https://github.com/mlcommons/algorithmic-efficiency

```
python3 datasets/dataset_setup.py \
  --data_dir=~/data \
  --ogbg
```

```
python submission_runner.py \
    --framework=pytorch \
    --workload=ogbg \
    --experiment_dir=/home/ubuntu/algorithmic-efficiency \
    --experiment_name=ogbg_pytorch \
    --submission_path=reference_algorithms/development_algorithms/ogbg/ogbg_pytorch/submission.py \
    --tuning_search_space=reference_algorithms/development_algorithms/ogbg/tuning_search_space.json

```

## failure logs w/o this change

https://www.internalfb.com/phabricator/paste/view/806006870

With it compilation works fine 

## Actual root cause

One possibility is that the dynamo is not recognizing a `jraph.GraphsTuple` as a NamedTuple but instead as a list - however the namedtuple check seems correct so maybe problem is the values aren't unpacked properly https://github.com/pytorch/pytorch/issues/106920

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov