### PR TITLE
Increased logging threshold for profiler matching

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1480,7 +1480,7 @@ class TestMemoryProfilerE2E(TestCase):
 
             # We generally don't care about tiny allocations during memory
             # profiling and they add a lot of noise to the unit test.
-            if size > 512
+            if size > 1024
         ]
 
         self.assertExpectedInline(


### PR DESCRIPTION
Fixed test_memory_profiler::TestMemoryProfilerE2E::test_memory_timeline by changing the (arbitrary) threshold for logging. With increased size allocations on newer AMD GPUs, a higher threshold over 1024 is preferred to account for those differences and yet satisfy the test requirements.
