### PR TITLE
Create fastpath backend context manager, similar to SDPA kernel backend manager

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -125,6 +125,21 @@ void Context::setSDPUseMath(bool e) {
   enabled_mathSDP = e;
 }
 
+// Create 64 bits of global context
+// assignGlobalCtx() assign a single bit position pos to bool value e
+void Context::assignGlobalCtx(int pos, bool e){
+  if (e)
+    flags_global_ctx |= ((uint_least64_t )1)<<pos;
+  else
+    flags_global_ctx &= ~(((uint_least64_t )1)<<pos);
+}
+
+// Create 64 bits of global context
+// getGlobalCtx() read a single bit position pos and return as bool
+bool Context::getGlobalCtx(int pos){
+  return (flags_global_ctx & (((uint_least64_t )1)<<pos)) == (((uint_least64_t )1)<<pos);
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static const char cublas_config_var_name[] = "CUBLAS_WORKSPACE_CONFIG";
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -170,6 +170,9 @@ class TORCH_API Context {
   void setSDPUseMath(bool);
   bool userEnabledMathSDP() const;
 
+  void assignGlobalCtx(int, bool);
+  bool getGlobalCtx(int);
+
   at::LinalgBackend linalgPreferredBackend() const;
   void setLinalgPreferredBackend(at::LinalgBackend);
 
@@ -307,6 +310,7 @@ class TORCH_API Context {
   bool enabled_flashSDP = true;
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;
+  uint_least64_t flags_global_ctx = 0;
 #ifdef USE_ROCM
   bool benchmark_cudnn = true;
 #else

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 from unittest import mock
 
 import torch
+import torch._op_ctl
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.fsdp import CPUOffload, MixedPrecision
@@ -413,11 +414,20 @@ class TestNoGrad(FSDPTest):
         input = fsdp_model.module.get_input(torch.device("cuda"))
         # Run a forward in eval mode
         fsdp_model.eval()
-        ref_output = fsdp_model(*input)
-        # Run a forward in `no_grad()` and compare
-        with torch.no_grad():
-            no_grad_output = fsdp_model(*input)
-        self.assertEqual(ref_output, no_grad_output)
+
+        # use AT FastPath backend manager to disable fastpath execution
+        # for numerical reproducibility
+        with torch._op_ctl.atfp_kernel(
+            enable_nested_tensor=False,
+            enable_encoder=False,
+            enable_mha=False,
+            enable_math=True,
+        ):
+            ref_output = fsdp_model(*input)
+            # Run a forward in `no_grad()` and compare
+            with torch.no_grad():
+                no_grad_output = fsdp_model(*input)
+            self.assertEqual(ref_output, no_grad_output)
 
 
 class TestAutograd(FSDPTest):

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1088,6 +1088,9 @@ def _set_sdp_use_mem_efficient(
 ) -> None: ...  # THPModule_setSDPUseMemEfficient
 def _get_math_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_math(arg: _bool) -> None: ...  # THPModule_setSDPUseMath
+def _set_global_ctx(arg: _int) -> None: ...  # THPModule_setGlobalCtx
+def _unset_global_ctx(arg: _int) -> None: ...  # THPModule_unsetGlobalCtx
+def _get_global_ctx(arg: _int) -> _bool: ...  # THPModule_getGlobalCtx
 def _get_mkldnn_enabled() -> _bool: ...  # THPModule_userEnabledMkldnn
 def _set_mkldnn_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledMkldnn
 def _get_cudnn_benchmark() -> _bool: ...  # THPModule_benchmarkCuDNN

--- a/torch/_op_ctl.py
+++ b/torch/_op_ctl.py
@@ -1,0 +1,168 @@
+import contextlib
+from enum import IntEnum
+
+import torch
+
+__all__ = [
+    "ATFPBackend",
+    "atfp_kernel",
+    "atfp_math_enabled",
+    "enable_atfp_math",
+    "atfp_mha_enabled",
+    "enable_atfp_mha",
+    "atfp_encoder_enabled",
+    "enable_atfp_encoder",
+    "atfp_nested_tensor_enabled",
+    "enable_atfp_nested_tensor",
+]
+
+
+class ATFPBackend(IntEnum):
+    r"""Enum class for the AT Inference Fastpath backends.
+
+    .. warning:: This class is in beta and subject to change.
+    """
+    ERROR = -1
+    MATH = 0
+    MHA = 1
+    ENCODER = 2
+    NESTED_TENSOR = 3
+    bits = 4
+
+
+def _write_global_ctx(ctx_no: int, enabled: bool, default: bool = True) -> None:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables global ctx represented by `ctx_no`.
+    """
+    # default (represented by global ctx value of 0/False) for ATFP backend feature enablement is true
+    # so ctx bit being set disables the feature, and we need to invert the boolean "enabled"
+    if enabled == default:
+        if not torch.jit.is_scripting():
+            torch._C._unset_global_ctx(ctx_no)
+        else:
+            torch.ops.prim._UnsetGlobalCtx(ctx_no)
+    else:
+        if not torch.jit.is_scripting():
+            torch._C._set_global_ctx(ctx_no)
+        else:
+            torch.ops.prim._SetGlobalCtx(ctx_no)
+
+
+def _is_global_ctx(ctx_no: int, default: bool = True) -> bool:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether global ctx `ctx_no` is enabled or disabled.
+    """
+    # default (represented by global ctx value of 0/False) for ATFP backend feature enablement is true
+    # so ctx bit being set disables the feature, and we need to invert the boolean "enabled"
+    if not torch.jit.is_scripting():
+        return torch._C._get_global_ctx(ctx_no) != default
+    else:
+        return torch.ops.prim._GetGlobalCtx(ctx_no) != default
+
+
+def atfp_math_enabled() -> bool:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether math kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(0)  # ATFPBackend.MATH
+
+
+def enable_atfp_math(enabled: bool) -> None:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables math kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(0, enabled)  # ATFPBackend.MATH
+
+
+def atfp_mha_enabled() -> bool:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether MHA kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(1)  # ATFPBackend.MHA
+
+
+def enable_atfp_mha(enabled: bool) -> None:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables MHA kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(1, enabled)  # ATFPBackend.MATH
+
+
+def atfp_encoder_enabled() -> bool:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether encoder kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(2)  # ATFPBackend.ENCODER
+
+
+def enable_atfp_encoder(enabled: bool) -> None:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables encoder kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(2, enabled)  # ATFPBackend.ENCODER
+
+
+def atfp_nested_tensor_enabled() -> bool:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Returns whether nested_tensor kernel for AT Inference Fastpath is enabled or not.
+    """
+    return _is_global_ctx(3)  # ATFPBackend.NESTED_TENSOR
+
+
+def enable_atfp_nested_tensor(enabled: bool) -> None:
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    Enables or disables nested_tensor kernel for AT Inference Fastpath.
+    """
+    _write_global_ctx(3, enabled)  # ATFPBackend.NESTED_TENSOR
+
+
+@contextlib.contextmanager
+def atfp_kernel(
+    *,
+    enable_nested_tensor: bool = True,
+    enable_encoder: bool = True,
+    enable_mha: bool = True,
+    enable_math: bool = True,
+):
+    r"""
+    .. warning:: This flag is beta and subject to change.
+
+    This context manager can be used to temporarily enable or disable any of the four backends for
+    Accelerated Transformer Inference Fastpath.
+    Upon exiting the context manager, the previous state of the flags will be restored.
+    """
+    previous_math: bool = atfp_math_enabled()
+    previous_mha: bool = atfp_mha_enabled()
+    previous_encoder: bool = atfp_encoder_enabled()
+    previous_nested_tensor: bool = atfp_nested_tensor_enabled()
+    try:
+        enable_atfp_math(enable_math)
+        enable_atfp_mha(enable_mha)
+        enable_atfp_encoder(enable_encoder)
+        enable_atfp_nested_tensor(enable_nested_tensor)
+        yield {}
+    finally:
+        enable_atfp_math(previous_math)
+        enable_atfp_mha(previous_mha)
+        enable_atfp_encoder(previous_encoder)
+        enable_atfp_nested_tensor(previous_nested_tensor)

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "can_use_flash_attention",
     "can_use_efficient_attention",
     "sdp_kernel",
+    "ATFPbackend",
 ]
 
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -638,6 +638,61 @@ PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
   else
     Py_RETURN_FALSE;
 }
+PyObject* THPModule_setGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "set_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "set_global_ctx expects 0 <= ctx_pos < 64, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  at::globalContext().assignGlobalCtx(ctx_no, true);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+PyObject* THPModule_unsetGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "unset_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "unset_global_ctx expects 0 <= ctx_pos < 64, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  at::globalContext().assignGlobalCtx(ctx_no, false);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THPModule_getGlobalCtx(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      THPUtils_checkLong(arg),
+      "set_global_ctx expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  auto ctx_no = static_cast<int>(THPUtils_unpackLong(arg));
+  THPUtils_assert(
+      ((ctx_no >= 0) && (ctx_no < 64)),
+      "get_global_ctx expects 0 <= ctx_pos < 64, "
+      "but got %d",
+      ctx_no);
+  HANDLE_TH_ERRORS
+  if (at::globalContext().getGlobalCtx(ctx_no))
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
   THPUtils_assert(
       PyBool_Check(arg),
@@ -1150,6 +1205,9 @@ static PyMethodDef TorchMethods[] = { // NOLINT
      METH_NOARGS,
      nullptr},
     {"_set_sdp_use_math", THPModule_setSDPUseMath, METH_O, nullptr},
+    {"_set_global_ctx", THPModule_setGlobalCtx, METH_O, nullptr},
+    {"_unset_global_ctx", THPModule_unsetGlobalCtx, METH_O, nullptr},
+    {"_get_global_ctx", THPModule_getGlobalCtx, METH_O, nullptr},
     {"_get_cudnn_enabled", THPModule_userEnabledCuDNN, METH_NOARGS, nullptr},
     {"_set_cudnn_enabled", THPModule_setUserEnabledCuDNN, METH_O, nullptr},
     {"_get_mkldnn_enabled", THPModule_userEnabledMkldnn, METH_NOARGS, nullptr},

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -182,6 +182,47 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
+        TORCH_SELECTIVE_SCHEMA("prim::_SetGlobalCtx(int ctx_pos) -> int"),
+        [](Stack& stack) {
+          // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+          int64_t ctx_pos = 0;
+          pop(stack, ctx_pos);
+          TORCH_CHECK(
+              (ctx_pos >= 0) && (ctx_pos < 64),
+              "prim::_SetGlobalCtx expects 0 <= ctx_pos < 64, but got %d",
+              ctx_pos);
+          at::globalContext().assignGlobalCtx(ctx_pos, true);
+          push(stack, 0);
+        },
+        aliasAnalysisConservative()),
+    OperatorGeneratorArgs(
+        TORCH_SELECTIVE_SCHEMA("prim::_UnsetGlobalCtx(int ctx_pos) -> int"),
+        [](Stack& stack) {
+          // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+          int64_t ctx_pos = 0;
+          pop(stack, ctx_pos);
+          TORCH_CHECK(
+              (ctx_pos >= 0) && (ctx_pos < 64),
+              "prim::_UnsetGlobalCtx expects 0 <= ctx_pos < 64, but got %d",
+              ctx_pos);
+          at::globalContext().assignGlobalCtx(ctx_pos, false);
+          push(stack, 0);
+        },
+        aliasAnalysisConservative()),
+    OperatorGeneratorArgs(
+        TORCH_SELECTIVE_SCHEMA("prim::_GetGlobalCtx(int ctx_pos) -> bool"),
+        [](Stack& stack) {
+          // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+          int64_t ctx_pos = 0;
+          pop(stack, ctx_pos);
+          TORCH_CHECK(
+              (ctx_pos >= 0) && (ctx_pos < 64),
+              "prim::_GetGlobalCtx expects 0 <= ctx_pos < 64, but got %d",
+              ctx_pos);
+          push(stack, (bool)(at::globalContext().getGlobalCtx(ctx_pos)));
+        },
+        aliasAnalysisConservative()),
+    OperatorGeneratorArgs(
         TORCH_SELECTIVE_SCHEMA("prim::TupleUnpack(Any tup) -> ..."),
         [](Stack& stack) { tupleUnpack(stack); },
         aliasAnalysisSpecialCase()),

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -4,6 +4,7 @@ from typing import Optional, Any, Union, Callable
 import torch
 import warnings
 from torch import Tensor
+from torch._op_ctl import atfp_math_enabled, atfp_encoder_enabled, atfp_nested_tensor_enabled
 from .. import functional as F
 from .module import Module
 from .activation import MultiheadAttention
@@ -334,7 +335,9 @@ class TransformerEncoder(Module):
         why_not_sparsity_fast_path = ''
         str_first_layer = "self.layers[0]"
         batch_first = first_layer.self_attn.batch_first
-        if not hasattr(self, "use_nested_tensor"):
+        if not atfp_nested_tensor_enabled():
+            why_not_sparsity_fast_path = "AT FastPath backend manager for enable_nested_tensor is False"
+        elif not hasattr(self, "use_nested_tensor"):
             why_not_sparsity_fast_path = "use_nested_tensor attribute not present"
         elif not self.use_nested_tensor:
             why_not_sparsity_fast_path = "self.use_nested_tensor (set in init) was not True"
@@ -633,7 +636,10 @@ class TransformerEncoderLayer(Module):
 
         # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf
         why_not_sparsity_fast_path = ''
-        if not src.dim() == 3:
+        batch_first = self.self_attn.batch_first or src.is_nested
+        if not atfp_encoder_enabled():
+            why_not_sparsity_fast_path = "AT FastPath backend manager has enable_encoder=False"
+        elif not src.dim() == 3:
             why_not_sparsity_fast_path = f"input not batched; expected src.dim() of 3 but got {src.dim()}"
         elif self.training:
             why_not_sparsity_fast_path = "training is enabled"
@@ -705,6 +711,7 @@ class TransformerEncoderLayer(Module):
                     mask_type,
                 )
 
+        assert atfp_math_enabled(), "TransformerEncoderLayer: Fallback math implementation not enabled"
 
         x = src
         if self.norm_first:


### PR DESCRIPTION
Summary: 

1. create context manager infrastructure with aten-managed context with room for 64 settings
   - as Python builtin for Python eager and torch.compile
   - as TS builtins guarded by torch.hit.is_scripting() for legacy compatibility with TS legacy code. (since "normal" Python builtins that are part of the Pytorch distro are not accessible in TS.)
2. Ability to start with True or False initialization (we always init the state to 0, but will invert some bits based on 
       desired startup/default polarity of a flag)
3. Create fastpath backend context manager using 4 context bits from 1 
       (similar to SDPA kernel backend manager, to give users instant familiarity with the mechanism)
4. Use context manager in FSDP test code (this is prep for a future update that broadens use of fastpath, and would
      otherwise break this FSDP test when the executions are performed using different kernels, showing divergence in
      the test, not thru an error, but the use of different kernels, with different FP rounding characteristics etc)

Test Plan: sandcastle, github

Differential Revision: D48325593



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc