### PR TITLE
Fix docstring for shape of `target` for MultiLabelSoftMarginLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1216,7 +1216,7 @@ class MultiLabelSoftMarginLoss(_WeightedLoss):
 
     Shape:
         - Input: :math:`(N, C)` where `N` is the batch size and `C` is the number of classes.
-        - Target: :math:`(N, C)`, label targets padded by -1 ensuring same shape as the input.
+        - Target: :math:`(N, C)`, label targets must have the same shape as the input.
         - Output: scalar. If :attr:`reduction` is ``'none'``, then :math:`(N)`.
     """
     __constants__ = ['reduction']


### PR DESCRIPTION
Fixes #92000

The documentation at https://pytorch.org/docs/stable/generated/torch.nn.MultiLabelSoftMarginLoss.html#multilabelsoftmarginloss states:
> label targets padded by -1 ensuring same shape as the input.

However, the shape of input and target tensor are compared, and an exception is raised if they differ in either dimension 0 or 1. Meaning the label targets are never padded. See the code snippet below and the resulting output. The documentation is therefore adjusted to:
> label targets must have the same shape as the input.

```
import torch
import torch.nn as nn

# Create some example data
input = torch.tensor(
    [
        [0.8, 0.2, -0.5],
        [0.1, 0.9, 0.3],
    ]
)
target1 = torch.tensor(
    [
        [1, 0, 1],
        [0, 1, 1],
        [0, 1, 1],
    ]
)
target2 = torch.tensor(
    [
        [1, 0],
        [0, 1],
    ]
)
target3 = torch.tensor(
    [
        [1, 0, 1],
        [0, 1, 1],
    ]
)
loss_func = nn.MultiLabelSoftMarginLoss()
try:
    loss = loss_func(input, target1).item()
except RuntimeError as e:
    print('target1 ', e)
try:
    loss = loss_func(input, target2).item()
except RuntimeError as e:
    print('target2 ', e)
loss = loss_func(input, target3).item()
print('target3 ', loss)
```

output:
```
target1  The size of tensor a (3) must match the size of tensor b (2) at non-singleton dimension 0
target2  The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 1
target3  0.6305370926856995
```