### PR TITLE
[fx][split] make sure we copy node.meta over during split

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1214,6 +1214,7 @@ exclude_patterns = [
     'test/fx/test_source_matcher_utils.py',
     'test/fx/test_subgraph_rewriter.py',
     'test/fx/test_z3_gradual_types.py',
+    'test/fx/test_fx_split.py',
     'test/jit/__init__.py',
     'test/jit/_imported_class_test/__init__.py',
     'test/jit/_imported_class_test/bar.py',

--- a/test/fx/test_fx_split.py
+++ b/test/fx/test_fx_split.py
@@ -1,0 +1,32 @@
+# Owner(s): ["module: fx"]
+
+import torch
+from torch.fx.passes.split_utils import split_by_tags
+
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestFXSplit(TestCase):
+    def test_split_preserve_node_meta(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x, y):
+                x = x + x
+                y = y * y
+                return x - y
+
+        gm = torch.fx.symbolic_trace(TestModule())
+        for node in gm.graph.nodes:
+            node.meta["name"] = node.name
+            if node.name == "add":
+                node.tag = "a"
+            elif node.name == "mul":
+                node.tag = "b"
+            elif node.name == "sub":
+                node.tag = "c"
+
+        split_gm = split_by_tags(gm, ["a", "b", "c"])
+        for m in split_gm.children():
+            for n in m.graph.nodes:
+                if n.op != "output":
+                    self.assertIn("name", n.meta)
+                    self.assertEqual(n.meta["name"], n.name)


### PR DESCRIPTION
Summary: Previously when we create placeholder nodes for sub graph modules, we didn't copy node.meta over.

Test Plan: CI

Differential Revision: D48330866

