### PR TITLE
add get buffer from exported program

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10,7 +10,13 @@ from functorch.experimental.control_flow import map
 from torch import Tensor
 from torch._export import DEFAULT_EXPORT_DYNAMO_CONFIG, dynamic_dim, export
 from torch._export.constraints import constrain_as_size, constrain_as_value
-from torch._export.utils import register_dataclass_as_pytree_node, is_param, get_param
+from torch._export.utils import (
+    get_buffer,
+    get_param,
+    is_buffer,
+    is_param,
+    register_dataclass_as_pytree_node,
+)
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -456,6 +462,21 @@ class TestExport(TestCase):
         self.assertEqual(num_params, 2)
         self.assertEqual(params[0].shape, [1, 10])  # weight
         self.assertEqual(params[1].shape, [1])  # bias
+
+    def test_buffer_util(self):
+        ep = export(torch.nn.BatchNorm2d(100, affine=False), (torch.ones(20, 100, 35, 45), ))
+        num_buffer = 0
+        buffer = []
+
+        for node in ep.graph.nodes:
+            if is_buffer(ep, node):
+                num_buffer += 1
+                buffer.append(get_buffer(ep, node))
+        self.assertEqual(num_buffer, 3)
+
+        self.assertEqual(buffer[0].shape, torch.Size([100]))  # running_mean
+        self.assertEqual(buffer[1].shape, torch.Size([100]))  # running_var
+        self.assertEqual(buffer[2].shape, torch.Size([]))  # num_batches_tracked
 
 
     def test_export_dynamo_config(self):

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -80,3 +80,27 @@ def get_param(
         return program.state_dict[parameter_name]
 
     return None
+
+
+def is_buffer(program: ExportedProgram, node: torch.fx.Node) -> bool:
+    """
+    Checks if the given node is a buffer within the exported program
+    """
+
+    return node.name in program.graph_signature.inputs_to_buffers
+
+
+def get_buffer(
+    program: ExportedProgram,
+    node: torch.fx.Node,
+) -> Optional[torch.Tensor]:
+    """
+    Returns the buffer associated with the given node in the exported program.
+    Returns None if the node is not a buffer within the exported program
+    """
+
+    if is_buffer(program, node):
+        buffer_name = program.graph_signature.inputs_to_buffers[node.name]
+        return program.state_dict[buffer_name]
+
+    return None


### PR DESCRIPTION
Summary: We have the util function to get params, for parity we also need util function to get buffer`

Test Plan:
```
buck test //caffe2/test:test_export
```

Differential Revision: D48610877

