### PR TITLE
[Fix] add validation logics to TCPStore queries

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -342,7 +342,7 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
   C10D_DEBUG("TCP client connected to host {}:{}", addr_.host, addr_.port);
 
   // client's first query for validation
-  validate(); 
+  validate();
 
   if (opts.waitWorkers) {
     waitForWorkers();

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -218,6 +218,8 @@ void TCPClient::setTimeout(std::chrono::milliseconds value) {
       sizeof(timeoutTV)));
 }
 
+using detail::queryMagicNumber;
+
 class SendBuffer {
   // ethernet mtu 1500 - 40 (ip v6 header) - 20 (tcp header)
   const size_t FLUSH_WATERMARK = 1440;
@@ -233,7 +235,11 @@ class SendBuffer {
  public:
   SendBuffer(detail::TCPClient& client, detail::QueryType cmd)
       : client(client) {
-    buffer.reserve(32); // enough for most commands
+    const uint8_t* tmp_ptr = (const uint8_t*)&queryMagicNumber;
+    buffer.reserve(36); // enough for most commands
+    for (int i = 0; i < 4; i ++) {
+      buffer.push_back(tmp_ptr[i]);
+    }
     buffer.push_back((uint8_t)cmd);
   }
 

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -237,7 +237,7 @@ class SendBuffer {
       : client(client) {
     const uint8_t* tmp_ptr = (const uint8_t*)&queryMagicNumber;
     buffer.reserve(36); // enough for most commands
-    for (int i = 0; i < 4; i ++) {
+    for (int i = 0; i < 4; i++) {
       buffer.push_back(tmp_ptr[i]);
     }
     buffer.push_back((uint8_t)cmd);

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -235,8 +235,8 @@ class SendBuffer {
  public:
   SendBuffer(detail::TCPClient& client, detail::QueryType cmd)
       : client(client) {
-    const uint8_t* tmp_ptr = (const uint8_t*)&queryMagicNumber;
-    buffer.reserve(36); // enough for most commands
+    auto *tmp_ptr = static_cast<const uint8_t>(queryMagicNumber);
+    buffer.reserve(32 + sizeof(queryMagicNumber)); // enough for most commands
     for (int i = 0; i < 4; i++) {
       buffer.push_back(tmp_ptr[i]);
     }

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -138,6 +138,8 @@ class TORCH_API TCPStore : public Store {
  private:
   int64_t incrementValueBy(const std::string& key, int64_t delta);
 
+  void validate(void);
+
   std::vector<uint8_t> doGet(const std::string& key);
 
   void doWait(

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -100,8 +100,8 @@ class TCPStoreMasterDaemon : public BackgroundThread {
   std::unordered_map<std::string, std::vector<int>> waitingSockets_;
   // From socket -> number of keys awaited
   std::unordered_map<int, size_t> keysAwaited_;
-  // miscellaneous sockets 
-  std::unordered_set<int> miscellaneousSockets_; 
+  // miscellaneous sockets
+  std::unordered_set<int> miscellaneousSockets_;
 
   Socket storeListenSocket_;
   std::vector<Socket> sockets_{};
@@ -577,7 +577,7 @@ void TCPStoreMasterDaemon::run() {
       int rawSocket = socket.handle();
       sockets_.emplace_back(std::move(socket));
       tcputil::addPollfd(fds, rawSocket, POLLIN);
-      // all clients are miscellaneous before getting its validation query 
+      // all clients are miscellaneous before getting its validation query
       addMiscellaneousSocket(rawSocket);
     }
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -263,7 +263,8 @@ void TCPStoreMasterDaemon::query(int socket) {
       validateHandler(socket);
     } else {
       // real miscellaneous client: the first msg is not VALIDATE
-      TORCH_CHECK(false, "Miscellaneous client without VALIDATE query is detected");
+      TORCH_CHECK(
+          false, "Miscellaneous client without VALIDATE query is detected");
     }
   } else if (qt == QueryType::SET) {
     setHandler(socket);
@@ -326,7 +327,9 @@ void TCPStoreMasterDaemon::validateHandler(int socket) {
   uint32_t validateNumber;
   tcputil::recvBytes<uint32_t>(socket, &validateNumber, 1);
   if (validateNumber != detail::validationMagicNumber) {
-    TORCH_CHECK(false, "Miscellaneous client with incorrect VALIDATE query is detected");
+    TORCH_CHECK(
+        false,
+        "Miscellaneous client with incorrect VALIDATE query is detected");
   }
 }
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -73,6 +73,7 @@ class TCPStoreMasterDaemon : public BackgroundThread {
 
   // The master runs on a single thread so only
   // one handler can be executed at a time
+  void validateHandler(int socket);
   void setHandler(int socket);
   void compareSetHandler(int socket);
   void addHandler(int socket);
@@ -85,6 +86,9 @@ class TCPStoreMasterDaemon : public BackgroundThread {
   void multiGetHandler(int socket);
   void multiSetHandler(int socket);
   void cancelWaitHandler(int socket);
+  void addMiscellaneousSocket(int socket);
+  void removeMiscellaneousSocket(int socket);
+  bool isMiscellaneousSocket(int socket);
 
   bool checkKeys(const std::vector<std::string>& keys) const;
   // Helper function to alerts waiting workers, used in setHandler, getHandler
@@ -96,6 +100,8 @@ class TCPStoreMasterDaemon : public BackgroundThread {
   std::unordered_map<std::string, std::vector<int>> waitingSockets_;
   // From socket -> number of keys awaited
   std::unordered_map<int, size_t> keysAwaited_;
+  // miscellaneous sockets 
+  std::unordered_set<int> miscellaneousSockets_; 
 
   Socket storeListenSocket_;
   std::vector<Socket> sockets_{};
@@ -244,23 +250,22 @@ void TCPStoreMasterDaemon::clearSocketWaitState(int socket) {
 
 // query communicates with the worker. The format
 // of the query is as follows:
-// queryMagicNumber | type of query | size of arg1 | arg1 | size of arg2
-// | arg2 | ...
+// type of query | size of arg1 | arg1 | size of arg2 | arg2 | ...
 // or, in the case of wait
-// queryMagicNumber | type of query | number of args | size of arg1
-// | arg1 | ...
+// type of query | number of args | size of arg1 | arg1 | ...
 void TCPStoreMasterDaemon::query(int socket) {
   QueryType qt;
-  uint32_t qPrefix;
-  tcputil::recvBytes<uint32_t>(socket, &qPrefix, 1);
-  if (qPrefix != detail::queryMagicNumber) {
-    TORCH_CHECK(
-        false, 
-        "TCPStore received an unexpected query magic number");
-  }
-
   tcputil::recvBytes<QueryType>(socket, &qt, 1);
-  if (qt == QueryType::SET) {
+
+  if (isMiscellaneousSocket(socket)) {
+    removeMiscellaneousSocket(socket);
+    if (qt == QueryType::VALIDATE) {
+      validateHandler(socket);
+    } else {
+      // real miscellaneous client: the first msg is not VALIDATE
+      TORCH_CHECK(false, "Miscellaneous client without VALIDATE query is detected");
+    }
+  } else if (qt == QueryType::SET) {
     setHandler(socket);
 
   } else if (qt == QueryType::COMPARE_SET) {
@@ -315,6 +320,14 @@ void TCPStoreMasterDaemon::doSet(
   tcpStore_[key] = newData;
   // On "set", wake up all clients that have been waiting
   wakeupWaitingClients(key);
+}
+
+void TCPStoreMasterDaemon::validateHandler(int socket) {
+  uint32_t validateNumber;
+  tcputil::recvBytes<uint32_t>(socket, &validateNumber, 1);
+  if (validateNumber != detail::validationMagicNumber) {
+    TORCH_CHECK(false, "Miscellaneous client with incorrect VALIDATE query is detected");
+  }
 }
 
 void TCPStoreMasterDaemon::setHandler(int socket) {
@@ -469,6 +482,23 @@ bool TCPStoreMasterDaemon::checkKeys(
   });
 }
 
+void TCPStoreMasterDaemon::addMiscellaneousSocket(int socket) {
+  if (miscellaneousSockets_.find(socket) == miscellaneousSockets_.end()) {
+    miscellaneousSockets_.insert(socket);
+  }
+}
+
+void TCPStoreMasterDaemon::removeMiscellaneousSocket(int socket) {
+  auto it = miscellaneousSockets_.find(socket);
+  if (it != miscellaneousSockets_.end()) {
+    miscellaneousSockets_.erase(it);
+  }
+}
+
+bool TCPStoreMasterDaemon::isMiscellaneousSocket(int socket) {
+  return miscellaneousSockets_.find(socket) != miscellaneousSockets_.end();
+}
+
 #ifdef _WIN32
 void TCPStoreMasterDaemon::run() {
   std::vector<struct pollfd> fds;
@@ -547,6 +577,8 @@ void TCPStoreMasterDaemon::run() {
       int rawSocket = socket.handle();
       sockets_.emplace_back(std::move(socket));
       tcputil::addPollfd(fds, rawSocket, POLLIN);
+      // all clients are miscellaneous before getting its validation query 
+      addMiscellaneousSocket(rawSocket);
     }
 
     // The pipe receives an event which tells us to shutdown the daemon

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -254,8 +254,9 @@ void TCPStoreMasterDaemon::query(int socket) {
   uint32_t qPrefix;
   tcputil::recvBytes<uint32_t>(socket, &qPrefix, 1);
   if (qPrefix != detail::queryMagicNumber) {
-    C10D_DEBUG("torch.distributed.TCPStore: a miscellaneous query is detected.");
-    return;
+    TORCH_CHECK(
+        false, 
+        "TCPStore received an unexpected query magic number");
   }
 
   tcputil::recvBytes<QueryType>(socket, &qt, 1);

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -244,9 +244,11 @@ void TCPStoreMasterDaemon::clearSocketWaitState(int socket) {
 
 // query communicates with the worker. The format
 // of the query is as follows:
-// queryMagicNumber | type of query | size of arg1 | arg1 | size of arg2 | arg2 | ...
+// queryMagicNumber | type of query | size of arg1 | arg1 | size of arg2
+// | arg2 | ...
 // or, in the case of wait
-// queryMagicNumber | type of query | number of args | size of arg1 | arg1 | ...
+// queryMagicNumber | type of query | number of args | size of arg1
+// | arg1 | ...
 void TCPStoreMasterDaemon::query(int socket) {
   QueryType qt;
   uint32_t qPrefix;

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -18,6 +18,9 @@
 namespace c10d {
 namespace detail {
 
+// Magic number prefixed to queries.
+static const uint32_t queryMagicNumber = 0xDEADC0DE;
+
 enum class QueryType : uint8_t {
   SET,
   COMPARE_SET,

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -18,10 +18,11 @@
 namespace c10d {
 namespace detail {
 
-// Magic number prefixed to queries.
-static const uint32_t queryMagicNumber = 0xDEADC0DE;
+// Magic number for client validation.
+static const uint32_t validationMagicNumber = 0x3C85F7CE;
 
 enum class QueryType : uint8_t {
+  VALIDATE,
   SET,
   COMPARE_SET,
   GET,

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -1080,7 +1080,8 @@ void LibUVStoreDaemon::stop() {
   }
 }
 
-bool LibUVStoreDaemon::isMiscellaneousClient(c10::intrusive_ptr<UvHandle> client) {
+bool LibUVStoreDaemon::isMiscellaneousClient(
+    c10::intrusive_ptr<UvHandle> client) {
   if (miscellaneousClients_.find(client) != miscellaneousClients_.end()) {
     miscellaneousClients_.erase(client);
     return true;


### PR DESCRIPTION
This PR fixes #106294.

Due to the lack of request validation mechanism, TCPStore in torch mistakenly treats nmap scan messages as valid query messages, which leads to DDP OOM. The simple solution enforces the very first query from a client is a validation query with a predefined magic number. If the validation fails, the server will terminate the connection.