### PR TITLE
Enable mypy check in torch/_inductor/fx_passes/post_grad.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -198,6 +198,7 @@ include_patterns = [
     'torch/_inductor/metrics.py',
     'torch/_inductor/select_algorithm.py',
     'torch/_inductor/wrapper_benchmark.py',
+    'torch/_inductor/fx_passes/post_grad.py',
     'torch/_inductor/kernel/mm_common.py',
     'torch/_inductor/utils.py',
     'torch/_C/_dynamo/**/*.py',

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -222,7 +222,7 @@ def cuda_and_enabled_mixed_mm_and_not_int8(match):
     extra_check=cuda_and_enabled_mixed_mm_and_not_int8,
 )
 def uint4x2_mixed_mm(match: Match, mat1, mat2, mat2_mm_shape, mat2_dtype):
-    return inductor.kernel.unpack_mixed_mm.tuned_uint4x2_mixed_mm(
+    return inductor.kernel.unpack_mixed_mm.tuned_uint4x2_mixed_mm(  # type: ignore[attr-defined]
         mat1, mat2, mat2_mm_shape, mat2_dtype
     )
 
@@ -245,7 +245,7 @@ def uint4x2_mixed_mm(match: Match, mat1, mat2, mat2_mm_shape, mat2_dtype):
     extra_check=cuda_and_enabled_mixed_mm,
 )
 def mixed_mm(match: Match, mat1, mat2, mat2_dtype):
-    return inductor.kernel.mm.tuned_mixed_mm(mat1, mat2, mat2_dtype)
+    return inductor.kernel.mm.tuned_mixed_mm(mat1, mat2, mat2_dtype)  # type: ignore[attr-defined]
 
 
 @register_graph_pattern(


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner init && lintrunner -a torch/_inductor/fx_passes/post_grad.py
...
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/fx_passes/post_grad.py
Success: no issues found in 1 source file


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov