### PR TITLE
Fix native_batch_norm_backward returning non-channels_last_3d grad

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -211,7 +211,7 @@ Tensor batch_norm_elementwise_backward_train(
     auto weight_nd = weight.defined() ? as_nd(weight) :
         at::scalar_tensor(1.0, input.options().dtype(mean.scalar_type()));
 
-    Tensor grad_input = Tensor grad_input = at::empty(input.sizes(), grad_out.options()).to(input.suggest_memory_format());
+    Tensor grad_input = at::empty(input.sizes(), grad_out.options()).to(input.suggest_memory_format());
     auto iter = TensorIteratorConfig()
         .add_output(grad_input)
         .add_input(grad_out)

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -211,7 +211,7 @@ Tensor batch_norm_elementwise_backward_train(
     auto weight_nd = weight.defined() ? as_nd(weight) :
         at::scalar_tensor(1.0, input.options().dtype(mean.scalar_type()));
 
-    Tensor grad_input = at::empty(input.sizes(), grad_out.options());
+    Tensor grad_input = Tensor grad_input = at::empty(input.sizes(), grad_out.options()).to(input.suggest_memory_format());
     auto iter = TensorIteratorConfig()
         .add_output(grad_input)
         .add_input(grad_out)

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -211,7 +211,7 @@ Tensor batch_norm_elementwise_backward_train(
     auto weight_nd = weight.defined() ? as_nd(weight) :
         at::scalar_tensor(1.0, input.options().dtype(mean.scalar_type()));
 
-    Tensor grad_input = at::empty(input.sizes(), grad_out.options()).to(input.suggest_memory_format());
+    Tensor grad_input = at::empty(input.sizes(), grad_out.options().memory_format(input.suggest_memory_format()));
     auto iter = TensorIteratorConfig()
         .add_output(grad_input)
         .add_input(grad_out)


### PR DESCRIPTION
Fix #107199

Checked out https://github.com/pytorch/pytorch/pull/106104 which caught this locally and verified that https://github.com/pytorch/pytorch/blob/551124f67090b7c672e9833ed10f41d31c57747c/torch/testing/_internal/common_modules.py#L2635-L2642 with the `p['device'] == 'cuda'` part shifted to `device_type = 'cuda'` now succeeds

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107270

