### PR TITLE
[pytorch][fakepg] enhance fakepg: broadcast and scatter

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -102,6 +102,35 @@ class TestFakePG(TestCase):
         gm = make_fx(allgather_fn)(torch.randn(2, 2, device='cuda'))
         FileCheck().check("all_gather").check("wait_tensor").run(str(gm.graph))
 
+    def test_broadcast(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        # src == rank
+        output = torch.ones(3, 3)
+        dist.broadcast(output, src=0)
+        self.assertEqual(tuple(output.shape), (3, 3))
+
+        # src != rank
+        output = torch.ones(3, 3)
+        dist.broadcast(output, src=1)
+        self.assertEqual(tuple(output.shape), (3, 3))
+
+    def test_scatter(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        # src == rank
+        output = torch.ones(3, 3)
+        to_scatter = [torch.ones(3, 3) * rank for rank in range(2)]
+        dist.scatter(output, to_scatter)
+        self.assertEqual(tuple(output.shape), (3, 3))
+
+        # src != rank
+        output = torch.ones(3, 3)
+        dist.scatter(output, None, src=1)
+        self.assertEqual(tuple(output.shape), (3, 3))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -5,9 +5,14 @@ from torch._C._distributed_c10d import (
     AllgatherOptions,
     AllreduceOptions,
     BarrierOptions,
-    ReduceScatterOptions
+    ReduceScatterOptions,
+    BroadcastOptions,
+    ScatterOptions
 )
 from torch.futures import Future
+
+from typing import List
+from torch import Tensor
 
 
 def ret_work(ret):
@@ -69,6 +74,17 @@ class FakeProcessGroup(dist.ProcessGroup):
     def barrier(self, opts=BarrierOptions()):
         # it should be no-op for fake pg
         pass
+
+    def broadcast(self, tensors: List[Tensor], opts=BroadcastOptions()):
+        return ret_work(tensors)
+
+    def scatter(
+        self,
+        output_tensors: List[Tensor],
+        input_tensors: List[List[Tensor]],
+        opts=ScatterOptions(),
+    ):
+        return ret_work(output_tensors)
 
     def getBackendName(self):
         return "fake"


### PR DESCRIPTION
Summary:
Add support for broadcast and scatter in FakeProcessGroup.

As a side note, we can't easily support broadcast_object_list or
scatter_object_list since they rely on actual broadcasted/scattered
values for pickle object deserialization. We could add support for rank 0, but
other to support ranks may need additional changes outside of
FakeProcessGroup.

Test Plan:
`buck2 run mode/dev-nosan -c fbcode.enable_gpu_sections=true
//caffe2/test/distributed:fake_pg`, on of TARGETS diff: D48481513

`python test/distributed/test_fake_pg.py` after github sync

Differential Revision: D48481512

