### PR TITLE
[ONNX] Relax not exist assertion for 'register_pytree_node'

### DIFF
--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -64,10 +64,7 @@ class _PyTreeExtensionContext:
         Raises:
             AssertionError: If the custom python type is already registered.
         """
-        if (
-            class_type not in pytree.SUPPORTED_NODES
-            and class_type not in self._extensions
-        ):
+        if class_type in pytree.SUPPORTED_NODES or class_type in self._extensions:
             # PyTree node already registered.
             # E.g., `huggingface/transformer` registers `ModelOutput` as PyTree node after
             # https://github.com/huggingface/transformers/pull/25358.

--- a/torch/onnx/_internal/fx/dynamo_graph_extractor.py
+++ b/torch/onnx/_internal/fx/dynamo_graph_extractor.py
@@ -64,10 +64,14 @@ class _PyTreeExtensionContext:
         Raises:
             AssertionError: If the custom python type is already registered.
         """
-        assert (
+        if (
             class_type not in pytree.SUPPORTED_NODES
             and class_type not in self._extensions
-        ), "PyTree node already registered"
+        ):
+            # PyTree node already registered.
+            # E.g., `huggingface/transformer` registers `ModelOutput` as PyTree node after
+            # https://github.com/huggingface/transformers/pull/25358.
+            return
         self._extensions[class_type] = (flatten_func, unflatten_func)
 
     def _register_huggingface_model_output_extension(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107245
* #107165
* #107158
* #106741

To not conflict with potential existing workaround or solution outside of exporter.
Latest huggingface/transformers main (>4.31) patches PyTorch PyTree with support over `ModelOutput` class.
`_PyTreeExtensionContext` is kept to support prior versions of transformers.