### PR TITLE
Update test_MaxUnpool_index_errors XFAIL after #107483

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -551,12 +551,10 @@ class TestPoolingNNDeviceType(NNTestCase):
         subtest(
             ('MaxUnpool2d', (2, 2), (1, 3, 4, 5), -1, True),
             name='case1',
-            decorators=[expectedFailureCUDA]
         ),
         subtest(
             ('MaxUnpool2d', (2, 2), (1, 3, 4, 5), 2 * 2 * 4 * 5, True),
             name='case2',
-            decorators=[expectedFailureCUDA]
         ),
         subtest(
             ('MaxUnpool2d', (2, 2), (1, 3, 4, 5), (2 * 2 * 4 * 5) - 1, False),
@@ -565,7 +563,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         subtest(
             ('MaxUnpool2d', (2, 3), (2, 1, 4, 2), 2 * 3 * 4 * 2, True),
             name='case4',
-            decorators=[expectedFailureCUDA]
         ),
         subtest(
             ('MaxUnpool2d', (2, 3), (2, 1, 4, 2), (2 * 3 * 4 * 2) - 1, False),
@@ -574,11 +571,10 @@ class TestPoolingNNDeviceType(NNTestCase):
         subtest(
             ('MaxUnpool3d', (2, 2, 2), (1, 3, 4, 5), -1, True),
             name='case6',
-            decorators=[expectedFailureCUDA]),
+        ),
         subtest(
             ('MaxUnpool3d', (2, 2, 2), (1, 3, 4, 5), 2 * 2 * 2 * 3 * 4 * 5, True),
             name='case7',
-            decorators=[expectedFailureCUDA]
         ),
         subtest(
             ('MaxUnpool3d', (2, 2, 2), (1, 3, 4, 5), (2 * 2 * 2 * 3 * 4 * 5) - 1, False),
@@ -587,7 +583,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         subtest(
             ('MaxUnpool3d', (2, 2, 2), (2, 3, 4, 1), 2 * 2 * 2 * 3 * 4 * 1, True),
             name='case9',
-            decorators=[expectedFailureCUDA]
         ),
         subtest(
             ('MaxUnpool3d', (2, 2, 2), (2, 3, 4, 1), (2 * 2 * 2 * 3 * 4 * 1) - 1, False),

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -19,7 +19,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_nn import NNTestCase, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import largeTensorTest, onlyNativeDeviceTypes, dtypes, \
     instantiate_device_type_tests, skipCUDAIfRocm, expectedFailureMeta, dtypesIfCUDA, onlyCPU, onlyCUDA, \
-    TEST_WITH_ROCM, expectedFailureCUDA
+    TEST_WITH_ROCM
 from torch.testing._internal.common_dtype import floating_types_and
 import torch.nn.functional as F
 import torch.nn as nn


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/107483 which reverted https://github.com/pytorch/pytorch/pull/95300, these tests are not XFAIL anymore.  So now we know the root cause of https://github.com/pytorch/pytorch/issues/103854.

As this is failing slow jobs in trunk atm, i.e. https://hud.pytorch.org/pytorch/pytorch/commit/6981bcbc35603e5d8ac7d00a2032925239009db5, I'm moving these tests back.

### Testing

Run locally and all tests passes.

```
PYTORCH_TEST_WITH_SLOW=1 PYTORCH_TEST_SKIP_FAST=1 python test/nn/test_pooling.py -k test_MaxUnpool_index_errors
```