### PR TITLE
[ONNX] Remove API reference for TorchScript export diagnostics

### DIFF
--- a/docs/source/onnx_diagnostics.rst
+++ b/docs/source/onnx_diagnostics.rst
@@ -24,9 +24,3 @@ Diagnostic Rules
     :glob:
 
     generated/onnx_diagnostics_rules/*
-
-API Reference
--------------
-
-.. autoclass:: torch.onnx._internal.diagnostics.TorchScriptOnnxExportDiagnostic
-    :members:

--- a/docs/source/scripts/onnx/build_onnx_diagnostics_rules_md.py
+++ b/docs/source/scripts/onnx/build_onnx_diagnostics_rules_md.py
@@ -12,6 +12,10 @@ def gen_docs(out_dir: str):
         rule = getattr(diagnostics.rules, field.name)
         if not isinstance(rule, infra.Rule):
             continue
+        if not rule.id.startswith("FXE"):
+            # Only generate docs for `dynamo_export` rules. Excluding rules for TorchScript
+            # ONNX exporter.
+            continue
         title = f"{rule.id}:{rule.name}"
         full_description_markdown = rule.full_description_markdown
         assert (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #107979

Remove both api reference and rules specific to TorchScript ONNX export. The page should display only info related to `torch.onnx.dynamo_export` diagnostics.
