### PR TITLE
Skip ROCm jobs on PR (for now)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -176,6 +176,7 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-build:
+    if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:


### PR DESCRIPTION
Follow AMD suggestion to relieve the queue on ROCM, let the jobs run in only trunk


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang