### PR TITLE
[clang-tidy] Get rid of WarningsAsErrors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,5 +46,4 @@ readability-container-size-empty,
 '
 HeaderFilterRegex: '^(c10/(?!test)|torch/csrc/(?!deploy/interpreter/cpython)).*$'
 AnalyzeTemporaryDtors: false
-WarningsAsErrors: '*'
 ...


### PR DESCRIPTION
Summary: WarningsAsErrors is very dangerous option reported several times

Test Plan: N/A

Differential Revision: D48646569

