### PR TITLE
[core][sparse][pruning] cuSPARSELt Kernels and ops.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3248,6 +3248,14 @@
     MkldnnCPU: mkldnn_linear_backward
   autogen: mkldnn_linear_backward.out
 
+- func: _cslt_compress(Tensor input) -> Tensor
+  dispatch:
+    CUDA: _cslt_compress
+
+- func: _cslt_sparse_mm(Tensor compressed_A, Tensor dense_B, Tensor? bias=None, bool transpose_result=False) -> Tensor
+  dispatch:
+    CUDA: _cslt_sparse_mm
+
 - func: _sparse_semi_structured_linear(Tensor input, Tensor weight, Tensor meta, *, Tensor? bias=None, str? activation=None) -> Tensor
   dispatch:
     CUDA: _sparse_semi_structured_linear

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -1,0 +1,270 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDADataType.h>
+#include <ATen/cuda/CUDASparse.h>
+#include <ATen/cuda/CUDAConfig.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/Dispatch.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/Half.h>
+#include <cusparse.h>
+#include <cstdint>
+#include <iostream>
+
+#if AT_CUSPARSELT_ENABLED()
+
+#include <cusparseLt.h>
+
+namespace at::native {
+
+cusparseLtHandle_t handle;
+bool handle_initialized = false;
+
+at::Tensor _cslt_compress(const Tensor& sparse_input)
+{
+    if (!handle_initialized){
+        TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
+        handle_initialized = true;
+    }
+    // create sparse descriptor, dtype
+    cusparseLtMatDescriptor_t sparse_input_descriptor;
+    cudaDataType type;
+    auto compression_factor = 9;
+
+    switch(
+        sparse_input.scalar_type()
+    )
+    {
+        case at::ScalarType::Char:
+            type = CUDA_R_8I;
+            compression_factor = 10;
+            break;
+        case at::ScalarType::Half:
+            type = CUDA_R_16F;
+            break;
+        case at::ScalarType::BFloat16:
+            type = CUDA_R_16BF;
+            break;
+        case at::ScalarType::Float:
+            type = CUDA_R_32F;
+            break;
+        default:
+            TORCH_CHECK(false, "Unsupported dtype for cuSPARSELt compressed matrix");
+            break;
+    }
+
+    // create a new compressed tensor with the same dtype as
+    auto compressed_tensor = sparse_input.new_empty(sparse_input.numel() * compression_factor / 16);
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &sparse_input_descriptor,
+        sparse_input.size(0),
+        sparse_input.size(1),
+        sparse_input.size(1),
+        16,
+        type,
+        CUSPARSE_ORDER_ROW,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+
+    // compress input
+    //--------------------------------------------------------------------------
+    size_t compressed_size, compressed_buffer_size;
+    TORCH_CUDASPARSE_CHECK(cusparseLtSpMMACompressedSize2(
+        &handle,
+        &sparse_input_descriptor,
+        &compressed_size,
+        &compressed_buffer_size));
+
+    auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+    auto compressedBufferPtr = allocator.allocate(compressed_buffer_size);
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtSpMMACompress2(
+        &handle,
+        &sparse_input_descriptor,
+        true,
+        CUSPARSE_OPERATION_NON_TRANSPOSE,
+        sparse_input.data_ptr(),
+        compressed_tensor.data_ptr(),
+        compressedBufferPtr.get(),
+        stream));
+
+    return compressed_tensor;
+}
+
+
+at::Tensor _cslt_sparse_mm(
+    const Tensor& compressed_A,
+    const Tensor& dense_B,
+    const c10::optional<Tensor>& bias_opt,
+    bool transpose_result
+)
+{
+  if (!handle_initialized){
+      TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
+      handle_initialized = true;
+  }
+  // cupsarselt constructs
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulPlan_t plan;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+
+  float alpha = 1.0;
+  float beta = 0.0;
+  cudaDataType type;
+  cusparseComputeType compute_type;
+  auto compression_factor = 9;
+
+  switch(compressed_A.scalar_type())
+  {
+    case at::ScalarType::Char:
+        type = CUDA_R_8I;
+        compute_type = CUSPARSE_COMPUTE_32I;
+        compression_factor = 10;
+        break;
+    case at::ScalarType::Half:
+        type = CUDA_R_16F;
+        compute_type = CUSPARSE_COMPUTE_16F;
+        break;
+    case at::ScalarType::BFloat16:
+        type = CUDA_R_16BF;
+        compute_type = CUSPARSE_COMPUTE_16F;
+        break;
+    case at::ScalarType::Float:
+        type = CUDA_R_32F;
+        compute_type = CUSPARSE_COMPUTE_TF32;
+        break;
+    default:
+        TORCH_CHECK(false, "Unsupported dtype for cuSPARSE compressed matrix multiplication.");
+        break;
+  }
+
+  int64_t k = dense_B.size(0);
+  int64_t n = dense_B.size(1);
+  int64_t m = (compressed_A.numel() * 16 / compression_factor  ) / k;
+
+  //initialize sparse descriptor
+  cusparseLtMatDescriptor_t sparse_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+      &handle,
+      &sparse_input_descriptor,
+      m,
+      k,
+      k,
+      16,
+      type,
+      CUSPARSE_ORDER_ROW,
+      CUSPARSELT_SPARSITY_50_PERCENT));
+
+  // initalize dense input descriptor
+  cusparseLtMatDescriptor_t dense_input_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &dense_input_descriptor,
+      (dense_B.is_contiguous()) ? k : n,
+      (dense_B.is_contiguous()) ? n : k,
+      (dense_B.is_contiguous()) ? n : k,
+      16,
+      type,
+      CUSPARSE_ORDER_ROW));
+
+  // create result tensor
+  auto res = (transpose_result) ? dense_B.new_empty({n, m})
+                                : dense_B.new_empty({m, n});
+
+
+  cusparseLtMatDescriptor_t res_descriptor;
+  TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+      &handle,
+      &res_descriptor,
+      m,
+      n,
+      (transpose_result) ? m: n,
+      16,
+      type,
+      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+
+  // intialize matmul
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+      &handle,
+      &matmul,
+      CUSPARSE_OPERATION_NON_TRANSPOSE,
+      (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE,
+      &sparse_input_descriptor,
+      &dense_input_descriptor,
+      &res_descriptor,
+      &res_descriptor,
+      compute_type));
+
+  // set bias pointer for matmut, need to assign to get location
+  if (bias_opt.has_value()) {
+    auto& bias = bias_opt.value();
+    void* dBias = bias.data_ptr();
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+        &handle, &matmul, CUSPARSELT_MATMUL_BIAS_POINTER, &dBias, sizeof(dBias)));
+  }
+
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+      &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
+
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatmulPlanInit(&handle, &plan, &matmul, &alg_sel));
+
+  size_t workspace_size;
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatmulGetWorkspace(&handle, &plan, &workspace_size));
+
+  auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+  auto workspacePtr = allocator.allocate(workspace_size);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
+      &handle,
+      &plan,
+      &alpha,
+      compressed_A.data_ptr(),
+      dense_B.data_ptr(),
+      &beta,
+      res.data_ptr(),
+      res.data_ptr(),
+      workspacePtr.get(),
+      // jank because of the way we want this to be an array of streams
+      &stream,
+      1));
+
+
+  //destroy descriptors
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
+  TORCH_CUDASPARSE_CHECK(
+      cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
+  // destroy plan
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
+
+  return res;
+}
+
+} // namespace at::native
+
+#else // No cuSPARSELt support, throw error if these functions are called.
+
+namespace at::native {
+
+at::Tensor _cslt_compress(const Tensor& sparse_input){
+    TORCH_CHECK(false, "cuSPARSELT not supported on your machine.");
+}
+
+at::Tensor _cslt_sparse_mm(
+    const Tensor& compressed_A,
+    const Tensor& dense_B,
+    const c10::optional<Tensor>& bias_opt,
+    bool transpose_result)
+{
+    TORCH_CHECK(false, "cuSPARSELT not supported on your machine.");
+}
+
+} // namespace at::native
+
+#endif

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -60,6 +60,8 @@ aten::_copy_from
 aten::_copy_from.out
 aten::_copy_from_and_resize
 aten::_copy_from_and_resize.out
+aten::_cslt_compress
+aten::_cslt_sparse_mm
 aten::_ctc_loss
 aten::_ctc_loss.Tensor
 aten::_ctc_loss.Tensor_out

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -33,10 +33,22 @@ from torch._inductor.utils import has_triton
 
 
 SEMI_STRUCTURED_SUPPORTED_DTYPES = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG.keys()
+SEMI_STRUCTURED_SUPPORTED_BACKENDS = []
 
 _IS_SM8X = False
 if torch.cuda.is_available():
     _IS_SM8X = torch.cuda.get_device_capability(0)[0] == 8
+    SEMI_STRUCTURED_SUPPORTED_BACKENDS.append("cutlass")
+
+    # check if cslt is available for now using this:
+    # TODO when we add cusparselt as a backend, we can update this to be use torch.cusparselt.is_available()
+    try:
+        torch._cslt_compress(torch.ones(128, 128).cuda())
+        SEMI_STRUCTURED_SUPPORTED_BACKENDS.append("cusparselt")
+    except Exception:
+        pass
+
+
 
 def rand_sparse_semi_structured_mask(
     r, c, dtype=torch.float16, device="cuda", choice=None
@@ -105,9 +117,16 @@ def rand_dense_2by4_all_patterns(r, c, dtype, device):
 
 class TestSparseSemiStructured(TestCase):
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
+    def setUp(self):
+        if not _IS_SM8X:
+            self.skipTest('Only runs on SM80')
+
+
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_to_sparse_semi_structured(self, dtype):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_to_sparse_semi_structured(self, dtype, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
+
         A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
         A_sparse = to_sparse_semi_structured(A)
 
@@ -119,13 +138,15 @@ class TestSparseSemiStructured(TestCase):
         assert isinstance(A_sparse, SparseSemiStructuredTensor)
 
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_mm_sparse_first_NT(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_mm_sparse_first_NT(self, dtype, device, backend):
         """
         Ensure torch.mm(A_sparse, B) is correct for float16 and will throw error for int8
         Ensure torch.mm(A_sparse, B.t()) is correct
         """
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
+
         A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
         A_sparse = to_sparse_semi_structured(A)
 
@@ -134,13 +155,18 @@ class TestSparseSemiStructured(TestCase):
         # Currently we don't support int matmul on GPU, so evaluate on CPU and copy over
         if dtype is torch.int8:
             # This should fail
-            with self.assertRaisesRegex(RuntimeError, "two_four_sgemm_cutlass_dispatch_layouts"):
-                sparse_result = torch.mm(A_sparse, B)
+            if backend == "cutlass":
+                with self.assertRaisesRegex(RuntimeError, "two_four_sgemm_cutlass_dispatch_layouts"):
+                    sparse_result = torch.mm(A_sparse, B)
+            else:
+                with self.assertRaisesRegex(RuntimeError,
+                                            "CUDA error: operation not supported when calling `cusparseLtMatmulDescriptorInit"):
+                    sparse_result = torch.mm(A_sparse, B)
 
             # test transpose
             # NOTE: CUTLASS and cuSPARSELt have slightly different int8 behavior.
             # CUTLASS will output to an int32 tensor while cuSPARSELt will output to a int8 tensor
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32)
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32 if backend == "cutlass" else torch.int8)
             sparse_result = torch.mm(A_sparse, B.t())
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
         else:
@@ -152,12 +178,13 @@ class TestSparseSemiStructured(TestCase):
             sparse_result = torch.mm(A_sparse, B.t())
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_mm_sparse_first_T(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_mm_sparse_first_T(self, dtype, device, backend):
         """
         Ensure torch.mm(A_sparse.t(), B) throws error
         """
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
         A_sparse = to_sparse_semi_structured(A)
 
@@ -169,12 +196,13 @@ class TestSparseSemiStructured(TestCase):
         ):
             torch.mm(A_sparse.t(), B)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_mm_sparse_second_T(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_mm_sparse_second_T(self, dtype, device, backend):
         """
         Ensure torch.mm(A, B_sparse.t()) is correct
         """
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         B = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
         B_sparse = to_sparse_semi_structured(B)
 
@@ -182,7 +210,7 @@ class TestSparseSemiStructured(TestCase):
 
         # Currently we don't support int matmul on GPU, so evaluate on CPU and copy over
         if dtype is torch.int8:
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32)
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32 if backend == "cutlass" else torch.int8)
             sparse_result = torch.mm(A, B_sparse.t())
         else:
             dense_result = torch.mm(A, B.t())
@@ -190,12 +218,13 @@ class TestSparseSemiStructured(TestCase):
 
         assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_mm_sparse_second_NT(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_mm_sparse_second_NT(self, dtype, device, backend):
         """
         Ensure torch.mm(A, B_sparse) throws error
         """
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         B = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
         B_sparse = to_sparse_semi_structured(B)
 
@@ -207,13 +236,14 @@ class TestSparseSemiStructured(TestCase):
         ):
             sparse_result = torch.mm(A, B_sparse)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
-    @parametrize("inference_mode", [subtest(False), subtest(True)])
-    def test_linear(self, inference_mode, device):
+    @parametrize("inference_mode", [subtest(True), subtest(False)])
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_linear(self, inference_mode, device, backend):
         """
         Test nn.Linear has the same numerics
         """
-        input = torch.rand(128, 128, device=device).half()
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
+        input = torch.rand(64, 128, 128, device=device).half()
         model = nn.Linear(128, 128).to(device).half()
         m, n = model.weight.shape
         mask = rand_sparse_semi_structured_mask(m, n, device=device, dtype=torch.bool)
@@ -230,31 +260,35 @@ class TestSparseSemiStructured(TestCase):
         else:
             sparse_result = model(input)
 
-        assert torch.allclose(dense_result, sparse_result, rtol=1e-5, atol=1e-5)
+        assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
-    def test_values(self):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_values(self, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = rand_sparse_semi_structured_mask(128, 128)
         A_sparse = to_sparse_semi_structured(A)
         assert A_sparse.values().shape == (128, 64)
         assert (A_sparse.values() == 1).all()
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
-    def test_indices(self):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_indices(self, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = rand_sparse_semi_structured_mask(128, 128)
         A_sparse = to_sparse_semi_structured(A)
         assert A_sparse.indices().shape == (128, 8)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_unsupported_shape(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_unsupported_shape(self, dtype, device, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = rand_sparse_semi_structured_mask(4, 4, dtype=dtype, device=device)
         with self.assertRaisesRegex(RuntimeError, "Error original_tensor.shape"):
             A_sparse = to_sparse_semi_structured(A)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @dtypes(*all_types_and_complex())
-    def test_unsupported_dtype(self, dtype, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_unsupported_dtype(self, dtype, device, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype, device=device)
 
         if dtype not in SEMI_STRUCTURED_SUPPORTED_DTYPES:
@@ -263,96 +297,105 @@ class TestSparseSemiStructured(TestCase):
         else:
             A_sparse = to_sparse_semi_structured(A)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
-    def test_unsupported_dim(self, device):
+    @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
+    def test_unsupported_dim(self, device, backend):
+        SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
         A = torch.rand(128, 128, 128, device=device, dtype=torch.float16)
 
         with self.assertRaisesRegex(RuntimeError, "Error original_tensor.dim"):
             A_sparse = to_sparse_semi_structured(A)
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
+    @parametrize("backend", ["cutlass"])
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_linear_cutlass(self, device, dtype):
-        def run_test(batch_shape, m, n, k, device, dtype, dtype_out, add_bias, activation, rtol, atol):
-            weight = rand_dense_2by4(m, k, dtype, device)
-            input = make_tensor((*batch_shape, n, k), dtype=dtype, device=device)
-            bias = make_tensor((m,), dtype=dtype_out, device=device) if add_bias else None
+    def test_linear_cutlass(self, device, dtype, backend):
+        if dtype is not torch.float32:
+            SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
 
-            dtype_dense = torch.float
-            input_dense = input.to(dtype_dense)
-            weight_dense = weight.to(dtype_dense)
-            bias_dense = bias.to(dtype_dense) if add_bias else None
-            output0 = torch.nn.functional.linear(input_dense, weight_dense, bias=bias_dense)
-            if activation == "relu":
-                relu = torch.nn.ReLU()
-                output0 = relu(output0)
-            elif activation == "silu":
-                silu = torch.nn.SiLU()
-                output0 = silu(output0)
+            def run_test(batch_shape, m, n, k, device, dtype, dtype_out, add_bias, activation, rtol, atol):
+                weight = rand_dense_2by4(m, k, dtype, device)
+                input = make_tensor((*batch_shape, n, k), dtype=dtype, device=device)
+                bias = make_tensor((m,), dtype=dtype_out, device=device) if add_bias else None
 
-            weight_sparse = weight.masked_select(weight != 0).view(m, k // 2)
+                dtype_dense = torch.float
+                input_dense = input.to(dtype_dense)
+                weight_dense = weight.to(dtype_dense)
+                bias_dense = bias.to(dtype_dense) if add_bias else None
+                output0 = torch.nn.functional.linear(input_dense, weight_dense, bias=bias_dense)
+                if activation == "relu":
+                    relu = torch.nn.ReLU()
+                    output0 = relu(output0)
+                elif activation == "silu":
+                    silu = torch.nn.SiLU()
+                    output0 = silu(output0)
 
-            meta = to_sparse_semi_structured(weight).indices()
+                weight_sparse = weight.masked_select(weight != 0).view(m, k // 2)
 
-            output1 = torch._sparse_semi_structured_linear(input, weight_sparse, meta, bias=bias, activation=activation)
-            torch.testing.assert_close(output1.to(dtype_dense), output0, rtol=rtol, atol=atol)
+                meta = to_sparse_semi_structured(weight).indices()
 
-        batch_shapes = [[], [3], [3, 1]]
-        dtype_out = {torch.int8: torch.int32, torch.half: torch.half, torch.bfloat16: torch.bfloat16}
-        activations = [None, "relu", "silu"]
-        rtol, atol = 1e-3, 1e-3
-        if dtype == torch.bfloat16:
-            rtol, atol = 5e-3, 5e-3
-        for batch_shape, m, n, k, add_bias, activation in \
-                itertools.product(batch_shapes, range(3), range(3), range(3), (False, True), activations):
-            if activation == "silu" and dtype == torch.int8:
-                continue  # SiLU not supported for integer inputs
+                output1 = torch._sparse_semi_structured_linear(input, weight_sparse, meta, bias=bias, activation=activation)
+                torch.testing.assert_close(output1.to(dtype_dense), output0, rtol=rtol, atol=atol)
 
-            m = 2 ** m * 32
-            n = 2 ** n * 32
-            k = 2 ** k * 128
-            run_test(batch_shape, m, n, k, device, dtype, dtype_out[dtype], add_bias, activation, rtol, atol)
+            batch_shapes = [[], [3], [3, 1]]
+            dtype_out = {torch.int8: torch.int32, torch.half: torch.half, torch.bfloat16: torch.bfloat16}
+            activations = [None, "relu", "silu"]
+            rtol, atol = 1e-3, 1e-3
+            if dtype == torch.bfloat16:
+                rtol, atol = 5e-3, 5e-3
+            for batch_shape, m, n, k, add_bias, activation in \
+                    itertools.product(batch_shapes, range(3), range(3), range(3), (False, True), activations):
+                if activation == "silu" and dtype == torch.int8:
+                    continue  # SiLU not supported for integer inputs
 
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
+                m = 2 ** m * 32
+                n = 2 ** n * 32
+                k = 2 ** k * 128
+                run_test(batch_shape, m, n, k, device, dtype, dtype_out[dtype], add_bias, activation, rtol, atol)
+
     @unittest.skipIf(not has_triton(), "Test needs triton and recent GPU arch")
+    @parametrize("backend", ["cutlass"])
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_conversions(self, device, dtype):
-        def run_test(r, c, device, dtype):
-            dense_ref = rand_dense_2by4(r, c, dtype, device)
+    def test_conversions(self, device, dtype, backend):
+        if dtype is not torch.float32:
+            SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
 
-            compressed = to_sparse_semi_structured(dense_ref)
+            def run_test(r, c, device, dtype):
+                dense_ref = rand_dense_2by4(r, c, dtype, device)
 
-            # The torch.ops.aten._to_sparse_semi_structured operator
-            # uses CUTLASS to perform conversion from given dense
-            # matrix to the pair of corresponding sparse and metadata
-            # matrices, with the later used here as a reference to
-            # compare the metadata matrix produced by conversion
-            # performed by SparseSemiStructuredTensor class
-            # constructor against.
-            _, meta_ref = torch.ops.aten._to_sparse_semi_structured(dense_ref)
-            meta = compressed.indices()
-            torch.testing.assert_close(meta, meta_ref, rtol=0, atol=0)
+                compressed = to_sparse_semi_structured(dense_ref)
 
+                # The torch.ops.aten._to_sparse_semi_structured operator
+                # uses CUTLASS to perform conversion from given dense
+                # matrix to the pair of corresponding sparse and metadata
+                # matrices, with the later used here as a reference to
+                # compare the metadata matrix produced by conversion
+                # performed by SparseSemiStructuredTensor class
+                # constructor against.
+                _, meta_ref = torch.ops.aten._to_sparse_semi_structured(dense_ref)
+                meta = compressed.indices()
+                torch.testing.assert_close(meta, meta_ref, rtol=0, atol=0)
+
+                dense = compressed.to_dense()
+                torch.testing.assert_close(dense, dense_ref, rtol=0, atol=0)
+
+            shapes = [[32, 128], [32, 256], [64, 128], [64, 256]]
+            for r, c in shapes:
+                run_test(r, c, device, dtype)
+
+    @unittest.skipIf(not has_triton(), "Test needs triton and recent GPU arch")
+    @parametrize("backend", ["cutlass"])
+    @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
+    def test_conversions_all_patterns(self, device, dtype, backend):
+        if dtype is not torch.float32:
+            SparseSemiStructuredTensor._FORCE_CUTLASS = (backend == "cutlass")
+            r, c = 32, 128
+
+            dense_inv, dense_val = rand_dense_2by4_all_patterns(r, c, dtype, device)
+
+            compressed = to_sparse_semi_structured(dense_inv)
             dense = compressed.to_dense()
-            torch.testing.assert_close(dense, dense_ref, rtol=0, atol=0)
 
-        shapes = [[32, 128], [32, 256], [64, 128], [64, 256]]
-        for r, c in shapes:
-            run_test(r, c, device, dtype)
-
-    @unittest.skipIf(not _IS_SM8X, "semi-structured sparsity not supported on this library version")
-    @unittest.skipIf(not has_triton(), "Test needs triton and recent GPU arch")
-    @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
-    def test_conversions_all_patterns(self, device, dtype):
-        r, c = 32, 128
-
-        dense_inv, dense_val = rand_dense_2by4_all_patterns(r, c, dtype, device)
-
-        compressed = to_sparse_semi_structured(dense_inv)
-        dense = compressed.to_dense()
-
-        torch.testing.assert_close(dense, dense_val, rtol=0, atol=0)
+            torch.testing.assert_close(dense, dense_val, rtol=0, atol=0)
 
 
 instantiate_device_type_tests(TestSparseSemiStructured, globals(), only_for="cuda")

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -16,9 +16,9 @@ _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG = {
     torch.int8: _SEMI_STRUCTURED_SPARSE_CONFIG(10, 32, 128),
     torch.float16: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 64),
     torch.bfloat16: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 64),
+    # TODO enable float32 support when adding cuSPARSELt as a backend
+    # torch.float32: _SEMI_STRUCTURED_SPARSE_CONFIG(9, 32, 32)
 }
-
-_WARNING_SHOWN = False
 
 
 class SparseSemiStructuredTensor(torch.Tensor):
@@ -29,20 +29,31 @@ class SparseSemiStructuredTensor(torch.Tensor):
     structured sparsity.
 
     Currently, this class supports 2:4 sparsity for int8, float16 and bfloat16 dtypes.
+    We also support 1:2 sparsity for float32 dtype.
 
     This subclass stores the dense tensor in a compressed form by only storing the specified elements and corresponding metadata.
     These two are stored next to each other in one contiguous tensor.
 
-    We choose to store the specified elements and the metadata in a single tensor for future compatibilty with cuSPARSELt.
+    We choose to store the specified elements and the metadata in a single tensor for compatibilty with cuSPARSELt,
+    which expects the data to be stored in this format.
 
-    compressed tensor = [ specified elements of original tensor |   metadata     ]
+    compressed tensor = [ specified elements of original tensor | metadata ]
 
     For an original tensor of size (m, k) we expect the first m * k // 2 elements to be the kept elements
     The rest of the tensor is metadata.
 
-    This subclass also overrides __torch_dispatch__ to use _sparse_semi_structured_linear for faster matrix multiplications
-    via sparse CUTLASS kernels. In the future we will also call into cuSPARSELt kernels for more performance gains.
+    The subclass supports two backend, either CUTLASS or cuSPASRELt.
+
+    When _FORCE_CUTLASS is set, or when cuSPARSELt is not available, this subclass calls into _sparse_semi_structured_linear
+    and sparse_semi_structured_from_dense for conversion to the compressed format.
+
+    When PyTorch is compiled with cuSPARSELt support, this subclass will call into _cslt_sparse_mm for sparse mm and
+    _cslt_compress to convert into the compressed format.
     """
+
+    _FUSE_TRANSPOSE = False
+    _FORCE_CUTLASS = False
+    _WARNING_SHOWN = False
 
     @staticmethod
     def __new__(
@@ -71,6 +82,18 @@ class SparseSemiStructuredTensor(torch.Tensor):
             ValueError: If both original_tensor and compressed_tensor are None.
 
         """
+        if not cls._WARNING_SHOWN:
+            warnings.warn(
+                (
+                    "The PyTorch API of SparseSemiStructuredTensor is in prototype stage "
+                    "and will change in the near future. Please open a Github issue "
+                    "for features requests and see our documentation on the torch.sparse "
+                    "module for further information about the project."
+                ),
+                UserWarning,
+            )
+            cls._WARNING_SHOWN = True
+
         if original_tensor is not None:
             previous_tensor = original_tensor
             original_shape = original_tensor.shape
@@ -118,21 +141,11 @@ class SparseSemiStructuredTensor(torch.Tensor):
         Raises:
             RuntimeError: If original_tensor is not a supported dtype, dim, shape, or device.
         """
-        global _WARNING_SHOWN
-        if not _WARNING_SHOWN:
-            warnings.warn(
-                (
-                    "The PyTorch API of SparseSemiStructuredTensor is in prototype stage "
-                    "and will change in the near future. Please open a Github issue "
-                    "for features requests and see our documentation on the torch.sparse "
-                    "module for further information about the project."
-                ),
-                UserWarning,
-            )
-            _WARNING_SHOWN = True
-
         # if original tensor is passed in, we need to compress it and store the compressed representation.
         if original_tensor is not None:
+            # TODO right now we have unified checks and constraints for cuSPARSELt and CUTLASS, these are not actually the same.
+            # We should consolidate similar checks here and leave backend specific checks like shape in the op implementation.
+
             # check device
             if not original_tensor.is_cuda:
                 raise RuntimeError(
@@ -156,8 +169,12 @@ class SparseSemiStructuredTensor(torch.Tensor):
 
             # check shape
             m, n = original_tensor.shape
-            min_rows = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_rows
-            min_cols = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_cols
+            min_rows = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                original_tensor.dtype
+            ].min_rows
+            min_cols = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                original_tensor.dtype
+            ].min_cols
             if m < min_rows or m % min_rows or n < min_cols or n % min_cols:
                 # TODO in the future we can add in padding to support dimensions that aren't perfect multiples
                 raise RuntimeError(
@@ -165,26 +182,34 @@ class SparseSemiStructuredTensor(torch.Tensor):
                     "Both dimensions must be larger or equal than and a multiple of ({min_rows}, {min_cols})"
                 )
 
-            # This code calculates the size of the compressed tensor.
-            # compression factor is different based on dtype it's given by the formula below for 2:4 sparsity:
-            # compression_factor = 1/2 + 1/bitwidth(dtype)
-            original_size = original_tensor.nelement()
-            compression_factor = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
-                original_tensor.dtype
-            ].compression_factor
-            compressed_size = original_size * compression_factor // 16
+            if self._FORCE_CUTLASS:
+                # This code calculates the size of the compressed tensor.
+                # compression factor is different based on dtype it's given by the formula below for 2:4 sparsity:
+                # compression_factor = 1/2 + 1/bitwidth(dtype)
+                original_size = original_tensor.nelement()
+                compression_factor = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[
+                    original_tensor.dtype
+                ].compression_factor
+                compressed_size = original_size * compression_factor // 16
 
-            compressed_tensor = torch.empty(
-                (compressed_size,),
-                dtype=original_tensor.dtype,
-                device=original_tensor.device,
-            )
+                compressed_tensor = torch.empty(
+                    (compressed_size,),
+                    dtype=original_tensor.dtype,
+                    device=original_tensor.device,
+                )
 
-            from torch.sparse._semi_structured_conversions import sparse_semi_structured_from_dense
+                from torch.sparse._semi_structured_conversions import (
+                    sparse_semi_structured_from_dense,
+                )
 
-            sparse, meta = sparse_semi_structured_from_dense(original_tensor)
-            compressed_tensor[: m * n // 2] = sparse.view(-1)
-            compressed_tensor[m * n // 2 :] = meta.view(original_tensor.dtype).view(-1)
+                sparse, meta = sparse_semi_structured_from_dense(original_tensor)
+                compressed_tensor[: m * n // 2] = sparse.view(-1)
+                compressed_tensor[m * n // 2 :] = meta.view(original_tensor.dtype).view(
+                    -1
+                )
+            else:
+                # use cuSPARSELt
+                compressed_tensor = torch._cslt_compress(original_tensor)
 
         # set values
         self.original_tensor = None
@@ -262,37 +287,57 @@ class SparseSemiStructuredTensor(torch.Tensor):
             # F.linear(x) = addmm(bias, input, weight.t()) = b + xW' = (b + xW')''
             #        = (W''x' + b')' = (Wx' + b')' = addmm(bias.T, weight, input).T
             if isinstance(input_B, cls) and input_B.transposed:
-                result = torch._sparse_semi_structured_linear(
-                    input_A, input_B.values(), input_B.indices(), bias=bias
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_A, input_B.values(), input_B.indices(), bias=bias
+                    )
+                else:
+                    return torch._cslt_sparse_mm(
+                        input_B.compressed_tensor, input_A.T, bias  # type: ignore[arg-type]
+                    ).t()
 
         # handle mm
         if func is torch.ops.aten.mm.default:
             input_A, input_B = args
 
             if isinstance(input_A, cls) and not input_A.transposed:
-                transposed_result = torch._sparse_semi_structured_linear(
-                    input_B.t(), input_A.values(), input_A.indices()
-                )
-                return transposed_result.t()
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_B.t(), input_A.values(), input_A.indices()
+                    ).t()
+                else:
+                    return torch._cslt_sparse_mm(
+                        input_A.compressed_tensor, input_B, None  # type: ignore[arg-type]
+                    )
 
             elif isinstance(input_B, cls) and input_B.transposed:
-                result = torch._sparse_semi_structured_linear(
-                    input_A, input_B.values(), input_B.indices()
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_A, input_B.values(), input_B.indices()
+                    )
+                else:
+                    return torch._cslt_sparse_mm(input_B.compressed_tensor, input_A.T, None).t()  # type: ignore[arg-type]
 
         # When torch is run with inference mode, pytorch does not decompose torch.ops.aten.linear into a .t() and addmm(),
-        # so we must match the aten.linear op.
+        # so we must match the aten.linear op. In this case, we need to explicitly handle collapsing to 2d matmul
         # TODO see if there's a way to force pytorch to decompose the op so we don't have to handle this here.
         if func is torch.ops.aten.linear.default:
             input_tensor, weight, bias = args
+            shape = input_tensor.shape
             if isinstance(weight, cls):
-                result = torch._sparse_semi_structured_linear(
-                    input_tensor, weight.values(), weight.indices(), bias=bias
-                )
-                return result
+                if cls._FORCE_CUTLASS:
+                    return torch._sparse_semi_structured_linear(
+                        input_tensor,
+                        weight.values(),
+                        weight.indices(),
+                        bias=bias
+                    )
+                else:
+                    return torch._cslt_sparse_mm(
+                        weight.compressed_tensor,  # type: ignore[arg-type]
+                        input_tensor.view(-1, shape[-1]).t(),
+                        bias
+                    ).t().view(*shape[:-1], -1)
 
         # handle values
         if func is torch.ops.aten.values.default:
@@ -307,7 +352,9 @@ class SparseSemiStructuredTensor(torch.Tensor):
             metadata = args[0].compressed_tensor[num_kept_elements:].view(m, -1)
 
             # the metadata is expected to be in different datatypes for fp16/int8 respectively for CUTLASS.
-            indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(args[0].dtype)
+            indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(
+                args[0].dtype
+            )
             return metadata.view(indices_dtype)
 
         error_string = "\n".join(
@@ -323,11 +370,13 @@ class SparseSemiStructuredTensor(torch.Tensor):
         m, n = self.shape
         indices_dtype = SparseSemiStructuredTensor.__get_indices_dtype(self.dtype)
 
-        from torch.sparse._semi_structured_conversions import sparse_semi_structured_to_dense
+        from torch.sparse._semi_structured_conversions import (
+            sparse_semi_structured_to_dense,
+        )
 
         return sparse_semi_structured_to_dense(
             self.compressed_tensor[: m * n // 2].view(m, -1),
-            self.compressed_tensor[m * n // 2 :].view(indices_dtype).view(m, -1)
+            self.compressed_tensor[m * n // 2 :].view(indices_dtype).view(m, -1),
         )
 
 
@@ -382,4 +431,4 @@ def to_sparse_semi_structured(
                 [-4370, -4370, -4370,  ..., -4370, -4370, -4370]], device='cuda:0',
        dtype=torch.int16))
     """
-    return SparseSemiStructuredTensor(original_tensor, transposed=transposed)
+    return SparseSemiStructuredTensor(original_tensor, original_shape=original_tensor.shape, transposed=transposed)


### PR DESCRIPTION
Summary:
This is a duplicate PR of 102133, which was reverted because it was
failing internal tests.

It seems like that internal builds did not like my guard to check if
cuSPARSELt was available or not.

Test Plan: python test/test_sparse_semi_structured.py

Differential Revision: D48440330

