### PR TITLE
Access ROCKSET_API_KEY from ephemeral runners

### DIFF
--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.ROCKSET_API_KEY != '' }}
         with:
           timeout_minutes: 10
           max_attempts: 10

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -18,6 +18,7 @@ jobs:
 
   upload-stats-to-rockset:
     runs-on: ubuntu-22.04
+    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   upload-stats-to-rockset:
     runs-on: ubuntu-22.04
+    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   upload-stats-to-rockset:
     runs-on: ubuntu-22.04
-    environment: upload-stats
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/nightly-rockset-uploads.yml
+++ b/.github/workflows/nightly-rockset-uploads.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
 
   upload-stats-to-rockset:
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -25,10 +25,13 @@ jobs:
           fetch-depth: 1
           submodules: false
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+
       - run: |
-          pip3 install requests==2.26
-          pip3 install rockset==1.0.3
-          pip3 install boto3==1.19.12
+          pip3 install requests==2.26 rockset==1.0.3 boto3==1.19.12
 
       - name: Upload external contribution stats
         uses: nick-fields/retry@v2.8.2

--- a/.github/workflows/upload-alerts.yml
+++ b/.github/workflows/upload-alerts.yml
@@ -14,6 +14,7 @@ jobs:
   upload-alerts:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-22.04
+    environment: upload-stats
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/upload-alerts.yml
+++ b/.github/workflows/upload-alerts.yml
@@ -13,18 +13,21 @@ on:
 jobs:
   upload-alerts:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+
       - name: Install Python Packages
         run: |
-          pip3 install rockset==1.0.3
-          pip3 install boto3==1.19.12
-          pip3 install requests==2.27.1
+          pip3 install rockset==1.0.3 boto3==1.19.12 requests==2.27.1
 
       - name: Create alerts
         run: |
@@ -33,6 +36,7 @@ jobs:
           echo "$output"
           echo "script-output=$output" >> "$GITHUB_OUTPUT"
         id: alert_creation_step
+
       - name: Upload alerts
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
@@ -42,6 +46,7 @@ jobs:
           alerts: '${{ steps.alert_creation_step.outputs.script-output }}'
           organization: "pytorch"
           repo: "pytorch"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/upload-alerts.yml
+++ b/.github/workflows/upload-alerts.yml
@@ -14,7 +14,6 @@ jobs:
   upload-alerts:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-22.04
-    environment: upload-stats
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -28,8 +28,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' ||
       needs.get_workflow_conclusion.outputs.conclusion == 'success' || needs.get_workflow_conclusion.outputs.conclusion == 'failure'
     runs-on: ubuntu-22.04
+    environment: upload-stats
     name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
-
     steps:
       - name: Print workflow information
         env:

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -27,7 +27,7 @@ jobs:
     if:
       github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' ||
       needs.get_workflow_conclusion.outputs.conclusion == 'success' || needs.get_workflow_conclusion.outputs.conclusion == 'failure'
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-22.04
     name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
 
     steps:
@@ -39,10 +39,13 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+
       - run: |
-          pip3 install requests==2.26
-          pip3 install rockset==1.0.3
-          pip3 install boto3==1.19.12
+          pip3 install requests==2.26 rockset==1.0.3 boto3==1.19.12
 
       - name: Upload test stats
         env:

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -25,6 +25,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' || needs.get-conclusion.outputs.conclusion == 'success' ||
         github.event.workflow_run.conclusion == 'failure' || needs.get-conclusion.outputs.conclusion == 'failure'
     runs-on: ubuntu-22.04
+    environment: upload-stats
     name: Upload dynamo performance stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -24,7 +24,7 @@ jobs:
     needs: get-conclusion
     if: github.event.workflow_run.conclusion == 'success' || needs.get-conclusion.outputs.conclusion == 'success' ||
         github.event.workflow_run.conclusion == 'failure' || needs.get-conclusion.outputs.conclusion == 'failure'
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-22.04
     name: Upload dynamo performance stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
     steps:
       - name: Checkout PyTorch
@@ -32,6 +32,11 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
 
       - run: |
           pip3 install requests==2.26 rockset==1.0.3 boto3==1.19.12

--- a/tools/stats/upload_test_stat_aggregates.py
+++ b/tools/stats/upload_test_stat_aggregates.py
@@ -40,9 +40,7 @@ def get_test_stat_aggregates(date: datetime.date) -> Any:
     rockset_api_key = os.environ["ROCKSET_API_KEY"]
     rockset_api_server = "api.rs2.usw2.rockset.com"
     iso_date = date.isoformat()
-    rs = rockset.RocksetClient(
-        host="api.usw2a1.rockset.com", api_key=rockset_api_key
-    )
+    rs = rockset.RocksetClient(host="api.usw2a1.rockset.com", api_key=rockset_api_key)
 
     # Define the name of the Rockset collection and lambda function
     collection_name = "commons"

--- a/tools/stats/upload_test_stat_aggregates.py
+++ b/tools/stats/upload_test_stat_aggregates.py
@@ -41,7 +41,7 @@ def get_test_stat_aggregates(date: datetime.date) -> Any:
     rockset_api_server = "api.rs2.usw2.rockset.com"
     iso_date = date.isoformat()
     rs = rockset.RocksetClient(
-        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+        host="api.usw2a1.rockset.com", api_key=rockset_api_key
     )
 
     # Define the name of the Rockset collection and lambda function


### PR DESCRIPTION
Hardening the access to ROCKSET_API_KEY by only using this key from ephemeral runners `ubuntu-22.04`
