### PR TITLE
Fix torch.compile FunctionalTensor inputs for higherOrderOps

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -11,6 +11,7 @@ import torch.utils._pytree as pytree
 import torch.utils.checkpoint
 from torch._dynamo.testing import normalize_gm
 from torch._functorch.aot_autograd import to_fun
+from torch._higher_order_ops.wrap import wrap
 
 
 class MockSubclass(torch.Tensor):
@@ -219,6 +220,61 @@ class GraphModule(torch.nn.Module):
                 f(x_view)
         finally:
             torch._disable_functionalization()
+
+    def test_compile_higher_order_with_functionalization(self):
+        backend = EagerRecordGraphAndInputs()
+        cnt = torch._dynamo.testing.CompileCounterWithBackend(backend)
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def f(x):
+            return wrap(lambda x: x.add_(1.0), x)
+
+        def check_count_and_graph(
+            exp_frame_count, exp_op_count, exp_n_graph, exp_graph
+        ):
+            self.assertEqual(cnt.frame_count, exp_frame_count)
+            self.assertEqual(cnt.op_count, exp_op_count)
+            self.assertEqual(len(backend.graphs), exp_n_graph)
+            actual = normalize_gm(
+                backend.graphs[exp_n_graph - 1].print_readable(print_output=False)
+            )
+            self.assertEqual(actual, exp_graph)
+
+        t = torch.randn([3, 4])
+        t_clone = t.clone()
+        t_clone2 = t.clone()
+        f(t)
+
+        expected_graph = """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_ : torch.Tensor):
+        l_x_ = L_x_
+
+        wrap_body_0 = self.wrap_body_0
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_);  wrap_body_0 = l_x_ = None
+        return (wrap,)
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, l_x_):
+            add_ = l_x_.add_(1.0);  l_x_ = None
+            return add_
+"""
+        check_count_and_graph(1, 1, 1, expected_graph)
+
+        ff = torch.func.functionalize(f)
+        ff_out = ff(t_clone)
+        # frame count and op count are incremented due to re-compilation
+        check_count_and_graph(2, 2, 2, expected_graph)
+
+        try:
+            x = torch._to_functional_tensor(t_clone2, mirror_autograd_meta=True)
+            torch._enable_functionalization(reapply_views=False)
+            aot_f_out = f(x)
+        finally:
+            torch._disable_functionalization()
+
+        # frame count and op count are incremented due to re-compilation
+        check_count_and_graph(3, 3, 3, expected_graph)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -238,7 +238,6 @@ class GraphModule(torch.nn.Module):
             actual = normalize_gm(
                 backend.graphs[exp_n_graph - 1].print_readable(print_output=False)
             )
-            breakpoint()
             self.assertExpectedInline(actual, exp_graph)
 
         t = torch.randn([3, 4])

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -238,7 +238,8 @@ class GraphModule(torch.nn.Module):
             actual = normalize_gm(
                 backend.graphs[exp_n_graph - 1].print_readable(print_output=False)
             )
-            self.assertEqual(actual, exp_graph)
+            breakpoint()
+            self.assertExpectedInline(actual, exp_graph)
 
         t = torch.randn([3, 4])
         t_clone = t.clone()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1248,7 +1248,8 @@ def wrap_fx_proxy_cls(
         if isinstance(value, torch.Tensor):
             # tensor subclasses will not be converted to FakeTensors and need to be cloned
             if not (
-                isinstance(value, FakeTensor) or is_fakified_functional_tensor(value)
+                isinstance(value, FakeTensor)
+                or is_fakified_functional_tensor(value, tx.fake_mode)
             ):
                 # NB: ensure strides are preserved
                 value = clone_input(value)
@@ -1260,10 +1261,7 @@ def wrap_fx_proxy_cls(
             example_value = get_fake_value(proxy.node, tx)
 
         # Handle recursive calls here
-        elif (
-            isinstance(example_value, FakeTensor)
-            and example_value.fake_mode is tx.fake_mode
-        ):
+        elif is_fake(example_value, tx.fake_mode):
             pass
 
         elif isinstance(example_value, torch.Tensor):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -18,11 +18,7 @@ import torch
 from torch import SymInt
 from torch._guards import GuardSource, TracingContext
 from torch._ops import HigherOrderOperator
-from torch._subclasses.fake_tensor import (
-    FakeTensor,
-    is_fake,
-    is_fakified_functional_tensor,
-)
+from torch._subclasses.fake_tensor import FakeTensor, is_fake
 from torch.fx.experimental.symbolic_shapes import (
     DimConstraint,
     DimDynamic,
@@ -1244,12 +1240,22 @@ def wrap_fx_proxy_cls(
 
     initial_example_value = example_value
 
+    def _is_functional_tensor_fakified_by_dynamo(x):
+        if isinstance(x, torch.Tensor) and torch._is_functional_tensor(x):
+            reapply_views = torch._C._functionalization_reapply_views_tls()
+            unwrapped = torch._C._functorch._unwrap_functional_tensor(x, reapply_views)
+            return (
+                isinstance(unwrapped, FakeTensor)
+                and unwrapped.fake_mode == tx.fake_mode
+            )
+        return False
+
     def _clone_input(value):
         if isinstance(value, torch.Tensor):
             # tensor subclasses will not be converted to FakeTensors and need to be cloned
             if not (
                 isinstance(value, FakeTensor)
-                or is_fakified_functional_tensor(value, tx.fake_mode)
+                or _is_functional_tensor_fakified_by_dynamo(value)
             ):
                 # NB: ensure strides are preserved
                 value = clone_input(value)
@@ -1261,7 +1267,10 @@ def wrap_fx_proxy_cls(
             example_value = get_fake_value(proxy.node, tx)
 
         # Handle recursive calls here
-        elif is_fake(example_value, tx.fake_mode):
+        elif (
+            isinstance(example_value, FakeTensor)
+            and example_value.fake_mode is tx.fake_mode
+        ) or _is_functional_tensor_fakified_by_dynamo(example_value):
             pass
 
         elif isinstance(example_value, torch.Tensor):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -160,27 +160,20 @@ def _is_tensor_constructor(func: OpOverload):
     )
 
 
-def is_fake(x, fake_mode=None):
-    if isinstance(x, FakeTensor) and (fake_mode is None or x.fake_mode == fake_mode):
+def is_fake(x):
+    if isinstance(x, FakeTensor):
         return True
     elif is_traceable_wrapper_subclass(x):
         flattened_tensors, _ = type(x).__tensor_flatten__(x)
         # need to recurse because we could have nested subclasses
-        all_fake = all(is_fake(x, fake_mode) for x in flattened_tensors)
-        any_fake = any(is_fake(x, fake_mode) for x in flattened_tensors)
+        all_fake = all(is_fake(x) for x in flattened_tensors)
+        any_fake = any(is_fake(x) for x in flattened_tensors)
         assert all_fake == any_fake, "got mixed fake and real tensors!"
         return all_fake
-    elif is_fakified_functional_tensor(x, fake_mode):
-        return True
-    return False
-
-
-def is_fakified_functional_tensor(x, fake_mode):
-    if isinstance(x, torch.Tensor) and torch._is_functional_tensor(x):
+    elif isinstance(x, torch.Tensor) and torch._is_functional_tensor(x):
         reapply_views = torch._C._functionalization_reapply_views_tls()
-        return is_fake(
-            torch._C._functorch._unwrap_functional_tensor(x, reapply_views), fake_mode
-        )
+        unwrapped = torch._C._functorch._unwrap_functional_tensor(x, reapply_views)
+        return is_fake(unwrapped)
     return False
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107604
* #107569

Before this PR, for the added [test](https://github.com/pytorch/pytorch/pull/107604/files#diff-c618f2274b6b5ccc533c580549d2e552edbd9fc5ac0da1aa4b00338525c8f78dR224), which feeds FunctionTensorWrapper inputs to higherOrderOperator, we have an assertion error in this line [code](https://github.com/pytorch/pytorch/pull/107604/files#diff-9f0663783bcd93e948e0491ef61b48123bdc9977bcc632fd707da578df13bfa1R1284).

The key difference of this PR is this [line ](https://github.com/pytorch/pytorch/pull/107604/files#diff-9f0663783bcd93e948e0491ef61b48123bdc9977bcc632fd707da578df13bfa1L1263)of check:
```python
        elif (
            isinstance(example_value, FakeTensor)
            and example_value.fake_mode is tx.fake_mode
        ):
```
The original intention of it seems to be dealing with case where we want to wrap an fx proxy for an intermediate fake tensor that's produced by some tensor ops and an example value is provided (as is the case for higherOrderOps [here](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/variables/higher_order_ops.py#L85)). A fakified FunctionalTensorWrapper(FakeTensor) always fails this check. This PR changes it to checking whether it's already fakified by tx.fake_mode.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @aakhundov