### PR TITLE
[ROCM] Add ROCm support to debug_dump and enable_debug_mode

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -243,7 +243,7 @@ void CUDAGraph::replay() {
 }
 
 void CUDAGraph::enable_debug_mode() {
-#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
+#if (!defined(USE_ROCM) || ROCM_VERSION >= 50300) || (defined(USE_ROCM) && ROCM_VERSION >= 50600)
   _cuda_graphs_debug = true;
 #else
   TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");
@@ -252,7 +252,7 @@ void CUDAGraph::enable_debug_mode() {
 }
 
 void CUDAGraph::debug_dump(const std::string& debug_path) {
-#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11030)
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11030)|| (defined(USE_ROCM) && ROCM_VERSION >= 50600)
   if (_cuda_graphs_debug) {
     TORCH_WARN("DEBUG: calling debug_dump()");
     if (has_graph_) {
@@ -264,7 +264,7 @@ void CUDAGraph::debug_dump(const std::string& debug_path) {
     TORCH_WARN("CUDA Graphs debug not enabled, set with torch._C._cuda_enable_graphs_debug_mode");
   }
 #else
-  TORCH_CHECK(false, "CUDA graphs may only be used in Pytorch built with CUDA >= 11.3 and is not yet supported on ROCM");
+  TORCH_CHECK(false, "CUDA graphs may only be used in Pytorch built with CUDA >= 11.3 or ROCM >= 5.6");
 #endif
 }
 

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -243,7 +243,7 @@ void CUDAGraph::replay() {
 }
 
 void CUDAGraph::enable_debug_mode() {
-#if (!defined(USE_ROCM) || ROCM_VERSION >= 50300)
+#if !defined(USE_ROCM) || ROCM_VERSION >= 50300
   _cuda_graphs_debug = true;
 #else
   TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -243,7 +243,7 @@ void CUDAGraph::replay() {
 }
 
 void CUDAGraph::enable_debug_mode() {
-#if (!defined(USE_ROCM) || ROCM_VERSION >= 50300) || (defined(USE_ROCM) && ROCM_VERSION >= 50600)
+#if (!defined(USE_ROCM) || ROCM_VERSION >= 50300)
   _cuda_graphs_debug = true;
 #else
   TORCH_CHECK(false, "CUDA graphs is not yet supported on ROCM");


### PR DESCRIPTION
enable_debug_mode and debug_dump are enabled in ROCM releases.  Add ROCM flags to #if defines so they can be accessed by PyTorch users.

Fixes #ISSUE_NUMBER


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang