### PR TITLE
Add fmt header files to Python package 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1357,6 +1357,12 @@ def main():
                 "include/tensorpipe/transport/uv/*.h",
             ]
         )
+        torch_package_data.extend(
+            [
+                "include/fmt/include/*.h",
+            ]
+        )
+    
     torchgen_package_data = [
         # Recursive glob doesn't work in setup.py,
         # https://github.com/pypa/setuptools/issues/1806


### PR DESCRIPTION
Same ability as this PR #105521

This change adds the fmt header files to torch_package_data if USE_DISTRIBUTED is set to ON in the CMake cache. 
The contents of the fmt third-party library will be used when extending the RPC third-party agent，So expect to be exposed together with the tensorpipe header file.
