### PR TITLE
Expose dynamic_dim and register_dataclass_as_pytree_node under torch.compiler

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -534,7 +534,7 @@ def _register_dataclass_output_as_pytree(example_outputs) -> None:
         type(out) for out in example_outputs_flat if dataclasses.is_dataclass(type(out))
     ]
     for output_type in output_dataclass_types:
-        from torch._export.utils import register_dataclass_as_pytree_node
+        from torch.compiler import register_dataclass_as_pytree_node
 
         register_dataclass_as_pytree_node(output_type)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -19,8 +19,8 @@ import torch._dynamo.testing
 from functorch.experimental.control_flow import cond
 from torch._dynamo import config
 from torch._dynamo.exc import UserError
-from torch._export import dynamic_dim
 from torch._export.constraints import constrain_as_size, constrain_as_value
+from torch.compiler import dynamic_dim
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ConstraintViolationError
 from torch.testing import FileCheck

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4,7 +4,8 @@ import unittest
 
 import torch
 import torch._dynamo as torchdynamo
-from torch._export import export, dynamic_dim, DEFAULT_EXPORT_DYNAMO_CONFIG
+from torch._export import export, DEFAULT_EXPORT_DYNAMO_CONFIG
+from torch.compiler import dynamic_dim, register_dataclass_as_pytree_node
 from torch._export.constraints import constrain_as_size, constrain_as_value
 from torch._export.utils import register_dataclass_as_pytree_node
 from torch.fx.experimental.proxy_tensor import make_fx

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -9,6 +9,7 @@ from typing import List, Set
 import operator
 
 import torch
+from torch.compiler import dynamic_dim
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing import FileCheck
 from torch._dynamo.eval_frame import is_dynamo_supported

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -2,8 +2,9 @@
 import unittest
 
 import torch
+from torch.compiler import dynamic_dim
 import torch._dynamo as torchdynamo
-from torch._export import dynamic_dim, export
+from torch._export import export
 from torch._export.db.case import ExportCase, normalize_inputs, SupportLevel
 from torch._export.db.examples import all_examples
 from torch._export.serde.serialize import (

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1798,8 +1798,7 @@ def export(
     Acceptable types of inputs (for `args` and `kwargs`) and outputs include:
 
     - Primitive types, i.e. `torch.Tensor`, `int`, `float`, `bool` and `str`.
-    - Dataclasses (must be registered with
-        torch._export.utils.register_dataclass_as_pytree_node` first)
+    - Dataclasses (must be registered with torch.compiler.register_dataclass_as_pytree_node` first)
     - (Nested) Data structures comprising of `dict`, `list`, `tuple`, `namedtuple` and `OrderedDict`
         containing all above types.
 
@@ -1858,7 +1857,7 @@ def export(
     Note:
     If you want to preserve dynamic branching behavior based on value or
     shape of torch.Tensor in the generated graph, you will need to use
-    `torch._export.dynamic_dim` to make a dimension of input tensor to be dynamic
+    `torch.compiler.dynamic_dim` to make a dimension of input tensor to be dynamic
     and rewrite the source code using control flow operations like
     `torch.ops.higher_order.cond`.
 
@@ -1875,7 +1874,7 @@ def export(
     Because static shape use cases are more dominant, `torch.export()` chooses to
     assume shapes are all static by default unless there are explicit user
     instructions that say otherwise. Specifically, users can use
-    `torch._export.dynamic_dim` to give a hint to `torch.export()` about dynamism
+    `torch.compiler.dynamic_dim` to give a hint to `torch.export()` about dynamism
     and range of an input tensor dimension.
 
     2. Dynamic Control Flow
@@ -1905,7 +1904,7 @@ def export(
     - Assumptions on static shapes of input tensors are automatically validated
       without additional effort.
     - Assumptions on dynamic shape of input tensors require explicit `Input Constraint`
-      constructed with `torch._export.dynamic_dim` APIs
+      constructed with `torch.compiler.dynamic_dim` APIs
     - Assumptions on range of intermediate values require explicit `Inline Constraint`,
       constructed use `constrain_as_size` and `constraint_as_value` APIs.
 
@@ -1958,9 +1957,9 @@ def export(
         constraints: An optional list of constraints on the dynamic arguments
         that specify their possible range of shapes. By default, shapes of
         input torch.Tensors are assumed to be static. If an input torch.Tensor
-        is expected to have dynamic shapes, please use `torch._export.dynamic_dim()`
+        is expected to have dynamic shapes, please use `torch.compiler.dynamic_dim()`
         to define `Constraint` objects that specify the dynamics and the possible
-        range of shapes. See torch._export.dynamic_dim() docstring for examples on
+        range of shapes. See torch.compiler.dynamic_dim() docstring for examples on
         how to use it.
 
     Returns:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1919,7 +1919,6 @@ def export(
                 dynamic_dim(x, 0),
                 dynamic_dim(x, 0) <= 5,
             ]
-
     This example means the program requires the dim 0 of input `x` to be less
     than or equal to 5 to be valid. You can inspect the constraints needed and
     then copy this exact function into your code to generated needed

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -55,40 +55,7 @@ from .passes.replace_view_ops_with_view_copy_ops_pass import (
 )
 from .wrappers import _wrap_submodules
 
-# Note - [On Export Dynamic Dimension UX]
-#
-# After a lot of discussion, we have settled on a dynamic marking API
-# for export that meets the following constraints:
-# 1) Stateless
-# 2) Safe for numerous .export calls within a single process
-# 3) Simple to use
-# 4) Can be extended to constraints easily
-#
-# While the underlying API is still torch._dynamo.mark_dynamic, we offer a higher
-# level API that meets the constraints above.
-#
-# This API produces an object that is meant to be passed into torch._dynamo.export
-# constraints field. See docs on torch._dynamo.export for more details.
-#
-# Note - The output type and structure here is NOT BC and NOT A CONTRACT, we reserve
-# the right to change the output here at any time, and will do so as we extend the API.
-#
-# result = torch._dynamo.export(
-#     my_model,
-#     constraints=[
-#         # if you do only dynamic_dim, this is sugar for
-#         # -Inf <= dynamic_dim(blah, 0) <= Inf; we don’t otherwise
-#         # permit direct int->bool conversion
-#         dynamic_dim(blah, 0),
-#         # operator overloading because it makes it clear whether
-#         # or not you’re inclusive-exclusive range or not
-#         0 <= dynamic_dim(blah, 1) <= 100,
-#         # NB: But we actually truncate ranges to be >= 2, because of
-#         # 0/1 specialization
-#     ]
-# )(
-#     *sixtyfour_tensors,
-# )
+
 def dynamic_dim(t: torch.Tensor, index: int):
     if not isinstance(t, torch.Tensor):
         raise UserError(

--- a/torch/_export/db/examples/cond_operands.py
+++ b/torch/_export/db/examples/cond_operands.py
@@ -1,7 +1,7 @@
 import torch
 
+from torch.compiler import dynamic_dim
 from torch._export.db.case import export_case
-from torch._export import dynamic_dim
 from functorch.experimental.control_flow import cond
 
 x = torch.randn(3, 2)

--- a/torch/_export/db/examples/dynamic_shape_round.py
+++ b/torch/_export/db/examples/dynamic_shape_round.py
@@ -1,7 +1,7 @@
 import torch
 
+from torch.compiler import dynamic_dim
 from torch._export.db.case import export_case, SupportLevel
-from torch._export import dynamic_dim
 
 x = torch.ones(3, 2)
 dynamic_constraint = dynamic_dim(x, 0)

--- a/torch/_export/db/examples/scalar_output.py
+++ b/torch/_export/db/examples/scalar_output.py
@@ -1,7 +1,7 @@
 import torch
 
+from torch.compiler import dynamic_dim
 from torch._export.db.case import export_case
-from torch._export import dynamic_dim
 
 x = torch.ones(3, 2)
 dynamic_constraint = dynamic_dim(x, 1)

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -10,6 +10,7 @@ from torch.utils._pytree import (
     ToStrFunc,
     UnflattenFunc,
 )
+from .error import ExportError, ExportErrorType
 
 
 def register_dataclass_as_pytree_node(
@@ -24,6 +25,18 @@ def register_dataclass_as_pytree_node(
     assert dataclasses.is_dataclass(
         typ
     ), f"Only dataclasses can be registered with this function: {typ}"
+
+    if to_str_fn:
+        raise ExportError(
+            ExportErrorType.NOT_SUPPORTED,
+            "serializing custom dataclass is not supported yet",
+        )
+
+    if maybe_from_str_fn:
+        raise ExportError(
+            ExportErrorType.NOT_SUPPORTED,
+            "deserializing custom dataclass is not supported yet",
+        )
 
     def default_flatten_fn(obj: Any) -> Tuple[List[Any], Context]:
         flattened = []


### PR DESCRIPTION
cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov