### PR TITLE
Ensure that FakeTensor.data_ptr() throws

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2849,7 +2849,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   void set_data_throws_if_uninitialized(bool should_throw) {
-    data_throws_if_uninitialized_ = true;
+    data_throws_if_uninitialized_ = should_throw;
   }
 
  protected:
@@ -3054,10 +3054,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // allocation scheme and relies on .mutable_data() to allocate data.
   // For PyTorch tensors, where there is no such lazy scheme, we do want
   // mutable_data() to throw if the storage is uninitialized. In particular,
-  // this happens in the FakeTensor case: FakeTensors have uninitialized storages
-  // and we want to prevent crashes when people send them into kernels that
-  // dereference the mutable_data().
-  bool data_throws_if_uninitialized_: 1;
+  // this happens in the FakeTensor case: FakeTensors have uninitialized
+  // storages and we want to prevent crashes when people send them into kernels
+  // that dereference the mutable_data().
+  bool data_throws_if_uninitialized_ : 1;
 
   // The set of DispatchKeys which describe this tensor.  NB: this
   // does NOT include Autograd (historically, it did, but

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -211,9 +211,11 @@ class FakeTensorTest(TestCase):
         with FakeTensorMode():
             x = torch.rand([4, 4], device="cpu", dtype=torch.float)
         with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
-            torch._C._test_dereference_float_data(x)
+            torch._C._test_dereference_data(x)
         with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
-            torch._C._test_dereference_float_data_ptr(x)
+            torch._C._test_dereference_data_ptr(x)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_templated_data_ptr(x)
 
     def test_mode(self):
         with FakeTensorMode():

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -978,6 +978,7 @@ class FakeTensor(torch.Tensor):
             elem.requires_grad,
             dispatch_device=True,
             device_for_backend_keys=device,
+            data_throws_if_uninitialized=True,
         )
 
         assert elem.device.type == "meta", elem.device.type

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -570,9 +570,9 @@ static PyObject* THPVariable_make_subclass(
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-      "_make_subclass(PyObject* cls, Tensor data, bool require_grad=False, *, c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, Device? device_for_backend_keys=None, bool data_throws_if_initialized=False)",
+      "_make_subclass(PyObject* cls, Tensor data, bool require_grad=False, *, c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, Device? device_for_backend_keys=None, bool data_throws_if_uninitialized=False)",
   });
-  ParsedArgs<7> parsed_args{};
+  ParsedArgs<8> parsed_args{};
   auto r = parser.parse(args, kwargs, parsed_args);
   PyObject* cls = r.pyobject(0);
   if (!PyType_Check(cls)) {

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -722,12 +722,19 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_is_main_interpreter", []() { return isMainPyInterpreter(); });
 
-  m.def("_test_dereference_float_data", [](const at::Tensor& x) {
-    float a = *((float*)(x.unsafeGetTensorImpl()->data()));
+  m.def("_test_dereference_data", [](const at::Tensor& x) {
+    const void* data_ptr = x.unsafeGetTensorImpl()->data();
+    float a = *((const float*)data_ptr);
     return a;
   });
-  m.def("_test_dereference_float_data_ptr", [](const at::Tensor& x) {
-    float a = *((float*)(x.data_ptr()));
+  m.def("_test_dereference_data_ptr", [](const at::Tensor& x) {
+    const void* data_ptr = x.data_ptr();
+    float a = *((const float*)data_ptr);
+    return a;
+  });
+  m.def("_test_dereference_templated_data_ptr", [](const at::Tensor& x) {
+    const float* data_ptr = x.data_ptr<float>();
+    float a = *data_ptr;
     return a;
   });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #107725

We (for some reason) have two paths for data_ptr accesses: one for
templated data_ptr and one for untemplated data_ptr.

The templated data_ptr path raises when the input is a FakeTensor. This
PR changes it so that if a new `data_throws_if_uninitialized_` field is set
on TensorImpl, then untemplated data_ptr access (which goes through a
helper function called TensorImpl::data()) will throw on FakeTensor.

Afaict we cannot unconditionally throw on untemplated data_ptr access
if the storage is uninitialized because (according to the docs) caffe2
relies on that, plus I don't want to regress perf for the regular Tensor
case too much.

Test Plan:
- some new tests