### PR TITLE
[2d] remove ShardedTensor from fsdp extension

### DIFF
--- a/torch/distributed/tensor/parallel/_data_parallel_utils.py
+++ b/torch/distributed/tensor/parallel/_data_parallel_utils.py
@@ -149,7 +149,6 @@ def _flatten_tensor(
 
 
 def _unflatten_tensor(tensor: torch.Tensor, spec: DTensorSpec) -> torch.Tensor:
-
     result = DistributedTensor.from_local(
         tensor,
         device_mesh=spec.mesh,

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -11,7 +11,6 @@ from torch.distributed.tensor.parallel._data_parallel_utils import (
     _flatten_tensor,
     _pre_load_state_dict,
     _unflatten_tensor,
-    _STShardingInfo,
 )
 
 __all__ = ["enable_2d_with_fsdp"]
@@ -40,11 +39,11 @@ def enable_2d_with_fsdp() -> bool:
             def pre_flatten_transform(
                 self,
                 tensor: torch.Tensor,
-            ) -> Tuple[torch.Tensor, Optional[_STShardingInfo]]:
+            ) -> Tuple[torch.Tensor, Optional[Any]]:
                 return _flatten_tensor(tensor)
 
             def post_unflatten_transform(
-                self, tensor: torch.Tensor, param_extension: _STShardingInfo
+                self, tensor: torch.Tensor, param_extension: Any
             ) -> torch.Tensor:
                 return _unflatten_tensor(tensor, param_extension)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107487
* #107473
* __->__ #107472

2D Parallel won't use ShardedTensor, and it causes headable for dynamo
to recoginize it, removing it from the runtime flatten/unflatten path