### PR TITLE
Add torch/_C/_onnx.pyi to ONNX exporter's .github/merge_rules.yaml

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -11,6 +11,7 @@
   - test/onnx/**
   - tools/onnx/**
   - torch/_C/__init__.pyi.in
+  - torch/_C/_onnx.pyi
   - torch/csrc/jit/passes/onnx.*
   - torch/csrc/jit/passes/onnx/**
   - torch/csrc/jit/serialization/export.*


### PR DESCRIPTION
Adds `orch/_C/_onnx.pyi` to `ONNX exporter` team at `.github/merge_rules.yaml`