### PR TITLE
[fbcode][RFC] Parallel fast cat on cpu in cat op

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -563,6 +563,82 @@ static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& 
   TORCH_CHECK(outBytes == totalBytes);
 }
 
+static void parallelFastCatOutDim0(
+    const Tensor& out,
+    const MaterializedITensorListRef& inputs) {
+  // Partition inputs into parallel chunks based on number of elements
+  size_t out_elements = out.numel();
+  if (out_elements < at::internal::GRAIN_SIZE || at::get_num_threads() == 1) {
+    fastCatOutDim0(out, inputs);
+    return;
+  }
+  size_t total_elements = 0;
+  size_t copy_elements = 0;
+  std::vector<std::pair<size_t, size_t>> input_chunks;
+  size_t start = 0;
+  size_t end = 0;
+  for (size_t i = 0; i < inputs.size(); i++) {
+    const Tensor& input = inputs.at(i);
+    const size_t input_elements = input.numel();
+    total_elements += input_elements;
+    TORCH_CHECK(out_elements >= total_elements);
+    if (i == inputs.size() - 1) {
+      TORCH_CHECK(out_elements == total_elements);
+    }
+    copy_elements += input_elements;
+    if (copy_elements >= at::internal::GRAIN_SIZE) {
+      end = i + 1;
+      input_chunks.emplace_back(start, end);
+      start = end;
+      copy_elements = 0;
+    }
+  }
+  if (start < inputs.size()) {
+    // The remaining elements < GRAIN_SIZE, but still have to be copied
+    input_chunks.emplace_back(start, inputs.size());
+  }
+
+  // Record starting bytes offset
+  size_t out_bytes = out.nbytes();
+  size_t total_bytes = 0;
+  std::vector<size_t> out_bytes_offset;
+  out_bytes_offset.emplace_back(0);
+  for (size_t i = 0; i < inputs.size(); i++) {
+    const Tensor& input = inputs.at(i);
+    const auto input_nbytes = input.nbytes();
+    total_bytes += input_nbytes;
+    TORCH_CHECK(out_bytes >= total_bytes);
+    if (i == inputs.size() - 1) {
+      TORCH_CHECK(out_bytes == total_bytes);
+    }
+    out_bytes_offset.emplace_back(total_bytes);
+  }
+
+  char* data_ptr = reinterpret_cast<char*>(out.data_ptr());
+  at::parallel_for(
+      0, input_chunks.size(), 1, [&](int64_t chunk_start, int64_t chunk_end) {
+        // Get the input idx range from the element range
+        for (int64_t chunk_idx = chunk_start; chunk_idx < chunk_end;
+             chunk_idx++) {
+          const size_t input_start = input_chunks.at(chunk_idx).first;
+          const size_t input_end = input_chunks.at(chunk_idx).second;
+          for (size_t i = input_start; i < input_end; i++) {
+            const Tensor& input = inputs.at(i);
+            if (i == inputs.size() - 1) {
+              TORCH_CHECK((out_bytes_offset.at(i) + input.nbytes()) == total_bytes);
+            } else {
+              TORCH_CHECK((out_bytes_offset.at(i) + input.nbytes()) <= total_bytes);
+            }
+            if (input.nbytes() > 0) {
+              std::memcpy(
+                  data_ptr + out_bytes_offset.at(i),
+                  input.data_ptr(),
+                  input.nbytes());
+            }
+          }
+        }
+      });
+}
 
 TORCH_IMPL_FUNC(cat_out_cpu)
 (const ITensorListRef& tensors,
@@ -584,9 +660,9 @@ TORCH_IMPL_FUNC(cat_out_cpu)
   bool serial_dtype = at::isFloatingType(dtype);
   // fast path for single thread when both inputs and result are contiguous and
   // not empty, and concat dim is 0
-  if (use_serial_kernel && all_contiguous && all_same_dtype && (MemoryFormat::Contiguous == memory_format)) {
+  if (all_contiguous && all_same_dtype && (MemoryFormat::Contiguous == memory_format)) {
     if (dim == 0) {
-      fastCatOutDim0(result, materialized);
+      parallelFastCatOutDim0(result, materialized);
       return;
     }
     // TODO: Add fast cat for higher dimensions and support multi-threaded fast cat


### PR DESCRIPTION
Summary:
The original implementation in D40433604 is not feasible to be directly upstreamed to OSS for two reasons:
- It is using folly executor, while I see all the intra-op parallelism in OSS repo is using torch parallel_for api (underlying is either native thread pool or simply OpenMP). I believe it is better to avoid additional dependencies there
- It requires some gflags directly specify a magic number of partitioning thresholds in terms of # of bytes. It is not clean

This diff is making use of the heuristic number (https://www.internalfb.com/code/fbsource/[297f89d5823451fe9f4b5985e6537e89a72bb75a]/fbcode/caffe2/aten/src/ATen/TensorIterator.h?lines=86) from PyTorch OSS repo to do a best effort partitioning based on element numbers with a rounding-up. It also uses torch parallel_for api for parallelism

Test Plan: Unit test and benchmarking, sending out for RFC

Differential Revision: D48286816

