### PR TITLE
Causing internal clang tidy to error

### DIFF
--- a/meta_gen_cpp_compile_commands.json
+++ b/meta_gen_cpp_compile_commands.json
@@ -1,3 +1,0 @@
-{
-    "command": "python setup.py develop"
-}


### PR DESCRIPTION
Summary:
This was causing an error with clang tidy for internal version of PyTorch:
https://www.internalfb.com/diff/D47044755?dst_version_fbid=1190859734932683&transaction_fbid=1553883761684581

Test Plan: See Summary

Reviewed By: dmpolukhin

Differential Revision: D48202402

