### PR TITLE
Fix aminmax on CUDA when input shape contains 0

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceOps.cpp
+++ b/aten/src/ATen/native/cuda/ReduceOps.cpp
@@ -63,7 +63,9 @@ void aminmax_kernel_impl(
     const Tensor& self, int64_t dim, bool keepdim, Tensor& min_result, Tensor& max_result) {
   at::TensorIterator iter = make_reduction("aminmax_cuda", min_result,
                                            max_result, self, dim, keepdim, self.scalar_type());
-  aminmax_launch_kernel(iter);
+  if (iter.numel() != 0) {
+    aminmax_launch_kernel(iter);
+  }
 }
 
 void min_all_kernel_impl(Tensor& result, const Tensor& input) {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2909,6 +2909,7 @@ def sample_inputs_aminmax(op_info, device, dtype, requires_grad, **kwargs):
         ((), {'dim': 0}),
         ((), {}),
         ((), {'dim': 0, 'keepdim': True}),
+        ((S, 0, S), {'dim': 0}),
     )
 
     for shape, kwargs in test_cases:


### PR DESCRIPTION
The CUDA kernel asserts numel() > 0, the CPU kernel doesn't and returns empty values (as expected)

Fixes #95349 and #85439 
