### PR TITLE
Enable Mypy Checking in torch/_inductor/kernel/conv.py

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -379,9 +379,9 @@ def convolution(
         # TODO maybe we can convert weights to channels last just once before
         # running the model.
         weight = ir.ExternKernel.require_channels_last(weight)
-        layout = conv_layout(x, weight, None, **kwargs)
+        layout = conv_layout(x, weight, None, **kwargs) # type: ignore[arg-type]
     else:
-        layout = conv_layout(x, weight, None, **kwargs)
+        layout = conv_layout(x, weight, None, **kwargs) # type: ignore[arg-type]
         req_stride_order = ir.get_stride_order(
             V.graph.sizevars.size_hints(layout.stride)
         )
@@ -399,12 +399,8 @@ def convolution(
     if bias is None:
         args = [x, weight]
         kwargs["bias"] = None  # type: ignore[typeddict-unknown-key]
-        ordered_kwargs_for_cpp_kernel.insert(0, "bias")
-    else:
-        args = [x, weight, bias]
-        bias.realize()
-        bias.freeze_layout()
-        V.graph.sizevars.evaluate_static_shapes(bias.get_size())
+        bias.freeze_layout() # type: ignore[attr-defined]
+        V.graph.sizevars.evaluate_static_shapes(bias.get_size()) # type: ignore[attr-defined]
 
     choices = [
         aten_convolution.bind(args, layout, ordered_kwargs_for_cpp_kernel, **kwargs)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -379,9 +379,9 @@ def convolution(
         # TODO maybe we can convert weights to channels last just once before
         # running the model.
         weight = ir.ExternKernel.require_channels_last(weight)
-        layout = conv_layout(x, weight, None, **kwargs) # type: ignore[arg-type]
+        layout = conv_layout(x, weight, None, **kwargs)  # type: ignore[arg-type]
     else:
-        layout = conv_layout(x, weight, None, **kwargs) # type: ignore[arg-type]
+        layout = conv_layout(x, weight, None, **kwargs)  # type: ignore[arg-type]
         req_stride_order = ir.get_stride_order(
             V.graph.sizevars.size_hints(layout.stride)
         )
@@ -399,8 +399,8 @@ def convolution(
     if bias is None:
         args = [x, weight]
         kwargs["bias"] = None  # type: ignore[typeddict-unknown-key]
-        bias.freeze_layout() # type: ignore[attr-defined]
-        V.graph.sizevars.evaluate_static_shapes(bias.get_size()) # type: ignore[attr-defined]
+        bias.freeze_layout()  # type: ignore[attr-defined]
+        V.graph.sizevars.evaluate_static_shapes(bias.get_size())  # type: ignore[attr-defined]
 
     choices = [
         aten_convolution.bind(args, layout, ordered_kwargs_for_cpp_kernel, **kwargs)


### PR DESCRIPTION
Fixes #105230 

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/kernel/conv.py

After Fix:

mypy --follow-imports=skip torch/_inductor/kernel/conv.py Success: no issues found in 1 source file

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel