### PR TITLE
Store the arguments used to trace the exported program in itself.

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -399,6 +399,7 @@ def export(
                 range_constraints,
                 equality_constraints,
                 [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
+                args,
             )
 
             exported_program = exported_program.transform(

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -269,6 +269,7 @@ class ExportedProgram:
         range_constraints: Dict[sympy.Symbol, RangeConstraint],
         equality_constraints: List[Tuple[InputDim, InputDim]],
         module_call_graph: List[ModuleCallEntry],
+        original_traced_arguments: Tuple[Any, ...],
     ):
         # Remove codegen related things from the graph. It should just be a flat graph.
         graph._codegen = torch.fx.graph.CodeGen()
@@ -280,6 +281,7 @@ class ExportedProgram:
         self._range_constraints: Dict[sympy.Symbol, RangeConstraint] = range_constraints
         self._equality_constraints: List[Tuple[InputDim, InputDim]] = equality_constraints
         self._module_call_graph: List[ModuleCallEntry] = module_call_graph
+        self.original_traced_arguments = original_traced_arguments
 
     @property
     @compatibility(is_backward_compatible=True)
@@ -410,6 +412,7 @@ class ExportedProgram:
             copy.deepcopy(self.range_constraints),
             copy.deepcopy(self.equality_constraints),
             copy.deepcopy(self._module_call_graph),
+            copy.deepcopy(self.original_traced_arguments)
         )
         transformed_ep.graph_module.meta.update(self.graph_module.meta)
         transformed_ep.graph_module.meta.update(res.graph_module.meta)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -9,7 +9,7 @@ import typing
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union, Iterable
 
 import sympy
 
@@ -17,7 +17,7 @@ import torch
 import torch._export.exported_program as ep
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
-from torch.utils._pytree import pytree_to_str, str_to_pytree
+from torch.utils._pytree import pytree_to_str, str_to_pytree, tree_map_only
 
 from .schema import (  # type: ignore[attr-defined]
     _Union,
@@ -238,27 +238,27 @@ def deserialize_signature(sig: GraphSignature) -> ep.ExportGraphSignature:
     )
 
 
-def serialize_state_dict(state_dict: Dict[str, Any]) -> bytes:
+def serialize_torch_artifact(artifact: Union[Dict[str, Any], Iterable[Any]]) -> bytes:
     buffer = io.BytesIO()
-    state_dict = dict(state_dict)
-    for name in state_dict:
-        # This is a workaround for backend's tensor deserialization problem:
-        # unpickleTensor() always create a tensor on the device where it was originally saved
-        # This behavior is bad for multi-gpu training, as we wish to directly load the tensor
-        # on the designated device.
-        # For now, we simply move the tensor to cpu before saving.
-        # TODO: this should be fixed by deserialization instead.
-        state_dict[name] = state_dict[name].cpu()
-    torch.save(state_dict, buffer)
+    # This is a workaround for backend's tensor deserialization problem:
+    # unpickleTensor() always create a tensor on the device where it was originally saved
+    # This behavior is bad for multi-gpu training, as we wish to directly load the tensor
+    # on the designated device.
+    # For now, we simply move the tensor to cpu before saving.
+    # TODO: this should be fixed by deserialization instead.
+    artifact = tree_map_only(torch.Tensor, lambda t: t.cpu(), artifact)
+    torch.save(artifact, buffer)
     return buffer.getvalue()
 
 
-def deserialize_state_dict(serialized: bytes) -> Dict[str, torch.Tensor]:
+def deserialize_torch_artifact(serialized: bytes) -> Union[Dict[str, torch.Tensor], List[torch.Tensor]]:
     if len(serialized) == 0:
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
     return torch.load(buffer)
+
+
 
 
 
@@ -735,7 +735,7 @@ class ExportedProgramSerializer:
         if "aten" not in self.opset_version:
             self.opset_version["aten"] = torch._C._get_max_operator_version()
 
-    def serialize(self, exported_program: ep.ExportedProgram) -> Tuple[ExportedProgram, bytes]:
+    def serialize(self, exported_program: ep.ExportedProgram) -> Tuple[ExportedProgram, bytes, bytes]:
         serialized_graph_module = (
             GraphModuleSerializer(
                 exported_program.graph_signature,
@@ -753,7 +753,8 @@ class ExportedProgramSerializer:
                 range_constraints=serialized_range_constraints,
                 equality_constraints=serialized_equality_constraints,
             ),
-            serialize_state_dict(exported_program.state_dict),
+            serialize_torch_artifact(exported_program.state_dict),
+            serialize_torch_artifact(exported_program.original_traced_arguments)
         )
 
 
@@ -1196,7 +1197,8 @@ class ExportedProgramDeserializer:
         return range_constraints
 
     def deserialize(
-        self, serialized_exported_program: ExportedProgram, serialized_state_dict: bytes
+        self, serialized_exported_program: ExportedProgram, serialized_state_dict: bytes,
+        serialized_original_traced_args: bytes,
     ) -> ep.ExportedProgram:
         symbol_name_to_range = {
             k: symbolic_shapes.ValueRanges(_int_to_sympy_int(v.min_val), _int_to_sympy_int(v.max_val))
@@ -1218,18 +1220,21 @@ class ExportedProgramDeserializer:
 
         upgrader = GraphModuleOpUpgrader(self.expected_opset_version, model_opset_version)
 
-        state_dict = deserialize_state_dict(serialized_state_dict)
+        state_dict = deserialize_torch_artifact(serialized_state_dict)
+        original_args = deserialize_torch_artifact(serialized_original_traced_args)
         equality_constraints = deserialize_equality_constraints(serialized_exported_program.equality_constraints)
+
 
         exported_program = ep.ExportedProgram(
             graph_module,
             graph_module.graph,
             sig,
             call_spec,
-            state_dict,
+            state_dict,  # type: ignore[arg-type]
             range_constraints,
             equality_constraints,
             module_call_graph,
+            original_args,  # type: ignore[arg-type]
         )
         return upgrader.upgrade(exported_program)
 
@@ -1284,15 +1289,15 @@ class EnumEncoder(json.JSONEncoder):
 def serialize(
     exported_program: ep.ExportedProgram,
     opset_version: Optional[Dict[str, int]] = None,
-) -> Tuple[bytes, bytes]:
-    serialized_exported_program, serialized_state_dict = (
+) -> Tuple[bytes, bytes, bytes]:
+    serialized_exported_program, serialized_state_dict, serialized_orig_args = (
         ExportedProgramSerializer(opset_version).serialize(exported_program)
     )
     json_program = json.dumps(
         dataclasses.asdict(serialized_exported_program), cls=EnumEncoder
     )
     json_bytes = json_program.encode('utf-8')
-    return json_bytes, serialized_state_dict
+    return json_bytes, serialized_state_dict, serialized_orig_args
 
 
 def _dict_to_dataclass(cls, data):
@@ -1330,6 +1335,7 @@ def _dict_to_dataclass(cls, data):
 def deserialize(
     exported_program_bytes: bytes,
     state_dict: bytes,
+    original_traced_args: bytes,
     expected_opset_version: Optional[Dict[str, int]] = None,
 ) -> ep.ExportedProgram:
     exported_program_str = exported_program_bytes.decode('utf-8')
@@ -1337,5 +1343,5 @@ def deserialize(
     serialized_exported_program = _dict_to_dataclass(ExportedProgram, exported_program_dict)
     return (
         ExportedProgramDeserializer(expected_opset_version)
-        .deserialize(serialized_exported_program, state_dict)
+        .deserialize(serialized_exported_program, state_dict, original_traced_args)
     )


### PR DESCRIPTION
Currently this argument is optional and only be present if the way to produce ExportedProgram is indeed via tracing.

In particular, ExportedProgram loaded from a serialized files will NOT have original_traced_args. This way it retains BC as old  serialized files are still loadable.


Fixes #ISSUE_NUMBER
