### PR TITLE
Enable mypy check in torch/_inductor/kernel/unpack_mixed_mm.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -199,6 +199,7 @@ include_patterns = [
     'torch/_inductor/select_algorithm.py',
     'torch/_inductor/wrapper_benchmark.py',
     'torch/_inductor/kernel/mm_common.py',
+    'torch/_inductor/kernel/unpack_mixed_mm.py',
     'torch/_inductor/utils.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes

--- a/torch/_inductor/kernel/unpack_mixed_mm.py
+++ b/torch/_inductor/kernel/unpack_mixed_mm.py
@@ -1,6 +1,7 @@
 import logging
+from typing import List
 
-from ..select_algorithm import autotune_select_algorithm, TritonTemplate
+from ..select_algorithm import autotune_select_algorithm, ChoiceCaller, TritonTemplate
 from .mm_common import mm_args, mm_configs, mm_grid, mm_options
 
 log = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ uint4x2_mixed_mm_template = TritonTemplate(
 
 def tuned_uint4x2_mixed_mm(mat1, mat2, mat2_mm_shape, mat2_dtype):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=None, use_4x2_dim=True)
-    choices = []
+    choices: List[ChoiceCaller] = []
     b_prologue_cast_type = f"tl.{mat2_dtype}".replace("torch.", "")
     for config in mm_configs(m, n, k):
         uint4x2_mixed_mm_template.maybe_append_choice(


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner init && lintrunner -a torch/_inductor/kernel/unpack_mixed_mm.py
...
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/kernel/unpack_mixed_mm.py
Success: no issues found in 1 source file
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov