### PR TITLE
Add ONNX export support for huggingface's bigscience/bloom-560m model

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -211,6 +211,30 @@ def skip_dynamic_fx_test(reason: str):
     return skip_dec
 
 
+def skip_load_checkpoint_after_model_creation(reason: str):
+    """Skip loading checkpoint right after model initialization.
+
+    Args:
+        reason: The reason for skipping dynamic exporting test.
+
+    Returns:
+        A decorator for skipping dynamic exporting test.
+    """
+
+    def skip_dec(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if self.load_checkpoint_during_init:
+                raise unittest.SkipTest(
+                    f"Skip loading checkpoint during model initialization for FX tests. {reason}"
+                )
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return skip_dec
+
+
 def skip_op_level_debug_test(reason: str):
     """Skip tests with op_level_debug enabled.
 

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -294,12 +294,11 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         with torch.onnx.enable_fake_mode() as fake_context:
             x = torch.rand(5, 2, 2)
             model = Model()
+            export_options = ExportOptions(fake_context=fake_context)
+            export_output = torch.onnx.dynamo_export(
+                model, x, export_options=export_options
+            )
 
-        # Export the model with fake inputs and parameters
-        export_options = ExportOptions(fake_context=fake_context)
-        export_output = torch.onnx.dynamo_export(
-            model, x, export_options=export_options
-        )
         assert (
             export_output is not None
         ), "ExportOutput must be created on successful export"
@@ -351,34 +350,49 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             fake_model = Model()
             fake_x = torch.rand(5, 2, 2)
 
-        # TODO: Split each scenario on its own test case
-        # Scenario 1: Fake model and fake input WITHOUT fake_context
-        with self.assertRaises(torch.onnx.OnnxExporterError):
-            export_options = ExportOptions(fake_context=None)
-            _ = torch.onnx.dynamo_export(
-                fake_model, fake_x, export_options=export_options
-            )
+            # TODO: Split each scenario on its own test case
+            # Scenario 1: Fake model and fake input WITHOUT fake_context
+            with self.assertRaises(torch.onnx.OnnxExporterError):
+                export_options = ExportOptions(fake_context=None)
+                _ = torch.onnx.dynamo_export(
+                    fake_model, fake_x, export_options=export_options
+                )
 
-        # Scenario 2: Fake model and real input WITHOUT fake_context
-        with self.assertRaises(torch.onnx.OnnxExporterError):
-            export_options = ExportOptions(fake_context=None)
-            _ = torch.onnx.dynamo_export(
-                fake_model, real_x, export_options=export_options
-            )
+            # Scenario 2: Fake model and real input WITHOUT fake_context
+            with self.assertRaises(torch.onnx.OnnxExporterError):
+                export_options = ExportOptions(fake_context=None)
+                _ = torch.onnx.dynamo_export(
+                    fake_model, real_x, export_options=export_options
+                )
 
-        # Scenario 3: Real model and real input WITH fake_context
-        with self.assertRaises(torch.onnx.OnnxExporterError):
-            export_options = ExportOptions(fake_context=fake_context)
-            _ = torch.onnx.dynamo_export(
-                real_model, real_x, export_options=export_options
-            )
+            # Scenario 3: Real model and real input WITH fake_context
+            with self.assertRaises(torch.onnx.OnnxExporterError):
+                export_options = ExportOptions(fake_context=fake_context)
+                _ = torch.onnx.dynamo_export(
+                    real_model, real_x, export_options=export_options
+                )
 
-        # Scenario 4: Fake model and real input WITH fake_context
-        with self.assertRaises(torch.onnx.OnnxExporterError):
-            export_options = ExportOptions(fake_context=fake_context)
-            _ = torch.onnx.dynamo_export(
-                fake_model, real_x, export_options=export_options
+            # Scenario 4: Fake model and real input WITH fake_context
+            with self.assertRaises(torch.onnx.OnnxExporterError):
+                export_options = ExportOptions(fake_context=fake_context)
+                _ = torch.onnx.dynamo_export(
+                    fake_model, real_x, export_options=export_options
+                )
+
+    def test_fake_tensor_mode_huggingface_bigscience__bloom_560m(self):
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import]
+
+        model_name = "bigscience/bloom-560m"
+        with torch.onnx.enable_fake_mode() as fake_context:
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            inputs = tokenizer("Hello world!", return_tensors="pt")
+            model = AutoModel.from_pretrained(model_name)
+
+            export_options = torch.onnx.ExportOptions(fake_context=fake_context)
+            export_output = torch.onnx.dynamo_export(
+                model, **inputs, export_options=export_options
             )
+            assert export_output.model_proto is not None
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -351,7 +351,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             fake_x = torch.rand(5, 2, 2)
 
             # TODO: Split each scenario on its own test case
-            # Scenario 1: Fake model and fake input WITHOUT fake_context
+            # Scenario 1: Fake model and fake input WITHOUT ExportOptions(fake_context=...)
             with self.assertRaises(torch.onnx.OnnxExporterError):
                 export_options = ExportOptions(fake_context=None)
                 _ = torch.onnx.dynamo_export(
@@ -392,7 +392,8 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             export_output = torch.onnx.dynamo_export(
                 model, **inputs, export_options=export_options
             )
-            assert export_output.model_proto is not None
+            onnx.checker.check_model(export_output.model_proto)
+            onnx.shape_inference.infer_shapes(export_output.model_proto)
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -998,6 +998,40 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             export_within_fake_mode=self.export_within_fake_mode,
         )
 
+    @pytorch_test_common.xfail(
+        "ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB"
+        "[ONNXRuntimeError] : Status Message: Indices vs updates dimensions differs at position=1 0 vs 3"
+    )
+    @pytorch_test_common.skip_dynamic_fx_test(
+        "RuntimeError:: SymIntArrayRef expected to contain only concrete integers"
+    )
+    @pytorch_test_common.skip_load_checkpoint_after_model_creation(
+        "HF Bloom model does not need `model.load_state_dict` to work."
+    )
+    def test_fake_tensor_mode_huggingface_bigscience__bloom_560m(self):
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import]
+
+        model_name = "bigscience/bloom-560m"
+
+        def create_args():
+            return tuple()
+
+        def create_kwargs(model_name=model_name):
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            return tokenizer("Hello world!", return_tensors="pt")
+
+        def create_model():
+            return AutoModel.from_pretrained(model_name)
+
+        self._test_fake_tensor_mode_exporter(
+            model_name.replace("/", "_"),
+            create_model,
+            create_args,
+            create_kwargs,
+            load_checkpoint_during_init=self.load_checkpoint_during_init,
+            export_within_fake_mode=self.export_within_fake_mode,
+        )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
Port fix from https://github.com/huggingface/safetensors/pull/318 into ONNX exporter until it is merged

* This add support for safetensors to be loaded within a FakeTensorMode, which results in creating `torch.empty((shape,), dtype=)`. This is done through a monkeypatch for the in-progress https://github.com/huggingface/safetensors/pull/318
* Adds a test for the HF bloom model (bigscience/bloom-560m)
* This PR also fixes existing fake tensor unit tests by moving the `torch.onnx.dynamo_export` to be inside the `enable_fake_mode()` context. Although calling `torch.onnx._dynamo_export` works for several models, the right way of using fake mode is calling the exporter within the context manager.