### PR TITLE
[c10d] Increase socket buffer size to allow ProcessGroup init up to 12k ranks

### DIFF
--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -562,7 +562,7 @@ bool SocketListenOp::tryListen(const ::addrinfo& addr) {
   }
 
   // NOLINTNEXTLINE(bugprone-argument-comment)
-  if (::listen(socket_->handle(), /*backlog=*/2048) != 0) {
+  if (::listen(socket_->handle(), -1 /* backlog */) != 0) {
     recordError(
         "The server socket has failed to listen on {} {}.",
         addr,
@@ -614,7 +614,7 @@ std::unique_ptr<SocketImpl> SocketListenFromFdOp::run() const {
         expected_port_)};
   }
 
-  if (::listen(socket->handle(), 2048 /* backlog */) != 0) {
+  if (::listen(socket->handle(), -1 /* backlog */) != 0) {
     throw SocketError{fmt::format(
         "Failed to listen on socket initialized from fd {}: {}.",
         socket->handle(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107878

The c10d socket and gloo listener both set their buffer size to 2048 which causes connection issue at 4k scale. This diff sets the buffer size to `-1` which uses `somaxconn` as the actual buffer size, aiming to enable 24k PG init without crash. The experiment shows the ability to successful creation of 12k ranks without crash.

split the original diff for OSS vs. internal.

Caution: we need the change on both gloo and c10d to enable 12k PG init. Updating only one side may not offer the benefit.

Differential Revision: [D48634654](https://our.internmc.facebook.com/intern/diff/D48634654/)