### PR TITLE
[quant][pt2e] Fix handling for SharedQuantizationSpec

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -186,6 +186,18 @@ class TestHelperModules:
             x = self.bn(x)
             return self.relu(x)
 
+    class Conv2dWithCat(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = torch.nn.Conv2d(3, 3, 3)
+            self.conv2 = torch.nn.Conv2d(3, 3, 3)
+
+        def forward(self, x, y):
+            x = self.conv1(x)
+            y = self.conv2(y)
+            z = torch.cat([x, y], dim=1)
+            return z
+
     class EmbeddingModule(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -223,6 +235,8 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
         torch.ops.quantized_decomposed.quantize_per_tensor.tensor: torch.ops.quantized_decomposed.quantize_per_tensor.tensor,
         torch.ops.quantized_decomposed.dequantize_per_tensor.tensor: torch.ops.quantized_decomposed.dequantize_per_tensor.tensor,
     }
+
+
 
     def _test_quantizer(
         self,
@@ -995,6 +1009,133 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 torch.ops.quantized_decomposed.dequantize_per_tensor.default
             ),
             ns.call_function(torch.ops.aten.sigmoid.default),
+            ns.call_function(
+                torch.ops.quantized_decomposed.quantize_per_tensor.default
+            ),
+        ]
+        self.checkGraphModuleNodes(
+            m, expected_node_list=node_list, expected_node_occurrence=node_occurrence
+        )
+
+    def test_shared_qspec(self):
+        class BackendAQuantizer(Quantizer):
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                for node in model.graph.nodes:
+                    if (
+                        node.op == "call_function"
+                        and node.target == torch.ops.aten.convolution.default
+                    ):
+                        input_act = node.args[0]
+                        assert isinstance(input_act, Node)
+                        weight = node.args[1]
+                        assert isinstance(weight, Node)
+                        bias = node.args[2]
+                        assert isinstance(bias, Node)
+                        act_qspec = QuantizationSpec(
+                            dtype=torch.uint8,
+                            quant_min=0,
+                            quant_max=255,
+                            qscheme=torch.per_tensor_affine,
+                            is_dynamic=False,
+                            observer_or_fake_quant_ctr=observer.default_observer,
+                        )
+                        weight_qspec = QuantizationSpec(
+                            dtype=torch.int8,
+                            quant_min=-128,
+                            quant_max=127,
+                            qscheme=torch.per_tensor_affine,
+                            is_dynamic=False,
+                            observer_or_fake_quant_ctr=observer.default_weight_observer,
+                        )
+                        bias_qspec = QuantizationSpec(
+                            dtype=torch.float32,
+                            is_dynamic=False,
+                            observer_or_fake_quant_ctr=observer.PlaceholderObserver,
+                        )
+                        node.meta["quantization_annotation"] = QuantizationAnnotation(
+                            input_qspec_map={
+                                input_act: act_qspec,
+                                weight: weight_qspec,
+                                bias: bias_qspec,
+                            },
+                            output_qspec=act_qspec,
+                            _annotated=True,
+                        )
+                    elif node.target is torch.ops.aten.cat.default:
+                        cat_node = node
+                        input_nodes = cat_node.args[0]
+                        first_input_node = input_nodes[0]
+                        input_qspec_map = {}
+                        act_qspec = QuantizationSpec(
+                            dtype=torch.uint8,
+                            quant_min=0,
+                            quant_max=255,
+                            qscheme=torch.per_tensor_affine,
+                            is_dynamic=False,
+                            observer_or_fake_quant_ctr=observer.default_observer,
+                        )
+                        input_qspec_map[first_input_node] = act_qspec
+                        share_qparams_with_input_act0_qspec = SharedQuantizationSpec((first_input_node, cat_node))
+                        for input_node in input_nodes[1:]:
+                            input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
+
+                        cat_node.meta[
+                            "quantization_annotation"
+                        ] = QuantizationAnnotation(
+                            input_qspec_map=input_qspec_map,
+                            output_qspec=share_qparams_with_input_act0_qspec,
+                            _annotated=True,
+                        )
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                pass
+
+            @classmethod
+            def get_supported_operators(cls) -> List[OperatorConfig]:
+                pass
+
+        m = TestHelperModules.Conv2dWithCat().eval()
+        example_inputs = (torch.randn(1, 3, 5, 5), torch.randn(1, 3, 5, 5))
+
+        # program capture
+        m, guards = torchdynamo.export(
+            m,
+            *copy.deepcopy(example_inputs),
+            aten_graph=True,
+        )
+        m = prepare_pt2e(m, BackendAQuantizer())
+        # make sure the two observers for input are shared
+        for n in m.graph.nodes:
+            if n.op == "call_function" and n.target == torch.ops.aten.cat.default:
+                inputs = n.args[0]
+                input0 = inputs[0]
+                input1 = inputs[1]
+                assert input0.op == "call_module"
+                assert input1.op == "call_module"
+                obs_ins0 = getattr(m, input0.target)
+                obs_ins1 = getattr(m, input1.target)
+                assert obs_ins0 == obs_ins1
+
+        m(*example_inputs)
+        m = convert_pt2e(m)
+
+        node_occurrence = {
+            # two for input of the first conv, one for output for the first conv
+            ns.call_function(
+                torch.ops.quantized_decomposed.quantize_per_tensor.default
+            ): 7,
+            ns.call_function(
+                torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            ): 7,
+        }
+        node_list = [
+            ns.call_function(
+                torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            ),
+            ns.call_function(
+                torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            ),
+            ns.call_function(torch.ops.aten.cat.default),
             ns.call_function(
                 torch.ops.quantized_decomposed.quantize_per_tensor.default
             ),

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1105,7 +1105,10 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         )
         m = prepare_pt2e(m, BackendAQuantizer())
         # make sure the two observers for input are shared
+        conv_output_obs = []
         for n in m.graph.nodes:
+            if n.op == "call_function" and n.target == torch.ops.aten.convolution.default:
+                conv_output_obs.append(getattr(m, list(n.users)[0].target))
             if n.op == "call_function" and n.target == torch.ops.aten.cat.default:
                 inputs = n.args[0]
                 input0 = inputs[0]
@@ -1115,6 +1118,9 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 obs_ins0 = getattr(m, input0.target)
                 obs_ins1 = getattr(m, input1.target)
                 assert obs_ins0 == obs_ins1
+        assert len(conv_output_obs) == 2, "expecting two observer that follows convolution ops"
+        # checking that the output observers for the two convs are shared as well
+        assert conv_output_obs[0] == conv_output_obs[1]
 
         m(*example_inputs)
         m = convert_pt2e(m)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -156,8 +156,9 @@ _TORCH_DTYPE_TO_QDTYPE = {
     torch.float32: torch.float32,
 }
 
-def _get_observer_kwargs(quant_spec: QuantizationSpec):
+def _get_observer_kwargs(quant_spec: Union[QuantizationSpec, FixedQParamsQuantizationSpec]):
     kwargs_dict = asdict(quant_spec)
+    # TODO: refactor observer to accept plain types
     kwargs_dict["dtype"] = _TORCH_DTYPE_TO_QDTYPE[quant_spec.dtype]
     return copy.deepcopy(kwargs_dict)
 
@@ -167,11 +168,11 @@ def _get_qspec_for_arg(
     named_modules: Dict[str, torch.nn.Module]
 ) -> Optional[QuantizationSpecBase]:
     while _is_activation_post_process_node(arg, named_modules):
-        arg = arg.args[0]
+        arg = arg.args[0]  # type: ignore[assignment]
     return input_qspec_map.get(arg, None)
 
 def _create_obs_or_fq_from_qspec(
-    quantization_spec: QuantizationSpec,
+    quantization_spec: Optional[QuantizationSpecBase],
     obs_or_fq_map: Dict[EdgeOrNode, ObserverOrFakeQuantize],
     is_qat: bool,
 ):
@@ -211,6 +212,7 @@ def _create_obs_or_fq_from_qspec(
         else:
             return observer_ctr()
 
+    assert isinstance(quantization_spec, QuantizationSpec)
     observer_or_fake_quant_ctr = quantization_spec.observer_or_fake_quant_ctr
     kwargs = _get_observer_kwargs(quantization_spec)
     kwargs.pop("observer_or_fake_quant_ctr")
@@ -695,9 +697,10 @@ def _get_arg_as_input_act_obs_or_fq(
     #
     if "quantization_annotation" in node.meta:
         input_qspec_map = node.meta["quantization_annotation"].input_qspec_map
-        input_arg_obs_or_fq = _DEFAULT_FP32_OBS_OR_FQ_CTR()
         input_arg_qspec = _get_qspec_for_arg(arg, input_qspec_map, named_modules)
-        if input_arg_qspec is not None:
+        if input_arg_qspec is None:
+            input_arg_obs_or_fq = _DEFAULT_FP32_OBS_OR_FQ_CTR()
+        else:
             input_arg_obs_or_fq = _create_obs_or_fq_from_qspec(input_arg_qspec, obs_or_fq_map, is_qat)
         return input_arg_obs_or_fq
 

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -64,9 +64,6 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     arg_as_output_act_obs_or_fq = _get_output_act_obs_or_fq(arg, named_modules, obs_or_fq_map, is_qat)
     arg_as_output_target_dtype, arg_as_output_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_output_act_obs_or_fq)
 
-    input_qspec_map = quantization_annotation.input_qspec_map
-    input_arg_qspec = _get_qspec_for_arg(arg, input_qspec_map, named_modules)
-
     if arg_as_input_target_is_dynamic or arg_as_input_target_dtype not in [torch.float, None]:
         if arg_as_input_target_dtype == arg_as_output_target_dtype and \
            arg_as_input_target_is_dynamic == arg_as_output_target_is_dynamic:
@@ -76,6 +73,8 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
             assert isinstance(observed_arg, Node), f"expect observed argument to be a Node, but got: {type(observed_arg)}"
             assert observed_arg in obs_or_fq_map, \
                 f"can't refer to a node that does not have observer/fake_quant inserted yet: {observed_arg}"
+            input_qspec_map = quantization_annotation.input_qspec_map
+            input_arg_qspec = _get_qspec_for_arg(arg, input_qspec_map, named_modules)
             if isinstance(input_arg_qspec, SharedQuantizationSpec):
                 # if the argument is set to use SharedQuantizationSpec, we will
                 # reset the observer instance to align with the configured edge/node

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -8,6 +8,7 @@ from torch.ao.quantization.fx.prepare import (
     _maybe_insert_output_observer_for_node,
     _save_state,
     _is_activation_post_process_node,
+    _get_qspec_for_arg,
 )
 from torch.fx import (
     GraphModule,
@@ -22,6 +23,7 @@ from typing import Dict, Tuple, Union, Any
 from torch.ao.quantization.quantizer import (
     QuantizationAnnotation,
     EdgeOrNode,
+    SharedQuantizationSpec,
 )
 from torch.ao.quantization import ObserverOrFakeQuantize
 
@@ -62,6 +64,9 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     arg_as_output_act_obs_or_fq = _get_output_act_obs_or_fq(arg, named_modules, obs_or_fq_map, is_qat)
     arg_as_output_target_dtype, arg_as_output_target_is_dynamic = _get_dtype_and_is_dynamic(arg_as_output_act_obs_or_fq)
 
+    input_qspec_map = quantization_annotation.input_qspec_map
+    input_arg_qspec = _get_qspec_for_arg(arg, input_qspec_map, named_modules)
+
     if arg_as_input_target_is_dynamic or arg_as_input_target_dtype not in [torch.float, None]:
         if arg_as_input_target_dtype == arg_as_output_target_dtype and \
            arg_as_input_target_is_dynamic == arg_as_output_target_is_dynamic:
@@ -71,7 +76,16 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
             assert isinstance(observed_arg, Node), f"expect observed argument to be a Node, but got: {type(observed_arg)}"
             assert observed_arg in obs_or_fq_map, \
                 f"can't refer to a node that does not have observer/fake_quant inserted yet: {observed_arg}"
-            arg_as_input_act_obs_or_fq = obs_or_fq_map[observed_arg]
+            if isinstance(input_arg_qspec, SharedQuantizationSpec):
+                # if the argument is set to use SharedQuantizationSpec, we will
+                # reset the observer instance to align with the configured edge/node
+                obs_or_fq_name = arg.target
+                setattr(model, obs_or_fq_name, arg_as_input_act_obs_or_fq)
+                named_modules[obs_or_fq_name] = arg_as_input_act_obs_or_fq
+            else:
+                # otherwise reuse the existing obs/fq
+                arg_as_input_act_obs_or_fq = obs_or_fq_map[observed_arg]
+            # we don't need to insert new observer node
             new_arg = arg
             obs_or_fq_map[(observed_arg, node)] = arg_as_input_act_obs_or_fq
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106922

Summary:
Previously if we have:
```
conv1 -> cat
conv2  /
```
and configure output of conv1/conv2 to be int8 quantized, and cat also int8 quantized and with shared inputs,
it will not produce expected results (input of cat will not be shared)

The problem is that there is some missing checks when inserting observers for input for cat

This PR fixes the problem.

Fixes: https://github.com/pytorch/pytorch/issues/106760
Test Plan:
python tes/test_quantization.py TestQuantzePT2E.test_shared_qspec

Reviewers:

Subscribers:

Tasks:

Tags: