### PR TITLE
[thread_pg] fix reduce_scatter to respect different cuda device

### DIFF
--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -167,11 +167,12 @@ class ReduceScatter:
                 dest_tensor_on_rank_i = data[i][0]
                 # Can't handle reduce_scatter with multiple output tensor
                 assert len(dest_tensor_on_rank_i) == 1
+                dst_tensor_device = dest_tensor_on_rank_i[0].device
                 if not start_reduction[i]:
-                    dest_tensor_on_rank_i[0].copy_(to_scatter[i])
+                    dest_tensor_on_rank_i[0].copy_(to_scatter[i].to(dst_tensor_device))
                     start_reduction[i] = True
                 else:
-                    dest_tensor_on_rank_i[0].add_(to_scatter[i])
+                    dest_tensor_on_rank_i[0].add_(to_scatter[i].to(dst_tensor_device))
 
 class Broadcast:
     def __init__(self, src):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107153
* __->__ #107152
* #107151

Same reason as the previous all_reduce PR, see context in the allreduce
PR https://github.com/pytorch/pytorch/pull/107151 instead