### PR TITLE
Enable Mypy Checking in torch/_inductor/exc.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -205,7 +205,7 @@ exclude_patterns = [
     'torch/_inductor/test_operators.py',
     'torch/_inductor/inductor_prims.py',
     'torch/_inductor/scheduler.py',
-    'torch/_inductor/exc.py',
+    'torch/_inductor/__init__.py',
     'torch/_inductor/sizevars.py',
     'torch/_inductor/triton_helpers.py',
     'torch/_inductor/freezing.py',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -205,7 +205,6 @@ exclude_patterns = [
     'torch/_inductor/test_operators.py',
     'torch/_inductor/inductor_prims.py',
     'torch/_inductor/scheduler.py',
-    'torch/_inductor/__init__.py',
     'torch/_inductor/sizevars.py',
     'torch/_inductor/triton_helpers.py',
     'torch/_inductor/freezing.py',

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -11,7 +11,9 @@ if os.environ.get("TORCHINDUCTOR_WRITE_MISSING_OPS") == "1":
             fd.write(str(target) + "\n")
 
 else:
-    pass
+
+    def _record_missing_op(target): # type: ignore[misc]
+        pass
 
 
 class OperatorIssue(RuntimeError):

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -12,7 +12,7 @@ if os.environ.get("TORCHINDUCTOR_WRITE_MISSING_OPS") == "1":
 
 else:
 
-    def _record_missing_op(target): # type: ignore[misc]
+    def _record_missing_op(target):  # type: ignore[misc]
         pass
 
 

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -11,9 +11,7 @@ if os.environ.get("TORCHINDUCTOR_WRITE_MISSING_OPS") == "1":
             fd.write(str(target) + "\n")
 
 else:
-
-    def _record_missing_op(target):
-        pass
+    pass
 
 
 class OperatorIssue(RuntimeError):


### PR DESCRIPTION
Fixes #105230 

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/exc.py

After Fix:

mypy --follow-imports=skip torch/_inductor/exc.py Success: no issues found in 1 source file


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel