### PR TITLE
[Vulkan] Introduce GPU Memory Layout qualifier

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -32,6 +32,7 @@ class vTensorStorage final {
   vTensorStorage(
       api::Context* context,
       const api::StorageType storage_type,
+      const api::GPUMemoryLayout gpu_memory_layout,
       const IntArrayRef sizes,
       const at::ScalarType dtype);
 
@@ -87,11 +88,29 @@ class vTensor final {
   vTensor(
       api::Context* context,
       IntArrayRef sizes,
+      const c10::ScalarType dtype,
+      const api::StorageType storage_type,
+      const api::GPUMemoryLayout memory_layout);
+
+  // Default constructor for quantized vTensor
+  vTensor(
+      api::Context* const context,
+      const IntArrayRef sizes,
+      double q_scale,
+      int64_t q_zero_point,
+      const c10::ScalarType dtype,
+      const api::StorageType storage_type,
+      const api::GPUMemoryLayout memory_layout);
+
+  // Allows construction of vTensor from aten Tensor params
+  vTensor(
+      api::Context* context,
+      IntArrayRef sizes,
       const c10::ScalarType dtype = c10::kFloat,
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
       const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
 
-  // Default constructor with quantization parameters
+  // Allows construction of quantized vTensor from aten Tensor params
   vTensor(
       api::Context* const context,
       const IntArrayRef sizes,
@@ -122,7 +141,9 @@ class vTensor final {
  private:
   // Tensor Options
   c10::ScalarType dtype_;
-  c10::MemoryFormat memory_format_;
+
+  // GPU specific memory layout qualifier
+  api::GPUMemoryLayout memory_layout_;
 
   // Sizes and Strides
   c10::SmallVector<int64_t, 6u> sizes_;
@@ -209,8 +230,12 @@ class vTensor final {
     return api::c10_scalartype(view_->texture_format());
   }
 
-  inline c10::MemoryFormat memory_format() const {
-    return memory_format_;
+  inline api::GPUMemoryLayout gpu_memory_layout() const {
+    return memory_layout_;
+  }
+
+  inline uint32_t gpu_memory_layout_as_uint() const {
+    return static_cast<uint32_t>(memory_layout_);
   }
 
   inline IntArrayRef sizes() const {

--- a/aten/src/ATen/native/vulkan/api/Types.h
+++ b/aten/src/ATen/native/vulkan/api/Types.h
@@ -6,11 +6,40 @@ namespace native {
 namespace vulkan {
 namespace api {
 
+/**
+ * The enum below is used to describe what type of GPU memory will be used to
+ * store a particular tensor's data.
+ *
+ * BUFFER means that a SSBO (Shader Storage Buffer Object) will be used.
+ * TEXTURE_3D means that a 3-dimensional image texture will be used.
+ * TEXTURE_2D means that a 2-dimensional image texture will be used.
+ *
+ * UNKNOWN is not expected to be used.
+ */
 enum class StorageType {
   BUFFER,
   TEXTURE_3D,
   TEXTURE_2D,
   UNKNOWN,
+};
+
+/**
+ * The enum below is used to describe how tensor data is laid out when stored in
+ * GPU memory. The name of the enum describes which dimension is tightly packed;
+ * so for tensors that are stored as image textures, loading a texel will
+ * retrieve 4 consecutive elements of the named dimension, and for tensors
+ * stored as buffers, the named dimension will have a stride of 1.
+ *
+ * The GPU memory layout qualifier will be used by compute shaders to determine
+ * how to convert between logical tensor coordinates and physical texel
+ * coordinates. For tensors that are stored as buffers, it is expected that the
+ * strides of the tensor will be used instead to convert between logical tensor
+ * coordinates and linear access indices.
+ */
+enum class GPUMemoryLayout : uint32_t {
+  TENSOR_WIDTH_PACKED = 0u,
+  TENSOR_HEIGHT_PACKED = 1u,
+  TENSOR_CHANNELS_PACKED = 2u,
 };
 
 } // namespace api


### PR DESCRIPTION
Summary:
Introduce a GPU memory Layout qualifier in `vTensor`, which will allow more efficient memory layouts when storing Tensors on the GPU.

The plan is for shaders to use the memory layout qualifier to convert between logical tensor coordinates and physical texel positions.

Test Plan:
As-is, this diff should be a no-op. Run standard tests to make sure everything works as expected.

```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1

buck run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1

```

Reviewed By: kimishpatel

Differential Revision: D48129905

