### PR TITLE
[core][sparse][pruning] cuSPARSELt Kernels and ops. (#107176)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3244,6 +3244,14 @@
     MkldnnCPU: mkldnn_linear_backward
   autogen: mkldnn_linear_backward.out
 
+- func: _cslt_compress(Tensor input) -> Tensor
+  dispatch:
+    CUDA: _cslt_compress
+
+- func: _cslt_sparse_mm(Tensor compressed_A, Tensor dense_B, Tensor? bias=None, bool transpose_result=False) -> Tensor
+  dispatch:
+    CUDA: _cslt_sparse_mm
+
 - func: _sparse_semi_structured_linear(Tensor input, Tensor weight, Tensor meta, *, Tensor? bias=None, str? activation=None) -> Tensor
   dispatch:
     CUDA: _sparse_semi_structured_linear

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -1,0 +1,265 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDADataType.h>
+#include <ATen/cuda/CUDASparse.h>
+#include <ATen/cuda/CUDAConfig.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/Dispatch.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/Half.h>
+#include <cusparse.h>
+#include <cstdint>
+
+#if AT_CUSPARSELT_ENABLED()
+
+#include <cusparseLt.h>
+
+namespace at::native {
+
+cusparseLtHandle_t handle;
+bool handle_initialized = false;
+
+at::Tensor _cslt_compress(const Tensor& sparse_input)
+{
+    if (!handle_initialized){
+        TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
+        handle_initialized = true;
+    }
+    // create sparse descriptor, dtype
+    cusparseLtMatDescriptor_t sparse_input_descriptor;
+    cudaDataType type;
+    auto compression_factor = 9;
+
+    switch(
+        sparse_input.scalar_type()
+    )
+    {
+        case at::ScalarType::Char:
+            type = CUDA_R_8I;
+            compression_factor = 10;
+            break;
+        case at::ScalarType::Half:
+            type = CUDA_R_16F;
+            break;
+        case at::ScalarType::BFloat16:
+            type = CUDA_R_16BF;
+            break;
+        case at::ScalarType::Float:
+            type = CUDA_R_32F;
+            break;
+        default:
+            TORCH_CHECK(false, "Unsupported dtype for cuSPARSELt compressed matrix");
+            break;
+    }
+
+    // create a new compressed tensor with the same dtype as
+    auto compressed_tensor = sparse_input.new_empty(sparse_input.numel() * compression_factor / 16);
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &sparse_input_descriptor,
+        sparse_input.size(0),
+        sparse_input.size(1),
+        sparse_input.size(1),
+        16,
+        type,
+        CUSPARSE_ORDER_ROW,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+
+    // compress input
+    //--------------------------------------------------------------------------
+    size_t compressed_size, compressed_buffer_size;
+    TORCH_CUDASPARSE_CHECK(cusparseLtSpMMACompressedSize2(
+        &handle,
+        &sparse_input_descriptor,
+        &compressed_size,
+        &compressed_buffer_size));
+
+    auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+    auto compressedBufferPtr = allocator.allocate(compressed_buffer_size);
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtSpMMACompress2(
+        &handle,
+        &sparse_input_descriptor,
+        true,
+        CUSPARSE_OPERATION_NON_TRANSPOSE,
+        sparse_input.data_ptr(),
+        compressed_tensor.data_ptr(),
+        compressedBufferPtr.get(),
+        nullptr));
+
+    return compressed_tensor;
+}
+
+
+at::Tensor _cslt_sparse_mm(
+    const Tensor& compressed_A,
+    const Tensor& dense_B,
+    const c10::optional<Tensor>& bias_opt,
+    bool transpose_result
+)
+{
+  if (!handle_initialized){
+      TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
+      handle_initialized = true;
+  }
+  // cupsarselt constructs
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+
+  float alpha = 1.0;
+  float beta = 0.0;
+  cudaDataType type;
+  cusparseComputeType compute_type;
+  auto compression_factor = 9;
+
+  switch(compressed_A.scalar_type())
+  {
+    case at::ScalarType::Char:
+        type = CUDA_R_8I;
+        compute_type = CUSPARSE_COMPUTE_32I;
+        compression_factor = 10;
+        break;
+    case at::ScalarType::Half:
+        type = CUDA_R_16F;
+        compute_type = CUSPARSE_COMPUTE_16F;
+        break;
+    case at::ScalarType::BFloat16:
+        type = CUDA_R_16BF;
+        compute_type = CUSPARSE_COMPUTE_16F;
+        break;
+    case at::ScalarType::Float:
+        type = CUDA_R_32F;
+        compute_type = CUSPARSE_COMPUTE_TF32;
+        break;
+    default:
+        TORCH_CHECK(false, "Unsupported dtype for cuSPARSE compressed matrix multiplication.");
+        break;
+  }
+
+  int64_t k = dense_B.size(0);
+  int64_t n = dense_B.size(1);
+  int64_t m = (compressed_A.numel() * 16 / compression_factor  ) / k;
+
+  //initialize sparse descriptor
+  cusparseLtMatDescriptor_t sparse_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &sparse_input_descriptor,
+      m,
+      k,
+      k,
+      16,
+      type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+
+  // initalize dense input descriptor
+  cusparseLtMatDescriptor_t dense_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &dense_input_descriptor,
+      (dense_B.is_contiguous()) ? k : n,
+      (dense_B.is_contiguous()) ? n : k,
+      (dense_B.is_contiguous()) ? n : k,
+      16,
+      type,
+      CUSPARSE_ORDER_ROW));
+
+  // create result tensor
+  auto res = (transpose_result) ? dense_B.new_empty({n, m})
+                                : dense_B.new_empty({m, n});
+
+
+  cusparseLtMatDescriptor_t res_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &res_descriptor,
+      m,
+      n,
+      (transpose_result) ? m: n,
+      16,
+      type,
+      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+
+  // intialize matmul
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+      &handle,
+      &matmul,
+      CUSPARSE_OPERATION_NON_TRANSPOSE,
+      (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE,
+      &sparse_input_descriptor,
+      &dense_input_descriptor,
+      &res_descriptor,
+      &res_descriptor,
+      compute_type));
+
+  // set bias pointer for matmut, need to assign to get location
+  if (bias_opt.has_value()) {
+    auto& bias = bias_opt.value();
+    void* dBias = bias.data_ptr();
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+        &handle, &matmul, CUSPARSELT_MATMUL_BIAS_POINTER, &dBias, sizeof(dBias)));
+  }
+
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+      &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatmulPlanInit(&handle, &plan, &matmul, &alg_sel));
+
+  size_t workspace_size;
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspacePtr = allocator.allocate(workspace_size);
+
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
+      &handle,
+      &plan,
+      &alpha,
+      compressed_A.data_ptr(),
+      dense_B.data_ptr(),
+      &beta,
+      res.data_ptr(),
+      res.data_ptr(),
+      workspacePtr.get(),
+      nullptr,
+      0));
+
+
+  //destroy descriptors
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
+  // destroy plan
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+  return res;
+}
+
+} // namespace at::native
+
+#else // No cuSPARSELt support, throw error if these functions are called.
+
+namespace at::native {
+
+at::Tensor _cslt_compress(const Tensor& sparse_input){
+    TORCH_CHECK(false, "cuSPARSELT not supported on your machine.");
+}
+
+at::Tensor _cslt_sparse_mm(
+    const Tensor& compressed_A,
+    const Tensor& dense_B,
+    const c10::optional<Tensor>& bias_opt,
+    bool transpose_result)
+{
+    TORCH_CHECK(false, "cuSPARSELT not supported on your machine.");
+}
+
+} // namespace at::native
+
+#endif

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -16,9 +16,9 @@ _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG = {
     torch.int8: _SEMI_STRUCTURED_SPARSE_CONFIG(10, 32, 128),
     torch.float16: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 64),
     torch.bfloat16: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 64),
+    # TODO enable float32 support when adding cuSPARSELt as a backend
+    # torch.float32: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 32)
 }
-
-_WARNING_SHOWN = False
 
 
 class SparseSemiStructuredTensor(torch.Tensor):
@@ -29,20 +29,31 @@ class SparseSemiStructuredTensor(torch.Tensor):
     structured sparsity.
 
     Currently, this class supports 2:4 sparsity for int8, float16 and bfloat16 dtypes.
+    We also support 1:2 sparsity for float32 dtype.
 
     This subclass stores the dense tensor in a compressed form by only storing the specified elements and corresponding metadata.
     These two are stored next to each other in one contiguous tensor.
 
-    We choose to store the specified elements and the metadata in a single tensor for future compatibilty with cuSPARSELt.
+    We choose to store the specified elements and the metadata in a single tensor for compatibilty with cuSPARSELt,
+    which expects the data to be stored in this format.
 
-    compressed tensor = [ specified elements of original tensor |   metadata     ]
+    compressed tensor = [ specified elements of original tensor | metadata ]
 
     For an original tensor of size (m, k) we expect the first m * k // 2 elements to be the kept elements
     The rest of the tensor is metadata.
 
-    This subclass also overrides __torch_dispatch__ to use _sparse_semi_structured_linear for faster matrix multiplications
-    via sparse CUTLASS kernels. In the future we will also call into cuSPARSELt kernels for more performance gains.
+    The subclass supports two backend, either CUTLASS or cuSPASRELt.
+
+    When _FORCE_CUTLASS is set, or when cuSPARSELt is not available, this subclass calls into _sparse_semi_structured_linear
+    and sparse_semi_structured_from_dense for conversion to the compressed format.
+
+    When PyTorch is compiled with cuSPARSELt support, this subclass will call into _cslt_sparse_mm for sparse mm and
+    _cslt_compress to convert into the compressed format.
     """
+
+    _FUSE_TRANSPOSE = False
+    _FORCE_CUTLASS = False
+    _WARNING_SHOWN = False
 
     @staticmethod
     def __new__(
@@ -71,6 +82,18 @@ class SparseSemiStructuredTensor(torch.Tensor):
             ValueError: If both original_tensor and compressed_tensor are None.
 
         """
+        if not cls._WARNING_SHOWN:
+            warnings.warn(
+                (
+                    "The PyTorch API of SparseSemiStructuredTensor is in prototype stage "
+                    "and will change in the near future. Please open a Github issue "
+                    "for features requests and see our documentation on the torch.sparse "
+                    "module for further information about the project."
+                ),
+                UserWarning,
+            )
+            cls._WARNING_SHOWN = True
+
         if original_tensor is not None:
             previous_tensor = original_tensor
             original_shape = original_tensor.shape
@@ -118,21 +141,11 @@ class SparseSemiStructuredTensor(torch.Tensor):
         Raises:
             RuntimeError: If original_tensor is not a supported dtype, dim, shape, or device.
         """
-        global _WARNING_SHOWN
-        if not _WARNING_SHOWN:
-            warnings.warn(
-                (
-                    "The PyTorch API of SparseSemiStructuredTensor is in prototype stage "
-                    "and will change in the near future. Please open a Github issue "
-                    "for features requests and see our documentation on the torch.sparse "
-                    "module for further information about the project."
-                ),
-                UserWarning,
-            )
-            _WARNING_SHOWN = True
-
         # if original tensor is passed in, we need to compress it and store the compressed representation.
         if original_tensor is not None:
+            # TODO right now we have unified checks and constraints for cuSPARSELt and CUTLASS, these are not actually the same.
+            # We should consolidate similar checks here and leave backend specific checks like shape in the op implementation.
+
             # check device
             if not original_tensor.is_cuda:
                 raise RuntimeError(
@@ -156,8 +169,12 @@ class SparseSemiStructuredTensor(torch.Tensor):
 
             # check shape
             m, n = original_tensor.shape
-            min_rows = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_rows
-            min_cols = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_cols
+            min_rows = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                original_tensor.dtype
+            ].min_rows
+            min_cols = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                original_tensor.dtype
+            ].min_cols
             if m < min_rows or m % min_rows or n < min_cols or n % min_cols:
                 # TODO in the future we can add in padding to support dimensions that aren't perfect multiples
                 raise RuntimeError(
@@ -165,26 +182,34 @@ class SparseSemiStructuredTensor(torch.Tensor):
                     "Both dimensions must be larger or equal than and a multiple of ({min_rows}, {min_cols})"
                 )
 
-            # This code calculates the size of the compressed tensor.
-            # compression factor is different based on dtype it's given by the formula below for 2:4 sparsity:
-            # compression_factor = 1/2 + 1/bitwidth(dtype)
-            original_size = original_tensor.nelement()
-            compression_factor = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
-                original_tensor.dtype
-            ].compression_factor
-            compressed_size = original_size * compression_factor // 16
+            if self._FORCE_CUTLASS:
+                # This code calculates the size of the compressed tensor.
+                # compression factor is different based on dtype it's given by the formula below for 2:4 sparsity:
+                # compression_factor = 1/2 + 1/bitwidth(dtype)
+                original_size = original_tensor.nelement()
+                compression_factor = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                    original_tensor.dtype
+                ].compression_factor
+                compressed_size = original_size * compression_factor // 16
 
-            compressed_tensor = torch.empty(
-                (compressed_size,),
-                dtype=original_tensor.dtype,
-                device=original_tensor.device,
-            )
+                compressed_tensor = torch.empty(
+                    (compressed_size,),
+                    dtype=original_tensor.dtype,
+                    device=original_tensor.device,
+                )
 
-            from torch.sparse._semi_structured_conversions import sparse_semi_structured_from_dense
+                from torch.sparse._semi_structured_conversions import (
+                    sparse_semi_structured_from_dense,
+                )
 
-            sparse, meta = sparse_semi_structured_from_dense(original_tensor)
-            compressed_tensor[: m * n // 2] = sparse.view(-1)
-            compressed_tensor[m * n // 2 :] = meta.view(original_tensor.dtype).view(-1)
+                sparse, meta = sparse_semi_structured_from_dense(original_tensor)
+                compressed_tensor[: m * n // 2] = sparse.view(-1)
+                compressed_tensor[m * n // 2 :] = meta.view(original_tensor.dtype).view(
+                    -1
+                )
+            else:
+                # use cuSPARSELt
+                compressed_tensor = torch._cslt_compress(original_tensor)
 
         # set values
         self.original_tensor = None
@@ -262,37 +287,57 @@ class SparseSemiStructuredTensor(torch.Tensor):
             # F.linear(x) = addmm(bias, input, weight.t()) = b + xW' = (b + xW')''
             #        = (W''x' + b')' = (Wx' + b')' = addmm(bias.T, weight, input).T
             if isinstance(input_B, cls) and input_B.transposed:
-                result = torch._sparse_semi_structured_linear(
-                    input_A, input_B.values(), input_B.indices(), bias=bias
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_A, input_B.values(), input_B.indices(), bias=bias
+                    )
+                else:
+                    return torch._cslt_sparse_mm(
+                        input_B.compressed_tensor, input_A.T, bias  # type: ignore[arg-type]
+                    ).t()
 
         # handle mm
         if func is torch.ops.aten.mm.default:
             input_A, input_B = args
 
             if isinstance(input_A, cls) and not input_A.transposed:
-                transposed_result = torch._sparse_semi_structured_linear(
-                    input_B.t(), input_A.values(), input_A.indices()
-                )
-                return transposed_result.t()
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_B.t(), input_A.values(), input_A.indices()
+                    ).t()
+                else:
+                    return torch._cslt_sparse_mm(
+                        input_A.compressed_tensor, input_B, None  # type: ignore[arg-type]
+                    )
 
             elif isinstance(input_B, cls) and input_B.transposed:
-                result = torch._sparse_semi_structured_linear(
-                    input_A, input_B.values(), input_B.indices()
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_A, input_B.values(), input_B.indices()
+                    )
+                else:
+                    return torch._cslt_sparse_mm(input_B.compressed_tensor, input_A.T, None).t()  # type: ignore[arg-type]
 
         # When torch is run with inference mode, pytorch does not decompose torch.ops.aten.linear into a .t() and addmm(),
-        # so we must match the aten.linear op.
+        # so we must match the aten.linear op. In this case, we need to explicitly handle collapsing to 2d matmul
         # TODO see if there's a way to force pytorch to decompose the op so we don't have to handle this here.
         if func is torch.ops.aten.linear.default:
             input_tensor, weight, bias = args
+            shape = input_tensor.shape
             if isinstance(weight, cls):
-                result = torch._sparse_semi_structured_linear(
-                    input_tensor, weight.values(), weight.indices(), bias=bias
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_tensor,
+                        weight.values(),
+                        weight.indices(),
+                        bias=bias
+                    )
+                else:
+                    return torch._cslt_sparse_mm(
+                        weight.compressed_tensor,  # type: ignore[arg-type]
+                        input_tensor.view(-1, shape[-1]).t(),
+                        bias
+                    ).t().view(*shape[:-1], -1)
 
         # handle values
         if func is torch.ops.aten.values.default:
@@ -307,7 +352,9 @@ class SparseSemiStructuredTensor(torch.Tensor):
             metadata = args[0].compressed_tensor[num_kept_elements:].view(m, -1)
 
             # the metadata is expected to be in different datatypes for fp16/int8 respectively for CUTLASS.
-            indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(args[0].dtype)
+            indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(
+                args[0].dtype
+            )
             return metadata.view(indices_dtype)
 
         error_string = "\n".join(
@@ -323,11 +370,13 @@ class SparseSemiStructuredTensor(torch.Tensor):
         m, n = self.shape
         indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(self.dtype)
 
-        from torch.sparse._semi_structured_conversions import sparse_semi_structured_to_dense
+        from torch.sparse._semi_structured_conversions import (
+            sparse_semi_structured_to_dense,
+        )
 
         return sparse_semi_structured_to_dense(
             self.compressed_tensor[: m * n // 2].view(m, -1),
-            self.compressed_tensor[m * n // 2 :].view(indices_dtype).view(m, -1)
+            self.compressed_tensor[m * n // 2 :].view(indices_dtype).view(m, -1),
         )
 
 
@@ -382,4 +431,4 @@ def to_sparse_semi_structured(
                 [-4370, -4370, -4370,  ..., -4370, -4370, -4370]], device='cuda:0',
        dtype=torch.int16))
     """
-    return SparseSemiStructuredTensor(original_tensor, transposed=transposed)
+    return SparseSemiStructuredTensor(original_tensor, original_shape=original_tensor.shape, transposed=transposed)


### PR DESCRIPTION
Summary:

This is a duplicate PR of 102133, which was reverted because it was
failing internal tests.

It seems like that internal builds did not like my guard to check if
cuSPARSELt was available or not.

Test Plan: Imported from OSS

Reviewed By: cpuhrsch

Differential Revision: D48363534

