### PR TITLE
[RFC] Option to check eager if compile fails

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -545,6 +545,7 @@ def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):
     ):
         counters["frames"]["total"] += 1
         try:
+            breakpoint()
             result = inner_convert(frame, cache_size, hooks, frame_state)
             counters["frames"]["ok"] += 1
             return result
@@ -563,6 +564,7 @@ def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):
             # need to make these exceptions not get wrapped
             soft_fail = isinstance(e, Unsupported)
             if not config.suppress_errors and not soft_fail:
+                breakpoint()
                 raise
 
             # Suppress the error.  NB: It's very important to do the

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -545,7 +545,6 @@ def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):
     ):
         counters["frames"]["total"] += 1
         try:
-            breakpoint()
             result = inner_convert(frame, cache_size, hooks, frame_state)
             counters["frames"]["ok"] += 1
             return result
@@ -564,7 +563,6 @@ def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):
             # need to make these exceptions not get wrapped
             soft_fail = isinstance(e, Unsupported)
             if not config.suppress_errors and not soft_fail:
-                breakpoint()
                 raise
 
             # Suppress the error.  NB: It's very important to do the

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -330,7 +330,6 @@ class _TorchDynamoContext:
             dynamic_ctx = enable_dynamic(self.dynamic, self.export)
             dynamic_ctx.__enter__()
             try:
-                # breakpoint()
                 return fn(*args, **kwargs)
             except Exception as e:
                 print("Failed to compile - checking eager...")

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -330,7 +330,18 @@ class _TorchDynamoContext:
             dynamic_ctx = enable_dynamic(self.dynamic, self.export)
             dynamic_ctx.__enter__()
             try:
+                # breakpoint()
                 return fn(*args, **kwargs)
+            except Exception as e:
+                print("Failed to compile - checking eager...")
+                torch._dynamo.decorators.disable(fn)
+                try:
+                    fn(*args, **kwargs)
+                except Exception as ee:
+                    print("Failed in compile AND eager, check your program!")
+                    raise ee
+                print("Eager ran successfully, compiler issue")
+                raise e
             finally:
                 set_eval_frame(prior)
                 dynamic_ctx.__exit__(None, None, None)


### PR DESCRIPTION
Suppress errors is problematic because it swallows exceptions and keeps going. The question for this RFC is - do want a regime wherein we can catch failures in the compiler, and then quickly check eager to see if it passes or fails?

There's 2 ways we can take this:

1) Replace suppress errors w/ this, and make the code here actually return the eager result - this acts as a fallback mechanism, and disable in one, without routing out to eval_frame.c OR reusing the buggy/failed compilation

OR

2) Agree that an exception is an exception, and just run eager to give the user signal on where the failure is (in eager AND compiled, or just in eager), and then always fail at this point.

I prefer the latter, but wanted to discuss.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107044



cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng