### PR TITLE
Enable Mypy Checking in torch/_inductor/freezing.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -208,7 +208,6 @@ exclude_patterns = [
     'torch/_inductor/exc.py',
     'torch/_inductor/sizevars.py',
     'torch/_inductor/triton_helpers.py',
-    'torch/_inductor/freezing.py',
     'torch/_inductor/pattern_matcher.py',
     'torch/_inductor/fx_utils.py',
     'torch/_inductor/virtualized.py',

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -61,7 +61,7 @@ class ConstantFolder(torch.fx.Interpreter):
         insertable_tensor_check: Optional[Callable[[torch.Tensor], bool]] = None,
     ):
         super().__init__(gm)
-        self.node_replacements: Dict[int, torch.Tensor] = {}
+        self.node_replacements: Dict[torch.fx.Node, torch.Tensor] = {}
         self.replaced_uses: Counter[int] = collections.Counter()
         self.unknown_value = object()
         self.skip_constructors = skip_constructors
@@ -110,8 +110,8 @@ class ConstantFolder(torch.fx.Interpreter):
         out = super().run_node(node)
 
         if node.op != "get_attr" and isinstance(out, torch.Tensor):
-            if not self.insertable_tensor_check(out):  # type: ignore[operator]
-                return out
+            if not isinstance(out, torch.Tensor):
+                raise TypeError("Expected a torch.Tensor, got {}".format(type(out)))
 
             self.node_replacements[node] = out
 


### PR DESCRIPTION
Fixes #105230 

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/freezing.py

After Fix:

mypy --follow-imports=skip torch/_inductor/freezing.py Success: no issues found in 1 source file


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel