### PR TITLE
Fix wrong error messages with torch.nn.AdaptiveMaxPool1d

### DIFF
--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -58,11 +58,11 @@ std::tuple<Tensor,Tensor> adaptive_max_pool1d(const Tensor & self, IntArrayRef o
   int ndim = self.ndimension();
   for (const auto i : c10::irange(1, ndim)) {
     TORCH_CHECK(
-        self.size(i) > 0,
+        self.sym_size(i) > 0,
         "adaptive_max_pool1d(): ",
         "Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ",
-        self.sizes(),
+        self.sym_sizes(),
         " with dimension ",
         i,
         " being empty");

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -55,6 +55,19 @@ std::tuple<Tensor,Tensor> adaptive_max_pool1d(const Tensor & self, IntArrayRef o
   checkDimRange("adaptive_max_pool1d", TensorArg(self, "self", 1), 2, 4 /* exclusive */);
   check1d("adaptive_max_pool1d", "output_size", output_size);
 
+  int ndim = self.ndimension();
+  for (const auto i : c10::irange(1, ndim)) {
+    TORCH_CHECK(
+        self.size(i) > 0,
+        "adaptive_max_pool1d(): ",
+        "Expected input to have non-zero size for non-batch dimensions, "
+        "but input has sizes ",
+        self.sizes(),
+        " with dimension ",
+        i,
+        " being empty");
+  }
+
   Tensor output, indices;
   std::tie(output, indices) = at::adaptive_max_pool2d(
       self.unsqueeze(-2),


### PR DESCRIPTION
Fixes #104822

A duplicate check is introduced into function `adaptive_max_pool1d`, but this is probably a relatively good approach.

Of course, it is also possible to transparently pass a flag in function `adaptive_max_pool1d` to function `adaptive_max_pool2d`(no need to add new parameter), and then supplement relevant Checks in `adaptive_max_pool2d`, but this approach is not clear enough first, and secondly, the amount of modification is relatively large.

At the same time, there is currently a duplicate check for `output_size`,which is cheched in both functions(`adaptive_max_pool1d` && `adaptive_max_pool2d`)

If you have better advice, please let me know, thank you