### PR TITLE
Ensure that FakeTensor.data_ptr() throws

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -207,6 +207,16 @@ class FakeTensorTest(TestCase):
         self.assertTrue(isinstance(x, FakeTensor))
         self.assertTrue(x.device.type == "cpu")
 
+    def test_data_ptr_throws(self):
+        with FakeTensorMode():
+            x = torch.rand([4, 4], device="cpu", dtype=torch.float)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_data(x)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_data_ptr(x)
+        with self.assertRaisesRegex(RuntimeError, "FakeTensor"):
+            torch._C._test_dereference_templated_data_ptr(x)
+
     def test_mode(self):
         with FakeTensorMode():
             y = torch.rand([4], device="cpu")

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -722,6 +722,22 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_is_main_interpreter", []() { return isMainPyInterpreter(); });
 
+  m.def("_test_dereference_data", [](const at::Tensor& x) {
+    const void* data_ptr = x.unsafeGetTensorImpl()->data();
+    float a = *((const float*)data_ptr);
+    return a;
+  });
+  m.def("_test_dereference_data_ptr", [](const at::Tensor& x) {
+    const void* data_ptr = x.data_ptr();
+    float a = *((const float*)data_ptr);
+    return a;
+  });
+  m.def("_test_dereference_templated_data_ptr", [](const at::Tensor& x) {
+    const float* data_ptr = x.data_ptr<float>();
+    float a = *data_ptr;
+    return a;
+  });
+
   m.def("_replace_", [](const at::Tensor& a, const at::Tensor& b) {
     return at::functionalization::impl::replace_(a, b);
   });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #107731

We (for some reason) have two paths for data_ptr accesses: one for
templated data_ptr and one for untemplated data_ptr.

The templated data_ptr path raises when the input's data has not been
allocated. In PyTorch this refers to FakeTensor/meta tensors (those
don't have data but have non-empty numel).

This PR changes the untemplated data_ptr access path to also error
when the input's data has not been allocated (i.e. the data_ptr is
nullptr and the Tensor has non-empty numel).

NB: If it helps reviewing: some of the caffe2 docs seem to be lying,
but I can't tell if it's intentional. `mutable_data<T>()` allocates storage, but
`mutable_data()` does not.

Test Plan:
- some new tests

Differential Revision: [D48577402](https://our.internmc.facebook.com/intern/diff/D48577402)