### PR TITLE
[inductor][fx passes] batch tanh in pre grad

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -198,6 +198,20 @@ class MyModule5(torch.nn.Module):
         return torch.sin(l1_out)
 
 
+class MyModule6(torch.nn.Module):
+    def __init__(self, device, has_bias=True):
+        super().__init__()
+        self.device = device
+
+    def forward(self, x):
+        inputs = torch.split(x.to(self.device), 500, dim=1)
+        x_split = torch.split(inputs[0].to(self.device), 100, dim=1)
+        y_split = torch.split(inputs[1].to(self.device), 100, dim=1)
+        tanh_1 = [torch.tanh(x_split[i]) for i in range(len(x_split))]
+        tanh_2 = [torch.tanh(y_split[i]) for i in range(len(y_split))]
+        return torch.cat(tanh_1, dim=1) + torch.cat(tanh_2, dim=1)
+
+
 @requires_cuda()
 @torch._inductor.config.patch(group_fusion=True, batch_fusion=True)
 class TestGroupBatchFusion(TestCase):
@@ -370,6 +384,29 @@ class TestGroupBatchFusion(TestCase):
             self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
             self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
             counters.clear()
+
+    def test_batch_tanh_pre_grad_fusion(self):
+        counters.clear()
+        module = MyModule6("cuda")
+        input = [torch.randn(50, 1000, requires_grad=True, device="cuda")]
+        traced = torch.compile(module)
+        ref = module(*input)
+        res = traced(*input)
+        self.compare_pred(module, traced, input)
+        self.assertEqual(counters["inductor"]["batch_fusion"], 2)
+        self.assertEqual(
+            counters["inductor"]["scmerge_split_removed"],
+            2,
+        )
+        self.assertEqual(
+            counters["inductor"]["scmerge_cat_removed"],
+            2,
+        )
+        ref.sum().backward()
+        res.sum().backward()
+        self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
+        self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
+        counters.clear()
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -291,6 +291,63 @@ class BatchLinearFusion(BatchFusion):
                 graph.erase_node(linear)
 
 
+class BatchTanhFusion(BatchFusion):
+    """
+    Batch tanh fusion in pre grad pass.
+    We only fuse the tahn if the input is after same split node.
+    """
+
+    def _getitem_args(self, getitem_node: torch.fx.Node):
+        if getitem_node.target != operator.__getitem__ or (
+            getitem_node.op != "call_function"
+        ):
+            return None
+        return getitem_node.args[0]
+
+    def match(self, node):
+        input = get_arg_value(node, 0, "input")
+        if (
+            CallFunctionVarArgs(torch.tanh).match(node)
+            and is_node_meta_valid(node)
+            and self._getitem_args(input) is not None
+        ):
+            group_key = (
+                "batch_tanh",
+                self._getitem_args(input),
+                str(input.meta["example_value"].shape),
+            )
+        else:
+            group_key = None
+        return group_key
+
+    def fuse(self, graph, subset):
+        batch_nodes = []
+        batch_inputs = []
+
+        for node in subset:
+            batch_nodes.append(node)
+            batch_inputs.append(get_arg_value(node, 0, "input"))
+
+        with graph.inserting_before(subset[0]):
+            stack_inputs = graph.call_function(torch.stack, args=(batch_inputs, 0))
+
+            batch_tanh = graph.call_function(
+                torch.tanh,
+                args=(stack_inputs,),
+            )
+            unbind_tanh = graph.call_function(
+                torch.unbind, args=(batch_tanh,), kwargs={"dim": 0}
+            )
+            for i, node in enumerate(batch_nodes):
+                with graph.inserting_after(unbind_tanh):
+                    getitem = graph.call_function(
+                        operator.getitem, args=(unbind_tanh, i)
+                    )
+                node.replace_all_uses_with(getitem)
+                getitem.meta.update(node.meta)
+                graph.erase_node(node)
+
+
 class BatchLayernormFusion(BatchFusion):
     """
     Batch layer norm fusion in pre grad pass
@@ -508,6 +565,11 @@ def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
 def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
     fusions = []
     if config.batch_fusion:
-        fusions += [BatchLinearFusion(), BatchLinearLHSFusion(), BatchLayernormFusion()]
+        fusions += [
+            BatchLinearFusion(),
+            BatchLinearLHSFusion(),
+            BatchLayernormFusion(),
+            BatchTanhFusion(),
+        ]
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)


### PR DESCRIPTION
Summary:
Daohang report this pattern in f469463749
{F1074472207}
 {F1074473348}
Hence, we can fuse the tanh after same split.
Typically the pattern looks like split->getitem0,...n-> tanh(geitem 0,..., n). Hence, we search for parent node of tahn nodes and the node should be getitem(parent, index). If tanh is after same split node, parent nodes of getitem nodes should be same.

Test Plan:
```
[jackiexu0313@devgpu005.cln5 ~/fbsource/fbcode (c78736187)]$ buck test mode/dev-nosan //caffe2/test/inductor:group_batch_fusion
File changed: fbcode//caffe2/test/inductor/test_group_batch_fusion.py
Buck UI: https://www.internalfb.com/buck2/df87affc-d294-4663-a50d-ebb71b98070d
Test UI: https://www.internalfb.com/intern/testinfra/testrun/9570149208311124
Network: Up: 0B  Down: 0B
Jobs completed: 16. Time elapsed: 1:19.9s.
Tests finished: Pass 6. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D48581140



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov