### PR TITLE
[BE] Add missing override to remove build warning spam

### DIFF
--- a/test/cpp/api/support.h
+++ b/test/cpp/api/support.h
@@ -41,7 +41,7 @@ struct WarningCapture : public WarningHandler {
     WarningUtils::set_warning_handler(this);
   }
 
-  ~WarningCapture() {
+  ~WarningCapture() override {
     WarningUtils::set_warning_handler(prev_);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107192
* #107089
* #107210
* __->__ #107191


```
In file included from /local/pytorch3/test/cpp/api/optim.cpp:7:
local/pytorch3/test/cpp/api/support.h:44:3: warning: '~WarningCapture' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  ~WarningCapture() {
  ^
local/pytorch3/c10/util/Exception.h:167:11: note: overridden virtual function is here
  virtual ~WarningHandler() = default;
  ```