### PR TITLE
[device_mesh] move remaining collectives to a separate file

### DIFF
--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -4,6 +4,11 @@ import os
 
 import torch
 import torch.distributed._functional_collectives as funcol
+from torch.distributed._tensor._collective_utils import (
+    mesh_all_to_all,
+    mesh_broadcast,
+    mesh_scatter,
+)
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Shard
 
@@ -161,7 +166,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     def test_broadcast_1d(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
-        mesh.broadcast(local_tensor, mesh_dim=0)
+        mesh_broadcast(local_tensor, mesh, mesh_dim=0)
         self.assertEqual(local_tensor, torch.zeros(3, 3))
 
     @with_comms
@@ -179,7 +184,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             )
             recv_tensor = torch.empty_like(splitted_list[mesh.get_rank()])
             # scatter on dim > 0 would generate non-contiguous tensor, verify that works
-            mesh.scatter(recv_tensor, splitted_list, mesh_dim=0)
+            mesh_scatter(recv_tensor, splitted_list, mesh, mesh_dim=0)
             self.assertEqual(recv_tensor, splitted_list[mesh.get_rank()])
 
     @with_comms
@@ -208,7 +213,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             )
 
             scattered_tensor = torch.empty_like(padded_tensor_list[my_rank])
-            device_mesh.scatter(scattered_tensor, padded_tensor_list, mesh_dim=0)
+            mesh_scatter(scattered_tensor, padded_tensor_list, device_mesh, mesh_dim=0)
 
             if pad_sizes[my_rank] != 0:
                 scattered_tensor = shard_placement._unpad_tensor(
@@ -339,7 +344,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 get_global_rank(dim_group, i) for i in range(dim_group_size)
             ]
             cloned_local_tensor = local_tensor.clone()
-            mesh.broadcast(cloned_local_tensor, mesh_dim=dim)
+            mesh_broadcast(cloned_local_tensor, mesh, mesh_dim=dim)
             res_num = global_ranks[0]
             self.assertEqual(cloned_local_tensor, torch.ones(3, 3) * res_num)
 
@@ -362,7 +367,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             received_tensor = torch.empty_like(
                 scattered_tensors[mesh.get_coordinate()[dim]]
             )
-            mesh.scatter(received_tensor, scattered_tensors, mesh_dim=dim)
+            mesh_scatter(received_tensor, scattered_tensors, mesh, mesh_dim=dim)
             self.assertEqual(received_tensor, torch.ones(3, 3) * self.rank)
 
     @with_comms
@@ -386,7 +391,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                 for idx in range(len(input_tensor_list))
             ]
             # scatter on dim > 0 would generate non-contiguous tensor, verify that works
-            mesh.all_to_all(output_tensor_list, input_tensor_list, mesh_dim=0)
+            mesh_all_to_all(output_tensor_list, input_tensor_list, mesh, mesh_dim=0)
             output_tensor = torch.cat(output_tensor_list, dim=scatter_dim)
             expected_tensor = torch.cat(expected_tensor_list, dim=scatter_dim)
 
@@ -422,7 +427,9 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
                     for idx in range(len(input_tensor_list))
                 ]
                 # scatter on dim > 0 would generate non-contiguous tensor, verify that works
-                mesh.all_to_all(output_tensor_list, input_tensor_list, mesh_dim=dim)
+                mesh_all_to_all(
+                    output_tensor_list, input_tensor_list, mesh, mesh_dim=dim
+                )
                 output_tensor = torch.cat(output_tensor_list, dim=scatter_dim)
                 expected_tensor = torch.cat(expected_tensor_list, dim=scatter_dim)
                 self.assertEqual(output_tensor, expected_tensor)

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -1,0 +1,160 @@
+import logging
+
+from typing import List, Optional
+
+import torch
+from torch.distributed._tensor.device_mesh import DeviceMesh
+from torch.distributed.distributed_c10d import (
+    all_to_all,
+    broadcast,
+    get_global_rank,
+    get_rank,
+    get_world_size,
+    GroupMember,
+    ProcessGroup,
+    scatter,
+    Work,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: we need to migrate these APIs to be functional collectives
+
+
+def mesh_scatter(
+    output: torch.Tensor,
+    scatter_list: List[torch.Tensor],
+    mesh: DeviceMesh,
+    mesh_dim: int = 0,
+    async_op: bool = False,
+) -> Optional[Work]:
+    """
+    scatter a list of tensors to a device mesh dimension. We by default
+    use the first rank of the mesh dimension as the source of truth, i.e
+    for a 2d mesh [[0, 1], [2, 3]], if we scatter on mesh_dim = 1, we will
+    scatter the tensor list on rank 0 to rank 0/1, and tensor list on rank
+    2 to rank 2/3.
+
+    Args:
+        output (torch.Tensor): the tensor to receive the scattered list.
+        scatter_list (List[torch.Tensor]): the tensor list to be scattered.
+        mesh_dim (int, optional): indicate which mesh dimension we want
+            to scatter on, we by default choose the first rank on the
+            mesh dimension as source of truth.
+
+    Returns:
+        A :class:`Work` object
+    """
+    # TODO: Ideally we should use the meta tensor way
+    # (to register a meta kernel for the collective op)
+    # so that it would avoid the communication. Need to
+    # remove the check below once that is done.
+    if output.is_meta:
+        return None
+    dim_group = mesh.get_dim_groups(mesh_dim)
+    assert isinstance(dim_group, ProcessGroup)
+    # src need to be global rank
+    src_for_dim = 0
+
+    if dim_group is not GroupMember.WORLD:
+        src_for_dim = get_global_rank(dim_group, 0)
+
+    if src_for_dim == get_rank():
+        fut = scatter(
+            output,
+            scatter_list=scatter_list,
+            src=src_for_dim,
+            group=dim_group,
+            async_op=async_op,
+        )
+    else:
+        fut = scatter(
+            output,
+            scatter_list=None,
+            src=src_for_dim,
+            group=dim_group,
+            async_op=async_op,
+        )
+
+    return fut
+
+
+def mesh_broadcast(
+    tensor: torch.Tensor,
+    mesh: DeviceMesh,
+    mesh_dim: int = 0,
+    async_op: bool = False,
+) -> Optional[Work]:
+    """
+    broadcast the tensor to a device mesh dimension. We by default
+    use the first rank of the mesh dimension as the source of truth, i.e
+    for a 2d mesh [[0, 1], [2, 3]], if we broadcast on mesh_dim = 1, we will
+    broadcast the tensor on rank 0 to rank 0/1, and tensor on rank 2
+    to rank 2/3.
+
+    Args:
+        tensor (torch.Tensor): tensor to broadcast.
+        mesh_dim (int, optional): indicate which mesh dimension we want
+            to scatter on, we by default choose the first rank on the
+            mesh dimension as source of truth.
+
+    Returns:
+        A :class:`Work` object
+    """
+    # TODO: Ideally we should use the meta tensor way
+    # (to register a meta kernel for the collective op)
+    # so that it would avoid the communication. Need to
+    # remove the check below once that is done.
+    if tensor.is_meta:
+        return None
+    dim_group = mesh.get_dim_groups(mesh_dim)
+    assert isinstance(dim_group, ProcessGroup)
+    # src need to be global rank
+    src_for_dim = 0
+    if dim_group is not GroupMember.WORLD:
+        src_for_dim = get_global_rank(dim_group, 0)
+
+    return broadcast(tensor, src=src_for_dim, group=dim_group, async_op=async_op)
+
+
+# TODO: test uneven split on GLOO and NCCL
+def mesh_all_to_all(
+    output_tensor_list: List[torch.Tensor],
+    input_tensor_list: List[torch.Tensor],
+    mesh: DeviceMesh,
+    mesh_dim: int = 0,
+    async_op: bool = False,
+) -> Optional[Work]:
+    dim_group = mesh.get_dim_groups(mesh_dim)
+    assert isinstance(dim_group, ProcessGroup)
+
+    work = None
+    # no direct dist.all_to_all support on 'gloo' so we manually do scatters
+    if mesh.device_type == "cpu":
+        logger.warning(
+            "ProcessGroupGloo does not support all_to_all, falling back with scatters!"
+        )
+        # TODO: pull the handle of uneven case in #492
+        dim_group_size = get_world_size(dim_group)
+        for i in range(dim_group_size):
+            # src need to be global rank
+            src_for_dim = i
+            if dim_group is not GroupMember.WORLD:
+                src_for_dim = get_global_rank(dim_group, i)
+
+            work = scatter(
+                output_tensor_list[i],
+                input_tensor_list if mesh.get_rank() == src_for_dim else [],
+                group=dim_group,
+                src=src_for_dim,
+                async_op=async_op,
+            )
+    else:
+        work = all_to_all(
+            output_tensor_list,
+            input_tensor_list,
+            dim_group,
+            async_op=async_op,
+        )
+    return work

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed._tensor.dispatch as op_dispatch
 import torch.distributed._tensor.random as random
 import torch.nn as nn
+from torch.distributed._tensor._collective_utils import mesh_broadcast
 from torch.distributed._tensor._utils import compute_global_tensor_info
 from torch.distributed._tensor.device_mesh import DeviceMesh, mesh_resources
 from torch.distributed._tensor.placement_types import (
@@ -112,7 +113,7 @@ class _FromTorchTensor(torch.autograd.Function):
                     # broadcast rank 0 tensor to all ranks
                     # only broadcast if run_check is True
                     input = input.contiguous()
-                    device_mesh.broadcast(input, mesh_dim=idx)
+                    mesh_broadcast(input, device_mesh, mesh_dim=idx)
 
         # We want a fresh Tensor object that shares memory with the input tensor
         dist_tensor = DTensor(

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -9,18 +9,12 @@ from torch.distributed.distributed_c10d import (
     _find_pg_by_ranks_and_tag,
     _get_default_group,
     _get_group_tag,
-    all_to_all,
-    broadcast,
-    get_global_rank,
     get_rank,
     get_world_size,
-    GroupMember,
     init_process_group,
     is_initialized,
     new_group,
     ProcessGroup,
-    scatter,
-    Work,
 )
 
 
@@ -275,138 +269,3 @@ class DeviceMesh:
         dimensions of the mesh. If this rank is not part of the mesh, return None.
         """
         return self._coordinate_on_dim if self._coordinate_on_dim else None
-
-    def scatter(
-        self,
-        output: torch.Tensor,
-        scatter_list: List[torch.Tensor],
-        mesh_dim: int = 0,
-        async_op: bool = False,
-    ) -> Optional[Work]:
-        """
-        scatter a list of tensors to a device mesh dimension. We by default
-        use the first rank of the mesh dimension as the source of truth, i.e
-        for a 2d mesh [[0, 1], [2, 3]], if we scatter on mesh_dim = 1, we will
-        scatter the tensor list on rank 0 to rank 0/1, and tensor list on rank
-        2 to rank 2/3.
-
-        Args:
-            output (torch.Tensor): the tensor to receive the scattered list.
-            scatter_list (List[torch.Tensor]): the tensor list to be scattered.
-            mesh_dim (int, optional): indicate which mesh dimension we want
-                to scatter on, we by default choose the first rank on the
-                mesh dimension as source of truth.
-
-        Returns:
-            A :class:`Work` object
-        """
-        # TODO: Ideally we should use the meta tensor way
-        # (to register a meta kernel for the collective op)
-        # so that it would avoid the communication. Need to
-        # remove the check below once that is done.
-        if output.is_meta:
-            return None
-        dim_group = self.get_dim_groups(mesh_dim)
-        assert isinstance(dim_group, ProcessGroup)
-        # src need to be global rank
-        src_for_dim = 0
-
-        if dim_group is not GroupMember.WORLD:
-            src_for_dim = get_global_rank(dim_group, 0)
-
-        if src_for_dim == get_rank():
-            fut = scatter(
-                output,
-                scatter_list=scatter_list,
-                src=src_for_dim,
-                group=dim_group,
-                async_op=async_op,
-            )
-        else:
-            fut = scatter(
-                output,
-                scatter_list=None,
-                src=src_for_dim,
-                group=dim_group,
-                async_op=async_op,
-            )
-
-        return fut
-
-    def broadcast(
-        self,
-        tensor: torch.Tensor,
-        mesh_dim: int = 0,
-        async_op: bool = False,
-    ) -> Optional[Work]:
-        """
-        broadcast the tensor to a device mesh dimension. We by default
-        use the first rank of the mesh dimension as the source of truth, i.e
-        for a 2d mesh [[0, 1], [2, 3]], if we broadcast on mesh_dim = 1, we will
-        broadcast the tensor on rank 0 to rank 0/1, and tensor on rank 2
-        to rank 2/3.
-
-        Args:
-            tensor (torch.Tensor): tensor to broadcast.
-            mesh_dim (int, optional): indicate which mesh dimension we want
-                to scatter on, we by default choose the first rank on the
-                mesh dimension as source of truth.
-
-        Returns:
-            A :class:`Work` object
-        """
-        # TODO: Ideally we should use the meta tensor way
-        # (to register a meta kernel for the collective op)
-        # so that it would avoid the communication. Need to
-        # remove the check below once that is done.
-        if tensor.is_meta:
-            return None
-        dim_group = self.get_dim_groups(mesh_dim)
-        assert isinstance(dim_group, ProcessGroup)
-        # src need to be global rank
-        src_for_dim = 0
-        if dim_group is not GroupMember.WORLD:
-            src_for_dim = get_global_rank(dim_group, 0)
-
-        return broadcast(tensor, src=src_for_dim, group=dim_group, async_op=async_op)
-
-    # TODO: test uneven split on GLOO and NCCL
-    def all_to_all(
-        self,
-        output_tensor_list: List[torch.Tensor],
-        input_tensor_list: List[torch.Tensor],
-        mesh_dim: int = 0,
-        async_op: bool = False,
-    ) -> Optional[Work]:
-        dim_group = self.get_dim_groups(mesh_dim)
-        assert isinstance(dim_group, ProcessGroup)
-
-        work = None
-        # no direct dist.all_to_all support on 'gloo' so we manually do scatters
-        if self.device_type == "cpu":
-            logger.warning(
-                "ProcessGroupGloo does not support all_to_all, falling back with scatters!"
-            )
-            # TODO: pull the handle of uneven case in #492
-            dim_group_size = get_world_size(dim_group)
-            for i in range(dim_group_size):
-                # src need to be global rank
-                src_for_dim = i
-                if dim_group is not GroupMember.WORLD:
-                    src_for_dim = get_global_rank(dim_group, i)
-
-                work = scatter(
-                    output_tensor_list[i],
-                    input_tensor_list if self.get_rank() == src_for_dim else [],
-                    group=dim_group,
-                    src=src_for_dim,
-                    async_op=async_op,
-                )
-        else:
-            work = all_to_all(
-                output_tensor_list,
-                input_tensor_list,
-                dim_group,
-                async_op=async_op,
-            )
-        return work

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 
+from torch.distributed._tensor._collective_utils import mesh_broadcast, mesh_scatter
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.fx.passes.shape_prop import TensorMetadata
 
@@ -166,7 +167,7 @@ class Shard(Placement):
         )
 
         output = torch.empty_like(scatter_list[my_coordinate[mesh_dim]])
-        mesh.scatter(output, scatter_list, mesh_dim=mesh_dim)
+        mesh_scatter(output, scatter_list, mesh, mesh_dim=mesh_dim)
 
         # Only unpad if the local_tensor was padded on the dimension.
         pad_size = pad_sizes[my_coordinate[mesh_dim]]
@@ -311,7 +312,7 @@ class Replicate(Placement):
             return tensor.new_empty(0, requires_grad=tensor.requires_grad)
 
         tensor = tensor.contiguous()
-        mesh.broadcast(tensor, mesh_dim=mesh_dim)
+        mesh_broadcast(tensor, mesh, mesh_dim=mesh_dim)
         return tensor
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107012

Move the remaining collectives to a separate file to prepare device mesh
to become a public distributed API

For those remaining utils, we need to upstream them to functional
collectives with proper implementation, added TODO there for a follow up
PR.