### PR TITLE
Generate mypy hints for torch.Tag, add a couple of pointwise ops

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6443,7 +6443,7 @@
     QuantizedCPU, QuantizedCUDA: quantized_clone
     NestedTensorCPU, NestedTensorCUDA: clone_nested
   autogen: clone.out
-  tags: core
+  tags: [core, pointwise]
 
 - func: positive(Tensor(a) self) -> Tensor(a)
   variants: function, method

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -8,7 +8,7 @@ from torchgen.api.python import (
     PythonSignatureNativeFunctionPair,
     returns_named_tuple_pyi,
 )
-from torchgen.gen import parse_native_yaml
+from torchgen.gen import parse_native_yaml, parse_tags_yaml
 
 from torchgen.model import DispatchKey, Variant
 from torchgen.utils import FileManager
@@ -1231,6 +1231,14 @@ def gen_pyi(
     # ~~~~~~~~~~~~~~~~~~
     dispatch_key_hints = [f"{d.name}: DispatchKey = ..." for d in DispatchKey]
 
+    # Tags Enum type hints
+    # ~~~~~~~~~~~~~~~~~~~~
+
+    tag_names = sorted(parse_tags_yaml(tags_yaml_path))
+    tag_attributes = "\n".join(
+        f"{name}: int = {index}" for index, name in enumerate(tag_names)
+    )
+
     # Write out the stub
     # ~~~~~~~~~~~~~~~~~~
 
@@ -1243,6 +1251,7 @@ def gen_pyi(
         "dtype_class_hints": dtype_class_hints,
         "dispatch_key_hints": dispatch_key_hints,
         "all_directive": all_directive,
+        "tag_attributes": tag_attributes,
     }
     fm.write_with_template(
         "torch/_C/__init__.pyi",

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1236,7 +1236,7 @@ def gen_pyi(
 
     tag_names = sorted(parse_tags_yaml(tags_yaml_path))
     tag_attributes = "\n".join(
-        f"{name}: int = {index}" for index, name in enumerate(tag_names)
+        f"{name}: _int = {index}" for index, name in enumerate(tag_names)
     )
 
     # Write out the stub

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1118,7 +1118,8 @@ class _LinalgBackend:
 
 class ConvBackend(Enum): ...
 
-class Tag(Enum): ...
+class Tag(Enum):
+    ${tag_attributes}
 
 # Defined in `valgrind.h` and `callgrind.h` respectively.
 def _valgrind_supported_platform() -> _bool: ...  # NVALGRIND

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -126,8 +126,8 @@ class ATenDialectVerifier(Verifier):
             )
 
         if (
-            torch.Tag.core not in op.tags  # type: ignore[attr-defined]
-            and torch.Tag.view_copy not in op.tags  # type: ignore[attr-defined]
+            torch.Tag.core not in op.tags
+            and torch.Tag.view_copy not in op.tags
         ):
             # NOTE(qihan): whether view_copy operators are marked as canonical is still under
             #            discussion.

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -2030,6 +2030,7 @@ convert_element_type = _make_prim(
     impl_aten=_convert_element_type_aten,
     return_type=RETURN_TYPE.NEW,
     doc=_convert_element_type_doc,
+    tags=(torch.Tag.pointwise,),
 )
 
 

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -143,7 +143,7 @@ def register_philox_rand():
         impl_aten=_philox_rand,
         impl_meta=_philox_rand_meta,
         doc="Philox based stateless rand operator",
-        tags=(torch.Tag.nondeterministic_seeded,),  # type: ignore[attr-defined]
+        tags=(torch.Tag.nondeterministic_seeded,),
     )
 
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -479,7 +479,7 @@ def _sparse_coo_tensor_with_dims_and_tensors(fake_mode, func, *args, **kwargs):
 
 # index.Tensor data-dependent in only some conditions
 @register_op_impl(
-    lambda func: torch.Tag.dynamic_output_shape in func.tags  # type: ignore[attr-defined]
+    lambda func: torch.Tag.dynamic_output_shape in func.tags
     and func
     not in [aten.index.Tensor, aten.nonzero.default, aten.repeat_interleave.Tensor]
 )
@@ -550,9 +550,7 @@ def nonzero(fake_mode, func, arg):
 
 
 # NB: this must be ordered after local_scalar_dense
-@register_op_impl(
-    lambda func: torch.Tag.data_dependent_output in func.tags  # type: ignore[attr-defined]
-)
+@register_op_impl(lambda func: torch.Tag.data_dependent_output in func.tags)
 def data_dep(fake_mode, func, *args, **kwargs):
     raise DataDependentOutputException(func)
 
@@ -1372,8 +1370,8 @@ class FakeTensorMode(TorchDispatchMode):
         # We dispatch size/stride/numel on the FakeTensor not its constant, so bail on inplace_view
         all_constant = all(e.constant is not None for e in flat_arg_fake_tensors)
         if (
-            torch.Tag.nondeterministic_seeded not in func.tags  # type: ignore[attr-defined]
-            and torch.Tag.inplace_view not in func.tags  # type: ignore[attr-defined]
+            torch.Tag.nondeterministic_seeded not in func.tags
+            and torch.Tag.inplace_view not in func.tags
             and all_constant
             and len(flat_arg_fake_tensors) != 0
             and not has_symbolic_sizes
@@ -1561,7 +1559,7 @@ class FakeTensorMode(TorchDispatchMode):
         def validate(x):
             nonlocal flat_arg_fake_tensors
             if not self.is_our_fake(x):
-                if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
+                if torch.Tag.inplace_view in func.tags:
                     raise Exception(
                         f"Can't call metadata mutating ops on non-Fake Tensor inputs. Found in {render_call(func, args, kwargs)}"
                     )
@@ -1637,7 +1635,7 @@ class FakeTensorMode(TorchDispatchMode):
         return wrap
 
     def cpp_meta_supports_symint(self, func):
-        if torch.Tag.view_copy in func.tags:  # type: ignore[attr-defined]
+        if torch.Tag.view_copy in func.tags:
             return True
         return func in [
             aten.empty.memory_format,
@@ -1719,7 +1717,7 @@ def run_fallback_kernel(fake_mode, func, args, kwargs, orig_not_implemented_exce
     # these should all be supported, just to be safe
     # avoid fallback for operators which inplace modify metadata
     # because the input fake tensors would be umodified
-    if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
+    if torch.Tag.inplace_view in func.tags:
         raise orig_not_implemented_exception
 
     inp_impls = {}

--- a/torch/_subclasses/fake_utils.py
+++ b/torch/_subclasses/fake_utils.py
@@ -74,9 +74,9 @@ class CrossRefFakeMode(TorchDispatchMode):
                 aten.set_.source_Storage_storage_offset,
             )
             and not self.ignore_op_fn(func)
-            and torch.Tag.dynamic_output_shape not in func.tags  # type: ignore[attr-defined]
-            and torch.Tag.inplace_view not in func.tags  # type: ignore[attr-defined]
-            and torch.Tag.data_dependent_output not in func.tags  # type: ignore[attr-defined]
+            and torch.Tag.dynamic_output_shape not in func.tags
+            and torch.Tag.inplace_view not in func.tags
+            and torch.Tag.data_dependent_output not in func.tags
         ):
             try:
                 with FakeTensorMode() as fake_mode:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -283,7 +283,7 @@ def proxy_call(proxy_mode, func, pre_dispatch, args, kwargs):
         and pytree.tree_all_only((SymInt, SymFloat, SymBool), lambda _: False, (args, kwargs))
     )
 
-    if torch.Tag.data_dependent_output in func.tags:  # type: ignore[attr-defined]
+    if torch.Tag.data_dependent_output in func.tags:
         # Check if all of the Tensor inputs are constants
         if all_constant:
             const_args, const_kwargs = pytree.tree_map_only(
@@ -392,7 +392,7 @@ def proxy_call(proxy_mode, func, pre_dispatch, args, kwargs):
         with maybe_disable_fake_tensor_mode():
             constant = args[0].clone()
     elif (
-        torch.Tag.nondeterministic_seeded not in func.tags  # type: ignore[attr-defined]
+        torch.Tag.nondeterministic_seeded not in func.tags
         and all_constant
         and any_constant
         and pytree.tree_all_only(torch.Tensor, lambda t: t.numel() <= CONSTANT_NUMEL_LIMIT, out)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106912
* #106911
* __->__ #106910

Replace https://github.com/pytorch/pytorch/pull/106739, since i had a bad CLA commit. 

- adds clone, and convert_element_dtype to pointwise
- adds codegen for mypy hints of torch.Tag and removes existing ignores for them
