### PR TITLE
[caffe2][SDT] Check whether `TORCH_DISABLE_SDT` macro is defined before referencing it

### DIFF
--- a/c10/util/static_tracepoint.h
+++ b/c10/util/static_tracepoint.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__)) && \
-    !TORCH_DISABLE_SDT
+    !(defined(TORCH_DISABLE_SDT) && TORCH_DISABLE_SDT)
 
 #define TORCH_HAVE_SDT 1
 


### PR DESCRIPTION
Summary:
Some jobs in the next diff in stack (D48229150) fail with the following message:

```
stderr: In file included from xplat/caffe2/c10/cuda/CUDACachingAllocator.cpp:9:
xplat/caffe2/c10/util/static_tracepoint.h:4:6: error: 'TORCH_DISABLE_SDT' is not defined, evaluates to 0 [-Werror,-Wundef]
    !TORCH_DISABLE_SDT
```

When porting USDT macros to PyTorch in D47159249, I must have not hit a codepath which treated warnings as errors during testing.

This diff fixes the issue by first checking whether the `TORCH_DISABLE_SDT` macro is defined before trying to access it in the `static_tracepoint.h` header.

Test Plan:
Similar to D47159249, tested the following macro on test scripts with `libbpf` USDTs:
* `CAFFE_DISABLE_SDT`

Reviewed By: chaekit

Differential Revision: D48251736

