### PR TITLE
Make openxla and opexla_eval backend show up in list_backends

### DIFF
--- a/torch/_dynamo/backends/torchxla.py
+++ b/torch/_dynamo/backends/torchxla.py
@@ -4,17 +4,21 @@ import warnings
 from functorch.compile import make_boxed_func
 
 from ..backends.common import aot_autograd
-from ..backends.registry import register_experimental_backend as register_backend
+from ..backends.registry import (
+    register_experimental_backend as register_experimental_backend,
+)
+
+from .registry import register_backend
 
 log = logging.getLogger(__name__)
 
 
-@register_backend
+@register_experimental_backend
 def torchxla_trivial(gm, fake_tensor_inputs):
     return gm
 
 
-@register_backend
+@register_experimental_backend
 def torchxla_trace_once(model, fake_tensor_inputs):
     warnings.warn(
         "This backend will be deprecated in 2.2, please use `openxla` backend instead"
@@ -33,7 +37,12 @@ def openxla_eval_boxed(model, fake_tensor_inputs):
 
 
 def xla_backend_helper(model, fake_tensor_inputs, boxed=False):
-    import torch_xla.core.dynamo_bridge as bridge  # type: ignore[import]
+    try:
+        import torch_xla.core.dynamo_bridge as bridge  # type: ignore[import]
+    except ImportError:
+        raise ImportError(
+            "Please follow the instruction in https://github.com/pytorch/xla#pytorchxla to install torch_xla"
+        )
 
     compiled_graph = None
 
@@ -51,12 +60,16 @@ def xla_backend_helper(model, fake_tensor_inputs, boxed=False):
 aot_torchxla_trivial = aot_autograd(
     fw_compiler=torchxla_trivial,
 )
-register_backend(name="aot_torchxla_trivial", compiler_fn=aot_torchxla_trivial)
+register_experimental_backend(
+    name="aot_torchxla_trivial", compiler_fn=aot_torchxla_trivial
+)
 
 aot_torchxla_trace_once = aot_autograd(
     fw_compiler=torchxla_trace_once,
 )
-register_backend(name="aot_torchxla_trace_once", compiler_fn=aot_torchxla_trace_once)
+register_experimental_backend(
+    name="aot_torchxla_trace_once", compiler_fn=aot_torchxla_trace_once
+)
 
 openxla = aot_autograd(
     fw_compiler=openxla_eval_boxed,

--- a/torch/_dynamo/backends/torchxla.py
+++ b/torch/_dynamo/backends/torchxla.py
@@ -4,7 +4,7 @@ import warnings
 from functorch.compile import make_boxed_func
 
 from ..backends.common import aot_autograd
-from .registry import register_experimental_backend, register_backend
+from .registry import register_backend, register_experimental_backend
 
 log = logging.getLogger(__name__)
 

--- a/torch/_dynamo/backends/torchxla.py
+++ b/torch/_dynamo/backends/torchxla.py
@@ -4,11 +4,7 @@ import warnings
 from functorch.compile import make_boxed_func
 
 from ..backends.common import aot_autograd
-from ..backends.registry import (
-    register_experimental_backend as register_experimental_backend,
-)
-
-from .registry import register_backend
+from .registry import register_experimental_backend, register_backend
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
The reason to keep the non-aot(openxla_eval) backend is discussed in https://github.com/pytorch/xla/issues/5430#issuecomment-1683191662.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov