### PR TITLE
grad_mode decorators without paren

### DIFF
--- a/test/dynamo/test_pre_dispatch.py
+++ b/test/dynamo/test_pre_dispatch.py
@@ -27,27 +27,27 @@ class PreDispatchTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(a_ref.grad, a_test.grad)
 
     def test_enable_grad_and_no_grad(self):
-        for grad_enabler in torch.enable_grad, torch.enable_grad():
-            def f(a):
-                b = a * 2
-                with torch.no_grad():
-                    c = b * 3
-                    d = grad_enabler(lambda: c * 4)()
-                    e = d * 5
-                return b + c + d + e
+        def f(a):
+            b = a * 2
+            with torch.no_grad():
+                c = b * 3
+                with torch.enable_grad():
+                    d = c * 4
+                e = d * 5
+            return b + c + d + e
 
-            f_compiled = torch.compile(f, backend="pre_dispatch_eager")
+        f_compiled = torch.compile(f, backend="pre_dispatch_eager")
 
-            a_ref = torch.randn(4, requires_grad=True)
-            a_test = a_ref.clone().detach().requires_grad_(True)
+        a_ref = torch.randn(4, requires_grad=True)
+        a_test = a_ref.clone().detach().requires_grad_(True)
 
-            out_ref = f(a_ref)
-            out_test = f_compiled(a_test)
-            self.assertEqual(out_ref, out_test)
+        out_ref = f(a_ref)
+        out_test = f_compiled(a_test)
+        self.assertEqual(out_ref, out_test)
 
-            out_ref.sum().backward()
-            out_test.sum().backward()
-            self.assertEqual(a_ref.grad, a_test.grad)
+        out_ref.sum().backward()
+        out_test.sum().backward()
+        self.assertEqual(a_ref.grad, a_test.grad)
 
     def test_autocast_simple(self):
         def f(a):

--- a/test/dynamo/test_pre_dispatch.py
+++ b/test/dynamo/test_pre_dispatch.py
@@ -27,27 +27,27 @@ class PreDispatchTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(a_ref.grad, a_test.grad)
 
     def test_enable_grad_and_no_grad(self):
-        def f(a):
-            b = a * 2
-            with torch.no_grad():
-                c = b * 3
-                with torch.enable_grad():
-                    d = c * 4
-                e = d * 5
-            return b + c + d + e
+        for grad_enabler in torch.enable_grad, torch.enable_grad():
+            def f(a):
+                b = a * 2
+                with torch.no_grad():
+                    c = b * 3
+                    d = grad_enabler(lambda: c * 4)()
+                    e = d * 5
+                return b + c + d + e
 
-        f_compiled = torch.compile(f, backend="pre_dispatch_eager")
+            f_compiled = torch.compile(f, backend="pre_dispatch_eager")
 
-        a_ref = torch.randn(4, requires_grad=True)
-        a_test = a_ref.clone().detach().requires_grad_(True)
+            a_ref = torch.randn(4, requires_grad=True)
+            a_test = a_ref.clone().detach().requires_grad_(True)
 
-        out_ref = f(a_ref)
-        out_test = f_compiled(a_test)
-        self.assertEqual(out_ref, out_test)
+            out_ref = f(a_ref)
+            out_test = f_compiled(a_test)
+            self.assertEqual(out_ref, out_test)
 
-        out_ref.sum().backward()
-        out_test.sum().backward()
-        self.assertEqual(a_ref.grad, a_test.grad)
+            out_ref.sum().backward()
+            out_test.sum().backward()
+            self.assertEqual(a_ref.grad, a_test.grad)
 
     def test_autocast_simple(self):
         def f(a):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1993,6 +1993,17 @@ class TestAutograd(TestCase):
             w = adder(x, y)
             self.assertFalse(torch.is_grad_enabled())
 
+    def test_enable_grad_decorator_no_paren(self):
+        x = torch.ones(1, requires_grad=True)
+
+        @torch.enable_grad
+        def doubler(x):
+            return x * 2
+
+        with torch.no_grad():
+            z = doubler(x)
+        self.assertTrue(z.requires_grad)
+
     def test_set_grad_generator_functions(self):
         @torch.no_grad()
         def gen_no_grad():

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -29,7 +29,7 @@ class no_grad(_DecoratorContextManager):
     This context manager is thread local; it will not affect computation
     in other threads.
 
-    Also functions as a decorator. (Make sure to instantiate with parenthesis.)
+    Also functions as a decorator.
 
     .. note::
         No-grad is one of several mechanisms that can enable or
@@ -52,6 +52,12 @@ class no_grad(_DecoratorContextManager):
         ... def doubler(x):
         ...     return x * 2
         >>> z = doubler(x)
+        >>> z.requires_grad
+        False
+        >>> @torch.no_grad
+        ... def tripler(x):
+        ...     return x * 3
+        >>> z = tripler(x)
         >>> z.requires_grad
         False
         >>> # factory function exception

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Union
 
 import torch
 
-from torch.utils._contextlib import _DecoratorContextManager, F
+from torch.utils._contextlib import _DecoratorContextManager, _NoParamDecoratorContextManager, F
 
 __all__ = [
     "no_grad",
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-class no_grad(_DecoratorContextManager):
+class no_grad(_NoParamDecoratorContextManager):
     r"""Context-manager that disables gradient calculation.
 
     Disabling gradient calculation is useful for inference, when you are sure
@@ -72,9 +72,6 @@ class no_grad(_DecoratorContextManager):
             super().__init__()
         self.prev = False
 
-    def __new__(cls, orig_func: Optional[F] = None) -> Union[F, "no_grad"]:
-        return no_grad()(orig_func) if orig_func else super().__new__(cls)
-
     def __enter__(self) -> None:
         self.prev = torch.is_grad_enabled()
         torch.set_grad_enabled(False)
@@ -83,7 +80,7 @@ class no_grad(_DecoratorContextManager):
         torch.set_grad_enabled(self.prev)
 
 
-class enable_grad(_DecoratorContextManager):
+class enable_grad(_NoParamDecoratorContextManager):
     r"""Context-manager that enables gradient calculation.
 
     Enables gradient calculation, if it has been disabled via :class:`~no_grad`
@@ -92,7 +89,7 @@ class enable_grad(_DecoratorContextManager):
     This context manager is thread local; it will not affect computation
     in other threads.
 
-    Also functions as a decorator. (Make sure to instantiate with parenthesis.)
+    Also functions as a decorator.
 
     .. note::
         enable_grad is one of several mechanisms that can enable or
@@ -118,6 +115,13 @@ class enable_grad(_DecoratorContextManager):
         ...     return x * 2
         >>> with torch.no_grad():
         ...     z = doubler(x)
+        >>> z.requires_grad
+        True
+        >>> @torch.enable_grad
+        ... def tripler(x):
+        ...     return x * 3
+        >>> with torch.no_grad():
+        ...     z = tripler(x)
         >>> z.requires_grad
         True
 
@@ -200,7 +204,7 @@ class inference_mode(_DecoratorContextManager):
     This context manager is thread local; it will not affect computation
     in other threads.
 
-    Also functions as a decorator. (Make sure to instantiate with parenthesis.)
+    Also functions as a decorator.
 
     .. note::
         Inference mode is one of several mechanisms that can enable or
@@ -208,7 +212,8 @@ class inference_mode(_DecoratorContextManager):
         more information on how they compare.
 
     Args:
-        mode (bool): Flag whether to enable or disable inference mode
+        mode_or_func (bool or function): Either a boolean flag whether to enable or disable inference mode
+            or a Python function to decorate with inference mode enabled
 
     Example::
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_AUTOGRAD)
@@ -229,6 +234,12 @@ class inference_mode(_DecoratorContextManager):
         >>> out = func(x)
         >>> out.requires_grad
         False
+        >>> @torch.inference_mode
+        ... def doubler(x):
+        ...     return x * 2
+        >>> out = doubler(x)
+        >>> out.requires_grad
+        False
 
     """
 
@@ -238,6 +249,11 @@ class inference_mode(_DecoratorContextManager):
         # Holds a context manager that can enable or disable inference mode
         self._inference_mode_raii_context: Optional[torch._C._InferenceMode] = None
         self.mode = mode
+
+    def __new__(cls, mode_or_func: Union[bool, F] = True) -> Union["inference_mode", F]:
+        if isinstance(mode_or_func, bool):
+            return super().__new__(cls, mode_or_func)
+        return cls()(mode_or_func)
 
     def __enter__(self) -> None:
         self._inference_mode_context = torch._C._InferenceMode(self.mode)

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -252,7 +252,9 @@ class inference_mode(_DecoratorContextManager):
 
     def __new__(cls, mode_or_func: Union[bool, F] = True) -> Union["inference_mode", F]:
         if isinstance(mode_or_func, bool):
-            return super().__new__(cls, mode_or_func)
+            obj = super().__new__(cls)
+            obj.__init__(mode_or_func)
+            return obj
         return cls()(mode_or_func)
 
     def __enter__(self) -> None:

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,8 +1,8 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import torch
 
-from torch.utils._contextlib import _DecoratorContextManager, _NoParamDecoratorContextManager, F
+from torch.utils._contextlib import _DecoratorContextManager, _NoParamDecoratorContextManager
 
 __all__ = [
     "no_grad",
@@ -250,7 +250,7 @@ class inference_mode(_DecoratorContextManager):
         self._inference_mode_raii_context: Optional[torch._C._InferenceMode] = None
         self.mode = mode
 
-    def __new__(cls, mode_or_func: Union[bool, F] = True) -> Union["inference_mode", F]:
+    def __new__(cls, mode_or_func=True):
         return super().__new__(cls) if isinstance(mode_or_func, bool) else cls()(mode_or_func)
 
     def __enter__(self) -> None:

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -2,7 +2,8 @@ from typing import Any, Optional
 
 import torch
 
-from torch.utils._contextlib import _DecoratorContextManager, _NoParamDecoratorContextManager
+from torch.utils._contextlib import (_DecoratorContextManager,
+                                     _NoParamDecoratorContextManager)
 
 __all__ = [
     "no_grad",
@@ -251,7 +252,9 @@ class inference_mode(_DecoratorContextManager):
         self.mode = mode
 
     def __new__(cls, mode_or_func=True):
-        return super().__new__(cls) if isinstance(mode_or_func, bool) else cls()(mode_or_func)
+        if isinstance(mode_or_func, bool):
+            return super().__new__(cls)
+        return cls()(mode_or_func)
 
     def __enter__(self) -> None:
         self._inference_mode_context = torch._C._InferenceMode(self.mode)

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -4,7 +4,7 @@ import torch
 
 from torch.utils._contextlib import (
     _DecoratorContextManager,
-    _NoParamDecoratorContextManager
+    _NoParamDecoratorContextManager,
 )
 
 __all__ = [

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -2,8 +2,10 @@ from typing import Any, Optional
 
 import torch
 
-from torch.utils._contextlib import (_DecoratorContextManager,
-                                     _NoParamDecoratorContextManager)
+from torch.utils._contextlib import (
+    _DecoratorContextManager,
+    _NoParamDecoratorContextManager
+)
 
 __all__ = [
     "no_grad",

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,8 +1,8 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import torch
 
-from torch.utils._contextlib import _DecoratorContextManager
+from torch.utils._contextlib import _DecoratorContextManager, F
 
 __all__ = [
     "no_grad",
@@ -65,6 +65,9 @@ class no_grad(_DecoratorContextManager):
         if not torch._jit_internal.is_scripting():
             super().__init__()
         self.prev = False
+
+    def __new__(cls, orig_func: Optional[F] = None) -> Union[F, "no_grad"]:
+        return no_grad()(orig_func) if orig_func else super().__new__(cls)
 
     def __enter__(self) -> None:
         self.prev = torch.is_grad_enabled()

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -251,11 +251,7 @@ class inference_mode(_DecoratorContextManager):
         self.mode = mode
 
     def __new__(cls, mode_or_func: Union[bool, F] = True) -> Union["inference_mode", F]:
-        if isinstance(mode_or_func, bool):
-            obj = super().__new__(cls)
-            obj.__init__(mode_or_func)
-            return obj
-        return cls()(mode_or_func)
+        return super().__new__(cls) if isinstance(mode_or_func, bool) else cls()(mode_or_func)
 
     def __enter__(self) -> None:
         self._inference_mode_context = torch._C._InferenceMode(self.mode)

--- a/torch/utils/_contextlib.py
+++ b/torch/utils/_contextlib.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import warnings
 import sys
-from typing import Any, Callable, TypeVar, cast, Optional, Union
+from typing import Any, Callable, TypeVar, cast
 
 # Used for annotating the decorator usage of _DecoratorContextManager (e.g.,
 # 'no_grad' and 'enable_grad').
@@ -146,5 +146,5 @@ class _DecoratorContextManager:
 class _NoParamDecoratorContextManager(_DecoratorContextManager):
     """Allow a context manager to be used as a decorator without parentheses"""
 
-    def __new__(cls, orig_func: Optional[F] = None) -> Union["_NoParamDecoratorContextManager", F]:
+    def __new__(cls, orig_func=None):
         return cls()(orig_func) if orig_func else super().__new__(cls)

--- a/torch/utils/_contextlib.py
+++ b/torch/utils/_contextlib.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import warnings
 import sys
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast, Optional, Union
 
 # Used for annotating the decorator usage of _DecoratorContextManager (e.g.,
 # 'no_grad' and 'enable_grad').
@@ -141,3 +141,10 @@ class _DecoratorContextManager:
     def clone(self):
         # override this method if your children class takes __init__ parameters
         return self.__class__()
+
+
+class _NoParamDecoratorContextManager(_DecoratorContextManager):
+    """Allow a context manager to be used as a decorator without parentheses"""
+
+    def __new__(cls, orig_func: Optional[F] = None) -> Union["_NoParamDecoratorContextManager", F]:
+        return cls()(orig_func) if orig_func else super().__new__(cls)

--- a/torch/utils/_contextlib.py
+++ b/torch/utils/_contextlib.py
@@ -147,4 +147,6 @@ class _NoParamDecoratorContextManager(_DecoratorContextManager):
     """Allow a context manager to be used as a decorator without parentheses"""
 
     def __new__(cls, orig_func=None):
-        return cls()(orig_func) if orig_func else super().__new__(cls)
+        if orig_func is None:
+            return super().__new__(cls)
+        return cls()(orig_func)


### PR DESCRIPTION
This PR implements the feature described in #107036 for `no_grad`, `enable_grad` and `inference_mode`.

Users can still use the above as before but they can also use them without parentheses.

For example:

```python
import torch

a = torch.ones(1, requires_grad=True)


def do_something():
    print(2 * a)


with torch.no_grad():
    do_something()  # tensor([2.])

torch.no_grad()(do_something)()  # tensor([2.])

torch.no_grad(do_something)()  # tensor([2.])

do_something()  # tensor([2.], grad_fn=<MulBackward0>)
```

For `inference_mode`, decorating without parenthesis is equivalent to decorating with the default `mode=True`, similiar to how dataclasses behave (https://docs.python.org/3/library/dataclasses.html#module-contents)

Closes #107036

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov