### PR TITLE
[exportdb] Fix generating docs

### DIFF
--- a/docs/source/scripts/exportdb/generate_example_rst.py
+++ b/docs/source/scripts/exportdb/generate_example_rst.py
@@ -145,7 +145,11 @@ def generate_tag_rst(tag_to_modules):
 
     for tag, modules_rst in tag_to_modules.items():
         doc_contents = f"{tag}\n{'=' * (len(tag) + 4)}\n"
-        doc_contents += "\n\n".join(modules_rst).replace("=", "-")
+        full_modules_rst = "\n\n".join(modules_rst)
+        full_modules_rst = re.sub(
+            r"={3,}", lambda match: "-" * len(match.group()), full_modules_rst
+        )
+        doc_contents += full_modules_rst
 
         with open(os.path.join(EXPORTDB_SOURCE, f"{tag}.rst"), "w") as f:
             f.write(doc_contents)


### PR DESCRIPTION
Previously I accidentally replaced all `=` with `-`, resulting in clowny code rendering like: 
![image](https://github.com/pytorch/pytorch/assets/10901756/738eaf92-8cc6-43bd-b531-224ec44afa9f)

The purpose of replacing the `=` with `-` is to change the RST heading size of modules. So now, I replace strings with more than 3 `=`'s with `-`. This should avoid incorrectly replacing code where we set variables with `=` and do equality checks with `==`.