### PR TITLE
Add wait_tensor so print always has a correct result for AsyncCollectiveTensor

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -330,6 +330,7 @@ class AsyncCollectiveTensor(torch.Tensor):
         return r
 
     def __repr__(self):
+        wait_tensor(self.elem)
         return f"AsyncCollectiveTensor({self.elem})"
 
     def trigger_wait(self):


### PR DESCRIPTION
As the title says, I was trying to test the functional collectives, and, when printing the resulting tensors, sometimes they wouldn't have finished the Async operation yet. According to the comments in the file, "AsyncTensor wrapper applied to returned tensor, which issues wait_tensor() at the time of first use". This is true in most cases, but not when print() is your first use. This PR fixes that.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107808

