### PR TITLE
Correctly handle Python cycles that go through SymInt/Bool fields on TensorImpl

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1669,6 +1669,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     get_extra_meta().custom_data_ptr_error_msg_ = std::move(s);
   }
 
+  // Unfortunately, this needs to be public so we can write tp_traverse on
+  // Tensor
+  ExtraMeta* maybe_get_extra_meta() {
+    return extra_meta_.get();
+  }
+
  protected:
   /**
    * Returns the human-readable name of the actual type of this object (e.g.,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107439
* __->__ #107457
* #107388
* #107358
* #107438

Without this PR, the next PR on this stack fails on `python test/test_cuda_expandable_segments.py -k test_direct_traceback`. This is because saving CapturedTraceback on ShapeEnv results in a cycle, as CapturedTraceback keeps strong reference to code object, which induces a cycle through Dynamo co_extra and eventually through the Tensor sizes/strides SymInt fields back to the ShapeEnv. I did not actually diagnose what the actual cycle was, but I guessed that the problem was lack of tp_traverse on TensorImpl sizes and I was right.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>