### PR TITLE
Binary out-of-place ge.Scalar / eq.Scalar support for NT

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8459,6 +8459,7 @@
   variants: method, function
   dispatch:
     QuantizedCPU: eq_quantized_cpu
+    NestedTensorCPU, NestedTensorCUDA: eq_scalar_nested
   tags: [core, pointwise]
 
 - func: eq.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
@@ -8495,6 +8496,7 @@
   variants: method, function
   dispatch:
     QuantizedCPU: ge_quantized_cpu
+    NestedTensorCPU, NestedTensorCUDA: ge_scalar_nested
   tags: [core, pointwise]
 
 - func: ge.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -305,5 +305,21 @@ Tensor& fill_nested_(Tensor& self, const Tensor& value) {
   return self;
 }
 
+Tensor ge_scalar_nested(const Tensor& self, const Scalar& other) {
+  return NestedTensor_elementwise_Tensor(
+      self, wrapped_scalar_tensor(other), "ge", false /*supports_striding*/,
+      [](const Tensor& b1, const Tensor& b2) {
+        return b1.ge(b2);
+      });
+}
+
+Tensor eq_scalar_nested(const Tensor& self, const Scalar& other) {
+  return NestedTensor_elementwise_Tensor(
+      self, wrapped_scalar_tensor(other), "eq", false /*supports_striding*/,
+      [](const Tensor& b1, const Tensor& b2) {
+        return b1.eq(b2);
+      });
+}
+
 } // namespace native
 } // namespace at

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -879,6 +879,20 @@ class TestNestedTensorDeviceType(TestCase):
             "NestedTensor must be contiguous to get buffer.",
             lambda: func(nt_noncontiguous))
 
+    @parametrize("func", [subtest(torch.ge, name='ge'),
+                          subtest(torch.eq, name='eq')])
+    def test_binary_ops_with_scalar(self, device, func):
+        nt_contiguous, nt_noncontiguous = random_nt_noncontiguous_pair(
+            (2, 3, 6, 7), device=device, dtype=torch.float32)
+        scalar = 0.0
+
+        # should work regardless of contiguity
+        for nt in (nt_contiguous, nt_noncontiguous):
+            nested_result = func(nt, scalar)
+            self.assertTrue(nested_result.is_nested)
+            for t, t_res in zip(nt.unbind(), nested_result.unbind()):
+                self.assertEqual(func(t, scalar), t_res)
+
     @dtypes(*floating_types_and_half())
     def test_nested_tensor_chunk(self, device, dtype):
         # Transformer use case


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #106785
* #106786
* #107890
* __->__ #107892
* #107891

