### PR TITLE
[PT2] - Add check for stack

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -967,7 +967,8 @@ class CheckFunctionManager:
                 maybe_stack = ""
                 maybe_user_stack = ""
                 if guard is not None:
-                    maybe_stack = f"\nStack:\n{''.join(guard.stack.format())}"
+                    if guard.stack:
+                        maybe_stack = f"\nStack:\n{''.join(guard.stack.format())}"
                     if guard.user_stack:
                         maybe_user_stack = (
                             f"\nUser stack:\n{''.join(guard.user_stack.format())}"


### PR DESCRIPTION
Summary:
Add check for `guard.stack` which was causing exceptions like:

```
toch._dynamo.exc.InternalTorchDynamoError: 'NoneType' object has no attribute 'format'
```

Test Plan: contbuild & OSS CI

Differential Revision: D48709458



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov