### PR TITLE
Use CUDA 12.1.1 patch version in CI

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -87,7 +87,7 @@ _UCC_COMMIT=7cb07a76ccedad7e56ceb136b865eb9319c258ea
 # from scratch
 case "$image" in
   pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9)
-    CUDA_VERSION=12.1.0
+    CUDA_VERSION=12.1.1
     CUDNN_VERSION=8
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=9
@@ -101,7 +101,7 @@ case "$image" in
     TRITON=yes
     ;;
   pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks)
-    CUDA_VERSION=12.1.0
+    CUDA_VERSION=12.1.1
     CUDNN_VERSION=8
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=9
@@ -159,7 +159,7 @@ case "$image" in
     INDUCTOR_BENCHMARKS=yes
     ;;
   pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9)
-    CUDA_VERSION=12.1.0
+    CUDA_VERSION=12.1.1
     CUDNN_VERSION=8
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=9

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -110,7 +110,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Pulls llibstdc++6 13.1.0-8ubuntu1~18.04 which is too new for conda
   # So remove libstdc++6.so.3.29 installed by https://anaconda.org/anaconda/libstdcxx-ng/files?version=11.2.0
   # Same is true for gcc-12 from Ubuntu-22.04
-  if grep -e [12][82].04.[62] /etc/issue >/dev/null; then
+  if grep -e [12][82].04.[623] /etc/issue >/dev/null; then
     rm /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/lib/libstdc++.so.6
   fi
 


### PR DESCRIPTION
Update cuda 12.1.1 

After : 
Nightly Linux - https://github.com/pytorch/builder/pull/1476
Nightly Windows - https://github.com/pytorch/builder/pull/1485
