### PR TITLE
Port "Fix kDefaultTimeout multiple definition build failure (#97270)" to release/2.0 branch

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -125,7 +125,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
     }
 
     void wait(const std::vector<std::string>& keys) override {
-      store_->wait(keys, Store::kDefaultTimeout);
+      store_->wait(keys, ::c10d::Store::kDefaultTimeout);
     }
 
     void wait(


### PR DESCRIPTION
#97270 fixed #90448 on the master branch by making the namespace explicit to avoid the constexpr conflict on GCC 11. Unfortunately, the issue persists on release/2.0 causing lost productivity across the Pytorch developer community to manually apply this patch. Let's please include it in the release branch.

@ezyang