### PR TITLE
fix: flake8-bugbear code B024

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,7 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B020,B023,B024,B026,B028,B903,B904,B905,B906,B907
+    B007,B008,B017,B019,B020,B023,B026,B028,B903,B904,B905,B906,B907
     # these ignores are from flake8-comprehensions; please fix!
     C407,
     # these ignores are from flake8-logging-format; please fix!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ ignore = [
     "B007", "B008", "B017",
     "B018", # Useless expression
     "B019", "B020",
-    "B023", "B024", "B026",
+    "B023", "B026",
     "B028", # No explicit `stacklevel` keyword argument found
     "B904",
     "E402",

--- a/torch/ao/quantization/fx/quantize_handler.py
+++ b/torch/ao/quantization/fx/quantize_handler.py
@@ -17,7 +17,7 @@ from torch.ao.quantization.utils import (
     QuantizerCls,
 )
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Type, Optional
 
 __all__ = [
@@ -77,6 +77,7 @@ class QuantizeHandler(ABC):
                             arg, self.modules, cache_for_no_tensor_check)):
                     self.num_tensor_args += 1
 
+    @abstractmethod
     def is_general_tensor_value_op(self) -> bool:
         """
         Returns True if the operator works for both floating point and
@@ -94,9 +95,11 @@ class QuantizeHandler(ABC):
         """
         return False
 
+    @abstractmethod
     def is_custom_module(self):
         return self.is_custom_module_
 
+    @abstractmethod
     def is_standalone_module(self):
         return self.is_standalone_module_
 

--- a/torch/ao/quantization/fx/quantize_handler.py
+++ b/torch/ao/quantization/fx/quantize_handler.py
@@ -39,7 +39,7 @@ def _default_root_node_getter(node_pattern):
     return node_pattern
 
 # Base Pattern Handler
-class QuantizeHandler(ABC): # noqa: B024
+class QuantizeHandler(ABC):  # noqa: B024
     """ Base handler class for the quantizer patterns
     """
     def __init__(

--- a/torch/ao/quantization/fx/quantize_handler.py
+++ b/torch/ao/quantization/fx/quantize_handler.py
@@ -17,7 +17,7 @@ from torch.ao.quantization.utils import (
     QuantizerCls,
 )
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Callable, Dict, List, Type, Optional
 
 __all__ = [
@@ -77,7 +77,6 @@ class QuantizeHandler(ABC):
                             arg, self.modules, cache_for_no_tensor_check)):
                     self.num_tensor_args += 1
 
-    @abstractmethod
     def is_general_tensor_value_op(self) -> bool:
         """
         Returns True if the operator works for both floating point and
@@ -95,11 +94,9 @@ class QuantizeHandler(ABC):
         """
         return False
 
-    @abstractmethod
     def is_custom_module(self):
         return self.is_custom_module_
 
-    @abstractmethod
     def is_standalone_module(self):
         return self.is_standalone_module_
 

--- a/torch/ao/quantization/fx/quantize_handler.py
+++ b/torch/ao/quantization/fx/quantize_handler.py
@@ -1,24 +1,18 @@
-import torch
-from torch.fx.graph import (
-    Node,
-)
+from abc import ABC
+from typing import Callable, Dict, List, Optional, Type
 
-from .utils import (
-    all_node_args_have_no_tensors,
-)
+import torch
+
 from torch.ao.quantization.backend_config import (
     BackendConfig,
     DTypeConfig,
     ObservationType,
 )
-from torch.ao.quantization.utils import (
-    NodePattern,
-    Pattern,
-    QuantizerCls,
-)
+from torch.ao.quantization.utils import NodePattern, Pattern, QuantizerCls
+from torch.fx.graph import Node
 
-from abc import ABC
-from typing import Callable, Dict, List, Type, Optional
+from .utils import all_node_args_have_no_tensors
+
 
 __all__ = [
     "QuantizeHandler",
@@ -45,7 +39,7 @@ def _default_root_node_getter(node_pattern):
     return node_pattern
 
 # Base Pattern Handler
-class QuantizeHandler(ABC):
+class QuantizeHandler(ABC): # noqa: B024
     """ Base handler class for the quantizer patterns
     """
     def __init__(

--- a/torch/ao/quantization/quantizer/quantizer.py
+++ b/torch/ao/quantization/quantizer/quantizer.py
@@ -37,7 +37,7 @@ SUPPORTED_QSCHEMES = [
 ]
 
 
-class QuantizationSpecBase(ABC):
+class QuantizationSpecBase(ABC):  # noqa: B024
     """Base class for different types of quantization specs that allows users to
     specify how to quantize a Tensor (input/output of a Node) in the model
     """

--- a/torch/distributed/_shard/sharding_spec/api.py
+++ b/torch/distributed/_shard/sharding_spec/api.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     # from run-time to resolve circular dependency.
     from torch.distributed._shard.sharded_tensor import ShardedTensor
 
-class PlacementSpec(ABC):
+class PlacementSpec(ABC):  # noqa: B024
     """
     Base class representing the placement of an entity. Subclasses of this
     class can be used to specify customized placements which might not be

--- a/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
+++ b/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 import inspect
 from typing import Dict, Type
 
@@ -39,12 +39,14 @@ class OverlappedOptimizer(ABC):
         """
         self.optim_cls = optim_cls
 
+    @abstractmethod
     def register_ddp(self, ddp: DistributedDataParallel) -> None:
         """Registers the overlapped optimizer with DDP."""
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support overlapped DDP."
         )
 
+    @abstractmethod
     def register_fsdp(self, fsdp: FullyShardedDataParallel) -> None:
         """Registers the overlapped optimizer with FSDP."""
         raise NotImplementedError(

--- a/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
+++ b/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
@@ -72,7 +72,11 @@ class _OverlappedStandardOptimizer(OverlappedOptimizer):
         )
 
     # TODO: register_fsdp once FSDP supports communication hook.
-
+    def register_fsdp(self, fsdp: FullyShardedDataParallel) -> None:
+        """Registers the overlapped optimizer with FSDP."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support overlapped FSDP."
+        )
 
 def _as_overlapped_optim(optim_cls: Type, params, *args, **kwargs):
     """

--- a/torch/onnx/_internal/fx/_pass.py
+++ b/torch/onnx/_internal/fx/_pass.py
@@ -296,7 +296,7 @@ class Transform(abc.ABC):
         return module
 
 
-class AnalysisResult(abc.ABC):
+class AnalysisResult(abc.ABC):  # noqa: B024
     ...
 
 

--- a/torchgen/api/types/types_base.py
+++ b/torchgen/api/types/types_base.py
@@ -12,7 +12,7 @@ if we want to generate code for another C++ library.
 Add new types to `types.py` if these types are ATen/c10 related.
 Add new types to `types_base.py` if they are basic and not attached to ATen/c10.
 """
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import auto, Enum
 from typing import List, Optional, Union
@@ -61,12 +61,15 @@ voidT = BaseCppType("", "void")
 
 
 class CType(ABC):
+    @abstractmethod
     def cpp_type(self, *, strip_ref: bool = False) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def cpp_type_registration_declarations(self) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def remove_const_ref(self) -> "CType":
         return self
 


### PR DESCRIPTION
See #106571 item B024

This fix concerns the addition of `abstractmethod` to methods declared inside abstract classes.

Should I also include PEP8 compliant reformatting on the files I had to modify ?