### PR TITLE
Allow float dtype when Autocast CPU Disabled

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -161,9 +161,6 @@ at::ScalarType get_autocast_privateuseone_dtype() {
 }
 
 void set_autocast_cpu_dtype(at::ScalarType dtype) {
-  TORCH_CHECK(
-      dtype == at::kBFloat16,
-      "Currently, AutocastCPU only support Bfloat16 as the autocast_cpu_dtype");
   autocast_cpu_dtype = dtype;
 }
 

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -258,7 +258,7 @@ class autocast:
 
         if self.device == "cpu":
             supported_dtype = [torch.bfloat16]
-            if self.fast_dtype not in supported_dtype:
+            if self.fast_dtype not in supported_dtype and enabled:
                 error_message = "In CPU autocast, but the target dtype is not supported. Disabling autocast.\n"
                 error_message += (
                     "CPU Autocast only supports dtype of torch.bfloat16 currently."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):

**Summary**
Fix the https://github.com/pytorch/pytorch/issues/100565 by allowing float32 data type when Autocast CPU is disabled.

**Test Plan**
```
python -u -m pytest -s -v test_autocast.py -k test_autocast_disabled_with_fp32_dtype
```

cc @mcarilli @ptrblck @jgong5