### PR TITLE
Enable a number inductor of tests on CPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6017,19 +6017,12 @@ class CommonTemplate:
         def fn1(i0, i1):
             return torch.lerp(i1, i0, 70000)
 
-        def compare(fn, inputs):
-            compiled = torch._dynamo.optimize("inductor")(fn)
-            expected = fn(*inputs)
-            actual = compiled(*inputs)
-            self.assertEqual(expected, actual)
-            self.assertEqual(expected.stride(), actual.stride())
-
-        compare(fn0, [torch.rand(10, 3, 10), torch.rand(3, 10, 10)])
-        compare(fn1, [torch.rand(3, 10, 10), torch.rand(3, 10, 10)])
+        self.common(fn0, [torch.rand(10, 3, 10), torch.rand(3, 10, 10)])
+        self.common(fn1, [torch.rand(3, 10, 10), torch.rand(3, 10, 10)])
 
     def test_unspec_inputs(self):
         if self.device == "cpu":
-            raise unittest.SkipTest("segfault with CPU backend")
+            raise unittest.SkipTest("Testing mixed devices")
 
         def fn(x, y):
             return x + y, x * y, x / y
@@ -6131,9 +6124,7 @@ class CommonTemplate:
             return attn.softmax(dim=-1)
 
         x = torch.rand(128, 32, 63)
-        res_ref = fn(x)
-        res = torch._dynamo.optimize("inductor")(fn)(x)
-        self.assertEqual(res, res_ref)
+        self.common(fn, (x,))
 
     def test_kwargs(self):
         if self.device == "cuda":
@@ -6235,8 +6226,6 @@ class CommonTemplate:
         )
 
     def test_index_dynamic_shapes(self):
-        if self.device == "cuda":
-            raise unittest.SkipTest("index dynamic shapes only supports cpu")
 
         # Repro from vision_maskrcnn
         def fn(arg0_1):
@@ -6248,7 +6237,7 @@ class CommonTemplate:
                 start=0,
                 step=1,
                 dtype=torch.int64,
-                device="cpu",
+                device=arg0_1.device,
                 requires_grad=False,
             )
             convert_element_type_1 = iota.to(torch.float32)
@@ -6260,7 +6249,7 @@ class CommonTemplate:
                 start=0,
                 step=1,
                 dtype=torch.int64,
-                device="cpu",
+                device=arg0_1.device,
                 requires_grad=False,
             )
             convert_element_type_3 = iota_1.to(torch.float32)
@@ -6500,9 +6489,9 @@ class CommonTemplate:
             return a[out_features.index(in_feature)]
 
         x = [
-            torch.rand([1, 256, 100, 152]),
-            torch.rand([1, 256, 50, 76]),
-            torch.rand([1, 256, 25, 38]),
+            torch.rand([1, 256, 100, 152], device=self.device),
+            torch.rand([1, 256, 50, 76], device=self.device),
+            torch.rand([1, 256, 25, 38], device=self.device),
         ]
         opt_fn = torch._dynamo.optimize("inductor")(fn)
         same(fn(x), opt_fn(x))
@@ -6514,8 +6503,7 @@ class CommonTemplate:
             return y
 
         x = torch.rand(48, 3, 512, 512)
-        opt_fn = torch._dynamo.optimize("inductor")(fn)
-        same(fn(x), opt_fn(x))
+        self.common(fn, (x,))
 
     @unittest.skipIf(not HAS_CPU, "requires C++ compiler")
     def test_data_type_propogation(self):
@@ -6654,12 +6642,12 @@ class CommonTemplate:
             return input_tensor
 
         args = [
-            ((4, 1024, 12, 64), (768, 3072, 64, 1), torch.float32, "cpu"),
-            ((48, 3, 512, 513), (787968, 262656, 513, 1), torch.float32, "cpu"),
+            ((4, 1024, 12, 64), (768, 3072, 64, 1)),
+            ((48, 3, 512, 513), (787968, 262656, 513, 1)),
         ]
-        args = [rand_strided(sh, st, dt, dev) for (sh, st, dt, dev) in args]
-        opt_fn = torch._dynamo.optimize("inductor")(fn)
-        same(fn(*args, 256), opt_fn(*args, 256))
+        args = [rand_strided(sh, st) for (sh, st) in args]
+        args.append(256)
+        self.common(fn, args)
 
     def test_cumsum_pattern_matcher_issue(self):
         def fn(input_ids) -> torch.Tensor:
@@ -6668,25 +6656,19 @@ class CommonTemplate:
             batch_size, seq_length = input_shape
             past_key_values_length = 0
             mask_seq_length = past_key_values_length + seq_length
-            attention_mask = torch.ones(batch_size, mask_seq_length)
+            attention_mask = torch.ones(batch_size, mask_seq_length, device=input_ids.device)
             attention_mask = attention_mask.long()
             return torch.cumsum(attention_mask, dim=1)
 
-        torch._dynamo.reset()
         x = torch.randn(2, 2)
-        opt = torch._dynamo.optimize("inductor")(fn)
-        res = opt(x)
-        ref = fn(x)
-        self.assertEqual(res, ref, atol=0, rtol=0)
+        self.common(fn, (x,), atol=0, rtol=0)
 
     def test_slice(self):
         def fn(a, b):
             return torch.ops.aten.slice.Tensor(a, 0, 0, -b)
 
-        torch._dynamo.reset()
         x = torch.rand(48, 3, 512, 512)
-        opt_fn = torch._dynamo.optimize("inductor")(fn)
-        same(fn(x, 2), opt_fn(x, 2))
+        self.common(fn, (x, 2))
 
     def test_inplace_resize_as(self):
         def fn(x, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6616,6 +6616,10 @@ class CommonTemplate:
                     elif node.target == "output":
                         self.assertEqual(get_data_type(node), torch.bfloat16)
 
+    # Calling div only torch.SymInt arguments is not yet supported.
+    # To support this behavior, we need to allow const-propping tensors that store symint data.
+    # For now, dynamo will explicitly graph break when it encounters user code with this behavior.
+    @expectedFailureCodegenDynamic
     def test_AllenaiLongformerBase_repro(self):
         def fn(query, scores, window_overlap):
             batch_size, seq_len, num_heads, _ = query.size()
@@ -6664,6 +6668,8 @@ class CommonTemplate:
         x = torch.randn(2, 2)
         self.common(fn, (x,), atol=0, rtol=0)
 
+    # It's a view so it doens't generate a kernel
+    @expectedFailureCodegenDynamic
     def test_slice(self):
         def fn(a, b):
             return torch.ops.aten.slice.Tensor(a, 0, 0, -b)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6226,7 +6226,6 @@ class CommonTemplate:
         )
 
     def test_index_dynamic_shapes(self):
-
         # Repro from vision_maskrcnn
         def fn(arg0_1):
             unsqueeze = arg0_1.unsqueeze(0)
@@ -6656,7 +6655,9 @@ class CommonTemplate:
             batch_size, seq_length = input_shape
             past_key_values_length = 0
             mask_seq_length = past_key_values_length + seq_length
-            attention_mask = torch.ones(batch_size, mask_seq_length, device=input_ids.device)
+            attention_mask = torch.ones(
+                batch_size, mask_seq_length, device=input_ids.device
+            )
             attention_mask = attention_mask.long()
             return torch.cumsum(attention_mask, dim=1)
 

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -46,6 +46,8 @@ importlib.import_module("filelock")
 # xfail by default, set is_skip=True to skip
 test_failures = {
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
+    # calling div on only symint args
+    "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(("cpu", "cuda")),
 }
 
 if TEST_WITH_ROCM:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107465

There were many test that their `_cuda` variants were not running on
cuda. I fixed a few of these, but I'm sure there's plenty more.
It'd be great to have a way to test that we're indeed compiling
something in these tests, but I don't know how to do this off the top of
my head.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov