### PR TITLE
Fix batch_norm_cpu to check the sizes of tensors

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -209,6 +209,22 @@ std::tuple<Tensor,Tensor> batch_norm_cpu_update_stats_template(
   auto save_mean_a = save_mean.accessor<param_t, 1>();
   auto save_var_transform_a = save_var_transform.accessor<param_t, 1>();
 
+  if (running_mean.defined()) {
+    TORCH_CHECK(
+        running_mean.size(0) == n_input,
+        "Running mean is not the right number of channels: ",
+        running_mean.size(0),
+        " != ",
+        n_input);
+  }
+  if (running_var.defined()) {
+    TORCH_CHECK(
+        running_var.size(0) == n_input,
+        "Running variance is not the right number of channels: ",
+        running_var.size(0),
+        " != ",
+        n_input);
+  }
   auto running_mean_a = conditional_accessor_1d<param_t>(running_mean);
   auto running_var_a = conditional_accessor_1d<param_t>(running_var);
 

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -34,6 +34,38 @@ void batch_norm_cpu_collect_linear_and_constant_terms(
     const Tensor& save_mean, const Tensor& save_invstd,
     const Tensor& running_mean, const Tensor& running_var, bool train, double eps) {
 
+  if (weight.defined()) {
+    TORCH_CHECK(
+        weight.size(0) == n_channel,
+        "Weight is not the right number of channels: ",
+        weight.size(0),
+        " != ",
+        n_channel);
+  }
+  if (bias.defined()) {
+    TORCH_CHECK(
+        bias.size(0) == n_channel,
+        "Bias is not the right number of channels: ",
+        bias.size(0),
+        " != ",
+        n_channel);
+  }
+  if (running_mean.defined()) {
+    TORCH_CHECK(
+        running_mean.size(0) == n_channel,
+        "Running mean is not the right number of channels: ",
+        running_mean.size(0),
+        " != ",
+        n_channel);
+  }
+  if (running_var.defined()) {
+    TORCH_CHECK(
+        running_var.size(0) == n_channel,
+        "Running variance is not the right number of channels: ",
+        running_var.size(0),
+        " != ",
+        n_channel);
+  }
   const param_t* weight_data = weight.defined() ? weight.data_ptr<param_t>() : nullptr;
   const param_t* bias_data = bias.defined() ? bias.data_ptr<param_t>() : nullptr;
 


### PR DESCRIPTION
When using `torch.ops.aten._native_batch_norm_legit.default` directly, if you accidentally pass the wrong shape of input tensors for weight, bias, or the stats, you get an ASAN exception on reading out of bounds from an accessor.
Instead, it should have a digestible error message that avoids memory corruption bugs.

Add a `TORCH_CHECK` that all of the inputs have the right dimensionality. This will raise a RuntimeError to python
if the check is violated. This behavior matches that of `F.batch_norm` which also uses `TORCH_CHECK` on the dimensionality
of its input tensors.

Added these error inputs as a unit test

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10