### PR TITLE
[inductor] Add cat + split_with_sizes elimination pass

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -555,8 +555,10 @@ class TestPaternMatcher(TestCase):
         # good case
         def fn(a, b, c):
             cat = torch.ops.aten.cat.default([a, b, c], 1)
-            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 1)
-            return [s ** 2 for s in split_with_sizes]
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(
+                cat, [2, 3, 5], 1
+            )
+            return [s**2 for s in split_with_sizes]
 
         args = [
             torch.randn(2, 2, device="cuda"),
@@ -573,8 +575,10 @@ class TestPaternMatcher(TestCase):
         # cat node has other users
         def fn(a, b, c):
             cat = torch.ops.aten.cat.default([a, b, c], 1)
-            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 1)
-            return [s ** 2 for s in split_with_sizes] + [cat ** 3]
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(
+                cat, [2, 3, 5], 1
+            )
+            return [s**2 for s in split_with_sizes] + [cat**3]
 
         args = [
             torch.randn(2, 2, device="cuda"),
@@ -591,8 +595,10 @@ class TestPaternMatcher(TestCase):
         # cat and split dims are different
         def fn(a, b, c):
             cat = torch.ops.aten.cat.default([a, b, c], 1)
-            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 0)
-            return [s ** 2 for s in split_with_sizes]
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(
+                cat, [2, 3, 5], 0
+            )
+            return [s**2 for s in split_with_sizes]
 
         args = [
             torch.randn(10, 2, device="cuda"),
@@ -610,7 +616,7 @@ class TestPaternMatcher(TestCase):
         def fn(a, b, c):
             cat = torch.ops.aten.cat.default([a, b, c], 1)
             split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [5, 5], 1)
-            return [s ** 2 for s in split_with_sizes]
+            return [s**2 for s in split_with_sizes]
 
         args = [
             torch.randn(2, 2, device="cuda"),
@@ -627,8 +633,10 @@ class TestPaternMatcher(TestCase):
         # cat input sizes and split sizes are different
         def fn(a, b, c):
             cat = torch.ops.aten.cat.default([a, b, c], 1)
-            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 5, 3], 1)
-            return [s ** 2 for s in split_with_sizes]
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(
+                cat, [2, 5, 3], 1
+            )
+            return [s**2 for s in split_with_sizes]
 
         args = [
             torch.randn(2, 2, device="cuda"),

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -551,6 +551,97 @@ class TestPaternMatcher(TestCase):
         self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
         self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
 
+    def test_cat_splitwithsizes(self):
+        # good case
+        def fn(a, b, c):
+            cat = torch.ops.aten.cat.default([a, b, c], 1)
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 1)
+            return [s ** 2 for s in split_with_sizes]
+
+        args = [
+            torch.randn(2, 2, device="cuda"),
+            torch.randn(2, 3, device="cuda"),
+            torch.randn(2, 5, device="cuda"),
+        ]
+        expected = fn(*args)
+        actual = torch.compile(fn)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 2)
+        counters.clear()
+
+        # cat node has other users
+        def fn(a, b, c):
+            cat = torch.ops.aten.cat.default([a, b, c], 1)
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 1)
+            return [s ** 2 for s in split_with_sizes] + [cat ** 3]
+
+        args = [
+            torch.randn(2, 2, device="cuda"),
+            torch.randn(2, 3, device="cuda"),
+            torch.randn(2, 5, device="cuda"),
+        ]
+        expected = fn(*args)
+        actual = torch.compile(fn)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+        counters.clear()
+
+        # cat and split dims are different
+        def fn(a, b, c):
+            cat = torch.ops.aten.cat.default([a, b, c], 1)
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 0)
+            return [s ** 2 for s in split_with_sizes]
+
+        args = [
+            torch.randn(10, 2, device="cuda"),
+            torch.randn(10, 3, device="cuda"),
+            torch.randn(10, 5, device="cuda"),
+        ]
+        expected = fn(*args)
+        actual = torch.compile(fn)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+        counters.clear()
+
+        # cat and split lenghts are different
+        def fn(a, b, c):
+            cat = torch.ops.aten.cat.default([a, b, c], 1)
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [5, 5], 1)
+            return [s ** 2 for s in split_with_sizes]
+
+        args = [
+            torch.randn(2, 2, device="cuda"),
+            torch.randn(2, 3, device="cuda"),
+            torch.randn(2, 5, device="cuda"),
+        ]
+        expected = fn(*args)
+        actual = torch.compile(fn)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+        counters.clear()
+
+        # cat input sizes and split sizes are different
+        def fn(a, b, c):
+            cat = torch.ops.aten.cat.default([a, b, c], 1)
+            split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 5, 3], 1)
+            return [s ** 2 for s in split_with_sizes]
+
+        args = [
+            torch.randn(2, 2, device="cuda"),
+            torch.randn(2, 3, device="cuda"),
+            torch.randn(2, 5, device="cuda"),
+        ]
+        expected = fn(*args)
+        actual = torch.compile(fn)(*args)
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 0)
+        self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 0)
+        counters.clear()
+
     def test_match_with_mutation(self):
         from torch._inductor.pattern_matcher import (
             CallFunction,

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -509,6 +509,60 @@ def splitwithsizes_cat_replace(match, input_):
     return input_
 
 
+def is_valid_cat_splitwithsizes(match):
+    cat_nodes = filter_nodes(match.nodes, aten.cat)
+    split_nodes = filter_nodes(match.nodes, aten.split_with_sizes)
+    if len(split_nodes) != 1 or len(cat_nodes) != 1:
+        return False
+    split_node, cat_node = split_nodes[0], cat_nodes[0]
+
+    # the cat node has other users: can't eliminate
+    if len(cat_node.users) > 1:
+        return False
+
+    # the dim of the cat and split should match
+    dim = get_arg_value(split_node, 2, "dim")
+    if dim != get_arg_value(cat_node, 1, "dim"):
+        return False
+
+    cat_inputs = list(get_arg_value(cat_node, 0))
+    split_sizes = get_arg_value(split_node, 1, "split_sizes")
+    # the number of input tensors in cat and the
+    # length of the split sizes should match
+    if len(cat_inputs) != len(split_sizes):
+        return False
+
+    for cat_input, split_size in zip(cat_inputs, split_sizes):
+        # each cat input tensor's size along dim
+        # should match the corresponding split size
+        if "val" not in cat_input.meta:
+            return False
+        cat_input_size = cat_input.meta["val"].size(dim)
+        if cat_input_size != split_size:
+            return False
+
+    return True
+
+
+@register_lowering_pattern(
+    CallFunction(
+        aten.split_with_sizes,
+        CallFunction(
+            aten.cat,
+            KeywordArg("input_"),
+            Ignored(),
+            _users=MULTIPLE,
+        ),
+        Ignored(),
+        Ignored(),
+    ),
+    pass_number=2,
+    extra_check=is_valid_cat_splitwithsizes,
+)
+def cat_splitwithsizes_replace(match, input_):
+    return input_
+
+
 def view_to_reshape(gm):
     """
     Replace view ops in the GraphModule to reshape ops.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107956

Summary:

When the `cat` inputs' sizes and the `split_sizes` of the downstream `split_with_sizes` match, the `cat` + `split_with_sizes` constellation can be eliminated. E.g. here:

```
@torch.compile
def fn(a, b, c):
    cat = torch.ops.aten.cat.default([a, b, c], 1)
    split_with_sizes = torch.ops.aten.split_with_sizes.default(cat, [2, 3, 5], 1)
    return [s ** 2 for s in split_with_sizes]

inputs = [
    torch.randn(2, 2, device="cuda"),
    torch.randn(2, 3, device="cuda"),
    torch.randn(2, 5, device="cuda"),
]
output = fn(*inputs)
```

This PR adds a new fx pass for such elimination. The new pass is similar to the existing [`splitwithsizes_cat_replace`](https://github.com/pytorch/pytorch/blob/b18e1b684a7673daa3a51128aae4e75ed7aa7cbc/torch/_inductor/fx_passes/post_grad.py#L508), but considers the ops in the opposite order.

Test Plan:

```
$ python test/inductor/test_pattern_matcher.py

...

----------------------------------------------------------------------
Ran 21 tests in 46.450s

OK
```

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8