### PR TITLE
[MPS] Implement `polar` via metal shader

### DIFF
--- a/aten/src/ATen/mps/EmptyTensor.cpp
+++ b/aten/src/ATen/mps/EmptyTensor.cpp
@@ -43,7 +43,6 @@ TensorBase empty_mps(
     int64_t nelements = c10::multiply_integers(size);
     auto dtype = dtype_or_default(dtype_opt);
     TORCH_CHECK_TYPE(dtype != ScalarType::Double, MPS_ERROR_DOUBLE_NOT_SUPPORTED);
-    //TORCH_CHECK_TYPE(!c10::isComplexType(dtype), "Complex types are unsupported on MPS");
     TORCH_CHECK_TYPE(dtype != ScalarType::BFloat16, "BFloat16 is not supported on MPS");
 
     auto dtype_meta = scalarTypeToTypeMeta(dtype);

--- a/aten/src/ATen/mps/EmptyTensor.cpp
+++ b/aten/src/ATen/mps/EmptyTensor.cpp
@@ -43,7 +43,7 @@ TensorBase empty_mps(
     int64_t nelements = c10::multiply_integers(size);
     auto dtype = dtype_or_default(dtype_opt);
     TORCH_CHECK_TYPE(dtype != ScalarType::Double, MPS_ERROR_DOUBLE_NOT_SUPPORTED);
-    TORCH_CHECK_TYPE(!c10::isComplexType(dtype), "Complex types are unsupported on MPS");
+    //TORCH_CHECK_TYPE(!c10::isComplexType(dtype), "Complex types are unsupported on MPS");
     TORCH_CHECK_TYPE(dtype != ScalarType::BFloat16, "BFloat16 is not supported on MPS");
 
     auto dtype_meta = scalarTypeToTypeMeta(dtype);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -303,7 +303,7 @@ Tensor& polar_out_mps(const Tensor& abs, const Tensor& angle, Tensor& output) {
   if (length == 0) {
     return output;
   }
-  auto output_as_real = at::view_as_real(output).index({at::indexing::Ellipsis, 0});
+  auto output_as_real = at::view_as_real(output).select(output.dim(), 0);
   auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(abs).add_input(angle).build();
 
   mps::binary_mps_impl(iter, "polar");

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -1,10 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/mps/MPSProfiler.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/TensorIndexing.h>
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <ATen/TensorIndexing.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -303,12 +303,8 @@ Tensor& polar_out_mps(const Tensor& abs, const Tensor& angle, Tensor& output) {
   if (length == 0) {
     return output;
   }
-  auto output_as_real = at::view_as_real(output).index({at::indexing::Ellipsis,0});
-  auto iter = TensorIteratorConfig()
-                  .add_output(output_as_real)
-                  .add_input(abs)
-                  .add_input(angle)
-                  .build();
+  auto output_as_real = at::view_as_real(output).index({at::indexing::Ellipsis, 0});
+  auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(abs).add_input(angle).build();
 
   mps::binary_mps_impl(iter, "polar");
   return output;

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -1,8 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/TensorIndexing.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -10,6 +12,8 @@
 #else
 #include <ATen/ops/maximum.h>
 #include <ATen/ops/minimum.h>
+#include <ATen/ops/polar_native.h>
+#include <ATen/ops/view_as_real.h>
 #endif
 
 namespace at::native {
@@ -124,6 +128,32 @@ REGISTER_COPYSIGN_INTEGRAL_OP(short);
 REGISTER_COPYSIGN_INTEGRAL_OP(char);
 REGISTER_COPYSIGN_INTEGRAL_OP(uchar);
 REGISTER_COPYSIGN_INTEGRAL_OP(bool);
+
+template<typename T>
+kernel void polar(constant void  * abs_         [[buffer(0)]],
+                  constant void  * angle_       [[buffer(1)]],
+                  device   void  * out_         [[buffer(2)]],
+                  constant uint3 * offsets      [[buffer(3)]],
+                  uint tid [[thread_position_in_grid]]) {
+  device   T* out = (device T*)((device uint8_t*)out_ + offsets[tid].x);
+  constant T* angle = (constant T*)((constant uint8_t*)angle_ + offsets[tid].z);
+  constant T* abs = (constant T*)((constant uint8_t*)abs_ + offsets[tid].y);
+  out[0] = abs[0] * cos(angle[0]);
+  out[1] = abs[0] * sin(angle[0]);
+}
+
+#define REGISTER_POLAR_OP(DTYPE)       \
+template                               \
+[[host_name("polar_" #DTYPE)]]         \
+kernel void polar<DTYPE>(              \
+  constant void    * abs,              \
+  constant void    * angle,            \
+  device   void    * out,              \
+  constant uint3   * offsets,          \
+  uint tid)
+
+REGISTER_POLAR_OP(float);
+REGISTER_POLAR_OP(half);
 
 )BINARY_METAL";
 
@@ -264,4 +294,23 @@ REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel);
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel);
 REGISTER_DISPATCH(copysign_stub, &copysign_mps_kernel);
 
+Tensor& polar_out_mps(const Tensor& abs, const Tensor& angle, Tensor& output) {
+  auto new_size = at::infer_size(abs.sizes(), angle.sizes());
+  if (!output.sizes().equals(new_size)) {
+    output.resize_(new_size);
+  }
+  uint32_t length = output.numel();
+  if (length == 0) {
+    return output;
+  }
+  auto output_as_real = at::view_as_real(output).index({at::indexing::Ellipsis,0});
+  auto iter = TensorIteratorConfig()
+                  .add_output(output_as_real)
+                  .add_input(abs)
+                  .add_input(angle)
+                  .build();
+
+  mps::binary_mps_impl(iter, "polar");
+  return output;
+}
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -67,6 +67,7 @@ static void binaryOpTensor(const Tensor& self,
               "MPS: ",
               op_name,
               " op with int64 input is supported natively starting from macOS 13.2");
+  TORCH_CHECK_TYPE(!isComplexType(self.scalar_type()), "Complex types are unsupported on MPS");
   MPSStream* mpsStream = getCurrentMPSStream();
 
   const bool is_self_scalar = self.dim() == 0;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -406,7 +406,7 @@
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function
   dispatch:
-    CPU, CUDA, Meta: view_as_complex
+    CPU, CUDA, MPS, Meta: view_as_complex
 
 - func: sgn(Tensor self) -> Tensor
   variants: function, method
@@ -1596,6 +1596,7 @@
 - func: polar.out(Tensor abs, Tensor angle, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, CUDA: polar_out
+    MPS: polar_out_mps
 
 - func: constant_pad_nd(Tensor self, SymInt[] pad, Scalar value=0) -> Tensor
   variants: function

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -568,7 +568,6 @@ def mps_ops_modifier(ops):
         'to_sparse': None,
         'unique': None,
         'vdot': None,
-        'view_as_complex': None,
         'segment_reduce_': None,
         '_upsample_bilinear2d_aa': None,
         'geometric' : None,
@@ -10760,7 +10759,7 @@ class TestConsistency(TestCaseMPS):
             if len(diff_cpu_out) == 0:
                 continue
             # rand_like does not work with certain dtypes, so cast to double and cast back
-            cpu_grad_outputs = tuple(torch.rand_like(t.to(dtype=torch.double)).to(dtype=dtype) for t in diff_cpu_out)
+            cpu_grad_outputs = tuple(torch.rand_like(t.to(dtype=torch.double)).to(dtype=t.dtype) for t in diff_cpu_out)
             mps_grad_outputs = tuple(t.to("mps") for t in cpu_grad_outputs)
 
             # Compare computed gradients with cpu given random grad_output vector

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10759,7 +10759,7 @@ class TestConsistency(TestCaseMPS):
             if len(diff_cpu_out) == 0:
                 continue
             # rand_like does not work with certain dtypes, so cast to double and cast back
-            cpu_grad_outputs = tuple(torch.rand_like(t.to(dtype=torch.double)).to(dtype=t.dtype) for t in diff_cpu_out)
+            cpu_grad_outputs = tuple(torch.rand_like(t, dtype=torch.double).to(dtype=t.dtype) for t in diff_cpu_out)
             mps_grad_outputs = tuple(t.to("mps") for t in cpu_grad_outputs)
 
             # Compare computed gradients with cpu given random grad_output vector

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -503,7 +503,6 @@ def mps_ops_modifier(ops):
         'ormqr': None,
         'pca_lowrank': None,
         'pinverse': None,
-        # 'polar': None,
         'polygamma': None,
         'polygammapolygamma_n_0': None,
         'polygammapolygamma_n_1': None,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -784,7 +784,6 @@ def mps_ops_error_inputs_modifier(ops):
 
         # unsupported complex dtypes
         'masked_fill',
-        'gradient',
         'fft.hfft',
         'fft.irfft',
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -77,6 +77,7 @@ def mps_ops_grad_modifier(ops):
         'masked.scatter': [torch.float16, torch.float32],
         'index_fill': [torch.float16, torch.float32],  # missing `aten::_unique`.
         'aminmax': [torch.float32],
+        'polar': [torch.float32],
 
         # Correctness issues
         'atanh': [torch.float32],
@@ -502,7 +503,7 @@ def mps_ops_modifier(ops):
         'ormqr': None,
         'pca_lowrank': None,
         'pinverse': None,
-        'polar': None,
+        # 'polar': None,
         'polygamma': None,
         'polygammapolygamma_n_0': None,
         'polygammapolygamma_n_1': None,


### PR DESCRIPTION
Use `view_as_real` to cast complex into a pair of floats and then it becomes just another binary operator.

Enable `polar` and `view_as_complex` consistency tests, but skip `test_output_grad_match_polar_cpu` as `mul` operator is yet not supported

Remove redundant `#ifdef __OBJC__` and capture and re-throw exceptions captured during `createCacheBlock` block. 
Fixes https://github.com/pytorch/pytorch/issues/78503

TODOs(in followup PRs):
  - Implement backwards (requires complex mul and sgn)
  - Measure the perf impact of computing the strides on the fly rather than ahead of time (unrelated to this PR)

Partially addresses https://github.com/pytorch/pytorch/issues/105665