### PR TITLE
[inductor] Add aten.multinomial to disallowed cudagraphs ops

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -431,10 +431,11 @@ def has_incompatible_cudagraph_ops(gm):
     forbidden_set = {
         "aten._fused_moving_avg_obs_fq_helper.default",
         "aten._fused_moving_avg_obs_fq_helper_functional.default",
+        "aten.multinomial.default",
         "fbgemm.dense_to_jagged.default",
         "fbgemm.jagged_to_padded_dense.default",
-        "run_with_rng_state",
         "run_and_save_rng_state",
+        "run_with_rng_state",
     }
     if torch.are_deterministic_algorithms_enabled():
         forbidden_set.update(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108105
* #108098
* #108087
* #108096

Fixes:
```python
CUDA_LAUNCH_BLOCKING=1 ./benchmarks/dynamo/torchbench.py --inference --performance --no-skip --inductor --freezing --only nanogpt_generate
loading model: 0it [00:00, ?it/s]number of parameters: 123.69M
loading model: 0it [00:07, ?it/s]
cuda eval  nanogpt_generate
ERROR:common:Backend dynamo failed in warmup()
Traceback (most recent call last):
  File "/data/users/jansel/pytorch/torch/_inductor/cudagraph_trees.py", line 1084, in _record
    static_outputs = model(inputs)
  File "/data/users/jansel/pytorch/torch/_inductor/codecache.py", line 401, in _run_from_cache
    return compiled_graph.compiled_artifact(inputs)
  File "/tmp/torchinductor_jansel/db/cdbk4ip3fucyoccnbnoik2crjpdkliwxll653l7l3wwsxiygmade.py", line 18375, in call
    buf239 = aten.multinomial.default(buf238, 1)
  File "/data/users/jansel/pytorch/torch/_ops.py", line 448, in __call__
    return self._op(*args, **kwargs or {})
RuntimeError: CUDA error: operation not permitted when stream is capturing
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov