### PR TITLE
ExportedProgram.transform now updates graph_signature automatically

### DIFF
--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -96,6 +96,63 @@ class TestPassInfra(TestCase):
         for before_node, after_node in zip(ep_before.graph.nodes, ep_after.graph.nodes):
             self.assertEqual(before_node.name, after_node.name)
 
+    def test_graph_signature_updated_after_transformation(self) -> None:
+        # Checks that pass infra correctly updates graph signature
+        # after transformations.
+        class CustomModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+                self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
+
+                self.register_buffer('my_buffer1', torch.tensor(3.0))
+                self.register_buffer('my_buffer2', torch.tensor(4.0))
+
+            def forward(self, x1, x2):
+                # Use the parameter, buffers, and both inputs in the forward method
+                output = (x1 + self.my_parameter) * self.my_buffer1 + x2 * self.my_buffer2
+
+                # Mutate one of the buffers (e.g., increment it by 1)
+                self.my_buffer2.add_(1.0)
+
+                return output
+
+        my_module = CustomModule()
+
+        # Test the custom module with two input tensors
+        input_tensor1 = torch.tensor(5.0)
+        input_tensor2 = torch.tensor(6.0)
+
+        ep_before = export(my_module, (input_tensor1, input_tensor2))
+
+        # Dummy pass to modify input names and add new nodes to intentionally
+        # change output node names
+        class ModifyInputOutputPass(_ExportPassBase):
+
+            def placeholder(self, name, arg, meta):
+                new_name = name + "_modified"
+                return super().placeholder(new_name, arg, meta)
+
+            def call_operator(self, op, args, kwargs, meta):
+                ret = super().call_operator(op, args, kwargs, meta)
+                new_args = (ret,) + args[1:]
+                new_ret = super().call_operator(op, new_args, kwargs, meta)
+                return new_ret
+
+
+        ep_after = ep_before.transform(ModifyInputOutputPass())
+        new_signature = ep_after.graph_signature
+
+        for inp in (
+            new_signature.user_inputs +
+            list(new_signature.inputs_to_parameters.keys()) +
+            list(new_signature.inputs_to_buffers.keys())
+        ):
+            self.assertTrue("_modified" in inp)
+
+        old_signature = ep_before.graph_signature
+        self.assertNotEqual(new_signature.user_outputs, old_signature.user_outputs)
+        self.assertNotEqual(new_signature.buffers_to_mutate.keys(), old_signature.buffers_to_mutate.keys())
 
 if __name__ == '__main__':
     run_tests()

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -357,7 +357,10 @@ class TestPasses(TestCase):
             exactly=True,
         ).run(gm.code)
 
-        gm = ep.transform(_FunctionalizeSideEffectfulOpsPass()).graph_module
+        # TODO(ycao): ExportedProgram.transform() forbids changes to number
+        # of inputs/outputs for now. When it supports that better, change this
+        # back to using ExportedProgram.transform()
+        gm = _FunctionalizeSideEffectfulOpsPass()(ep.graph_module).graph_module
 
         with self.assertRaisesRegex(
             RuntimeError,

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -403,16 +403,95 @@ class ExportedProgram:
         """
         return unlift_exported_program_lifted_states(self)
 
-
     def transform(self, *passes: PassType) -> "ExportedProgram":
         pm = PassManager(list(passes))
         res = pm(self.graph_module)
         transformed_gm = res.graph_module if res is not None else self.graph_module
         assert transformed_gm is not None
+
+        def get_output_node_names(gm):
+            output_node = list(gm.graph.nodes)[-1]
+            assert output_node.op == "output"
+
+            return [str(arg) for arg in output_node.args[0]]
+
+        def get_input_node_names(gm):
+            return [node.name for node in gm.graph.nodes if node.op == "placeholder"]
+
+        def generate_new_graph_signature(old_signature, old_gm, new_gm):
+            """
+            Update graph_signature according to graph after transformation.
+            Transformations can lead to node name changes, which are used in
+            graph_signature to identify inputs and outputs. Therefore, after each
+            transformation, we need to update the graph_signature according to
+            new node names.
+
+            WARNING: This implementation makes a few assumptions
+                - The transformation doesn't change number of inputs/outputs
+                - Each input/output still has the same meaning.
+                    - For inputs, that means that the inputs in transformed
+                        graph map to the same lifted parameter/buffer or user
+                        input as the input of the same position in the graph
+                        before transformation.
+                    - Similarly for outputs, each output should correspond to the
+                        same mutated buffer or user output as the output value of
+                        the same position  in the graph before transformation.
+
+            It is difficult to programatically validate these assumptions, but they
+            should hold true most of the time as inputs/outputs of the graph rarely
+            need to be changed.
+            """
+            old_graph_input_node_names = get_input_node_names(old_gm)
+            new_graph_input_node_names = get_input_node_names(new_gm)
+            assert len(old_graph_input_node_names) == len(new_graph_input_node_names), f"""
+                Number of input nodes changed from {len(old_graph_input_node_names)}
+                to {len(new_graph_input_node_names)} after transformation. This
+                transformation is currently not supported.
+                """
+
+            old_graph_output_node_names = get_output_node_names(old_gm)
+            new_graph_output_node_names = get_output_node_names(new_gm)
+            assert len(old_graph_output_node_names) == len(new_graph_output_node_names), f"""
+                Number of output values changed from {len(old_graph_output_node_names)}
+                to {len(new_graph_output_node_names)} after transformation. This
+                transformation is currently not supported.
+                """
+
+            node_names_mapping = dict(zip(
+                old_graph_input_node_names + old_graph_output_node_names,
+                new_graph_input_node_names + new_graph_output_node_names
+            ))
+
+            new_signature = copy.deepcopy(old_signature)
+            new_signature.user_inputs = [
+                node_names_mapping[old_user_input]
+                for old_user_input in old_signature.user_inputs
+            ]
+            new_signature.user_outputs = [
+                node_names_mapping[old_user_output]
+                for old_user_output in old_signature.user_outputs
+            ]
+            new_signature.inputs_to_parameters = {
+                node_names_mapping[old_input_name]: old_signature.inputs_to_parameters[old_input_name]
+                for old_input_name in old_signature.inputs_to_parameters.keys()
+            }
+            new_signature.inputs_to_buffers = {
+                node_names_mapping[old_input_name]: old_signature.inputs_to_buffers[old_input_name]
+                for old_input_name in old_signature.inputs_to_buffers.keys()
+            }
+            new_signature.buffers_to_mutate = {
+                node_names_mapping[old_output_name]: old_signature.buffers_to_mutate[old_output_name]
+                for old_output_name in old_signature.buffers_to_mutate.keys()
+            }
+            return new_signature
+
+
+        new_graph_signature = generate_new_graph_signature(
+            self.graph_signature, self.graph_module, transformed_gm)
         transformed_ep = ExportedProgram(
             transformed_gm,
             transformed_gm.graph,
-            copy.deepcopy(self.graph_signature),
+            new_graph_signature,
             copy.deepcopy(self.call_spec),
             self.state_dict,
             copy.deepcopy(self.range_constraints),


### PR DESCRIPTION
            Update graph_signature according to graph after transformation.
            Transformations can lead to node name changes, which are used in
            graph_signature to identify inputs and outputs. Therefore, after each
            transformation, we need to update the graph_signature according to
            new node names.
            WARNING: This implementation makes a few assumptions
                - The transformation doesn't change number of inputs/outputs
                - Each input/output still has the same meaning.
                    - For inputs, that means that the inputs in transformed
                        graph map to the same lifted parameter/buffer or user
                        input as the input of the same position in the graph
                        before transformation.
                    - Similarly for outputs, each output should correspond to the
                        same mutated buffer or user output as the output value of
                        the same position  in the graph before transformation.
            It is difficult to programatically validate these assumptions, but they
            should hold true most of the time as inputs/outputs of the graph rarely
            need to be changed.