### PR TITLE
Actually raise an error on all graph breaks with fullgraph=True

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -600,10 +600,16 @@ def optimize(
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
 
     if nopython:
+        # TODO: Maybe we don't need to do this, we can just call
+        # convert_frame (no assert) with one_graph set appropriately.
+        # This would change the suppress_errors behavior (today it does
+        # nothing if you do fullgraph, but maybe you do want it to
+        # do something)
         return optimize_assert(
             backend,
             dynamic=dynamic,
             hooks=hooks,
+            nopython=nopython,
         )
     return _optimize_catch_errors(
         convert_frame.convert_frame(backend, hooks=hooks),
@@ -1323,6 +1329,7 @@ def optimize_assert(
     export=False,
     export_constraints=None,
     dynamic=None,
+    nopython=False,
 ):
     """
     The same as `torch._dynamo.optimize(backend, nopython=True)`
@@ -1334,7 +1341,7 @@ def optimize_assert(
 
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(
-            backend, export=export, export_constraints=export_constraints
+            backend, export=export, export_constraints=export_constraints, one_graph=nopython
         ),
         hooks,
         backend_ctx_ctor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107683

Previously, if you had a graph break inside a fullgraph=True compile,
but Dynamo was able to compile a partial graph, we would let the graph
through anyway (instead of erroring).  Now you error.

Fixes https://github.com/pytorch/pytorch/issues/107639

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @Xia-Weiwen