### PR TITLE
Throw error if setting static grads to `None` in `zero_grad()`

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -303,6 +303,18 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
     def test_mark_static_address_unguarded(self):
         self._test_mark_static_address(guarded=False)
 
+    def test_optimizer_zero_grad_static_err(self):
+        mod = torch.nn.Linear(10, 10)
+
+        for param in mod.parameters():
+            param.grad = torch.randn_like(param)
+            torch._dynamo.mark_static_address(param.grad)
+
+        optim = torch.optim.SGD(mod.parameters(), lr=1e-2)
+
+        with self.assertRaises(RuntimeError):
+            optim.zero_grad(set_to_none=True)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -789,6 +789,7 @@ class Optimizer:
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
+        from torch._dynamo.utils import get_static_address_type
         foreach = self.defaults.get('foreach', False) or self.defaults.get('fused', False)
 
         if not hasattr(self, "_zero_grad_profile_name"):
@@ -804,7 +805,7 @@ class Optimizer:
             for group in self.param_groups:
                 for p in group['params']:
                     if p.grad is not None:
-                        if set_to_none:
+                        if set_to_none and get_static_address_type(p.grad) is not None:
                             p.grad = None
                         else:
                             if p.grad.grad_fn is not None:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -805,7 +805,11 @@ class Optimizer:
             for group in self.param_groups:
                 for p in group['params']:
                     if p.grad is not None:
-                        if set_to_none and get_static_address_type(p.grad) is None:
+                        if set_to_none:
+                            if get_static_address_type(p.grad) is not None:
+                                raise RuntimeError("zero_grad(set_to_none=True) only expects grads that"
+                                                   "are not marked as tensors with static addresses. "
+                                                   "Use zero_grad(set_to_none=False) instead.")
                             p.grad = None
                         else:
                             if p.grad.grad_fn is not None:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -807,9 +807,9 @@ class Optimizer:
                     if p.grad is not None:
                         if set_to_none:
                             if get_static_address_type(p.grad) is not None:
-                                raise RuntimeError("zero_grad(set_to_none=True) only expects grads that"
-                                                   "are not marked as tensors with static addresses. "
-                                                   "Use zero_grad(set_to_none=False) instead.")
+                                raise RuntimeError("Default zero_grad(set_to_none=True) will not respect grads that "
+                                                   "are marked as tensors with static addresses in dynamo and will "
+                                                   "set them to None. Use zero_grad(set_to_none=False) instead.")
                             p.grad = None
                         else:
                             if p.grad.grad_fn is not None:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -805,7 +805,7 @@ class Optimizer:
             for group in self.param_groups:
                 for p in group['params']:
                     if p.grad is not None:
-                        if set_to_none and get_static_address_type(p.grad) is not None:
+                        if set_to_none and get_static_address_type(p.grad) is None:
                             p.grad = None
                         else:
                             if p.grad.grad_fn is not None:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -807,9 +807,10 @@ class Optimizer:
                     if p.grad is not None:
                         if set_to_none:
                             if get_static_address_type(p.grad) is not None:
-                                raise RuntimeError("Default zero_grad(set_to_none=True) will not respect grads that "
-                                                   "are marked as tensors with static addresses in dynamo and will "
-                                                   "set them to None. Use zero_grad(set_to_none=False) instead.")
+                                err = ("Default zero_grad(set_to_none=True) will not respect grads that "
+                                       "are marked as tensors with static addresses in dynamo and will "
+                                       "set them to None. Use zero_grad(set_to_none=False) instead.")
+                                raise RuntimeError(err)
                             p.grad = None
                         else:
                             if p.grad.grad_fn is not None:


### PR DESCRIPTION
If a tensor is marked a static address for dynamo, this implies that the pointer will be the same across calls to the optimizer step. For this constraint to hold, we should not set grads marked as static to None. 

After some discussion, I opted to throw an error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @Xia-Weiwen