### PR TITLE
[Redo] Enhance fakepg: alltoall and alltoall_base

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -131,6 +131,28 @@ class TestFakePG(TestCase):
         dist.scatter(output, None, src=1)
         self.assertEqual(tuple(output.shape), (3, 3))
 
+    def test_alltoall(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        output_list = [torch.ones(3, 3) for _ in range(2)]
+        input_list = [torch.ones(3, 3) for _ in range(2)]
+        dist.all_to_all(output_list, input_list)
+        self.assertEqual(len(output_list), 2)
+        for output in output_list:
+            self.assertEqual(tuple(output.shape), (3, 3))
+
+    def test_alltoall_base(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        out_tensor = torch.ones(3, 3)
+        in_tensor = torch.ones(3, 3)
+        output_split = [1, 1]
+        input_split = [1, 1]
+        dist.all_to_all_single(out_tensor, in_tensor, output_split, input_split)
+        self.assertEqual(tuple(out_tensor.shape), (3, 3))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -7,7 +7,8 @@ from torch._C._distributed_c10d import (
     BarrierOptions,
     ReduceScatterOptions,
     BroadcastOptions,
-    ScatterOptions
+    ScatterOptions,
+    AllToAllOptions
 )
 from torch.futures import Future
 
@@ -85,6 +86,24 @@ class FakeProcessGroup(dist.ProcessGroup):
         opts=ScatterOptions(),
     ):
         return ret_work(output_tensors)
+
+    def alltoall(
+        self,
+        output_tensors: List[Tensor],
+        input_tensors: List[Tensor],
+        opts=AllToAllOptions(),
+    ):
+        return ret_work(output_tensors)
+
+    def alltoall_base(
+        self,
+        output_tensor: Tensor,
+        input_tensor: Tensor,
+        output_split_sizes: List[int],
+        input_split_sizes: List[int],
+        opts=AllToAllOptions(),
+    ):
+        return ret_work(output_tensor)
 
     def getBackendName(self):
         return "fake"


### PR DESCRIPTION
[ghstack-poisoned]

Redo https://github.com/pytorch/pytorch/pull/107624, previously tried to land via `ghstack land`, but that doesn't work with pytorch repo which has protected main branch. As a result, that PR was only merged to [gh/xmfan/1/base](https://github.com/pytorch/pytorch/tree/gh/xmfan/1/base). 

This PR manually merges [gh/xmfan/1/base](https://github.com/pytorch/pytorch/tree/gh/xmfan/1/base) into main, via pytorchbot
