### PR TITLE
Register AutoRT backend for Windows DirectX

### DIFF
--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -57,6 +57,7 @@ enum class Backend {
   HPU,
   Lazy,
   MTIA,
+  AutoRT,
   PrivateUse1,
   NumOptions
 };
@@ -120,6 +121,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::HPU;
   } else if (t == DispatchKey::MTIA || t == DispatchKey::AutogradMTIA) {
     return Backend::MTIA;
+  } else if (t == DispatchKey::AutoRT || t == DispatchKey::AutogradAutoRT) {
+    return Backend::AutoRT;
   } else if (
       t == DispatchKey::PrivateUse1 || t == DispatchKey::AutogradPrivateUse1) {
     return Backend::PrivateUse1;
@@ -190,6 +193,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::HPU;
     case Backend::MTIA:
       return DispatchKey::MTIA;
+    case Backend::AutoRT:
+      return DispatchKey::AutoRT;
     case Backend::PrivateUse1:
       return DispatchKey::PrivateUse1;
     default:
@@ -244,6 +249,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::HPU;
     case Backend::MTIA:
       return DeviceType::MTIA;
+    case Backend::AutoRT:
+      return DeviceType::AutoRT;
     case Backend::PrivateUse1:
     case Backend::SparsePrivateUse1:
     case Backend::QuantizedPrivateUse1:
@@ -316,6 +323,8 @@ static inline const char* toString(Backend b) {
       return "HPU";
     case Backend::MTIA:
       return "MTIA";
+    case Backend::AutoRT:
+      return "AutoRT";
     case Backend::PrivateUse1:
       return "PrivateUseOne";
     default:

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -34,6 +34,7 @@ DeviceType parse_type(const std::string& device_string) {
           {"meta", DeviceType::Meta},
           {"hpu", DeviceType::HPU},
           {"mtia", DeviceType::MTIA},
+          {"autort", DeviceType::AutoRT},
           {"privateuseone", DeviceType::PrivateUse1},
       }};
   auto device = std::find_if(

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -121,6 +121,11 @@ struct C10_API Device final {
     return type_ == DeviceType::MTIA;
   }
 
+  /// Return true if the device is of AutoRT type.
+  bool is_autort() const noexcept {
+    return type_ == DeviceType::AutoRT;
+  }
+
   /// Return true if the device is of HPU type.
   bool is_hpu() const noexcept {
     return type_ == DeviceType::HPU;

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -49,6 +49,8 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
       return lower_case ? "ipu" : "IPU";
     case DeviceType::MTIA:
       return lower_case ? "mtia" : "MTIA";
+    case DeviceType::AutoRT:
+      return lower_case ? "autort" : "AUTORT";
     case DeviceType::PrivateUse1:
       return get_privateuse1_backend(/*lower_case=*/lower_case);
     default:
@@ -94,6 +96,7 @@ bool isValidDeviceType(DeviceType d) {
     case DeviceType::HPU:
     case DeviceType::IPU:
     case DeviceType::MTIA:
+    case DeviceType::AutoRT:
     case DeviceType::PrivateUse1:
       return true;
     default:

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -28,6 +28,7 @@ namespace c10 {
   _(Lazy, extra)                                  \
   _(Meta, extra)                                  \
   _(MTIA, extra)                                  \
+  _(AutoRT, extra)                                \
   _(PrivateUse1, extra)
 
 enum class DeviceType : int8_t {
@@ -51,12 +52,13 @@ enum class DeviceType : int8_t {
   Lazy = 17, // Lazy Tensors
   IPU = 18, // Graphcore IPU
   MTIA = 19, // Meta training and inference devices
-  PrivateUse1 = 20, // PrivateUse1 device
+  AutoRT = 20, // AutoRT for DirectX/FPGA devices
+  PrivateUse1 = 21, // PrivateUse1 device
   // NB: If you add more devices:
   //  - Change the implementations of DeviceTypeName and isValidDeviceType
   //    in DeviceType.cpp
   //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 22,
 };
 
 constexpr DeviceType kCPU = DeviceType::CPU;
@@ -75,6 +77,7 @@ constexpr DeviceType kVE = DeviceType::VE;
 constexpr DeviceType kLazy = DeviceType::Lazy;
 constexpr DeviceType kIPU = DeviceType::IPU;
 constexpr DeviceType kMTIA = DeviceType::MTIA;
+constexpr DeviceType kAutoRT = DeviceType::AutoRT;
 constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
 
 // define explicit int constant
@@ -82,7 +85,7 @@ constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
     static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
 
 static_assert(
-    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 22,
     "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
     "for this constant to reflect the actual number of DeviceTypes we support "
     "in PyTorch; it's important that this number is not too large as we "

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -43,6 +43,7 @@ namespace c10 {
   _(VE, extra)                                  \
   _(Lazy, extra)                                \
   _(MTIA, extra)                                \
+  _(AutoRT, extra)                              \
   _(PrivateUse1, extra)                         \
   _(PrivateUse2, extra)                         \
   _(PrivateUse3, extra)                         \

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -56,6 +56,8 @@ static const char* backend_to_string(const at::Backend& backend) {
       return "torch.xla";
     case at::Backend::Meta:
       return "torch.meta";
+    case at::Backend::AutoRT:
+      return "torch.autort";
     default:
       AT_ERROR("Unimplemented backend ", backend);
   }


### PR DESCRIPTION
This backend registration allows Windows users to use Pytorch for DirectX by device name "autort" instead of "privateuseone".