### PR TITLE
[cuda] Fix the incorrect types in int8_gemm

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1023,7 +1023,7 @@ void int8_gemm(
       reinterpret_cast<cublasLtHandle_t>(at::cuda::getCurrentCUDABlasHandle());
 
   // cublas team: alpha and beta need to be the same dtype as of scaleType
-  at::opmath_type<int32_t> alpha_val = 1.0;
+  at::opmath_type<int32_t> alpha_val = 1;
   int32_t beta_val = 0;
 
   cublasStatus_t cublasStatus = cublasLtMatmul(

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1022,8 +1022,10 @@ void int8_gemm(
   cublasLtHandle_t ltHandle =
       reinterpret_cast<cublasLtHandle_t>(at::cuda::getCurrentCUDABlasHandle());
 
-  at::opmath_type<int8_t> alpha_val = 1.0;
-  float beta_val = 0;
+  // cublas team: alpha and beta need to be the same dtype as of scaleType
+  at::opmath_type<int32_t> alpha_val = 1.0;
+  int32_t beta_val = 0;
+
   cublasStatus_t cublasStatus = cublasLtMatmul(
       ltHandle,
       computeDesc.descriptor(),


### PR DESCRIPTION
Fixes #107671

From cublas team: alpha and beta need to be of the same C++ type as of scaleType, which is `int32_t` here.

cc @csarofeen @ptrblck @eqy @albanD 