### PR TITLE
AOTInductor: error: ‘c10::Dispatcher’ has not been declared for CPU model

### DIFF
--- a/torch/_inductor/codegen/aot_inductor_interface.cpp
+++ b/torch/_inductor/codegen/aot_inductor_interface.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/inductor/aot_inductor_interface.h>
 #include <torch/csrc/inductor/aot_inductor_model_container.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>


### PR DESCRIPTION
Differential Revision: D48675055



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov