### PR TITLE
[dynamo][ci] Exclude functorch/test_vmap.py from PyTorch-TorchDynamo tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -272,6 +272,9 @@ test_dynamo_shard() {
       export/test_db \
       functorch/test_dims \
       functorch/test_aotdispatch \
+      # TODO - ongoing effort to integrate torch.compile and vmap. Remove when
+      # the work completes
+      functorch/test_vmap \
     --shard "$1" "$NUM_TEST_SHARDS" \
     --verbose
   assert_git_not_dirty


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107077
* #106917
* __->__ #107057

