### PR TITLE
Implement "RAdamW" optimizer

### DIFF
--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -147,13 +147,13 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
             &\hspace{18mm} \rho_{\infty} \leftarrow 2/(1-\beta_2) -1                      \\[-1.ex]
             &\rule{110mm}{0.4pt}  \\
             &\textbf{for} \: t=1 \: \textbf{to} \: \ldots \: \textbf{do}                         \\
-            &\hspace{6mm}g_t           \leftarrow   \nabla_{\theta} f_t (\theta_{t-1})           \\
-            &\hspace{5mm} \textbf{if} \: \lambda \neq 0                                          \\
-            &\hspace{10mm}\textbf{if} \: \textit{decoupled\_weight\_decay}                       \\
-            &\hspace{15mm} \theta_t \leftarrow \theta_{t-1} - \gamma \lambda \theta_{t-1}                    \\
-            &\hspace{10mm}\textbf{else}                                                          \\
-            &\hspace{15mm} g_t \leftarrow g_t + \lambda \theta_{t-1}                             \\
-            &\hspace{15mm} \theta_t \leftarrow \theta_{t-1}                 \\
+            &\hspace{6mm} g_t \leftarrow \nabla_{\theta} f_t (\theta_{t-1})                      \\
+            &\hspace{6mm} \theta_t \leftarrow \theta_{t-1}                                       \\
+            &\hspace{6mm} \textbf{if} \: \lambda \neq 0                                          \\
+            &\hspace{12mm}\textbf{if} \: \textit{decoupled\_weight\_decay}                       \\
+            &\hspace{18mm} \theta_t \leftarrow \theta_{t} - \gamma \lambda \theta_{t}            \\
+            &\hspace{12mm}\textbf{else}                                                          \\
+            &\hspace{18mm} g_t \leftarrow g_t + \lambda \theta_{t}                               \\
             &\hspace{6mm}m_t           \leftarrow   \beta_1 m_{t-1} + (1 - \beta_1) g_t          \\
             &\hspace{6mm}v_t           \leftarrow   \beta_2 v_{t-1} + (1-\beta_2) g^2_t          \\
             &\hspace{6mm}\widehat{m_t} \leftarrow   m_t/\big(1-\beta_1^t \big)                   \\

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -174,9 +174,9 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
 
     This implementation provides an option to use either the original weight_decay implementation as in Adam
     (where the weight_decay is applied to the gradient) or the one from AdamW (where weight_decay is applied
-    to the weight) through the decoupled_weight_decay option. When decoupled_weight_decay is set to True,
-    it uses the AdamW style weight decay, otherwise it uses the original Adam style. This flexibility allows
-    it to align with both the original implementation and the `author's implementation`_. Further information
+    to the weight) through the decoupled_weight_decay option. When decoupled_weight_decay is set to False
+    (default), it uses the original Adam style weight decay, otherwise, it uses the AdamW style which
+    corresponds more closely to the `author's implementation in the RAdam paper`_. Further information
     about decoupled weight decay can be found in `Decoupled Weight Decay Regularization`_.
 
     """ + fr"""

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -174,9 +174,10 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
 
     This implementation provides an option to use either the original weight_decay implementation as in Adam
     (where the weight_decay is applied to the gradient) or the one from AdamW (where weight_decay is applied
-    to the weight) through the `decoupled_weight_decay` option. When `decoupled_weight_decay` is set to `True`,
+    to the weight) through the decoupled_weight_decay option. When decoupled_weight_decay is set to True,
     it uses the AdamW style weight decay, otherwise it uses the original Adam style. This flexibility allows
-    it to align with both the original implementation and the `author's implementation`_.
+    it to align with both the original implementation and the `author's implementation`_. Further information
+    about decoupled weight decay can be found in `Decoupled Weight Decay Regularization`_.
 
     """ + fr"""
     Args:

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -172,9 +172,12 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
 
     For further details regarding the algorithm we refer to `On the variance of the adaptive learning rate and beyond`_.
 
-    This implementation uses the same weight_decay implementation as Adam (were the weight_decay is applied
-    to the gradient) and not the one from AdamW (were weight_decay is applied to the update). This
-    is different from the `author's implementation`_.
+    This implementation provides an option to use either the original weight_decay implementation as in Adam
+    (where the weight_decay is applied to the gradient) or the one from AdamW (where weight_decay is applied
+    to the weight) through the `decoupled_weight_decay` option. When `decoupled_weight_decay` is set to `True`,
+    it uses the AdamW style weight decay, otherwise it uses the original Adam style. This flexibility allows
+    it to align with both the original implementation and the `author's implementation`_.
+
     """ + fr"""
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -150,9 +150,10 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
             &\hspace{6mm}g_t           \leftarrow   \nabla_{\theta} f_t (\theta_{t-1})           \\
             &\hspace{5mm} \textbf{if} \: \lambda \neq 0                                          \\
             &\hspace{10mm}\textbf{if} \: \textit{decoupled\_weight\_decay}                       \\
-            &\hspace{15mm} \theta_{t-1} \leftarrow \theta_{t-1} - \gamma \lambda \theta_{t-1}                    \\
+            &\hspace{15mm} \theta_t \leftarrow \theta_{t-1} - \gamma \lambda \theta_{t-1}                    \\
             &\hspace{10mm}\textbf{else}                                                          \\
             &\hspace{15mm} g_t \leftarrow g_t + \lambda \theta_{t-1}                             \\
+            &\hspace{15mm} \theta_t \leftarrow \theta_{t-1}                 \\
             &\hspace{6mm}m_t           \leftarrow   \beta_1 m_{t-1} + (1 - \beta_1) g_t          \\
             &\hspace{6mm}v_t           \leftarrow   \beta_2 v_{t-1} + (1-\beta_2) g^2_t          \\
             &\hspace{6mm}\widehat{m_t} \leftarrow   m_t/\big(1-\beta_1^t \big)                   \\
@@ -162,9 +163,9 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
             &\hspace{12mm} l_t \leftarrow \frac{\sqrt{ (1-\beta^t_2) }}{ \sqrt{v_t} +\epsilon  } \\
             &\hspace{12mm} r_t \leftarrow
       \sqrt{\frac{(\rho_t-4)(\rho_t-2)\rho_{\infty}}{(\rho_{\infty}-4)(\rho_{\infty}-2) \rho_t}} \\
-            &\hspace{12mm}\theta_t \leftarrow \theta_{t-1} - \gamma \widehat{m_t} r_t l_t        \\
+            &\hspace{12mm}\theta_t \leftarrow \theta_t - \gamma \widehat{m_t} r_t l_t        \\
             &\hspace{6mm}\textbf{else}                                                           \\
-            &\hspace{12mm}\theta_t \leftarrow \theta_{t-1} - \gamma \widehat{m_t}                \\
+            &\hspace{12mm}\theta_t \leftarrow \theta_t - \gamma \widehat{m_t}                \\
             &\rule{110mm}{0.4pt}                                                          \\[-1.ex]
             &\bf{return} \:  \theta_t                                                     \\[-1.ex]
             &\rule{110mm}{0.4pt}                                                          \\[-1.ex]

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -150,7 +150,7 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
             &\hspace{6mm}g_t           \leftarrow   \nabla_{\theta} f_t (\theta_{t-1})           \\
             &\hspace{5mm} \textbf{if} \: \lambda \neq 0                                          \\
             &\hspace{10mm}\textbf{if} \: \textit{decoupled\_weight\_decay}                       \\
-            &\hspace{15mm} \theta_t \leftarrow \theta_t - \gamma \lambda \theta_{t-1}                    \\
+            &\hspace{15mm} \theta_{t-1} \leftarrow \theta_{t-1} - \gamma \lambda \theta_{t-1}                    \\
             &\hspace{10mm}\textbf{else}                                                          \\
             &\hspace{15mm} g_t \leftarrow g_t + \lambda \theta_{t-1}                             \\
             &\hspace{6mm}m_t           \leftarrow   \beta_1 m_{t-1} + (1 - \beta_1) g_t          \\

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -177,7 +177,7 @@ RAdam.__doc__ = r"""Implements RAdam algorithm.
     (where the weight_decay is applied to the gradient) or the one from AdamW (where weight_decay is applied
     to the weight) through the decoupled_weight_decay option. When decoupled_weight_decay is set to False
     (default), it uses the original Adam style weight decay, otherwise, it uses the AdamW style which
-    corresponds more closely to the `author's implementation in the RAdam paper`_. Further information
+    corresponds more closely to the `author's implementation`_ in the RAdam paper. Further information
     about decoupled weight decay can be found in `Decoupled Weight Decay Regularization`_.
 
     """ + fr"""

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -26,7 +26,7 @@ class RAdam(Optimizer):
         betas=(0.9, 0.999),
         eps=1e-8,
         weight_decay=0,
-        decoupled_weight_decay: bool=False,
+        decoupled_weight_decay: bool = False,
         *,
         foreach: Optional[bool] = None,
         differentiable: bool = False,
@@ -208,7 +208,7 @@ def radam(
     state_steps: List[Tensor],
     # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
     # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
-    decoupled_weight_decay: bool=False,
+    decoupled_weight_decay: bool = False,
     foreach: Optional[bool] = None,
     differentiable: bool = False,
     *,

--- a/torch/optim/radam.pyi
+++ b/torch/optim/radam.pyi
@@ -10,4 +10,5 @@ class RAdam(Optimizer):
         betas: Tuple[float, float] = ...,
         eps: float = ...,
         weight_decay: float = ...,
+        decoupled_weight_decay: bool = ...,
     ) -> None: ...


### PR DESCRIPTION
Fixes #107282

## Overview

- basic design decision was followed as they made on #103881 (tensor operation, test cases, order & position of argument etc.)
- for the algorithm for decoupled weight decay, I referred to [1, 2]

## backwards-incompatible changes

- positional argument `decoupled_weight_decay` is added to:
    -  `torch.optim.radam`

The existing code which refers to these APIs can be affected.

Note: Positional argument `decoupled_weight_decay` is added to `torch.optim.RAdam`. However, since it was added to the last position and with default value, it is not affected.

## Reference

- [1] [Decoupled Weight Decay Regularization](https://arxiv.org/abs/1711.05101)
- [2] https://github.com/LiyuanLucasLiu/RAdam/blob/master/radam/radam.py#L5-L94

## TODO

- [x] implement tensor operation
- [x] implement test cases
- [x] modify doc-string
- [x] pass unit test code locally `python test/test_optim.py -k test_radam`