### PR TITLE
[ONNX] Support `torch.compile(backend="onnxrt", options=OrtBackendOptions(...))`

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -730,6 +730,7 @@ Preview: torch.onnx TorchDynamo Exporter
 
 .. autofunction:: torch.onnx.dynamo_export
 .. autofunction:: torch.onnx.enable_fake_mode
+.. autofunction:: torch.onnx.is_onnxrt_backend_supported
 
 .. autosummary::
     :toctree: generated

--- a/torch/_dynamo/backends/onnxrt.py
+++ b/torch/_dynamo/backends/onnxrt.py
@@ -2,26 +2,33 @@
 # to the right people, please tag related GitHub issues with `module: onnx`.
 #
 # Maintainers' Github IDs: wschin, thiagocrepaldi, BowenBao, abock
-from torch.onnx._internal.onnxruntime import has_onnxruntime, make_aot_ort
+from torch.onnx._internal.onnxruntime import (
+    is_onnxrt_backend_supported,
+    torch_compile_backend,
+)
 from .registry import register_backend
 
-if has_onnxruntime():
-    aot_ort, ort = make_aot_ort(dynamic=True)
-    register_backend(name="onnxrt", compiler_fn=aot_ort)
+
+def has_onnxruntime():
+    # FIXME(abock): update test/dynamo/test_backends.py to call is_onnxrt_backend_supported()
+    return is_onnxrt_backend_supported()
+
+
+if is_onnxrt_backend_supported():
+    register_backend(name="onnxrt", compiler_fn=torch_compile_backend)
 else:
 
     def information_displaying_backend(*args, **kwargs):
         raise ImportError(
             "onnxrt is not registered as a backend. "
             "Please make sure all dependencies such as "
-            "numpy, onnx, onnxscript, and onnxruntime-training are installed. "
-            "Suggested procedure to fix dependency problem: "
-            "(1) pip or conda install numpy onnx onnxscript onnxruntime-training. "
-            "(2) open a new python terminal "
-            "(3) Run `from torch.onnx._internal.onnxruntime import has_onnxruntime`. "
-            "(4) Run `has_onnxruntime()`. "
-            "(5) If has_onnxruntime() returns True, then you can use `onnxrt` backend. "
-            "(6) If has_onnxruntime() returns False, please execute the package importing section in "
+            "numpy, onnx, onnxscript-preview, and onnxruntime-training are installed. "
+            "Suggested procedure to fix dependency problem:\n"
+            "  (1) pip or conda install numpy onnx onnxscript-preview onnxruntime-training.\n"
+            "  (2) Open a new python terminal.\n"
+            "  (3) Call the API `torch.onnx.is_onnxrt_backend_supported()`:\n"
+            "  (4)   If it returns `True`, then you can use `onnxrt` backend.\n"
+            "  (5)   If it returns `False`, please execute the package importing section in "
             "torch/onnx/_internal/onnxruntime.py under pdb line-by-line to see which import fails."
         )
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -56,6 +56,13 @@ from ._internal.exporter import (  # usort:skip. needs to be last to avoid circu
     DiagnosticOptions,
 )
 
+from ._internal.onnxruntime import (
+    is_onnxrt_backend_supported,
+    OrtBackend as _OrtBackend,
+    OrtBackendOptions as _OrtBackendOptions,
+    OrtExecutionProvider as _OrtExecutionProvider,
+)
+
 __all__ = [
     # Modules
     "symbolic_helper",
@@ -101,6 +108,8 @@ __all__ = [
     "enable_fake_mode",
     "OnnxRegistry",
     "DiagnosticOptions",
+    # DORT / torch.compile
+    "is_onnxrt_backend_supported",
 ]
 
 # Set namespace for exposed private names
@@ -114,6 +123,10 @@ OnnxExporterError.__module__ = "torch.onnx"
 enable_fake_mode.__module__ = "torch.onnx"
 OnnxRegistry.__module__ = "torch.onnx"
 DiagnosticOptions.__module__ = "torch.onnx"
+is_onnxrt_backend_supported.__module__ = "torch.onnx"
+_OrtExecutionProvider.__module__ = "torch.onnx"
+_OrtBackendOptions.__module__ = "torch.onnx"
+_OrtBackend.__module__ = "torch.onnx"
 
 producer_name = "pytorch"
 producer_version = _C_onnx.PRODUCER_VERSION


### PR DESCRIPTION
This reworks the DORT backend factory function to support the options kwarg of torch.compile, and defines a concrete OrtBackendOptions type that can be used to influence the backend.

Caching is also implemented in order to reuse backends with equal options.

Wrapping the backend in auto_autograd also becomes an option, which allows `OrtBackend` to always be returned as the callable for torch.compile; wrapping happens internally if opted into (True by default).

Lastly, expose options for configuring preferred execution providers (will be attempted first), whether or not to attempt to infer an ORT EP from a torch found device in the graph or inputs, and finally the default/fallback EPs.

### Demo

The following demo runs `Gelu` through `torch.compile(backend="onnxrt")` using various backend options through a dictionary form and a strongly typed form. It additionally exports the model through both the ONNX TorchScript exporter and the new TorchDynamo exporter.

```python
import math

import onnx.inliner
import onnxruntime
import torch
import torch.onnx

torch.manual_seed(0)


class Gelu(torch.nn.Module):
    def forward(self, x):
        return x * (0.5 * torch.erf(math.sqrt(0.5) * x) + 1.0)


@torch.compile(
    backend="onnxrt",
    options={
        "preferred_execution_providers": [
            "NotARealEP",
            "CPUExecutionProvider",
        ],
        "export_options": torch.onnx.ExportOptions(dynamic_shapes=True),
    },
)
def dort_gelu(x):
    return Gelu()(x)

ort_session_options = onnxruntime.SessionOptions()
ort_session_options.log_severity_level = 0

dort_gelu2 = torch.compile(
    Gelu(),
    backend="onnxrt",
    options=torch.onnx._OrtBackendOptions(
        preferred_execution_providers=[
            "NotARealEP",
            "CPUExecutionProvider",
        ],
        export_options=torch.onnx.ExportOptions(dynamic_shapes=True),
        ort_session_options=ort_session_options,
    ),
)

x = torch.randn(10)

torch.onnx.export(Gelu(), (x,), "gelu_ts.onnx")

export_output = torch.onnx.dynamo_export(Gelu(), x)
export_output.save("gelu_dynamo.onnx")
inlined_model = onnx.inliner.inline_local_functions(export_output.model_proto)
onnx.save_model(inlined_model, "gelu_dynamo_inlined.onnx")

print("Torch Eager:")
print(Gelu()(x))

print("DORT:")
print(dort_gelu(x))
print(dort_gelu2(x))
```

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov