### PR TITLE
[dynamo][easy] Only xfail test_dynamic_shapes_float_guard_dynamic_shapes if z3 is available

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import importlib
 import unittest
 import warnings
 
@@ -69,11 +70,13 @@ tests = [
 for test in tests:
     make_dynamic_cls(test)
 
-unittest.expectedFailure(
-    # SymPy is incorrectly transforming 's0 / 6 == 0.5' into 'False'.
-    # Ref: https://github.com/sympy/sympy/issues/25146
-    DynamicShapesReproTests.test_dynamic_shapes_float_guard_dynamic_shapes
-)
+if importlib.util.find_spec("z3"):
+    # this only fails when z3 is available
+    unittest.expectedFailure(
+        # SymPy is incorrectly transforming 's0 / 6 == 0.5' into 'False'.
+        # Ref: https://github.com/sympy/sympy/issues/25146
+        DynamicShapesReproTests.test_dynamic_shapes_float_guard_dynamic_shapes
+    )
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -1,5 +1,4 @@
 # Owner(s): ["module: dynamo"]
-import importlib
 import unittest
 import warnings
 
@@ -70,7 +69,7 @@ tests = [
 for test in tests:
     make_dynamic_cls(test)
 
-if importlib.util.find_spec("z3"):
+if TEST_Z3:
     # this only fails when z3 is available
     unittest.expectedFailure(
         # SymPy is incorrectly transforming 's0 / 6 == 0.5' into 'False'.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #107137

This test only fails when z3 is available. So we should only xfail it if z3 is available, otherwise the test passes with an unexpected success.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov

Differential Revision: [D48323103](https://our.internmc.facebook.com/intern/diff/D48323103)