### PR TITLE
Fix possible naming collision issue

### DIFF
--- a/caffe2/python/test/net_name_test.py
+++ b/caffe2/python/test/net_name_test.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from unittest.mock import patch
+
+from caffe2.python.test_util import TestCase
+
+
+class NetNameTest(TestCase):
+    @patch("caffe2.python.core.Net.current_prefix", return_value="prefix")
+    def test_net_name(self, _current_prefix):
+        from caffe2.python.core import Net
+
+        self.assertEqual(Net._get_next_net_name("test"), "prefix/test")
+        self.assertEqual(Net._get_next_net_name("test"), "prefix/test_1")
+        self.assertEqual(Net._get_next_net_name("test_1_2"), "prefix/test_1_2")
+        self.assertEqual(Net._get_next_net_name("test_1"), "prefix/test_1_1")
+        self.assertEqual(Net._get_next_net_name("test_1"), "prefix/test_1_3")


### PR DESCRIPTION
Summary: As pointed out in https://github.com/pytorch/pytorch/pull/107479, using a set prevents collisions like "a" => "a", "a" => "a_1", "a_1" => "a_1" (but should go to "a_1_1"). We can combine using counters and a set to avoid this problem. Still gets us the performance benefit in the case of collisions with a very minor penalty in a case with no collision.

Test Plan:
Extract this code and run:
```
# New version
from typing import Dict, Set

class Net:
    _net_names_used_counters: Dict[str, int] = {}
    _net_names_used: Set[str] = set()

    staticmethod
    def current_prefix():
        return "test_prefix"

    staticmethod
    def _get_next_net_name(basename):
        basename = "/".join(x for x in [Net.current_prefix(), basename] if x)
        idx = Net._net_names_used_counters.get(basename, 0)
        while (name := basename if idx == 0 else f"{basename}_{idx}") in Net._net_names_used:
            idx += 1
        Net._net_names_used_counters[basename] = idx + 1
        Net._net_names_used.add(name)
        return name

print(Net._get_next_net_name("basename"))
print(Net._get_next_net_name("x_basename"))
print(Net._get_next_net_name("basename"))
print(Net._get_next_net_name("basename"))
print(Net._get_next_net_name("x_basename"))
print(Net._get_next_net_name("basename_1"))

> test_prefix/basename
> test_prefix/x_basename
> test_prefix/basename_1
> test_prefix/basename_2
> test_prefix/x_basename_1
> test_prefix/basename_1_1
```

Differential Revision: D48576516

