### PR TITLE
remove the duplicate method `is_private_use1` in class Device

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -156,11 +156,6 @@ struct C10_API Device final {
     return type_ == DeviceType::CPU;
   }
 
-  /// Return true if the device is of PrivateUse1 type.
-  bool is_privateuse1() const noexcept {
-    return type_ == DeviceType::PrivateUse1;
-  }
-
   /// Return true if the device supports arbitrary strides.
   bool supports_as_strided() const noexcept {
     return type_ != DeviceType::IPU && type_ != DeviceType::XLA &&


### PR DESCRIPTION
In the `Device` class, there are two methods with similar functions called `is_private_use1` and `is_privateuseone`. 
https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/c10/core/Device.h#L84-L87

https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/c10/core/Device.h#L159-L162
The former is not being utilized and therefore, this PR removes it.
