### PR TITLE
Enable Mypy Checking in torch/_inductor/bounds.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -197,7 +197,7 @@ exclude_patterns = [
     'torch/_inductor/coordinate_descent_tuner.py',
     'torch/_inductor/debug.py',
     'torch/_inductor/hooks.py',
-    'torch/_inductor/bounds.py',
+    'torch/_inductor/decomposition.py',
     'torch/_inductor/config.py',
     'torch/_inductor/ir.py',
     'torch/_inductor/codecache.py',

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -47,7 +47,7 @@ class BoundVars:
                 "masked_subblock" not in node.target
                 and "set_indirect" not in node.target
             ):
-                self._bounds[node] = ValueRanges.unknown()  # type: ignore
+                self._bounds[node] = ValueRanges.unknown()  # type: ignore[index]
 
         with V.set_ops_handler(ValueRangeAnalysis()):
             interpreter = InterpreterShim(self.loop_body.root_block.graph, submodules)
@@ -63,7 +63,7 @@ class BoundVars:
                 subblock = self.loop_body.subblocks[key]
                 # The result within the lambda will reference to the final
                 # set of modules at the end of the for-loop as it stores a reference to it
-                result[key] = lambda mask, value: self.masked_subblock(  # type: ignore
+                result[key] = lambda mask, value: self.masked_subblock(  # type: ignore[misc, assignment]
                     subblock, self._bounds, mask, value, result
                 )
             else:

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -47,7 +47,7 @@ class BoundVars:
                 "masked_subblock" not in node.target
                 and "set_indirect" not in node.target
             ):
-                self._bounds[node] = ValueRanges.unknown()
+                self._bounds[node] = ValueRanges.unknown() # type: ignore
 
         with V.set_ops_handler(ValueRangeAnalysis()):
             interpreter = InterpreterShim(self.loop_body.root_block.graph, submodules)
@@ -63,7 +63,7 @@ class BoundVars:
                 subblock = self.loop_body.subblocks[key]
                 # The result within the lambda will reference to the final
                 # set of modules at the end of the for-loop as it stores a reference to it
-                result[key] = lambda mask, value: self.masked_subblock(
+                result[key] = lambda mask, value: self.masked_subblock( # type: ignore
                     subblock, self._bounds, mask, value, result
                 )
             else:

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -47,7 +47,7 @@ class BoundVars:
                 "masked_subblock" not in node.target
                 and "set_indirect" not in node.target
             ):
-                self._bounds[node] = ValueRanges.unknown() # type: ignore
+                self._bounds[node] = ValueRanges.unknown()  # type: ignore
 
         with V.set_ops_handler(ValueRangeAnalysis()):
             interpreter = InterpreterShim(self.loop_body.root_block.graph, submodules)
@@ -63,7 +63,7 @@ class BoundVars:
                 subblock = self.loop_body.subblocks[key]
                 # The result within the lambda will reference to the final
                 # set of modules at the end of the for-loop as it stores a reference to it
-                result[key] = lambda mask, value: self.masked_subblock( # type: ignore
+                result[key] = lambda mask, value: self.masked_subblock(  # type: ignore
                     subblock, self._bounds, mask, value, result
                 )
             else:


### PR DESCRIPTION
Fixes #105230 

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/bounds.py

After Fix:

mypy --follow-imports=skip torch/_inductor/bounds.py Success: no issues found in 1 source file

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel