### PR TITLE
[PyTorch] torch.empty_permuted: rename param name from 'physical_layout' to 'dim_order'

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2309,7 +2309,7 @@
     QuantizedCPU, QuantizedCUDA, QuantizedMeta: empty_unknown_quantized
   tags: core
 
-- func: empty_permuted(SymInt[] size, int[] physical_layout, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: empty_permuted(SymInt[] size, int[] dim_order, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CompositeExplicitAutograd: empty_permuted_symint
   autogen: empty_permuted.out

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -131,11 +131,11 @@ def floordiv(a, b):
 # to decompose to empty_strided (but inductor is OK with it, because we are
 # cool with strides and everything goes to empty_strided)
 @register_decomposition([aten.empty_permuted.default])
-def empty_permuted(size, physical_layout, **kwargs):
+def empty_permuted(size, dim_order, **kwargs):
     perm = [0] * len(size)
-    for p, l in enumerate(physical_layout):
+    for p, l in enumerate(dim_order):
         perm[l] = p
-    return torch.empty([size[l] for l in physical_layout], **kwargs).permute(perm)
+    return torch.empty([size[l] for l in dim_order], **kwargs).permute(perm)
 
 
 @register_decomposition([aten.convolution_backward])

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -2513,25 +2513,25 @@ empty_strided = _make_prim(
 
 def _empty_permuted_meta(
     shape: ShapeType,
-    physical_layout: DimsSequenceType,
+    dim_order: DimsSequenceType,
     *,
     dtype: torch.dtype,
     device: torch.device,
     requires_grad: bool,
 ) -> TensorLikeType:
-    p_strides = utils.make_contiguous_strides_for([shape[l] for l in physical_layout])
+    p_strides = utils.make_contiguous_strides_for([shape[l] for l in dim_order])
     dim = len(shape)
     torch._check(
-        len(physical_layout) == dim,
+        len(dim_order) == dim,
         lambda: (
             "Number of dimensions in the tensor input does not match the "
-            f"length of the physical layout; i.e. len(size) = {dim} "
-            f"is not equal to len(physical_layout) = {len(physical_layout)}"
+            f"length of the dim order; i.e. len(size) = {dim} "
+            f"is not equal to len(dim_order) = {len(dim_order)}"
         ),
     )
     strides = [0] * len(shape)
     seen_dims = set()
-    for p, l in enumerate(physical_layout):
+    for p, l in enumerate(dim_order):
         torch._check(
             0 <= l < dim,
             lambda: (
@@ -2552,13 +2552,13 @@ def _empty_permuted_meta(
 
 
 _empty_permuted_doc = """
-    Creates a tensor with uninitialized values according to some physical layout,
+    Creates a tensor with uninitialized values according to some dim order,
     that is guaranteed to be non-overlapping and dense.
 """
 
 # TODO: add layout, pin_memory
 empty_permuted = _make_prim(
-    schema="empty_permuted(SymInt[] shape, int[] physical_layout, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor",  # noqa: B950
+    schema="empty_permuted(SymInt[] shape, int[] dim_order, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor",  # noqa: B950
     return_type=RETURN_TYPE.NEW,
     meta=_empty_permuted_meta,
     impl_aten=torch.empty_permuted,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4541,7 +4541,7 @@ def empty(
 @out_wrapper()
 def empty_permuted(
     shape,
-    physical_layout,
+    dim_order,
     dtype: Optional[torch.dtype] = None,
     layout: torch.layout = torch.strided,
     device: Optional[torch.device] = None,
@@ -4550,7 +4550,7 @@ def empty_permuted(
 ) -> TensorLikeType:
     return prims.empty_permuted(
         shape,
-        physical_layout,
+        dim_order,
         dtype=dtype,
         device=device,
         requires_grad=requires_grad,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -12410,17 +12410,17 @@ Example::
 add_docstr(
     torch.empty_permuted,
     r"""
-empty_permuted(size, physical_layout, *, dtype=None, layout=None, device=None, requires_grad=False, pin_memory=False) -> Tensor
+empty_permuted(size, dim_order, *, dtype=None, layout=None, device=None, requires_grad=False, pin_memory=False) -> Tensor
 
 Creates an uninitialized, non-overlapping and dense tensor with the
-specified :attr:`size`, with :attr:`physical_layout` specifying how the
+specified :attr:`size`, with :attr:`dim_order` specifying how the
 dimensions are physically laid out in memory (each logical dimension is listed
-from outermost to innermost).  :attr:`physical_layout` is a generalization
+from outermost to innermost).  :attr:`dim_order` is a generalization
 of NCHW/NHWC notation: if each dimension is assigned a number according to
 what order they occur in size (N=0, C=1, H=2, W=3), then NCHW is ``(0, 1, 2, 3)``
 while NHWC is ``(0, 2, 3, 1)``.  Equivalently, the strides of the output
-tensor ``t`` are such that ``t.stride(physical_layout[i]) == contiguous_strides[i]``
-(notably, this function is *not* equivalent to ``torch.empty(size).permute(physical_layout)``).
+tensor ``t`` are such that ``t.stride(dim_order[i]) == contiguous_strides[i]``
+(notably, this function is *not* equivalent to ``torch.empty(size).permute(dim_order)``).
 
 Unlike :func:`torch.empty_strided`, this is guaranteed to produce a dense
 tensor with no overlaps.  If possible, prefer using this function over
@@ -12435,7 +12435,7 @@ tensor with no overlaps.  If possible, prefer using this function over
 
 Args:
     size (tuple of int): the shape of the output tensor
-    physical_layout (tuple of int): the ordering of dimensions physically in memory
+    dim_order (tuple of int): the ordering of dimensions physically in memory
 
 Keyword args:
     {dtype}

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1823,7 +1823,7 @@ def error_inputs_empty_permuted(op_info, device, **kwargs):
     yield ErrorInput(
         SampleInput((2,), args=((0, 1),)),
         error_type=RuntimeError,
-        error_regex="Number of dimensions in size does not match the length of the physical_layout"
+        error_regex="Number of dimensions in size does not match the length of the dim_order"
     )
     yield ErrorInput(
         SampleInput((2,), args=((3,),)),


### PR DESCRIPTION
Summary:
Alignes well with the new `tensor.dim_order()` fn.
Since this is arg and not kwarg, and same dtype, this change shouldn't be BC breaking.

Test Plan: CI

Differential Revision: D48176693



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel