### PR TITLE
reseed all Generators in Dataloader's _worker_loop()

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -35,7 +35,7 @@ from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, IS_JETSON,
                                                   IS_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
                                                   load_tests, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE,
-                                                  IS_MACOS, TEST_CUDA)
+                                                  IS_MACOS, TEST_CUDA, IS_LINUX)
 
 
 try:
@@ -1562,6 +1562,39 @@ except RuntimeError as e:
         for ind in range(num_epochs):
             for batch_idx, sample in enumerate(dataloader):
                 self.assertEqual(sample.tolist(), [batch_idx % num_workers] * batch_size)
+
+    @unittest.skipIf(not IS_LINUX, "Only linux supports fork()-ing Generators.")
+    def test_worker_generator_seed(self):
+        # Tests for the RNG seeding behaviour within _worker_loop.
+        torch.manual_seed(0)
+        g1 = torch.Generator().manual_seed(1)
+        g2 = torch.Generator().manual_seed(2)
+
+        class MyDataset(SynchronizedDataset):
+            def __getitem__(self, idx):
+                self.sync_once()
+                HIGH = 100_000
+                from_global = torch.randint(0, HIGH, size=(1,)).item()
+                from_g1 = torch.randint(0, HIGH, size=(1,), generator=g1).item()
+                from_g2 = torch.randint(0, HIGH, size=(1,), generator=g2).item()
+
+                return from_global, from_g1, from_g2
+
+
+        num_workers = 2
+        dataset = MyDataset(size=10, num_workers=num_workers, batch_size=1)
+        dl = DataLoader(dataset, num_workers=num_workers)
+
+        for from_global, from_g1, from_g2 in dl:
+            # Assert RNG of all Generators are different within a given worker (each "batch" comes from a single worker)
+            assert len(set([from_global, from_g1, from_g2])) == 3
+
+        # Make sure that the Generators' RNG is different across workers.
+        # We check that by making sure all the samples of a given Generator are different across Dataloader entry.
+        # If Generators weren't re-seeded in the workers loop, we would see values being duplicated `num_workers` times.
+        all_from_global, all_from_g1, all_from_g2 = zip(*dl)
+        for all_from_generator in (all_from_global, all_from_g1, all_from_g2):
+            assert len(set(all_from_generator)) == len(dataset)
 
     def test_worker_init_fn(self):
         dataset = SeedDataset(4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6496,6 +6496,35 @@ class TestTorch(TestCase):
         g2_normal = q.normal_(generator=g2)
         self.assertEqual(g1_normal, g2_normal)
 
+    def test_generator_registry(self):
+        registry = torch.random._generator_registry
+
+        # Here, all manually-created Generators should be out of scope and have no strong ref to them
+        # So the registry should be empty.
+        assert not registry
+
+        # We create a Generator but it goes out of scope immediately; the registry is still empty
+        torch.Generator()
+        assert not registry
+
+        g1 = torch.Generator()
+        assert len(registry) == 1
+        g2 = torch.Generator()
+        assert len(registry) == 2
+
+        del g1
+        assert len(registry) == 1
+
+        def f(registry_len_before_call):
+            g = torch.Generator()
+            assert len(registry) == registry_len_before_call + 1
+
+        # We call f and check that the Generator created within f is registered.
+        # When f gets out of scope, so does its Generator, and we check that it's not in the registry anymore
+        registry_len_before_call = len(registry)
+        f(registry_len_before_call)
+        assert len(registry) == registry_len_before_call
+
     def test_invalid_generator_raises(self):
         self.assertRaises(RuntimeError, lambda: torch.Generator('opengl'))
 

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -7,6 +7,7 @@
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THPGenerator {
   PyObject_HEAD at::Generator cdata;
+  PyObject* weakreflist;
 };
 
 // Creates a new Python object wrapping the default at::Generator. The reference

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,6 +1,7 @@
 import contextlib
 from typing import Generator
 import warnings
+import weakref
 
 from torch._C import default_generator
 import torch
@@ -167,3 +168,7 @@ def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="device
         torch.set_rng_state(cpu_rng_state)
         for device, device_rng_state in zip(devices, device_rng_states):
             device_mod.set_rng_state(device_rng_state, device)
+
+# We keep track of all Generator instances (except the default one) via a registry of weak references.
+# The Generators that have no strong references to them are automatically discarded from the registry.
+_generator_registry = weakref.WeakSet()

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -223,6 +223,14 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
         seed = base_seed + worker_id
         random.seed(seed)
         torch.manual_seed(seed)
+        for generator in torch.random._generator_registry:
+            # We have to reseed non-global Generators as well (TODO: explain why, will do if PR is likely to be merged)
+            # Note that we can't use generator.manual_seed(seed) here, otherwise the RNG of the generator
+            # would be the same as the global one.
+            # We also need to create a generator_seed that depends on the current generator state, otherwise
+            # all Generator instances within a given worker would have the same RNG.
+            generator_seed = torch.empty((), dtype=torch.int64).random_(generator=generator).item() + seed
+            generator.manual_seed(generator_seed)
         if HAS_NUMPY:
             np_seed = _generate_state(base_seed, worker_id)
             import numpy as np


### PR DESCRIPTION
This PR addresses https://fb.workplace.com/groups/pytorch.oss.dev/posts/1699944830430051 and does a bunch of stacked changes:

1. Make `Generator` weakref-able (C++ part)
2. Create a registry of manually-created `Generator` objects (via weakrefs)
3. Use this registry in the `Dataloader`'s `_worker_loop` to re-seed all existing `Generator` instances: this extends what is already applied to the global `Generator`, which is already re-seeded.

TODO: a bit of docs and justification, which I'll do if this PR is mergeable.

CC @albanD as previously discussed

cc @ezyang @gchanan @SsnL @VitalyFedyunin @ejguan @dzhulgakov @pbelevich