### PR TITLE
Fix python decomps for OpOverloadPackets and add tests

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -234,8 +234,6 @@ aten::fmod.Tensor_out
 aten::fmod_.Scalar
 aten::fmod_.Tensor
 aten::full
-aten::full.names
-aten::full.names_out
 aten::full.out
 aten::gcd
 aten::gcd.out

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -763,6 +763,8 @@ aten::frexp.Tensor
 aten::frexp.Tensor_out
 aten::from_file
 aten::from_file.out
+aten::full.names
+aten::full.names_out
 aten::full_like
 aten::full_like.out
 aten::gather

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -99,18 +99,21 @@ def _unsqueeze_to_dim(x: Tensor, dim: int) -> Tensor:
 
 
 @register_decomposition(aten.tanh_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def tanh_backward(out_grad: Tensor, y: Tensor):
     return out_grad * (1 - y * y).conj_physical()
 
 
 @register_decomposition(aten.sigmoid_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def sigmoid_backward(out_grad: Tensor, y: Tensor):
     return out_grad * (y * (1 - y)).conj_physical()
 
 
 @register_decomposition(aten.softplus_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def softplus_backward(out_grad: Tensor, x: Tensor, beta: float, threshold: float):
     z = (x * beta).exp()
@@ -118,6 +121,7 @@ def softplus_backward(out_grad: Tensor, x: Tensor, beta: float, threshold: float
 
 
 @register_decomposition(aten.elu_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def elu_backward(
     grad_output: Tensor,
@@ -159,12 +163,14 @@ def fill_tensor(self, value: Tensor):
 
 
 @register_decomposition(aten.hardsigmoid)
+@out_wrapper()
 @pw_cast_for_opmath
 def hardsigmoid(self: Tensor) -> Tensor:
     return torch.clamp(torch.clamp(self + 3, min=0), max=6) / 6
 
 
 @register_decomposition(aten.hardsigmoid_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def hardsigmoid_backward(grad_output: Tensor, self: Tensor):
     return torch.where(
@@ -175,6 +181,7 @@ def hardsigmoid_backward(grad_output: Tensor, self: Tensor):
 
 
 @register_decomposition(aten.hardtanh_backward)
+@out_wrapper("grad_input")
 def hardtanh_backward(
     grad_output: Tensor, self: Tensor, min_val: float, max_val: float
 ):
@@ -182,12 +189,14 @@ def hardtanh_backward(
 
 
 @register_decomposition(aten.hardswish)
+@out_wrapper()
 @pw_cast_for_opmath
 def hardswish(self: Tensor) -> Tensor:
     return self * torch.clamp(torch.clamp(self + 3, min=0), max=6) / 6
 
 
 @register_decomposition(aten.hardswish_backward)
+@out_wrapper()
 @pw_cast_for_opmath
 def hardswish_backward(grad_output: Tensor, self: Tensor) -> Tensor:
     return torch.where(
@@ -198,11 +207,13 @@ def hardswish_backward(grad_output: Tensor, self: Tensor) -> Tensor:
 
 
 @register_decomposition(aten.threshold_backward)
+@out_wrapper("grad_input")
 def threshold_backward(grad_output: Tensor, self: Tensor, threshold: float):
     return torch.where(self <= threshold, 0.0, grad_output)
 
 
 @register_decomposition(aten.leaky_relu_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def leaky_relu_backward(
     grad_output: Tensor, self: Tensor, negative_slope: float, self_is_result: bool
@@ -211,6 +222,7 @@ def leaky_relu_backward(
 
 
 @register_decomposition(aten.gelu_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def gelu_backward(grad: Tensor, self: Tensor, approximate: str = "none"):
     M_SQRT2 = 1.41421356237309504880
@@ -252,12 +264,14 @@ def mish_backward(grad_output: Tensor, input: Tensor):
 
 
 @register_decomposition(aten.silu)
+@out_wrapper()
 @pw_cast_for_opmath
 def silu(self: Tensor) -> Tensor:
     return self * torch.sigmoid(self)
 
 
 @register_decomposition(aten.silu_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def silu_backward(grad_output: Tensor, self: Tensor) -> Tensor:
     sigmoid = 1 / (1 + torch.exp(-self))
@@ -282,6 +296,7 @@ def _prelu_kernel_backward(
 
 @register_decomposition(aten.rrelu_with_noise)
 @aten.rrelu_with_noise.default.py_impl(DispatchKey.AutogradCUDA)
+@out_wrapper()
 @pw_cast_for_opmath
 def rrelu_with_noise(
     self: Tensor,
@@ -318,6 +333,7 @@ def rrelu_with_noise_(
 
 
 @register_decomposition(aten.rrelu_with_noise_backward)
+@out_wrapper()
 @pw_cast_for_opmath
 def rrelu_with_noise_backward(
     grad_output: Tensor,
@@ -338,6 +354,7 @@ def rrelu_with_noise_backward(
 
 
 @register_decomposition(aten.log_sigmoid_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def log_sigmoid_backward(grad_output: Tensor, self: Tensor, buffer: Tensor) -> Tensor:
     in_negative = self < 0
@@ -374,6 +391,7 @@ def to_real_dtype(dtype: torch.dtype):
 
 
 @register_decomposition(aten.mse_loss)
+@out_wrapper()
 @pw_cast_for_opmath
 def mse_loss(
     self: Tensor, target: Tensor, reduction: int = Reduction.MEAN.value
@@ -383,6 +401,7 @@ def mse_loss(
 
 
 @register_decomposition(aten.mse_loss_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def mse_loss_backward(
     grad_output: Tensor, input: Tensor, target: Tensor, reduction: int
@@ -392,6 +411,7 @@ def mse_loss_backward(
 
 
 @register_decomposition(aten.smooth_l1_loss)
+@out_wrapper()
 @pw_cast_for_opmath
 def smooth_l1_loss(
     self: Tensor,
@@ -498,6 +518,7 @@ def _nll_loss_backward(
 
 
 @register_decomposition(aten.glu_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def glu_backward(grad_output: Tensor, self: Tensor, dim: int) -> Tensor:
     assert self.dim() > 0, "glu does not support 0-dimensional tensors"
@@ -518,6 +539,7 @@ def glu_backward(grad_output: Tensor, self: Tensor, dim: int) -> Tensor:
 
 
 @register_decomposition(aten.nll_loss_backward)
+@out_wrapper("grad_input")
 def nll_loss_backward(
     grad_output: Tensor,
     self: Tensor,
@@ -561,6 +583,7 @@ def nll_loss_backward(
 
 
 @register_decomposition(aten.nll_loss2d_backward)
+@out_wrapper("grad_input")
 def nll_loss2d_backward(
     grad_output: Tensor,
     self: Tensor,
@@ -595,6 +618,7 @@ def nll_loss2d_backward(
 
 
 @register_decomposition(aten.binary_cross_entropy)
+@out_wrapper()
 @pw_cast_for_opmath
 def binary_cross_entropy(
     self: Tensor,
@@ -616,6 +640,7 @@ def binary_cross_entropy(
 
 
 @register_decomposition(aten.binary_cross_entropy_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def binary_cross_entropy_backward(
     grad_output: Tensor,
@@ -646,6 +671,7 @@ def soft_margin_loss(
 
 
 @register_decomposition(aten.soft_margin_loss_backward)
+@out_wrapper("grad_input")
 @pw_cast_for_opmath
 def soft_margin_loss_backward(
     grad_output: Tensor,
@@ -660,11 +686,13 @@ def soft_margin_loss_backward(
 
 
 @register_decomposition(aten.dist)
+@out_wrapper()
 def dist(input: Tensor, other: Tensor, p: float = 2):
     return aten.norm(input - other, p=p)
 
 
 @register_decomposition(aten._euclidean_dist)
+@out_wrapper()
 def _euclidean_dist(x1: Tensor, x2: Tensor) -> Tensor:
     x1_norm = x1.pow(2).sum(-1, True)
     x1_pad = torch.ones_like(x1_norm, memory_format=torch.contiguous_format)
@@ -677,6 +705,7 @@ def _euclidean_dist(x1: Tensor, x2: Tensor) -> Tensor:
 
 
 @register_decomposition(aten.slice_backward)
+@out_wrapper()
 def slice_backward(
     grad_output: Tensor,
     input_sizes: List[int],
@@ -741,12 +770,14 @@ def slice_forward(
 
 
 @register_decomposition(aten.select_backward)
+@out_wrapper()
 def select_backward(grad_output: Tensor, input_sizes: List[int], dim: int, index: int):
     grad_input = grad_output.new_zeros(input_sizes)
     return torch.select_scatter(grad_input, grad_output, dim, index)
 
 
 @register_decomposition(aten.diagonal_backward)
+@out_wrapper()
 def diagonal_backward(
     grad_output: Tensor, input_sizes: List[int], offset: int, dim1: int, dim2: int
 ):
@@ -763,6 +794,7 @@ def _cast_grad_to_input_dtype(
 
 
 @register_decomposition(aten._softmax_backward_data)
+@out_wrapper("grad_input")
 @compute_only_pw_cast_for_opmath
 def _softmax_backward_data(
     grad_output: Tensor, output: Tensor, dim: int, input_dtype: torch.dtype
@@ -780,6 +812,7 @@ def _softmax_backward_data(
 
 
 @register_decomposition(aten._log_softmax_backward_data)
+@out_wrapper()
 @compute_only_pw_cast_for_opmath
 def _log_softmax_backward_data(
     grad_output: Tensor, output: Tensor, dim: int, input_dtype: torch.dtype
@@ -992,6 +1025,7 @@ def col2im(
 
 
 @register_decomposition(aten.native_dropout_backward)
+@out_wrapper()
 def native_dropout_backward(grad_output: Tensor, mask: Tensor, scale: float):
     # According to the CUDA kernel implementation we should have this test;
     # but it seems to fail tests!
@@ -1006,6 +1040,7 @@ def native_dropout_backward(grad_output: Tensor, mask: Tensor, scale: float):
 
 
 @register_decomposition(aten.unfold_backward)
+@out_wrapper()
 def unfold_backward(
     grad: Tensor, input_size: List[int], dimension: int, size: int, step: int
 ) -> Tensor:
@@ -1055,6 +1090,7 @@ def dropout(input: Tensor, p: float, train: Optional[bool]):
 
 
 @register_decomposition(aten.native_dropout)
+@out_wrapper("out0", "out1")
 def native_dropout(input: Tensor, p: float, train: Optional[bool]):
     if train and p != 0:
         if p == 1:
@@ -1124,6 +1160,7 @@ def rsub_Scalar(self: Tensor, other: float, alpha: float = 1) -> Tensor:
 
 
 @register_decomposition(aten.embedding)
+@out_wrapper()
 def embedding(
     weight: Tensor,
     indices: Tensor,
@@ -1144,6 +1181,7 @@ def embedding(
 
 
 @register_decomposition(aten.embedding_dense_backward)
+@out_wrapper()
 def embedding_dense_backward(
     grad_output: Tensor,
     indices: Tensor,
@@ -1625,6 +1663,7 @@ def native_batch_norm_helper(
 
 
 @register_decomposition(aten.native_batch_norm)
+@out_wrapper("out", "save_mean", "save_invstd")
 def native_batch_norm(
     input: Tensor,
     weight: Optional[Tensor],
@@ -1780,6 +1819,7 @@ def _native_batch_norm_legit_functional(
 
 
 @register_decomposition(aten._fused_dropout)
+@out_wrapper("out0", "out1")
 @pw_cast_for_opmath
 def _fused_dropout_decomposition(input, p, generator=None):
     assert generator is None
@@ -1809,6 +1849,7 @@ def wrap_output_with_input_device_(x, common_device):
 
 
 @register_decomposition(aten._to_copy)
+@out_wrapper()
 def _to_copy(
     x: Tensor,
     *,
@@ -1847,6 +1888,7 @@ def _to_copy(
 # This is only valid if we're running the graph without autograd, such as if the backward pass has been traced.
 # Note that this decomposition causes issues with in-place ops
 @register_decomposition([aten.detach, aten.lift, aten.lift_fresh])
+@out_wrapper()
 def nop_decomposition(x):
     return aten.alias(x)
 
@@ -1855,6 +1897,7 @@ def nop_decomposition(x):
 # native_batch_norm needs to decompose into other ops before autograd.
 @aten.cudnn_batch_norm.default.py_impl(DispatchKey.Autograd)
 @register_decomposition(aten.cudnn_batch_norm)
+@out_wrapper("out0", "out1", "out2", "out3")
 def cudnn_batch_norm(
     input: Tensor,
     weight: Tensor,
@@ -2033,6 +2076,7 @@ def native_batch_norm_backward_out(
 
 
 @register_decomposition(aten.cudnn_batch_norm_backward)
+@out_wrapper("out0", "out1", "out2")
 def cudnn_batch_norm_backward(
     input: Tensor,
     grad_output: Tensor,
@@ -2059,6 +2103,7 @@ def cudnn_batch_norm_backward(
 
 
 @register_decomposition(aten._adaptive_avg_pool2d)
+@out_wrapper()
 @pw_cast_for_opmath
 def adaptive_avg_pool2d(input: Tensor, output_size: Tuple[int, int]):
     # Preconditions
@@ -2277,6 +2322,7 @@ def log_sigmoid_forward(self: Tensor) -> Tuple[Tensor, Tensor]:
 
 
 @register_decomposition(aten.uniform)
+@out_wrapper()
 def uniform(
     x: Tensor,
     low: Union[bool, int, float] = 0.0,
@@ -3206,6 +3252,7 @@ def is_same_size(a: Tensor, b: Tensor) -> bool:
 
 
 @register_decomposition([aten._reshape_alias, aten._unsafe_view])
+@out_wrapper()
 def _reshape_alias(x, shape, *args):
     return aten.view(x, shape)
 
@@ -3269,6 +3316,7 @@ def _nll_loss_forward(
 
 
 @register_decomposition(aten.nll_loss_forward)
+@out_wrapper("output", "total_weight")
 def nll_loss_forward(
     self: Tensor,
     target: Tensor,
@@ -3296,6 +3344,7 @@ def nll_loss_forward(
 
 
 @register_decomposition(aten.nll_loss2d_forward)
+@out_wrapper("output", "total_weight")
 def nll_loss2d_forward(
     self: Tensor,
     target: Tensor,
@@ -3401,6 +3450,7 @@ def _affine_grid_generator_5d(theta: Tensor, size: List[int], align_corners: boo
 
 
 @register_decomposition(aten.affine_grid_generator)
+@out_wrapper()
 @pw_cast_for_opmath
 def affine_grid_generator(theta: Tensor, size: List[int], align_corners: bool):
     torch._check(
@@ -3580,6 +3630,7 @@ def _grid_sampler_2d(
 
 
 @register_decomposition(aten.grid_sampler_2d)
+@out_wrapper()
 @pw_cast_for_opmath
 def grid_sampler_2d(
     a: Tensor,
@@ -3613,6 +3664,7 @@ def mv(self, vec):
 
 
 @register_decomposition(aten.binary_cross_entropy_with_logits)
+@out_wrapper()
 def binary_cross_entropy_with_logits(
     self, target, weight=None, pos_weight=None, reduction=Reduction.MEAN.value
 ):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1546,13 +1546,13 @@ def _pad1d_backward_common(grad_output, input, padding, *, is_reflection):
 
 
 @register_meta(aten.reflection_pad1d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_reflection_pad1d_backward(grad_output, input, padding):
     return _pad1d_backward_common(grad_output, input, padding, is_reflection=True)
 
 
 @register_meta(aten.replication_pad1d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_replication_pad1d_backward(grad_output, input, padding):
     return _pad1d_backward_common(grad_output, input, padding, is_reflection=False)
 
@@ -1630,7 +1630,7 @@ def meta_replication_pad2d(input, padding):
         aten.replication_pad2d_backward.grad_input,
     ]
 )
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_pad2d_backward(grad_output, self, padding):
     dim_w = 2
     dim_h = 1
@@ -1746,7 +1746,7 @@ def meta_replication_pad3d(input, padding):
         aten.replication_pad3d_backward.grad_input,
     ]
 )
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_pad3d_backward(grad_output, input, padding):
     torch._check(len(padding) == 6, lambda: "padding size is expected to be 6")
     assert input.ndim > 3
@@ -2491,7 +2491,7 @@ def meta_avg_pool3d(
 
 
 @register_meta(aten.avg_pool3d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_avg_pool3d_backward(
     grad_output,
     input,
@@ -2621,7 +2621,7 @@ def meta__adaptive_avg_pool2d_backward(grad_out, self):
 
 
 @register_meta(aten._adaptive_avg_pool3d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta__adaptive_avg_pool3d_backward(grad_output, self):
     _adaptive_pool_empty_output_check(grad_output, "adaptive_avg_pool3d_backward")
     return torch.empty_like(self, memory_format=torch.legacy_contiguous_format)
@@ -2688,7 +2688,7 @@ def meta_adaptive_max_pool2d(input, output_size):
 
 
 @register_meta(aten.adaptive_max_pool2d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_adaptive_max_pool2d_backward(grad_output, input, indices):
     ndim = grad_output.ndim
     torch._check(
@@ -2752,7 +2752,7 @@ def meta_adaptive_max_pool3d(input, output_size):
 
 
 @register_meta(aten.adaptive_max_pool3d_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_adaptive_max_pool3d_backward(grad_output, input, indices):
     _adaptive_pool_empty_output_check(grad_output, "adaptive_max_pool3d_backward")
     return input.new_empty(input.shape)
@@ -2775,6 +2775,7 @@ def meta_complex(real, imag):
 
 
 @register_meta([aten.nonzero_static.default, aten.nonzero_static.out])
+@out_wrapper()
 def nonzero_static(self, *, size: int, fill_value: int = -1):
     return self.new_empty((size, self.dim()), dtype=torch.long)
 
@@ -3593,6 +3594,7 @@ def meta_masked_scatter_(self, mask, source):
 
 
 @register_meta(aten.masked_scatter)
+@out_wrapper()
 def meta_masked_scatter(self, mask, source):
     self, mask = _maybe_broadcast(self, mask)
     output = torch.empty_like(self, memory_format=torch.contiguous_format)
@@ -4344,7 +4346,7 @@ def meta_max_pool3d_with_indices(
 
 
 @register_meta(aten.max_pool3d_with_indices_backward)
-@out_wrapper()
+@out_wrapper("grad_input")
 def meta_max_pool3d_with_indices_backward(
     grad_output,
     input,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -76,6 +76,8 @@ TensorLike = torch.Tensor
 TensorSequenceType = Union[List[TensorLikeType], Tuple[TensorLikeType, ...]]
 TensorOrNumberLikeType = Union[TensorLikeType, NumberType]
 
+CustomOutParamAnnotation = "__custom_out_param__"
+
 
 def same_shape(a: ShapeType, b: ShapeType, *, allow_rhs_unbacked=False) -> bool:
     if len(a) != len(b):

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -8,6 +8,7 @@ from typing import Callable, NamedTuple, Optional, overload, Sequence, Tuple
 import torch
 import torch._prims_common as utils
 from torch._prims_common import (
+    CustomOutParamAnnotation,
     ELEMENTWISE_TYPE_PROMOTION_KIND,
     Number,
     NumberType,
@@ -194,8 +195,18 @@ def _safe_copy_out(
 
 
 def out_wrapper(*out_names: str, exact_dtype: bool = False):
-    is_tensor = len(out_names) == 0
-    assert is_tensor or len(out_names) >= 2
+    # The wrapped function needs to convert the output parameters to ensure
+    # compatability between the Python API (which always uses "out" as the
+    # parameter name and may be a tuple) and the Aten API (which may have
+    # multiple output parematers and use different parameter names such as
+    # "grad_input", "indices" or "values".)
+
+    default_out_names = ("out",)
+    if len(out_names) == 0:
+        # Use default in out name
+        out_names = default_out_names
+
+    is_tensor = len(out_names) == 1
 
     def _out_wrapper(fn: Callable) -> Callable:
         """
@@ -282,9 +293,15 @@ def out_wrapper(*out_names: str, exact_dtype: bool = False):
         _fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
             parameters=params, return_annotation=return_type  # type: ignore[arg-type]
         )
+
         _fn.__annotations__ = fn.__annotations__
         _fn.__annotations__["out"] = out_type
         _fn.__annotations__["return"] = return_type
+
+        # In the special case of having a single tensor out parameter with a
+        # name other than out, add a special annotation to name the parameter
+        if is_tensor and out_names != default_out_names:
+            _fn.__annotations__[CustomOutParamAnnotation] = out_names[0]
 
         # Add an indicator attribute that can be used in special cases
         # where having a function wrapped by `out_wrapper` is not desirable e.g.

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1939,6 +1939,7 @@ def where(
 # Data Movement References
 #
 @register_decomposition(aten.clone)
+@out_wrapper()
 def clone(
     a: TensorLikeType, *, memory_format: torch.memory_format = torch.preserve_format
 ) -> TensorLikeType:
@@ -2511,6 +2512,7 @@ def mean(
 
 
 @register_decomposition(aten.std_mean)
+@out_wrapper("out0", "out1")
 def std_mean(
     a: TensorLikeType,
     dim: Optional[DimsType] = None,
@@ -2536,6 +2538,7 @@ def std_mean(
 
 
 @register_decomposition(aten.var_mean)
+@out_wrapper("out0", "out1")
 def var_mean(
     a: TensorLikeType,
     dim: Optional[DimsType] = None,
@@ -2673,6 +2676,7 @@ def as_strided(
 
 
 @register_decomposition(aten.as_strided_scatter)
+@out_wrapper()
 def as_strided_scatter(
     input: TensorLikeType,
     src: TensorLikeType,
@@ -2782,6 +2786,7 @@ def conj(input: TensorLikeType) -> TensorLikeType:
 
 # This replicates at::constant_pad_nd, defined in ATen/native/PadNd.cpp
 @register_decomposition(aten.constant_pad_nd)
+@out_wrapper()
 def constant_pad_nd(
     input: TensorLikeType, pad: List[int], value: NumberType = 0
 ) -> TensorLikeType:
@@ -2959,6 +2964,7 @@ def flatten(a: TensorLikeType, start_dim: int = 0, end_dim: int = -1) -> TensorL
 
 
 @register_decomposition(aten.flip)
+@out_wrapper()
 def flip(a: TensorLikeType, dims: DimsSequenceType) -> TensorLikeType:
     if not isinstance(dims, tuple) and not isinstance(dims, list):
         raise ValueError("dims has to be a sequence of ints")
@@ -3108,6 +3114,7 @@ def native_group_norm(
 
 
 @register_decomposition(aten.native_layer_norm)
+@out_wrapper("out0", "out1", "out2")
 def native_layer_norm(
     input: Tensor,
     normalized_shape: ShapeType,
@@ -3519,6 +3526,7 @@ def _get_unfold_shape_stride(
 
 
 @register_decomposition(aten.repeat)
+@out_wrapper()
 def repeat(a: Tensor, *repeat_shape) -> Tensor:
     repeat_shape = utils.extract_shape_from_varargs(repeat_shape, validate=False)
     torch._check(
@@ -3697,6 +3705,7 @@ def reshape_as(self: TensorLikeType, other: TensorLikeType) -> TensorLikeType:
 
 
 @register_decomposition(aten.roll)
+@out_wrapper()
 def roll(
     a: TensorLikeType, shifts: DimsType, dims: DimsType = tuple()
 ) -> TensorLikeType:
@@ -3748,6 +3757,7 @@ def roll(
 
 
 @register_decomposition(aten.rot90)
+@out_wrapper()
 def rot90(
     a: TensorLikeType, k: int = 1, dims: DimsSequenceType = (0, 1)
 ) -> TensorLikeType:
@@ -3885,6 +3895,7 @@ def index_copy_(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
 
 
 @register_decomposition(aten.index_fill)
+@out_wrapper()
 def index_fill(
     x: TensorLike, dim: int, index: TensorLike, value: Union[NumberType, TensorLike]
 ):
@@ -4558,6 +4569,7 @@ def empty_permuted(
 
 
 @register_decomposition(aten.new_empty)
+@out_wrapper()
 def new_empty(
     a: TensorLikeType,
     size: ShapeType,
@@ -4581,6 +4593,7 @@ def new_empty(
 
 
 @register_decomposition(aten.new_empty_strided)
+@out_wrapper()
 def new_empty_strided(
     a: TensorLikeType,
     size: ShapeType,
@@ -4636,6 +4649,7 @@ def zeros(
 
 
 @register_decomposition(aten.new_zeros)
+@out_wrapper()
 def new_zeros(
     a: TensorLikeType,
     size: ShapeType,
@@ -4688,6 +4702,7 @@ def ones(
 
 
 @register_decomposition(aten.new_ones)
+@out_wrapper()
 def new_ones(
     a: TensorLikeType,
     size: ShapeType,
@@ -4714,6 +4729,7 @@ def new_ones(
 
 
 @register_decomposition(aten.new_full)
+@out_wrapper()
 def new_full(
     a: TensorLikeType,
     size: ShapeType,
@@ -4739,6 +4755,7 @@ def new_full(
 
 
 @register_decomposition(aten.empty_like)
+@out_wrapper()
 def empty_like(
     a: TensorLikeType,
     *,
@@ -5193,6 +5210,7 @@ def movedim(
 
 # NOTE: for convenience, shape can be a tuple of ints or a tuple containing a tuple of ints
 @register_decomposition(aten.empty_strided)
+@out_wrapper()
 def empty_strided(
     shape: Union[ShapeType, Tuple[ShapeType]],
     strides: StrideType,
@@ -5262,7 +5280,7 @@ def eye(
     # result.requires_grad_(requires_grad)
 
 
-@register_decomposition(aten.full)
+@register_decomposition([aten.full.default, aten.full.out])
 @out_wrapper()
 def full(
     shape: ShapeType,
@@ -5315,6 +5333,7 @@ def full_like(
 
 
 @register_decomposition(aten.zeros_like)
+@out_wrapper()
 def zeros_like(
     a: TensorLikeType,
     *,
@@ -5338,6 +5357,7 @@ def zeros_like(
 
 
 @register_decomposition(aten.ones_like)
+@out_wrapper()
 def ones_like(
     a: TensorLikeType,
     *,
@@ -5429,6 +5449,7 @@ def _uniform_helper(
 
 
 @register_decomposition(aten.masked_fill)
+@out_wrapper()
 def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLikeType):
     python_type = utils.dtype_to_type(a.dtype)
     if isinstance(value, Number):
@@ -5641,6 +5662,7 @@ def _trilu_checks(
 
 # This is based on tril_indices_cuda in aten/src/ATen/native/cuda/TensorFactories.cu
 @register_decomposition(aten.tril_indices)
+@out_wrapper()
 def tril_indices(
     row: int,
     col: int,
@@ -5700,6 +5722,7 @@ def _get_triu_sizes(row: int, col: int, offset: int) -> Tuple[int, int, int]:
 
 
 @register_decomposition(aten.triu_indices)
+@out_wrapper()
 def triu_indices(
     row: int,
     col: int,
@@ -5975,6 +5998,7 @@ def deg2rad(self: TensorLikeType):
 
 
 @register_decomposition(aten.count_nonzero)
+@out_wrapper()
 def count_nonzero(self, dim: Optional[DimsType] = None):
     return (self != 0).sum(dim)
 


### PR DESCRIPTION
- Extend `test_torch_dispatch_meta_outplace` to test torch ops that do not have an out parameter but have aten op overloads that have out parameters. Additionally, Python decompositions may register `OpOverloadPacket`'s so decompositions need to be tested to ensure all `OpOverloads` still function for the `Meta` key (e.g. if a python decomposition is registered for an aten op `aten.foo` with overloads `[default, out]`, the python function needs to support receiving out arguments)

- Add out parameter wrappers to python decomps for aten ops that have out overloads

CC. @ezyang @albanD @lezcano 

Fixes #107713
