### PR TITLE
fixing internal test failure on non sm_80 machines

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -10,6 +10,7 @@ from torch._dynamo.utils import count_calls, counters
 from torch._inductor.fx_passes import joint_graph
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
@@ -63,6 +64,7 @@ class TestPaternMatcher(TestCase):
         self.assertEqual("mixed_mm" in code, mixed_mm_expected)
         self.assertEqual("fallback_mixed_mm" in code, fallback_mixed_mm_expected)
 
+    @unittest.skipIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_mixed_mm=True)
     def test_mixed_mm(self):
         def fn(a, b):
@@ -90,6 +92,7 @@ class TestPaternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
+    @unittest.skipIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_mixed_mm=True, max_autotune_gemm=True)
     def test_mixed_mm_epi_works(self):
         def fn(a, b, c, d):
@@ -119,6 +122,7 @@ class TestPaternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
+    @unittest.skipIf(not SM80OrLater, "need sm_80")
     def test_mixed_mm_gating(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
@@ -154,6 +158,7 @@ class TestPaternMatcher(TestCase):
         )
         self._test_mixed_impl(fn, args, False, False)
 
+    @unittest.skipIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm(self):
         def fn(a, b):
@@ -188,6 +193,7 @@ class TestPaternMatcher(TestCase):
             torch.testing.assert_close(ref, test)
             self.assertTrue("uint4x2_mixed_mm" in code)
 
+    @unittest.skipIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm_epi(self):
         def fn(a, b, c, d):


### PR DESCRIPTION
Summary:
These tests were failing on non sm_80+ machines used for internal CI, added check to skip this.

D48295360 added new tests that work in OSS but not in phabricator CI

https://www.internalfb.com/intern/test/562950057441807?ref_report_id=0

https://www.internalfb.com/intern/test/281475080709193?ref_report_id=0

Test Plan: see phabricator result

Differential Revision: D48417499



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov