### PR TITLE
Use docker-build env to access GHCR_PAT

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   docker-build:
     runs-on: [self-hosted, linux.2xlarge]
+    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: [self-hosted, linux.2xlarge]
+    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
     timeout-minutes: 240
     strategy:
       matrix:


### PR DESCRIPTION
This will restrict the access to GHCR_PAT to only [docker-build](https://github.com/pytorch/pytorch/settings/environments/1258682414/edit) env.