### PR TITLE
[HSDP] Add device_mesh to FSDP kwarg and add dtensor state_dict support for HSDP

### DIFF
--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -45,54 +45,86 @@ class TestDummyModel(torch.nn.Module):
     def get_input(self):
         return torch.rand(8, 8, device="cuda")
 
-
-class TestFSDPDeviceMeshInit(DTensorTestBase):
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_fsdpdevice_mesh_init_1d(self):
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
-
-        print(model.get_state_dict_type(model))
-
-        # for k, v in model.state_dict().items():
-        #     print(v)
-            # self.assertEqual(v.device_mesh, device_mesh)
-
-
-class TestDtensorShardedOptimStateDict(DTensorTestBase):
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_optim_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+class TestFSDPWithDeviceMeshAndDTensor(DTensorTestBase):
+    def _create_model(self, device_mesh=None):
         model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
         model(model.get_input()).sum().backward()
         optim.step()
 
+        return model, optim
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_fsdp_init_with_device_mesh(self):
+        mesh_tensor = torch.arange(self.world_size)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        model, optim = self._create_model(device_mesh)
+
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+            optim_state_dict_config=ShardedOptimStateDictConfig(),
+        )
+        state_dict_type = model.get_state_dict_type(model)
+        # If device_mesh is used when initializing FSDP, the field _use_dtensor will
+        # automatically be set to True.
+        self.assertEqual(getattr(state_dict_type.state_dict_config, "_use_dtensor"), True)
+        self.assertEqual(getattr(state_dict_type.optim_state_dict_config, "_use_dtensor"), True)
+
+        for k, v in model.state_dict().items():
+            self.assertEqual(v.placements, (Shard(0)))
+            self.assertEqual(v.device_mesh, device_mesh)
+
+        for k, v in optim.state_dict()["state"].items():
+            if isinstance(v, DTensor):
+                self.assertEqual(v.placements, (Shard(0)))
+                self.assertEqual(v.device_mesh, device_mesh)
+
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @parametrize("offload_to_cpu", [True, False])
+    def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
+        mesh_tensor = torch.arange(self.world_size)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        model, optim = self._create_model(device_mesh)
+
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=True, offload_to_cpu=offload_to_cpu
+                offload_to_cpu=offload_to_cpu
             ),
         )
+        dtensor_sd = model.state_dict()
         dtensor_osd = FSDP.optim_state_dict(model, optim)
 
+        ref_model, ref_optim = self._create_model()
         FSDP.set_state_dict_type(
-            model,
+            ref_model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=False, offload_to_cpu=False
+                offload_to_cpu=offload_to_cpu
             ),
         )
-        sharded_tensor_osd = FSDP.optim_state_dict(model, optim)
+        sharded_tensor_sd = model.state_dict()
+        sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
 
+        # Check dtensor and sharded_tensor model state dict values are identical
+        for dtensor_sd, sharded_tensor_sd in zip(
+            dtensor_sd.items(), sharded_tensor_sd.items()
+        ):
+            k1, v1 = dtensor_sd
+            k2, v2 = sharded_tensor_sd
+            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+                self.assertEqual(k1, k2)
+                # check whether local_tensor are the same
+                self.assertEqual(v1.to_local(), v2.local_tensor())
+                # check whether device are the same
+                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+
+        # Check dtensor and sharde_tensor optim state dict values are identical
         for dtensor_osd_state, sharded_tensor_osd_state in zip(
             dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
         ):
@@ -117,16 +149,12 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
     def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
         mesh_tensor = torch.arange(self.world_size)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
-        optim.step()
+        model, optim = self._create_model(device_mesh)
 
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=True,
                 offload_to_cpu=offload_to_cpu,
             ),
         )
@@ -166,69 +194,22 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
                 # check whether DTensor are the same
                 self.assertEqual(v1, v2)
 
-
-# TODO: consolidate test cases once we test all DTensor usage
-class TestDtensorShardedModelStateDict(DTensorTestBase):
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_model_state_dict(self, offload_to_cpu):
-        # Compare the result of SHARDED_STATE_DICT using ShardedTensor and DTensor
-        # and check whether they are identical
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
-        model(model.get_input()).sum().backward()
-
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=True,
-                offload_to_cpu=offload_to_cpu,
-            ),
-        )
-        dtensor_sd = model.state_dict()
-
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=False,
-                offload_to_cpu=offload_to_cpu,
-            ),
-        )
-        sharded_tensor_sd = model.state_dict()
-
-        for dtensor_sd, sharded_tensor_sd in zip(
-            dtensor_sd.items(), sharded_tensor_sd.items()
-        ):
-            k1, v1 = dtensor_sd
-            k2, v2 = sharded_tensor_sd
-            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-                self.assertEqual(k1, k2)
-                # check whether local_tensor are the same
-                self.assertEqual(v1.to_local(), v2.local_tensor())
-                # check whether device are the same
-                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
-
     @with_comms
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
         mesh_tensor = torch.arange(self.world_size)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
+        model, optim = self._create_model(device_mesh)
 
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=True,
+            optim_state_dict_config=ShardedOptimStateDictConfig(
                 offload_to_cpu=offload_to_cpu,
             ),
         )
+        state_dict_type = model.get_state_dict_type(model)
 
         checkpoint = io.BytesIO()
         torch.save(model.state_dict(), checkpoint)
@@ -253,7 +234,6 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
             self.assertEqual(v1, v2)
 
 
-instantiate_parametrized_tests(TestDtensorShardedOptimStateDict)
-instantiate_parametrized_tests(TestDtensorShardedModelStateDict)
+instantiate_parametrized_tests(TestFSDPWithDeviceMeshAndDTensor)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -106,7 +106,8 @@ class TestFSDPHybridShard(FSDPTest):
     def test_raises_manual_wrap_hybrid_shard_when_none_policy(self):
         model = MyModel().cuda()
         err_ctx = self.assertRaisesRegex(
-            ValueError, "requires explicit specification of process group"
+            ValueError,
+            "requires explicit specification of process group or device_mesh.",
         )
 
         with err_ctx:

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -78,6 +78,7 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
         mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
         model, optim = self._create_model(use_device_mesh=True)
+        print(model.state_dict())
 
         FSDP.set_state_dict_type(
             model,
@@ -86,6 +87,8 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
             optim_state_dict_config=ShardedOptimStateDictConfig(),
         )
         state_dict_type = model.get_state_dict_type(model)
+        print(model.state_dict())
+        print(f"state_dict_type:{state_dict_type}")
         # If device_mesh is used when initializing FSDP, the field _use_dtensor will
         # automatically be set to True.
         self.assertEqual(state_dict_type.state_dict_config._use_dtensor, True)
@@ -100,149 +103,149 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
                 self.assertEqual(v.placements, (Replicate(), Shard(0)))
                 self.assertEqual(v.device_mesh, device_mesh)
 
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
-        model, optim = self._create_model(use_device_mesh=True)
+    # @with_comms
+    # @skip_if_lt_x_gpu(2)
+    # @parametrize("offload_to_cpu", [True, False])
+    # def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
+    #     model, optim = self._create_model(use_device_mesh=True)
 
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
-            optim_state_dict_config=ShardedOptimStateDictConfig(
-                offload_to_cpu=offload_to_cpu
-            ),
-        )
-        dtensor_sd = model.state_dict()
-        dtensor_osd = FSDP.optim_state_dict(model, optim)
+    #     FSDP.set_state_dict_type(
+    #         model,
+    #         StateDictType.SHARDED_STATE_DICT,
+    #         state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
+    #         optim_state_dict_config=ShardedOptimStateDictConfig(
+    #             offload_to_cpu=offload_to_cpu
+    #         ),
+    #     )
+    #     dtensor_sd = model.state_dict()
+    #     dtensor_osd = FSDP.optim_state_dict(model, optim)
 
-        ref_model, ref_optim = self._create_model(use_device_mesh=False)
-        FSDP.set_state_dict_type(
-            ref_model,
-            StateDictType.SHARDED_STATE_DICT,
-            optim_state_dict_config=ShardedOptimStateDictConfig(
-                offload_to_cpu=offload_to_cpu
-            ),
-        )
-        sharded_tensor_sd = model.state_dict()
-        sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
+    #     ref_model, ref_optim = self._create_model(use_device_mesh=False)
+    #     FSDP.set_state_dict_type(
+    #         ref_model,
+    #         StateDictType.SHARDED_STATE_DICT,
+    #         optim_state_dict_config=ShardedOptimStateDictConfig(
+    #             offload_to_cpu=offload_to_cpu
+    #         ),
+    #     )
+    #     sharded_tensor_sd = model.state_dict()
+    #     sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
 
-        # Check dtensor and sharded_tensor model state dict values are identical
-        for dtensor_sd, sharded_tensor_sd in zip(
-            dtensor_sd.items(), sharded_tensor_sd.items()
-        ):
-            k1, v1 = dtensor_sd
-            k2, v2 = sharded_tensor_sd
-            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-                self.assertEqual(k1, k2)
-                # check whether local_tensor are the same
-                self.assertEqual(v1.to_local(), v2.local_tensor())
-                # check whether device are the same
-                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+    #     # Check dtensor and sharded_tensor model state dict values are identical
+    #     for dtensor_sd, sharded_tensor_sd in zip(
+    #         dtensor_sd.items(), sharded_tensor_sd.items()
+    #     ):
+    #         k1, v1 = dtensor_sd
+    #         k2, v2 = sharded_tensor_sd
+    #         if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+    #             self.assertEqual(k1, k2)
+    #             # check whether local_tensor are the same
+    #             self.assertEqual(v1.to_local(), v2.local_tensor())
+    #             # check whether device are the same
+    #             self.assertEqual(v1.to_local().device, v2.local_tensor().device)
 
-        # Check dtensor and sharde_tensor optim state dict values are identical
-        for dtensor_osd_state, sharded_tensor_osd_state in zip(
-            dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
-        ):
-            # check FQN are the same
-            self.assertEqual(dtensor_osd_state[0], sharded_tensor_osd_state[0])
-            for dtensor_hyper_param, sharded_tensor_hyper_param in zip(
-                dtensor_osd_state[1].items(),
-                sharded_tensor_osd_state[1].items(),
-            ):
-                k1, v1 = dtensor_hyper_param
-                k2, v2 = sharded_tensor_hyper_param
-                if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-                    self.assertEqual(k1, k2)
-                    # check whether local_tensor are the same
-                    self.assertEqual(v1.to_local(), v2.local_tensor())
-                    # check whether device are the same
-                    self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+    #     # Check dtensor and sharde_tensor optim state dict values are identical
+    #     for dtensor_osd_state, sharded_tensor_osd_state in zip(
+    #         dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
+    #     ):
+    #         # check FQN are the same
+    #         self.assertEqual(dtensor_osd_state[0], sharded_tensor_osd_state[0])
+    #         for dtensor_hyper_param, sharded_tensor_hyper_param in zip(
+    #             dtensor_osd_state[1].items(),
+    #             sharded_tensor_osd_state[1].items(),
+    #         ):
+    #             k1, v1 = dtensor_hyper_param
+    #             k2, v2 = sharded_tensor_hyper_param
+    #             if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+    #                 self.assertEqual(k1, k2)
+    #                 # check whether local_tensor are the same
+    #                 self.assertEqual(v1.to_local(), v2.local_tensor())
+    #                 # check whether device are the same
+    #                 self.assertEqual(v1.to_local().device, v2.local_tensor().device)
 
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
-        model, optim = self._create_model(use_device_mesh=True)
+    # @with_comms
+    # @skip_if_lt_x_gpu(2)
+    # @parametrize("offload_to_cpu", [True, False])
+    # def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
+    #     model, optim = self._create_model(use_device_mesh=True)
 
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            optim_state_dict_config=ShardedOptimStateDictConfig(
-                offload_to_cpu=offload_to_cpu
-            ),
-        )
+    #     FSDP.set_state_dict_type(
+    #         model,
+    #         StateDictType.SHARDED_STATE_DICT,
+    #         optim_state_dict_config=ShardedOptimStateDictConfig(
+    #             offload_to_cpu=offload_to_cpu
+    #         ),
+    #     )
 
-        checkpoint = io.BytesIO()
-        torch.save(FSDP.optim_state_dict(model, optim), checkpoint)
-        # Deepcopy to save current optim_state_dict to compare with the optim_state_dict loaded back below.
-        ref_optim_state_dict = deepcopy(FSDP.optim_state_dict(model, optim))
+    #     checkpoint = io.BytesIO()
+    #     torch.save(FSDP.optim_state_dict(model, optim), checkpoint)
+    #     # Deepcopy to save current optim_state_dict to compare with the optim_state_dict loaded back below.
+    #     ref_optim_state_dict = deepcopy(FSDP.optim_state_dict(model, optim))
 
-        # Update the parameters so FSDP.optim_state_dict() will be different from ref_optim_state_dict.
-        model(model.get_input()).sum().backward()
-        optim.step()
+    #     # Update the parameters so FSDP.optim_state_dict() will be different from ref_optim_state_dict.
+    #     model(model.get_input()).sum().backward()
+    #     optim.step()
 
-        # Load ref_optim_state_dict back.
-        checkpoint.seek(0)
-        load_ref_optim_state_dict = torch.load(checkpoint)
-        optim.load_state_dict(
-            FSDP.optim_state_dict_to_load(model, optim, load_ref_optim_state_dict)
-        )
-        new_optim_state_dict = FSDP.optim_state_dict(model, optim)
+    #     # Load ref_optim_state_dict back.
+    #     checkpoint.seek(0)
+    #     load_ref_optim_state_dict = torch.load(checkpoint)
+    #     optim.load_state_dict(
+    #         FSDP.optim_state_dict_to_load(model, optim, load_ref_optim_state_dict)
+    #     )
+    #     new_optim_state_dict = FSDP.optim_state_dict(model, optim)
 
-        # Check whether new_optim_state_dict is the same as ref_optim_state_dict.
-        for new_optim_state_dict, ref_optim_state_dict in zip(
-            new_optim_state_dict["state"].items(),
-            ref_optim_state_dict["state"].items(),
-        ):
-            # check FQN are the same
-            self.assertEqual(new_optim_state_dict[0], ref_optim_state_dict[0])
-            for new_optim_hyper_param, ref_optim_hyper_param in zip(
-                new_optim_state_dict[1].items(),
-                ref_optim_state_dict[1].items(),
-            ):
-                k1, v1 = new_optim_hyper_param
-                k2, v2 = ref_optim_hyper_param
-                # check whether keys are the same
-                self.assertEqual(k1, k2)
-                # check whether DTensor are the same
-                self.assertEqual(v1, v2)
+    #     # Check whether new_optim_state_dict is the same as ref_optim_state_dict.
+    #     for new_optim_state_dict, ref_optim_state_dict in zip(
+    #         new_optim_state_dict["state"].items(),
+    #         ref_optim_state_dict["state"].items(),
+    #     ):
+    #         # check FQN are the same
+    #         self.assertEqual(new_optim_state_dict[0], ref_optim_state_dict[0])
+    #         for new_optim_hyper_param, ref_optim_hyper_param in zip(
+    #             new_optim_state_dict[1].items(),
+    #             ref_optim_state_dict[1].items(),
+    #         ):
+    #             k1, v1 = new_optim_hyper_param
+    #             k2, v2 = ref_optim_hyper_param
+    #             # check whether keys are the same
+    #             self.assertEqual(k1, k2)
+    #             # check whether DTensor are the same
+    #             self.assertEqual(v1, v2)
 
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
-        model, optim = self._create_model(use_device_mesh=True)
+    # @with_comms
+    # @skip_if_lt_x_gpu(2)
+    # @parametrize("offload_to_cpu", [True, False])
+    # def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
+    #     model, optim = self._create_model(use_device_mesh=True)
 
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
-        )
-        state_dict_type = model.get_state_dict_type(model)
+    #     FSDP.set_state_dict_type(
+    #         model,
+    #         StateDictType.SHARDED_STATE_DICT,
+    #         state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
+    #     )
+    #     state_dict_type = model.get_state_dict_type(model)
 
-        checkpoint = io.BytesIO()
-        torch.save(model.state_dict(), checkpoint)
-        # Deepcopy to save current state_dict to compare with the state_dict loaded back below.
-        ref_state_dict = deepcopy(model.state_dict())
+    #     checkpoint = io.BytesIO()
+    #     torch.save(model.state_dict(), checkpoint)
+    #     # Deepcopy to save current state_dict to compare with the state_dict loaded back below.
+    #     ref_state_dict = deepcopy(model.state_dict())
 
-        # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
-        model(model.get_input()).sum().backward()
-        optim.step()
+    #     # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
+    #     model(model.get_input()).sum().backward()
+    #     optim.step()
 
-        # Load ref_state_dict back.
-        checkpoint.seek(0)
-        load_ref_state_dict = torch.load(checkpoint)
-        model.load_state_dict(load_ref_state_dict)
-        new_state_dict = model.state_dict()
+    #     # Load ref_state_dict back.
+    #     checkpoint.seek(0)
+    #     load_ref_state_dict = torch.load(checkpoint)
+    #     model.load_state_dict(load_ref_state_dict)
+    #     new_state_dict = model.state_dict()
 
-        # Check whether new_state_dict is the same as ref_state_dict.
-        for (k1, v1), (k2, v2) in zip(ref_state_dict.items(), new_state_dict.items()):
-            # check whether fqn are the same
-            self.assertEqual(k1, k2)
-            # check whether DTensor are the same
-            self.assertEqual(v1, v2)
+    #     # Check whether new_state_dict is the same as ref_state_dict.
+    #     for (k1, v1), (k2, v2) in zip(ref_state_dict.items(), new_state_dict.items()):
+    #         # check whether fqn are the same
+    #         self.assertEqual(k1, k2)
+    #         # check whether DTensor are the same
+    #         self.assertEqual(v1, v2)
 
 
 instantiate_parametrized_tests(TestHSDPWithDeviceMeshAndDTensor)

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -43,17 +43,25 @@ class TestDummyModel(torch.nn.Module):
         return self.net4(self.net3(self.net2(self.net1(x))))
 
     def get_input(self):
-        return torch.rand(8, 8, device="cuda")
+        return torch.rand(4, 8, device="cuda")
 
 
 class TestDtensorShardedOptimStateDict(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
     @with_comms
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_optim_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size)
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), _device_mesh=device_mesh)
+        model = FSDP(
+            TestDummyModel().cuda(),
+            _device_mesh=device_mesh,
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+        )
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
         model(model.get_input()).sum().backward()
         optim.step()
@@ -98,9 +106,13 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size)
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), _device_mesh=device_mesh)
+        model = FSDP(
+            TestDummyModel().cuda(),
+            _device_mesh=device_mesh,
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+        )
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
         model(model.get_input()).sum().backward()
         optim.step()
@@ -152,15 +164,23 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
 
 # TODO: consolidate test cases once we test all DTensor usage
 class TestDtensorShardedModelStateDict(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
     @with_comms
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_model_state_dict(self, offload_to_cpu):
         # Compare the result of SHARDED_STATE_DICT using ShardedTensor and DTensor
         # and check whether they are identical
-        mesh_tensor = torch.arange(self.world_size)
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), _device_mesh=device_mesh)
+        model = FSDP(
+            TestDummyModel().cuda(),
+            _device_mesh=device_mesh,
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+        )
         model(model.get_input()).sum().backward()
 
         FSDP.set_state_dict_type(
@@ -172,6 +192,7 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
             ),
         )
         dtensor_sd = model.state_dict()
+        # print(f"rank:{dist.get_rank()}, dtensor_sd:{dtensor_sd}")
 
         FSDP.set_state_dict_type(
             model,
@@ -199,9 +220,13 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size)
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), _device_mesh=device_mesh)
+        model = FSDP(
+            TestDummyModel().cuda(),
+            _device_mesh=device_mesh,
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+        )
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
 
         FSDP.set_state_dict_type(
@@ -234,30 +259,6 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
             self.assertEqual(k1, k2)
             # check whether DTensor are the same
             self.assertEqual(v1, v2)
-
-
-class TestFSDPDeviceMeshInit(DTensorTestBase):
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_fsdp_device_mesh_init_1d(self):
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), _device_mesh=device_mesh)
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
-
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_fsdp_device_mesh_init_2d(self):
-        mesh_tensor = torch.arange(self.world_size).view(2, -1)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            _device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
 
 
 instantiate_parametrized_tests(TestDtensorShardedOptimStateDict)

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
-from torch.distributed._tensor import DeviceMesh, DTensor
+from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import (
     ShardedOptimStateDictConfig,
@@ -46,68 +46,102 @@ class TestDummyModel(torch.nn.Module):
         return torch.rand(4, 8, device="cuda")
 
 
-class TestFSDPDeviceMeshInit(DTensorTestBase):
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_fsdpdevice_mesh_init_1d(self):
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(TestDummyModel().cuda(), device_mesh=device_mesh)
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
-
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_fsdpdevice_mesh_init_2d(self):
+class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
+    def _create_model(self, use_device_mesh=True):
         mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
 
+        if use_device_mesh:
+            model = FSDP(
+                TestDummyModel().cuda(),
+                device_mesh=device_mesh,
+                sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+            )
+        else:
+            intra_node_pg = device_mesh.get_dim_groups(mesh_dim=1)
+            inter_node_pg = device_mesh.get_dim_groups(mesh_dim=0)
+            model = FSDP(
+                TestDummyModel().cuda(),
+                process_group=(intra_node_pg, inter_node_pg),
+                sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+            )
 
-class TestDtensorShardedOptimStateDict(DTensorTestBase):
-    @property
-    def world_size(self):
-        return 8
-
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_optim_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size).view(2, -1)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            _device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
         model(model.get_input()).sum().backward()
         optim.step()
 
+        return model, optim
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_hsdp_init_with_device_mesh(self):
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        model, optim = self._create_model(device_mesh)
+
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+            optim_state_dict_config=ShardedOptimStateDictConfig(),
+        )
+        state_dict_type = model.get_state_dict_type(model)
+        # If device_mesh is used when initializing FSDP, the field _use_dtensor will
+        # automatically be set to True.
+        self.assertEqual(getattr(state_dict_type.state_dict_config, "_use_dtensor"), True)
+        self.assertEqual(getattr(state_dict_type.optim_state_dict_config, "_use_dtensor"), True)
+
+        for k, v in model.state_dict().items():
+            self.assertEqual(v.placements, (Replicate(), Shard(0)))
+            self.assertEqual(v.device_mesh, device_mesh)
+
+        for k, v in optim.state_dict()["state"].items():
+            if isinstance(v, DTensor):
+                self.assertEqual(v.placements, (Replicate(), Shard(0)))
+                self.assertEqual(v.device_mesh, device_mesh)
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @parametrize("offload_to_cpu", [True, False])
+    def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
+        mesh_tensor = torch.arange(self.world_size).view(2, -1)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        model, optim = self._create_model(use_device_mesh=True)
+
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=True, offload_to_cpu=offload_to_cpu
+                offload_to_cpu=offload_to_cpu
             ),
         )
+        dtensor_sd = model.state_dict()
         dtensor_osd = FSDP.optim_state_dict(model, optim)
 
+        ref_model, ref_optim = self._create_model(use_device_mesh=False)
         FSDP.set_state_dict_type(
-            model,
+            ref_model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=False, offload_to_cpu=False
+                offload_to_cpu=offload_to_cpu
             ),
         )
-        sharded_tensor_osd = FSDP.optim_state_dict(model, optim)
+        sharded_tensor_sd = model.state_dict()
+        sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
 
+        # Check dtensor and sharded_tensor model state dict values are identical
+        for dtensor_sd, sharded_tensor_sd in zip(
+            dtensor_sd.items(), sharded_tensor_sd.items()
+        ):
+            k1, v1 = dtensor_sd
+            k2, v2 = sharded_tensor_sd
+            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+                self.assertEqual(k1, k2)
+                # check whether local_tensor are the same
+                self.assertEqual(v1.to_local(), v2.local_tensor())
+                # check whether device are the same
+                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+
+        # Check dtensor and sharde_tensor optim state dict values are identical
         for dtensor_osd_state, sharded_tensor_osd_state in zip(
             dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
         ):
@@ -130,22 +164,14 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size).view(2, -1)
+        mesh_tensor = torch.arange(self.world_size)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            _device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(model.get_input()).sum().backward()
-        optim.step()
+        model, optim = self._create_model(use_device_mesh=True)
 
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
             optim_state_dict_config=ShardedOptimStateDictConfig(
-                use_dtensor=True,
                 offload_to_cpu=offload_to_cpu,
             ),
         )
@@ -185,82 +211,22 @@ class TestDtensorShardedOptimStateDict(DTensorTestBase):
                 # check whether DTensor are the same
                 self.assertEqual(v1, v2)
 
-
-# TODO: consolidate test cases once we test all DTensor usage
-class TestDtensorShardedModelStateDict(DTensorTestBase):
-    @property
-    def world_size(self):
-        return 8
-
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    @parametrize("offload_to_cpu", [True, False])
-    def test_dtensor_sharded_model_state_dict(self, offload_to_cpu):
-        # Compare the result of SHARDED_STATE_DICT using ShardedTensor and DTensor
-        # and check whether they are identical
-        mesh_tensor = torch.arange(self.world_size).view(2, -1)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            _device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        model(model.get_input()).sum().backward()
-
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=True,
-                offload_to_cpu=offload_to_cpu,
-            ),
-        )
-        dtensor_sd = model.state_dict()
-        # print(f"rank:{dist.get_rank()}, dtensor_sd:{dtensor_sd}")
-
-        FSDP.set_state_dict_type(
-            model,
-            StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=False,
-                offload_to_cpu=offload_to_cpu,
-            ),
-        )
-        sharded_tensor_sd = model.state_dict()
-
-        for dtensor_sd, sharded_tensor_sd in zip(
-            dtensor_sd.items(), sharded_tensor_sd.items()
-        ):
-            k1, v1 = dtensor_sd
-            k2, v2 = sharded_tensor_sd
-            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-                self.assertEqual(k1, k2)
-                # check whether local_tensor are the same
-                self.assertEqual(v1.to_local(), v2.local_tensor())
-                # check whether device are the same
-                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
-
     @with_comms
     @skip_if_lt_x_gpu(2)
     @parametrize("offload_to_cpu", [True, False])
     def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
-        mesh_tensor = torch.arange(self.world_size).view(2, -1)
+        mesh_tensor = torch.arange(self.world_size)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        model = FSDP(
-            TestDummyModel().cuda(),
-            _device_mesh=device_mesh,
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=0.1)
+        model, optim = self._create_model(use_device_mesh=True)
 
         FSDP.set_state_dict_type(
             model,
             StateDictType.SHARDED_STATE_DICT,
-            state_dict_config=ShardedStateDictConfig(
-                use_dtensor=True,
+            optim_state_dict_config=ShardedOptimStateDictConfig(
                 offload_to_cpu=offload_to_cpu,
             ),
         )
+        state_dict_type = model.get_state_dict_type(model)
 
         checkpoint = io.BytesIO()
         torch.save(model.state_dict(), checkpoint)
@@ -285,7 +251,6 @@ class TestDtensorShardedModelStateDict(DTensorTestBase):
             self.assertEqual(v1, v2)
 
 
-instantiate_parametrized_tests(TestDtensorShardedOptimStateDict)
-instantiate_parametrized_tests(TestDtensorShardedModelStateDict)
+instantiate_parametrized_tests(TestHSDPWithDeviceMeshAndDTensor)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -78,7 +78,6 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
         mesh_tensor = torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
         model, optim = self._create_model(use_device_mesh=True)
-        print(model.state_dict())
 
         FSDP.set_state_dict_type(
             model,
@@ -87,8 +86,7 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
             optim_state_dict_config=ShardedOptimStateDictConfig(),
         )
         state_dict_type = model.get_state_dict_type(model)
-        print(model.state_dict())
-        print(f"state_dict_type:{state_dict_type}")
+
         # If device_mesh is used when initializing FSDP, the field _use_dtensor will
         # automatically be set to True.
         self.assertEqual(state_dict_type.state_dict_config._use_dtensor, True)
@@ -103,149 +101,149 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
                 self.assertEqual(v.placements, (Replicate(), Shard(0)))
                 self.assertEqual(v.device_mesh, device_mesh)
 
-    # @with_comms
-    # @skip_if_lt_x_gpu(2)
-    # @parametrize("offload_to_cpu", [True, False])
-    # def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
-    #     model, optim = self._create_model(use_device_mesh=True)
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @parametrize("offload_to_cpu", [True, False])
+    def test_dtensor_sharded_tensor_state_dict_identical(self, offload_to_cpu):
+        model, optim = self._create_model(use_device_mesh=True)
 
-    #     FSDP.set_state_dict_type(
-    #         model,
-    #         StateDictType.SHARDED_STATE_DICT,
-    #         state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
-    #         optim_state_dict_config=ShardedOptimStateDictConfig(
-    #             offload_to_cpu=offload_to_cpu
-    #         ),
-    #     )
-    #     dtensor_sd = model.state_dict()
-    #     dtensor_osd = FSDP.optim_state_dict(model, optim)
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+            state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
+            optim_state_dict_config=ShardedOptimStateDictConfig(
+                offload_to_cpu=offload_to_cpu
+            ),
+        )
+        dtensor_sd = model.state_dict()
+        dtensor_osd = FSDP.optim_state_dict(model, optim)
 
-    #     ref_model, ref_optim = self._create_model(use_device_mesh=False)
-    #     FSDP.set_state_dict_type(
-    #         ref_model,
-    #         StateDictType.SHARDED_STATE_DICT,
-    #         optim_state_dict_config=ShardedOptimStateDictConfig(
-    #             offload_to_cpu=offload_to_cpu
-    #         ),
-    #     )
-    #     sharded_tensor_sd = model.state_dict()
-    #     sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
+        ref_model, ref_optim = self._create_model(use_device_mesh=False)
+        FSDP.set_state_dict_type(
+            ref_model,
+            StateDictType.SHARDED_STATE_DICT,
+            optim_state_dict_config=ShardedOptimStateDictConfig(
+                offload_to_cpu=offload_to_cpu
+            ),
+        )
+        sharded_tensor_sd = model.state_dict()
+        sharded_tensor_osd = FSDP.optim_state_dict(ref_model, ref_optim)
 
-    #     # Check dtensor and sharded_tensor model state dict values are identical
-    #     for dtensor_sd, sharded_tensor_sd in zip(
-    #         dtensor_sd.items(), sharded_tensor_sd.items()
-    #     ):
-    #         k1, v1 = dtensor_sd
-    #         k2, v2 = sharded_tensor_sd
-    #         if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-    #             self.assertEqual(k1, k2)
-    #             # check whether local_tensor are the same
-    #             self.assertEqual(v1.to_local(), v2.local_tensor())
-    #             # check whether device are the same
-    #             self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+        # Check dtensor and sharded_tensor model state dict values are identical
+        for dtensor_sd, sharded_tensor_sd in zip(
+            dtensor_sd.items(), sharded_tensor_sd.items()
+        ):
+            k1, v1 = dtensor_sd
+            k2, v2 = sharded_tensor_sd
+            if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+                self.assertEqual(k1, k2)
+                # check whether local_tensor are the same
+                self.assertEqual(v1.to_local(), v2.local_tensor())
+                # check whether device are the same
+                self.assertEqual(v1.to_local().device, v2.local_tensor().device)
 
-    #     # Check dtensor and sharde_tensor optim state dict values are identical
-    #     for dtensor_osd_state, sharded_tensor_osd_state in zip(
-    #         dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
-    #     ):
-    #         # check FQN are the same
-    #         self.assertEqual(dtensor_osd_state[0], sharded_tensor_osd_state[0])
-    #         for dtensor_hyper_param, sharded_tensor_hyper_param in zip(
-    #             dtensor_osd_state[1].items(),
-    #             sharded_tensor_osd_state[1].items(),
-    #         ):
-    #             k1, v1 = dtensor_hyper_param
-    #             k2, v2 = sharded_tensor_hyper_param
-    #             if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
-    #                 self.assertEqual(k1, k2)
-    #                 # check whether local_tensor are the same
-    #                 self.assertEqual(v1.to_local(), v2.local_tensor())
-    #                 # check whether device are the same
-    #                 self.assertEqual(v1.to_local().device, v2.local_tensor().device)
+        # Check dtensor and sharde_tensor optim state dict values are identical
+        for dtensor_osd_state, sharded_tensor_osd_state in zip(
+            dtensor_osd["state"].items(), sharded_tensor_osd["state"].items()
+        ):
+            # check FQN are the same
+            self.assertEqual(dtensor_osd_state[0], sharded_tensor_osd_state[0])
+            for dtensor_hyper_param, sharded_tensor_hyper_param in zip(
+                dtensor_osd_state[1].items(),
+                sharded_tensor_osd_state[1].items(),
+            ):
+                k1, v1 = dtensor_hyper_param
+                k2, v2 = sharded_tensor_hyper_param
+                if isinstance(v1, DTensor) and isinstance(v2, ShardedTensor):
+                    self.assertEqual(k1, k2)
+                    # check whether local_tensor are the same
+                    self.assertEqual(v1.to_local(), v2.local_tensor())
+                    # check whether device are the same
+                    self.assertEqual(v1.to_local().device, v2.local_tensor().device)
 
-    # @with_comms
-    # @skip_if_lt_x_gpu(2)
-    # @parametrize("offload_to_cpu", [True, False])
-    # def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
-    #     model, optim = self._create_model(use_device_mesh=True)
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @parametrize("offload_to_cpu", [True, False])
+    def test_dtensor_sharded_optim_load_state_dict(self, offload_to_cpu):
+        model, optim = self._create_model(use_device_mesh=True)
 
-    #     FSDP.set_state_dict_type(
-    #         model,
-    #         StateDictType.SHARDED_STATE_DICT,
-    #         optim_state_dict_config=ShardedOptimStateDictConfig(
-    #             offload_to_cpu=offload_to_cpu
-    #         ),
-    #     )
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+            optim_state_dict_config=ShardedOptimStateDictConfig(
+                offload_to_cpu=offload_to_cpu
+            ),
+        )
 
-    #     checkpoint = io.BytesIO()
-    #     torch.save(FSDP.optim_state_dict(model, optim), checkpoint)
-    #     # Deepcopy to save current optim_state_dict to compare with the optim_state_dict loaded back below.
-    #     ref_optim_state_dict = deepcopy(FSDP.optim_state_dict(model, optim))
+        checkpoint = io.BytesIO()
+        torch.save(FSDP.optim_state_dict(model, optim), checkpoint)
+        # Deepcopy to save current optim_state_dict to compare with the optim_state_dict loaded back below.
+        ref_optim_state_dict = deepcopy(FSDP.optim_state_dict(model, optim))
 
-    #     # Update the parameters so FSDP.optim_state_dict() will be different from ref_optim_state_dict.
-    #     model(model.get_input()).sum().backward()
-    #     optim.step()
+        # Update the parameters so FSDP.optim_state_dict() will be different from ref_optim_state_dict.
+        model(model.get_input()).sum().backward()
+        optim.step()
 
-    #     # Load ref_optim_state_dict back.
-    #     checkpoint.seek(0)
-    #     load_ref_optim_state_dict = torch.load(checkpoint)
-    #     optim.load_state_dict(
-    #         FSDP.optim_state_dict_to_load(model, optim, load_ref_optim_state_dict)
-    #     )
-    #     new_optim_state_dict = FSDP.optim_state_dict(model, optim)
+        # Load ref_optim_state_dict back.
+        checkpoint.seek(0)
+        load_ref_optim_state_dict = torch.load(checkpoint)
+        optim.load_state_dict(
+            FSDP.optim_state_dict_to_load(model, optim, load_ref_optim_state_dict)
+        )
+        new_optim_state_dict = FSDP.optim_state_dict(model, optim)
 
-    #     # Check whether new_optim_state_dict is the same as ref_optim_state_dict.
-    #     for new_optim_state_dict, ref_optim_state_dict in zip(
-    #         new_optim_state_dict["state"].items(),
-    #         ref_optim_state_dict["state"].items(),
-    #     ):
-    #         # check FQN are the same
-    #         self.assertEqual(new_optim_state_dict[0], ref_optim_state_dict[0])
-    #         for new_optim_hyper_param, ref_optim_hyper_param in zip(
-    #             new_optim_state_dict[1].items(),
-    #             ref_optim_state_dict[1].items(),
-    #         ):
-    #             k1, v1 = new_optim_hyper_param
-    #             k2, v2 = ref_optim_hyper_param
-    #             # check whether keys are the same
-    #             self.assertEqual(k1, k2)
-    #             # check whether DTensor are the same
-    #             self.assertEqual(v1, v2)
+        # Check whether new_optim_state_dict is the same as ref_optim_state_dict.
+        for new_optim_state_dict, ref_optim_state_dict in zip(
+            new_optim_state_dict["state"].items(),
+            ref_optim_state_dict["state"].items(),
+        ):
+            # check FQN are the same
+            self.assertEqual(new_optim_state_dict[0], ref_optim_state_dict[0])
+            for new_optim_hyper_param, ref_optim_hyper_param in zip(
+                new_optim_state_dict[1].items(),
+                ref_optim_state_dict[1].items(),
+            ):
+                k1, v1 = new_optim_hyper_param
+                k2, v2 = ref_optim_hyper_param
+                # check whether keys are the same
+                self.assertEqual(k1, k2)
+                # check whether DTensor are the same
+                self.assertEqual(v1, v2)
 
-    # @with_comms
-    # @skip_if_lt_x_gpu(2)
-    # @parametrize("offload_to_cpu", [True, False])
-    # def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
-    #     model, optim = self._create_model(use_device_mesh=True)
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @parametrize("offload_to_cpu", [True, False])
+    def test_dtensor_sharded_model_load_state_dict(self, offload_to_cpu):
+        model, optim = self._create_model(use_device_mesh=True)
 
-    #     FSDP.set_state_dict_type(
-    #         model,
-    #         StateDictType.SHARDED_STATE_DICT,
-    #         state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
-    #     )
-    #     state_dict_type = model.get_state_dict_type(model)
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+            state_dict_config=ShardedStateDictConfig(offload_to_cpu=offload_to_cpu),
+        )
+        state_dict_type = model.get_state_dict_type(model)
 
-    #     checkpoint = io.BytesIO()
-    #     torch.save(model.state_dict(), checkpoint)
-    #     # Deepcopy to save current state_dict to compare with the state_dict loaded back below.
-    #     ref_state_dict = deepcopy(model.state_dict())
+        checkpoint = io.BytesIO()
+        torch.save(model.state_dict(), checkpoint)
+        # Deepcopy to save current state_dict to compare with the state_dict loaded back below.
+        ref_state_dict = deepcopy(model.state_dict())
 
-    #     # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
-    #     model(model.get_input()).sum().backward()
-    #     optim.step()
+        # Update the parameters so model.state_dict() will be different from ref_dtensor_sd.
+        model(model.get_input()).sum().backward()
+        optim.step()
 
-    #     # Load ref_state_dict back.
-    #     checkpoint.seek(0)
-    #     load_ref_state_dict = torch.load(checkpoint)
-    #     model.load_state_dict(load_ref_state_dict)
-    #     new_state_dict = model.state_dict()
+        # Load ref_state_dict back.
+        checkpoint.seek(0)
+        load_ref_state_dict = torch.load(checkpoint)
+        model.load_state_dict(load_ref_state_dict)
+        new_state_dict = model.state_dict()
 
-    #     # Check whether new_state_dict is the same as ref_state_dict.
-    #     for (k1, v1), (k2, v2) in zip(ref_state_dict.items(), new_state_dict.items()):
-    #         # check whether fqn are the same
-    #         self.assertEqual(k1, k2)
-    #         # check whether DTensor are the same
-    #         self.assertEqual(v1, v2)
+        # Check whether new_state_dict is the same as ref_state_dict.
+        for (k1, v1), (k2, v2) in zip(ref_state_dict.items(), new_state_dict.items()):
+            # check whether fqn are the same
+            self.assertEqual(k1, k2)
+            # check whether DTensor are the same
+            self.assertEqual(v1, v2)
 
 
 instantiate_parametrized_tests(TestHSDPWithDeviceMeshAndDTensor)

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -821,7 +821,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
             fsdp_model(inp)
         # Check for no recompiles (if there were incorrect de-dup guards, then
         # the frame count would be equal to the number of forward calls)
-        self.assertEqual(cnt.frame_count, 3)
+        self.assertEqual(cnt.frame_count, 1)
 
     def test_fsdp_staticmethod(self):
         """
@@ -863,8 +863,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
             # passing args to the staticmethod (e.g. doubly passing `self`)
             # 3 is expected here for 1 forward.
             # Graph 1 should be add and imul
-            # Graphs 2 and 3 are forward hooks on device mesh, and are fine to capture.
-            self.assertEqual(cnt.frame_count, 3)
+            self.assertEqual(cnt.frame_count, 1)
         for test_out in test_outs:
             self.assertEqual(test_out, ref_out)
 

--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -116,7 +116,7 @@ def _ext_chunk_dtensor(
     # TODO: Address composability issue and remove the assertion.
     assert (
         _extensions is None
-    ), "Currently does not support composability when use_dtensor = True"
+    ), "Currently does not support composability when _use_dtensor = True"
     return _create_chunk_dtensor(
         tensor,
         rank,

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -97,9 +97,9 @@ NO_RESHARD_AFTER_FORWARD_STRATEGIES = (
 def _init_process_group_state(
     state: _FSDPState,
     process_group: ProcessGroupType,
-    device_mesh: DeviceMesh,
     sharding_strategy: ShardingStrategy,
     policy: Optional[_Policy],
+    device_mesh: Optional[DeviceMesh] = None,
 ) -> _FSDPState:
     if process_group is not None and device_mesh is not None:
         raise ValueError(
@@ -114,7 +114,7 @@ def _init_process_group_state(
             # process groups.
             raise ValueError(
                 f"Manual wrapping with {sharding_strategy} requires explicit specification",
-                f"of process group or device_mesh."
+                "of process group or device_mesh.",
             )
         else:
             state = _init_process_group_state_for_hybrid_shard(

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -154,13 +154,13 @@ def _init_process_group_state_for_hybrid_shard(
     if device_mesh:
         if _is_valid_hybrid_shard_device_mesh(device_mesh):
             state._device_mesh = device_mesh
-            # We currenlty only allow _inter_node_pg to be the outermost dimension, and the
+            # We currently only allow _inter_node_pg to be the outermost dimension, and the
             # process_group(intra_node) to be the innermost dimension.
             state._inter_node_pg = device_mesh.get_dim_groups(mesh_dim=0)
             state.process_group = device_mesh.get_dim_groups(mesh_dim=1)
         else:
             raise ValueError(
-                "Expected device_mesh to be passed in has ndim=2 "
+                "Expected device_mesh to have ndim=2 "
                 f"but got {len(device_mesh.get_dim_groups())}"
             )
     elif process_group is None:
@@ -201,9 +201,7 @@ def _is_valid_hybrid_shard_pg_type(process_group: Any) -> bool:
 
 @no_type_check
 def _is_valid_hybrid_shard_device_mesh(device_mesh: DeviceMesh) -> bool:
-    return (
-        isinstance(device_mesh, DeviceMesh) and len(device_mesh.get_dim_groups()) == 2
-    )
+    return isinstance(device_mesh, DeviceMesh) and device_mesh.ndim == 2
 
 
 @no_type_check

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -24,6 +24,7 @@ import torch.distributed.fsdp._exec_order_utils as exec_order_utils
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.distributed.fsdp.fully_sharded_data_parallel as fsdp_file
 import torch.nn as nn
+from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp._common_utils import (
@@ -98,21 +99,35 @@ def _init_process_group_state(
     process_group: ProcessGroupType,
     sharding_strategy: ShardingStrategy,
     policy: Optional[_Policy],
+    device_mesh: DeviceMesh = None,
 ) -> _FSDPState:
+    if process_group is not None and device_mesh is not None:
+        raise ValueError(
+            "Cannot pass both process_group and device_mesh at the "
+            "same time. Please just pass only one of them."
+        )
     is_hybrid_strategy = sharding_strategy in HYBRID_SHARDING_STRATEGIES
     if is_hybrid_strategy:
-        if process_group is None and policy is None:
+        if process_group is None and policy is None and device_mesh is None:
             # Raise an error here, since this is manual wrapping with no process group
             # passed in, there is no way to ensure all wrapped FSDP instances use the same
             # process groups.
             raise ValueError(
                 f"Manual wrapping with {sharding_strategy} requires explicit specification of process group."
             )
-        state = _init_process_group_state_for_hybrid_shard(state, process_group)
+        else:
+            state = _init_process_group_state_for_hybrid_shard(
+                state, process_group, device_mesh
+            )
     else:
-        state.process_group = (
-            process_group if process_group is not None else _get_default_group()
-        )
+        if device_mesh:
+            state._device_mesh = device_mesh
+            state.process_group = device_mesh.get_dim_groups(mesh_dim=0)
+        else:
+            state.process_group = (
+                process_group if process_group is not None else _get_default_group()
+            )
+
     state.rank = state.process_group.rank()
     state.world_size = state.process_group.size()
     data_parallel_world_size = state.world_size
@@ -131,9 +146,23 @@ def _init_process_group_state(
 
 @no_type_check
 def _init_process_group_state_for_hybrid_shard(
-    state: _FSDPState, process_group
+    state: _FSDPState,
+    process_group: ProcessGroupType,
+    device_mesh: DeviceMesh,
 ) -> _FSDPState:
-    if process_group is None:
+    if device_mesh is not None:
+        if _is_valid_hybrid_shard_device_mesh(device_mesh):
+            state._device_mesh = device_mesh
+            # TODO: We will make updates to get the mesh_dim instead of hardcoding it.
+            # Temporarily hardcoding it for intermediate HSDP DTensor state_dict devlopment.
+            state.process_group = device_mesh.get_dim_groups(mesh_dim=1)
+            state._inter_node_pg = device_mesh.get_dim_groups(mesh_dim=0)
+        else:
+            raise ValueError(
+                "Expected device_mesh to be passed in has ndim=2 "
+                f"but got {len(device_mesh.get_dim_groups())}"
+            )
+    elif process_group is None:
         default_group = _get_default_group()
         intra_node_group, inter_node_group = _init_intra_and_inter_node_groups(
             default_group, state._device_handle.device_count()
@@ -166,6 +195,13 @@ def _is_valid_hybrid_shard_pg_type(process_group: Any) -> bool:
         isinstance(process_group, tuple)
         and len(process_group) == 2
         and all(isinstance(pg, dist.ProcessGroup) for pg in process_group)
+    )
+
+
+@no_type_check
+def _is_valid_hybrid_shard_device_mesh(device_mesh: DeviceMesh) -> bool:
+    return (
+        isinstance(device_mesh, DeviceMesh) and len(device_mesh.get_dim_groups()) == 2
     )
 
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -113,8 +113,8 @@ def _init_process_group_state(
             # passed in, there is no way to ensure all wrapped FSDP instances use the same
             # process groups.
             raise ValueError(
-                f"Manual wrapping with {sharding_strategy} requires explicit specification",
-                "of process group or device_mesh.",
+                f"Manual wrapping with {sharding_strategy}",
+                "requires explicit specification of process group or device_mesh.",
             )
         else:
             state = _init_process_group_state_for_hybrid_shard(

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -287,7 +287,7 @@ def _unflatten_communicated_optim_state(
                 views = flat_param_views[state_name]
             optim_state: Union[torch.Tensor, ShardedTensor, DTensor] = next(views)
             if shard_state:
-                if not fsdp_state._optim_state_dict_config.use_dtensor:
+                if not fsdp_state._optim_state_dict_config._use_dtensor:
                     assert fsdp_state.process_group is not None
                     optim_state = _ext_chunk_tensor(
                         optim_state,

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -287,7 +287,16 @@ def _unflatten_communicated_optim_state(
                 views = flat_param_views[state_name]
             optim_state: Union[torch.Tensor, ShardedTensor, DTensor] = next(views)
             if shard_state:
-                if not fsdp_state._optim_state_dict_config._use_dtensor:
+                osd_config = fsdp_state._optim_state_dict_config
+                if (
+                    hasattr(osd_config, "_use_dtensor")
+                    and osd_config._use_dtensor is True
+                ):
+                    assert fsdp_state._device_mesh is not None
+                    optim_state = _ext_chunk_dtensor(
+                        optim_state, fsdp_state.rank, fsdp_state._device_mesh
+                    )
+                else:
                     assert fsdp_state.process_group is not None
                     optim_state = _ext_chunk_tensor(
                         optim_state,
@@ -296,12 +305,6 @@ def _unflatten_communicated_optim_state(
                         fsdp_state._device_handle.device_count(),
                         fsdp_state.process_group,
                     )
-                else:
-                    assert fsdp_state._device_mesh is not None
-                    optim_state = _ext_chunk_dtensor(
-                        optim_state, fsdp_state.rank, fsdp_state._device_mesh
-                    )
-
             unflat_state_param[state_name] = optim_state
 
         # Add zero-dimension tensor state: take the target rank's value
@@ -1665,24 +1668,25 @@ def _gather_orig_param_state(
             if not torch.is_tensor(value) or value.dim() == 0:
                 continue
 
-            value = value[: flat_param._numels[param_idx]].reshape(
-                flat_param._shapes[param_idx]
-            )
-            if shard_state:
-                if not fsdp_state._optim_state_dict_config.use_dtensor:
-                    assert fsdp_state.process_group is not None
-                    value = _ext_chunk_tensor(
-                        value,
-                        fsdp_state.rank,
-                        fsdp_state.world_size,
-                        fsdp_state._device_handle.device_count(),
-                        fsdp_state.process_group,
-                    )
-                else:
-                    assert fsdp_state._device_mesh is not None
-                    value = _ext_chunk_dtensor(
-                        value, fsdp_state.rank, fsdp_state._device_mesh
-                    )
-            value = value.cpu()
-            gathered_state[state_name] = value
+        value = value[: flat_param._numels[param_idx]].reshape(
+            flat_param._shapes[param_idx]
+        )
+        if shard_state:
+            osd_config = fsdp_state._optim_state_dict_config
+            if hasattr(osd_config, "_use_dtensor") and osd_config._use_dtensor is True:
+                assert fsdp_state._device_mesh is not None
+                value = _ext_chunk_dtensor(
+                    value, fsdp_state.rank, fsdp_state._device_mesh
+                )
+            else:
+                assert fsdp_state.process_group is not None
+                value = _ext_chunk_tensor(
+                    value,
+                    fsdp_state.rank,
+                    fsdp_state.world_size,
+                    fsdp_state._device_handle.device_count(),
+                    fsdp_state.process_group,
+                )
+        value = value.cpu()
+        gathered_state[state_name] = value
     return gathered_state

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1665,25 +1665,25 @@ def _gather_orig_param_state(
             if not torch.is_tensor(value) or value.dim() == 0:
                 continue
 
-        value = value[: flat_param._numels[param_idx]].reshape(
-            flat_param._shapes[param_idx]
-        )
-        if shard_state:
-            osd_config = fsdp_state._optim_state_dict_config
-            if getattr(osd_config, "_use_dtensor", False):
-                assert fsdp_state._device_mesh is not None
-                value = _ext_chunk_dtensor(
-                    value, fsdp_state.rank, fsdp_state._device_mesh
-                )
-            else:
-                assert fsdp_state.process_group is not None
-                value = _ext_chunk_tensor(
-                    value,
-                    fsdp_state.rank,
-                    fsdp_state.world_size,
-                    fsdp_state._device_handle.device_count(),
-                    fsdp_state.process_group,
-                )
-        value = value.cpu()
-        gathered_state[state_name] = value
+            value = value[: flat_param._numels[param_idx]].reshape(
+                flat_param._shapes[param_idx]
+            )
+            if shard_state:
+                osd_config = fsdp_state._optim_state_dict_config
+                if getattr(osd_config, "_use_dtensor", False):
+                    assert fsdp_state._device_mesh is not None
+                    value = _ext_chunk_dtensor(
+                        value, fsdp_state.rank, fsdp_state._device_mesh
+                    )
+                else:
+                    assert fsdp_state.process_group is not None
+                    value = _ext_chunk_tensor(
+                        value,
+                        fsdp_state.rank,
+                        fsdp_state.world_size,
+                        fsdp_state._device_handle.device_count(),
+                        fsdp_state.process_group,
+                    )
+            value = value.cpu()
+            gathered_state[state_name] = value
     return gathered_state

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -288,10 +288,7 @@ def _unflatten_communicated_optim_state(
             optim_state: Union[torch.Tensor, ShardedTensor, DTensor] = next(views)
             if shard_state:
                 osd_config = fsdp_state._optim_state_dict_config
-                if (
-                    hasattr(osd_config, "_use_dtensor")
-                    and osd_config._use_dtensor is True
-                ):
+                if getattr(osd_config, "_use_dtensor", False):
                     assert fsdp_state._device_mesh is not None
                     optim_state = _ext_chunk_dtensor(
                         optim_state, fsdp_state.rank, fsdp_state._device_mesh
@@ -1673,7 +1670,7 @@ def _gather_orig_param_state(
         )
         if shard_state:
             osd_config = fsdp_state._optim_state_dict_config
-            if hasattr(osd_config, "_use_dtensor") and osd_config._use_dtensor is True:
+            if getattr(osd_config, "_use_dtensor", False):
                 assert fsdp_state._device_mesh is not None
                 value = _ext_chunk_dtensor(
                     value, fsdp_state.rank, fsdp_state._device_mesh

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -11,8 +11,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from torch.autograd.graph import register_multi_grad_hook
-from torch.distributed import get_backend, get_world_size
-from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
     _assert_in_training_states,
@@ -198,24 +196,6 @@ def _check_flat_params_on_expected_device(state: _FSDPState, module: nn.Module):
             )
 
 
-def _init_device_mesh(
-    root_state: _FSDPState,
-) -> Optional[DeviceMesh]:
-    # We are testing 1D DeviceMesh where dist.get_world_size(pg) == dist.get_world_size() for now.
-    # TODO: Address cases when dist.get_world_size(pg) != dist.get_world_size(). This would capture
-    #       what 1D DeviceMesh currently would not work for:
-    #       1) HSDP Hybrid Sharding, 2) 2D FSDP + TP, 3) dist.new_group() cannot be expressed in 1D DeviceMesh.
-    if root_state.process_group != dist.distributed_c10d._get_default_group():
-        return None
-    if get_backend() == "fake" or not root_state.compute_device:
-        return None
-
-    device_type = root_state.compute_device.type
-    mesh_tensor = torch.arange(get_world_size(root_state.process_group))
-    device_mesh = DeviceMesh(device_type, mesh_tensor, _validate_mesh=False)
-    return device_mesh
-
-
 @no_type_check
 def _share_state_and_init_handle_attrs(
     root_state: _FSDPState,
@@ -234,7 +214,6 @@ def _share_state_and_init_handle_attrs(
     for attr_name in HOMOGENEOUS_ATTR_NAMES:
         attr_name_to_values[attr_name] = set()
     root_state._all_handles = root_state._exec_order_data.all_handles  # share reference
-    root_state._device_mesh = _init_device_mesh(root_state)
     # Update _has_optim_in_backward for each handle.
     for handle in root_state._all_handles:
         flat_param = handle.flat_param
@@ -270,7 +249,8 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
-        fsdp_state._device_mesh = root_state._device_mesh
+        if hasattr(root_state, "_device_mesh"):
+            fsdp_state._device_mesh = root_state._device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -252,6 +252,8 @@ def _share_state_and_init_handle_attrs(
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()
+        # TODO: remove this if check after we integrate device_mesh in Composable APIs.
+        # Currently, it is needed since root_state of composable APIs doesn't have DeviceMesh passed in yet.
         if hasattr(root_state, "_device_mesh"):
             fsdp_state._device_mesh = root_state._device_mesh
     for attr_name, attr_values in attr_name_to_values.items():

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -249,12 +249,11 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
-        device_mesh = root_state._device_mesh
-        if device_mesh:
-            fsdp_state._device_mesh = device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()
+        if hasattr(root_state, "_device_mesh"):
+            fsdp_state._device_mesh = root_state._device_mesh
     for attr_name, attr_values in attr_name_to_values.items():
         if len(attr_values) != 1:
             raise ValueError(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -249,8 +249,9 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
-        if hasattr(root_state, "_device_mesh"):
-            fsdp_state._device_mesh = root_state._device_mesh
+        device_mesh = root_state._device_mesh
+        if device_mesh:
+            fsdp_state._device_mesh = device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -79,8 +79,7 @@ def _gather_state_dict(
                 tensor = tensor.to(tensor.device_mesh.device_type)
             # FSDP all_gather: [Shard(0)] -> [Replicate()]
             # HSDP all_gather: [Replicate(), Shard(0)] -> [Replicate(), Replicate()]
-            # We need to do a deep-copy here so we do not change the original placements associated with the DTensor.
-            placements = copy.deepcopy(tensor.placements)
+            placements = list(copy.deepcopy(tensor.placements))
             placements[-1] = Replicate()
             tensor = tensor.redistribute(
                 device_mesh=tensor.device_mesh,
@@ -176,5 +175,5 @@ def _create_chunk_dtensor(
     # FSDP placements: [Shard(0)]
     # HSDP placements: [Replicate(), Shard(0)]
     placements = [Replicate() for _ in range(device_mesh.ndim)]
-    placements[-1] = shard_placement  # type: ignore[misc]
+    placements[-1] = shard_placement  # type: ignore[call-overload]
     return DTensor.from_local(local_tensor, device_mesh, placements)

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -53,6 +53,8 @@ def _all_gather_sharded_tensor(
     return tensor
 
 
+# TODO: Make this API work for both FSDP, and 2D. Move it outside of FSDP.
+# External users are interesting in using this API.
 def _gather_state_dict(
     state_dict: Dict[str, Any],
     pg: Optional[dist.ProcessGroup] = None,

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import math
 from typing import Any, Dict, Optional
@@ -76,8 +77,14 @@ def _gather_state_dict(
         elif isinstance(tensor, DTensor):
             if tensor.device != tensor.device_mesh.device_type:
                 tensor = tensor.to(tensor.device_mesh.device_type)
+            # FSDP all_gather: [Shard(0)] -> [Replicate()]
+            # HSDP all_gather: [Replicate(), Shard(0)] -> [Replicate(), Replicate()]
+            # We need to do a deep-copy here so we do not change the original placements associated with the DTensor.
+            placements = copy.deepcopy(tensor.placements)
+            placements[-1] = Replicate()
             tensor = tensor.redistribute(
-                device_mesh=tensor.device_mesh, placements=[Replicate()]
+                device_mesh=tensor.device_mesh,
+                placements=placements,
             )
             tensor = tensor.to_local()
         new_state_dict[key] = tensor
@@ -153,10 +160,11 @@ def _create_chunk_dtensor(
     Shard a tensor to chunks along the first dimension. The local rank will gets its
     corresponding chunk as the local tensor to create a DTensor.
     """
+    inner_dim = device_mesh.ndim - 1
     shard_placement = DShard(0)
     tensor_list, _ = shard_placement._split_tensor(
         tensor,
-        device_mesh.size(dim=0),
+        device_mesh.size(dim=inner_dim),
         with_padding=False,
         contiguous=True,
     )
@@ -164,4 +172,9 @@ def _create_chunk_dtensor(
     # Each chunk is a view of the input tensor. If the original tensor change, the view will also be changed.
     # We need to explicitly call .detach() to return a new tensor detached from the current graph.
     local_tensor = tensor_list[rank].clone().detach()
-    return DTensor.from_local(local_tensor, device_mesh, [shard_placement])
+
+    # FSDP placements: [Shard(0)]
+    # HSDP placements: [Replicate(), Shard(0)]
+    placements = [Replicate() for _ in range(device_mesh.ndim)]
+    placements[-1] = shard_placement  # type: ignore[misc]
+    return DTensor.from_local(local_tensor, device_mesh, placements)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -662,8 +662,7 @@ def _sharded_pre_load_state_dict_hook(
         else:
             if param.device != fsdp_state._device_mesh.device_type:
                 param = param.to(fsdp_state._device_mesh.device_type)
-            # We need to do a deep-copy here so we do not change the original placements associated with the DTensor.
-            placements = copy.deepcopy(param.placements)
+            placements = list(copy.deepcopy(param.placements))
             placements[-1] = Replicate()
             param = param.redistribute(
                 device_mesh=param.device_mesh,

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -542,7 +542,7 @@ def _sharded_post_state_dict_hook(
 
     def param_hook(state_dict: Dict[str, Any], prefix: str, fqn: str):
         param = state_dict[fqn]
-        if not fsdp_state._state_dict_config.use_dtensor:
+        if not fsdp_state._state_dict_config._use_dtensor:
             sharded_tensor = _ext_chunk_tensor(
                 tensor=param,
                 rank=fsdp_state.rank,
@@ -606,7 +606,7 @@ def _sharded_pre_load_state_dict_hook(
             fqn_from_global_root = f"{prefix}{fqn}"
         param = state_dict.pop(fqn_from_global_root)
 
-        if not fsdp_state._state_dict_config.use_dtensor:
+        if not fsdp_state._state_dict_config._use_dtensor:
             # All-gather the param (ShardedTensor)
             param, shards = _ext_pre_load_state_dict_transform(param)
 

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -341,9 +341,9 @@ class ShardedStateDictConfig(StateDictConfig):
             as ``DTensor``, and if ``False``, then FSDP saves them as
             ``ShardedTensor``. (Default: ``False``)
 
-    .. warning:: `_use_dtensor` is a private field of ShardedStateDictConfig and
-      it is used by FSDP to determine the type of state dict values. Users should not
-      manually modify `_use_dtensor`.
+    .. warning:: ``_use_dtensor`` is a private field of :class:`ShardedStateDictConfig`
+      and it is used by FSDP to determine the type of state dict values. Users should not
+      manually modify ``_use_dtensor``.
     """
 
     _use_dtensor: bool = False
@@ -396,9 +396,9 @@ class ShardedOptimStateDictConfig(OptimStateDictConfig):
             as ``DTensor``, and if ``False``, then FSDP saves them as
             ``ShardedTensor``. (Default: ``False``)
 
-    .. warning:: `_use_dtensor` is a private field of ShardedOptimStateDictConfig and
-      it is used by FSDP to determine the type of state dict values. Users should not
-      manually modify `_use_dtensor`.
+    .. warning:: ``_use_dtensor`` is a private field of :class:`ShardedOptimStateDictConfig`
+      and it is used by FSDP to determine the type of state dict values. Users should not
+      manually modify ``_use_dtensor``.
     """
 
     _use_dtensor: bool = False

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -283,13 +283,9 @@ class StateDictConfig:
         offload_to_cpu (bool): If ``True``, then FSDP offloads the state dict
             values to CPU, and if ``False``, then FSDP keeps them on GPU.
             (Default: ``False``)
-        use_dtensor (bool): If ``True``, then FSDP saves the state dict values
-            as ``DTensor`` if the value is sharded, and if ``False``, then FSDP
-            saves them as ``ShardedTensor``. (Default: ``False``)
     """
 
     offload_to_cpu: bool = False
-    use_dtensor: bool = False
 
 
 @dataclass
@@ -336,7 +332,20 @@ class LocalStateDictConfig(StateDictConfig):
 
 @dataclass
 class ShardedStateDictConfig(StateDictConfig):
-    pass
+    """
+    ``ShardedStateDictConfig`` is a config class meant to be used with
+    ``StateDictType.SHARDED_STATE_DICT``.
+
+    Attributes:
+        _use_dtensor (bool): If ``True``, then FSDP saves the state dict values
+            as ``DTensor``, and if ``False``, then FSDP saves them as
+            ``ShardedTensor``. (Default: ``False``)
+
+    .. warning:: `_use_dtensor` is a private field of ShardedStateDictConfig and
+    it is used by FSDP to determine the type of state dict values. Users should not
+    manually modify `_use_dtensor`.
+    """
+    _use_dtensor: bool = False
 
 
 @dataclass
@@ -352,14 +361,10 @@ class OptimStateDictConfig:
             tensor values to CPU, and if ``False``, then FSDP keeps them on the
             original device (which is GPU unless parameter CPU offloading is
             enabled). (Default: ``True``)
-        use_dtensor (bool): If ``True``, then FSDP saves the state dict values
-            as ``DTensor`` if the value is sharded, and if ``False``, then FSDP
-            saves them as ``ShardedTensor``. (Default: ``False``)
     """
 
     # TODO: actually use this flag in the _optim_utils.py
     offload_to_cpu: bool = True
-    use_dtensor: bool = False
 
 
 @dataclass
@@ -381,7 +386,20 @@ class LocalOptimStateDictConfig(OptimStateDictConfig):
 
 @dataclass
 class ShardedOptimStateDictConfig(OptimStateDictConfig):
-    pass
+    """
+    ``ShardedOptimStateDictConfig`` is a config class meant to be used with
+    ``StateDictType.SHARDED_STATE_DICT``.
+
+    Attributes:
+        _use_dtensor (bool): If ``True``, then FSDP saves the state dict values
+            as ``DTensor``, and if ``False``, then FSDP saves them as
+            ``ShardedTensor``. (Default: ``False``)
+
+    .. warning:: `_use_dtensor` is a private field of ShardedStateDictConfig and
+    it is used by FSDP to determine the type of state dict values. Users should not
+    manually modify `_use_dtensor`.
+    """
+    _use_dtensor: bool = False
 
 
 @dataclass

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -342,9 +342,10 @@ class ShardedStateDictConfig(StateDictConfig):
             ``ShardedTensor``. (Default: ``False``)
 
     .. warning:: `_use_dtensor` is a private field of ShardedStateDictConfig and
-    it is used by FSDP to determine the type of state dict values. Users should not
-    manually modify `_use_dtensor`.
+      it is used by FSDP to determine the type of state dict values. Users should not
+      manually modify `_use_dtensor`.
     """
+
     _use_dtensor: bool = False
 
 
@@ -395,10 +396,11 @@ class ShardedOptimStateDictConfig(OptimStateDictConfig):
             as ``DTensor``, and if ``False``, then FSDP saves them as
             ``ShardedTensor``. (Default: ``False``)
 
-    .. warning:: `_use_dtensor` is a private field of ShardedStateDictConfig and
-    it is used by FSDP to determine the type of state dict values. Users should not
-    manually modify `_use_dtensor`.
+    .. warning:: `_use_dtensor` is a private field of ShardedOptimStateDictConfig and
+      it is used by FSDP to determine the type of state dict values. Users should not
+      manually modify `_use_dtensor`.
     """
+
     _use_dtensor: bool = False
 
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -773,11 +773,11 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
 
             # If device_mesh is passed in when initalizing FSDP, we automatically turn the
             # _use_dtensor flag to be true for ShardedStateDictConfig() and ShardedOptimStateDictConfig().
-            if module.device_mesh and isinstance(
+            if getattr(module, "device_mesh", None) and isinstance(
                 state_dict_settings.state_dict_config, ShardedStateDictConfig
             ):
                 state_dict_settings.state_dict_config._use_dtensor = True
-            if module.device_mesh and isinstance(
+            if getattr(module, "device_mesh", None) and isinstance(
                 state_dict_settings.optim_state_dict_config, ShardedOptimStateDictConfig
             ):
                 state_dict_settings.optim_state_dict_config._use_dtensor = True

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -23,6 +23,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
+from torch.distributed._tensor import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_WRAPPED_MODULE,
     ActivationWrapper,
@@ -422,6 +423,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         ignored_states: Union[
             Optional[Iterable[torch.nn.Parameter]], Optional[Iterable[torch.nn.Module]]
         ] = None,
+        _device_mesh: DeviceMesh = None,
     ):
         torch._C._log_api_usage_once("torch.distributed.fsdp")
         super().__init__()
@@ -437,7 +439,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # Note that this is done before auto_wrapping, so that child FSDP modules simply pick up
         # the same process group state as the root FSDP module.
         _init_process_group_state(
-            self, process_group, sharding_strategy, auto_wrap_policy
+            self, process_group, sharding_strategy, auto_wrap_policy, _device_mesh
         )
         if auto_wrap_policy is not None:
             root_kwargs = {

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -408,7 +408,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         self,
         module: nn.Module,
         process_group: ProcessGroupType = None,
-        device_mesh: Optional[DeviceMesh] = None,
         sharding_strategy: Optional[ShardingStrategy] = None,
         cpu_offload: Optional[CPUOffload] = None,
         auto_wrap_policy: Optional[Union[Callable, ModuleWrapPolicy]] = None,
@@ -424,6 +423,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         ignored_states: Union[
             Optional[Iterable[torch.nn.Parameter]], Optional[Iterable[torch.nn.Module]]
         ] = None,
+        device_mesh: Optional[DeviceMesh] = None,
     ):
         torch._C._log_api_usage_once("torch.distributed.fsdp")
         super().__init__()

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -440,7 +440,11 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # the same process group state as the root FSDP module.
         self.device_mesh = device_mesh
         _init_process_group_state(
-            self, process_group, device_mesh, sharding_strategy, auto_wrap_policy
+            self,
+            process_group,
+            sharding_strategy,
+            auto_wrap_policy,
+            device_mesh,
         )
         if auto_wrap_policy is not None:
             root_kwargs = {
@@ -769,14 +773,14 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
 
             # If device_mesh is passed in when initalizing FSDP, we automatically turn the
             # _use_dtensor flag to be true for ShardedStateDictConfig() and ShardedOptimStateDictConfig().
-            if getattr(module, "device_mesh") and isinstance(
+            if module.device_mesh and isinstance(
                 state_dict_settings.state_dict_config, ShardedStateDictConfig
             ):
-                setattr(state_dict_settings.state_dict_config, "_use_dtensor", True)
-            if getattr(module, "device_mesh") and isinstance(
+                state_dict_settings.state_dict_config._use_dtensor = True
+            if module.device_mesh and isinstance(
                 state_dict_settings.optim_state_dict_config, ShardedOptimStateDictConfig
             ):
-                setattr(state_dict_settings.optim_state_dict_config,  "_use_dtensor", True)
+                state_dict_settings.optim_state_dict_config._use_dtensor = True
         return state_dict_settings
 
     @staticmethod

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -408,7 +408,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         self,
         module: nn.Module,
         process_group: ProcessGroupType = None,
-        device_mesh: DeviceMesh = None,
+        device_mesh: Optional[DeviceMesh] = None,
         sharding_strategy: Optional[ShardingStrategy] = None,
         cpu_offload: Optional[CPUOffload] = None,
         auto_wrap_policy: Optional[Union[Callable, ModuleWrapPolicy]] = None,


### PR DESCRIPTION
This PR:
1) Add device_mesh kwarg to FSDP. Remove init_device_mesh() from _runtime_utils.py, as device_mesh would be passed in by user as an kwarg.
2) change use_dtensor flag for state_dict_config and optim_state_dict_config to be private. If device_mesh is used with sharded model/optim state dict, _use_dtensor flag would be set to True and model/optim state dict would return dtensor state_dict. Otherwise, _use_dtensor flag would be set to False and model/optim state dict would return sharded_tensor state_dict.
3) Update _optim_utils.py, _shard_utils.py, and _state_dict_utils.py to add support for HSDP to return 2D DTensor state_dict.





cc @zhaojuanmao @mrshenli @rohan-varma @awgu @fegin @penguinwu