### PR TITLE
[dynamo] Fix KJT variable error when torchrec import fails.

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -570,7 +570,7 @@ class KeyedJaggedTensorVariable(UserDefinedObjectVariable):
     def is_matching_object(obj):
         try:
             from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-        except ImportError:
+        except Exception:
             return False
         else:
             return type(obj) is KeyedJaggedTensor


### PR DESCRIPTION
Fix the follow error:

```
File "/scratch/eellison/work/pytorch/torch/_dynamo/convert_frame.py", line 426, in transform
tracer = InstructionTranslator(
File "/scratch/eellison/work/pytorch/torch/_dynamo/symbolic_convert.py", line 2018, in init
self.symbolic_locals = collections.OrderedDict(
File "/scratch/eellison/work/pytorch/torch/_dynamo/symbolic_convert.py", line 2021, in
VariableBuilder(
File "/scratch/eellison/work/pytorch/torch/_dynamo/variables/builder.py", line 220, in call
vt = self._wrap(value).clone(**self.options())
File "/scratch/eellison/work/pytorch/torch/_dynamo/variables/builder.py", line 624, in _wrap
elif KeyedJaggedTensorVariable.is_matching_object(value):
File "/scratch/eellison/work/pytorch/torch/_dynamo/variables/user_defined.py", line 572, in is_matching_object
from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/init.py", line 8, in
import torchrec.distributed # noqa
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/init.py", line 36, in
from torchrec.distributed.model_parallel import DistributedModelParallel # noqa
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/model_parallel.py", line 19, in
from torchrec.distributed.planner import (
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/planner/init.py", line 22, in
from torchrec.distributed.planner.planners import EmbeddingShardingPlanner # noqa
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/planner/planners.py", line 19, in
from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/planner/constants.py", line 10, in
from torchrec.distributed.embedding_types import EmbeddingComputeKernel
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/torchrec/distributed/embedding_types.py", line 14, in
from fbgemm_gpu.split_table_batched_embeddings_ops import EmbeddingLocation
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/fbgemm_gpu/init.py", line 21, in
from . import _fbgemm_gpu_docs # noqa: F401, E402
File "/scratch/eellison/work/torchdynamo/lib/python3.8/site-packages/fbgemm_gpu/_fbgemm_gpu_docs.py", line 18, in
torch.ops.fbgemm.jagged_2d_to_dense,
File "/scratch/eellison/work/pytorch/torch/_ops.py", line 748, in getattr
raise AttributeError(
torch._dynamo.exc.InternalTorchDynamoError: '_OpNamespace' 'fbgemm' object has no attribute 'jagged_2d_to_dense'
```

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov