### PR TITLE
[export] Add schema version to serializer/deserializer

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -370,6 +370,7 @@ class TestDeserialize(TestCase):
 
 instantiate_parametrized_tests(TestDeserialize)
 
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestSchemaVersioning(TestCase):
     def test_error(self):
         def f(x):

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass, fields
 from enum import IntEnum
 from typing import Dict, List, Optional, Tuple
 
+
+# NOTE: Please update this value if any modifications are made to the schema
+SCHEMA_VERSION = 0
+
 # TODO (zhxchen17) Move to a separate file.
 class _Union:
     @classmethod
@@ -247,3 +251,4 @@ class ExportedProgram:
     opset_version: Dict[str, int]
     range_constraints: Dict[str, RangeConstraint]
     equality_constraints: List[Tuple[Tuple[str, int], Tuple[str, int]]]
+    schema_version: int


### PR DESCRIPTION
Added a version number to the schema for BC issues. We will add this number to the serialized ExportedProgram and then when deserializing, if the number does not match up with the existing deserializer, we will error. We should update the number of there are any major changes to the schema.