### PR TITLE
[ROCm] Add conditions for channels last logic

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -243,10 +243,13 @@ class GraphLowering(torch.fx.Interpreter):
         if nconv == 0:
             return False
 
-        #Ignore channels last for non-MI200 HIP GPUs
+        # Currently on ROCm we are seeing some slow downs in gcnArch that do not
+        # have optimal NHWC implementations. On ROCm MI200 series we will
+        # default to the enforced last channels behavior, but on non-MI200 series
+        # we will disable the forced layout.
         if torch.version.hip and torch.cuda.is_available():
             gpu_name = torch.cuda.get_device_name(0)
-            if not re.search("MI2\d\d", gpu_name):
+            if not re.search(r"MI2\d\d", gpu_name):
                 return False
 
         # For cpu backend and mkldnn enabled, we always using channels_last for a better performance.

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -243,6 +243,12 @@ class GraphLowering(torch.fx.Interpreter):
         if nconv == 0:
             return False
 
+        #Ignore channels last for non-MI200 HIP GPUs
+        if torch.version.hip and torch.cuda.is_available():
+            gpu_name = torch.cuda.get_device_name(0)
+            if not re.search("MI2\d\d", gpu_name):
+                return False
+
         # For cpu backend and mkldnn enabled, we always using channels_last for a better performance.
         if (
             all(


### PR DESCRIPTION
Although there are some performance benefits by enforcing NHWC convolutions as inductor's fallback method for all hardware this may not be the case. Currently on ROCm we are seeing some slow downs in gcnArch that do not have optimal NHWC implementations and would like to introduce some control on this behavior in pytorch. On ROCm MI200 series we will default to the enforced last channels behavior aligned with the rest of pytorch but on non-MI200 series we will disable the forced layout.

For now we are using torch.cuda.get_device_name(0) for this control but we will replace with gcnArchName when https://github.com/pytorch/pytorch/pull/107477 lands.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov