### PR TITLE
make sure mkldnn convolution given same stride as ref path for nc11 contiguous input

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -63,7 +63,8 @@ Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor, c10::optional<ScalarType> dt
          )
       );
   cpu_tensor.as_strided_(dims, pub_tensor.get_strides());
-  return cpu_tensor.contiguous();
+  // Make sure that NC11 strides follow formula of contiguous tensor.
+  return cpu_tensor.contiguous().resize_(dims, c10::MemoryFormat::Contiguous);
 }
 
 Tensor dense_to_mkldnn(const Tensor& cpu_tensor, c10::optional<ScalarType> dtype) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106966


On SPR machine, the mkldnn bfloat16 convolution always return a channels last output, and we will convert it to channels first if input and weight are channels first, there has an issue when we do such conversion if output is nc11(4*512*1*1), we always mark it as public format ideep tensor, and even we calling ```to_dense``` before returning the output, the output's stride is still a channels last stride(512, 1, 512, 512), this PR will calling ```resize_``` to make sure the stride is contiguous stride.

cc @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10