### PR TITLE
[RFC][dynamo] Separate cache sizes for nn module guard specialization

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5705,7 +5705,7 @@ def fn():
         with unittest.mock.patch("torch._dynamo.config.error_on_recompile", True):
             with self.assertRaises(torch._dynamo.exc.RecompileError):
                 fn(torch.rand(2, 3), torch.rand(2, 3))
-                fn(torch.rand(2, 3), (1, 2, 3))
+                fn(torch.rand(2, 3, 4), torch.rand(2, 3, 4))
 
     @expectedFailureDynamic
     @torch._dynamo.config.patch(automatic_dynamic_shapes=False)

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1449,6 +1449,95 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         res = opt_m(x)
         self.assertTrue(torch.allclose(ref, res))
 
+    def test_no_recompile_on_nn_guarded_modules(self):
+        size = (10, 10)
+        specialized_instance_cache_size_limit = 1
+        num_submodules = 4
+        cnts = torch._dynamo.testing.CompileCounterWithBackend("eager")
+
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(*size)
+
+            def forward(self, x):
+                a = torch.sin(torch.cos(x))
+                return self.linear(a)
+
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mods = [SubModule() for _ in range(num_submodules)]
+                self.mods = [torch.compile(mod, backend=cnts) for mod in self.mods]
+
+            def forward(self, x):
+                for mod in self.mods:
+                    x = mod(x)
+                return x
+
+        mod = MockModule()
+        # Each submod is compiled separately and has a different nn module
+        # guard. Ensure that recompilation logic is handle correctly.
+        with unittest.mock.patch(
+            "torch._dynamo.config.error_on_recompile", True
+        ), unittest.mock.patch(
+            "torch._dynamo.config.specialized_instance_cache_size_limit",
+            specialized_instance_cache_size_limit,
+        ):
+            x = torch.randn(*size)
+            mod(x)
+            self.assertEqual(cnts.frame_count, num_submodules)
+
+    def test_cache_size_limit_on_guarded_nn_modules(self):
+        specialized_instance_cache_size_limit = 2
+        num_submodules = 4
+        cnts = torch._dynamo.testing.CompileCounterWithBackend("eager")
+
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                a = torch.sin(torch.cos(x))
+                return self.relu(a)
+
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mods = [SubModule() for _ in range(num_submodules)]
+                self.mods = [torch.compile(mod, backend=cnts) for mod in self.mods]
+
+            def forward(self, x):
+                for mod in self.mods:
+                    x = mod(x)
+                return x
+
+        mod = MockModule()
+        # For the third iteration, we would reach the cache size limit, and
+        # therefore the total number of expected frame count is 2 *
+        # num_submodules. We also delay the detection of cache_size_limit until
+        # after the check_fn is formed, and therefore we see 1 extra frame
+        # count.
+        with unittest.mock.patch(
+            "torch._dynamo.config.specialized_instance_cache_size_limit",
+            specialized_instance_cache_size_limit,
+        ):
+            for size in [
+                (4,),
+                (4, 4),
+                (4, 4, 4),
+                (
+                    4,
+                    4,
+                    4,
+                    4,
+                ),
+            ]:
+                x = torch.randn(size)
+                mod(x)
+        self.assertEqual(cnts.frame_count, 2 * num_submodules + 1)
+
 
 class MockModule(torch.nn.Module):
     def __init__(self):

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -2,7 +2,7 @@ import logging
 import types
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import DefaultDict, Dict, Tuple
 
 from . import config
 from .exc import unimplemented
@@ -57,7 +57,7 @@ class CodeObjectCacheSizeTracker:
     """
 
     total_cache_size: int = 0
-    specialized_instance_cache_size: defaultdict[int] = field(
+    specialized_instance_cache_size: DefaultDict[Tuple, int] = field(
         default_factory=lambda: defaultdict(int)
     )
 
@@ -87,7 +87,6 @@ def erase_cache_size_entry(input_code, tracker, cache_key):
     tracker.specialized_instance_cache_size.clear()
     tracker.total_cache_size = 0
     cache_size_tracker.pop(input_code)
-
 
 
 def update_cache_size(guarded_nn_modules, input_code):

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -1,0 +1,176 @@
+import logging
+import types
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict
+
+from . import config
+from .exc import unimplemented
+from .utils import guard_failures, troubleshooting_url
+
+log = logging.getLogger(__name__)
+"""
+[Note on cache size limit]
+
+TorchDynamo keeps the optimized bytecode resulting from each compilation on the
+extra scratch space of the code object. Currently, the cache is implemented as
+linked list, where each node contains check_fn and the optimized bytecode.
+check_fn is used to find out which code object we are interested in.
+
+This file has logic to track cache size limit. When a cache size limit is
+reached, we instruct eval_frame.c to fallback to eager for this frame, as this
+frame is friendly to compilation.
+
+There are two different types of cache size limits we are interested in:
+1) Total cache size limit per code object - config.cache_size_limit
+2) Per-specilized instance cache size limit per code object - config.specialized_instance_cache_size_limit
+
+Lets start with understanding why we need (2). Earlier, we had only one
+cache_size_limit, i.e., only (1). But we observed different scenarios where
+situations demanded completely different cache size limit. On one hand, we
+wanted the total cache size limit to be small because functions that are not
+compilation-friendly and recompile on every invocation would take a long time to
+burst the cache. But on the other hand, there was a different commonly-occurring
+scenario that demanded large cache size limit. Dynamo inserts guards on the
+instance of nn module instances (typically seen as a guard on self) to
+differentiate between different instances of nn module. This is a quite common
+pattern in how models are typically constructed. As a result, this would require
+us to have a very large cache_size limit (like 64).
+
+To solve this problem, we introduce a second cache size limit - (2) - which
+tracks the cache size limit per specialized instance. Here specialized instance
+is represented by a tuple of guarded nn module instances (there could be
+multiple guarded nn module instances in the same frame). The tuple could be
+empty as well, denoting the absence of any guarded nn module instance.
+Therefore, this new limit (2) enables us to effectively reduce the cache size
+per specialized instance to a smaller value. With this change, the purpose of
+(1) becomes more of a safeguard mechanism where we want to have a max limit of
+recompilations per frame.
+"""
+
+
+@dataclass
+class CodeObjectCacheSizeTracker:
+    """
+    Tracks the different cache size limits per code object. See the note at the
+    top of the file.
+    """
+
+    total_cache_size: int = 0
+    specialized_instance_cache_size: defaultdict[int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+
+
+cache_size_tracker: Dict[types.CodeType, CodeObjectCacheSizeTracker] = defaultdict(
+    lambda: CodeObjectCacheSizeTracker()
+)
+
+
+def format_func_info(code):
+    return f"'{code.co_name}' ({code.co_filename}:{code.co_firstlineno})"
+
+
+def compute_specialized_instance_cache_key(guarded_nn_modules):
+    cache_key = ()
+    if guarded_nn_modules:
+        # TODO - Ed mentioned about WeakKeyDictionary somewhere, find out why it
+        # is needed.
+        sorted_nn_modules = [
+            guarded_nn_modules[x] for x in sorted(guarded_nn_modules.keys())
+        ]
+        cache_key = tuple(sorted_nn_modules)
+    return cache_key
+
+
+def erase_cache_size_entry(input_code, tracker, cache_key):
+    tracker.specialized_instance_cache_size.clear()
+    tracker.total_cache_size = 0
+    cache_size_tracker.pop(input_code)
+
+
+
+def update_cache_size(guarded_nn_modules, input_code):
+    tracker = cache_size_tracker[input_code]
+    cache_key = compute_specialized_instance_cache_key(guarded_nn_modules)
+
+    # Check cache size limits
+    cache_size_limit = config.cache_size_limit
+    if tracker.total_cache_size >= cache_size_limit:
+        erase_cache_size_entry(input_code, tracker, cache_key)
+        cache_size_limit_reached(
+            input_code, "config.cache_size_limit", cache_size_limit
+        )
+
+    specialized_instance_cache_size_limit = config.specialized_instance_cache_size_limit
+    if (
+        tracker.specialized_instance_cache_size[cache_key]
+        >= specialized_instance_cache_size_limit
+    ):
+        erase_cache_size_entry(input_code, tracker, cache_key)
+        cache_size_limit_reached(
+            input_code,
+            "config.specialized_instance_cache_size_limit",
+            specialized_instance_cache_size_limit,
+        )
+
+    # Update the keys
+    print("Adding a cache entry", format_func_info(input_code), cache_key)
+    tracker.total_cache_size += 1
+    tracker.specialized_instance_cache_size[cache_key] += 1
+
+
+def is_recompilation(guarded_nn_modules, input_code):
+    # We can't just rely on total cache size to detect recompilation. If we are
+    # compiling the code object for a different specialized instance, we don't
+    # want to call it recompilation. Recompilation happens only if we are
+    # recompiling for a specialized instance.
+    if get_cache_size(input_code) == 0:
+        return False
+
+    tracker = cache_size_tracker[input_code]
+    cache_key = compute_specialized_instance_cache_key(guarded_nn_modules)
+
+    # cache_key already present in the tracker means we are recompiling
+    print("Search for cache_key", format_func_info(input_code), cache_key)
+    return cache_key in tracker.specialized_instance_cache_size
+
+
+def get_cache_size(input_code):
+    if input_code in cache_size_tracker:
+        return cache_size_tracker[input_code].total_cache_size
+    return 0
+
+
+def cache_size_limit_reached(code, cache_size_limit_type, cache_size_limit):
+    def format_guard_failures(code):
+        # For the common case, it's sufficient to see just the most recent failure.
+        # We could add a verbose mode if needed
+        return f"  reasons: {str(guard_failures[code][-1])}\n"
+
+    if config.report_guard_failures:
+        assert code in guard_failures, "TODO(whc) any other recompile reasons?"
+
+        log.warning(
+            "torch._dynamo hit %s (%s)\n"
+            "   function: %s\n"
+            "   reasons:  %s\n"
+            "to diagnose recompilation issues, see %s.",
+            cache_size_limit_type,
+            cache_size_limit,
+            format_func_info(code),
+            format_guard_failures(code),
+            troubleshooting_url,
+        )
+    else:
+        log.warning(
+            "torch._dynamo hit %s (%s)\n"
+            "   function: %s\n"
+            "to diagnose recompilation issues, set env variable TORCHDYNAMO_REPORT_GUARD_FAILURES=1"
+            " and also see %s.",
+            cache_size_limit_type,
+            cache_size_limit,
+            format_func_info(code),
+            troubleshooting_url,
+        )
+    unimplemented(f"{cache_size_limit_type} reached")

--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -115,7 +115,6 @@ def update_cache_size(guarded_nn_modules, input_code):
         )
 
     # Update the keys
-    print("Adding a cache entry", format_func_info(input_code), cache_key)
     tracker.total_cache_size += 1
     tracker.specialized_instance_cache_size[cache_key] += 1
 
@@ -132,7 +131,6 @@ def is_recompilation(guarded_nn_modules, input_code):
     cache_key = compute_specialized_instance_cache_key(guarded_nn_modules)
 
     # cache_key already present in the tracker means we are recompiling
-    print("Search for cache_key", format_func_info(input_code), cache_key)
     return cache_key in tracker.specialized_instance_cache_size
 
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -31,8 +31,11 @@ minimum_call_count = 1
 dead_code_elimination = True
 
 # disable (for a function) when cache reaches this size
+# TODO - The values are kept same to ensure that we do not regress from the
+# current state. Once we are certain that the change is stable, we can decrease
+# the specialized_instance_cache_size_limit to a smaller value like 8.
 cache_size_limit = 64
-specialized_instance_cache_size_limit = 16  # TODO - kept too high conservatively
+specialized_instance_cache_size_limit = 64
 
 # whether or not to specialize on int inputs.  This only has an effect with
 # dynamic_shapes; when dynamic_shapes is False, we ALWAYS specialize on int

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -32,6 +32,7 @@ dead_code_elimination = True
 
 # disable (for a function) when cache reaches this size
 cache_size_limit = 64
+specialized_instance_cache_size_limit = 16  # TODO - kept too high conservatively
 
 # whether or not to specialize on int inputs.  This only has an effect with
 # dynamic_shapes; when dynamic_shapes is False, we ALWAYS specialize on int


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107077
* #107117
* #106917

~~~
TorchDynamo keeps the optimized bytecode resulting from each compilation on the
extra scratch space of the code object. Currently, the cache is implemented as
linked list, where each node contains check_fn and the optimized bytecode.
check_fn is used to find out which code object we are interested in.
This file has logic to track cache size limit. When a cache size limit is
reached, we instruct eval_frame.c to fallback to eager for this frame, as this
frame is friendly to compilation.

There are two different types of cache size limits we are interested in:
1) Total cache size limit per code object - config.cache_size_limit
2) Per-specilized instance cache size limit per code object - config.specialized_instance_cache_size_limit

Lets start with understanding why we need (2). Earlier, we had only one
cache_size_limit, i.e., only (1). But we observed different scenarios where
situations demanded completely different cache size limit. On one hand, we
wanted the total cache size limit to be small because functions that are not
compilation-friendly and recompile on every invocation would take a long time to
burst the cache. But on the other hand, there was a different commonly-occurring
scenario that demanded large cache size limit. Dynamo inserts guards on the
instance of nn module instances (typically seen as a guard on self) to
differentiate between different instances of nn module. This is a quite common
pattern in how models are typically constructed. As a result, this would require
us to have a very large cache_size limit (like 64).

To solve this problem, we introduce a second cache size limit - (2) - which
tracks the cache size limit per specialized instance. Here specialized instance
is represented by a tuple of guarded nn module instances (there could be
multiple guarded nn module instances in the same frame). The tuple could be
empty as well, denoting the absence of any guarded nn module instance.
Therefore, this new limit (2) enables us to effectively reduce the cache size
per specialized instance to a smaller value. With this change, the purpose of
(1) becomes more of a safeguard mechanism where we want to have a max limit of
recompilations per frame.
~~~

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov