### PR TITLE
[POC] Add `frozen_offload`

### DIFF
--- a/test/distributed/_composable/test_offload.py
+++ b/test/distributed/_composable/test_offload.py
@@ -1,0 +1,81 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import functools
+import unittest
+
+import torch
+import torch.nn as nn
+from torch.distributed._composable.offload import frozen_offload, to_gpu
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, device: torch.device):
+        super().__init__()
+        self.lin1 = nn.Linear(dim, 4 * dim, device=device)
+        self.relu = nn.ReLU()
+        self.lin2 = nn.Linear(4 * dim, dim, device=device)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.relu(self.lin2(self.relu(self.lin1(x))))
+
+
+class FrozenMLP(MLP):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for param in self.parameters():
+            param.requires_grad_(False)
+
+
+class TestFrozenOffload(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_parity(self):
+        torch.manual_seed(0)
+        lin_dim = 1024
+        model = nn.Sequential(
+            FrozenMLP(lin_dim, torch.device("cuda")),
+            MLP(lin_dim, torch.device("cuda")),
+            nn.Linear(lin_dim, lin_dim, device="cuda"),
+            nn.ReLU(),
+        )
+        ref_model = copy.deepcopy(model)
+        ref_optim = torch.optim.Adam(
+            [p for p in ref_model.parameters() if p.requires_grad], lr=1e-2
+        )
+        frozen_offload(model[0])
+        optim = torch.optim.Adam(
+            [p for p in model.parameters() if p.requires_grad], lr=1e-2
+        )
+        # For users: replace the following hook with any other backward hook
+        # to run `to_gpu()` to prefetch for the next iteration
+        model[2].weight.register_post_accumulate_grad_hook(
+            functools.partial(to_gpu, model[0])
+        )
+        # Check that initialization is correct
+        for (n1, p1), (n2, p2) in zip(
+            model[0].named_parameters(), ref_model[0].named_parameters()
+        ):
+            self.assertEqual(n1, n2)
+            self.assertEqual(p1.device, torch.device("cpu"))
+            self.assertTrue(p2.is_cuda)
+            self.assertEqual(p1.cuda(), p2)
+
+        # Check that training is correct (e.g. stream sync)
+        torch.manual_seed(42)
+        inp = torch.randn((16, lin_dim), device="cuda")
+        for i in range(10):
+            losses = []
+            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                _optim.zero_grad()
+                loss = _model(inp).sum()
+                losses.append(loss)
+                loss.backward()
+                _optim.step()
+
+            self.assertEqual(losses[0], losses[1])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_composable/offload.py
+++ b/torch/distributed/_composable/offload.py
@@ -1,0 +1,124 @@
+from enum import auto, Enum
+from typing import List, Optional
+
+import torch
+
+import torch.nn as nn
+
+from torch.distributed._composable_state import _State
+from .contract import contract
+
+
+class _DeviceState(Enum):
+    CPU = auto()
+    GPU_UNSYNCED = auto()
+    GPU_SYNCED = auto()
+
+
+@contract()
+def frozen_offload(
+    module: nn.Module,
+):
+    state = frozen_offload.state(module)
+    _check_module_params(module)
+    _init_data(state, module)
+    state._forward_handle = module.register_forward_hook(to_cpu)
+    state._forward_pre_handle = module.register_forward_pre_hook(_to_gpu_synced)
+
+
+def to_cpu(module: nn.Module, *unused_args, **unused_kwargs):
+    """
+    Frees the GPU parameter memory.
+    """
+    state = frozen_offload.state(module)
+    if state is None:
+        return
+    if state._device_state == _DeviceState.CPU:
+        return
+    with torch.profiler.record_function("frozen_offload::to_cpu"):
+        # Choose to not persist any changes from the GPU copy to the CPU copy
+        for param, cpu_view in zip(state._params, state._cpu_views):
+            param.data = cpu_view
+        # state._gpu_flat_tensor.untyped_storage().resize_(0)
+        state._gpu_flat_tensor.record_stream(torch.cuda.current_stream())
+        state._gpu_flat_tensor = None
+        state._device_state = _DeviceState.CPU
+
+
+def to_gpu(module: nn.Module, *unused_args, **unused_kwargs):
+    """
+    Allocates GPU memory for the parameters and copies them from CPU to GPU in
+    a separate CUDA stream. This must be followed with a ``wait_on_copy()``
+    call to ensure correct synchronization (due to the stream usage).
+    """
+    state = frozen_offload.state(module)
+    if state is None:
+        return
+    if state._device_state in (_DeviceState.GPU_UNSYNCED, _DeviceState.GPU_SYNCED):
+        return
+    with torch.profiler.record_function("frozen_offload::to_gpu"):
+        with torch.cuda.stream(state._stream):
+            state._gpu_flat_tensor = state._cpu_flat_tensor.to(torch.device("cuda"), non_blocking=True)
+            offset = 0
+            for param, numel, size in zip(state._params, state._numels, state._sizes):
+                param.data = state._gpu_flat_tensor[offset : offset + numel].view(size)
+                offset += numel
+        state._device_state = _DeviceState.GPU_UNSYNCED
+    
+
+def _to_gpu_synced(module: nn.Module, *unused_args, **unused_kwargs):
+    # NOTE: If `to_gpu()` was called in the last iteration's backward, then
+    # this `to_gpu()` call here will be a no-op, and we only use this function
+    # for the stream wait.
+    to_gpu(module, *unused_args, **unused_kwargs)
+    state = frozen_offload.state(module)
+    if state is None:
+        return
+    with torch.profiler.record_function("frozen_offload::wait_stream"):
+        torch.cuda.current_stream().wait_stream(state._stream)
+        state._device_state = _DeviceState.GPU_SYNCED
+
+
+def _init_data(state: _State, module: nn.Module) -> None:
+    state._params: List[nn.Parameter] = []
+    state._numels: List[int] = []
+    state._sizes: List[torch.Size] = []
+    state._stream = torch.cuda.Stream()
+    state._device_state = _DeviceState.CPU
+    total_numel = 0
+    for param in module.parameters():
+        state._params.append(param)
+        state._numels.append(param.numel())
+        state._sizes.append(param.size())
+        total_numel += param.numel()
+    if len(state._params) == 0:
+        return
+    cpu_flat_tensor = torch.empty(
+        (total_numel,), device=torch.device("cpu"), dtype=state._params[0].dtype
+    ).pin_memory()
+    state._cpu_views: List[torch.Tensor] = []
+    offset = 0
+    for param, numel, size in zip(state._params, state._numels, state._sizes):
+        cpu_flat_tensor[offset : offset + numel].view(size).copy_(param)
+        state._cpu_views.append(cpu_flat_tensor[offset : offset + numel].view(size))
+        param.data = state._cpu_views[-1]
+        offset += numel
+    state._cpu_flat_tensor = cpu_flat_tensor
+    state._gpu_flat_tensor: Optional[torch.Tensor] = None
+
+
+def _check_module_params(module: nn.Module) -> None:
+    dtype = None
+    for param_name, param in module.named_parameters():
+        if param.requires_grad:
+            raise AssertionError(
+                "frozen_offload requires all parameters to be frozen "
+                f"(requires_grad=False) but got {param_name} with requires_grad=True"
+            )
+        if dtype is not None:
+            if param.dtype != dtype:
+                raise NotImplementedError(
+                    "frozen_offload currently only supports uniform dtype but "
+                    f"got both {dtype} and {param.dtype}"
+                )
+            dtype = param.dtype


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108052
* #107784
* #106080
* #106068

This is a proof-of-concept for an internal use case request. `frozen_offload` only applies to a module with all frozen parameters. In default, the parameters are offloaded to CPU (as views into a single contiguous tensor for copy efficiency), and for forward computation, the parameters are moved to GPU.

![Screenshot 2023-08-28 at 10 10 01 AM](https://github.com/pytorch/pytorch/assets/31054793/866d1245-f1a2-44c9-ad41-03759acc854c)
