### PR TITLE
[quant][pt2e][fix] Remove the requirement of using no_grad for reference model that contains quantized conv2d

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1875,14 +1875,13 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         quantizer.set_global(operator_config)
         example_inputs = (torch.randn(1, 3, 3, 3),)
 
-        with torch.no_grad():
-            self._test_representation(
-                M().eval(),
-                example_inputs,
-                quantizer,
-                ref_node_occurrence={},
-                non_ref_node_occurrence={}
-            )
+        self._test_representation(
+            M().eval(),
+            example_inputs,
+            quantizer,
+            ref_node_occurrence={},
+            non_ref_node_occurrence={}
+        )
 
     def test_representation_add(self):
         class M(torch.nn.Module):

--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -141,11 +141,16 @@ class TestOutDtypeOp(TestCase):
             )
 
         inp = (torch.randn(5, 5, requires_grad=True), torch.randn(5, 5, requires_grad=True))
-        with self.assertRaisesRegex(RuntimeError, "Autograd not implemented for out_dtype"):
-            f(*inp)
+        # error is delayed
+        f(*inp)
 
         with torch.no_grad():
             f(*inp)
+
+        with self.assertRaisesRegex(RuntimeError, "does not require grad and does not have a grad_fn"):
+            out = f(*inp)
+            loss = out - torch.ones(out.shape)
+            loss.backward()
 
     def test_out_dtype_wrong_output(self) -> None:
         def multiple_out(x):

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -119,7 +119,7 @@ def out_dtype_dense(
     return res
 
 
-out_dtype.py_impl(DispatchKey.Autograd)(autograd_not_implemented(out_dtype, deferred_error=False))
+out_dtype.py_impl(DispatchKey.Autograd)(autograd_not_implemented(out_dtype, deferred_error=True))
 
 
 @out_dtype.py_impl(ProxyTorchDispatchMode)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106924

Summary:
att

we don't actually need gradient for conv2d, just need it to run without error, so we delayed the error of out_dtype gradient
to the time when user actually requested it

Test Plan:
python test/test_quantization.py TestQuantizePT2E.test_representation_conv2d

Reviewers:

Subscribers:

Tasks:

Tags: