### PR TITLE
Create fastpath backend context manager, similar to SDPA kernel backend manager

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -117,6 +117,17 @@ void Context::setSDPUseMath(bool e) {
   enabled_mathSDP = e;
 }
 
+void Context::assignGlobalCtx(int pos, bool e){
+  if (e)
+    flags_global_ctx |= 1<<pos;
+  else
+    flags_global_ctx &= ~(1<<pos);
+}
+
+bool Context::getGlobalCtx(int pos){
+  return (flags_global_ctx & (1<<pos)) == (1<<pos);
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static const char cublas_config_var_name[] = "CUBLAS_WORKSPACE_CONFIG";
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -165,6 +165,9 @@ class TORCH_API Context {
   void setSDPUseMath(bool);
   bool userEnabledMathSDP() const;
 
+  void assignGlobalCtx(int, bool);
+  bool getGlobalCtx(int);
+
   at::LinalgBackend linalgPreferredBackend() const;
   void setLinalgPreferredBackend(at::LinalgBackend);
 
@@ -299,6 +302,7 @@ class TORCH_API Context {
   bool enabled_flashSDP = true;
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;
+  int_least64_t flags_global_ctx = 0;
 #ifdef USE_ROCM
   bool benchmark_cudnn = true;
 #else

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1017,6 +1017,9 @@ def _set_sdp_use_mem_efficient(
 ) -> None: ...  # THPModule_setSDPUseMemEfficient
 def _get_math_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_math(arg: _bool) -> None: ...  # THPModule_setSDPUseMath
+def _set_global_ctx(arg: _int) -> None: ...  # THPModule_setGlobalCtx
+def _unset_global_ctx(arg: _int) -> None: ...  # THPModule_unsetGlobalCtx
+def _get_global_ctx(arg: _int) -> _bool: ...  # THPModule_getGlobalCtx
 def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn
 def _set_mkldnn_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledMkldnn
 def _get_cudnn_benchmark() -> _bool: ...  # THPModule_benchmarkCuDNN

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -64,5 +64,6 @@ from torch.backends import (
     mkldnn as mkldnn,
     mps as mps,
     openmp as openmp,
+    ops as ops,
     quantized as quantized,
 )

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "math_sdp_enabled",
     "enable_math_sdp",
     "sdp_kernel",
+    "ATFPbackend",
 ]
 
 

--- a/torch/backends/ops/__init__.py
+++ b/torch/backends/ops/__init__.py
@@ -1,0 +1,162 @@
+import contextlib
+import sys
+from enum import IntEnum
+
+from typing import Union
+
+import torch
+
+__all__ = [
+    "ATFPBackend",
+    "atfp_kernel",
+    "atfp_math_enabled",
+    "enable_atfp_math",
+    "atfp_mha_enabled",
+    "enable_atfp_mha",
+    "atfp_encoder_enabled",
+    "enable_atfp_encoder",
+    "atfp_nested_tensor_enabled",
+    "enable_atfp_nested_tensor",
+]
+
+
+class ATFPBackend(IntEnum):
+    r"""Enum class for the AT Inference Fastpath backends.
+
+    .. warning:: This class is in beta and subject to change.
+    """
+    ERROR = -1
+    MATH = 0
+    MHA = 1
+    ENCODER = 2
+    NESTED_TENSOR = 3
+    bits = 4
+
+
+def _write_global_ctx(ctx_no: int, enabled: bool, default: bool = True):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables global ctx represented by `ctx_no`.
+    """
+    # default (represented by global ctx value of 0/False) for ATFP backend feature enablement is true
+    # so ctx bit being set disables the feature, and we need to invert the boolean "enabled"
+    if enabled == default:
+        torch._C._unset_global_ctx(ctx_no)
+    else:
+        torch._C._set_global_ctx(ctx_no)
+
+
+def _is_global_ctx(ctx_no: int, default: bool = True):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether global ctx `ctx_no` is enabled or disabled.
+    """
+    # default (represented by global ctx value of 0/False) for ATFP backend feature enablement is true
+    # so ctx bit being set disables the feature, and we need to invert the boolean "enabled"
+    return torch._C._get_global_ctx(ctx_no) != default
+
+
+def atfp_math_enabled():
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether math kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(ATFPBackend.MATH)
+
+
+def enable_atfp_math(enabled: bool):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables math kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(ATFPBackend.MATH, enabled)
+
+
+def atfp_mha_enabled():
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether MHA kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(ATFPBackend.MHA)
+
+
+def enable_atfp_mha(enabled: bool):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables MHA kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(ATFPBackend.MATH, enabled)
+
+
+def atfp_encoder_enabled():
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether encoder kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(ATFPBackend.MHA)
+
+
+def enable_atfp_encoder(enabled: bool):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables encoder kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(ATFPBackend.ENCODER, enabled)
+
+
+def atfp_nested_tensor_enabled():
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether nested_tensor kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(ATFPBackend.NESTED_TENSOR)
+
+
+def enable_atfp_nested_tensor(enabled: bool):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables nested_tensor kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(ATFPBackend.NESTED_TENSOR, enabled)
+
+
+@contextlib.contextmanager
+def atfp_kernel(
+    *,
+    enable_nested_tensor: bool = True,
+    enable_encoder: bool = True,
+    enable_mha: bool = True,
+    enable_math: bool = True,
+):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    This context manager can be used to temporarily enable or disable any of the four backends for
+    Accelerated Transformer Inference Fastpath.
+    Upon exiting the context manager, the previous state of the flags will be restored.
+    """
+    previous_math: bool = atfp_math_enabled()
+    previous_mha: bool = atfp_mha_enabled()
+    previous_encoder: bool = atfp_encoder_enabled()
+    previous_nested_tensor: bool = atfp_nested_tensor_enabled()
+    try:
+        enable_atfp_math(enable_math)
+        enable_atfp_mha(enable_mha)
+        enable_atfp_encoder(enable_encoder)
+        enable_atfp_nested_tensor(enable_nested_tensor)
+        yield {}
+    finally:
+        enable_atfp_math(previous_math)
+        enable_atfp_mha(previous_mha)
+        enable_atfp_encoder(previous_encoder)
+        enable_atfp_nested_tensor(previous_nested_tensor)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -604,6 +604,61 @@ PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
   else
     Py_RETURN_FALSE;
 }
+PyObject* THPModule_setGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "set_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "set_global_ctx expects an int, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  at::globalContext().assignGlobalCtx(ctx_no, true);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+PyObject* THPModule_unsetGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "set_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "unset_global_ctx expects an int, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  at::globalContext().assignGlobalCtx(ctx_no, false);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THPModule_getGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "set_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "get_global_ctx expects an int, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  if (at::globalContext().getGlobalCtx(ctx_no))
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
   THPUtils_assert(
       PyBool_Check(arg),
@@ -1096,6 +1151,9 @@ static PyMethodDef TorchMethods[] = {
      METH_NOARGS,
      nullptr},
     {"_set_sdp_use_math", THPModule_setSDPUseMath, METH_O, nullptr},
+    {"_set_globaL_ctx", THPModule_setGlobalCtx, METH_O, nullptr},
+    {"_unset_globaL_ctx", THPModule_unsetGlobalCtx, METH_O, nullptr},
+    {"_get_global_ctx", THPModule_getGlobalCtx, METH_O, nullptr},
     {"_get_cudnn_enabled", THPModule_userEnabledCuDNN, METH_NOARGS, nullptr},
     {"_set_cudnn_enabled", THPModule_setUserEnabledCuDNN, METH_O, nullptr},
     {"_get_mkldnn_enabled", THPModule_userEnabledMkldnn, METH_NOARGS, nullptr},


### PR DESCRIPTION
Summary: Create fastpath backend context manager, similar to SDPA kernel backend manager.  This allows us control over reproducibility by giving us control over the backend/kernel that will be selected

PRs like #106824 demonstrate the need for controlling what kernels are used in various situations, this gives users a general solution to the problem.

cc: @drisspg  

Test Plan: sandcastle, github

Differential Revision: D48256968

