### PR TITLE
[TP][EZ] Update doc for TP parallel style

### DIFF
--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -54,7 +54,7 @@ class PairwiseParallel(ParallelStyle):
         PairwiseParallel does not support ``nn.MultiheadAttention``,
         ``nn.Transformer`` well at this moment. One workaround is to
         use ``ColwiseParallel`` and ``RowwiseParallel`` directly. We recommend to
-        use `PairwiseParallel` only for even-number-layer MLP for now.
+        use ``PairwiseParallel`` only for even-number-layer MLP for now.
     """
 
     def __init__(self, _prepare_input=None, _prepare_output=None) -> None:

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -51,8 +51,10 @@ class PairwiseParallel(ParallelStyle):
     We assume both input and output need to be replicate DTensors.
 
     .. warning::
-        PairwiseParallel only supports ``nn.Multihead Attention``,
-        ``nn.Transformer`` or even-number-layer MLP for now.
+        PairwiseParallel does not support ``nn.Multihead Attention``,
+        ``nn.Transformer`` well at this moment. One workaround is to
+        use `ColwiseParallel` and `RowwiseParallel` directly. We recommend to
+        use `PairwiseParallel` only for even-number-layer MLP for now.
     """
 
     def __init__(self, _prepare_input=None, _prepare_output=None) -> None:
@@ -73,8 +75,10 @@ class SequenceParallel(PairwiseParallel):
     We assume both input and output need to be sharded DTensors.
 
     .. warning::
-        SequenceParallel only supports ``nn.Multihead Attention``,
-        ``nn.Transformer`` or even-number-layer MLP for now.
+        SequenceParallel does not support ``nn.Multihead Attention``,
+        ``nn.Transformer`` well at this moment. One workaround is to
+        use `ColwiseParallel` and `RowwiseParallel` directly. We recommend to
+        use `SequenceParallel` only for even-number-layer MLP for now.
     """
 
     def __init__(self) -> None:

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -51,7 +51,7 @@ class PairwiseParallel(ParallelStyle):
     We assume both input and output need to be replicate DTensors.
 
     .. warning::
-        PairwiseParallel does not support ``nn.Multihead Attention``,
+        PairwiseParallel does not support ``nn.MultiheadAttention``,
         ``nn.Transformer`` well at this moment. One workaround is to
         use `ColwiseParallel` and `RowwiseParallel` directly. We recommend to
         use `PairwiseParallel` only for even-number-layer MLP for now.

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -52,9 +52,10 @@ class PairwiseParallel(ParallelStyle):
 
     .. warning::
         PairwiseParallel does not support ``nn.MultiheadAttention``,
-        ``nn.Transformer`` well at this moment. One workaround is to
-        use ``ColwiseParallel`` and ``RowwiseParallel`` directly. We recommend to
-        use ``PairwiseParallel`` only for even-number-layer MLP for now.
+        ``nn.Transformer`` well at this moment. One workaround is to apply
+        ``ColwiseParallel`` and ``RowwiseParallel`` to the components of
+        transformer. We recommend to use ``PairwiseParallel`` only
+        for even-number-layer MLP for now.
     """
 
     def __init__(self, _prepare_input=None, _prepare_output=None) -> None:
@@ -76,9 +77,10 @@ class SequenceParallel(PairwiseParallel):
 
     .. warning::
         SequenceParallel does not support ``nn.MultiheadAttention``,
-        ``nn.Transformer`` well at this moment. One workaround is to
-        use ``ColwiseParallel`` and ``RowwiseParallel`` directly. We recommend to
-        use ``SequenceParallel`` only for even-number-layer MLP for now.
+        ``nn.Transformer`` well at this moment. One workaround is to apply
+        ``ColwiseParallel`` and ``RowwiseParallel`` to the components of
+        transformer. We recommend to use ``SequenceParallel`` only
+        for even-number-layer MLP for now.
     """
 
     def __init__(self) -> None:

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -75,10 +75,10 @@ class SequenceParallel(PairwiseParallel):
     We assume both input and output need to be sharded DTensors.
 
     .. warning::
-        SequenceParallel does not support ``nn.Multihead Attention``,
+        SequenceParallel does not support ``nn.MultiheadAttention``,
         ``nn.Transformer`` well at this moment. One workaround is to
-        use `ColwiseParallel` and `RowwiseParallel` directly. We recommend to
-        use `SequenceParallel` only for even-number-layer MLP for now.
+        use ``ColwiseParallel`` and ``RowwiseParallel`` directly. We recommend to
+        use ``SequenceParallel`` only for even-number-layer MLP for now.
     """
 
     def __init__(self) -> None:

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -53,7 +53,7 @@ class PairwiseParallel(ParallelStyle):
     .. warning::
         PairwiseParallel does not support ``nn.MultiheadAttention``,
         ``nn.Transformer`` well at this moment. One workaround is to
-        use `ColwiseParallel` and `RowwiseParallel` directly. We recommend to
+        use ``ColwiseParallel`` and ``RowwiseParallel`` directly. We recommend to
         use `PairwiseParallel` only for even-number-layer MLP for now.
     """
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107819


We need to update the doc for PairwiseParallel and SequenceParallel so that users don't get wrong impressions that these working for ``nn.Transformer``.

