### PR TITLE
Support integer implementations for max_pool1d/2d/3d (cpu and cuda)

### DIFF
--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -216,7 +216,7 @@ void max_pool3d_with_indices_out_cpu_template(
     /* indices will contain ti,i,j locations for each output point */
     indices.resize_({nslices, otime, oheight, owidth});
 
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
+    AT_DISPATCH_ALL_TYPES(input.scalar_type(),
       "max_pool3d_with_indices_cpu",
       [&] {
         scalar_t *input_data = input.data_ptr<scalar_t>();
@@ -246,7 +246,7 @@ void max_pool3d_with_indices_out_cpu_template(
     /* indices will contain ti,i,j locations for each output point */
     indices.resize_({nbatch, nslices, otime, oheight, owidth});
 
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
+    AT_DISPATCH_ALL_TYPES(input.scalar_type(),
       "max_pool3d_with_indices_cpu",
       [&] {
         scalar_t *input_data = input.data_ptr<scalar_t>();

--- a/aten/src/ATen/native/cpu/MaxPooling.cpp
+++ b/aten/src/ATen/native/cpu/MaxPooling.cpp
@@ -31,7 +31,7 @@ void max_pool1d_impl(
     Tensor& output,
     const Tensor& input,
     const PoolingParams1D& p) {
-  AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool1d_impl", [&] {
+  AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool1d_impl", [&] {
     const Tensor in = input.contiguous();
     scalar_t* const OP = output.data_ptr<scalar_t>();
     const scalar_t* const IP = in.data_ptr<scalar_t>();

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -343,7 +343,7 @@ const Tensor& indices) {
 
   const int count = safe_downcast<int, int64_t>(output.numel());
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
     "max_pool2d_with_indices_out_cuda_frame",
     [&] {
       using accscalar_t = acc_type<scalar_t, true>;

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -387,7 +387,7 @@ void max_pool3d_with_indices_out_cuda_template(
   }
   Tensor work_indices = indices;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16,
     input.scalar_type(),
     "max_pool3d_with_indices_out_frame",
     [&]{

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13082,8 +13082,8 @@ op_db: List[OpInfo] = [
            check_batched_forward_grad=False,
            # TODO: add shape checks
            assert_jit_shape_analysis=False,
-           dtypes=floating_types_and(torch.bfloat16),
-           dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
+           dtypes=all_types_and(torch.bfloat16),
+           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
            skips=(
                # Pre-existing condition; Needs to be fixed
                DecorateInfo(unittest.skip("Works on some configs"), 'TestNNCOpInfo',
@@ -13108,7 +13108,7 @@ op_db: List[OpInfo] = [
            check_batched_forward_grad=False,
            assert_jit_shape_analysis=True,
            dtypes=all_types_and(torch.bfloat16),
-           dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
+           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
            error_inputs_func=error_inputs_max_pool2d,
            sample_inputs_func=sample_inputs_max_pool),
     OpInfo('max_pool2d_with_indices_backward',
@@ -13147,8 +13147,8 @@ op_db: List[OpInfo] = [
            check_batched_forward_grad=False,
            # TODO: add shape checks
            assert_jit_shape_analysis=False,
-           dtypes=floating_types(),
-           dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
+           dtypes=all_types(),
+           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
            # TODO: investigate nondeterminism
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            error_inputs_func=error_inputs_max_pool3d,


### PR DESCRIPTION
Fixes #107412


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10

cc: @cchan @ezhang887


also supports `torch.compile`
```python
import torch
f = lambda y:torch.nn.functional.max_pool1d(y, kernel_size=3)

f_compiled = torch.compile(f)

x = torch.randn(3,3,3, device="cpu").to(torch.int8)
print(x)
print(f_compiled(x))
```

output
```
tensor([[[ 0,  0,  1],
         [ 0,  0,  0],
         [ 0, -1,  0]],

        [[ 0,  1,  0],
         [-1, -1,  0],
         [ 0,  1,  0]],

        [[ 1,  0,  0],
         [ 1,  1,  0],
         [-1,  0, -1]]], dtype=torch.int8)
tensor([[[1],
         [0],
         [0]],

        [[1],
         [0],
         [1]],

        [[1],
         [1],
         [0]]], dtype=torch.int8)
```