### PR TITLE
[quant][pt2e] Move specific quantizer related things outside of main quant code base (#106806)

### DIFF
--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -18,7 +18,7 @@ from torch._inductor import config
 from torch._inductor.compile_fx import compile_fx
 from torch._inductor.utils import override_lowering, run_and_get_code
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
-from torch.ao.quantization.quantizer import X86InductorQuantizer
+from torch.ao.quantization.quantizer.x86_inductor_quantizer import X86InductorQuantizer
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_quantization import (

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -17,23 +17,24 @@ from torch.ao.quantization import (
     QConfigMapping,
 )
 from torch.ao.quantization.quantizer import (
-    ComposableQuantizer,
     DerivedQuantizationSpec,
-    EmbeddingQuantizer,
     FixedQParamsQuantizationSpec,
-    OperatorConfig,
-    XNNPACKQuantizer,
     QuantizationAnnotation,
     QuantizationSpec,
     Quantizer,
     SharedQuantizationSpec,
 )
+from torch.ao.quantization.quantizer.xnnpack_quantizer import (
+    XNNPACKQuantizer,
+    get_symmetric_quantization_config,
+)
 from torch.ao.quantization.quantizer.composable_quantizer import (  # noqa: F811
     ComposableQuantizer,
 )
-from torch.ao.quantization.quantizer.xnnpack_quantizer import (
-    get_symmetric_quantization_config,
+from torch.ao.quantization.quantizer.embedding_quantizer import (  # noqa: F811
+    EmbeddingQuantizer,
 )
+
 from torch.ao.quantization.quantize_pt2e import (
     _convert_to_reference_decomposed_fx,
     convert_pt2e,
@@ -603,10 +604,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             def validate(self, model: torch.fx.GraphModule) -> None:
                 pass
 
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
-                pass
-
         example_inputs = (torch.randn(1, 3, 5, 5),)
         node_occurrence = {
             # two for input of the first conv, one for output for the first conv
@@ -672,10 +669,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                         )
 
             def validate(self, model: torch.fx.GraphModule) -> None:
-                pass
-
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
                 pass
 
         m = torch.nn.Conv2d(2, 2, 1)
@@ -775,10 +768,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                         )
 
             def validate(self, model: torch.fx.GraphModule) -> None:
-                pass
-
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
                 pass
 
         m = TestHelperModules.ConvMaxPool2d()
@@ -881,10 +870,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             def validate(self, model: torch.fx.GraphModule) -> None:
                 pass
 
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
-                pass
-
         m = TestHelperModules.ConvWithBNRelu(relu=False, bn=False).eval()
         example_inputs = (torch.randn(1, 3, 5, 5),)
 
@@ -956,10 +941,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                         )
 
             def validate(self, model: torch.fx.GraphModule) -> None:
-                pass
-
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
                 pass
 
         m = M().eval()
@@ -1089,9 +1070,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             def validate(self, model: torch.fx.GraphModule) -> None:
                 pass
 
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
-                pass
 
         m = TestHelperModules.Conv2dWithCat().eval()
         example_inputs = (torch.randn(1, 3, 5, 5), torch.randn(1, 3, 5, 5))
@@ -1584,10 +1562,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                     n.meta["quantization_annotation"] = None
 
             def validate(self, model: torch.fx.GraphModule) -> None:
-                pass
-
-            @classmethod
-            def get_supported_operators(cls) -> List[OperatorConfig]:
                 pass
 
         quantizer = XNNPACKQuantizer()

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -3,7 +3,7 @@ import copy
 import torch
 import torch._dynamo as torchdynamo
 import torch.nn as nn
-from torch.ao.quantization.quantizer import (
+from torch.ao.quantization.quantizer.x86_inductor_quantizer import (
     X86InductorQuantizer,
 )
 from torch.ao.quantization.quantize_pt2e import (

--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -16,9 +16,6 @@ from .fx.prepare import prepare as fx_prepare
 from .quantize_fx import _convert_to_reference_decomposed_fx
 from torch.ao.quantization import QConfigMapping
 from torch.ao.quantization.quantizer import (  # noqa: F401
-    OperatorConfig,
-    OperatorPatternType,
-    QuantizationConfig,
     Quantizer,
     QuantizationSpecBase,
     QuantizationSpec,
@@ -26,18 +23,6 @@ from torch.ao.quantization.quantizer import (  # noqa: F401
     SharedQuantizationSpec,
     DerivedQuantizationSpec,
     QuantizationAnnotation,
-    XNNPACKQuantizer,
-    EmbeddingQuantizer,
-    ComposableQuantizer,
-)
-from torch.ao.quantization.quantizer.utils import (  # noqa: F401
-    get_bias_qspec,
-    get_input_act_qspec,
-    get_output_act_qspec,
-    get_weight_qspec,
-)
-from torch.ao.quantization.quantizer.xnnpack_quantizer import (  # noqa: F401
-    get_symmetric_quantization_config,
 )
 from torch.ao.quantization.backend_config import BackendConfig
 

--- a/torch/ao/quantization/quantizer/__init__.py
+++ b/torch/ao/quantization/quantizer/__init__.py
@@ -1,35 +1,21 @@
-from .composable_quantizer import ComposableQuantizer
-from .embedding_quantizer import EmbeddingQuantizer
 from .quantizer import (
     DerivedQuantizationSpec,
     EdgeOrNode,
     FixedQParamsQuantizationSpec,
-    OperatorConfig,
-    OperatorPatternType,
     QuantizationAnnotation,
-    QuantizationConfig,
     QuantizationSpec,
     QuantizationSpecBase,
     Quantizer,
     SharedQuantizationSpec,
 )
-from .x86_inductor_quantizer import X86InductorQuantizer
-from .xnnpack_quantizer import XNNPACKQuantizer
 
 __all__ = [
-    "ComposableQuantizer",
     "EdgeOrNode",
-    "OperatorConfig",
-    "OperatorPatternType",
-    "QuantizationConfig",
-    "EmbeddingQuantizer",
     "Quantizer",
-    "XNNPACKQuantizer",
     "QuantizationSpecBase",
     "QuantizationSpec",
     "FixedQParamsQuantizationSpec",
     "SharedQuantizationSpec",
     "DerivedQuantizationSpec",
     "QuantizationAnnotation",
-    "X86InductorQuantizer",
 ]

--- a/torch/ao/quantization/quantizer/composable_quantizer.py
+++ b/torch/ao/quantization/quantizer/composable_quantizer.py
@@ -6,7 +6,7 @@ import torch
 
 from torch.fx import Node
 
-from .quantizer import OperatorConfig, QuantizationAnnotation, Quantizer
+from .quantizer import QuantizationAnnotation, Quantizer
 
 __all__ = [
     "ComposableQuantizer",
@@ -69,7 +69,3 @@ class ComposableQuantizer(Quantizer):
 
     def validate(self, model: torch.fx.GraphModule) -> None:
         pass
-
-    @classmethod
-    def get_supported_operators(cls) -> List[OperatorConfig]:
-        return []

--- a/torch/ao/quantization/quantizer/embedding_quantizer.py
+++ b/torch/ao/quantization/quantizer/embedding_quantizer.py
@@ -7,12 +7,14 @@ import torch
 import torch.nn.functional as F
 from torch.ao.quantization.observer import PerChannelMinMaxObserver
 from torch.ao.quantization.quantizer.quantizer import (
-    OperatorConfig,
-    OperatorPatternType,
     QuantizationAnnotation,
-    QuantizationConfig,
     QuantizationSpec,
     Quantizer,
+)
+from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
+    OperatorConfig,
+    OperatorPatternType,
+    QuantizationConfig,
 )
 
 __all__ = [

--- a/torch/ao/quantization/quantizer/utils.py
+++ b/torch/ao/quantization/quantizer/utils.py
@@ -1,75 +1,8 @@
-from typing import List, Optional
+from typing import List
 
 import torch
-from torch.ao.quantization.quantizer.quantizer import (
-    QuantizationAnnotation,
-    QuantizationConfig,
-    QuantizationSpec,
-)
+from torch.ao.quantization.quantizer.quantizer import QuantizationAnnotation
 from torch.fx import Node
-
-__all__ = [
-    "get_input_act_qspec",
-    "get_output_act_qspec",
-    "get_weight_qspec",
-    "get_bias_qspec",
-]
-
-
-def get_input_act_qspec(quantization_config: Optional[QuantizationConfig]):
-    if quantization_config is None:
-        return None
-    if quantization_config.input_activation is None:
-        return None
-    quantization_spec: QuantizationSpec = quantization_config.input_activation
-    assert quantization_spec.qscheme in [
-        torch.per_tensor_affine,
-        torch.per_tensor_symmetric,
-    ]
-    return quantization_spec
-
-
-def get_output_act_qspec(quantization_config: Optional[QuantizationConfig]):
-    if quantization_config is None:
-        return None
-    if quantization_config.output_activation is None:
-        return None
-    quantization_spec: QuantizationSpec = quantization_config.output_activation
-    assert quantization_spec.qscheme in [
-        torch.per_tensor_affine,
-        torch.per_tensor_symmetric,
-    ]
-    return quantization_spec
-
-
-def get_weight_qspec(quantization_config: Optional[QuantizationConfig]):
-    if quantization_config is None:
-        return None
-    assert quantization_config is not None
-    if quantization_config.weight is None:
-        return None
-    quantization_spec: QuantizationSpec = quantization_config.weight
-    if quantization_spec.qscheme not in [
-        torch.per_tensor_symmetric,
-        torch.per_channel_symmetric,
-    ]:
-        raise ValueError(
-            f"Unsupported quantization_spec {quantization_spec} for weight"
-        )
-    return quantization_spec
-
-
-def get_bias_qspec(quantization_config: Optional[QuantizationConfig]):
-    if quantization_config is None:
-        return None
-    assert quantization_config is not None
-    if quantization_config.bias is None:
-        return None
-    quantization_spec: QuantizationSpec = quantization_config.bias
-    assert (
-        quantization_spec.dtype == torch.float
-    ), "Only float dtype for bias is supported for bias right now"
-    return quantization_spec
 
 
 def _annotate_input_qspec_map(node: Node, input_node: Node, qspec):

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -13,26 +13,22 @@ from torch.ao.quantization.observer import (
 )
 from torch.ao.quantization.pt2e.graph_utils import find_sequential_partitions
 from torch.ao.quantization.qconfig import _ObserverOrFakeQuantizeConstructor
-from torch.ao.quantization.quantizer.utils import (
+from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
+    _is_annotated,
     get_bias_qspec,
     get_input_act_qspec,
     get_output_act_qspec,
     get_weight_qspec,
+    OperatorConfig,
+    OperatorPatternType,
+    QuantizationConfig,
 )
 from torch.fx import Node
 from torch.fx.passes.utils.source_matcher_utils import (
     get_source_partitions,
     SourcePartition,
 )
-from .quantizer import (
-    OperatorConfig,
-    OperatorPatternType,
-    QuantizationAnnotation,
-    QuantizationConfig,
-    QuantizationSpec,
-    Quantizer,
-)
-from .xnnpack_quantizer_utils import _is_annotated
+from .quantizer import QuantizationAnnotation, QuantizationSpec, Quantizer
 
 __all__ = [
     "X86InductorQuantizer",

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -20,17 +20,16 @@ from torch.ao.quantization.observer import (
 
 from torch.ao.quantization.qconfig import _ObserverOrFakeQuantizeConstructor
 
-from torch.fx import Node
+from torch.ao.quantization.quantizer import QuantizationSpec, Quantizer
 
-from .quantizer import (
+from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
+    OP_TO_ANNOTATOR,
     OperatorConfig,
     OperatorPatternType,
     QuantizationConfig,
-    QuantizationSpec,
-    Quantizer,
 )
 
-from .xnnpack_quantizer_utils import OP_TO_ANNOTATOR
+from torch.fx import Node
 
 
 __all__ = [

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -1,28 +1,67 @@
 import itertools
 import operator
-from typing import Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Callable, Dict, List, NamedTuple, Optional
 
 import torch
 import torch.nn.functional as F
 from torch.ao.quantization.pt2e.graph_utils import find_sequential_partitions
-from torch.ao.quantization.quantizer import QuantizationSpecBase, SharedQuantizationSpec
+from torch.ao.quantization.quantizer import (
+    QuantizationAnnotation,
+    QuantizationSpec,
+    QuantizationSpecBase,
+    SharedQuantizationSpec,
+)
 
-# TODO: move these to this file
 from torch.ao.quantization.quantizer.utils import (
     _annotate_input_qspec_map,
     _annotate_output_qspec,
     _is_sym_size_node,
     _node_only_used_for_sym_size,
-    get_bias_qspec,
-    get_input_act_qspec,
-    get_output_act_qspec,
-    get_weight_qspec,
 )
 from torch.fx import Node
 from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
 
-# TODO: move QuantizationConfig here
-from .quantizer import QuantizationAnnotation, QuantizationConfig
+
+__all__ = [
+    "OperatorConfig",
+    "OperatorPatternType",
+    "QuantizationConfig",
+    "get_input_act_qspec",
+    "get_output_act_qspec",
+    "get_weight_qspec",
+    "get_bias_qspec",
+]
+
+
+# In the absence of better name, just winging it with QuantizationConfig
+@dataclass(eq=True, frozen=True)
+class QuantizationConfig:
+    input_activation: Optional[QuantizationSpec]
+    output_activation: Optional[QuantizationSpec]
+    weight: Optional[QuantizationSpec]
+    bias: Optional[QuantizationSpec]
+    # TODO: remove, since we can use observer_or_fake_quant_ctr to express this
+    is_qat: bool = False
+
+
+OperatorPatternType = List[Callable]
+OperatorPatternType.__module__ = (
+    "torch.ao.quantization.quantizer.xnnpack_quantizer_utils"
+)
+
+
+class OperatorConfig(NamedTuple):
+    # fix List[str] with List[List[Union[nn.Module, FunctionType, BuiltinFunctionType]]]
+    # Basically we are mapping a quantization config to some list of patterns.
+    # a pattern is defined as a list of nn module, function or builtin function names
+    # e.g. [nn.Conv2d, torch.relu, torch.add]
+    # We have not resolved whether fusion can be considered internal details of the
+    # quantizer hence it does not need communication to user.
+    # Note this pattern is not really informative since it does not really
+    # tell us the graph structure resulting from the list of ops.
+    config: QuantizationConfig
+    operators: List[OperatorPatternType]
 
 
 # make everything private for now
@@ -50,6 +89,62 @@ def _mark_nodes_as_annotated(nodes: List[Node]):
             if "quantization_annotation" not in node.meta:
                 node.meta["quantization_annotation"] = QuantizationAnnotation()
             node.meta["quantization_annotation"]._annotated = True
+
+
+def get_input_act_qspec(quantization_config: Optional[QuantizationConfig]):
+    if quantization_config is None:
+        return None
+    if quantization_config.input_activation is None:
+        return None
+    quantization_spec: QuantizationSpec = quantization_config.input_activation
+    assert quantization_spec.qscheme in [
+        torch.per_tensor_affine,
+        torch.per_tensor_symmetric,
+    ]
+    return quantization_spec
+
+
+def get_output_act_qspec(quantization_config: Optional[QuantizationConfig]):
+    if quantization_config is None:
+        return None
+    if quantization_config.output_activation is None:
+        return None
+    quantization_spec: QuantizationSpec = quantization_config.output_activation
+    assert quantization_spec.qscheme in [
+        torch.per_tensor_affine,
+        torch.per_tensor_symmetric,
+    ]
+    return quantization_spec
+
+
+def get_weight_qspec(quantization_config: Optional[QuantizationConfig]):
+    if quantization_config is None:
+        return None
+    assert quantization_config is not None
+    if quantization_config.weight is None:
+        return None
+    quantization_spec: QuantizationSpec = quantization_config.weight
+    if quantization_spec.qscheme not in [
+        torch.per_tensor_symmetric,
+        torch.per_channel_symmetric,
+    ]:
+        raise ValueError(
+            f"Unsupported quantization_spec {quantization_spec} for weight"
+        )
+    return quantization_spec
+
+
+def get_bias_qspec(quantization_config: Optional[QuantizationConfig]):
+    if quantization_config is None:
+        return None
+    assert quantization_config is not None
+    if quantization_config.bias is None:
+        return None
+    quantization_spec: QuantizationSpec = quantization_config.bias
+    assert (
+        quantization_spec.dtype == torch.float
+    ), "Only float dtype for bias is supported for bias right now"
+    return quantization_spec
 
 
 def _annotate_linear(


### PR DESCRIPTION
Summary:

Currently in quantizer/quantize_pt2e we import things from specific quantizers (XNNPACKQuantizer, QuantizationConfig) etc.
this PR removes them so it's clearer that they are not part of the core quantization code base

This PR also removed get_supported_operators from main Quantizer since we haven't seen a clear need for this API

Test Plan:
CIs

Imported from OSS

Differential Revision: D48340367



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov