### PR TITLE
Enable Mypy Checking in torch/_inductor/triton_heuristics.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -202,6 +202,7 @@ include_patterns = [
     'torch/_inductor/kernel/mm_common.py',
     'torch/_inductor/kernel/unpack_mixed_mm.py',
     'torch/_inductor/utils.py',
+    'torch/_inductor/triton_heuristics.py',
     'torch/_C/_dynamo/**/*.py',
     'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]


### PR DESCRIPTION
Fixes #105230

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/triton_heuristics.py

After Fix:

mypy --follow-imports=skip torch/_inductor/triton_heuristics.py Success: no issues found in 1 source file

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel