### PR TITLE
Memory tracker does not report the module name correctly. 

### DIFF
--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -260,6 +260,12 @@ class MemoryTracker:
             inputs: Sequence[torch.Tensor],
             outputs: Sequence[torch.Tensor],
         ) -> None:
+            if self._cur_module_name == f"{name}.forward":
+                # This module is done. We need to get the parent module name.
+                # We assume that the name before the last '.' is the parent module name.
+                parent_module_name = ".".join(name.split(".")[:-1])
+                self._cur_module_name = f"{parent_module_name}.forward"
+
             if (
                 hasattr(module, "_memory_tracker_is_root")
                 and module._memory_tracker_is_root

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -261,7 +261,7 @@ class MemoryTracker:
             outputs: Sequence[torch.Tensor],
         ) -> None:
             if self._cur_module_name == f"{name}.forward":
-                # This module is done. We need to get the parent module name.
+                # When this module is done, we need to get the parent module name.
                 # We assume that the name before the last '.' is the parent module name.
                 parent_module_name = ".".join(name.split(".")[:-1])
                 self._cur_module_name = f"{parent_module_name}.forward"


### PR DESCRIPTION
If a module contains a sub module followed by some functional method. The name of the functional method is mistakenly labeled to be within the sub module. It should be the parent module. It can be shown in the following example:

```
import torch

from torch.distributed._tools import MemoryTracker

class MyModel(torch.nn.Module):
    def __init__(self):
        super(MyModel, self).__init__()
        self.linear = torch.nn.Linear(10, 10)


    def forward(self, input):
        res = self.linear(input)
        res = torch.relu(res)
        res = res.softmax(-1)
        return res


class Parent(torch.nn.Module):
    def __init__(self):
        super(Parent, self).__init__()
        self.child = MyModel()

    def forward(self, input):
        return self.child(input)

def run():
    model = Parent()
    memory_tracker = MemoryTracker()
    memory_tracker.start_monitor(model)
    input = torch.randn(5, 10)
    res = model(input)
    memory_tracker.stop()
    allocated = memory_tracker.memories_allocated
    for i in range(0, len(allocated)):
        print(f"{allocated[i][0]}\t{allocated[i][1]}")


if __name__ == "__main__":
    run()
```

In current master, the output is:
```
.randn.default_0        0.0
child.linear.forward.t.default_0        0.0
child.linear.forward.addmm.default_0    0.0
child.linear.forward.relu.default_0     0.0
child.linear.forward._softmax.default_0 0.0
```

It shows that relu and _softmax are part of the linear. However, they should be part of child. 

With the PR, the output is:

```
.randn.default_0        0.0
child.linear.forward.t.default_0        0.0
child.linear.forward.addmm.default_0    0.0
child.forward.relu.default_0    0.0
child.forward._softmax.default_0        0.0
```

The name is shown correctly. 
