### PR TITLE
[TP][2D][EZ] Fix Error in FSDP 2D test

### DIFF
--- a/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
@@ -95,7 +95,7 @@ def init_model(
     # 2-D mesh is [dp, tp]
     twod_mesh = DeviceMesh(
         device_type="cuda",
-        mesh=torch.arange(0, world_size).view(model_parallel_size, -1),
+        mesh=torch.arange(0, world_size).view(-1, model_parallel_size),
     )
 
     fsdp_pg = twod_mesh.get_dim_groups()[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107975

As title, TP dimension should be the second dim, so we need to pass tp_degree to the second rather the first dim of the mesh tensor.
