### PR TITLE
[DTensor] Add util API to compute_local_shape_and_global_offset for checkpointing purpose 

### DIFF
--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
+from torch.distributed._tensor import distribute_tensor
 from torch.distributed._tensor._utils import compute_local_offset, compute_local_shape
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Replicate, Shard
@@ -11,88 +12,120 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     with_comms,
 )
 
+import torch.distributed as dist
 
 class UtilTest(DTensorTestBase):
     @property
     def world_size(self):
         return 8
 
-    @with_comms
-    def test_compute_local_offset_1d(self):
+    # @with_comms
+    # def test_compute_local_offset_1d(self):
         # mesh: 8 * 1
-        mesh_tensor = torch.arange(self.world_size)
+        # mesh_tensor = torch.arange(self.world_size)
+        # device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        # my_rank = device_mesh.get_rank()
+        # size = torch.Size([10])
+
+        # placement = [Shard(0)]
+        # local_size = compute_local_shape(size, device_mesh, placement)
+        # local_offset = compute_local_offset(size, device_mesh, placement)
+        # print(f"rank:{dist.get_rank()}, my_rank:{my_rank}, local_size:{local_size}, local_offset:{local_offset}")
+
+        # tensor = torch.ones([10])
+        # tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
+        # # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
+        # chunk_sizes = [
+        #     tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
+        #     for idx, tensor in enumerate(range(self.world_size))
+        # ]
+
+        # self.assertEqual(local_size[0], chunk_sizes[my_rank])
+        # # Offset for empty shard on the current dimension is equal to
+        # # global tensor dim size on the current dimension.
+        # self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
+
+    @with_comms
+    def test_compute_local_offset_2d(self):
+        mesh_tensor= torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        placements = [Shard(0), Shard(0)]
         my_rank = device_mesh.get_rank()
-        size = torch.Size([10])
+        size = torch.Size([10, 2])
 
-        placement = [Shard(0)]
-        local_size = compute_local_shape(size, device_mesh, placement)
-        local_offset = compute_local_offset(size, device_mesh, placement)
+        local_size = compute_local_shape(size, device_mesh, placements)
+        local_offset = compute_local_offset(size, device_mesh, placements)
+        # print(f"rank:{dist.get_rank()}, my_rank:{my_rank}, local_size:{local_size}, local_offset:{local_offset}")
 
-        tensor = torch.ones([10])
-        tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
-        # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
-        chunk_sizes = [
-            tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
-            for idx, tensor in enumerate(range(self.world_size))
-        ]
+        # tensor = torch.arange(10)
+        # tensor_lists_dim_0 = (list(torch.chunk(tensor, mesh_tensor.size(dim=0))))
+        # tensor_lists_dim_2 = []
+        # for t in tensor_lists_dim_0:
+        #     tensor_lists_dim_2.append(list(torch.chunk(t, mesh_tensor.size(dim=1))))
 
-        self.assertEqual(local_size[0], chunk_sizes[my_rank])
-        # Offset for empty shard on the current dimension is equal to
-        # global tensor dim size on the current dimension.
-        self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
+        # print(tensor_lists_dim_2)
 
-    @with_comms
-    def test_compute_local_shape_2d(self):
-        # mesh: 4 * 2
-        mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
-        mesh = DeviceMesh(self.device_type, mesh_tensor)
-        size = torch.Size([8, 6])
+        # dtensor = distribute_tensor(tensor, device_mesh, placements=placements)
+        # print(f"rank:{dist.get_rank()}, dtensor:{dtensor}")
 
-        # replicate, replicate
-        placements1 = [Replicate(), Replicate()]
-        local_size1 = compute_local_shape(size, mesh, placements1)
-        self.assertEqual(local_size1, torch.Size([8, 6]))
 
-        # replicate, shard
-        placements2 = [Replicate(), Shard(0)]
-        local_size2 = compute_local_shape(size, mesh, placements2)
-        self.assertEqual(local_size2, torch.Size([4, 6]))
+        # tensor_lists_dim_1 = []
+        # for tensor_list in tensor_lists_dim_0:
+        #     tensor_lists_dim_1.append(list.torch.chunk(tensor_list, mesh_tensor.size(dim=1)))
+        # print(f"tensor_lists_dim_2:{tensor_lists_dim_2}")
+        # print(f"tensor_lists:{tensor_lists_dim_1}")
 
-        # shard, shard
-        placements3 = [Shard(0), Shard(1)]
-        local_size3 = compute_local_shape(size, mesh, placements3)
-        self.assertEqual(local_size3, torch.Size([2, 3]))
+    # @with_comms
+    # def test_compute_local_shape_2d(self):
+    #     # mesh: 4 * 2
+    #     mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
+    #     mesh = DeviceMesh(self.device_type, mesh_tensor)
+    #     size = torch.Size([8, 6])
 
-    @with_comms
-    def test_compute_local_shape_2d_uneven(self):
-        # mesh: 4 * 2
-        mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
-        mesh = DeviceMesh(self.device_type, mesh_tensor)
-        size = torch.Size([7, 7])
-        rank_coordinates = mesh.get_coordinate()
+    #     # replicate, replicate
+    #     placements1 = [Replicate(), Replicate()]
+    #     local_size1 = compute_local_shape(size, mesh, placements1)
+    #     self.assertEqual(local_size1, torch.Size([8, 6]))
 
-        # replicate, shard
-        placements2 = [Replicate(), Shard(0)]
-        local_size2 = compute_local_shape(size, mesh, placements2)
-        if rank_coordinates[1] < 1:
-            self.assertEqual(local_size2, torch.Size([4, 7]))
-        else:
-            self.assertEqual(local_size2, torch.Size([3, 7]))
+    #     # replicate, shard
+    #     placements2 = [Replicate(), Shard(0)]
+    #     local_size2 = compute_local_shape(size, mesh, placements2)
+    #     self.assertEqual(local_size2, torch.Size([4, 6]))
 
-        # shard, shard
-        placements3 = [Shard(0), Shard(1)]
-        local_size3 = compute_local_shape(size, mesh, placements3)
-        # first dim
-        if rank_coordinates[0] < 3:
-            self.assertEqual(local_size3[0], 2)
-        else:
-            self.assertEqual(local_size3[0], 1)
-        # second dim
-        if rank_coordinates[1] < 1:
-            self.assertEqual(local_size3[1], 4)
-        else:
-            self.assertEqual(local_size3[1], 3)
+    #     # shard, shard
+    #     placements3 = [Shard(0), Shard(1)]
+    #     local_size3 = compute_local_shape(size, mesh, placements3)
+    #     self.assertEqual(local_size3, torch.Size([2, 3]))
+
+    # @with_comms
+    # def test_compute_local_shape_2d_uneven(self):
+    #     # mesh: 4 * 2
+    #     mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
+    #     mesh = DeviceMesh(self.device_type, mesh_tensor)
+    #     size = torch.Size([7, 7])
+    #     rank_coordinates = mesh.get_coordinate()
+
+    #     # replicate, shard
+    #     placements2 = [Replicate(), Shard(0)]
+    #     local_size2 = compute_local_shape(size, mesh, placements2)
+    #     if rank_coordinates[1] < 1:
+    #         self.assertEqual(local_size2, torch.Size([4, 7]))
+    #     else:
+    #         self.assertEqual(local_size2, torch.Size([3, 7]))
+
+    #     # shard, shard
+    #     placements3 = [Shard(0), Shard(1)]
+    #     local_size3 = compute_local_shape(size, mesh, placements3)
+    #     # first dim
+    #     if rank_coordinates[0] < 3:
+    #         self.assertEqual(local_size3[0], 2)
+    #     else:
+    #         self.assertEqual(local_size3[0], 1)
+    #     # second dim
+    #     if rank_coordinates[1] < 1:
+    #         self.assertEqual(local_size3[1], 4)
+    #     else:
+    #         self.assertEqual(local_size3[1], 3)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -1,8 +1,14 @@
 # Owner(s): ["oncall: distributed"]
 
+import itertools
+
 import torch
 from torch.distributed._tensor import distribute_tensor
-from torch.distributed._tensor._utils import compute_local_offset, compute_local_shape
+from torch.distributed._tensor._utils import (
+    compute_local_offset,
+    compute_local_shape,
+    compute_local_shape_and_global_offset,
+)
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Replicate, Shard
 
@@ -12,125 +18,147 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     with_comms,
 )
 
-import torch.distributed as dist
 
 class UtilTest(DTensorTestBase):
     @property
     def world_size(self):
         return 8
 
-    # @with_comms
-    # def test_compute_local_offset_1d(self):
+    @with_comms
+    def test_compute_local_offset_1d(self):
         # mesh: 8 * 1
-        # mesh_tensor = torch.arange(self.world_size)
-        # device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        # my_rank = device_mesh.get_rank()
-        # size = torch.Size([10])
+        mesh_tensor = torch.arange(self.world_size)
+        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        my_rank = device_mesh.get_rank()
+        size = torch.Size([10])
 
-        # placement = [Shard(0)]
-        # local_size = compute_local_shape(size, device_mesh, placement)
-        # local_offset = compute_local_offset(size, device_mesh, placement)
-        # print(f"rank:{dist.get_rank()}, my_rank:{my_rank}, local_size:{local_size}, local_offset:{local_offset}")
+        placement = [Shard(0)]
+        local_size = compute_local_shape(size, device_mesh, placement)
+        local_offset = compute_local_offset(size, device_mesh, placement)
 
-        # tensor = torch.ones([10])
-        # tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
-        # # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
-        # chunk_sizes = [
-        #     tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
-        #     for idx, tensor in enumerate(range(self.world_size))
-        # ]
+        tensor = torch.ones([10])
+        tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
+        # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
+        chunk_sizes = [
+            tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
+            for idx, tensor in enumerate(range(self.world_size))
+        ]
 
-        # self.assertEqual(local_size[0], chunk_sizes[my_rank])
-        # # Offset for empty shard on the current dimension is equal to
-        # # global tensor dim size on the current dimension.
-        # self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
+        self.assertEqual(local_size[0], chunk_sizes[my_rank])
+        # Offset for empty shard on the current dimension is equal to
+        # global tensor dim size on the current dimension.
+        self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
 
     @with_comms
-    def test_compute_local_offset_2d(self):
-        # mesh_tensor= torch.arange(self.world_size)
-        mesh_tensor= torch.arange(self.world_size).view(2, -1)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        placements = [Shard(0), Shard(0)]
-        # placements = [Shard(0)]
-        my_rank = device_mesh.get_rank()
-        size = torch.Size([8, 4])
+    def test_compute_local_shape_2d(self):
+        # mesh: 4 * 2
+        mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
+        mesh = DeviceMesh(self.device_type, mesh_tensor)
+        size = torch.Size([8, 6])
 
-        dtensor = distribute_tensor(torch.arange(32).view(8, 4), device_mesh, placements)
-        # print(f"rank: {device_mesh.get_rank()}, dtensor: {dtensor}")
+        # replicate, replicate
+        placements1 = [Replicate(), Replicate()]
+        local_size1 = compute_local_shape(size, mesh, placements1)
+        self.assertEqual(local_size1, torch.Size([8, 6]))
 
-        local_size = compute_local_shape(size, device_mesh, placements)
-        local_offset = compute_local_offset(size, device_mesh, placements)
-        # print(f"rank:{dist.get_rank()}, my_rank:{my_rank}, local_size:{local_size}, local_offset:{local_offset}")
+        # replicate, shard
+        placements2 = [Replicate(), Shard(0)]
+        local_size2 = compute_local_shape(size, mesh, placements2)
+        self.assertEqual(local_size2, torch.Size([4, 6]))
 
-        # tensor = torch.arange(10)
-        # tensor_lists_dim_0 = (list(torch.chunk(tensor, mesh_tensor.size(dim=0))))
-        # tensor_lists_dim_2 = []
-        # for t in tensor_lists_dim_0:
-        #     tensor_lists_dim_2.append(list(torch.chunk(t, mesh_tensor.size(dim=1))))
+        # shard, shard
+        placements3 = [Shard(0), Shard(1)]
+        local_size3 = compute_local_shape(size, mesh, placements3)
+        self.assertEqual(local_size3, torch.Size([2, 3]))
 
-        # print(tensor_lists_dim_2)
+    @with_comms
+    def test_compute_local_shape_2d_uneven(self):
+        # mesh: 4 * 2
+        mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
+        mesh = DeviceMesh(self.device_type, mesh_tensor)
+        size = torch.Size([7, 7])
+        rank_coordinates = mesh.get_coordinate()
 
-        # dtensor = distribute_tensor(tensor, device_mesh, placements=placements)
-        # print(f"rank:{dist.get_rank()}, dtensor:{dtensor}")
+        # replicate, shard
+        placements2 = [Replicate(), Shard(0)]
+        local_size2 = compute_local_shape(size, mesh, placements2)
+        if rank_coordinates[1] < 1:
+            self.assertEqual(local_size2, torch.Size([4, 7]))
+        else:
+            self.assertEqual(local_size2, torch.Size([3, 7]))
 
+        # shard, shard
+        placements3 = [Shard(0), Shard(1)]
+        local_size3 = compute_local_shape(size, mesh, placements3)
+        # first dim
+        if rank_coordinates[0] < 3:
+            self.assertEqual(local_size3[0], 2)
+        else:
+            self.assertEqual(local_size3[0], 1)
+        # second dim
+        if rank_coordinates[1] < 1:
+            self.assertEqual(local_size3[1], 4)
+        else:
+            self.assertEqual(local_size3[1], 3)
 
-        # tensor_lists_dim_1 = []
-        # for tensor_list in tensor_lists_dim_0:
-        #     tensor_lists_dim_1.append(list.torch.chunk(tensor_list, mesh_tensor.size(dim=1)))
-        # print(f"tensor_lists_dim_2:{tensor_lists_dim_2}")
-        # print(f"tensor_lists:{tensor_lists_dim_1}")
+    @with_comms
+    def test_compute_local_shape_and_global_offset_1D(self):
+        one_d_placements = [[Shard(0)], [Replicate()]]
 
-    # @with_comms
-    # def test_compute_local_shape_2d(self):
-    #     # mesh: 4 * 2
-    #     mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
-    #     mesh = DeviceMesh(self.device_type, mesh_tensor)
-    #     size = torch.Size([8, 6])
+        for placements in one_d_placements:
+            mesh_tensor = torch.arange(self.world_size)
+            device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+            global_tensor = torch.arange(64).view(8, 8)
+            global_shape = global_tensor.size()
 
-    #     # replicate, replicate
-    #     placements1 = [Replicate(), Replicate()]
-    #     local_size1 = compute_local_shape(size, mesh, placements1)
-    #     self.assertEqual(local_size1, torch.Size([8, 6]))
+            dtensor = distribute_tensor(global_tensor, device_mesh, placements)
+            local_size, global_offset = compute_local_shape_and_global_offset(
+                global_shape, device_mesh, placements
+            )
 
-    #     # replicate, shard
-    #     placements2 = [Replicate(), Shard(0)]
-    #     local_size2 = compute_local_shape(size, mesh, placements2)
-    #     self.assertEqual(local_size2, torch.Size([4, 6]))
+            # TODO: make this test cleaner and work for nD
+            dim0_start = global_offset[0]
+            dim0_end = global_offset[0] + local_size[0]
 
-    #     # shard, shard
-    #     placements3 = [Shard(0), Shard(1)]
-    #     local_size3 = compute_local_shape(size, mesh, placements3)
-    #     self.assertEqual(local_size3, torch.Size([2, 3]))
+            # Check the local tensor of dtensor is exactly the same
+            # if we slice the global_tensor with local_size and global_offset
+            self.assertEqual(
+                dtensor.to_local(),
+                global_tensor[dim0_start:dim0_end],
+            )
 
-    # @with_comms
-    # def test_compute_local_shape_2d_uneven(self):
-    #     # mesh: 4 * 2
-    #     mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
-    #     mesh = DeviceMesh(self.device_type, mesh_tensor)
-    #     size = torch.Size([7, 7])
-    #     rank_coordinates = mesh.get_coordinate()
+    @with_comms
+    def test_compute_local_shape_and_global_offset_2D(self):
+        two_d_placements_options = [Shard(0), Shard(1), Replicate()]
+        # Generating 6 two-d placements combinations
+        two_d_placements = list(
+            itertools.combinations_with_replacement(two_d_placements_options, 2)
+        )
 
-    #     # replicate, shard
-    #     placements2 = [Replicate(), Shard(0)]
-    #     local_size2 = compute_local_shape(size, mesh, placements2)
-    #     if rank_coordinates[1] < 1:
-    #         self.assertEqual(local_size2, torch.Size([4, 7]))
-    #     else:
-    #         self.assertEqual(local_size2, torch.Size([3, 7]))
+        for placements in two_d_placements:
+            # mesh: 2 * 4
+            mesh_tensor = torch.arange(self.world_size).reshape(2, 4)
+            device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+            global_tensor = torch.arange(64).view(8, 8)
+            global_shape = global_tensor.size()
 
-    #     # shard, shard
-    #     placements3 = [Shard(0), Shard(1)]
-    #     local_size3 = compute_local_shape(size, mesh, placements3)
-    #     # first dim
-    #     if rank_coordinates[0] < 3:
-    #         self.assertEqual(local_size3[0], 2)
-    #     else:
-    #         self.assertEqual(local_size3[0], 1)
-    #     # second dim
-    #     if rank_coordinates[1] < 1:
-    #         self.assertEqual(local_size3[1], 4)
-    #     else:
-    #         self.assertEqual(local_size3[1], 3)
+            dtensor = distribute_tensor(global_tensor, device_mesh, placements)
+            local_size, global_offset = compute_local_shape_and_global_offset(
+                global_shape, device_mesh, placements
+            )
+
+            # TODO: make this test cleaner and work for nD
+            dim0_start = global_offset[0]
+            dim0_end = global_offset[0] + local_size[0]
+            dim1_start = global_offset[1]
+            dim1_end = global_offset[1] + local_size[1]
+
+            # Check the local tensor of dtensor is exactly the same
+            # if we slice the global_tensor with local_size and global_offset
+            self.assertEqual(
+                dtensor.to_local(),
+                global_tensor[dim0_start:dim0_end, dim1_start:dim1_end],
+            )
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -47,11 +47,16 @@ class UtilTest(DTensorTestBase):
 
     @with_comms
     def test_compute_local_offset_2d(self):
+        # mesh_tensor= torch.arange(self.world_size)
         mesh_tensor= torch.arange(self.world_size).view(2, -1)
         device_mesh = DeviceMesh(self.device_type, mesh_tensor)
         placements = [Shard(0), Shard(0)]
+        # placements = [Shard(0)]
         my_rank = device_mesh.get_rank()
-        size = torch.Size([10, 2])
+        size = torch.Size([8, 4])
+
+        dtensor = distribute_tensor(torch.arange(32).view(8, 4), device_mesh, placements)
+        # print(f"rank: {device_mesh.get_rank()}, dtensor: {dtensor}")
 
         local_size = compute_local_shape(size, device_mesh, placements)
         local_offset = compute_local_offset(size, device_mesh, placements)

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -42,6 +42,12 @@ def compute_local_shape(
         return tuple(local_shape)
 
 
+import torch.distributed as dist
+
+def p0(line):
+    if dist.get_rank() == 3:
+        print(line)
+
 def compute_local_offset(
     global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
 ) -> Tuple[int, ...]:
@@ -74,6 +80,7 @@ def compute_local_offset(
                 )
                 local_shape[shard_dim] = shard_size
                 local_offsets[shard_dim] = shard_offset
+                p0(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
         return tuple(local_offsets)
 
 

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -62,12 +62,18 @@ def compute_local_offset(
         # if rank not in the mesh, return empty offset
         return ()
     else:
-        local_offsets = [0] * len(global_shape)
+        # local_offsets = [0] * len(global_shape)
         local_shape = list(global_shape)
+        global_offsets = []
+        sum_over_dim = [False] * len(global_shape)
 
         for idx, placement in enumerate(placements):
             mesh_dim_size = mesh.size(idx)
             if isinstance(placement, Shard):
+
+                local_offsets = [0] * len(global_shape)
+
+
                 shard_dim = placement.dim
                 assert shard_dim < len(
                     local_shape
@@ -80,7 +86,12 @@ def compute_local_offset(
                 )
                 local_shape[shard_dim] = shard_size
                 local_offsets[shard_dim] = shard_offset
-                p0(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
+                global_offsets.append(local_offsets)
+            # p0(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
+            # last_dim = len(global_shape) - 1
+            # global_offsets = torch.sum(torch.tensor(global_offsets), last_dim)
+            if dist.get_rank() == 4:
+                print(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
         return tuple(local_offsets)
 
 

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -11,6 +11,7 @@ from torch.distributed._tensor.placement_types import (
 )
 
 
+# TODO: audit existing code base to see if we can safely remove this API.
 def compute_local_shape(
     global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
 ) -> Tuple[int, ...]:
@@ -42,12 +43,7 @@ def compute_local_shape(
         return tuple(local_shape)
 
 
-import torch.distributed as dist
-
-def p0(line):
-    if dist.get_rank() == 3:
-        print(line)
-
+# TODO: audit existing code base to see if we can safely remove this API.
 def compute_local_offset(
     global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
 ) -> Tuple[int, ...]:
@@ -62,18 +58,12 @@ def compute_local_offset(
         # if rank not in the mesh, return empty offset
         return ()
     else:
-        # local_offsets = [0] * len(global_shape)
+        local_offsets = [0] * len(global_shape)
         local_shape = list(global_shape)
-        global_offsets = []
-        sum_over_dim = [False] * len(global_shape)
 
         for idx, placement in enumerate(placements):
             mesh_dim_size = mesh.size(idx)
             if isinstance(placement, Shard):
-
-                local_offsets = [0] * len(global_shape)
-
-
                 shard_dim = placement.dim
                 assert shard_dim < len(
                     local_shape
@@ -86,13 +76,74 @@ def compute_local_offset(
                 )
                 local_shape[shard_dim] = shard_size
                 local_offsets[shard_dim] = shard_offset
-                global_offsets.append(local_offsets)
-            # p0(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
-            # last_dim = len(global_shape) - 1
-            # global_offsets = torch.sum(torch.tensor(global_offsets), last_dim)
-            if dist.get_rank() == 4:
-                print(f"idx:{idx}, placement:{placement}, mesh_dim_size:{mesh_dim_size}, shard_dim:{shard_dim}, local_shape[shard_dim]:{local_shape[shard_dim]}, my_coordinate[idx]:{my_coordinate[idx]}, shard_offset:{shard_offset}, local_offsets:{local_offsets}, local_shape:{local_shape}")
         return tuple(local_offsets)
+
+
+def compute_local_shape_and_global_offset(
+    global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
+) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+    """
+    Compute the local tensor shape and the global offsets into the original tensor
+    of a DTensor on its current global rank. This is useful for checkpointing purpose.
+
+    Example (2 host with 4GPUs each):
+    # Below is a DeviceMesh with mesh_shape of (2, 4)
+    mesh = DeviceMesh(device_type="cuda",
+                        mesh=[
+                        [0, 1, 2, 3],
+                        [4, 5, 6, 7]
+                        ],
+    )
+
+    Let's say we distribute a global_tensor of shape (8,4) over the above DeviceMesh
+    with a placements of [Shard(0), Shard(0)].
+    The local shape and global offset will be as follows:
+    rank0 -- local_shape:[1, 4], global_offset:[0, 0]
+    rank1 -- local_shape:[1, 4], global_offset:[1, 0]
+    rank2 -- local_shape:[1, 4], global_offset:[2, 0]
+    rank5 -- local_shape:[1, 4], global_offset:[5, 0]
+    rank3 -- local_shape:[1, 4], global_offset:[3, 0]
+    rank4 -- local_shape:[1, 4], global_offset:[4, 0]
+    rank6 -- local_shape:[1, 4], global_offset:[6, 0]
+    rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+    """
+    my_coordinate = mesh.get_coordinate()
+
+    if my_coordinate is None:
+        # if rank not in the mesh, return empty offset
+        return ((), ())
+    else:
+        local_shape = list(global_shape)
+        global_offset = [0] * len(global_shape)
+
+        for idx, placement in enumerate(placements):
+            mesh_dim_size = mesh.size(idx)
+            if isinstance(placement, Shard):
+                shard_dim = placement.dim
+                local_offset = [0] * len(global_shape)
+                assert shard_dim < len(
+                    local_shape
+                ), f"Sharding dim {shard_dim} greater than tensor ndim {len(local_shape)}"
+                shard_size, shard_offset = placement._local_shard_size_on_dim(
+                    local_shape[shard_dim],
+                    mesh_dim_size,
+                    my_coordinate[idx],
+                    return_offset=True,
+                )
+
+                local_shape[shard_dim] = shard_size
+                local_offset[shard_dim] = shard_offset
+
+                # On a given dimension, if the local_offset[shard_dim] is smaller than global_offset[shard_dim],
+                # it means that this dimension has been already sharded in previous placement.
+                # Therefore, we cannot simply replace the global_offset[shard_dim] with local_offset[shard_dim].
+                # Instead, for the given shard_dim, we need to add local_offset[shard_dim] to existing global_offset[shard_dim].
+                if global_offset[shard_dim] <= local_offset[shard_dim]:
+                    global_offset[shard_dim] = local_offset[shard_dim]
+                else:
+                    global_offset[shard_dim] += local_offset[shard_dim]
+
+        return tuple(local_shape), tuple(global_offset)
 
 
 def compute_global_tensor_info(

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -306,7 +306,6 @@ def init_device_mesh(
         >>> # xdoctest: +SKIP
         >>> from torch.distributed._tensor.device_mesh import init_device_mesh
         >>>
-        >>> one_d_mesh = init_device_mesh("cuda", mesh_shape=(8,))
         >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, 8), mesh_dim_names=("dp", "tp"))
     """
     if mesh_dim_names is not None and len(mesh_shape) != len(mesh_dim_names):

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -306,6 +306,7 @@ def init_device_mesh(
         >>> # xdoctest: +SKIP
         >>> from torch.distributed._tensor.device_mesh import init_device_mesh
         >>>
+        >>> one_d_mesh = init_device_mesh("cuda", mesh_shape=(8,))
         >>> two_d_mesh = init_device_mesh("cuda", mesh_shape=(2, 8), mesh_dim_names=("dp", "tp"))
     """
     if mesh_dim_names is not None and len(mesh_shape) != len(mesh_dim_names):


### PR DESCRIPTION
The compute_local_shape_and_global_offset API does the following:
1) Calculate both local_shape and global_offset in one API to replace two API calls (compute_local_size and compute_local_shape).
2) Generate the correct global_offset for checkpointing purposes. We are currently using compute_local_offset for downstream checkpoint components, which could lead to incorrect results. For checkpointing, we need global_offset instead of local_offset. In some cases, global_offset does not equal to local_offset, when a dimension is sharded multipe times on different mesh dimension (e.g. placements = [Shard(0), Shard(0)]). 

Follow-up PRs:
1) Replace related downstream components to use compute_local_shape_and_global_offset instead of compute_local_size and compute_local_offset.
2) Audit existing code base to see if we can remove compute_local_size and compute_local_offset, since they are currently being used.

cc. @wanchaol 