### PR TITLE
disable multi_linear_share_same_input for dynamic shape case

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -589,6 +589,30 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         v = torch.randn(x_shape, dtype=torch.float32)
         self._test_common(mod, (v,), 0, 0)
 
+    def test_multi_linear_share_same_input_dynamic(self):
+        # llama pattern.
+        class M(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+                self.w1 = torch.nn.Linear(16, 16, bias=False)
+                self.w2 = torch.nn.Linear(16, 16, bias=False)
+
+            def forward(self, x):
+                return F.silu(self.w1(x)) * F.relu(self.w2(x))
+
+        mod = M().to(torch.bfloat16).eval()
+        if torch.ops.mkldnn._is_mkldnn_bf16_supported():
+            v = torch.randn(2, 4, 16).to(torch.bfloat16)
+            # 1. view(match_count=4, match_nodes=4).
+            # 2. mm to packed linear(match_count=2, match_nodes=2).
+            # 3. view+linear+view to linear(match_count=2, match_nodes=6).
+
+            match_count = 8
+            match_nodes = 12
+            self._test_common(mod, (v,), match_count, match_nodes, rtol=1e-2, atol=1e-2)
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CPU and torch.backends.mkldnn.is_available():

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -665,7 +665,6 @@ if torch._C._has_mkldnn:
             linear_input_node = reshape_2_node.args[0].args[0].args[0]
             # check linear's input's shape[:-1] == reshape_2[:-1]
             # and check product(reshape_2[:-1]) == reshape_1[0]
-            can_remove_reshape = True
             if dynamic_shapes:
                 # TODO: Haozhe investigate how add guard here
                 return
@@ -673,10 +672,9 @@ if torch._C._has_mkldnn:
                 can_remove_reshape = linear_input_node.meta.get("val").shape[
                     :-1
                 ] == torch.Size(reshape_2[:-1])
-                can_remove_reshape == can_remove_reshape and (
+                can_remove_reshape = can_remove_reshape and (
                     reduce(lambda x, y: x * y, reshape_2[:-1]) == reshape_1[0]
                 )
-                pass
 
             if can_remove_reshape:
                 repl = graph.call_function(mkldnn._linear_pointwise.default, args)

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -655,6 +655,14 @@ if torch._C._has_mkldnn:
         def reshape_linear_reshape_pattern(match, *args, **kwargs):
             reshape_1 = kwargs.get("reshape_1")
             reshape_2 = kwargs.get("reshape_2")
+            dynamic_shapes = not all(
+                isinstance(x, int) for x in (reshape_1 + reshape_2)
+            )
+            if dynamic_shapes:
+                # For dynamic shapes, we are unsafe to compair the shapes for reshape_1 and reshape_2
+                # since the can be changed in runtime
+                return
+
             graph = match.graph
             node = match.output_node()
             if reshape_1[0] == reduce(lambda x, y: x * y, reshape_2[:-1]):

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -686,7 +686,7 @@ if torch._C._has_mkldnn:
                 reshape_1_node = old_linear_node.args[0]
                 graph.erase_node(reshape_2_node)
                 graph.erase_node(old_linear_node)
-                if reshape_1_node.users == 0:
+                if len(reshape_1_node.users) == 0:
                     graph.erase_node(reshape_1_node)
 
         def is_linear_add_bias(match):

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -659,20 +659,32 @@ if torch._C._has_mkldnn:
             dynamic_shapes = not all(
                 isinstance(x, int) for x in ([reshape_1[0]] + reshape_2[:-1])
             )
-            if dynamic_shapes:
-                # For dynamic shapes, we are unsafe to compair the shapes for reshape_1 and reshape_2
-                # since they can be changed during runtime
-                return
 
             graph = match.graph
-            node = match.output_node()
-            if reshape_1[0] == reduce(lambda x, y: x * y, reshape_2[:-1]):
+            reshape_2_node = match.output_node()
+            linear_input_node = reshape_2_node.args[0].args[0].args[0]
+            # check linear's input's shape[:-1] == reshape_2[:-1]
+            # and check product(reshape_2[:-1]) == reshape_1[0]
+            can_remove_reshape = True
+            if dynamic_shapes:
+                # TODO: Haozhe investigate how add guard here
+                return
+            else:
+                can_remove_reshape = linear_input_node.meta.get("val").shape[
+                    :-1
+                ] == torch.Size(reshape_2[:-1])
+                can_remove_reshape == can_remove_reshape and (
+                    reduce(lambda x, y: x * y, reshape_2[:-1]) == reshape_1[0]
+                )
+                pass
+
+            if can_remove_reshape:
                 repl = graph.call_function(mkldnn._linear_pointwise.default, args)
-                repl.meta.update(node.meta)
-                node.replace_all_uses_with(repl)
-                old_linear_node = node.args[0]
+                repl.meta.update(reshape_2_node.meta)
+                reshape_2_node.replace_all_uses_with(repl)
+                old_linear_node = reshape_2_node.args[0]
                 reshape_1_node = old_linear_node.args[0]
-                graph.erase_node(node)
+                graph.erase_node(reshape_2_node)
                 graph.erase_node(old_linear_node)
                 if reshape_1_node.users == 0:
                     graph.erase_node(reshape_1_node)

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -655,8 +655,9 @@ if torch._C._has_mkldnn:
         def reshape_linear_reshape_pattern(match, *args, **kwargs):
             reshape_1 = kwargs.get("reshape_1")
             reshape_2 = kwargs.get("reshape_2")
+            assert len(reshape_1) == 2
             dynamic_shapes = not all(
-                isinstance(x, int) for x in (reshape_1 + reshape_2)
+                isinstance(x, int) for x in ([reshape_1[0]] + reshape_2[:-1])
             )
             if dynamic_shapes:
                 # For dynamic shapes, we are unsafe to compair the shapes for reshape_1 and reshape_2

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -661,7 +661,7 @@ if torch._C._has_mkldnn:
             )
             if dynamic_shapes:
                 # For dynamic shapes, we are unsafe to compair the shapes for reshape_1 and reshape_2
-                # since the can be changed in runtime
+                # since they can be changed during runtime
                 return
 
             graph = match.graph


### PR DESCRIPTION
`reshape_linear_reshape_pattern` will fail for dynamic shapes and break the fusion.
We will disable this optimization for dynamic shapes, since the shape might be changed during runtime so we cannot compare the size hint.


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107123



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov