### PR TITLE
[MPS] Use Metal Events to synchronize buffers in MPSAllocator (Part 1)

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <ATen/mps/MPSAllocatorInterface.h>
+#include <ATen/mps/MPSEvent.h>
 #include <ATen/mps/MPSStream.h>
+
 #include <cstdio>
 #include <mutex>
 #include <set>
@@ -19,8 +21,6 @@ namespace at {
 namespace mps {
 namespace HeapAllocator {
 
-#define MB(x) round_page(x * 1048576UL)
-
 static const size_t kMaxSmallAlloc = MB(1);    // largest "small" allocation is 1 MiB
 static const size_t kMinLargeAlloc = MB(10);   // allocations between 1 and 10 MiB may use kLargeHeap
 static const size_t kRoundLarge    = MB(2);    // round up large allocations to 2 MiB
@@ -28,6 +28,7 @@ static const size_t kSmallHeap     = MB(8);    // "small" allocations are packed
 static const size_t kLargeHeap     = MB(32);   // "large" allocations may be packed in 32 MiB heaps
 static const size_t kXLargeHeapD   = MB(128);  // "extra large" allocations on Discrete devices may be packed in 128 MiB heaps
 static const size_t kXLargeHeapU   = MB(1024); // "extra large" allocations on Unified devices may be packed in 1 GiB heaps
+static const size_t kMaxScalarAlloc = (sizeof(int64_t)); // largest "scalar" allocation
 
 // buffer pools could be customized with a combination of usage flags
 enum UsageFlags : uint32_t {
@@ -50,26 +51,28 @@ enum DebugVerbosity : uint32_t {
 
 struct HeapBlock;
 
-struct BufferBlock
-{
+struct BufferBlock {
   id<MTLBuffer> buffer;
+  void* cpu_ptr = nullptr; // stores the pointer to CPU mapping of a Shared MTLBuffer
   size_t size; // size after alignment
   size_t requested_size; // requested size (before alignment)
   // buffer shape is used for retrieving base of views in cached graphs
   std::vector<int64_t> shape;
-  bool in_use;
+  bool in_use = false;
   HeapBlock* heap;
   id_t buf_id;
   // counter to candidate least recently used buffers for garbage collection
-  uint32_t gc_count;
-  uint32_t use_count;
+  uint32_t gc_count = 0;
+  uint32_t use_count = 0;
   // counter to assign unique ids to buffer blocks
   static uint64_t buffer_counter;
+  // Metal events used to sync GPU/CPU operations on the shared-storage buffers
+  MPSEventPtr event;
 
   BufferBlock(size_t Size, size_t RequestedSize = 0, const id<MTLBuffer> Buffer = nullptr,
               HeapBlock* Heap = nullptr) :
               buffer(Buffer), size(Size), requested_size(RequestedSize),
-              in_use(false), heap(Heap), buf_id(++buffer_counter), gc_count(0), use_count(0) { }
+              heap(Heap), buf_id(Buffer ? ++buffer_counter : 0) { }
 
   static bool Comparator(const BufferBlock* a, const BufferBlock* b) {
     return (a->size != b->size) ? a->size < b->size : (uintptr_t)a->buffer < (uintptr_t)b->buffer;
@@ -83,30 +86,27 @@ struct BufferBlock
 typedef bool (*BufferComparison)(const BufferBlock*, const BufferBlock*);
 
 struct BufferPool;
-struct AllocParams
-{
+struct AllocParams {
   AllocParams(size_t Alloc_Size, size_t Requested_Size, BufferPool* Pool) :
-              search_key(Alloc_Size), pool(Pool), buffer_block(nullptr),
-              requested_size(Requested_Size), has_memory_pressure(false) { }
+              search_key(Alloc_Size), pool(Pool), requested_size(Requested_Size) { }
   size_t size() const { return search_key.size; }
 
   BufferBlock search_key;
   BufferPool* pool;
-  BufferBlock* buffer_block;
+  BufferBlock* buffer_block = nullptr;
   size_t requested_size;
   // true if we exceed the low watermark limit. In this case
   // we apply strategies to relieve the pressure before allocation.
-  bool has_memory_pressure;
+  bool has_memory_pressure = false;
   // true if we're allocating on a unified memory device
-  bool has_unified_memory;
+  bool has_unified_memory = true;
 };
 
-struct HeapBlock
-{
+struct HeapBlock {
   id<MTLHeap> heap;
   struct { size_t total, available; } size;
   BufferPool* pool;
-  unsigned int n_buffers;
+  unsigned int n_buffers = 0;
   id_t heap_id;
   // indicates if we split this heap to sub-allocate 'several' buffers (otherwise single buffer)
   bool is_split;
@@ -115,7 +115,7 @@ struct HeapBlock
 
   HeapBlock(size_t Size, const id<MTLHeap> Heap = nullptr, BufferPool *Pool = nullptr) :
             heap(Heap), size({.total = Size, .available = Size}), pool(Pool),
-            n_buffers(0), heap_id(++heap_counter), is_split(true) { }
+            heap_id(Heap ? ++heap_counter : 0), is_split(true) { }
 
   static MTLResourceOptions getOptions(uint32_t usage) {
     // TODO: check the caching performance of write-combined mode
@@ -171,10 +171,14 @@ struct HeapBlock
     return heapBlock;
   }
   static bool Comparator(const HeapBlock* a, const HeapBlock* b) {
-    return a->size.available < b->size.available;
+    return (a->size.available != b->size.available) ? a->size.available < b->size.available :
+                                                      (uintptr_t)a->heap < (uintptr_t)b->heap;
   }
   static NSUInteger heapAvailableSize(id<MTLHeap> heap, size_t Alignment = vm_page_size) {
-      return [heap maxAvailableSizeWithAlignment:Alignment];
+    return [heap maxAvailableSizeWithAlignment:Alignment];
+  }
+  NSUInteger Size() {
+    return [heap size];
   }
   id<MTLBuffer> newMTLBuffer(size_t length, uint32_t usage) {
     id<MTLBuffer> buf = [heap newBufferWithLength:length options:getOptions(usage)];
@@ -208,43 +212,50 @@ struct HeapBlock
 };
 typedef bool (*HeapComparison)(const HeapBlock*, const HeapBlock*);
 
-struct BufferPool
-{
+struct BufferPool {
+  enum class Kind {
+    PRIVATE_SMALL,
+    PRIVATE_LARGE,
+    SHARED_SMALL,
+    SHARED_LARGE,
+    SCALAR,
+  };
+
   BufferPool(const id<MTLDevice> Device, uint32_t Usage) :
-             device(Device), usage(Usage), n_buffers(0), allocated_size(0), available_size(0),
-             heaps(HeapBlock::Comparator), buffers(BufferBlock::Comparator) { }
+             device(Device), usage(Usage),
+             heaps(HeapBlock::Comparator), available_buffers(BufferBlock::Comparator) { }
 
   const id<MTLDevice> device;
   // usage flags to customize the pool for various purposes (see UsageFlags enum)
   const uint32_t usage;
   // total number of buffers in the pool
-  uint32_t n_buffers;
+  uint32_t n_buffers = 0;
   // total allocations size on this pool
-  size_t allocated_size;
+  size_t allocated_size = 0;
   // total memory available in the pool
-  size_t available_size;
+  size_t available_size = 0;
   // list of heaps ordered by their "available" (not total) memory size
   std::set<HeapBlock*, HeapComparison> heaps;
   // list of only "available" buffers in the pool (i.e., buffers not in-use)
-  std::set<BufferBlock*, BufferComparison> buffers;
+  std::set<BufferBlock*, BufferComparison> available_buffers;
+  // list of buffers that are in a state of "limbo" where they've already been freed
+  // from PyTorch-side, but were not returned to pool due to still being
+  // in-use by command buffers with retainCount > 1. In this state, the buffer is
+  // neither ready to be recycled, nor could be returned to pool as available.
+  // These buffers will be returned to pool once the command buffer's
+  // completionHandler callbacks are called.
+  std::unordered_set<BufferBlock*> buffers_pending_free;
   // list of heaps pending size update
   std::unordered_set<HeapBlock*> heaps_pending_update;
 };
 
-class MPSHeapAllocatorImpl
-{
+class MPSHeapAllocatorImpl {
 public:
   explicit MPSHeapAllocatorImpl() :
     m_device(at::mps::MPSDevice::getInstance()->device()),
-    m_large_pool_shared (m_device, UsageFlags::SHARED  | UsageFlags::HAZARD),
-    m_large_pool_private(m_device, UsageFlags::PRIVATE | UsageFlags::HAZARD),
-    m_small_pool_shared (m_device, UsageFlags::SMALL   | UsageFlags::SHARED  | UsageFlags::HAZARD),
-    m_small_pool_private(m_device, UsageFlags::SMALL   | UsageFlags::PRIVATE | UsageFlags::HAZARD),
-    // no Hazard Tracking required for the Scalar pool (synchronized manually)
-    m_scalar_pool(m_device, UsageFlags::SMALL | UsageFlags::SHARED | UsageFlags::SCALAR),
-    m_total_allocated_memory(0), m_current_allocated_memory(0),
-    m_max_buffer_size([m_device maxBufferLength]), m_stream(getDefaultMPSStream())
-  {
+    m_max_buffer_size([m_device maxBufferLength]),
+    m_stream(getDefaultMPSStream()),
+    m_event_pool(getMPSEventPool()) {
     init_allocator();
   }
   ~MPSHeapAllocatorImpl() {
@@ -256,6 +267,8 @@ public:
   void free(void* ptr);
   // releases all the cached buffers and their associated heaps
   void emptyCache();
+  // free inactive buffers that are pending to be freed
+  void freeInactiveBuffers();
   // returns true if buffer was allocated from the shared pool
   bool isSharedBuffer(const void* ptr);
   // get the requested unaligned size of an MTLBuffer
@@ -268,6 +281,16 @@ public:
   id_t getBufferId(const void* ptr);
   // allocate a buffer from a specialized pool to import CPU scalars into GPU
   id<MTLBuffer> allocScalarBufferWithValue(void* value, size_t size);
+  // returns a CPU-mapping of the input buffer and its retainCount,
+  // if only it has Shared storage-mode and allocated on MPSAllocator
+  std::pair<const void*, uint32_t> getSharedBufferPtr(const void* buffer);
+  // records events for a list of MTLBuffers (list is used to lock the mutex once)
+  // returns true if records any event (given if passed buffers exist and are shared-storage)
+  bool recordEvents(c10::ArrayRef<const void*> buffers);
+  // waits for the event to signal the completion of GPU execution
+  // on the passed shared buffers (list is used to lock the mutex once)
+  // returns true if actually waited on any event
+  bool waitForEvents(c10::ArrayRef<const void*> buffers);
   // this indicates how far (in Megabytes) the current total allocations are from the
   // low watermark limit which is used to detect if we're under memory pressure
   // This returns zero if we've reached the low watermark limit
@@ -309,20 +332,16 @@ private:
   std::recursive_mutex m_mutex;
   // allocated buffers by device pointer
   ska::flat_hash_map<const void*, BufferBlock*> m_allocated_buffers;
-  // unallocated cached buffers larger than 1 MB
-  BufferPool m_large_pool_shared, m_large_pool_private;
-  // unallocated cached buffers 1 MB or smaller
-  BufferPool m_small_pool_shared, m_small_pool_private;
-  // small cached buffers to import scalar values into MPS stream
-  BufferPool m_scalar_pool;
+  // using a container for pools to simplify iterating them
+  ska::flat_hash_map<BufferPool::Kind, std::unique_ptr<BufferPool>> m_pools;
   // total memory allocated by HeapAllocator (including blocks in pools)
-  size_t m_total_allocated_memory;
+  size_t m_total_allocated_memory = 0;
   // currently active memory allocations in use (i.e., blocks not in pools)
-  size_t m_current_allocated_memory;
+  size_t m_current_allocated_memory = 0;
   // max buffer size allowed by Metal
-  size_t m_max_buffer_size;
+  size_t m_max_buffer_size = 0;
   // maximum total size allowed to be allocated
-  size_t m_max_total_allowed_size;
+  size_t m_max_total_allowed_size = 0;
   // high watermark ratio is a hard limit for the total allowed allocations
   // 0. : disables high watermark limit (may cause system failure if system-wide OOM occurs)
   // 1. : recommended maximum allocation size (i.e., device.recommendedMaxWorkingSetSize)
@@ -342,8 +361,11 @@ private:
   uint32_t m_debug_verbosity;
   // default MPS stream
   MPSStream* m_stream;
+  // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
+  std::shared_ptr<MPSEventPool> m_event_pool;
 
   void init_allocator();
+  void init_buffer_pools();
   HeapBlock* get_free_heap(AllocParams& params);
   bool get_free_buffer(AllocParams& params);
   BufferBlock* get_allocated_buffer_block(const void* ptr);
@@ -357,20 +379,14 @@ private:
   bool release_cached_buffers();
   // free unused cached blocks to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
-
-  BufferPool& get_pool(size_t Size, uint32_t usage) {
-    if (usage & UsageFlags::SCALAR)
-      return m_scalar_pool;
-    return Size <= kMaxSmallAlloc ? ((usage & UsageFlags::SHARED) ? m_small_pool_shared : m_small_pool_private) :
-                                    ((usage & UsageFlags::SHARED) ? m_large_pool_shared : m_large_pool_private);
-  }
-
-  size_t get_allocation_size(size_t Length, uint32_t usage) const  {
-    MTLSizeAndAlign sizeAlign = [m_device heapBufferSizeAndAlignWithLength:Length
-                                                                   options:HeapBlock::getOptions(usage)];
-    return BufferBlock::alignUp(sizeAlign.size, sizeAlign.align);
-  }
+  // returns the suitable buffer pool type for the usage or
+  // requested/allocated sizes
+  BufferPool& get_pool(size_t requested_size, size_t aligned_size, uint32_t usage);
+  // returns the aligned allocation size that is optimized
+  // for the buffers to get reused frequently
+  size_t get_allocation_size(size_t size, uint32_t usage) const;
   // maximum size of device memory available for allocation in current process
+  // Note: the recommendedMaxWorkingSetSize is typically 75% of the total system memory.
   size_t max_device_size() const { return [m_device recommendedMaxWorkingSetSize]; }
   // there are implicit allocations from MPS backend, so we need to query the 'device' for
   // total allocated size instead of manually tracking in MPSAllocator

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -6,6 +6,8 @@
 #include <c10/util/Registry.h>
 #include <ATen/core/ATen_fwd.h>
 
+#define MB(x) (x * 1048576UL)
+
 namespace at { namespace mps {
 
 // this is a public interface to access MPSAllocator.
@@ -14,6 +16,7 @@ class IMPSAllocator : public c10::Allocator {
 public:
   // see the comments in MPSAllocator.h for the description of these methods.
   virtual void emptyCache() const = 0;
+  virtual void freeInactiveBuffers() const = 0;
   virtual ssize_t getUnalignedBufferSize(const void* ptr) const = 0;
   virtual IntArrayRef getBufferShape(const void* ptr) const = 0;
   virtual id_t getBufferId(const void* ptr) const = 0;
@@ -30,6 +33,9 @@ public:
   virtual size_t getTotalAllocatedMemory() const = 0;
   virtual size_t getCurrentAllocatedMemory() const = 0;
   virtual size_t getDriverAllocatedMemory() const = 0;
+  virtual std::pair<const void*, uint32_t> getSharedBufferPtr(const void* ptr) const = 0;
+  virtual bool recordEvents(c10::ArrayRef<const void*> buffers) const = 0;
+  virtual bool waitForEvents(c10::ArrayRef<const void*> buffers) const = 0;
 };
 
 class IMpsAllocatorCallback {


### PR DESCRIPTION
- This PR is the first part of a bigger change to use `MPSEvent` to synchronize shared-buffers between CPU/GPU.
- Add APIs to record and wait for `MPSEvents` in `MPSAllocator`.
- Use a container list for Buffer Pools to simplify iterating over them.
