### PR TITLE
[export] Serialize map correctly

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -31,7 +31,6 @@ from torch.testing._internal.common_utils import (
 
 
 def get_filtered_export_db_tests():
-    unsupported_tags = {"torch.cond", "torch.map"}
     unsupported_test_names = {
         "dynamic_shape_constructor",  # 'NoneType' object has no attribute 'from_tensor'
         "dictionary",  # Graph output must be a tuple()
@@ -44,7 +43,6 @@ def get_filtered_export_db_tests():
         for name, case in all_examples().items()
         if (
             case.support_level == SupportLevel.SUPPORTED and
-            not (unsupported_tags & case.tags) and
             name not in unsupported_test_names
         )
     ]
@@ -180,7 +178,7 @@ class TestSerialize(TestCase):
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestDeserialize(TestCase):
-    def check_graph(self, fn, inputs, constraints=None) -> None:
+    def check_graph(self, fn, inputs, constraints=None, _check_meta=True) -> None:
         """Export a graph, serialize it, deserialize it, and compare the results."""
         # TODO(angelayi): test better with some sort of wrapper
         constraints = [] if constraints is None else constraints
@@ -204,7 +202,13 @@ class TestDeserialize(TestCase):
             else:
                 self.assertEqual(orig, loaded)
 
-        def _check_graph_nodes(gm1, gm2):
+        def _check_graph_nodes(gm1, gm2, _check_meta=True):
+            # TODO: The _check_meta flag bypasses checking for
+            # source_fn/nn_module_stack as there is an issue with
+            # roundtripping the source_fn value on torch.ops.map nodes
+            # original source_fn: <functorch.experimental._map.MapWrapper object at 0x7f80a0549930>
+            # deserialized source_fn: 'functorch.experimental._map.map'
+
             self.assertEqual(len(gm1.graph.nodes), len(gm2.graph.nodes))
 
             for node1, node2 in zip(gm1.graph.nodes, gm2.graph.nodes):
@@ -249,8 +253,15 @@ class TestDeserialize(TestCase):
                         false_graph1 = getattr(gm1, node1.args[2].target)
                         false_graph2 = getattr(gm2, node2.args[2].target)
                         _check_graph_nodes(false_graph1, false_graph2)
+                    elif node1.target == torch.ops.map_impl:
+                        map_graph1 = getattr(gm1, node1.args[0].target)
+                        map_graph2 = getattr(gm2, node2.args[0].target)
+                        _check_graph_nodes(map_graph1, map_graph2, False)
 
-                if node1.op not in ("get_attr", "placeholder", "output"):
+                if (
+                    _check_meta and
+                    node1.op not in ("get_attr", "placeholder", "output")
+                ):
                     # Check "nn_module_stack" metadata
                     self.assertEqual(
                         node1.meta.get("nn_module_stack", None),
@@ -262,7 +273,7 @@ class TestDeserialize(TestCase):
                         node2.meta.get("source_fn", None),
                     )
 
-        _check_graph_nodes(ep.graph_module, deserialized_ep.graph_module)
+        _check_graph_nodes(ep.graph_module, deserialized_ep.graph_module, _check_meta)
 
     def test_multi_return(self) -> None:
         """
@@ -375,6 +386,18 @@ class TestDeserialize(TestCase):
 
         self.check_graph(M(), inputs)
 
+    def test_map(self):
+        from functorch.experimental import control_flow
+
+        def f(x, y):
+            return x + y
+
+        def g(xs, y):
+            return control_flow.map(f, xs, y)
+
+        inputs = (torch.ones(3, 2, 2), torch.ones(2))
+        self.check_graph(g, inputs, _check_meta=False)
+
     @parametrize(
         "name,case",
         get_filtered_export_db_tests(),
@@ -383,7 +406,8 @@ class TestDeserialize(TestCase):
     def test_exportdb_supported(self, name: str, case: ExportCase) -> None:
         model = case.model
         inputs = normalize_inputs(case.example_inputs)
-        self.check_graph(model, inputs.args)
+        _check_meta = "map" not in name
+        self.check_graph(model, inputs.args, _check_meta=_check_meta)
 
     def test_constraints(self):
         def f(x, y):
@@ -440,6 +464,10 @@ unittest.expectedFailure(
 )
 unittest.expectedFailure(
     TestDeserialize.test_exportdb_supported_case_pytree_flatten
+)
+# getattr node in the graph from a torch.tensor call
+unittest.expectedFailure(
+    TestDeserialize.test_exportdb_supported_case_cond_branch_nonlocal_variables
 )
 
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -417,18 +417,31 @@ class GraphModuleSerializer:
                 metadata=self.serialize_metadata(node),
             )
         elif isinstance(node.target, torch._ops.HigherOrderOperator):
-            assert isinstance(
-                node.meta["val"], FakeTensor
-            ), "Only single tensor output is supported for HigherOrderOperator serialization."
 
-            inputs = [NamedArgument(
-                name="",  # TODO(zhxchen17) This is sad, should be improved when HOO has schema arg names.
-                arg=self.serialize_input(a),
-            ) for a in node.args]
+            inputs = [
+                NamedArgument(
+                    name="",  # TODO(zhxchen17) This is sad, should be improved when HOO has schema arg names.
+                    arg=self.serialize_input(a),
+                ) for a in node.args
+            ]
+
+            meta_val = node.meta["val"]
+
+            if isinstance(meta_val, torch.Tensor):
+                outputs = [Argument.create(as_tensor=self.serialize_tensor_output(node.name, meta_val))]
+            elif isinstance(meta_val, (list, tuple)) and all(isinstance(v, torch.Tensor) for v in meta_val):
+                arg_list = self._handle_getitem_users(node)
+                outputs = [Argument.create(as_tensors=arg_list)]
+            else:
+                raise SerializeError(
+                    "Only single tensor output or list of tensor output "
+                    "is supported for HigherOrderOperator serialization"
+                )
+
             ex_node = Node(
                 target=self.serialize_operator(node.target),
                 inputs=inputs,
-                outputs=[Argument.create(as_tensor=self.serialize_tensor_output(node.name, node.meta['val']))],
+                outputs=outputs,
                 metadata=self.serialize_metadata(node),
             )
         else:
@@ -649,14 +662,15 @@ class GraphModuleSerializer:
         """
         assert node.op == "call_function" and isinstance(node.target, torch._ops.OpOverload)
 
-        meta_val = node.meta["val"]
-
         assert isinstance(node.target, torch._ops.OpOverload)
         returns = node.target._schema.returns
 
-        # Check single value return
         if len(returns) == 0:
             return []
+
+        meta_val = node.meta["val"]
+
+        # Check single value return
         if _is_single_tensor_return(node.target):
             return [Argument.create(as_tensor=self.serialize_tensor_output(node.name, meta_val))]
         elif len(returns) == 1 and isinstance(meta_val, torch.SymInt):
@@ -671,6 +685,27 @@ class GraphModuleSerializer:
         # Either way, start by gathering a list of TensorArguments with the correct names.
         # For consistent naming with FX, consult the downstream `getitem` node and
         # make sure our outputs have the same name.
+
+        arg_list = self._handle_getitem_users(node)
+
+        # Then, pack the return value differently depending on what the return type is.
+        if len(returns) == 1:
+            return_type = returns[0].real_type
+            assert isinstance(return_type, torch.ListType) and isinstance(
+                return_type.getElementType(), torch.TensorType
+            ), "Only tensors and lists of tensors supported"
+
+            return [Argument.create(as_tensors=arg_list)]
+        else:
+            assert all(
+                isinstance(ret.real_type, torch.TensorType) for ret in returns
+            ), f"Multiple returns can only have tensor returns, got: {[ret.real_type for ret in returns]}"
+
+            return [Argument.create(as_tensor=arg) for arg in arg_list]
+
+    def _handle_getitem_users(self, node: torch.fx.Node) -> List[TensorArgument]:
+        meta_val = node.meta["val"]
+
         idx_to_name = {}
         for user in node.users:
             assert user.target is operator.getitem, f"User node {user} of {node} is incorrect"
@@ -689,20 +724,7 @@ class GraphModuleSerializer:
                 self.serialize_tensor_output(idx_to_name[i], element_meta_val)
             )
 
-        # Then, pack the return value differently depending on what the return type is.
-        if len(returns) == 1:
-            return_type = returns[0].real_type
-            assert isinstance(return_type, torch.ListType) and isinstance(
-                return_type.getElementType(), torch.TensorType
-            ), "Only tensors and lists of tensors supported"
-
-            return [Argument.create(as_tensors=arg_list)]
-        else:
-            assert all(
-                isinstance(ret.real_type, torch.TensorType) for ret in returns
-            ), f"Multiple returns can only have tensor returns, got: {[ret.real_type for ret in returns]}"
-
-            return [Argument.create(as_tensor=arg) for arg in arg_list]
+        return arg_list
 
     def serialize_graph(self, graph_module: torch.fx.GraphModule) -> Graph:
         assert isinstance(graph_module, torch.fx.GraphModule)
@@ -925,12 +947,24 @@ class GraphModuleDeserializer:
         elif isinstance(target, torch._ops.HigherOrderOperator):
             assert (
                 len(serialized_node.outputs) == 1
-                and serialized_node.outputs[0].as_tensor is not None
-            ), "Only single tensor output is supported for higher order operators."
-            name = serialized_node.outputs[0].as_tensor.name
+                and serialized_node.outputs[0].type in ("as_tensors", "as_tensor")
+            ), "Only single tensor output or list of tensor output is supported for higher order operators."
+
+            output = serialized_node.outputs[0]
+
+            name = (
+                output.value.name
+                if output.type == "as_tensor"
+                else None  # FX will generate a name for us.
+            )
             args = tuple(self.deserialize_input(input.arg) for input in serialized_node.inputs)
             fx_node = self.graph.create_node("call_function", target, args, {}, name)
-            self.sync_fx_node(serialized_node.outputs[0].as_tensor.name, fx_node)
+
+            if output.type == "as_tensor":
+                self.sync_fx_node(name, fx_node)
+            if output.type == "as_tensors":
+                self.deserialize_multiple_outputs(serialized_node, fx_node)
+
         elif isinstance(target, torch._ops.OpOverload):
             # For convenience: if this node returns a single tensor, name the
             # newly-created node after it. This ensures that these tensor values


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107837
* #107818

Summary: Previously serializing graphs using map would error
because map returns a singleton tensor list rather than a
single tensor. So this diff adds support for if a higher order operator
returns a list of tensors as output.

We also run into an issue with roundtripping the source_fn on
map nodes/subgraphs. The source_fn originally is
<functorch.experimental._map.MapWrapper object at 0x7f80a0549930>, which
serializes to `functorch.experimental._map.map`. However, we are unable
to construct the function from this string. This should be fixed once
map becomes a fully supported operator like
torch.ops.higher_order.cond.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D48631302](https://our.internmc.facebook.com/intern/diff/D48631302)