### PR TITLE
Fix torch.compile with FakeTensor that has SymInt sizes

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -965,8 +965,8 @@ class VariableBuilder:
                 functools.partial(
                     GuardBuilder.TENSOR_MATCH,
                     value=value
-                    # Need to hold a reference to FakeTensor otherwise it gets garbage collected
-                    if isinstance(source, NumpyTensorSource) else TensorWeakRef(value),
+                    if isinstance(source, NumpyTensorSource)
+                    else TensorWeakRef(value),
                 )
             ),
             should_specialize=self.tensor_should_specialize(),

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -954,30 +954,6 @@ class VariableBuilder:
         # the subgraph.
         # See NOTE [HigherOrderOperator tracing design] for more details.
 
-        if isinstance(value, FakeTensor):
-            # Replace all the symints in original fake_tensor with concrete ints.
-            # Relying on _automatic_dynamic to determine if this is a dynamic shaped tensor
-            assert all(isinstance(sz, (int, torch.SymInt)) for sz in value.size())
-            assert all(isinstance(st, (int, torch.SymInt)) for st in value.stride())
-            specialized_size = tuple(
-                sz if isinstance(sz, int) else sz.node.require_hint()
-                for sz in value.size()
-            )
-            specialized_stride = tuple(
-                st if isinstance(st, int) else st.node.require_hint()
-                for st in value.stride()
-            )
-            empty = torch.empty_strided(
-                specialized_size,
-                specialized_stride,
-                dtype=value.dtype,
-                device=value.device,
-                requires_grad=value.requires_grad,
-            )
-            value = value.fake_mode.from_tensor(
-                empty, source=source, static_shapes=True
-            )
-
         tensor_proxy = self.tx.output.root_tracer.create_graph_input(
             re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(value), source=source
         )
@@ -990,9 +966,7 @@ class VariableBuilder:
                     GuardBuilder.TENSOR_MATCH,
                     value=value
                     # Need to hold a reference to FakeTensor otherwise it gets garbage collected
-                    if isinstance(source, NumpyTensorSource)
-                    or isinstance(value, FakeTensor)
-                    else TensorWeakRef(value),
+                    if isinstance(source, NumpyTensorSource) else TensorWeakRef(value),
                 )
             ),
             should_specialize=self.tensor_should_specialize(),

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -54,8 +54,8 @@ class TensorCheck {
     if (ndim != dim_) {
       return false;
     }
-    const auto& sizes = v.sizes();
-    const auto& strides = v.strides();
+    const auto& sizes = v.sym_sizes();
+    const auto& strides = v.sym_strides();
     for (auto i : c10::irange(ndim)) {
       auto known_size = sizes_[i];
       auto known_stride = strides_[i];
@@ -113,8 +113,8 @@ class TensorCheck {
                   << ndim;
       return fail_reason.str();
     }
-    const auto& sizes = v.sizes();
-    const auto& strides = v.strides();
+    const auto& sizes = v.sym_sizes();
+    const auto& strides = v.sym_strides();
     for (auto i : c10::irange(ndim)) {
       auto known_size = sizes_[i];
       auto known_stride = strides_[i];

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2244,6 +2244,13 @@ class ShapeEnv:
         We try our best to express stride in terms of the sizes, so as to not
         introduce new symbolic variables.
         """
+
+
+        # Dynamo may want to wrap FakeTensors with SymInt sizes up e.g. make_fx(opt_f(), tracing_mode="symbolic").
+        # We create symbols in shape_env using the backed hints behind SymInt.
+        # Case 1: when SymInt is backed, dynamo can proceed with FakeTensors that have concrete shape.
+        # produce_guards will trigger specializations on the outer stuff
+        # Case 2: when the SymInt is unbacked, we will throw an data dependent error in require_hint().
         def maybe_specialize_sym_int_with_hint(maybe_sym) -> int:
             assert isinstance(maybe_sym, (int, torch.SymInt))
             return maybe_sym if isinstance(maybe_sym, int) else maybe_sym.node.require_hint()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107662

**Motivation:**
When input FakeTensor to torch.compile has SymInt sizes (e.g. make_fx(opt_f, tracing_mode="symbolic"):
1. We cannot create a FakeTensor from that input in dynamo due to the SymInts.
2. We cannot check input tensors in guard check function and will abort due to tensor check calls sizes/strides.

For 1, we specialize the FakeTensor's SymInts using their hints. This is mostly safe since inputs mostly have concrete shapes and not computed from some DynamicOutputShape ops. We'll throw a data dependent error if the symint is unbacked. 

For 2, we replace size/stride calls with the sym_* variants in TENSOR_CHECK guards' check function.

**Test Plan:**
See added tests.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov 