### PR TITLE
Decomp for aten.dropout

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5664,12 +5664,11 @@ class CommonTemplate:
         result, (fw_code, bw_code) = run_fw_bw_and_get_code(
             lambda: run(torch.randn([8, 32], device=self.device))
         )
+
         if self.device == "cuda":
             self.assertEqual(fw_code.count("tl.rand"), 1)
             self.assertEqual(bw_code.count("tl.rand"), 0)
-            expected_kernel = 4
-        else:
-            expected_kernel = 6
+        expected_kernel = 4
 
         self.assertEqual(
             torch._inductor.metrics.generated_kernel_count, expected_kernel

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1042,6 +1042,16 @@ def logit_backward(
         )
 
 
+@register_decomposition(aten.dropout)
+@aten.dropout.default.py_impl(DispatchKey.CompositeImplicitAutograd)
+@aten.dropout.default.py_impl(DispatchKey.Autograd)
+def dropout(input: Tensor, p: float, train: Optional[bool]):
+    if train and p != 0:
+        return aten.native_dropout(input, p, train)[0]
+    else:
+        return input
+
+
 @register_decomposition(aten.native_dropout)
 def native_dropout(input: Tensor, p: float, train: Optional[bool]):
     if train and p != 0:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -329,7 +329,7 @@ def full_like(
         dtype=dtype or self.dtype,
         layout=layout or self.layout,
         device=device or self.device,
-        requires_grad=requires_grad or self.requires_grad,
+        requires_grad=requires_grad,
     )
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1467,7 +1467,6 @@ def philox_rand(size, seed, offset, stride, device, dtype):
 
 @register_lowering(aten.native_dropout, type_promotion_kind=None)
 def native_dropout(x, p, train):
-    assert train and p not in (0, 1), "inference should have been handled as a decomp"
     if config.fallback_random:
         return pytree.tree_map(
             TensorBox.create, ir.FallbackKernel.create(aten.native_dropout, x, p, train)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -177,7 +177,6 @@ def celu(
     return torch.where(a > 0, a, rhs)
 
 
-@register_decomposition(aten.dropout)
 @_inplace_wrapper
 @out_wrapper()
 def dropout(

--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -173,26 +173,6 @@ def remove_tensor_overload_for_qdq_ops(match_pattern: GraphModule) -> None:
         if n.target in _MAP:
             n.target = _MAP[n.target]
 
-def _is_dropout_filter(
-    match: "InternalMatch",  # type: ignore[name-defined]
-    original_graph: Graph,
-    pattern_graph: Graph,
-) -> bool:
-    """
-    Match filter for the subgraph rewriter that returns True if the matched
-    graph includes all the ops used in the aten dropout pattern.
-    """
-    ops_to_match = {
-        torch.ops.aten.empty_like.default,
-        torch.ops.aten.bernoulli_.float,
-        torch.ops.aten.div_.Scalar,
-        torch.ops.aten.mul.Tensor,
-    }
-    for n in match.nodes_map.values():
-        if n.target in ops_to_match:
-            ops_to_match.remove(n.target)
-    return len(ops_to_match) == 0
-
 def _replace_dropout_for_eval(m: GraphModule):
     """
     Replace the aten training dropout pattern with a noop, intended for eval.
@@ -215,27 +195,11 @@ def _replace_dropout_for_eval(m: GraphModule):
     match_pattern = get_aten_graph_module(dropout_train, example_inputs)
     replacement_pattern = get_aten_graph_module(dropout_eval, example_inputs)
 
-    # Note: The match pattern looks like:
-    #
-    #   empty_like_default = torch.ops.aten.empty_like.default(x)
-    #   bernoulli__float = torch.ops.aten.bernoulli_.float(empty_like_default)
-    #   div__scalar = torch.ops.aten.div_.Scalar(bernoulli__float, 0.5)
-    #   mul_tensor = torch.ops.aten.mul.Tensor(x, div__scalar)
-    #
-    # We need to use `ignore_literals=True` here to handle arbitrary dropout
-    # probability (not just 0.5). However, without a match filter, this would
-    # also match any mul op, since `div__scalar` is also a literal, e.g.:
-    #
-    #   mul_tensor = torch.ops.aten.mul.Tensor(x, 0.8)
-    #
-    # Therefore, we need both `ignore_literals=True` and `_is_dropout_filter`
-    # to make sure we are in fact replacing the dropout pattern.
-
     replace_pattern_with_filters(
         m,
         match_pattern,
         replacement_pattern,
-        match_filters=[_is_dropout_filter],
+        match_filters=[],
         ignore_literals=True,
     )
     m.recompile()


### PR DESCRIPTION
From @SherlockNoMad (original PR #106274):

When exporting dropout with cpu tensor, we get following graph module
```
    class GraphModule(torch.nn.Module):
        def forward(self, arg0_1: f32[512, 10]):
            empty_memory_format: f32[512, 10] = torch.ops.aten.empty.memory_format([512, 10], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False, memory_format = torch.contiguous_format)
            bernoulli_p: f32[512, 10] = torch.ops.aten.bernoulli.p(empty_memory_format, 0.9);  empty_memory_format = None
            div_scalar: f32[512, 10] = torch.ops.aten.div.Scalar(bernoulli_p, 0.9);  bernoulli_p = None
            mul_tensor: f32[512, 10] = torch.ops.aten.mul.Tensor(arg0_1, div_scalar);  arg0_1 = div_scalar = None
            return (mul_tensor,)
```
In addition, if we export with eval() mode, we will have an empty graph.

However, when exporting with cuda tensor, we got
```
    class GraphModule(torch.nn.Module):
        def forward(self, arg0_1: f32[512, 10]):
            native_dropout_default = torch.ops.aten.native_dropout.default(arg0_1, 0.1, True);  arg0_1 = None
            getitem: f32[512, 10] = native_dropout_default[0];  native_dropout_default = None
            return (getitem,)
and exporting under eval() mode will still have a dropout node in graph.
```
This PR make exporting with CPU tensor also produce aten.native_dropout.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107716