### PR TITLE
[1/N] Introduce init_device_mesh()

### DIFF
--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -163,20 +163,19 @@ class InitDeviceMeshTest(DTensorTestBase):
         return 8
 
     @with_comms
-    def test_default_init_device_mesh(self):
-        default_mesh = init_device_mesh(self.device_type)
-        ref_mesh = DeviceMesh(self.device_type, torch.arange(8))
-        self.assertEqual(default_mesh, ref_mesh)
+    def test_init_device_mesh_with_mesh_dim_names(self):
+        mesh_shape = [2, 4]
+        ref_mesh = DeviceMesh(self.device_type, torch.arange(8).view(mesh_shape))
 
-    @with_comms
-    def test_init_device_mesh(self):
-        mesh_dims = [2, 4]
+        # test init_device_mesh with mesh_dim_names
         mesh_dim_names = ["DP", "TP"]
-        two_d_mesh = init_device_mesh(self.device_type, mesh_dims, mesh_dim_names)
-
-        ref_mesh = DeviceMesh(self.device_type, torch.arange(8).view(mesh_dims))
+        two_d_mesh = init_device_mesh(self.device_type, mesh_shape, mesh_dim_names)
         self.assertEqual(two_d_mesh, ref_mesh)
-        self.assertEqual(two_d_mesh._mesh_dim_names, mesh_dim_names)
+        self.assertEqual(two_d_mesh.mesh_dim_names, mesh_dim_names)
+
+        # test init_device_mesh without mesh_dim_names
+        two_d_mesh = init_device_mesh(self.device_type, mesh_shape)
+        self.assertEqual(two_d_mesh, ref_mesh)
 
 
 class DeviceMeshCollectiveTest(DTensorTestBase):

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -163,13 +163,15 @@ class InitDeviceMeshTest(DTensorTestBase):
         return 8
 
     @with_comms
-    def test_init_device_mesh_with_mesh_dim_names(self):
+    def test_init_device_mesh(self):
         mesh_shape = (2, 4)
         ref_mesh = DeviceMesh(self.device_type, torch.arange(8).view(mesh_shape))
 
         # test init_device_mesh with mesh_dim_names
         mesh_dim_names = ("DP", "TP")
-        two_d_mesh = init_device_mesh(self.device_type, mesh_shape, mesh_dim_names)
+        two_d_mesh = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
         self.assertEqual(two_d_mesh, ref_mesh)
         self.assertEqual(two_d_mesh.mesh_dim_names, mesh_dim_names)
 

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -164,11 +164,11 @@ class InitDeviceMeshTest(DTensorTestBase):
 
     @with_comms
     def test_init_device_mesh_with_mesh_dim_names(self):
-        mesh_shape = [2, 4]
+        mesh_shape = (2, 4)
         ref_mesh = DeviceMesh(self.device_type, torch.arange(8).view(mesh_shape))
 
         # test init_device_mesh with mesh_dim_names
-        mesh_dim_names = ["DP", "TP"]
+        mesh_dim_names = ("DP", "TP")
         two_d_mesh = init_device_mesh(self.device_type, mesh_shape, mesh_dim_names)
         self.assertEqual(two_d_mesh, ref_mesh)
         self.assertEqual(two_d_mesh.mesh_dim_names, mesh_dim_names)

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
-from typing import List, Optional, TYPE_CHECKING, Tuple, Union
+from typing import List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 import torch.distributed as dist
@@ -277,6 +277,7 @@ class DeviceMesh:
 def init_device_mesh(
     device_type: str,
     mesh_shape: Tuple[int],
+    *,
     mesh_dim_names: Optional[Tuple[str]] = None,
 ) -> DeviceMesh:
     """
@@ -288,10 +289,10 @@ def init_device_mesh(
 
     Args:
         device_type (str): device type of the mesh. Currently supports: cpu, cuda/cuda-like.
-        mesh_shape: Tuple[int]: A sequence describes the dimension of the multi-dimesnion array
+        mesh_shape: Tuple[int]: A tuple describes the dimension of the multi-dimesnion array
         that describes the layout of devices.
     Kwargs:
-        mesh_dim_names: Optional[Tuple[str]]: A sequence of mesh dim names to be assigned to each dimension
+        mesh_dim_names: Optional[Tuple[str]]: A tuple of mesh dim names to be assigned to each dimension
         of the multi-dimensional array that describes the layout of devices. Its length must match the length
         of `mesh_shape`.
 
@@ -303,8 +304,8 @@ def init_device_mesh(
 
     Example:
         >>> # xdoctest: +SKIP
-        >>> two_d_mesh = init_device_mesh("cuda", mesh_dims=[2, 8], mesh_dim_names=["dp", "tp"])
-        >>> two_d_mesh = init_device_mesh("cuda", mesh_dims=[2, -1], mesh_dim_names=["dp", "tp"])
+        >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, 8), mesh_dim_names=("dp", "tp"))
+        >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, -1), mesh_dim_names=("dp", "tp"))
     """
     if mesh_dim_names is not None and len(mesh_shape) != len(mesh_dim_names):
         raise RuntimeError(

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -1,9 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
+import math
 from typing import List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
-import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 
 from torch.distributed.distributed_c10d import (
@@ -304,15 +304,16 @@ def init_device_mesh(
 
     Example:
         >>> # xdoctest: +SKIP
+        >>> from torch.distributed._tensor.device_mesh import init_device_mesh
+        >>>
         >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, 8), mesh_dim_names=("dp", "tp"))
-        >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, -1), mesh_dim_names=("dp", "tp"))
     """
     if mesh_dim_names is not None and len(mesh_shape) != len(mesh_dim_names):
         raise RuntimeError(
             f"Please provide a mesh_dim_name to each mesh_dim! Found {len(mesh_dim_names)} instead of {len(mesh_shape)}."
         )
 
-    mesh = torch.arange(dist.get_world_size()).view(mesh_shape)
+    mesh = torch.arange(math.prod(mesh_shape)).view(mesh_shape)
     device_mesh = DeviceMesh(
         device_type=device_type,
         mesh=mesh,

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -103,7 +103,7 @@ class DeviceMesh:
         device_type: str,
         mesh: Union[torch.Tensor, "ArrayLike"],
         *,
-        mesh_dim_names: Optional[Tuple[str]] = None,
+        mesh_dim_names: Optional[Tuple[str, ...]] = None,
         _init_process_groups: bool = True,
         _validate_mesh: bool = True,
     ) -> None:
@@ -276,9 +276,9 @@ class DeviceMesh:
 
 def init_device_mesh(
     device_type: str,
-    mesh_shape: Tuple[int],
+    mesh_shape: Tuple[int, ...],
     *,
-    mesh_dim_names: Optional[Tuple[str]] = None,
+    mesh_dim_names: Optional[Tuple[str, ...]] = None,
 ) -> DeviceMesh:
     """
     Initializes a `DeviceMesh` based on `device_type`, `mesh_shape`, and `mesh_dim_names` parameters.


### PR DESCRIPTION
This PR introduces init_device_mesh() as an API to standardize UX device_mesh initialization.  

The functionality of slicing out a submesh from a given mesh would come in later PRs.