### PR TITLE
Use TORCH_SYM_CHECK for check_size_nonnegative on SymIntArrayRef

### DIFF
--- a/aten/src/ATen/EmptyTensor.h
+++ b/aten/src/ATen/EmptyTensor.h
@@ -4,11 +4,21 @@
 namespace at {
 namespace detail {
 
-template <class ArrayRefType>
-inline void check_size_nonnegative(ArrayRefType size) {
+inline void check_size_nonnegative(ArrayRef<int64_t> size) {
   for (const auto& x : size) {
     TORCH_CHECK(
         x >= 0,
+        "Trying to create tensor with negative dimension ",
+        x,
+        ": ",
+        size);
+  }
+}
+
+inline void check_size_nonnegative(ArrayRef<c10::SymInt> size) {
+  for (const auto& x : size) {
+    TORCH_SYM_CHECK(
+        x.sym_ge(0),
         "Trying to create tensor with negative dimension ",
         x,
         ": ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107785

See https://github.com/pytorch/pytorch/pull/106788 for context.

I think I don't actually need this for anything real, but this is pretty
mild so might as well.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>