### PR TITLE
[dynamo]bugfix:implement numel() for SizeVariable

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2191,6 +2191,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         def fn():
             return torch.Size([10, 8]).numel()
+
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
         num = torch.Size([10, 8]).numel()
         self.assertEqual(opt_fn(), num)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2186,6 +2186,15 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(same(ref, res))
 
+    def test_torch_size_numel(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn():
+            return torch.Size([10, 8]).numel()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+        num = torch.Size([10, 8]).numel()
+        self.assertEqual(opt_fn(), num)
+
     def test_size_dim(self):
         cnts = torch._dynamo.testing.CompileCounter()
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -553,6 +553,12 @@ class SizeVariable(TupleVariable):
             assert not kwargs and len(args) == 1
             out = self.get_item_dyn(tx, args[0])
             return out
+        elif name == "numel":
+            result = 1
+            for v in self.items:
+                assert isinstance(v, ConstantVariable)
+                result = result * v.value
+            return ConstantVariable(result).add_options(self)
         return super().call_method(tx, name, args, kwargs)
 
     def get_item_dyn(self, tx, arg: VariableTracker):


### PR DESCRIPTION
fix the issue that SizeVariable does not support numel() method
Fixes #106407

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov