### PR TITLE
Ensure that FakeTensor.data_ptr() throws

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -207,6 +207,16 @@ class FakeTensorTest(TestCase):
         self.assertTrue(isinstance(x, FakeTensor))
         self.assertTrue(x.device.type == "cpu")
 
+    def test_data_ptr_throws(self):
+        with FakeTensorMode():
+            x = torch.rand([4, 4], device="cpu", dtype=torch.float)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_data(x)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_data_ptr(x)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_templated_data_ptr(x)
+
     def test_mode(self):
         with FakeTensorMode():
             y = torch.rand([4], device="cpu")

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -978,6 +978,7 @@ class FakeTensor(torch.Tensor):
             elem.requires_grad,
             dispatch_device=True,
             device_for_backend_keys=device,
+            data_throws_if_uninitialized=True,
         )
 
         assert elem.device.type == "meta", elem.device.type

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -570,9 +570,9 @@ static PyObject* THPVariable_make_subclass(
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-      "_make_subclass(PyObject* cls, Tensor data, bool require_grad=False, *, c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, Device? device_for_backend_keys=None)",
+      "_make_subclass(PyObject* cls, Tensor data, bool require_grad=False, *, c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, Device? device_for_backend_keys=None, bool data_throws_if_uninitialized=False)",
   });
-  ParsedArgs<7> parsed_args{};
+  ParsedArgs<8> parsed_args{};
   auto r = parser.parse(args, kwargs, parsed_args);
   PyObject* cls = r.pyobject(0);
   if (!PyType_Check(cls)) {
@@ -609,6 +609,9 @@ static PyObject* THPVariable_make_subclass(
   }
   if (!r.isNone(6)) {
     data.unsafeGetTensorImpl()->_change_backend_component_keys(r.device(6));
+  }
+  if (r.toBool(7)) {
+    data.unsafeGetTensorImpl()->set_data_throws_if_uninitialized(true);
   }
 
   return THPVariable_NewWithVar(

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -722,6 +722,22 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_is_main_interpreter", []() { return isMainPyInterpreter(); });
 
+  m.def("_test_dereference_data", [](const at::Tensor& x) {
+    const void* data_ptr = x.unsafeGetTensorImpl()->data();
+    float a = *((const float*)data_ptr);
+    return a;
+  });
+  m.def("_test_dereference_data_ptr", [](const at::Tensor& x) {
+    const void* data_ptr = x.data_ptr();
+    float a = *((const float*)data_ptr);
+    return a;
+  });
+  m.def("_test_dereference_templated_data_ptr", [](const at::Tensor& x) {
+    const float* data_ptr = x.data_ptr<float>();
+    float a = *data_ptr;
+    return a;
+  });
+
   m.def("_replace_", [](const at::Tensor& a, const at::Tensor& b) {
     return at::functionalization::impl::replace_(a, b);
   });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #107726

We (for some reason) have two paths for data_ptr accesses: one for
templated data_ptr and one for untemplated data_ptr.

The templated data_ptr path raises when the input is a FakeTensor. This
PR changes it so that if a new `data_throws_if_uninitialized_` field is set
on TensorImpl, then untemplated data_ptr access (which goes through a
helper function called TensorImpl::data()) will throw on FakeTensor.

Afaict we cannot unconditionally throw on untemplated data_ptr access
if the storage is uninitialized because (according to the docs) caffe2
relies on that, plus I don't want to regress perf for the regular Tensor
case too much.

Test Plan:
- some new tests