### PR TITLE
[ndk] Clean up LLVM and libc++ 12 and 13

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -163,8 +163,6 @@ def get_c2_fbobjc_xplat_compiler_flags():
 
 def get_c2_fbandroid_xplat_compiler_flags():
     flags = [
-        # T95767731 -- remove this once all builds are on at least llvm-13
-        "-Wno-unknown-warning-option",
         "-Wno-unused-but-set-variable",
         "-DHAVE_MMAP",
     ]


### PR DESCRIPTION
Reviewed By: simpleton

Differential Revision: D48410595

