### PR TITLE
[AOTInductor] Proxy Executor for Extern Fallback kernels

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -903,6 +903,7 @@ struct TORCH_API ListType
   static ListTypePtr ofComplexDoubles();
   static ListTypePtr ofBools();
   static ListTypePtr ofStrings();
+  static ListTypePtr ofNumbers();
 
  private:
   ListType(TypePtr elem) : SingleElementType(std::move(elem)) {}

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -268,6 +268,10 @@ ListTypePtr ListType::ofStrings() {
   static auto value = ListType::create(StringType::get());
   return value;
 }
+ListTypePtr ListType::ofNumbers() {
+  static auto value = ListType::create(NumberType::get());
+  return value;
+}
 
 TypePtr OptionalType::get(TypePtr inner) {
   static ska::flat_hash_map<TypePtr, TypePtr> containerTypePtrs;

--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -58,13 +58,17 @@ TEST(AotInductorTest, BasicTest) {
       reinterpret_cast<AOTInductorTensorHandle>(inputs.data());
   AOTInductorTensorHandle outputs_handle =
       reinterpret_cast<AOTInductorTensorHandle>(outputs.data());
+
+  AOTInductorProxyExecutorHandle proxy_executor_handle = nullptr;
+
   AOT_INDUCTOR_ERROR_CHECK(AOTInductorModelContainerRun(
       container_handle,
       inputs_handle,
       inputs.size(),
       outputs_handle,
       outputs.size(),
-      stream_handle));
+      stream_handle,
+      proxy_executor_handle));
 
   ASSERT_TRUE(torch::allclose(results_ref, outputs[0]));
   AOT_INDUCTOR_ERROR_CHECK(AOTInductorModelContainerDelete(container_handle));

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -523,6 +523,8 @@ class GraphModuleSerializer:
         )
 
     def serialize_input(self, arg) -> Argument:
+        import torch._inductor.ir as inductor_ir
+
         if isinstance(arg, torch.fx.Node):
             if arg.op == "get_attr":
                 assert isinstance(arg.target, str)
@@ -535,6 +537,13 @@ class GraphModuleSerializer:
                 return Argument.create(as_sym_bool=SymBoolArgument.create(as_name=arg.name))
             else:
                 return Argument.create(as_tensor=TensorArgument(name=arg.name))
+        elif isinstance(arg, (inductor_ir.InputBuffer, inductor_ir.ComputedBuffer)):
+            # Other branches are for arguments in fx node.
+            # This is a special branch for handling buffers (representing tensor arguments)
+            # for inductor's ExternalFallbackNode
+            # export_extern_kernel_node() is using this function to serialize arguments
+            assert arg.name is not None, "Input buffer must have valid name"
+            return Argument.create(as_tensor=TensorArgument(name=arg.name))
         elif isinstance(arg, bool):
             return Argument.create(as_bool=arg)
         elif isinstance(arg, str):
@@ -578,11 +587,29 @@ class GraphModuleSerializer:
                 return Argument.create(
                     as_tensors=[TensorArgument(name=a.name) for a in arg],
                 )
-            elif any(isinstance(a, torch.fx.Node) for a in arg):
+            elif all(isinstance(a, (torch.fx.Node, type(None))) for a in arg):
+                # list of optional tensors
                 def serialize_optional_tensor_args(a):
                     if a is None:
                         return OptionalTensorArgument.create(as_none=())
                     elif isinstance(a, torch.fx.Node):
+                        return OptionalTensorArgument.create(as_tensor=a.name)
+                    else:
+                        raise SerializeError(f"Unsupported list/tuple argument: {a}")
+                return Argument.create(
+                    as_optional_tensors=list(map(serialize_optional_tensor_args, arg))
+                )
+            elif all(isinstance(a, (inductor_ir.InputBuffer, inductor_ir.ComputedBuffer)) for a in arg):
+                # list of tensors
+                return Argument.create(
+                    as_tensors=[TensorArgument(name=a.name) for a in arg],
+                )
+            elif all(isinstance(a, (inductor_ir.InputBuffer, inductor_ir.ComputedBuffer, type(None))) for a in arg):
+                # list of optional tensors
+                def serialize_optional_tensor_args(a):
+                    if a is None:
+                        return OptionalTensorArgument.create(as_none=())
+                    elif isinstance(a, torch._inductor.ir.InputBuffer):
                         return OptionalTensorArgument.create(as_tensor=a.name)
                     else:
                         raise SerializeError(f"Unsupported list/tuple argument: {a}")

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -49,7 +49,13 @@ def aot_compile(
         gm,
         example_inputs,
         config_patches=options,
-    )()
+    )
+
+    # AOTInductor returns result as a string, not callable
+    # Maybe this check is not neded?
+    if callable(result):
+        result = result()
+
     lib_path = result[0] if isinstance(result, (list, tuple)) else result
     return lib_path
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -933,7 +933,7 @@ class AotCodeCache:
     clear = staticmethod(cache.clear)
 
     @classmethod
-    def compile(cls, graph, source_code, cuda):
+    def compile(cls, graph, source_code, serialized_extern_kernel_nodes, cuda):
         # TODO: update cpp_compile_command for different platforms
         picked_vec_isa = invalid_vec_isa if cuda else pick_vec_isa()
         cpp_command = repr(
@@ -953,6 +953,13 @@ class AotCodeCache:
             lock_dir = get_lock_dir()
             lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
             with lock:
+                # Currently, this only support serializing extern nodes in fbcode
+                # Eventually, we should also have a serializer for OSS.
+                if config.is_fbcode() and serialized_extern_kernel_nodes:
+                    output_json = os.path.splitext(input_path)[0] + ".json"
+                    with open(output_json, "w") as f:
+                        f.write(serialized_extern_kernel_nodes)
+
                 output_so = os.path.splitext(input_path)[0] + ".so"
 
                 if not os.path.exists(output_so):

--- a/torch/_inductor/codegen/aot_inductor_interface.cpp
+++ b/torch/_inductor/codegen/aot_inductor_interface.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/inductor/aot_inductor_interface.h>
 #include <torch/csrc/inductor/aot_inductor_model_container.h>
 #include <iostream>
+#include <torch/csrc/inductor/proxy_executor.h>
 #include <stdexcept>
 #include <vector>
 
@@ -49,7 +50,8 @@ AOTInductorError AOTInductorModelContainerRun(
     size_t num_inputs,
     AOTInductorTensorHandle outputs_handle,
     size_t num_outputs,
-    AOTInductorStreamHandle stream_handle) {
+    AOTInductorStreamHandle stream_handle,
+    AOTInductorProxyExecutorHandle proxy_executor_handle) {
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
@@ -69,8 +71,11 @@ AOTInductorError AOTInductorModelContainerRun(
   }
 
   auto stream = reinterpret_cast<cudaStream_t>(stream_handle);
+
+  torch::aot_inductor::ProxyExecutor* proxy_executor = reinterpret_cast<torch::aot_inductor::ProxyExecutor*>(proxy_executor_handle);
+
   CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { container->run(input_tensors, output_tensors, stream); })
+      { container->run(input_tensors, output_tensors, stream, proxy_executor); })
 }
 
 AOTInductorError AOTInductorModelContainerGetNumInputs(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -110,10 +110,16 @@ VECTORIZABLE_RTYPES = {
 }
 
 PYTHON_TO_CPP = {
+    "Tensor": "at::Tensor",
     "int": "long",
     "float": "double",
     "bool": "bool",
+    "str": "std::string",
     "ScalarType": "c10::ScalarType",
+    "MemoryFormat": "at::MemoryFormat",
+    "Layout": "at::Layout",
+    "Device": "at::Device",
+    "number": "at::Scalar",
 }
 
 CONTAINER_PYTHON_TO_CPP = {

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -28,11 +28,14 @@ from unittest.mock import patch
 import sympy
 from sympy import Expr, Integer
 
+import torch._export.serde.schema as export_schema
+
 import torch._logging
 
 import torch.fx
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import identity
+from torch._export.serde.serialize import GraphModuleSerializer
 from torch._prims_common import (
     compute_required_storage_length,
     is_boolean_dtype,
@@ -3565,6 +3568,12 @@ class DynamicScalar(IRNode):
 
 
 @dataclasses.dataclass
+class ExternKernelNode:
+    name: str
+    node: export_schema.Node
+
+
+@dataclasses.dataclass
 class FallbackKernel(ExternKernelAlloc):
     def __init__(
         self,
@@ -3582,6 +3591,8 @@ class FallbackKernel(ExternKernelAlloc):
             tuple(nontensor_args),
         )
         self.use_cpp_op_schema = False
+
+        self.op_overload = kernel
 
         op_overload_packet = (
             kernel._overloadpacket
@@ -3690,8 +3701,48 @@ class FallbackKernel(ExternKernelAlloc):
             return devices[0]
         return None
 
+    # ProxyExecutor Design Note
+    # We export the ExternFallbackNodes (for custom ops) into a serialized file
+    # and run it with a host side proxy executor to address the ABI problem
+    # This is currently only implemented for fbcode. Eventually, we will also make this work for OSS.
+    # Detailed design doc can be found at
+    # https://docs.google.com/document/d/1wC4DOZFaYym2t1Esz0X5yxlLI3RDnSiyRbUus3bkJ64/edit?usp=sharing
+    def export_extern_kernel_node(self):
+        args, kwargs = self.unflatten_args(self.inputs, self.constant_args)
+        ordered_kwargs = [
+            kwargs.get(key, None) for key in self.ordered_kwargs_for_cpp_kernel
+        ]
+
+        serializer = GraphModuleSerializer(None, None, None)
+        named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
+
+        # TODO: only single output is supported
+        output_arguments = [
+            export_schema.Argument.create(
+                as_tensor=export_schema.TensorArgument(name=self.get_name())
+            )
+        ]
+
+        node = ExternKernelNode(
+            name=self.get_name(),
+            node=export_schema.Node(
+                target=self.kernel,
+                inputs=named_arguments,
+                outputs=output_arguments,
+                metadata={},
+            ),
+        )
+
+        V.graph.extern_kernel_nodes.append(node)
+
+        return [*args, *ordered_kwargs]
+
     def codegen(self, wrapper):
         if self.use_cpp_op_schema:
+            exported_args = None
+            if config.is_fbcode():
+                exported_args = self.export_extern_kernel_node()
+
             args = [*self.codegen_args(), *self.codegen_kwargs()]
             wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
                 self.get_name(),
@@ -3700,6 +3751,8 @@ class FallbackKernel(ExternKernelAlloc):
                 self.cpp_op_schema,
                 self.cpp_kernel_key,
                 self.cpp_kernel_overlad_name,
+                self.op_overload,
+                exported_args,
             )
         else:
             super().codegen(wrapper)

--- a/torch/csrc/inductor/aot_inductor_interface.h
+++ b/torch/csrc/inductor/aot_inductor_interface.h
@@ -44,6 +44,9 @@ using AOTInductorStreamHandle = AOTInductorStreamOpaque*;
 struct AOTInductorTensorOpaque {};
 using AOTInductorTensorHandle = AOTInductorTensorOpaque*;
 
+struct AOTInductorProxyExecutorOpaque {};
+using AOTInductorProxyExecutorHandle = AOTInductorProxyExecutorOpaque*;
+
 extern "C" {
 // Creates an AOTInductor model container. The parameter num_models
 // specifies the number of model instances that may be run concurrently for
@@ -63,7 +66,8 @@ AOTInductorError AOTInductorModelContainerRun(
     size_t num_inputs,
     AOTInductorTensorHandle outputs_handle,
     size_t num_outputs,
-    AOTInductorStreamHandle stream_handle);
+    AOTInductorStreamHandle stream_handle,
+    AOTInductorProxyExecutorHandle proxy_executor_handle);
 
 // Retrieves the number of inputs for the model.
 AOTInductorError AOTInductorModelContainerGetNumInputs(

--- a/torch/csrc/inductor/aot_inductor_model_container.h
+++ b/torch/csrc/inductor/aot_inductor_model_container.h
@@ -5,6 +5,7 @@
 #include <shared_mutex>
 
 #include <torch/csrc/inductor/aot_inductor_model.h>
+#include <torch/csrc/inductor/proxy_executor.h>
 
 namespace torch {
 namespace aot_inductor {
@@ -56,12 +57,13 @@ class AOTInductorModelContainer {
   void run(
       const std::vector<at::Tensor>& inputs,
       std::vector<at::Tensor>& outputs,
-      cudaStream_t stream) {
+      cudaStream_t stream,
+      ProxyExecutor* proxy_executor) {
     auto* model = get_available_model();
     try {
       AOT_VECTOR_SIZE_CHECK(inputs, num_inputs());
       AOT_VECTOR_SIZE_CHECK(outputs, num_outputs());
-      model->run(inputs, outputs, stream);
+      model->run(inputs, outputs, stream, proxy_executor);
     } catch (...) {
       std::lock_guard lk(models_mutex_);
       available_models_.push_back(model);

--- a/torch/csrc/inductor/proxy_executor.h
+++ b/torch/csrc/inductor/proxy_executor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <ATen/core/ivalue.h>
+#include <c10/macros/Export.h>
+#include <string>
+
+namespace torch {
+namespace aot_inductor {
+
+class TORCH_API ProxyExecutor : public torch::CustomClassHolder {
+ public:
+  ProxyExecutor() {}
+  virtual ~ProxyExecutor() {}
+
+  virtual void call_function(
+      int extern_node_index,
+      int num_ints,
+      int64_t* flatten_int_args,
+      int num_tensors,
+      void** flatten_tensor_args) = 0;
+};
+
+} // namespace aot_inductor
+} // namespace torch


### PR DESCRIPTION
Summary:
This is a prototype for running extern fallback kernels with a host side proxy executor.

Sample of generated cpp wrapper call:
```
        at::Tensor buf0;  // output buffer
        void* tensor_args_var_0[] = {&arg0_1, &arg0_1, &arg1_1, &arg0_1, &arg1_1, &buf0};
        int64_t int_args_var_1[] = {81, 81, 7, 7, 7, 81};
        proxy_executor->call_function("buf0", int_args_var_1, tensor_args_var_0);
```

- In my current implementation, proxy executor interprets the raw pointers according to the ops schema.
This assumes that custom op MUST have a valid schema registered to Dispatcher. (I would like to validate this assumption)
- I am using callboxed() API of the custom kernels. This is inevitable, as we wish to have a single call_function API for all possible custom kernels.

- These are all the input argument types I have support so far.
       union Argument {
         # Bool value does not matter
         1: bool asNone;
         2: TensorArgument asTensor;
         3: list<TensorArgument> asTensors;
         5: i64 asInt;
         7: list<i64> asInts;
         8: double asFloat;
         9: list<double> asFloats;
         10: string asString;
         10.5: list<string> asStrings;
         11: SymIntArgument asSymInt;
         12: list<SymIntArgument> asSymInts;
         13: ScalarType asScalarType;
         14: MemoryFormat asMemoryFormat;
         15: Layout asLayout;
         16: Device asDevice;
         17: bool asBool;
         18: list<bool> asBools;
       }

- Need a policy for handling unpopulated argument with default values. Here are the options, and it has BC  implications.
1. requires exported fx graph to explicitly populate default values, if users doesn't specify.
2. requires cpp wrapper to explicitly populate default values, if fx graph doesn't specify.
3. Proxy executor look up from opSchema for default values.

Test Plan:
frontend:
buck2 run mode/dev-sand mode/inplace -c fbcode.enable_gpu_sections=True sigmoid/frontend:export_main

test:
 buck2 run mode/dev-sand //deeplearning/aot_inductor/test:test_custom_ops

backend:
buck2 run mode/dev-nosan //deeplearning/aot_inductor/fb:main

Differential Revision: D48006843



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov


ShipIt is confused by this PR. Since the original diff was reverted and the PR was never merged, adding:
@diff-train-skip-merge