### PR TITLE
[submodule] Fix eltwise share buffer issue in ideep

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -567,6 +567,24 @@ class TestMkldnn(TestCase):
         self.assertEqual(y1, y2)
         self.assertEqual(x1.grad, x2.grad.to_dense())
 
+    def test_gelu_transpose(self):
+        m = torch.nn.GELU()
+        x = torch.randn((4, 6, 6), dtype=torch.float32) * 10
+        y_target = torch.randn((4, 6, 6), dtype=torch.float32) * 10
+        x1 = x.clone().requires_grad_(True)
+        x2 = x.clone().requires_grad_(True)
+        y1 = m(x1).transpose(-1, -2)
+        loss1 =  torch.mean((y1 - y_target) ** 2.0)
+        loss1.backward()
+
+        torch._C._set_mkldnn_enabled(False)
+        y2 = m(x2).transpose(-1, -2)
+        loss2 =  torch.mean((y2 - y_target) ** 2.0)
+        loss2.backward()
+
+        self.assertEqual(y1, y2)
+        self.assertEqual(x1.grad, x2.grad)
+
     @unittest.skipIf(IS_WINDOWS, "Limit support for bf16 path")
     def test_gelu_bf16(self):
         m = torch.nn.GELU()

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -577,13 +577,15 @@ class TestMkldnn(TestCase):
         loss1 = torch.mean((y1 - y_target) ** 2.0)
         loss1.backward()
 
-        torch._C._set_mkldnn_enabled(False)
-        y2 = m(x2).transpose(-1, -2)
-        loss2 = torch.mean((y2 - y_target) ** 2.0)
-        loss2.backward()
-
-        self.assertEqual(y1, y2)
-        self.assertEqual(x1.grad, x2.grad)
+        try:
+            torch._C._set_mkldnn_enabled(False)
+            y2 = m(x2).transpose(-1, -2)
+            loss2 = torch.mean((y2 - y_target) ** 2.0)
+            loss2.backward()
+            self.assertEqual(y1, y2)
+            self.assertEqual(x1.grad, x2.grad)
+        finally:
+            torch._C._set_mkldnn_enabled(True)
 
     @unittest.skipIf(IS_WINDOWS, "Limit support for bf16 path")
     def test_gelu_bf16(self):

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -574,12 +574,12 @@ class TestMkldnn(TestCase):
         x1 = x.clone().requires_grad_(True)
         x2 = x.clone().requires_grad_(True)
         y1 = m(x1).transpose(-1, -2)
-        loss1 =  torch.mean((y1 - y_target) ** 2.0)
+        loss1 = torch.mean((y1 - y_target) ** 2.0)
         loss1.backward()
 
         torch._C._set_mkldnn_enabled(False)
         y2 = m(x2).transpose(-1, -2)
-        loss2 =  torch.mean((y2 - y_target) ** 2.0)
+        loss2 = torch.mean((y2 - y_target) ** 2.0)
         loss2.backward()
 
         self.assertEqual(y1, y2)

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -567,26 +567,6 @@ class TestMkldnn(TestCase):
         self.assertEqual(y1, y2)
         self.assertEqual(x1.grad, x2.grad.to_dense())
 
-    def test_gelu_transpose(self):
-        m = torch.nn.GELU()
-        x = torch.randn((4, 6, 6), dtype=torch.float32) * 10
-        y_target = torch.randn((4, 6, 6), dtype=torch.float32) * 10
-        x1 = x.clone().requires_grad_(True)
-        x2 = x.clone().requires_grad_(True)
-        y1 = m(x1).transpose(-1, -2)
-        loss1 = torch.mean((y1 - y_target) ** 2.0)
-        loss1.backward()
-
-        try:
-            torch._C._set_mkldnn_enabled(False)
-            y2 = m(x2).transpose(-1, -2)
-            loss2 = torch.mean((y2 - y_target) ** 2.0)
-            loss2.backward()
-            self.assertEqual(y1, y2)
-            self.assertEqual(x1.grad, x2.grad)
-        finally:
-            torch._C._set_mkldnn_enabled(True)
-
     @unittest.skipIf(IS_WINDOWS, "Limit support for bf16 path")
     def test_gelu_bf16(self):
         m = torch.nn.GELU()


### PR DESCRIPTION
Fix [#107876 ](https://github.com/pytorch/pytorch/issues/107876).

This PR is to fix [#107876 ](https://github.com/pytorch/pytorch/issues/107876), which root cause is that, eltwise is lack of the logic of dealing with src and diff_src with different shapes. After initializing a new diff_src and reordering back to diff_src's buffer, like inner_product and matmul, the issue https://github.com/pytorch/pytorch/issues/107876 can be addressed.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @Guobing-Chen @Xia-Weiwen