### PR TITLE
add torch.float16 support for xla amp

### DIFF
--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -306,7 +306,7 @@ class autocast:
                     "Current CUDA Device does not support bfloat16. Please switch dtype to float16."
                 )
         elif self.device == "xla":
-            supported_dtype = [torch.bfloat16, torch.float16]]
+            supported_dtype = [torch.bfloat16, torch.float16]
             if self.fast_dtype not in supported_dtype:
                 error_message = "In XLA autocast, but the target dtype is not supported. Disabling autocast.\n"
                 error_message += (

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -309,9 +309,7 @@ class autocast:
             supported_dtype = [torch.bfloat16, torch.float16]
             if self.fast_dtype not in supported_dtype:
                 error_message = "In XLA autocast, but the target dtype is not supported. Disabling autocast.\n"
-                error_message += (
-                    "XLA Autocast only supports dtype of torch.bfloat16 and torch.float16 currently."
-                )
+                error_message += "XLA Autocast only supports dtype of torch.bfloat16 and torch.float16 currently."
                 warnings.warn(error_message)
                 enabled = False
         self._enabled = enabled

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -306,11 +306,11 @@ class autocast:
                     "Current CUDA Device does not support bfloat16. Please switch dtype to float16."
                 )
         elif self.device == "xla":
-            supported_dtype = [torch.bfloat16]
+            supported_dtype = [torch.bfloat16, torch.float16]]
             if self.fast_dtype not in supported_dtype:
                 error_message = "In XLA autocast, but the target dtype is not supported. Disabling autocast.\n"
                 error_message += (
-                    "XLA Autocast only supports dtype of torch.bfloat16 currently."
+                    "XLA Autocast only supports dtype of torch.bfloat16 and torch.float16 currently."
                 )
                 warnings.warn(error_message)
                 enabled = False


### PR DESCRIPTION
The "bfloat16 only" limitation is only applied to google TPU but not other backends like GPU and other accelerators

Fixes #107953


cc @bdhirsh @mcarilli @ptrblck @leslie-fang-intel @jgong5