### PR TITLE
Single source of truth for guard logging

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1,6 +1,5 @@
 import collections
 import functools
-import inspect
 import itertools
 import logging
 import os
@@ -19,7 +18,7 @@ from torch.fx.experimental.symbolic_shapes import (
     GuardOnDataDependentSymNode,
 )
 from torch.fx.graph_module import _forward_from_src as original_forward_from_src
-from torch.utils._traceback import format_frame, format_traceback_short
+from torch.utils._traceback import format_traceback_short
 
 from . import config, exc
 from .allowed_functions import is_allowed
@@ -69,21 +68,8 @@ from .utils import (
 )
 
 log = logging.getLogger(__name__)
-guards_log = torch._logging.getArtifactLogger(__name__, "guards")
-verbose_guards_log = torch._logging.getArtifactLogger(__name__, "verbose_guards")
 bytecode_log = torch._logging.getArtifactLogger(__name__, "bytecode")
 recompiles_log = torch._logging.getArtifactLogger(__name__, "recompiles")
-
-
-# For user stack printing
-@functools.lru_cache(None)
-def uninteresting_files():
-    import torch._dynamo.external_utils
-
-    mods = [
-        torch._dynamo.external_utils,
-    ]
-    return {inspect.getfile(m) for m in mods}
 
 
 class Tracker:
@@ -552,45 +538,6 @@ def _compile(
         )
 
         guarded_code = GuardedCode(out_code, check_fn.check_fn)
-
-        if guards_log.isEnabledFor(logging.DEBUG):
-            guard_str = "GUARDS:\n"
-            base = os.path.dirname(__file__)
-            for guard in sorted(output.guards):
-                if guard.code_list is None:
-                    continue
-
-                extra = ""
-                if guard.user_stack:
-                    for fs in reversed(guard.user_stack):
-                        if fs.filename not in uninteresting_files():
-                            break
-                    else:
-                        fs = guard.user_stack[-1]
-                    extra = f"  # {format_frame(fs, line=True)}"
-                elif guard.stack:
-                    extra = f"  # {format_frame(guard.stack.summary()[-1])}"
-
-                for code in guard.code_list:
-                    guard_str += f"  {code:<60}{extra}\n"
-            guards_log.debug("%s", guard_str)
-
-        if verbose_guards_log.isEnabledFor(logging.DEBUG):
-            for guard in sorted(output.guards):
-                if guard.code_list is None:
-                    continue
-                cat_code = " and ".join(guard.code_list)
-                maybe_user_stack = ""
-                if guard.user_stack:
-                    maybe_user_stack = (
-                        f"\nUser stack:\n{''.join(guard.user_stack.format())}"
-                    )
-                verbose_guards_log.debug(
-                    "GUARD: %s\nStack:\n%s%s",
-                    cat_code,
-                    "".join(guard.stack.format()),
-                    maybe_user_stack,
-                )
 
         if not output.is_empty_graph() and hooks.guard_export_fn is not None:
             # We should not run the guard_export_fn when Dynamo does not

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import functools
 import importlib
+import inspect
 import itertools
 import logging
 import math
@@ -39,7 +40,7 @@ from torch.fx.experimental.symbolic_shapes import (
     SYMPY_INTERP,
 )
 
-from torch.utils._traceback import report_compile_source_on_error
+from torch.utils._traceback import format_frame, report_compile_source_on_error
 from torch.utils.weak import TensorWeakRef, WeakIdRef
 
 from . import config, convert_frame, mutation_guard
@@ -61,9 +62,23 @@ from .utils import (
 )
 
 log = logging.getLogger(__name__)
+guards_log = torch._logging.getArtifactLogger(__name__, "guards")
+verbose_guards_log = torch._logging.getArtifactLogger(__name__, "verbose_guards")
+
 TensorGuards = torch._C._dynamo.guards.TensorGuards
 check_obj_id = torch._C._dynamo.guards.check_obj_id
 check_type_id = torch._C._dynamo.guards.check_type_id
+
+
+# For user stack printing
+@functools.lru_cache(None)
+def uninteresting_files():
+    import torch._dynamo.external_utils
+
+    mods = [
+        torch._dynamo.external_utils,
+    ]
+    return {inspect.getfile(m) for m in mods}
 
 
 CLOSURE_VARS = collections.OrderedDict(
@@ -143,6 +158,14 @@ def strip_getattr_getitem(name):
     return re.split(r"[.\[]", name)[0]
 
 
+# The ready to eval generated code (possibly multiple parts) for a guard, plus
+# the original guard object that created it for provenance
+@dataclasses.dataclass
+class GuardCodeList:
+    code_list: List[str]
+    guard: Guard
+
+
 class GuardBuilder(GuardBuilderBase):
     def __init__(
         self,
@@ -174,12 +197,12 @@ class GuardBuilder(GuardBuilderBase):
 
         self.argnames: List[str] = []
         # Code is python expression strings generated for each guard
-        self.code: List[str] = []
+        self.code: List[GuardCodeList] = []
         # shape_env_code is only used by local_builder and is used for
         # shape env code.  This exists only because we need to make sure
         # shape env guards get run after tensor match guards (since the
         # tensor match guards make sure we actually have tensors)
-        self.shape_env_code: List[str] = []
+        self.shape_env_code: List[GuardCodeList] = []
 
         # [Note - On Eager Tensor Guards]
         # Most of the time, we generate Python code in a guard to directly
@@ -193,6 +216,7 @@ class GuardBuilder(GuardBuilderBase):
         # check it against this example", and it all ends up getting
         # swept up into a single call to ___check_tensors.  Invariant:
         # len(tensor_check_names) == len(tensor_check_examples).
+        # TODO: something here
         self.tensor_check_names: List[str] = []
         self.tensor_check_examples: List[torch.Tensor] = []
 
@@ -384,7 +408,10 @@ class GuardBuilder(GuardBuilderBase):
 
         def setup_guard():
             assert istype(val.training, bool)
-            self.code.append(f"{ref}.training == {val.training}")
+            # TODO: Why doesn't this use produce_guard_code?
+            self.code.append(
+                GuardCodeList([f"{ref}.training == {val.training}"], guard)
+            )
 
         if hasattr(val, "training"):
             # There are cases where a monkeypatched object has a guard made between __new__ and __init__
@@ -694,9 +721,9 @@ class GuardBuilder(GuardBuilderBase):
         ), f"_produce_guard_code must be called from inside GuardedCode. Called from {func_name}"
 
         if shape_env:
-            self.shape_env_code.extend(code_list)
+            self.shape_env_code.append(GuardCodeList(code_list, guard))
         else:
-            self.code.extend(code_list)
+            self.code.append(GuardCodeList(code_list, guard))
 
         # Not all guards have names, some can be installed globally (see asserts on HAS_GRAD)
         if provided_guarded_object is None:
@@ -908,9 +935,55 @@ class CheckFunctionManager:
         largs += ["**___kwargs_ignored"]
         args = ",".join(largs)
 
-        code_parts = (
-            ["___guarded_code.valid"] + local_builder.code + global_builder.code
-        )
+        guards_log.debug("GUARDS:")
+
+        # Don't report this guard, it's always the same, useless!
+        code_parts = ["___guarded_code.valid"]
+        base = os.path.dirname(__file__)
+
+        def add_code_part(code, guard):
+            if guards_log.isEnabledFor(logging.DEBUG):
+                extra = ""
+                if guard is not None:
+                    if guard.user_stack:
+                        for fs in reversed(guard.user_stack):
+                            if fs.filename not in uninteresting_files():
+                                break
+                        else:
+                            fs = guard.user_stack[-1]
+                        extra = f"  # {format_frame(fs, line=True)}"
+                    elif guard.stack:
+                        extra = f"  # {format_frame(guard.stack.summary()[-1])}"
+
+                guards_log.debug("%s", f"{code:<60}{extra}")
+
+            if verbose_guards_log.isEnabledFor(logging.DEBUG):
+                maybe_stack = ""
+                maybe_user_stack = ""
+                if guard is not None:
+                    maybe_stack = f"\nStack:\n{''.join(guard.stack.format())}"
+                    if guard.user_stack:
+                        maybe_user_stack = (
+                            f"\nUser stack:\n{''.join(guard.user_stack.format())}"
+                        )
+                verbose_guards_log.debug(
+                    "Guard: %s%s%s",
+                    code,
+                    maybe_stack,
+                    maybe_user_stack,
+                )
+
+            code_parts.append(code)
+
+        # TODO: Maybe better not to repeatedly spam the same guard information
+        # for each individual piece?  Not sure.
+        for gcl in local_builder.code:
+            for code in gcl.code_list:
+                add_code_part(code, gcl.guard)
+
+        for gcl in global_builder.code:
+            for code in gcl.code_list:
+                add_code_part(code, gcl.guard)
 
         tensor_check_names = (
             local_builder.tensor_check_names + global_builder.tensor_check_names
@@ -966,7 +1039,8 @@ class CheckFunctionManager:
             tensor_check_args = ", ".join(
                 tensor_check_names + ["tensor_check_names=tensor_check_names"]
             )
-            code_parts.append(f"___check_tensors({tensor_check_args})")
+            # TODO: we can give stack reporting here
+            add_code_part(f"___check_tensors({tensor_check_args})", None)
 
         aotautograd_guards: List[GuardEnvExpr] = (
             self.output_graph.tracing_context.guards_context.aotautograd_guards
@@ -977,12 +1051,14 @@ class CheckFunctionManager:
             if isinstance(guard, DuplicateInputs):
                 source_a = guard.input_source_a
                 source_b = guard.input_source_b
-                code_part = f"{source_a.name()} is {source_b.name()}"
-                code_parts.append(code_part)
+                add_code_part(f"{source_a.name()} is {source_b.name()}", None)
             else:
                 raise RuntimeError(f"Unknown GuardEnvExpr: {guard}")
 
-        code_parts.extend(local_builder.shape_env_code)
+        for gcl in local_builder.shape_env_code:
+            for code in gcl.code_list:
+                add_code_part(code, gcl.guard)
+
         assert not global_builder.shape_env_code
 
         closure_vars = collections.OrderedDict(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107567
* #107439
* #107471
* #107562
* __->__ #107532
* #107530
* #107516
* #107505

Instead of (poorly) reconstructing the guard list from the guards on OutputGraph, we log them at the horses mouth: when we actually codegen the guard. This only requires very modest refactoring: as we translate guards into code parts, we also have to pass the source guard along so we can use it to give stack information.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov