### PR TITLE
[export] Store the arguments used to trace the exported program in itself

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -78,7 +78,7 @@ class TestSerialize(TestCase):
             ),
         )
 
-        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
+        serialized = ExportedProgramSerializer().serialize(exported_module)[0]
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.native_layer_norm.default")
         # aten::native_layer_norm returns 3 tensnors
@@ -103,7 +103,7 @@ class TestSerialize(TestCase):
         input.requires_grad = True
         exported_module = export(MyModule(), (input,))
 
-        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
+        serialized = ExportedProgramSerializer().serialize(exported_module)[0]
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.split.Tensor")
         self.assertEqual(len(node.outputs), 1)
@@ -146,7 +146,7 @@ class TestSerialize(TestCase):
             (torch.ones([512, 512], requires_grad=True),),
         )
 
-        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
+        serialized = ExportedProgramSerializer().serialize(exported_module)[0]
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.var_mean.correction")
         self.assertEqual(len(node.outputs), 2)
@@ -170,7 +170,7 @@ class TestSerialize(TestCase):
 
         x, _ = torch.sort(torch.randn(3, 4))
         exported_module = export(f, (x,))
-        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
+        serialized = ExportedProgramSerializer().serialize(exported_module)[0]
 
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.searchsorted.Tensor")
@@ -190,8 +190,8 @@ class TestDeserialize(TestCase):
         ep = export(fn, inputs, {}, constraints)
         ep.graph.eliminate_dead_code()
 
-        serialized_struct, state_dict, orig_args = serialize(ep, opset_version={"aten": 0})
-        deserialized_ep = deserialize(serialized_struct, state_dict, orig_args, expected_opset_version={"aten": 0})
+        serialized_struct, state_dict = serialize(ep, opset_version={"aten": 0})
+        deserialized_ep = deserialize(serialized_struct, state_dict, expected_opset_version={"aten": 0})
         deserialized_ep.graph.eliminate_dead_code()
 
         orig_outputs = ep(*inputs)
@@ -436,7 +436,9 @@ class TestSchemaVersioning(TestCase):
         serialized_ep, serialized_state_dict = ExportedProgramSerializer().serialize(ep)
         serialized_ep.schema_version = -1
         with self.assertRaisesRegex(SerializeError, r"Serialized schema version -1 does not match our current"):
-            ExportedProgramDeserializer().deserialize(serialized_ep, serialized_state_dict)
+            ExportedProgramDeserializer().deserialize(
+                serialized_ep, serialized_state_dict
+            )
 
 
 class TestOpVersioning(TestCase):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -78,7 +78,7 @@ class TestSerialize(TestCase):
             ),
         )
 
-        serialized, _ = ExportedProgramSerializer().serialize(exported_module)
+        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.native_layer_norm.default")
         # aten::native_layer_norm returns 3 tensnors
@@ -103,7 +103,7 @@ class TestSerialize(TestCase):
         input.requires_grad = True
         exported_module = export(MyModule(), (input,))
 
-        serialized, _ = ExportedProgramSerializer().serialize(exported_module)
+        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.split.Tensor")
         self.assertEqual(len(node.outputs), 1)
@@ -146,7 +146,7 @@ class TestSerialize(TestCase):
             (torch.ones([512, 512], requires_grad=True),),
         )
 
-        serialized, _ = ExportedProgramSerializer().serialize(exported_module)
+        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.var_mean.correction")
         self.assertEqual(len(node.outputs), 2)
@@ -170,7 +170,7 @@ class TestSerialize(TestCase):
 
         x, _ = torch.sort(torch.randn(3, 4))
         exported_module = export(f, (x,))
-        serialized, _ = ExportedProgramSerializer().serialize(exported_module)
+        serialized, *_ = ExportedProgramSerializer().serialize(exported_module)
 
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.searchsorted.Tensor")
@@ -190,8 +190,8 @@ class TestDeserialize(TestCase):
         ep = export(fn, inputs, {}, constraints)
         ep.graph.eliminate_dead_code()
 
-        serialized_struct, state_dict = serialize(ep, opset_version={"aten": 0})
-        deserialized_ep = deserialize(serialized_struct, state_dict, expected_opset_version={"aten": 0})
+        serialized_struct, state_dict, orig_args = serialize(ep, opset_version={"aten": 0})
+        deserialized_ep = deserialize(serialized_struct, state_dict, orig_args, expected_opset_version={"aten": 0})
         deserialized_ep.graph.eliminate_dead_code()
 
         orig_outputs = ep(*inputs)

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -442,7 +442,6 @@ def save(
     from .serde.serialize import serialize
     from .serde.schema import SCHEMA_VERSION
     serialized_program, serialized_state_dict = serialize(ep, opset_version)
-    serialized_orig_args = serialize_torch_artifact(ep.original_traced_arguments)
 
     if isinstance(f, (str, pathlib.Path)):
         f = str(f)
@@ -451,7 +450,6 @@ def save(
         # Save serialized_ep and serialized_state_dict to the zip file
         zipf.writestr('serialized_exported_program.json', serialized_program)
         zipf.writestr('serialized_state_dict.json', serialized_state_dict)
-        zipf.writestr('serialized_original_args.json', serialized_orig_args)
         zipf.writestr('version', str(SCHEMA_VERSION))
 
         # Add extra files if provided
@@ -484,12 +482,10 @@ def load(
         # Load serialized_ep and serialized_state_dict from the zip file
         serialized_ep = zipf.read('serialized_exported_program.json')
         serialized_state_dict = zipf.read('serialized_state_dict.json')
-        serialized_orig_args = zipf.read('serialized_original_args.json')
 
         # Deserialize ExportedProgram
-        from .serde.serialize import deserialize, deserialize_torch_artifact
+        from .serde.serialize import deserialize
         ep = deserialize(serialized_ep, serialized_state_dict, expected_opset_version)
-        original_args = deserialize_torch_artifact(serialized_orig_args)
 
         # Populate extra_files map
         if extra_files is not None:

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -413,6 +413,7 @@ def export(
         range_constraints,
         equality_constraints,
         [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
+        args,
     )
 
     exported_program = exported_program.transform(

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -259,3 +259,4 @@ class ExportedProgram:
     range_constraints: Dict[str, RangeConstraint]
     equality_constraints: List[Tuple[Tuple[str, int], Tuple[str, int]]]
     schema_version: int
+    original_traced_arguments: str

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -11,7 +11,7 @@ import typing
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union, Iterable
 
 import sympy
 
@@ -19,7 +19,7 @@ import torch
 import torch._export.exported_program as ep
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
-from torch.utils._pytree import pytree_to_str, str_to_pytree
+from torch.utils._pytree import pytree_to_str, str_to_pytree, tree_map_only
 
 from .schema import (  # type: ignore[attr-defined]
     _Union,
@@ -242,27 +242,27 @@ def deserialize_signature(sig: GraphSignature) -> ep.ExportGraphSignature:
     )
 
 
-def serialize_state_dict(state_dict: Dict[str, Any]) -> bytes:
+def serialize_torch_artifact(artifact: Union[Dict[str, Any], Iterable[Any]]) -> bytes:
     buffer = io.BytesIO()
-    state_dict = dict(state_dict)
-    for name in state_dict:
-        # This is a workaround for backend's tensor deserialization problem:
-        # unpickleTensor() always create a tensor on the device where it was originally saved
-        # This behavior is bad for multi-gpu training, as we wish to directly load the tensor
-        # on the designated device.
-        # For now, we simply move the tensor to cpu before saving.
-        # TODO: this should be fixed by deserialization instead.
-        state_dict[name] = state_dict[name].cpu()
-    torch.save(state_dict, buffer)
+    # This is a workaround for backend's tensor deserialization problem:
+    # unpickleTensor() always create a tensor on the device where it was originally saved
+    # This behavior is bad for multi-gpu training, as we wish to directly load the tensor
+    # on the designated device.
+    # For now, we simply move the tensor to cpu before saving.
+    # TODO: this should be fixed by deserialization instead.
+    artifact = tree_map_only(torch.Tensor, lambda t: t.cpu(), artifact)
+    torch.save(artifact, buffer)
     return buffer.getvalue()
 
 
-def deserialize_state_dict(serialized: bytes) -> Dict[str, torch.Tensor]:
+def deserialize_torch_artifact(serialized: bytes) -> Union[Dict[str, torch.Tensor], List[torch.Tensor]]:
     if len(serialized) == 0:
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
     return torch.load(buffer)
+
+
 
 
 
@@ -782,7 +782,7 @@ class ExportedProgramSerializer:
         if "aten" not in self.opset_version:
             self.opset_version["aten"] = torch._C._get_max_operator_version()
 
-    def serialize(self, exported_program: ep.ExportedProgram) -> Tuple[ExportedProgram, bytes]:
+    def serialize(self, exported_program: ep.ExportedProgram) -> Tuple[ExportedProgram, bytes, bytes]:
         serialized_graph_module = (
             GraphModuleSerializer(
                 exported_program.graph_signature,
@@ -801,7 +801,8 @@ class ExportedProgramSerializer:
                 equality_constraints=serialized_equality_constraints,
                 schema_version=SCHEMA_VERSION,
             ),
-            serialize_state_dict(exported_program.state_dict),
+            serialize_torch_artifact(exported_program.state_dict),
+            serialize_torch_artifact(exported_program.original_traced_arguments)
         )
 
 
@@ -1280,7 +1281,8 @@ class ExportedProgramDeserializer:
         return range_constraints
 
     def deserialize(
-        self, serialized_exported_program: ExportedProgram, serialized_state_dict: bytes
+        self, serialized_exported_program: ExportedProgram, serialized_state_dict: bytes,
+        serialized_original_traced_args: bytes,
     ) -> ep.ExportedProgram:
         if serialized_exported_program.schema_version != SCHEMA_VERSION:
             raise SerializeError(
@@ -1308,18 +1310,21 @@ class ExportedProgramDeserializer:
 
         upgrader = GraphModuleOpUpgrader(self.expected_opset_version, model_opset_version)
 
-        state_dict = deserialize_state_dict(serialized_state_dict)
+        state_dict = deserialize_torch_artifact(serialized_state_dict)
+        original_args = deserialize_torch_artifact(serialized_original_traced_args)
         equality_constraints = deserialize_equality_constraints(serialized_exported_program.equality_constraints)
+
 
         exported_program = ep.ExportedProgram(
             graph_module,
             graph_module.graph,
             sig,
             call_spec,
-            state_dict,
+            state_dict,  # type: ignore[arg-type]
             range_constraints,
             equality_constraints,
             module_call_graph,
+            original_args,  # type: ignore[arg-type]
         )
         return upgrader.upgrade(exported_program)
 
@@ -1374,15 +1379,15 @@ class EnumEncoder(json.JSONEncoder):
 def serialize(
     exported_program: ep.ExportedProgram,
     opset_version: Optional[Dict[str, int]] = None,
-) -> Tuple[bytes, bytes]:
-    serialized_exported_program, serialized_state_dict = (
+) -> Tuple[bytes, bytes, bytes]:
+    serialized_exported_program, serialized_state_dict, serialized_orig_args = (
         ExportedProgramSerializer(opset_version).serialize(exported_program)
     )
     json_program = json.dumps(
         dataclasses.asdict(serialized_exported_program), cls=EnumEncoder
     )
     json_bytes = json_program.encode('utf-8')
-    return json_bytes, serialized_state_dict
+    return json_bytes, serialized_state_dict, serialized_orig_args
 
 
 def _dict_to_dataclass(cls, data):
@@ -1420,6 +1425,7 @@ def _dict_to_dataclass(cls, data):
 def deserialize(
     exported_program_bytes: bytes,
     state_dict: bytes,
+    original_traced_args: bytes,
     expected_opset_version: Optional[Dict[str, int]] = None,
 ) -> ep.ExportedProgram:
     exported_program_str = exported_program_bytes.decode('utf-8')
@@ -1427,5 +1433,5 @@ def deserialize(
     serialized_exported_program = _dict_to_dataclass(ExportedProgram, exported_program_dict)
     return (
         ExportedProgramDeserializer(expected_opset_version)
-        .deserialize(serialized_exported_program, state_dict)
+        .deserialize(serialized_exported_program, state_dict, original_traced_args)
     )

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -234,7 +234,7 @@ class ExportedProgram:
         range_constraints: Dict[sympy.Symbol, Any],
         equality_constraints: List[Tuple[Any, Any]],
         module_call_graph: List[ModuleCallEntry],
-        original_traced_arguments: Tuple[Any, ...] = None,
+        original_traced_arguments: Tuple[Any, ...] = (),
     ):
         from torch._export.exported_program import (
             _create_graph_module_for_export,

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -234,6 +234,7 @@ class ExportedProgram:
         range_constraints: Dict[sympy.Symbol, Any],
         equality_constraints: List[Tuple[Any, Any]],
         module_call_graph: List[ModuleCallEntry],
+        original_traced_arguments: Tuple[Any, ...] = None,
     ):
         from torch._export.exported_program import (
             _create_graph_module_for_export,
@@ -258,6 +259,7 @@ class ExportedProgram:
             Tuple[InputDim, InputDim]
         ] = equality_constraints
         self._module_call_graph: List[ModuleCallEntry] = module_call_graph
+        self._original_traced_arguments = original_traced_arguments
 
     @property
     @compatibility(is_backward_compatible=False)
@@ -298,6 +300,11 @@ class ExportedProgram:
     @compatibility(is_backward_compatible=False)
     def module_call_graph(self):
         return self._module_call_graph
+
+    @property
+    @compatibility(is_backward_compatible=False)
+    def original_traced_arguments(self):
+        return self._original_traced_arguments
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         import torch._export.error as error
@@ -528,6 +535,7 @@ class ExportedProgram:
             _get_updated_range_constraints(transformed_gm),
             copy.deepcopy(self.equality_constraints),
             copy.deepcopy(self._module_call_graph),
+            self.original_traced_arguments,
         )
         transformed_ep.graph_module.meta.update(self.graph_module.meta)
         transformed_ep.graph_module.meta.update(res.graph_module.meta)


### PR DESCRIPTION
Proper fix would be to do something like https://github.com/pytorch/pytorch/pull/107877, but since that depends on internal changes and it would take too long for diff train to land we will first just make OSS work using torch.save.

Added the original arguments to the serialized exported program as it is a state on the exported artifact.