### PR TITLE
fix: adam(w) ignore stride mismatch when dim is size 1

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -130,19 +130,29 @@ bool check_fast_path_restrictions(
   // strides.
   for (const auto& tensor_list : tensorLists) {
     for (const auto j : c10::irange(tensorLists[0].size())) {
-      if (tensorLists[0][j].sizes() != tensor_list[j].sizes()) {
+      const auto& ref_size = tensorLists[0][j].sizes();
+      const auto& ref_stride = tensorLists[0][j].strides();
+      const auto& tensor_list_size = tensor_list[j].sizes();
+      const auto& tensor_list_stride = tensor_list[j].strides();
+
+      if (ref_size != tensor_list_size) {
         return false;
       }
-      if (tensorLists[0][j].strides() != tensor_list[j].strides()) {
-        for (auto it1 = tensorLists[0][j].sizes().begin(),
-                  it2 = tensorLists[0][j].strides().begin(),
-                  it3 = tensor_list[j].strides().begin();
-             it1 != tensorLists[0][j].sizes().end() &&
-             it2 != tensorLists[0][j].strides().end() &&
-             it3 != tensor_list[j].strides().end();
-             ++it1, ++it2, ++it3) {
+
+      if (ref_stride != tensor_list_stride) {
+        if (ref_stride.size() != tensor_list_stride.size()) {
+          return false;
+        }
+
+        for (auto ref_size_it = ref_size.begin(),
+                  ref_stride_it = ref_stride.begin(),
+                  tensor_list_stride_it = tensor_list_stride.begin();
+             ref_size_it != ref_size.end() &&
+             ref_stride_it != ref_stride.end() &&
+             tensor_list_stride_it != tensor_list_stride.end();
+             ++ref_size_it, ++ref_stride_it, ++tensor_list_stride_it) {
           // if dim is of size 1, the stride doesn't matter
-          if (*it1 != 1 && *it2 != *it3) {
+          if (*ref_size_it != 1 && *ref_stride_it != *tensor_list_stride_it) {
             return false;
           }
         }

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -134,7 +134,18 @@ bool check_fast_path_restrictions(
         return false;
       }
       if (tensorLists[0][j].strides() != tensor_list[j].strides()) {
-        return false;
+        for (auto it1 = tensorLists[0][j].sizes().begin(),
+                  it2 = tensorLists[0][j].strides().begin(),
+                  it3 = tensor_list[j].strides().begin();
+             it1 != tensorLists[0][j].sizes().end() &&
+             it2 != tensorLists[0][j].strides().end() &&
+             it3 != tensor_list[j].strides().end();
+             ++it1, ++it2, ++it3) {
+          // if dim is of size 1, the stride doesn't matter
+          if (*it1 != 1 && *it2 != *it3) {
+            return false;
+          }
+        }
       }
     }
   }

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -130,10 +130,10 @@ bool check_fast_path_restrictions(
   // strides.
   for (const auto& tensor_list : tensorLists) {
     for (const auto j : c10::irange(tensorLists[0].size())) {
-      const auto& ref_size = tensorLists[0][j].sizes();
-      const auto& ref_stride = tensorLists[0][j].strides();
-      const auto& tensor_list_size = tensor_list[j].sizes();
-      const auto& tensor_list_stride = tensor_list[j].strides();
+      const auto& ref_sizes = tensorLists[0][j].sizes();
+      const auto& ref_strides = tensorLists[0][j].strides();
+      const auto& tensor_list_sizes = tensor_list[j].sizes();
+      const auto& tensor_list_strides = tensor_list[j].strides();
 
       if (ref_size != tensor_list_size) {
         return false;

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1120,7 +1120,7 @@ class TestForeach(TestCase):
         w = torch.nn.Parameter(torch.zeros((2, 1, 100), device='cuda'))
         x = torch.rand((10, 2, 100), device='cuda')
         optimizer = optim.AdamW([w], lr=0.0001, fused=True)
-        y = torch.bmm(x.transpose(0, 1), w.transpose(1,2))
+        y = torch.bmm(x.transpose(0, 1), w.transpose(1, 2))
         y.sum().backward()
         self.assertNotEqual(w.stride(), w.grad.stride())
         optimizer.step()


### PR DESCRIPTION
Fixes #106951

when dim is of size 1, stride mismatch does not matter

As discussed in #78050 strides are inconsistent and may sometimes change when dim 1 during autograd.

Thus we fix the fused_adam(w) check to account for this case.

cc: @clchan @ezhang887

cc for review @janeyx99 @albanD 


cc @vincentqb @jbschlosser @albanD @janeyx99 @crcrpar