### PR TITLE
[BE] RPC is missing RRef docs

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -221,7 +221,11 @@ other workers, and calling the appropriate functions to retrieve or modify their
 parameters during training. See :ref:`remote-reference-protocol` for more
 details.
 
-.. autoclass:: RRef
+.. autoclass:: PyRRef(RRef)
+    :members:
+    :inherited-members:
+
+.. autoclass:: PyRRef
     :members:
     :inherited-members:
 

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -223,7 +223,7 @@ details.
 
 .. autoclass:: RRef
     :members:
-
+    :inherited-members:
 
 .. toctree::
     :caption: More Information about RRef

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -225,9 +225,6 @@ details.
     :members:
     :inherited-members:
 
-.. autoclass:: PyRRef
-    :members:
-    :inherited-members:
 
 .. toctree::
     :caption: More Information about RRef


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106902

Current `RRef` class derives from `PyRRef` which has all the method definitions and documentations, and we don't see any of this in the current documentation:

<img width="891" alt="image" src="https://github.com/pytorch/pytorch/assets/14858254/62897766-a660-4846-97bf-182e4aa45079">

Changing to :inherited-member: so sphinx can pick up these methods


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @kwen2501 @awgu @penguinwu @svekars @carljparker