### PR TITLE
Add Numpy import guard - fix windows smoke tests

### DIFF
--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -11,7 +11,11 @@ import warnings
 
 from typing import cast, Dict, Optional, Set
 
-import numpy as np
+try:
+    import numpy
+    HAS_NUMPY = True
+except ModuleNotFoundError:
+    HAS_NUMPY = False
 
 import torch
 import torch._functorch.deprecated as deprecated_func
@@ -20,6 +24,7 @@ from torch.fx._symbolic_trace import is_fx_tracing
 from . import config
 from .external_utils import is_compiling
 from .utils import is_safe_constant, NP_SUPPORTED_MODULES
+
 
 """
 A note on allowed functions:

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -12,10 +12,11 @@ import warnings
 from typing import cast, Dict, Optional, Set
 
 try:
-    import numpy
+    import numpy as np
     HAS_NUMPY = True
 except ModuleNotFoundError:
     HAS_NUMPY = False
+    np = None
 
 import torch
 import torch._functorch.deprecated as deprecated_func
@@ -320,4 +321,4 @@ def is_builtin_constant(obj):
 
 
 def is_numpy(obj):
-    return isinstance(obj, np.ndarray) or id(obj) in _numpy_function_ids
+    return HAS_NUMPY and (isinstance(obj, np.ndarray) or id(obj) in _numpy_function_ids)

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -13,6 +13,7 @@ from typing import cast, Dict, Optional, Set
 
 try:
     import numpy as np
+
     HAS_NUMPY = True
 except ModuleNotFoundError:
     HAS_NUMPY = False

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -13,10 +13,7 @@ from typing import cast, Dict, Optional, Set
 
 try:
     import numpy as np
-
-    HAS_NUMPY = True
 except ModuleNotFoundError:
-    HAS_NUMPY = False
     np = None
 
 import torch
@@ -322,4 +319,6 @@ def is_builtin_constant(obj):
 
 
 def is_numpy(obj):
-    return HAS_NUMPY and (isinstance(obj, np.ndarray) or id(obj) in _numpy_function_ids)
+    return (isinstance(obj, np.ndarray) if np is not None else False) or id(
+        obj
+    ) in _numpy_function_ids


### PR DESCRIPTION
Follow up after: https://github.com/pytorch/pytorch/pull/106211

Fixes nightly failure build failure:
https://github.com/pytorch/pytorch/actions/runs/5853088203/job/15871284383

```
(testenv) C:\actions-runner\_work\pytorch\pytorch\builder\windows>python C:\actions-runner\_work\pytorch\pytorch/builder\test_example_code\cnn_smoke.py 
C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\nn\modules\transformer.py:20: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:84.)
  device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
Traceback (most recent call last):
tensor([0.], device='cuda:0', grad_fn=<ViewBackward0>)
  File "C:\actions-runner\_work\pytorch\pytorch\builder\test_example_code\cnn_smoke.py", line 30, in <module>
    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.1)
  File "C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\optim\sgd.py", line 26, in __init__
    super().__init__(params, defaults)
  File "C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\optim\optimizer.py", line 266, in __init__
    self.add_param_group(cast(dict, param_group))
  File "C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\_compile.py", line 22, in inner
    import torch._dynamo
  File "C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\_dynamo\__init__.py", line 2, in <module>
    from . import allowed_functions, convert_frame, eval_frame, resume_execution
  File "C:\actions-runner\_work\pytorch\pytorch\builder\windows\conda\envs\testenv\lib\site-packages\torch\_dynamo\allowed_functions.py", line 14, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

Similar to:
https://github.com/pytorch/pytorch/blob/461c703ee6b82efe9a04d09e57856fee58da375e/torch/utils/data/_utils/__init__.py#L38-L42

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov