### PR TITLE
Only check for fusions within a node distance of 64

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -120,6 +120,9 @@ aggressive_fusion = False
 # how many nodes to allow into a single fusion
 max_fusion_size = 64
 
+# node distance to allow for fusions
+max_fusion_proximity = 64
+
 # replace small reductions with pointwise, disable with `= 1`
 unroll_reductions_threshold = 8
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1042,7 +1042,8 @@ class Scheduler:
 
         def check_all_pairs(nodes):
             for node1_index, node1 in enumerate(nodes):
-                for node2 in nodes[node1_index + 1 :]:
+                start = node1_index + 1
+                for node2 in nodes[start : (start + config.max_fusion_proximity)]:
                     key = (node1, node2)
                     if key in seen:
                         continue
@@ -1131,7 +1132,7 @@ class Scheduler:
             abs(node1.min_order - node2.max_order),
             abs(node2.min_order - node1.max_order),
         )
-        return proximity_score > 64
+        return proximity_score > config.max_fusion_proximity
 
     def can_fuse(self, node1: BaseSchedulerNode, node2: BaseSchedulerNode):
         """


### PR DESCRIPTION
After Animesh's change to help with peak memory, nodes farther than 64 edges in the graph won't be fused anyway, this ensures the scheduler doesn't add those nodes to the list possible fusions. Makes a fusion pass O(N) instead of O(N^2)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @ngimel