### PR TITLE
Fix sym_{sizes,strides} slow path

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1864,6 +1864,40 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
         # https://github.com/pytorch/pytorch/issues/79079
         self.assertFalse(torch._C._dispatch_isTensorSubclassLike(torch.empty(0)))
 
+    def test_sym_sizes_strides_slow_path(self):
+        class TestTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, *args, **kwargs):
+                r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+                    cls, (0,), dispatch_sizes_strides_policy="sizes")
+                return r
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                if func in (
+                    torch.ops.aten.sym_size.default,
+                    torch.ops.aten.sym_stride.default
+                ):
+                    from torch._dynamo.source import ConstantSource
+                    from torch.fx.experimental.symbolic_shapes import ShapeEnv, DimDynamic
+                    shape_env = ShapeEnv()
+                    si = shape_env.create_symintnode(
+                        shape_env.create_symbol(
+                            123,
+                            source=ConstantSource(f"abc"),
+                            dynamic_dim=DimDynamic.DUCK,
+                            constraint_dim=None,
+                        ),
+                        hint=123
+                    )
+                    return (si,)
+
+        t = TestTensor()
+        si = t.size()[0]
+        self.assertIsInstance(si, torch.SymInt)
+        si = t.stride()[0]
+        self.assertIsInstance(si, torch.SymInt)
+
     def test_strides_slow_path(self):
         for use_wrapper_subclass in [True, False]:
             class StridesNotImplemented(torch.Tensor):

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1884,7 +1884,7 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
                     si = shape_env.create_symintnode(
                         shape_env.create_symbol(
                             123,
-                            source=ConstantSource(f"abc"),
+                            source=ConstantSource("abc"),
                             dynamic_dim=DimDynamic.DUCK,
                             constraint_dim=None,
                         ),

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -592,7 +592,7 @@ static void set_tensor_attr_with_capsule(
     py::capsule& capsule,
     const char* attr_name) {
   c10::optional<PyObject*> mb_obj =
-    tensor->pyobj_slot()->check_pyobj(getPyInterpreter());
+      tensor->pyobj_slot()->check_pyobj(getPyInterpreter());
   TORCH_CHECK(
       mb_obj.has_value(), "Tensor subclass's PyInterpreter has no value");
   py::handle(mb_obj.value()).attr(attr_name) = capsule;
@@ -624,18 +624,17 @@ c10::IntArrayRef ConcretePyInterpreterVTable::sizes(
       "sizes must be a list or a tuple");
   int64_t len = py::len(out);
   int64_t* ptr = new int64_t[len];
-  auto capsule = py::capsule(ptr, [](void* p) {
-    delete[] reinterpret_cast<int64_t*>(p);
-  });
+  auto capsule =
+      py::capsule(ptr, [](void* p) { delete[] reinterpret_cast<int64_t*>(p); });
   int64_t idx = 0;
   for (auto it = out.begin(); it != out.end(); ++it, ++idx) {
     ptr[idx] = py::cast<int64_t>(*it);
+  }
   set_tensor_attr_with_capsule(
       const_cast<c10::TensorImpl*>(self), capsule, "_sizes_capsule");
   return c10::IntArrayRef(ptr, len);
   END_HANDLE_TH_ERRORS_PYBIND
 }
-
 
 c10::SymIntArrayRef ConcretePyInterpreterVTable::sym_sizes(
     const c10::TensorImpl* self) const {
@@ -661,12 +660,12 @@ c10::SymIntArrayRef ConcretePyInterpreterVTable::sym_sizes(
       "sym_size must be a list or a tuple");
   int64_t len = py::len(out);
   c10::SymInt* ptr = new c10::SymInt[len];
-  auto capsule = py::capsule(ptr, [](void* p) {
-    delete[] reinterpret_cast<c10::SymInt*>(p);
-  });
+  auto capsule = py::capsule(
+      ptr, [](void* p) { delete[] reinterpret_cast<c10::SymInt*>(p); });
   int64_t idx = 0;
   for (auto it = out.begin(); it != out.end(); ++it, ++idx) {
     ptr[idx] = py::cast<c10::SymInt>(*it);
+  }
   set_tensor_attr_with_capsule(
       const_cast<c10::TensorImpl*>(self), capsule, "_sym_sizes_capsule");
   return c10::SymIntArrayRef(ptr, len);
@@ -770,12 +769,12 @@ c10::SymIntArrayRef ConcretePyInterpreterVTable::sym_strides(
       "sym_strides must be a list or a tuple");
   int64_t len = py::len(out);
   c10::SymInt* ptr = new c10::SymInt[len];
-  auto capsule = py::capsule(ptr, [](void* p) {
-    delete[] reinterpret_cast<c10::SymInt*>(p);
-  });
+  auto capsule = py::capsule(
+      ptr, [](void* p) { delete[] reinterpret_cast<c10::SymInt*>(p); });
   int64_t idx = 0;
   for (auto it = out.begin(); it != out.end(); ++it, ++idx) {
     ptr[idx] = py::cast<c10::SymInt>(*it);
+  }
   set_tensor_attr_with_capsule(
       const_cast<c10::TensorImpl*>(self), capsule, "_sym_strides_capsule");
   return c10::SymIntArrayRef(ptr, len);

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -47,7 +47,6 @@ __all__ = [
     "is_tensor_method_or_property",
     "wrap_torch_function",
     "enable_reentrant_dispatch",
-    "get_buffer",
 ]
 
 @functools.lru_cache(None)
@@ -1907,13 +1906,3 @@ def enable_reentrant_dispatch():
             yield
         finally:
             pass
-
-def get_buffer(tensor_subclass, data, prefix):
-    import ctypes
-    assert prefix in {"stride", "size", "sym_size"}
-    buffer_name = f"_{prefix}_buffer"
-    if not hasattr(tensor_subclass, buffer_name):
-        SizeType = ctypes.c_longlong * len(data)
-        setattr(tensor_subclass, buffer_name, SizeType(*data))
-    ptr = ctypes.addressof(getattr(tensor_subclass, buffer_name))
-    return (ptr, len(data))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #107089
* __->__ #107839

Previously, when SymInt is returned from sym_sizes slow path, it would segfault.

This is useful for tensors that have symbolic sizes and use the sym_sizes slow path, e.g. NestedTensor returning SingletonSymInt as its sizes in the slow path.

See also: https://github.com/pytorch/pytorch/pull/106405/files#r1303714865