### PR TITLE
adding _int_mm to out_dtype mm WIP

### DIFF
--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -102,6 +102,19 @@ class TestOutDtypeOp(TestCase):
         compiled = torch.compile(f, backend="eager", fullgraph=True)
         self.assertTrue(torch.allclose(f(*inp), compiled(*inp)))
 
+    def test_out_dtype_int_mm(self):
+        def func(x, w):
+            return out_dtype(torch.ops.aten.mm.default, torch.int32, x, w)
+
+        w = torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda")
+        x = torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda")
+        ref = torch._int_mm(x, w)
+        test_out = func(x, w)
+        func_comp = torch.compile(func, mode="max-autotune")
+        test_out_c = func_comp(x, w)
+        self.assertTrue(torch.allclose(ref, test_out))
+        self.assertTrue(torch.allclose(ref, test_out_c))
+
     def test_out_dtype_mul_scalar_numerical(self):
         def f(x, y):
             return out_dtype(

--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -111,6 +111,7 @@ class TestOutDtypeOp(TestCase):
         ref = torch._int_mm(x, w)
         test_out = func(x, w)
         func_comp = torch.compile(func, mode="max-autotune")
+        # func_comp = torch.compile(func, backend="eager", fullgraph=True)
         test_out_c = func_comp(x, w)
         self.assertTrue(torch.allclose(ref, test_out))
         self.assertTrue(torch.allclose(ref, test_out_c))

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -55,8 +55,6 @@ class OutDtypeOperator(HigherOrderOperator):
         self.__module__ = "torch.ops.higher_order"
 
     def __call__(self, op, output_dtype, *args):
-        # import pdb
-        # pdb.set_trace()
         if not isinstance(op, torch._ops.OpOverload):
             raise ValueError("out_dtype's first argument must be an OpOverload")
         if op._schema.is_mutable:
@@ -89,8 +87,6 @@ out_dtype.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
 
 
 def trace_out_dtype(proxy_mode, func_overload, op, output_dtype, *args):
-    import pdb
-    pdb.set_trace()
     with disable_proxy_modes_tracing():
         # This is a simplified implementation of this operator just for tracing.
         # Actual implementation may also first promote the arguments
@@ -112,6 +108,8 @@ def out_dtype_dense(
 ):
     if (
         len(args)==2 and
+        isinstance(args[0], torch.Tensor) and
+        isinstance(args[1], torch.Tensor) and
         args[0].dtype == torch.int8 and
         args[1].dtype == torch.int8 and
         args[0].is_cuda and

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -55,6 +55,8 @@ class OutDtypeOperator(HigherOrderOperator):
         self.__module__ = "torch.ops.higher_order"
 
     def __call__(self, op, output_dtype, *args):
+        # import pdb
+        # pdb.set_trace()
         if not isinstance(op, torch._ops.OpOverload):
             raise ValueError("out_dtype's first argument must be an OpOverload")
         if op._schema.is_mutable:
@@ -87,6 +89,8 @@ out_dtype.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
 
 
 def trace_out_dtype(proxy_mode, func_overload, op, output_dtype, *args):
+    import pdb
+    pdb.set_trace()
     with disable_proxy_modes_tracing():
         # This is a simplified implementation of this operator just for tracing.
         # Actual implementation may also first promote the arguments
@@ -138,8 +142,6 @@ def out_dtype_proxy(
     output_dtype: torch.dtype,
     *args
 ):
-    import pdb
-    pdb.set_trace()
     mode = _get_current_dispatch_mode()
     assert (mode is not None), "Mode should always be enabled for python fallback key"
     with _pop_mode_temporarily() as mode:

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -106,6 +106,16 @@ def out_dtype_dense(
     output_dtype: torch.dtype,
     *args
 ):
+    if (
+        len(args)==2 and
+        args[0].dtype == torch.int8 and
+        args[1].dtype == torch.int8 and
+        args[0].is_cuda and
+        args[1].is_cuda and
+        op == torch.ops.aten.mm.default and
+        output_dtype == torch.int32
+    ):
+        return torch._int_mm(*args)
     flat_inputs = pytree.tree_flatten(args)[0] + [torch.ones(1, dtype=output_dtype)]
     promote_dtype: torch.dtype = elementwise_dtypes(
         *flat_inputs,
@@ -128,6 +138,8 @@ def out_dtype_proxy(
     output_dtype: torch.dtype,
     *args
 ):
+    import pdb
+    pdb.set_trace()
     mode = _get_current_dispatch_mode()
     assert (mode is not None), "Mode should always be enabled for python fallback key"
     with _pop_mode_temporarily() as mode:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2977,6 +2977,8 @@ class ExternKernel(InputsKernel):
                 non_tensor_args.append(arg)
 
         def unflatten_args(new_tensor_args, new_non_tensor_args):
+            import pdb
+            pdb.set_trace()
             result = []
             it_tensors = iter(new_tensor_args)
             it_non_tensors = iter(new_non_tensor_args)
@@ -3011,7 +3013,7 @@ class ExternKernel(InputsKernel):
                 example_args.append(ir_node_to_tensor(x, guard_shape=True))
 
         new_args, new_kwargs = unflatten_args(example_args, non_tensor_args)
-        example_output = kernel(*new_args, **new_kwargs)
+        example_output = kernel(*new_args, **new_kwargs) # this destroys the non tensor ops
 
         return example_output, tensor_args, non_tensor_args, unflatten_args, schema
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107664

Summary: it looks like out_dtype doesn't work with max-autotune in
torch.compile

Test Plan: python pytorch/torch/_inductor/ir.py -k "int_mm"

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler