### PR TITLE
Always import test selection tools

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1447,7 +1447,7 @@ def do_sharding(
             which_shard <= num_shards
         ), "Selected shard must be less than or equal to total number of shards"
 
-        # Do sharding
+    # Do sharding
     shards = calculate_shards(
         num_shards,
         selected_tests,


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/107070 made emit_metrics importable without boto3, so we could just import all the files without the try catch.  