### PR TITLE
Enable mypy check in torch/_inductor/optimize_indexing.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -199,7 +199,6 @@ exclude_patterns = [
     'torch/_inductor/debug.py',
     'torch/_inductor/hooks.py',
     'torch/_inductor/decomposition.py',
-    'torch/_inductor/optimize_indexing.py',
     'torch/_inductor/bounds.py',
     'torch/_inductor/config.py',
     'torch/_inductor/ir.py',

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -54,7 +54,7 @@ def try_to_reduce_precision(node, bounds, indirect_vars, indices, replacement_va
         if dominated.target in ["store", "output"]:
             continue
 
-        if "set_indirect" in dominated.target:
+        if isinstance(dominated.target, str) and "set_indirect" in dominated.target:
             idx = int(dominated.target[len("set_indirect") :])
             indirect_var = indirect_vars[idx]
 


### PR DESCRIPTION
Fixes #105230

```shell
$ lintrunner init && lintrunner -a torch/_inductor/optimize_indexing.py
...
ok No lint issues.
Successfully applied all patches.
```

```shell
$ mypy torch/_inductor/optimize_indexing.py
Success: no issues found in 1 source file

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov