### PR TITLE
Fix trymerge broken trunk detection when the merge base job was retried (successfully)

### DIFF
--- a/.github/scripts/gql_mocks.json
+++ b/.github/scripts/gql_mocks.json
@@ -47422,5 +47422,1441 @@
         }
       }
     }
+  },
+  "query_sha=987321fccb8ab37e061c69e26e83543eca6f4d1c0a8f8f55d4d34df8f46009b4 name=pytorch number=107160 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "closed": true,
+          "isCrossRepository": false,
+          "author": {
+            "login": "mrshenli"
+          },
+          "title": "Add distributed/c10d *.hpp files to lintrunner",
+          "body": "Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):\n* #106988\n* __->__ #107160\n* #107141\n* #107140\n\n",
+          "headRefName": "gh/mrshenli/385/head",
+          "headRepository": {
+            "nameWithOwner": "pytorch/pytorch"
+          },
+          "baseRefName": "gh/mrshenli/385/base",
+          "baseRefOid": "bd326fb89a91d0ed02a2c9c4459c330ab5d83962",
+          "baseRepository": {
+            "nameWithOwner": "pytorch/pytorch",
+            "isPrivate": false,
+            "defaultBranchRef": {
+              "name": "main"
+            }
+          },
+          "mergeCommit": null,
+          "commits_with_authors": {
+            "nodes": [
+              {
+                "commit": {
+                  "author": {
+                    "user": {
+                      "login": "mrshenli"
+                    },
+                    "email": "cs.shenli@gmail.com",
+                    "name": "Shen Li"
+                  },
+                  "oid": "1abba7bb35f1562329d0235dedf171790cd162a5"
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ",
+              "hasNextPage": false
+            },
+            "totalCount": 1
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "checkSuites": {
+                    "edges": [
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Facebook GitHub Tools",
+                            "databaseId": 12274
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Meta Internal-Only Changes Check",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://opensource.facebook.com/",
+                                "databaseId": 15885150280,
+                                "title": "There is no internal Diff connected, this can be merged now"
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LUKEg=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl0A="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Netlify",
+                            "databaseId": 13473
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl1g="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Azure Pipelines",
+                            "databaseId": 9426
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl3M="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Dependabot",
+                            "databaseId": 29110
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl4Y="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "Codecov",
+                            "databaseId": 254
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl6E="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "PyTorch Bot",
+                            "databaseId": 40112
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl8U="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "CircleCI Checks",
+                            "databaseId": 18001
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl-E="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "copilot4prs",
+                            "databaseId": 299760
+                          },
+                          "workflowRun": null,
+                          "checkRuns": {
+                            "nodes": [],
+                            "pageInfo": {
+                              "endCursor": null,
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": null
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkl_4="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Labeler"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5859347680"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "triage",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347680/job/15885150017",
+                                "databaseId": 15885150017,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LUJ0E=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4MkmT8="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Auto Request Review"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5859347714"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Auto Request Review",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347714/job/15885150117",
+                                "databaseId": 15885150117,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LUJ6U=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4MkmZo="
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": true
+                    }
+                  },
+                  "status": {
+                    "contexts": [
+                      {
+                        "context": "EasyCLA",
+                        "state": "SUCCESS",
+                        "targetUrl": "https://easycla.lfx.linuxfoundation.org/#/?version=2"
+                      }
+                    ]
+                  },
+                  "pushedDate": null,
+                  "oid": "1abba7bb35f1562329d0235dedf171790cd162a5"
+                }
+              }
+            ]
+          },
+          "changedFiles": 1,
+          "files": {
+            "nodes": [
+              {
+                "path": ".lintrunner.toml"
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ",
+              "hasNextPage": false
+            }
+          },
+          "reviews": {
+            "nodes": [
+              {
+                "author": {
+                  "login": "rohan-varma"
+                },
+                "state": "APPROVED"
+              },
+              {
+                "author": {
+                  "login": "fegin"
+                },
+                "state": "APPROVED"
+              },
+              {
+                "author": {
+                  "login": "Skylion007"
+                },
+                "state": "APPROVED"
+              }
+            ],
+            "pageInfo": {
+              "startCursor": "Y3Vyc29yOnYyOpO5MjAyMy0wOC0xNFQxMjo1MjoyNi0wNzowMLkyMDIzLTA4LTE0VDEyOjUyOjI2LTA3OjAwzl4HgZ0=",
+              "hasPreviousPage": false
+            }
+          },
+          "comments": {
+            "nodes": [
+              {
+                "bodyText": "\ud83d\udd17 Helpful Links\n\ud83e\uddea See artifacts and rendered test results at hud.pytorch.org/pr/107160\n\n\ud83d\udcc4 Preview Python docs built from this PR\n\ud83d\udcc4 Preview C++ docs built from this PR\n\u2753 Need help or want to give feedback on the CI? Visit the bot commands wiki or our office hours\n\nNote: Links to docs will display an error until the docs builds have been completed.\n\u2705 4 Unrelated Failures\nAs of commit 1abba7b:\nBROKEN TRUNK - The following job failed but were present on the merge base a5d841e:\ud83d\udc49 Rebase onto the `viable/strict` branch to avoid these failures\n\nlinux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu) (gh)\n\n\nUNSTABLE - The following jobs failed but were likely due to flakiness present on trunk and has been marked as unstable:\n\nlinux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable) (gh)\nlinux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable) (gh)\nlinux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable) (gh)\n\n\nThis comment was automatically generated by Dr. CI and updates every 15 minutes.",
+                "createdAt": "2023-08-14T18:34:37Z",
+                "author": {
+                  "login": "pytorch-bot"
+                },
+                "authorAssociation": "NONE",
+                "editor": {
+                  "login": "pytorch-bot"
+                },
+                "databaseId": 1677868692,
+                "url": "https://github.com/pytorch/pytorch/pull/107160#issuecomment-1677868692"
+              },
+              {
+                "bodyText": "@pytorchbot merge -f \"rocm and sm86 test failures are irrelevant\"",
+                "createdAt": "2023-08-14T23:14:42Z",
+                "author": {
+                  "login": "mrshenli"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1678209833,
+                "url": "https://github.com/pytorch/pytorch/pull/107160#issuecomment-1678209833"
+              },
+              {
+                "bodyText": "Merge started\nYour change will be merged immediately since you used the force (-f) flag, bypassing any CI checks (ETA: 1-5 minutes).  Please use -f as last resort and instead consider -i/--ignore-current to continue the merge ignoring current failures.  This will allow currently pending tests to finish and report signal before the merge.\nLearn more about merging in the wiki.\nQuestions? Feedback? Please reach out to the PyTorch DevX TeamAdvanced Debugging\nCheck the merge workflow status\nhere",
+                "createdAt": "2023-08-14T23:16:31Z",
+                "author": {
+                  "login": "pytorchmergebot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1678211333,
+                "url": "https://github.com/pytorch/pytorch/pull/107160#issuecomment-1678211333"
+              },
+              {
+                "bodyText": "@pytorchbot drci",
+                "createdAt": "2023-08-15T03:40:20Z",
+                "author": {
+                  "login": "huydhn"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1678383244,
+                "url": "https://github.com/pytorch/pytorch/pull/107160#issuecomment-1678383244"
+              }
+            ],
+            "pageInfo": {
+              "startCursor": "Y3Vyc29yOnYyOpHOZAI-lA==",
+              "hasPreviousPage": false
+            }
+          },
+          "labels": {
+            "edges": [
+              {
+                "node": {
+                  "name": "Merged"
+                }
+              },
+              {
+                "node": {
+                  "name": "ciflow/trunk"
+                }
+              },
+              {
+                "node": {
+                  "name": "topic: not user facing"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "query_sha=7d01fb92d2ac98a33cbeff4e8b490a40433f3110e3bf9dd70d88bc496d846e56 cursor=Y3Vyc29yOnYyOpHPAAAAA4MkmZo= name=pytorch number=107160 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "1abba7bb35f1562329d0235dedf171790cd162a5",
+                  "checkSuites": {
+                    "edges": [
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "TorchBench CI (pytorch-linux-py3.8-cu116)"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5859347720"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "run-torchbench",
+                                "conclusion": "NEUTRAL",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347720/job/15885150148",
+                                "databaseId": 15885150148,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LUJ8Q=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SKIPPED"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkmak="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "pull"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5859347753"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885150752",
+                                "databaseId": 15885150752,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885150980",
+                                "databaseId": 15885150980,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151164",
+                                "databaseId": 15885151164,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151330",
+                                "databaseId": 15885151330,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151555",
+                                "databaseId": 15885151555,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3_8-clang8-xla / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151767",
+                                "databaseId": 15885151767,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151965",
+                                "databaseId": 15885151965,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152195",
+                                "databaseId": 15885152195,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-no-ops / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152375",
+                                "databaseId": 15885152375,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152560",
+                                "databaseId": 15885152560,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3-clang12-mobile-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152715",
+                                "databaseId": 15885152715,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152902",
+                                "databaseId": 15885152902,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153099",
+                                "databaseId": 15885153099,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153323",
+                                "databaseId": 15885153323,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153513",
+                                "databaseId": 15885153513,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153706",
+                                "databaseId": 15885153706,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153866",
+                                "databaseId": 15885153866,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-pch / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154064",
+                                "databaseId": 15885154064,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154274",
+                                "databaseId": 15885154274,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154465",
+                                "databaseId": 15885154465,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154662",
+                                "databaseId": 15885154662,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162205",
+                                "databaseId": 15885162205,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162644",
+                                "databaseId": 15885162644,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162883",
+                                "databaseId": 15885162883,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885163500",
+                                "databaseId": 15885163500,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885462401",
+                                "databaseId": 15885462401,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885462611",
+                                "databaseId": 15885462611,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 1, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885476955",
+                                "databaseId": 15885476955,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 2, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477117",
+                                "databaseId": 15885477117,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 3, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477318",
+                                "databaseId": 15885477318,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 4, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477523",
+                                "databaseId": 15885477523,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 5, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477702",
+                                "databaseId": 15885477702,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-jammy-py3.9-clang12-asan / test (default, 6, 6, linux.4xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477888",
+                                "databaseId": 15885477888,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490122",
+                                "databaseId": 15885490122,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490317",
+                                "databaseId": 15885490317,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490500",
+                                "databaseId": 15885490500,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490694",
+                                "databaseId": 15885490694,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490891",
+                                "databaseId": 15885490891,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885491060",
+                                "databaseId": 15885491060,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.11-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885491248",
+                                "databaseId": 15885491248,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885492940",
+                                "databaseId": 15885492940,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493098",
+                                "databaseId": 15885493098,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493246",
+                                "databaseId": 15885493246,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493441",
+                                "databaseId": 15885493441,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493604",
+                                "databaseId": 15885493604,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (dynamo, 1, 2, linux.2xlarge, unstable)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493774",
+                                "databaseId": 15885493774,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-py3.8-clang9 / test (dynamo, 2, 2, linux.2xlarge, unstable)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493957",
+                                "databaseId": 15885493957,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885495819",
+                                "databaseId": 15885495819,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885495996",
+                                "databaseId": 15885495996,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496184",
+                                "databaseId": 15885496184,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LZb3g=",
+                              "hasNextPage": true
+                            }
+                          },
+                          "conclusion": "FAILURE"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkmeg="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "Lint"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5859347806"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "Test `run_test.py` is usable without boto3/rockset",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150390",
+                                "databaseId": 15885150390,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (with_torch)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150586",
+                                "databaseId": 15885150586,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (without_torch)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150768",
+                                "databaseId": 15885150768,
+                                "title": null
+                              },
+                              {
+                                "name": "Test collect_env (older_python_version)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150959",
+                                "databaseId": 15885150959,
+                                "title": null
+                              },
+                              {
+                                "name": "pr-sanity-checks",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151163",
+                                "databaseId": 15885151163,
+                                "title": null
+                              },
+                              {
+                                "name": "workflow-checks / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151341",
+                                "databaseId": 15885151341,
+                                "title": null
+                              },
+                              {
+                                "name": "quick-checks / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151533",
+                                "databaseId": 15885151533,
+                                "title": null
+                              },
+                              {
+                                "name": "lintrunner / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151724",
+                                "databaseId": 15885151724,
+                                "title": null
+                              },
+                              {
+                                "name": "Test tools / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151937",
+                                "databaseId": 15885151937,
+                                "title": null
+                              },
+                              {
+                                "name": "toc / linux-job",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885152118",
+                                "databaseId": 15885152118,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7LUL3Y=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4Mkmlk="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-libtorch-pre-cxx11"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5860028171"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028171/job/15887257026",
+                                "databaseId": 15887257026,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028171/job/15888410482",
+                                "databaseId": 15888410482,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7MF53I=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4NEaWI="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-libtorch-cxx11-abi"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5860028173"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028173/job/15887257023",
+                                "databaseId": 15887257023,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028173/job/15888235896",
+                                "databaseId": 15888235896,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7MDPXg=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4NEaW8="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "trunk"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5860028213"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "win-vs2019-cuda11.8-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257380",
+                                "databaseId": 15887257380,
+                                "title": null
+                              },
+                              {
+                                "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257617",
+                                "databaseId": 15887257617,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257818",
+                                "databaseId": 15887257818,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257988",
+                                "databaseId": 15887257988,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258198",
+                                "databaseId": 15887258198,
+                                "title": null
+                              },
+                              {
+                                "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258568",
+                                "databaseId": 15887258568,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258822",
+                                "databaseId": 15887258822,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258996",
+                                "databaseId": 15887258996,
+                                "title": null
+                              },
+                              {
+                                "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887259175",
+                                "databaseId": 15887259175,
+                                "title": null
+                              },
+                              {
+                                "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887267721",
+                                "databaseId": 15887267721,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887453866",
+                                "databaseId": 15887453866,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454139",
+                                "databaseId": 15887454139,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454378",
+                                "databaseId": 15887454378,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64-mps / filter",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454594",
+                                "databaseId": 15887454594,
+                                "title": null
+                              },
+                              {
+                                "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887467541",
+                                "databaseId": 15887467541,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": "FAILURE",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887855756",
+                                "databaseId": 15887855756,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": "FAILURE",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887855946",
+                                "databaseId": 15887855946,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+                                "conclusion": "FAILURE",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887856086",
+                                "databaseId": 15887856086,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977549",
+                                "databaseId": 15887977549,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977721",
+                                "databaseId": 15887977721,
+                                "title": null
+                              },
+                              {
+                                "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977933",
+                                "databaseId": 15887977933,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154209",
+                                "databaseId": 15888154209,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154343",
+                                "databaseId": 15888154343,
+                                "title": null
+                              },
+                              {
+                                "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154485",
+                                "databaseId": 15888154485,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7MB_3U=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "FAILURE"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4NEafI="
+                      },
+                      {
+                        "node": {
+                          "app": {
+                            "name": "GitHub Actions",
+                            "databaseId": 15368
+                          },
+                          "workflowRun": {
+                            "workflow": {
+                              "name": "linux-binary-manywheel"
+                            },
+                            "url": "https://github.com/pytorch/pytorch/actions/runs/5860028215"
+                          },
+                          "checkRuns": {
+                            "nodes": [
+                              {
+                                "name": "manywheel-py3_8-cuda11_8-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15887257243",
+                                "databaseId": 15887257243,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15887257487",
+                                "databaseId": 15887257487,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15888983848",
+                                "databaseId": 15888983848,
+                                "title": null
+                              },
+                              {
+                                "name": "manywheel-py3_8-cuda11_8-test / test",
+                                "conclusion": "SUCCESS",
+                                "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15889673030",
+                                "databaseId": 15889673030,
+                                "title": null
+                              }
+                            ],
+                            "pageInfo": {
+                              "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7MZK0Y=",
+                              "hasNextPage": false
+                            }
+                          },
+                          "conclusion": "SUCCESS"
+                        },
+                        "cursor": "Y3Vyc29yOnYyOpHPAAAAA4NEafU="
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": false
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "query_sha=ada119ceda3e867b82ccea3406111b1cab554821289b906c554518aeaffdfde2 cr_cursor=Y3Vyc29yOnYyOpHPAAAAA7LZb3g= cs_cursor=Y3Vyc29yOnYyOpHPAAAAA4Mkmak= name=pytorch number=107160 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "1abba7bb35f1562329d0235dedf171790cd162a5",
+                  "checkSuites": {
+                    "nodes": [
+                      {
+                        "checkRuns": {
+                          "nodes": [
+                            {
+                              "name": "linux-focal-py3.8-gcc7 / test (docs_test, 1, 1, linux.2xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496371",
+                              "databaseId": 15885496371,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-focal-py3.8-gcc7 / test (jit_legacy, 1, 1, linux.2xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496602",
+                              "databaseId": 15885496602,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-focal-py3.8-gcc7 / test (backwards_compat, 1, 1, linux.2xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496802",
+                              "databaseId": 15885496802,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-focal-py3.8-gcc7 / test (distributed, 1, 2, linux.2xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497028",
+                              "databaseId": 15885497028,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-focal-py3.8-gcc7 / test (distributed, 2, 2, linux.2xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497303",
+                              "databaseId": 15885497303,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-docs / build-docs-cpp-false",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497550",
+                              "databaseId": 15885497550,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-docs / build-docs-python-false",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497726",
+                              "databaseId": 15885497726,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-docs / build-docs-functorch-false",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497924",
+                              "databaseId": 15885497924,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.12xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885558623",
+                              "databaseId": 15885558623,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885826767",
+                              "databaseId": 15885826767,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827009",
+                              "databaseId": 15885827009,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827241",
+                              "databaseId": 15885827241,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827460",
+                              "databaseId": 15885827460,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827794",
+                              "databaseId": 15885827794,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827993",
+                              "databaseId": 15885827993,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841073",
+                              "databaseId": 15885841073,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841288",
+                              "databaseId": 15885841288,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841502",
+                              "databaseId": 15885841502,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "FAILURE",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841715",
+                              "databaseId": 15885841715,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841913",
+                              "databaseId": 15885841913,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 1, 3, linux.8xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885845849",
+                              "databaseId": 15885845849,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 2, 3, linux.8xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885846053",
+                              "databaseId": 15885846053,
+                              "title": null
+                            },
+                            {
+                              "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 3, 3, linux.8xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885846297",
+                              "databaseId": 15885846297,
+                              "title": null
+                            }
+                          ],
+                          "pageInfo": {
+                            "endCursor": "Y3Vyc29yOnYyOpHPAAAAA7Lexxk=",
+                            "hasNextPage": false
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/.github/scripts/rockset_mocks.json
+++ b/.github/scripts/rockset_mocks.json
@@ -42651,5 +42651,4648 @@
       "steps": 0
     }
   ],
-  "f9a10a148958be8bd6474b8ab36da3f0aedd6a70 dc0bf418c1045b64911c56a27e685d2bb4ffa5d3": []
+  "f9a10a148958be8bd6474b8ab36da3f0aedd6a70 dc0bf418c1045b64911c56a27e685d2bb4ffa5d3": [],
+  "1abba7bb35f1562329d0235dedf171790cd162a5 a5d841ef01e615e2a654fb12cf0cd08697d12ccf": [
+    {
+      "workflow_name": "trunk",
+      "id": 15887453866,
+      "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:47:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887453866",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885150768,
+      "name": "Test collect_env (without_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150768",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15820443883,
+      "name": "try_merge_pr_106930",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:34:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833302798/job/15820443883",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 10
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15823577679,
+      "name": "try_merge_pr_106933",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:28:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834314175/job/15823577679",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 10
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822007977,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:34:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833807615/job/15822007977",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820117669,
+      "name": "linux-focal-py3.8-gcc7 / test (backwards_compat, 1, 1, linux.2xlarge)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T13:33:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820117669",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885150586,
+      "name": "Test collect_env (with_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:36:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150586",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820050266,
+      "name": "Upload test stats for 5829292539, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:34:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180285/job/15820050266",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820138130,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 4, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:23:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820138130",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15888154485,
+      "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T22:03:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154485",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15821082113,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:06:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833498968/job/15821082113",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887258198,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:14:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258198",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887257380,
+      "name": "win-vs2019-cuda11.8-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:50:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257380",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820491690,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:33:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820491690",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820131031,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:09:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820131031",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819662451,
+      "name": "linux-jammy-py3-clang12-mobile-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:29:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819662451",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819661722,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:45:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819661722",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885841288,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:34:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841288",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15821061810,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:05:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833492576/job/15821061810",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820136415,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:55:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820136415",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15822276961,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:44:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833891277/job/15822276961",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819658742,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:42:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819658742",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885496802,
+      "name": "linux-focal-py3.8-gcc7 / test (backwards_compat, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:01:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496802",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885491060,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:21:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885491060",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885150752,
+      "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:43:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885150752",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822018268,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:34:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833811535/job/15822018268",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821866902,
+      "name": "Upload test stats for 5830568999, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:33:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833757957/job/15821866902",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820115906,
+      "name": "linux-docs / build-docs-cpp-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:42:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820115906",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "TorchBench CI (pytorch-linux-py3.8-cu116)",
+      "id": 15885150148,
+      "name": "run-torchbench",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-14T18:34:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347720/job/15885150148",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885846053,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 2, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:11:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885846053",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "RuntimeError: raised from 0"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15888154343,
+      "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:55:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154343",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822344666,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:45:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833912711/job/15822344666",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821174297,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:08:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833532405/job/15821174297",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822007475,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:36:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833807615/job/15822007475",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820177119,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:34:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833224174/job/15820177119",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822188003,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:40:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833863073/job/15822188003",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820421299,
+      "name": "win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:14:31Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820421299",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820046453,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:30:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180645/job/15820046453",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885827993,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:11:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827993",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493957,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 2, 2, linux.2xlarge, unstable)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:14:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493957",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "AttributeError: 'Context' object has no attribute 'owner'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885462401,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:09:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885462401",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885162644,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:00:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162644",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885162205,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:56:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162205",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887977933,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:34:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977933",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823520127,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834296546/job/15823520127",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821694064,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:24:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833703425/job/15821694064",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820177339,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:34:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833224174/job/15820177339",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819659057,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819659057",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820420849,
+      "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:01:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820420849",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820347030,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T14:49:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820347030",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823335510,
+      "name": "Upload test stats for 5832473667, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:22:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834234914/job/15823335510",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887977549,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:59:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977549",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload torch dynamo performance stats",
+      "id": 15821709051,
+      "name": "get-conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:24:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833707893/job/15821709051",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820421074,
+      "name": "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:26:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820421074",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823520768,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295047/job/15823520768",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822511253,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:54:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833968337/job/15822511253",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-debug",
+      "id": 15819653954,
+      "name": "libtorch-cpu-shared-with-deps-debug-build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:16:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056517/job/15819653954",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "sccache: error: couldn't connect to server"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885150959,
+      "name": "Test collect_env (older_python_version)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150959",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "You are using pip version 20.3.4, however version 23.2.1 is available."
+      ],
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819661492,
+      "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:28:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819661492",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885826767,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:45:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885826767",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885152375,
+      "name": "linux-focal-py3.8-gcc7-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:46:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152375",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823515366,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295047/job/15823515366",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819659537,
+      "name": "linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:32:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819659537",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819658770,
+      "name": "linux-bionic-py3_8-clang8-xla / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:36:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819658770",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15823505212,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834292116/job/15823505212",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821033230,
+      "name": "Upload test stats for 5831769803, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:08:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833480473/job/15821033230",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-release",
+      "id": 15819653892,
+      "name": "libtorch-cpu-shared-with-deps-release-build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:38:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056524/job/15819653892",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "sccache: error: couldn't connect to server"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822717899,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:58:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834029387/job/15822717899",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820492541,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:56:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820492541",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820492325,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:26:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820492325",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819662904,
+      "name": "linux-focal-py3.8-clang10-onnx / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:32:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819662904",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819661259,
+      "name": "linux-jammy-py3.9-clang12-asan / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:33:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819661259",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822414670,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:48:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833938221/job/15822414670",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885462611,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:08:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885462611",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885162883,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:20:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885162883",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885153323,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:54:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153323",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822931494,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:09:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834104370/job/15822931494",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823512843,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834294278/job/15823512843",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822153681,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:39:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833853747/job/15822153681",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823329549,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:18:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834234914/job/15823329549",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15820715145,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:53:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833384767/job/15820715145",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820130194,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:21:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820130194",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821024308,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:05:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833479503/job/15821024308",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "unstable",
+      "id": 15819653912,
+      "name": "introduction",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:16:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056520/job/15819653912",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885841913,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:16:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841913",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885153866,
+      "name": "linux-jammy-py3.9-clang12-asan / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:46:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153866",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820492101,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:59:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820492101",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823342925,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:18:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834239313/job/15823342925",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15821420527,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:16:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833612801/job/15821420527",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823329302,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:18:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834234914/job/15823329302",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822038885,
+      "name": "Upload test stats for 5832105391, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:39:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833816420/job/15822038885",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820463648,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:44:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833308539/job/15820463648",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887257818,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:25:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257818",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821861310,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:29:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833757957/job/15821861310",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820504498,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T14:03:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820504498",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "inductor/test_torchinductor.py::TritonCodeGenTests::test_optimize_indexing_dtype_with_constraint"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820819270,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:56:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833415081/job/15820819270",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15819731274,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:24:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833082059/job/15819731274",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819655220,
+      "name": "Test collect_env (older_python_version)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:19:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819655220",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "You are using pip version 20.3.4, however version 23.2.1 is available."
+      ],
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820517631,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:28:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820517631",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820050462,
+      "name": "Upload test stats for 5831582467, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:35:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180645/job/15820050462",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15823378625,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:22:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834250981/job/15823378625",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821694334,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:24:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833703425/job/15821694334",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820528876,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 1, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:49:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820528876",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: barrier timeout"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885841073,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:27:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841073",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885151767,
+      "name": "linux-bionic-py3_8-clang8-xla / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:50:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151767",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15887257023,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:28:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028173/job/15887257023",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15821642813,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:39:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057439/job/15821642813",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885477117,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 2, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:31:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477117",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887257988,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:18:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257988",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820138372,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 5, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:05:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820138372",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819659327,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:45:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819659327",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820067199,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_cpu_accuracy, 2, 2, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:54:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820067199",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821030160,
+      "name": "Upload test stats for 5830928412, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:09:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833479503/job/15821030160",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885477523,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 4, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:34:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477523",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822007829,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:07:24Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833807615/job/15822007829",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820135955,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:36:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820135955",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819660259,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819660259",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15822896947,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:04:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834093284/job/15822896947",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819890860,
+      "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:14:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819890860",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885827460,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:35:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827460",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15822562130,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:54:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833984047/job/15822562130",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887855756,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-14T22:04:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887855756",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "inductor/test_torchinductor_opinfo.py::TestInductorOpInfoCUDA::test_comprehensive_tanh_cuda_float16"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885151163,
+      "name": "pr-sanity-checks",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:36:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151163",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823520380,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:51Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834296546/job/15823520380",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820130565,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:48:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820130565",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823342696,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:18:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834239313/job/15823342696",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819891063,
+      "name": "macos-12-py3-arm64-mps / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:24:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819891063",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819658515,
+      "name": "macos-12-py3-arm64 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:24:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819658515",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885152560,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:00:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152560",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15820159170,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:34:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833218189/job/15820159170",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887855946,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-14T22:10:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887855946",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "profiler/test_profiler.py::TestProfiler::test_kineto_profiler_with_environment_variable"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15889673030,
+      "name": "manywheel-py3_8-cuda11_8-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:41:26Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15889673030",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820819082,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:56:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833415081/job/15820819082",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822419497,
+      "name": "Upload test stats for 5832207325, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:55:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833938221/job/15822419497",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819656831,
+      "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:43:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819656831",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493441,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:50:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493441",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15888154209,
+      "name": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T22:28:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15888154209",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822024610,
+      "name": "Upload test stats for 5830567669, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:39:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833811535/job/15822024610",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820491177,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:06:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820491177",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885841715,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-14T19:50:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841715",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "inductor/test_torchinductor.py::TritonCodeGenTests::test_optimize_indexing_dtype_with_constraint"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885497924,
+      "name": "linux-docs / build-docs-functorch-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:53:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497924",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885497303,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:45:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497303",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15820158983,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:07:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833218189/job/15820158983",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887856086,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-14T23:02:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887856086",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "inductor/test_torchinductor_opinfo.py::TestInductorOpInfoCUDA::test_comprehensive_nn_functional_instance_norm_cuda_float32"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887454594,
+      "name": "macos-12-py3-arm64-mps / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:01:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454594",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887258568,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:53:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258568",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820529046,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 2, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:57:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820529046",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885496371,
+      "name": "linux-focal-py3.8-gcc7 / test (docs_test, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:54:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496371",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885495819,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:47:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885495819",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885154662,
+      "name": "linux-focal-py3.8-gcc7-mobile-lightweight-dispatch-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:43:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154662",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823499109,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834290498/job/15823499109",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820885821,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:59:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833433706/job/15820885821",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885477318,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 3, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:14:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477318",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887267721,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:04:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887267721",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820117442,
+      "name": "linux-focal-py3.8-gcc7 / test (jit_legacy, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:40:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820117442",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819670994,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:41:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819670994",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822722338,
+      "name": "Upload test stats for 5832770394, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:02:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834029387/job/15822722338",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819890677,
+      "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:21:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819890677",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "test_fx.py::TestFXAPIBackwardCompatibility::test_function_back_compat"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820446892,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_torchbench, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:46:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820446892",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493774,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 1, 2, linux.2xlarge, unstable)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:19:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493774",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885153706,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153706",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15823402021,
+      "name": "try_merge_pr_106933",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834258738/job/15823402021",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: 1 jobs have failed, first few of them are: [trunk / macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)](https://github.com/pytorch/pytorch/actions/runs/5821071251/job/15783353741)"
+      ],
+      "steps": 10
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885497028,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:14:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497028",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "AttributeError: Can't get attribute 'foo_add' on <module 'torch.testing._internal.distributed.rpc.rpc_test' from '/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/testing/_internal/distributed/rpc/rpc_test.py'> Default RPC pickler does not serialize"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885490122,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:45:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490122",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885151965,
+      "name": "linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:47:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151965",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821335453,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:13:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833583885/job/15821335453",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820467764,
+      "name": "Upload test stats for 5831360036, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:49:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833308539/job/15820467764",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823576500,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:26:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834313815/job/15823576500",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820107258,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:53:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820107258",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820067423,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_torchbench_cpu_accuracy, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:25:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820067423",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823517751,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295808/job/15823517751",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822193686,
+      "name": "Upload test stats for 5832736393, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:43:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833863073/job/15822193686",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820346854,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T16:15:42Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820346854",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15819661951,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:20:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833059541/job/15819661951",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885827241,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:31:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827241",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885497550,
+      "name": "linux-docs / build-docs-cpp-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:58:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497550",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823510054,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834293505/job/15823510054",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820447388,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_timm_dynamic, 2, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:50:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820447388",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819654256,
+      "name": "Test `run_test.py` is usable without boto3/rockset",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:18:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819654256",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820046193,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:30:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180645/job/15820046193",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15819656377,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:22:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057439/job/15819656377",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821861129,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:29:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833757957/job/15821861129",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820116633,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:20:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820116633",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885154465,
+      "name": "linux-focal-py3.8-clang10-onnx / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:46:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154465",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885154274,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:56:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154274",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15820208517,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:36:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833234579/job/15820208517",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Create Release",
+      "id": 15819653896,
+      "name": "Create Release",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:21:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056513/job/15819653896",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823517922,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295808/job/15823517922",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885490317,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:24:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490317",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822007675,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:35:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833807615/job/15822007675",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820491913,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:57:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820491913",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819661968,
+      "name": "linux-focal-py3.8-gcc7-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:33:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819661968",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819660500,
+      "name": "win-vs2019-cpu-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:41:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819660500",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819655476,
+      "name": "lintrunner / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:29:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819655476",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15821579045,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:22:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833666262/job/15821579045",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819658236,
+      "name": "linux-focal-rocm5.6-py3.8 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:40:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819658236",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885496602,
+      "name": "linux-focal-py3.8-gcc7 / test (jit_legacy, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:55:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496602",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823499372,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834290498/job/15823499372",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820504689,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:32:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820504689",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "[  FAILED  ] NVFuserTest.FusionGroupAllreduce5_CUDA"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819671247,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:49:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819671247",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820642631,
+      "name": "Upload test stats for 5832208316, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:53:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833361559/job/15820642631",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819657065,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819657065",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885496184,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:31:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885496184",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885154064,
+      "name": "linux-focal-py3.8-gcc7-pch / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:48:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885154064",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822627339,
+      "name": "Upload test stats for 5830545176, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:59:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834001243/job/15822627339",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820447701,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_distributed, 1, 1, linux.g5.12xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:56:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820447701",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819899447,
+      "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:42:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819899447",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 14
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819657714,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-no-ops / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:43:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819657714",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-release",
+      "id": 15820293173,
+      "name": "libtorch-cpu-shared-with-deps-release-test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:41:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056524/job/15820293173",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820045036,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:30:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180285/job/15820045036",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493246,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:26:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493246",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885477702,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 5, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:18:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477702",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823512631,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834294278/job/15823512631",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819659041,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:46:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819659041",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819657381,
+      "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:33:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819657381",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822033044,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:35:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833816420/job/15822033044",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887454139,
+      "name": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:55:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454139",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "test_fx.py::TestFXAPIBackwardCompatibility::test_function_back_compat"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820182105,
+      "name": "Upload test stats for 5832932140, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:37:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833224174/job/15820182105",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819657847,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819657847",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15820690035,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:01:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057341/job/15820690035",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "undefined reference to `c10::detail::torchInternalAssertFail(char const*, char const*, unsigned int, char const*, std::string const&)'"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "Labeler",
+      "id": 15885150017,
+      "name": "triage",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:34:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347680/job/15885150017",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822188217,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:40:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833863073/job/15822188217",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15819656697,
+      "name": "manywheel-py3_8-cuda11_8-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:48:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057439/job/15819656697",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885153513,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153513",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820463897,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:44:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833308539/job/15820463897",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822158121,
+      "name": "Upload test stats for 5832105391, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:42:59Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833853747/job/15822158121",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820346652,
+      "name": "linux-focal-rocm5.6-py3.8 / test (default, 1, 3, linux.rocm.gpu, unstable)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T14:50:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820346652",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "inductor/test_torchinductor_opinfo.py::TestInductorOpInfoCUDA::test_comprehensive_tanh_cuda_float16"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887977721,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T22:15:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887977721",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885151341,
+      "name": "workflow-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:37:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151341",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819657407,
+      "name": "linux-focal-rocm5.6-py3.8",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T13:16:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819657407",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820885676,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:59:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833433706/job/15820885676",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820446719,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_timm, 2, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:38:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820446719",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820067632,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_huggingface_dynamic_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:01:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820067632",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload torch dynamo performance stats",
+      "id": 15821714856,
+      "name": "Upload dynamo performance stats for 5829729877, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:25:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833707893/job/15821714856",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 7
+    },
+    {
+      "workflow_name": "windows-binary-libtorch-debug",
+      "id": 15821452846,
+      "name": "libtorch-cpu-shared-with-deps-debug-test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:37:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056517/job/15821452846",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "An error occurred while attempting to read the response stream"
+      ],
+      "steps": 18
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823522231,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834297269/job/15823522231",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820136654,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:03:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820136654",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "AttributeError: 'Context' object has no attribute 'owner'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820116375,
+      "name": "linux-docs / build-docs-functorch-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:38:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820116375",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820107031,
+      "name": "linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:59:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820107031",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "ossf-scorecard",
+      "id": 15819653638,
+      "name": "Scorecards analysis",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T13:16:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056522/job/15819653638",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885495996,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:38:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885495996",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885490500,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:24:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490500",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885151555,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:01:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151555",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821027282,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:05:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833480473/job/15821027282",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823348346,
+      "name": "Upload test stats for 5831056140, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:22:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834239313/job/15823348346",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15822424783,
+      "name": "manywheel-py3_8-cuda11_8-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:06:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057439/job/15822424783",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "An error occurred while attempting to read the response stream"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885152195,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:00:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152195",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819659755,
+      "name": "linux-focal-py3-clang7-mobile-custom-build-static / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:28:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819659755",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15823263443,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:16:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834212884/job/15823263443",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822349910,
+      "name": "Upload test stats for 5832106255, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:49:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833912711/job/15822349910",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822620921,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:55:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834001243/job/15822620921",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820447542,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_torchbench_dynamic, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:34:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820447542",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823522267,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295808/job/15823522267",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885476955,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 1, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:52:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885476955",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15820158613,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:36:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833218189/job/15820158613",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820067864,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_dynamic_cpu_accuracy, 1, 2, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:55:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820067864",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822718091,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:58:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834029387/job/15822718091",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15819662195,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833059541/job/15819662195",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15821081857,
+      "name": "update-html (whl)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:07:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833498968/job/15821081857",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820137310,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 1, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:42:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820137310",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820130003,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:36:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820130003",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819670532,
+      "name": "linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:02:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819670532",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820517993,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:01:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820517993",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819657964,
+      "name": "win-vs2019-cuda11.8-py3 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:01:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819657964",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 15
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885151330,
+      "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:19:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151330",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823517639,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834294278/job/15823517639",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885153099,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885153099",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885152902,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:35:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152902",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Validate and merge PR",
+      "id": 15823416981,
+      "name": "try_merge_pr_106791",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T17:05:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834263431/job/15823416981",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 10
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15819657054,
+      "name": "cuda12.1-py3.10-gcc9-sm80 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:45:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15819657054",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15819656528,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:30:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15819656528",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822511009,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:51:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833968337/job/15822511009",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819662230,
+      "name": "linux-focal-py3.8-gcc7-pch / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:33:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819662230",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819661018,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / filter",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819661018",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 5
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819654752,
+      "name": "Test collect_env (with_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:19:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819654752",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822516137,
+      "name": "Upload test stats for 5831359766, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:58:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833968337/job/15822516137",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15820436900,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:44:00Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833300843/job/15820436900",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885827794,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:35:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827794",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885827009,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:37:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885827009",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "RuntimeError: CUDA error: device-side assert triggered"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822931961,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:35:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834104370/job/15822931961",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823525027,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834296546/job/15823525027",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820505037,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:14:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820505037",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820890318,
+      "name": "Upload test stats for 5831769803, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:04:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833433706/job/15820890318",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15825108480,
+      "name": "linux-focal-py3.8-gcc7 / test (backwards_compat, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:35:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15825108480",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820504858,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:15:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820504858",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820117865,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:35:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820117865",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "AttributeError: Can't get attribute 'foo_add' on <module 'torch.testing._internal.distributed.rpc.rpc_test' from '/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/testing/_internal/distributed/rpc/rpc_test.py'> Default RPC pickler does not serialize"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822033254,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:34:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833816420/job/15822033254",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15887257487,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:58:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15887257487",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822153846,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:39:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833853747/job/15822153846",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819670044,
+      "name": "pytorch-linux-focal-py3-clang7-android-ndk-r19c-build / build (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:28:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819670044",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885150390,
+      "name": "Test `run_test.py` is usable without boto3/rockset",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:36:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885150390",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820529213,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 3, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:46:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820529213",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: raised from 0"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819670313,
+      "name": "linux-bionic-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:42:17Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819670313",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 19
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823504318,
+      "name": "Upload test stats for 5832736396, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:27:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834290498/job/15823504318",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821178513,
+      "name": "Upload test stats for 5830923119, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:11:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833532405/job/15821178513",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820447228,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_timm_dynamic, 1, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:46:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820447228",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822414859,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:50:22Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833938221/job/15822414859",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15821727831,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:25:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833714313/job/15821727831",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885150980,
+      "name": "linux-bionic-py3.11-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:47:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885150980",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887259175,
+      "name": "caffe2-linux-focal-py3.8-gcc7 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:09:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887259175",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887257617,
+      "name": "libtorch-linux-bionic-cuda12.1-py3.7-gcc9-debug / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:20:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887257617",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885151533,
+      "name": "quick-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:38:06Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151533",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820116135,
+      "name": "linux-docs / build-docs-python-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:52:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820116135",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885846297,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 3, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:10:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885846297",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885477888,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 6, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:39:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885477888",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822932149,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:05:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834104370/job/15822932149",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819660757,
+      "name": "linux-bionic-py3.8-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:32:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819660757",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820638167,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:50:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833361559/job/15820638167",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15820571830,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:51:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833341434/job/15820571830",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819654946,
+      "name": "Test collect_env (without_torch)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:17:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819654946",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15819784157,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:23:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833099306/job/15819784157",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Close stale pull requests",
+      "id": 15821992241,
+      "name": "stale",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:34:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833802424/job/15821992241",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15820158813,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:37:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833218189/job/15820158813",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Auto Request Review",
+      "id": 15885150117,
+      "name": "Auto Request Review",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:34:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347714/job/15885150117",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15819890404,
+      "name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:32:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15819890404",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885490891,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:30:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490891",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885152715,
+      "name": "linux-jammy-py3-clang12-mobile-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:43:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885152715",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821174572,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:07:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833532405/job/15821174572",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15829003045,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T20:27:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15829003045",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820137768,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 3, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:02:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820137768",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820137496,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 2, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:38:45Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820137496",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820117233,
+      "name": "linux-focal-py3.8-gcc7 / test (docs_test, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:39:19Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820117233",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823509870,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:27Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834293505/job/15823509870",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15820873105,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:09:51Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057246/job/15820873105",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "An error occurred while attempting to read the response stream"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820068284,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_torchbench_dynamic_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:22:36Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820068284",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819655739,
+      "name": "Test tools / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:20:16Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819655739",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Update viable/strict",
+      "id": 15822423413,
+      "name": "do_update_viablestrict",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:50:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833941152/job/15822423413",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821024095,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:03:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833479503/job/15821024095",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822621113,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:55:18Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834001243/job/15822621113",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887258996,
+      "name": "macos-12-py3-arm64 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:01:08Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258996",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 18
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887258822,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:19:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887258822",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820130349,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:18:33Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820130349",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820117035,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:20:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820117035",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821695295,
+      "name": "Upload test stats for 5831770573, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:28:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833701675/job/15821695295",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822344466,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:45:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833912711/job/15822344466",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885497726,
+      "name": "linux-docs / build-docs-python-false",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:13:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885497726",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885491248,
+      "name": "linux-bionic-py3.11-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:14:12Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885491248",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "AttributeError: 'Context' object has no attribute 'owner'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885151937,
+      "name": "Test tools / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:38:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151937",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15888410482,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:46:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028171/job/15888410482",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15819969798,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:27:44Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833158532/job/15819969798",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15819667287,
+      "name": "Upload test stats for 5833056520, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:23:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833059541/job/15819667287",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885558623,
+      "name": "linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:00:58Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885558623",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'torch.version'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885490694,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 1, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:47:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885490694",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821341449,
+      "name": "Upload test stats for 5830927324, attempt 2",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:16:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833583885/job/15821341449",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823514238,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:29Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834293505/job/15823514238",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820066998,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_cpu_accuracy, 1, 2, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:54:05Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820066998",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15820517823,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T16:02:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057478/job/15820517823",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885841502,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:22:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885841502",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493604,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:28:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493604",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885492940,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:55:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885492940",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820068085,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_timm_dynamic_cpu_accuracy, 2, 2, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:56:09Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820068085",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820066793,
+      "name": "linux-focal-cpu-py3.8-gcc7-inductor / test (inductor_huggingface_cpu_accuracy, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:01:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820066793",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885493098,
+      "name": "linux-bionic-py3.8-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:25:43Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885493098",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823515146,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834295047/job/15823515146",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15822931728,
+      "name": "update-html (whl/test)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:08:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834104370/job/15822931728",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15888235896,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:37:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028173/job/15888235896",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "undefined reference to `c10::detail::torchInternalAssertFail(char const*, char const*, unsigned int, char const*, std::string const&)'"
+      ],
+      "steps": 22
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15887257026,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:35:15Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028171/job/15887257026",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15887257243,
+      "name": "manywheel-py3_8-cuda11_8-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:23:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15887257243",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820446553,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_timm, 1, 2, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:35:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820446553",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Close stale pull requests",
+      "id": 15820147797,
+      "name": "stale",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:34:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833214347/job/15820147797",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819654485,
+      "name": "pr-sanity-checks",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T13:16:50Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819654485",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885163500,
+      "name": "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T19:04:14Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885163500",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 13
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821027576,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:03:38Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833480473/job/15821027576",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821689541,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:23:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833701675/job/15821689541",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-cxx11-abi",
+      "id": 15819656172,
+      "name": "libtorch-cpu-shared-with-deps-cxx11-abi-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:52:13Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057341/job/15819656172",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819656027,
+      "name": "workflow-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:20:01Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819656027",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885151164,
+      "name": "linux-bionic-py3.8-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:47:28Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885151164",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "linux-binary-libtorch-pre-cxx11",
+      "id": 15819655965,
+      "name": "libtorch-cpu-shared-with-deps-pre-cxx11-build / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:58:40Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057246/job/15819655965",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 23
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15885845849,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / test (distributed, 1, 3, linux.8xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:11:23Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347753/job/15885845849",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821335251,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:13:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833583885/job/15821335251",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820446179,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "failure",
+      "completed_at": "2023-08-11T15:18:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820446179",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "inductor/test_torchinductor.py::TritonCodeGenTests::test_optimize_indexing_dtype_with_constraint"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821689231,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:23:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833701675/job/15821689231",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819656287,
+      "name": "quick-checks / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:20:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819656287",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload Alerts to AWS/Rockset",
+      "id": 15821987765,
+      "name": "upload-alerts",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:33:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833800487/job/15821987765",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 8
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15819656573,
+      "name": "toc / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:20:10Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833056575/job/15819656573",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887467541,
+      "name": "macos-12-py3-arm64-mps / test (default, 1, 1)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:18:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887467541",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 14
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820116833,
+      "name": "linux-focal-py3.8-gcc7 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:59:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820116833",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819662668,
+      "name": "linux-bionic-py3.11-clang9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:33:07Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819662668",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820637960,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:50:34Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833361559/job/15820637960",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820447069,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_huggingface_dynamic, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:52:11Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820447069",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "trunk",
+      "id": 15887454378,
+      "name": "macos-12-py3-arm64 / test (default, 3, 3, macos-m1-12)",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T20:48:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028213/job/15887454378",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'sympy'"
+      ],
+      "steps": 21
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820232944,
+      "name": "linux-bionic-py3_8-clang8-xla / test (xla, 1, 1, linux.12xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:48:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820232944",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "ModuleNotFoundError: No module named 'torch.version'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820135329,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 2, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:19:53Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820135329",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820501695,
+      "name": "cuda12.1-py3.10-gcc9-sm80 / test (inductor_torchbench_smoketest_perf, 1, 1, linux.gcp.a100)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:06:48Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820501695",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 28
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15819656795,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:43:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15819656795",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823581783,
+      "name": "Upload test stats for 5832605935, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:31:37Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834313815/job/15823581783",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820138642,
+      "name": "linux-jammy-py3.9-clang12-asan / test (default, 6, 6, linux.4xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:10:35Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820138642",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820135044,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 1, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:42:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820135044",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr_dynamic_shapes"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820045264,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:30:47Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833180285/job/15820045264",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "linux-binary-manywheel",
+      "id": 15888983848,
+      "name": "manywheel-py3_8-cuda12_1-with-pypi-cudnn-test / test",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T21:15:02Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5860028215/job/15888983848",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15820823829,
+      "name": "Upload test stats for 5832106286, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:00:04Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833415081/job/15820823829",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "inductor",
+      "id": 15820446354,
+      "name": "cuda12.1-py3.10-gcc9-sm86 / test (inductor_huggingface, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:55:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057440/job/15820446354",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885151724,
+      "name": "lintrunner / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:46:41Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885151724",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820136204,
+      "name": "linux-bionic-py3.11-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:27:32Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820136204",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820505251,
+      "name": "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:19:03Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820505251",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "dynamo/test_dynamic_shapes.py::DynamicShapesAotAutogradFallbackTests::test_aot_sequence_nr"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823526260,
+      "name": "Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}",
+      "conclusion": "skipped",
+      "completed_at": "2023-08-11T15:24:55Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834297269/job/15823526260",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 0
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819660020,
+      "name": "linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:06:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819660020",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    },
+    {
+      "workflow_name": "Lint",
+      "id": 15885152118,
+      "name": "toc / linux-job",
+      "conclusion": "success",
+      "completed_at": "2023-08-14T18:37:49Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5859347806/job/15885152118",
+      "head_sha": "1abba7bb35f1562329d0235dedf171790cd162a5",
+      "failure_captures": null,
+      "steps": 22
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823522040,
+      "name": "get_workflow_conclusion",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:54Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834297269/job/15823522040",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820131308,
+      "name": "linux-bionic-py3.8-clang9 / test (dynamo, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:05:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820131308",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "AttributeError: 'Context' object has no attribute 'owner'"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15823576699,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:26:52Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5834313815/job/15823576699",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15822018003,
+      "name": "check-api-rate",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:34:25Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833811535/job/15822018003",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 3
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820135652,
+      "name": "linux-bionic-py3.11-clang9 / test (default, 3, 3, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:22:30Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820135652",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820130753,
+      "name": "linux-bionic-py3.8-clang9 / test (crossref, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T15:24:20Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820130753",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 26
+    },
+    {
+      "workflow_name": "Upload test stats",
+      "id": 15821698803,
+      "name": "Upload test stats for 5832208322, attempt 1",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:27:21Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833703425/job/15821698803",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 9
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15821082849,
+      "name": "update-html (whl/lts/1.8)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:05:46Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833498968/job/15821082849",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "Update S3 HTML indices for download.pytorch.org",
+      "id": 15821082520,
+      "name": "update-html (whl/nightly)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:35:57Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833498968/job/15821082520",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 4
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15820118074,
+      "name": "linux-focal-py3.8-gcc7 / test (distributed, 2, 2, linux.2xlarge)",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T14:52:56Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820118074",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": [
+        "RuntimeError: simulation"
+      ],
+      "steps": 26
+    },
+    {
+      "workflow_name": "pull",
+      "id": 15819658527,
+      "name": "linux-bionic-cuda11.8-py3.10-gcc9 / build",
+      "conclusion": "success",
+      "completed_at": "2023-08-11T13:46:39Z",
+      "html_url": "https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15819658527",
+      "head_sha": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+      "failure_captures": null,
+      "steps": 16
+    }
+  ]
 }

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -731,17 +731,29 @@ class TestBypassFailures(TestCase):
                 # than the one on the base commit. This should still count as broken trunk
                 "pr_num": 104214,
                 "mock_merge_base": "436d035dc74db9c703297a62163b0cad0c546665",
+                "unrelated_failure_count": 1,
             },
             {
                 # This PR had one broken trunk failure and it used ghstack
                 "pr_num": 105145,
                 "mock_merge_base": "194fe1d12f9860734cc28ed21bdabda2fbb06336",
+                "unrelated_failure_count": 1,
+            },
+            {
+                # The failure on the merge base was retried successfully and
+                # its conclusion changed from failure to success. We want to
+                # keep the failure record from the merge base so that it can
+                # be used to detect broken trunk
+                "pr_num": 107160,
+                "mock_merge_base": "a5d841ef01e615e2a654fb12cf0cd08697d12ccf",
+                "unrelated_failure_count": 4,
             },
         ]
 
         for case in test_cases:
             pr_num = case["pr_num"]
             mock_merge_base = case["mock_merge_base"]
+            unrelated_failure_count = case["unrelated_failure_count"]
 
             pr = GitHubPR("pytorch", "pytorch", cast(int, pr_num))
             with mock.patch(
@@ -762,7 +774,7 @@ class TestBypassFailures(TestCase):
                     checks, list(checks.keys()), ok_failed_checks_threshold=0
                 )
                 self.assertTrue(len(pending) == 0)
-                self.assertTrue(len(failed) == 1)
+                self.assertTrue(len(failed) == unrelated_failure_count)
 
     def test_ignore_current(self, *args: Any) -> None:
         # Test various interactions of the failure classifier, mostly that

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1616,7 +1616,7 @@ def get_classifications(
             # when merging
             #
             # When overwrite_failed_run_attempt is False, only overwrite the job
-            # with the result from the latest attempt if the latest attemp failed.
+            # with the result from the latest attempt if the latest retry failed.
             # This option is for jobs from the merger_base where we want to record
             # failures for broken trunk
             if d[key_no_suffix][key]["id"] < val["id"] and (

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1600,23 +1600,47 @@ def get_classifications(
     if merge_base is not None:
 
         def insert(
-            d: Dict[str, Dict[str, Dict[str, Any]]], key: str, val: Dict[str, Any]
+            d: Dict[str, Dict[str, Dict[str, Any]]],
+            key: str,
+            val: Dict[str, Any],
+            overwrite_failed_run_attempt: bool,
         ) -> None:
             key_no_suffix = remove_job_name_suffix(key)
             if key not in d[key_no_suffix]:
                 d[key_no_suffix][key] = val
                 return
 
-            if d[key_no_suffix][key]["id"] < val["id"]:
+            # When overwrite_failed_run_attempt is set to True, always overwrite
+            # the job with the result from the latest attempt. This option is for
+            # jobs from the pull request head_sha where the latest retry is used
+            # when merging
+            #
+            # When overwrite_failed_run_attempt is False, only overwrite the job
+            # with the result from the latest attempt if the latest attemp failed.
+            # This option is for jobs from the merger_base where we want to record
+            # failures for broken trunk
+            if d[key_no_suffix][key]["id"] < val["id"] and (
+                overwrite_failed_run_attempt or not is_passing_status(val["conclusion"])
+            ):
                 d[key_no_suffix][key] = val
 
         rockset_results = get_rockset_results(head_sha, merge_base)
         for rockset_result in rockset_results:
             name = f"{rockset_result['workflow_name']} / {rockset_result['name']}"
             if rockset_result["head_sha"] == head_sha:
-                insert(head_sha_jobs, name, rockset_result)
+                insert(
+                    head_sha_jobs,
+                    name,
+                    rockset_result,
+                    overwrite_failed_run_attempt=True,
+                )
             else:
-                insert(merge_base_jobs, name, rockset_result)
+                insert(
+                    merge_base_jobs,
+                    name,
+                    rockset_result,
+                    overwrite_failed_run_attempt=False,
+                )
 
     checks_with_classifications = checks.copy()
     for name, check in checks.items():


### PR DESCRIPTION
This fixes a discrepancy bug between Dr.CI and trymerge when detecting broken trunk failures. 
 Take https://github.com/pytorch/pytorch/pull/107160 as an example:

* Dr.CI correctly identifies the broken trunk failure
* while trymerge records it as a new failure

The issue is that the merge base [failure](https://github.com/pytorch/pytorch/actions/runs/5833057579/job/15820504498) was flaky.  It was retried successfully and its conclusion went from a failure to a success.  The Rockset query returns all run attempts and while Dr.CI correctly records the failure, trymerge overwrites it with the successful retry.   Thus, the latter saw a new failure.

This change makes trymerge keep the merge base failure similar to what Dr.CI does https://github.com/pytorch/test-infra/blob/main/torchci/pages/api/drci/drci.ts#L158-L168

cc @albanD