### PR TITLE
improved error message for IO mismatch

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2185,7 +2185,6 @@ def forward(self, x):
         ):
             torch._dynamo.export(f, torch.randn(10), torch.randn(10), aten_graph=False)
 
-
     def test_export_meta(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2156,6 +2156,36 @@ def forward(self, x):
             inspect.getfullargspec(out_graph.forward).args[1:], expected_argument_names
         )
 
+    def test_dataclass_input(self):
+        from dataclasses import dataclass
+
+        @dataclass
+        class Tensors:
+            x: torch.Tensor
+            y: torch.Tensor
+
+        def f(t):
+            return t.x + t.y
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "graph-captured input #0.*Tensor.*not among original args.*Tensors",
+        ):
+            torch._dynamo.export(
+                f, Tensors(x=torch.randn(10), y=torch.randn(10)), aten_graph=False
+            )
+
+    def test_none_out(self):
+        def f(x, y):
+            _ = x + y
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "traced result #0.*NoneType.*not among graph-captured outputs.*or original args.*Tensor.*Tensor",
+        ):
+            torch._dynamo.export(f, torch.randn(10), torch.randn(10), aten_graph=False)
+
+
     def test_export_meta(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -922,10 +922,12 @@ def rewrite_signature(
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
     def produce_matching(sources, candidates):
-        source_types = " or ".join([
-            desc + " (" + ", ".join([str(type(arg)) for arg in args]) + ")"
-            for desc, args in sources.items()
-        ])
+        source_types = " or ".join(
+            [
+                desc + " (" + ", ".join([str(type(arg)) for arg in args]) + ")"
+                for desc, args in sources.items()
+            ]
+        )
         source_args = [arg for args in sources.values() for arg in args]
         matched_elements_positions = []
         dict_of_source_args = dict()
@@ -964,7 +966,10 @@ def rewrite_signature(
 
     assert graph_captured_output is not None
     matched_output_elements_positions = produce_matching(
-        sources={"graph-captured outputs": list(graph_captured_output), "original args": flat_args},
+        sources={
+            "graph-captured outputs": list(graph_captured_output),
+            "original args": flat_args,
+        },
         candidates={"traced result": flat_results_traced},
     )
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -921,45 +921,51 @@ def rewrite_signature(
 ):
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
-    def produce_matching(source_args, candidate_args, loc):
+    def produce_matching(sources, candidates):
+        source_types = " or ".join([
+            desc + " (" + ", ".join([str(type(arg)) for arg in args]) + ")"
+            for desc, args in sources.items()
+        ])
+        source_args = [arg for args in sources.values() for arg in args]
         matched_elements_positions = []
         dict_of_source_args = dict()
-        for i in range(0, len(source_args)):
-            element_id = id(source_args[i])
-            dict_of_source_args[element_id] = i
+        for i, arg in enumerate(source_args):
+            dict_of_source_args[id(arg)] = i
 
-        for i in range(0, len(candidate_args)):
-            arg = candidate_args[i]
-            # 1-element tensor arg can be unspec int/float
-            if isinstance(arg, torch.Tensor) and torch.numel(arg) == 1:
-                if id(arg) in dict_of_source_args:
-                    matched_elements_positions.append(dict_of_source_args[id(arg)])
-                elif id(arg.item()) in dict_of_source_args:
-                    matched_elements_positions.append(
-                        dict_of_source_args[id(arg.item())]
-                    )
+        for candidate_desc, candidate_args in candidates.items():
+            for i, arg in enumerate(candidate_args):
+                # 1-element tensor arg can be unspec int/float
+                if isinstance(arg, torch.Tensor) and torch.numel(arg) == 1:
+                    if id(arg) in dict_of_source_args:
+                        matched_elements_positions.append(dict_of_source_args[id(arg)])
+                    elif id(arg.item()) in dict_of_source_args:
+                        matched_elements_positions.append(
+                            dict_of_source_args[id(arg.item())]
+                        )
+                    else:
+                        raise AssertionError(
+                            f"{candidate_desc} #{i} ({type(arg)}) is not among {source_types}"
+                        )
                 else:
-                    raise AssertionError(
-                        f"Dynamo {loc} is not consistent with traced {loc}"
-                    )
-            else:
-                assert (
-                    id(arg) in dict_of_source_args
-                ), f"Dynamo {loc} is a strict subset of traced {loc}"
-                matched_elements_positions.append(dict_of_source_args[id(arg)])
+                    if id(arg) not in dict_of_source_args:
+                        raise AssertionError(
+                            f"{candidate_desc} #{i} ({type(arg)}) is not among {source_types}"
+                        )
+                    matched_elements_positions.append(dict_of_source_args[id(arg)])
 
         return matched_elements_positions
 
     matched_input_elements_positions = produce_matching(
-        flat_args, graph_captured_input, "input"
+        sources={"original args": flat_args},
+        candidates={"graph-captured input": graph_captured_input},
     )
 
     flat_results_traced, out_spec_traced = pytree.tree_flatten(dynamo_traced_result)
 
     assert graph_captured_output is not None
-    flat_both = list(graph_captured_output) + flat_args
     matched_output_elements_positions = produce_matching(
-        flat_both, flat_results_traced, "output"
+        sources={"graph-captured outputs": list(graph_captured_output), "original args": flat_args},
+        candidates={"traced result": flat_results_traced},
     )
 
     new_graph = FlattenInputOutputSignature(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107907

Previously when we found some input or output mismatch between original args / traced result vs. graph-captured input / output, we would have a pretty sparse error message. (This might be partly due to the urge to reuse the same code for matching both inputs and outputs.)

With this PR we now point out which input or output is problematic, what its type is, and also present the expected types along with descriptions of what they mean. We don't suggest any fixes, but the idea is that it should be evident what went wrong looking at the error message.

Differential Revision: [D48668059](https://our.internmc.facebook.com/intern/diff/D48668059/)

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov