### PR TITLE
[inductor][easy] mixed_mm tests - only run bf16 if it is supported

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -80,16 +80,20 @@ class TestPaternMatcher(TestCase):
         ]
 
         if torch.cuda.is_bf16_supported():
-            args_list.extend([
-                (
-                    torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                    torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-                ),
-                (
-                    torch.randn(8, 8, device="cuda", dtype=torch.float32),
-                    torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
-                ),
-            ])
+            args_list.extend(
+                [
+                    (
+                        torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+                        torch.randint(
+                            -128, 127, (2, 8), dtype=torch.int8, device="cuda"
+                        ),
+                    ),
+                    (
+                        torch.randn(8, 8, device="cuda", dtype=torch.float32),
+                        torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
+                    ),
+                ]
+            )
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
@@ -115,12 +119,14 @@ class TestPaternMatcher(TestCase):
         ]
 
         if torch.cuda.is_bf16_supported():
-            args_list.append((
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-            ))
+            args_list.append(
+                (
+                    torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+                    torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+                    torch.randn(8, device="cuda", dtype=torch.bfloat16),
+                    torch.randn(8, device="cuda", dtype=torch.bfloat16),
+                )
+            )
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -74,18 +74,22 @@ class TestPaternMatcher(TestCase):
                 torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
             ),
             (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-            ),
-            (
                 torch.randn(8, 5, device="cuda", dtype=torch.float16),
                 torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),
             ),
-            (
-                torch.randn(8, 8, device="cuda", dtype=torch.float32),
-                torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
-            ),
         ]
+
+        if torch.cuda.is_bf16_supported():
+            args_list.extend([
+                (
+                    torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+                    torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+                ),
+                (
+                    torch.randn(8, 8, device="cuda", dtype=torch.float32),
+                    torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
+                ),
+            ])
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
@@ -103,18 +107,20 @@ class TestPaternMatcher(TestCase):
                 torch.randn(8, device="cuda"),
             ),
             (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-            ),
-            (
                 torch.randn(8, 5, device="cuda", dtype=torch.float16),
                 torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),
                 torch.randn(2, device="cuda", dtype=torch.float16),
                 torch.randn(2, device="cuda", dtype=torch.float16),
             ),
         ]
+
+        if torch.cuda.is_bf16_supported():
+            args_list.append((
+                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+                torch.randn(8, device="cuda", dtype=torch.bfloat16),
+                torch.randn(8, device="cuda", dtype=torch.bfloat16),
+            ))
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #107354

These tests are failing internally on V100s. We should skip the bf16 tests on machines that don't support bf16.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov

Differential Revision: [D48422076](https://our.internmc.facebook.com/intern/diff/D48422076)