### PR TITLE
[reland][inductor] make thread order consistent with loop order

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -3,6 +3,9 @@
 import sys
 import unittest
 
+from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
 try:
     import triton  # noqa: F401
 except ImportError:
@@ -29,4 +32,5 @@ class TestTritonHeuristics(TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    if IS_LINUX and HAS_CUDA:
+        run_tests()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -4,15 +4,16 @@ import sys
 import unittest
 
 try:
-    import triton
+    import triton  # noqa: F401
 except ImportError:
     if __name__ == "__main__":
         sys.exit(0)
     raise unittest.SkipTest("requires triton")
 
 from torch._dynamo.test_case import run_tests, TestCase
+from torch._inductor import config
 from torch._inductor.triton_heuristics import triton_config
-from  torch._inductor import config
+
 
 class TestTritonHeuristics(TestCase):
     def test_triton_config(self):
@@ -25,6 +26,7 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= config.triton.max_block[label])
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1,0 +1,30 @@
+# Owner(s): ["module: inductor"]
+
+import sys
+import unittest
+
+try:
+    import triton
+except ImportError:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest("requires triton")
+
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._inductor.triton_heuristics import triton_config
+from  torch._inductor import config
+
+class TestTritonHeuristics(TestCase):
+    def test_triton_config(self):
+        """
+        Make sure block size does not exceed the maximum defined in inductor config.
+        """
+        cfg = triton_config([2048, 2], 64, 64)
+        for label in "XYZ":
+            key = f"{label}BLOCK"
+            if key not in cfg.kwargs:
+                continue
+            self.assertTrue(cfg.kwargs[key] <= config.triton.max_block[label])
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -833,11 +833,14 @@ class TritonKernel(Kernel):
         )
 
     def initialize_range_tree(self, pid_cache):
-        names = ["xindex", "yindex", "zindex"][: len(self.numels) - 1] + ["rindex"]
+        names = list(
+            reversed(["xindex", "yindex", "zindex"][: len(self.numels) - 1])
+        ) + ["rindex"]
         for i in range(len(self.numels)):
+            pid_idx = i if names[i][0] == "r" else "xyz".find(names[i][0])
             self.range_trees.append(
                 IterationRangesRoot(
-                    names[i], self.numels[i], names[i][0], i, self, pid_cache
+                    names[i], self.numels[i], names[i][0], pid_idx, self, pid_cache
                 )
             )
         for tree in self.range_trees:
@@ -2000,6 +2003,13 @@ class TritonKernel(Kernel):
                 sizes.append(f"{tree.prefix.upper()}BLOCK")
             elif tree.prefix == "r" and tree.numel != 1:
                 sizes.append("1")
+
+        if sizes[0:3] == ["ZBLOCK", "YBLOCK", "XBLOCK"]:
+            sizes[0:3] = reversed(sizes[0:3])
+
+        if sizes[0:2] == ["YBLOCK", "XBLOCK"]:
+            sizes[0:2] = reversed(sizes[0:2])
+
         return f"[{', '.join(sizes)}]"
 
     def call_kernel(self, name: str):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -905,15 +905,15 @@ def pick_loop_order(stride_lengths, sizes, priority_idx=()):
 
         # equivalent to
         # np.logical_or(stride_lengths[:, b] == 0, stride_lengths[:, a] < stride_lengths[:, b]).all()
-        a_first = all(
+        a_first = sum(
             sl_b == 0 or sl_a < sl_b for sl_a, sl_b in zip(stride_len_a, stride_len_b)
         )
-        b_first = all(
+        b_first = sum(
             sl_a == 0 or sl_b < sl_a for sl_a, sl_b in zip(stride_len_a, stride_len_b)
         )
-        if a_first and not b_first:
+        if a_first > b_first:
             return -1
-        if b_first and not a_first:
+        if b_first > a_first:
             return 1
 
         # otherwise contiguous

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -672,6 +672,10 @@ def triton_config(
     override the num_elements_per_warp.
     """
     # Ideally we want to read this from some device config
+
+    # for a 2d size_hints [a, b], a should be mapped to YBLOCK rather than XBLOCK
+    size_hints = list(reversed(size_hints))
+
     maxGridSize = [2147483647, 65535, 65535]
 
     target = conditional_product(x, y, z)
@@ -687,13 +691,13 @@ def triton_config(
 
     # if we are below original block size, scale up where we can;
     # or if the calculated grid size is larger than the limit, we bump up the corresponding dimension
-    while x < size_hints[0] and (
+    while x < min(size_hints[0], config.triton.max_block["X"]) and (
         x * maxGridSize[0] < size_hints[0] or conditional_product(x, y, z) < target
     ):
         x *= 2
     while (
         y
-        and y < size_hints[1]
+        and y < min(size_hints[1], config.triton.max_block["Y"])
         and (
             y * maxGridSize[1] < size_hints[1] or conditional_product(x, y, z) < target
         )
@@ -701,7 +705,7 @@ def triton_config(
         y *= 2
     while (
         z
-        and z < size_hints[2]
+        and z < min(size_hints[2], config.triton.max_block["Z"])
         and (
             z * maxGridSize[2] < size_hints[2] or conditional_product(x, y, z) < target
         )
@@ -1005,8 +1009,17 @@ def foreach(meta, num_warps, filename=None):
     )
 
 
-def grid(xnumel, ynumel=None, znumel=None):
+def grid(*numels):
     """Helper function to compute triton grids"""
+
+    if len(numels) == 1:
+        xnumel, ynumel, znumel = numels[0], None, None
+    elif len(numels) == 2:
+        xnumel, ynumel, znumel = numels[1], numels[0], None
+    elif len(numels) == 3:
+        xnumel, ynumel, znumel = numels[2], numels[1], numels[0]
+    else:
+        raise AssertionError(f"invalid size for numels {len(numels)}")
 
     def get_grid_dim(numel, block):
         if numel is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107902

This PR relands https://github.com/pytorch/pytorch/pull/106827 which get reverted because of causing compilation error for some ads model.

Yanbo provide a repro in one of the 14k model ( `pytest ./generated/test_KaiyangZhou_deep_person_reid.py -k test_044`). This is also the model I used to confirm the fix and come up with a unit test. In this model, we call `tritoin_heuristics.triton_config` with size_hints [2048, 2]. Previously this would result in a trition config with XBLOCK=2048 and YBLOCK=2 . But since we change the mapping between size_hints and XYZ dimension, we now generate a triton config with XBLOCK=2 and YBLOCK=2048.  This fails compilation since we set max YBLOCK to be 1024.

My fix is to make sure we never generate a triton config that exceeds the maximum block size.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov