### PR TITLE
[WIP] Reset eval_frame when entering bytecode to allow for CPython 3.11 optimizations

### DIFF
--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -905,6 +905,14 @@ static PyObject* _custom_eval_frame(
       frame->f_iblock);
   #endif
 
+  // In CPython 3.11 and above, a custom evaluation frame
+  // means certain optimizations are disabled.
+  // As after this point we are practically evaluating
+  // CPython bytecode using the standard interpreter,
+  // unset the eval frame to let CPython know that it can
+  // perform its optimizations. 
+  tstate->interp->eval_frame = NULL;
+
   if (throw_flag) {
     // When unwinding generators, eval frame is called with throw_flag ==
     // true.  Frame evaluation is supposed to continue unwinding by propagating


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/108074

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov