### PR TITLE
Use aot_compile instead of compile_fx_aot in _export.aot_compile

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -440,7 +440,7 @@ def aot_compile(
     Returns:
         Path to the generated shared library, and the exported program
     """
-    from torch._inductor.compile_fx import compile_fx_aot
+    from torch._inductor import aot_compile as inductor_aot_compile
     from torch._inductor.decomposition import select_decomp_table
 
     global DECOMP_TABLE
@@ -455,9 +455,9 @@ def aot_compile(
     )
     all_args = (*param_buffer_values, *flat_example_inputs)
 
-    so_path = compile_fx_aot(
+    so_path = inductor_aot_compile(
         ep.graph_module,
         all_args,  # type: ignore[arg-type]
-        config_patches=options,
+        options=options,
     )
     return so_path, ep


### PR DESCRIPTION
`torch._inductor` module provides function [aot_compile()](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/__init__.py#L30) which internally uses `_inductor.compile_fx.compile_fx_aot()`.

Since `torch._inductor` module has AOT compilation function `_inductor.aot_compile()` we supposed to use it instead of using module internal function `_inductor.compile_fx.compile_fx_aot()`.

Also, `_inductor.aot_compile()` has a logic to process `compile_fx_aot()` output to get actual lib path.

cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan