### PR TITLE
[ROCm] enable missed cpp tests - test_libtorch_jit (test_jit and test_lazy)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -584,8 +584,7 @@ test_libtorch() {
       test_libtorch_api
     fi
 
-    # still disable rocm
-    if [[ "$BUILD_ENVIRONMENT" != *rocm* && (-z "${SHARD}" || "${SHARD}" == "2") ]]; then
+    if [[ -z "${SHARD}" || "${SHARD}" == "2" ]]; then
       test_libtorch_jit
     fi
 


### PR DESCRIPTION
[ROCm] enable missed cpp tests - test_libtorch_jit (test_jit and test_lazy)



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo