### PR TITLE
[ROCm] Remove expected inductor UT fails for batch norm

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6422,6 +6422,7 @@ class CommonTemplate:
             (torch.randn(32), torch.randn(32)),
         )
 
+    @skipIfRocm
     def test_conv_with_as_strided(self):
         class Model(nn.Module):
             def __init__(self):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -304,7 +304,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     ("round", "decimals_3"): {f16},
     "sparse.sampled_addmm": {f32, f64},
     ("std_mean", "unbiased"): {f16},
-    "tanh": {f16},
     "tensor_split": {b8, f16, f32, f64, i32, i64},
     "to_sparse": {f16, f32, f64},
     "uniform": {f16, f32, f64},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -331,14 +331,6 @@ inductor_gradient_expected_failures_single_sample["cuda"] = {
 
 if not TEST_WITH_ROCM:
     inductor_gradient_expected_failures_single_sample["cuda"]["tanh"] = {f16}
-else:
-    # aten.miopen_batch_norm is unsupported for lowering
-    inductor_expected_failures_single_sample["cuda"].update(
-        {
-            "nn.functional.batch_norm": {f16, f32},
-            "nn.functional.instance_norm": {f16, f32},
-        }
-    )
 
 if not TEST_MKL:
     inductor_expected_failures_single_sample["cpu"].update(


### PR DESCRIPTION
Removing expected failures relating to inductor batch_norm on ROCm

Also removing the addition of `tanh` to expected failures list as this is a cuda exclusive failure already captured here (cc: @peterbell10)
```
if not TEST_WITH_ROCM:
    inductor_gradient_expected_failures_single_sample["cuda"]["tanh"] = {f16}
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov