### PR TITLE
[core aten] Remove split.Tensor from core aten

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5301,7 +5301,6 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: split
-  tags: core
 
 - func: split.sizes(Tensor(a -> *) self, SymInt[] split_size, int dim=0) -> Tensor(a)[]
   variants: function, method


### PR DESCRIPTION
Removing split.Tensor from core aten as it can be decomposed into split_with_sizes

