### PR TITLE
enable mkl_gemm_bf16bf16f32 in cpublas::gemm

### DIFF
--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -330,6 +330,52 @@ void gemm(
 void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
+    const float alpha,
+    const at::BFloat16 *a, int64_t lda,
+    const at::BFloat16 *b, int64_t ldb,
+    const float beta,
+    float *c, int64_t ldc) {
+  internal::normalize_last_dims(transa, transb, m, n, k, &lda, &ldb, &ldc);
+#if AT_BUILD_WITH_BLAS() && defined(BLAS_HAS_SBGEMM)
+   if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {
+      int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
+      char transa_ = to_blas(transa), transb_ = to_blas(transb);
+      float alpha_ = alpha, beta_ = beta;
+      sbgemm_(&transa_, &transb_,
+              &m_, &n_, &k_,
+              &alpha_,
+              a, &lda_,
+              b, &ldb_,
+              &beta_,
+              c, &ldc_);
+      return;
+   }
+#endif
+#ifdef MKL_HAS_SBGEMM
+  if (use_blas_gemm(transa, transb, m, n, k, lda, ldb, ldc)) {
+    int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
+    mkl_gemm_bf16bf16f32(transa, transb, m_, n_, k_, alpha, a, lda_, b, ldb_, beta, c, ldc_);
+    return;
+  }
+#endif
+  // for the fallback path, first compute gemm with beta = 0,
+  // and then add c in full precision.
+  int64_t c_size = n * m;
+  std::vector<at::BFloat16> bfloat_c(c_size, 0.f);
+  gemm_stub(
+      at::kCPU, at::kBFloat16,
+      transa, transb, m, n, k, alpha, a, lda, b, ldb, 0.f, bfloat_c.data(), m);
+  for (const auto j : c10::irange(n)) {
+    for (const auto i : c10::irange(m)) {
+      auto offset = j * ldc + i;
+      c[offset] = beta * c[offset] + c10::convert<float>(bfloat_c[j * m + i]);
+    }
+  }
+}
+
+void gemm(
+    TransposeType transa, TransposeType transb,
+    int64_t m, int64_t n, int64_t k,
     const int64_t alpha,
     const int64_t *a, int64_t lda,
     const int64_t *b, int64_t ldb,

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -368,7 +368,12 @@ void gemm(
   for (const auto j : c10::irange(n)) {
     for (const auto i : c10::irange(m)) {
       auto offset = j * ldc + i;
-      c[offset] = beta * c[offset] + c10::convert<float>(bfloat_c[j * m + i]);
+      // beta == 0 won't propagate NaN from C
+      if (beta == 0.f) {
+        c[offset] = c10::convert<float>(bfloat_c[j * m + i]);
+      } else {
+        c[offset] = beta * c[offset] + c10::convert<float>(bfloat_c[j * m + i]);
+      }
     }
   }
 }

--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -73,6 +73,15 @@ void gemm(
 void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
+    const float alpha,
+    const at::BFloat16 *a, int64_t lda,
+    const at::BFloat16 *b, int64_t ldb,
+    const float beta,
+    float *c, int64_t ldc);
+
+void gemm(
+    TransposeType transa, TransposeType transb,
+    int64_t m, int64_t n, int64_t k,
     c10::complex<double> alpha,
     const c10::complex<double> *a, int64_t lda,
     const c10::complex<double> *b, int64_t ldb,

--- a/aten/src/ATen/native/mkl/LinearAlgebra.h
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/native/TransposeType.h>
 #include <c10/util/complex.h>
+#include <c10/core/ScalarType.h>
 
 namespace at {
 namespace native {
@@ -28,5 +29,11 @@ void mkl_gemm_batched(
     int batch_size, int M, int N, int K, c10::complex<double> alpha,
     const c10::complex<double>** A, int lda, const c10::complex<double>** B, int ldb,
     c10::complex<double> beta, c10::complex<double>** C, int ldc);
+
+void mkl_gemm_bf16bf16f32(
+    TransposeType trans_A, TransposeType trans_B,
+    int M, int N, int K, const float alpha,
+    const c10::BFloat16* A, int lda, const c10::BFloat16* B, int ldb,
+    const float beta, float* C, int ldc);
 
 }}  // namespace at::native

--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -367,6 +367,15 @@ FOREACH(mklrtl ${mklrtls} "")
   ENDFOREACH(mkliface)
 ENDFOREACH(mklrtl)
 
+IF (MKL_LIBRARIES)
+  SET(CMAKE_REQUIRED_LIBRARIES ${MKL_LIBRARIES})
+  check_function_exists("cblas_gemm_bf16bf16f32" MKL_HAS_SBGEMM)
+  set(CMAKE_REQUIRED_LIBRARIES)
+  IF(MKL_HAS_SBGEMM)
+    add_compile_options(-DMKL_HAS_SBGEMM)
+  ENDIF(MKL_HAS_SBGEMM)
+ENDIF (MKL_LIBRARIES)
+
 # Check for older versions
 IF (NOT MKL_LIBRARIES)
   SET(MKL_VERSION 900)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107196

This one is a wrapper upon `mkl_gemm_bf16bf16f32` which is used in flash attention kernel on intel 4th gen xeon.
Fallback path has also been implemented on cpublas::gemm in case `mkl_gemm_bf16bf16f32` is not available.

The primary target of this change is to help build kernels in `scaled_dot_product_attention`, e.g. flash attention and efficient attention.  In the attention kernel, `q @ k.T = attn`, q and k will be given as bfloat16 and attn is float32. This is actually both beneficial for both performance and accuracy, since attn will be used to compute lazy softmax which has to be done in float32.

This patch also adds routine from OpenBlas `sbgemm_` which also has a signature of bf16 * bf16 -> fp32; but since OpenBlas routine has different name from MKL's, we can not use `sbgemm_` in MKL.

In the fallback path, it takes two steps to do the computation: first do gemm with beta = 0; then add beta * C in full precision. Idea from @peterbell10 not to truncate C to bfloat16, so as to avoid unnecessary accuracy loss.

ref: https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2023-0/cblas-gemm-bf16bf16f32.html


cc @jgong5 @XiaobingSuper @sanchitintel @ashokei @jingxu10