### PR TITLE
torch._numpy: keep f16 CUDA tensors in f16 where possible

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -11,7 +11,7 @@ import torch._numpy as w
 import torch._numpy._ufuncs as _ufuncs
 import torch._numpy._util as _util
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_equal
+from torch._numpy.testing import assert_allclose, assert_equal
 
 # These function receive one array_like arg and return one array_like result
 one_arg_funcs = [
@@ -569,3 +569,17 @@ def test_ndarrays_to_tensors():
     assert len(out) == 2
     assert isinstance(out[0], tuple) and len(out[0]) == 2
     assert isinstance(out[0][0], torch.Tensor)
+
+
+def test_f16_on_cuda():
+    # make sure operations with float16 tensors give same results on CUDA and on CPU
+    t = torch.arange(5, dtype=torch.float16)
+    assert_allclose(w.vdot(t.cuda(), t.cuda()), w.vdot(t, t))
+    assert_allclose(w.inner(t.cuda(), t.cuda()), w.inner(t, t))
+    assert_allclose(w.matmul(t.cuda(), t.cuda()), w.matmul(t, t))
+    assert_allclose(w.einsum("i,i", t.cuda(), t.cuda()), w.einsum("i,i", t, t))
+
+    assert_allclose(w.mean(t.cuda()), w.mean(t))
+
+    assert_allclose(w.cov(t.cuda(), t.cuda()), w.cov(t, t).tensor.cuda())
+    assert_allclose(w.corrcoef(t.cuda()), w.corrcoef(t).tensor.cuda())

--- a/torch/_numpy/_binary_ufuncs_impl.py
+++ b/torch/_numpy/_binary_ufuncs_impl.py
@@ -57,7 +57,9 @@ def matmul(x, y):
     #  - RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'
     dtype = _dtypes_impl.result_type_impl(x, y)
     is_bool = dtype == torch.bool
-    is_half = dtype == torch.float16
+    is_half = (x.dtype == torch.float16 or y.dtype == torch.float16) and (
+        x.is_cpu or y.is_cpu
+    )
 
     work_dtype = dtype
     if is_bool:

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -533,7 +533,7 @@ def corrcoef(
         raise NotImplementedError
     xy_tensor = _xy_helper_corrcoef(x, y, rowvar)
 
-    is_half = dtype == torch.float16
+    is_half = (xy_tensor.dtype == torch.float16) and xy_tensor.is_cpu
     if is_half:
         # work around torch's "addmm_impl_cpu_" not implemented for 'Half'"
         dtype = torch.float32
@@ -563,7 +563,7 @@ def cov(
     if ddof is None:
         ddof = 1 if bias == 0 else 0
 
-    is_half = dtype == torch.float16
+    is_half = (m.dtype == torch.float16) and m.is_cpu
     if is_half:
         # work around torch's "addmm_impl_cpu_" not implemented for 'Half'"
         dtype = torch.float32
@@ -1202,7 +1202,7 @@ def vdot(a: ArrayLike, b: ArrayLike, /):
         t_b = t_b.flatten()
 
     dtype = _dtypes_impl.result_type_impl(t_a, t_b)
-    is_half = dtype == torch.float16
+    is_half = dtype == torch.float16 and (t_a.is_cpu or t_b.is_cpu)
     is_bool = dtype == torch.bool
 
     # work around torch's "dot" not implemented for 'Half', 'Bool'
@@ -1257,7 +1257,7 @@ def dot(a: ArrayLike, b: ArrayLike, out: Optional[OutArray] = None):
 
 def inner(a: ArrayLike, b: ArrayLike, /):
     dtype = _dtypes_impl.result_type_impl(a, b)
-    is_half = dtype == torch.float16
+    is_half = dtype == torch.float16 and (a.is_cpu or b.is_cpu)
     is_bool = dtype == torch.bool
 
     if is_half:
@@ -1393,7 +1393,7 @@ def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=
     target_dtype = _dtypes_impl.result_type_impl(*tensors) if dtype is None else dtype
 
     # work around 'bmm' not implemented for 'Half' etc
-    is_half = target_dtype == torch.float16
+    is_half = target_dtype == torch.float16 and all(t.is_cpu for t in tensors)
     if is_half:
         target_dtype = torch.float32
 

--- a/torch/_numpy/_reductions_impl.py
+++ b/torch/_numpy/_reductions_impl.py
@@ -218,16 +218,8 @@ def mean(
 ):
     dtype = _atleast_float(dtype, a.dtype)
 
-    is_half = dtype == torch.float16
-    if is_half:
-        # XXX revisit when the pytorch version has pytorch/pytorch#95166
-        dtype = torch.float32
-
     axis_kw = {} if axis is None else {"dim": axis}
     result = a.mean(dtype=dtype, **axis_kw)
-
-    if is_half:
-        result = result.to(torch.float16)
 
     return result
 


### PR DESCRIPTION
Contain workarounds for _RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'_ to CPU tensors, do computations on CUDA tensors in f16.

Fixes https://github.com/Quansight-Labs/numpy_pytorch_interop/issues/170

We do not really systematically test CUDA tensors in torch._numpy, so I only spot-checked locally that the affected functions work with `tensor.to("cuda")`.  



cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305