### PR TITLE
[thread_pg] fix all_reduce to respect different cuda device

### DIFF
--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -86,12 +86,19 @@ class AllReduce:
     def work(self, data):
         for i in range(len(data[0])):
             tensors = []
+            # use rank0 as the device for sum
+            rank_0_device = data[0][i].device
+            # collect all data to the list and make them
+            # all on rank 0 device
             for src_rank in range(0, len(data)):
-                tensors.append(data[src_rank][i])
+                tensors.append(data[src_rank][i].to(rank_0_device))
+
+            # now mimic reduce across all ranks
             res = _reduce_ops[self.op](tensors)
-            with torch.no_grad():
-                for src_rank in range(len(data)):
-                    data[src_rank][i].copy_(res)
+
+            # copy all the reduced value to each rank
+            for src_rank in range(len(data)):
+                data[src_rank][i].copy_(res.to(data[src_rank][i].device))
 
 
 class AllGather:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107153
* #107152
* __->__ #107151

The previous implementation only works on CPU and it does not respect
the fact that each rank have its data in different devices (i.e. cuda),
so the implementation will raise the error like below:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1!
```

See report in https://github.com/pytorch/pytorch/pull/105604#issuecomment-1675472670

This PR fix this issue and tested that the failed tests on GPU now works