### PR TITLE
benchmark: convert output of fp64 to torch.float64

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -27,7 +27,7 @@ hf_Reformer,pass,5
 hf_T5_large,pass_due_to_skip,0
 hf_Whisper,pass,0
 lennard_jones,pass,0
-llama,fail_accuracy,0
+llama,pass,0
 maml_omniglot,pass,0
 mnasnet1_0,pass,0
 mobilenet_v2,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -28,7 +28,7 @@ hf_T5_generate,pass,23
 hf_T5_large,pass_due_to_skip,0
 hf_Whisper,pass,0
 lennard_jones,pass,0
-llama,fail_accuracy,0
+llama,pass,0
 maml_omniglot,pass,0
 mnasnet1_0,pass,0
 mobilenet_v2,pass,0

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2018,6 +2018,12 @@ class BenchmarkRunner:
             )
             self.init_optimizer(name, current_device, model_fp64.parameters())
             fp64_outputs = self.run_n_iterations(model_fp64, inputs_fp64)
+            fp64_outputs = tree_map(
+                lambda x: x.to(torch.float64)
+                if isinstance(x, torch.Tensor) and x.is_floating_point()
+                else x,
+                fp64_outputs,
+            )
         except Exception:
             log.warning(
                 "fp64 golden ref were not generated for %s. Setting accuracy check to cosine",


### PR DESCRIPTION
This PR adds converting the output of fp64 to torch.float64 before checking for accuracy.

Why we need this change?
For llama of torchbench, it converts output to float before returning it.
https://github.com/pytorch/benchmark/blob/bad4e9ac19852f320c0d21e97f526e0c2838633e/torchbenchmark/models/llama/model.py#L241

While in the correctness checker, it will not compare the res results with fp64_ref if the fp64_ref.dtype is not torch.float64. So llama fails the accuracy check in the low-precision case, even though res is closer to fp64_ref than ref.
https://github.com/pytorch/pytorch/blob/e108f33299e4ea8fd39a1a81cf5ba6f3b509b6cb/torch/_dynamo/utils.py#L1025

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107376
* __->__ #107375



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov