### PR TITLE
Mark test_lstm_packed as slow

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -385,6 +385,7 @@ class CPUReproTests(TestCase):
                         inps_var = [v_var]
                         self.assertEqual(fn_opt(*inps_var), mod(*inps_var))
 
+    @slowTest
     def test_lstm_packed(self):
         params_dict = {
             "unbatched": [True, False],


### PR DESCRIPTION
The test takes >30 minutes to run on some configurations and keeps getting unmarked as slow by the automatic slow test detection.
Examples:
https://ossci-raw-job-status.s3.amazonaws.com/log/15824750763
https://ossci-raw-job-status.s3.amazonaws.com/log/15802766247

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov