### PR TITLE
[export] Custom object serialization

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -392,7 +392,7 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
       .def(torch::init<std::vector<int64_t>>())
       .def_pickle(
           [](c10::intrusive_ptr<PickleTester> self) { // __getstate__
-            return std::vector<int64_t>{1, 3, 3, 7};
+            return self->vals;
           },
           [](std::vector<int64_t> state) { // __setstate__
             return c10::make_intrusive<PickleTester>(std::move(state));

--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -392,7 +392,7 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
       .def(torch::init<std::vector<int64_t>>())
       .def_pickle(
           [](c10::intrusive_ptr<PickleTester> self) { // __getstate__
-            return self->vals;
+            return std::vector<int64_t>{1, 3, 3, 7};
           },
           [](std::vector<int64_t> state) { // __setstate__
             return c10::make_intrusive<PickleTester>(std::move(state));

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -557,8 +557,6 @@ class TestSerializeCustomClass(TestCase):
         serialized_vals = serialize(ep)
         deserialized_ep = deserialize(*serialized_vals)
 
-        self.assertTrue(torch.allclose(ep(torch.ones(4, 4)), deserialized_ep(torch.ones(4, 4))))
-
         for node in deserialized_ep.graph.nodes:
             if (
                 node.op == "call_function" and
@@ -567,7 +565,7 @@ class TestSerializeCustomClass(TestCase):
                 arg = node.args[0]
                 self.assertTrue(isinstance(arg, torch._C.ScriptObject))
                 self.assertEqual(arg.__getstate__(), custom_obj.__getstate__())
-                self.assertEqual(arg.top(), custom_obj.top())
+                self.assertEqual(arg.top(), 7)
 
 
 if __name__ == '__main__':

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -566,6 +566,7 @@ class TestSerializeCustomClass(TestCase):
                 arg0, arg1 = node.args
                 self.assertTrue(isinstance(arg1, torch._C.ScriptObject))
                 self.assertEqual(arg1.__getstate__(), custom_obj.__getstate__())
+                self.assertEqual(arg1.top(), custom_obj.top())
 
 
 if __name__ == '__main__':

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -3,6 +3,7 @@ import dataclasses
 from collections import defaultdict
 from enum import auto, Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
+import warnings
 
 import sympy
 
@@ -295,6 +296,27 @@ def unlift_exported_program_lifted_states(ep: "ExportedProgram") -> torch.nn.Mod
     return new_gm
 
 
+def _create_graph_module_for_export(root, graph):
+    try:
+        gm = torch.fx.GraphModule(root, graph)
+    except SyntaxError:
+        # If custom objects stored in memory are being used in the graph,
+        # the generated python code will result in a syntax error on the custom
+        # object, since it is unable to parse the in-memory object. However
+        # we can still run the graph eagerly through torch.fx.Interpreter,
+        # so we will bypass this error.
+        warnings.warn(
+            "Unable to execute the generated python source code from "
+            "the graph. The graph module will no longer be directly callable, "
+            "but you can still run the ExportedProgram, and if needed, you can "
+            "run the graph module eagerly using torch.fx.Interpreter."
+        )
+        gm = torch.fx.GraphModule(root, torch.fx.Graph())
+        gm._graph = graph
+
+    return gm
+
+
 class ExportedProgram:
     def __init__(
         self,
@@ -309,7 +331,7 @@ class ExportedProgram:
     ):
         # Remove codegen related things from the graph. It should just be a flat graph.
         graph._codegen = torch.fx.graph.CodeGen()
-        self._graph_module = torch.fx.GraphModule(root, graph)
+        self._graph_module = _create_graph_module_for_export(root, graph)
         if isinstance(root, torch.fx.GraphModule):
             self._graph_module.meta.update(root.meta)
 

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -138,6 +138,11 @@ class GraphArgument:
     graph: 'Graph'
 
 
+@dataclass
+class CustomObjArgument:
+    blob: str
+
+
 # This is actually a union type
 @dataclass(repr=False)
 class Argument(_Union):
@@ -162,6 +167,7 @@ class Argument(_Union):
     as_sym_bools: List[SymBoolArgument]
     as_graph: GraphArgument
     as_optional_tensors: List[OptionalTensorArgument]
+    as_custom_obj: CustomObjArgument
 
 
 @dataclass


### PR DESCRIPTION
Some NvidaTRT folks were asking for a way to integrate the serialization of custom objects with export's serialization. After some discussion (more background [here](https://docs.google.com/document/d/1lJfxakmgeoEt50inWZ53MdUtOSa_0ihwCuPy_Ak--wc/edit)), we settled on a way for users to register their custom object's serializer/deserializer functions.

Since TorchScript's `.def_pickle` already exists for [registering custom classes](https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html), and `tensorrt.ICudaEngine` already contains a `.def_pickle` implementation, we'll start off by reusing the existing framework and integrating it with export's serialization. 

TorchScript's `.def_pickle` requires users to register two functions, which end up being the `__getstate__` and `__setstate__` methods on the class. The semantics of `__getstate__` and `__setstate__` in TorchScript are equivalent to that of Python pickle modules. This is then registered using pybind's `py::pickle` function [here](https://www.internalfb.com/code/fbsource/[f44e048145e4697bccfaec300798fce7daefb858]/fbcode/caffe2/torch/csrc/jit/python/script_init.cpp?lines=861-916) to be used with Python's pickle to initialize a ScriptObject with the original class, and set the state back to what it used to be.

I attempted to call `__getstate__` and `__setstate__` directly, but I couldn't figure out how to initial the object to be called with `__setstate__` in python. One option would be to create a `torch._C.ScriptObject` and then set the class and call `__setstate__`, but there is no constructor initialized for ScriptObjects. Another option would be to construct an instance of the serialized class itself, but if the class constructor required arguments, I wouldn't know what to initialize it with. In ScriptObject's `py::pickle` registration it directly creates the object [here](https://www.internalfb.com/code/fbsource/[f44e048145e4697bccfaec300798fce7daefb858]/fbcode/caffe2/torch/csrc/jit/python/script_init.cpp?lines=892-906), which is why I was thinking that just directly using Python's `pickle` will be ok since it is handled here.

So, what I did is that I check if the object is pickle-able, meaning it contains `__getstate__` and `__setstate__` methods, and if so, I serialize it with Python's pickle. TorchScript does have its own implementation of [pickle/unpickle](https://www.internalfb.com/code/fbsource/[59cbc569ccbcaae0db9ae100c96cf0bae701be9a][history]/fbcode/caffe2/torch/csrc/jit/serialization/pickle.h?lines=19%2C82), but it doesn't seem to have pybinded functions callable from python.

A question is -- is it ok to combine this pickle + json serialization? 