### PR TITLE
[MPS] Fix `torch.std` for negative dimentions

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -504,7 +504,7 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
     for (const auto i : c10::irange(num_input_dims)) {
       bool found = false;
       for (const auto j : c10::irange(num_reduce_dims)) {
-        if (i == dim_value[j]) {
+        if (i == maybe_wrap_dim(dim_value[j], num_input_dims)) {
           found = true;
           break;
         }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5471,6 +5471,7 @@ def sample_inputs_std_var(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(tensor_nd(), dim=None, correction=0, keepdim=True)
     yield SampleInput(tensor_nd(), dim=None, correction=None)
     yield SampleInput(tensor_nd(), correction=0, keepdim=True)
+    yield SampleInput(make_tensor(3, 4, 5, device=device, dtype=dtype), dim=-3)
 
 
 def sample_inputs_std_var_unbiased(op_info, device, dtype, requires_grad, **kwargs):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5471,7 +5471,7 @@ def sample_inputs_std_var(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(tensor_nd(), dim=None, correction=0, keepdim=True)
     yield SampleInput(tensor_nd(), dim=None, correction=None)
     yield SampleInput(tensor_nd(), correction=0, keepdim=True)
-    yield SampleInput(make_tensor(3, 4, 5, device=device, dtype=dtype), dim=-3)
+    yield SampleInput(make_tensor(3, 4, 5, device=device, dtype=dtype, requires_grad=requires_grad), dim=-3)
 
 
 def sample_inputs_std_var_unbiased(op_info, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
By simply comparing output dimentions to a properly wrapped dim
Add regression test to opinfo

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca98536</samp>

> _`reduceTensor` bug_
> _negative dimensions wrapped_
> _autumn tests added_

Fixes https://github.com/pytorch/pytorch/issues/107116