### PR TITLE
[profiler] DISABLE_CUPTI_LAZY_REINIT for CUDA 12 as well

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -145,11 +145,10 @@ class _KinetoProfile:
             if dist_info:
                 self.add_metadata_json("distributedInfo", json.dumps(dist_info))
 
-            # FIXME: CUPTI Lazy Re-init and CUDA Graph crashes with CUDA 11.
-            is_cuda11_or_lower = (torch.version.cuda is not None) and (
-                [int(x) for x in torch.version.cuda.split(".")] < [12, 0]
-            )
-            if is_cuda11_or_lower and hasattr(torch, "_inductor"):
+            # FIXME: CUPTI Lazy Re-init and CUDA Graph crashes.
+            # This is a known issue in CUDA 11 but we have also occasionally
+            # observed it in CUDA 12
+            if hasattr(torch, "_inductor"):
                 import torch._inductor.config as inductor_config
 
                 if inductor_config.triton.cudagraphs:


### PR DESCRIPTION
Summary:
Apparently CUDA 12 + CUPTI can fail with an illegal memory access, similar to what we saw with CUDA 11 (https://github.com/pytorch/pytorch/issues/75504).

For now we'll just turn on DISABLE_CUPTI_LAZY_REINIT, which will fix this internally. In OSS, this will probably still break - which will hopefully give us a repro.

Differential Revision: D48568888

