### PR TITLE
Remove aws ossci metrics upload keys from rocm

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -33,14 +33,6 @@ on:
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
 
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID:
-        required: true
-        description: access key id for test stats upload
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY:
-        required: true
-        description: secret acess key for test stats upload
-
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -223,6 +223,3 @@ jobs:
       build-environment: linux-focal-rocm5.6-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -103,9 +103,6 @@ jobs:
       build-environment: linux-focal-rocm5.6-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
   linux-jammy-py3_9-clang12-asan-build:
     name: linux-jammy-py3.9-clang12-asan

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -197,6 +197,3 @@ jobs:
       build-environment: linux-focal-rocm5.6-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
@huydhn 
Our current workflow is to upload to GH and then upload from GH to S3 when uploading test stats at the end of a workflow.

I think these keys could be used to directly upload from the runner to S3 but we don't do that right now.  

I'm not sure how high priority they keys are.

Rocm artifacts can still be seen on the HUD page

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang