### PR TITLE
Move overloaded_args from FunctionSignature to PythonArgs

### DIFF
--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -153,7 +153,7 @@ py::object torchDispatchFromTensorImpl(
       PyGILState_Check(),
       "GIL must be held before you call parseIValuesToPyArgsKwargs");
 
-  std::vector<py::handle> overloaded_args;
+  std::vector<PyObject*> overloaded_args;
   // TODO: there should be a shorter way to spell this
   // TODO: fix the constness of target
   at::Tensor self_t = at::Tensor(
@@ -280,7 +280,7 @@ void ConcretePyInterpreterVTable::dispatch(
 
   py::gil_scoped_acquire g;
 
-  std::vector<py::handle> overloaded_args;
+  std::vector<PyObject*> overloaded_args;
   py::handle torch_api_function_overload = getTorchApiFunction(op);
 
   // Find overloaded tensors

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -775,7 +775,7 @@ py::object _get_operation_for_overload_or_packet(
     const py::kwargs& kwargs,
     bool is_overload,
     c10::optional<c10::DispatchKey> dk) {
-  std::vector<py::handle> overloaded_args;
+  std::vector<PyObject*> overloaded_args;
   size_t total_arg_num = args.size() + kwargs.size();
   for (const auto i : c10::irange(args.size())) {
     is_tensor_and_append_overloaded(args[i].ptr(), &overloaded_args);

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1017,7 +1017,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
   py::tuple args = py::cast(args_vec);
 
   // Handle __torch_function__ dispatch
-  std::vector<py::handle> overloaded_args;
+  std::vector<PyObject*> overloaded_args;
   size_t total_arg_num = args.size() + kwargs.size();
   for (const auto& arg : args) {
     is_tensor_and_append_overloaded(arg.ptr(), &overloaded_args);

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1532,14 +1532,17 @@ PythonArgs PythonArgParser::raw_parse(
     std::vector<py::handle> overloaded_args;
     signature.parse(self, args, kwargs, parsed_args, overloaded_args, true);
     check_deprecated(signature);
-    return PythonArgs(traceable, signature, parsed_args, std::move(overloaded_args));
+    return PythonArgs(
+        traceable, signature, parsed_args, std::move(overloaded_args));
   }
 
   for (auto& signature : signatures_) {
     std::vector<py::handle> overloaded_args;
-    if (signature.parse(self, args, kwargs, parsed_args, overloaded_args, false)) {
+    if (signature.parse(
+            self, args, kwargs, parsed_args, overloaded_args, false)) {
       check_deprecated(signature);
-      return PythonArgs(traceable, signature, parsed_args, std::move(overloaded_args));
+      return PythonArgs(
+          traceable, signature, parsed_args, std::move(overloaded_args));
     }
   }
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -432,16 +432,7 @@ auto handle_torch_function(
       (char*)(func_name_override ? func_name_override : r.get_func_name().c_str()));
   TORCH_INTERNAL_ASSERT(
       torch_api_function.ptr() != nullptr, "torch API function must exist");
-  py::object ret;
   py::tuple args_ = combine_self_args(self, args);
-  // overloaded_args already all have unique types
-  std::vector<py::object> overloaded_types;
-  overloaded_types.reserve(r.signature.overloaded_args.size());
-  for (auto& arg : r.signature.overloaded_args) {
-    overloaded_types.push_back(
-        py::reinterpret_borrow<py::object>((PyObject*)Py_TYPE(arg.ptr())));
-  }
-  py::tuple py_types = py::cast(overloaded_types);
   return handle_torch_function_no_python_arg_parser(
       r.signature.overloaded_args,
       args_.ptr(),

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -509,7 +509,7 @@ auto handle_torch_function_indexing(
  *  entry in overloaded_args for this type with higher precedence than
  *  the superclass.
  *
- *  See torch._overrides._get_overloaded_types_and_args for the equivalent
+ *  See torch._overrides._get_overloaded_args for the equivalent
  *  function in the Python __torch_function__ implementation.
  *
  *  The precedence-determining algorithm implemented in this function is

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -193,7 +193,7 @@ struct FunctionSignature {
       PyObject* args,
       PyObject* kwargs,
       PyObject* dst[],
-      std::vector<py::handle>& overloaded_args,
+      std::vector<PyObject*>& overloaded_args,
       bool raise_exception);
 
   std::string toString() const;
@@ -210,12 +210,12 @@ struct FunctionSignature {
 
 // PythonArgs contains bound Python arguments for an actual invocation
 // along with references to the matched signature.
-struct PYBIND11_EXPORT PythonArgs {
+struct PythonArgs {
   PythonArgs(
       bool traceable,
       const FunctionSignature& signature,
       PyObject** args,
-      std::vector<py::handle> overloaded_args)
+      std::vector<PyObject*> overloaded_args)
       : idx(signature.index),
         traceable(traceable),
         signature(signature),
@@ -226,7 +226,7 @@ struct PYBIND11_EXPORT PythonArgs {
   bool traceable;
   const FunctionSignature& signature;
   PyObject** args;
-  std::vector<py::handle> overloaded_args;
+  std::vector<PyObject*> overloaded_args; // NOTE: borrowed references
 
   inline bool has_torch_function();
   inline std::string get_func_name();
@@ -314,7 +314,7 @@ struct FunctionParameter {
 
   bool check(
       PyObject* obj,
-      std::vector<py::handle>& overloaded_args,
+      std::vector<PyObject*>& overloaded_args,
       int argnum,
       int64_t* failed_idx = nullptr);
 
@@ -1211,7 +1211,7 @@ auto handle_torch_function(
 enum class TorchFunctionName { TorchFunction, TorchDispatch };
 
 auto TORCH_PYTHON_API handle_torch_function_no_python_arg_parser(
-    at::ArrayRef<py::handle> overloaded_args,
+    at::ArrayRef<PyObject*> overloaded_args,
     PyObject* args,
     PyObject* kwargs,
     const char* func_name,
@@ -1248,7 +1248,7 @@ auto handle_torch_function_indexing(
  */
 bool is_tensor_and_append_overloaded(
     PyObject* obj,
-    std::vector<py::handle>* overloaded_args);
+    std::vector<PyObject*>* overloaded_args);
 
 /*
  * Check if the input obj is Tensor List or Tensor Tuple type. First check
@@ -1264,7 +1264,7 @@ bool is_tensor_and_append_overloaded(
  */
 bool is_tensor_list_and_append_overloaded(
     PyObject* obj,
-    std::vector<py::handle>* overloaded_args,
+    std::vector<PyObject*>* overloaded_args,
     int argnum,
     bool throw_error);
 
@@ -1277,7 +1277,7 @@ bool is_tensor_list_and_append_overloaded(
  * 'obj': the input tensor that is overloaded
  */
 void append_overloaded_tensor(
-    std::vector<py::handle>* overloaded_args,
+    std::vector<PyObject*>* overloaded_args,
     PyObject* obj);
 
 /* Given an argument that is definitely a type and is definitely overloaded,
@@ -1289,7 +1289,7 @@ void append_overloaded_tensor(
  * 'obj': the input class that has a __torch_dispatch__ classmethod.
  */
 void append_overloaded_type(
-    std::vector<py::handle>* overloaded_args,
+    std::vector<PyObject*>* overloaded_args,
     PyObject* obj);
 
 } // namespace torch

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -367,8 +367,7 @@ inline PythonArgs PythonArgParser::parse(PyObject* self, ParsedArgs<0>& dst) {
 }
 
 inline bool PythonArgs::has_torch_function() {
-  return !overloaded_args.empty() ||
-      at::impl::torch_function_mode_enabled();
+  return !overloaded_args.empty() || at::impl::torch_function_mode_enabled();
 }
 
 inline std::string PythonArgs::get_func_name() {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -201,7 +201,6 @@ struct PYBIND11_EXPORT FunctionSignature {
   int index;
   bool hidden;
   bool deprecated;
-  bool disable_torch_function;
 };
 
 struct PythonArgs {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -135,6 +135,8 @@ struct ParsedArgs {
   PyObject* args[N];
 };
 
+// A PythonArgParser contains a list of valid signatures. Instances are
+// typically global variables and should be immutable.
 struct PYBIND11_EXPORT PythonArgParser {
   explicit PythonArgParser(
       const std::vector<std::string>& fmts,
@@ -179,6 +181,9 @@ struct PYBIND11_EXPORT PythonArgParser {
   bool traceable;
 };
 
+// FunctionSignature represents a single valid signature for a Python function.
+// It is immutable once constructed. The contained data can be concurrently
+// accessed by multiple calls.
 struct FunctionSignature {
   explicit FunctionSignature(const std::string& fmt, int index);
 
@@ -203,6 +208,8 @@ struct FunctionSignature {
   bool deprecated;
 };
 
+// PythonArgs contains bound Python arguments for an actual invocation
+// along with references to the matched signature.
 struct PYBIND11_EXPORT PythonArgs {
   PythonArgs(
       bool traceable,
@@ -300,6 +307,8 @@ struct PYBIND11_EXPORT PythonArgs {
   at::Scalar scalar_slow(PyObject* arg);
 };
 
+// FunctionParameter is a single formal parameter of a Python function.
+// It is immutable once constructed.
 struct FunctionParameter {
   FunctionParameter(const std::string& fmt, bool keyword_only);
 


### PR DESCRIPTION
This moves the `overloaded_args` field from FunctionSignature to PythonArgs. FunctionSignature is shared by all calls and should be immutable. PythonArgs contains the parsing results for an single call to the PyTorch API. 

I did not measure a difference in performance in the "overrides_benchmark", although I expect there to be a bit more work in the common case. Note that the noise factor for the benchmark is much larger than the differences reported below:

Before:
```
Type tensor had a minimum time of 2.3615360260009766 us and a standard deviation of 0.7833134150132537 us.
Type SubTensor had a minimum time of 10.473251342773438 us and a standard deviation of 0.1973132457351312 us.
Type WithTorchFunction had a minimum time of 5.484819412231445 us and a standard deviation of 0.13305981701705605 us.
Type SubWithTorchFunction had a minimum time of 11.098146438598633 us and a standard deviation of 0.15598918253090233 us.
```
After:
```
Type tensor had a minimum time of 2.2134780883789062 us and a standard deviation of 0.802064489107579 us.
Type SubTensor had a minimum time of 10.625839233398438 us and a standard deviation of 0.15155907021835446 us.
Type WithTorchFunction had a minimum time of 5.520820617675781 us and a standard deviation of 0.23115111980587244 us.
Type SubWithTorchFunction had a minimum time of 11.227846145629883 us and a standard deviation of 0.23032321769278497 us.
```

Fixes #106974
