### PR TITLE
fix get device index if has _utils._get_device_index in privateuse1

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -314,14 +314,32 @@ def _meta_deserialize(obj, location):
 
 
 def _validate_privateuse1_device(location, backend_name):
-    device = torch.device(location)
-    device_index = device.index if device.index else 0
+    '''
+    Check whether the device index of privateuse1 is valid
+
+    Register a device_module of privateuse1 by torch._register_device_module.
+    Implement the following methods in device_module like cuda:
+    device_module._utils._get_device_index(location, True),
+    device_module.device_count().
+
+    Args:
+        location: string of device
+        backend_name: the name of privateuse1, which can be renamed
+
+    Returns:
+        device_index: int
+    '''
     if not hasattr(torch, backend_name):
         raise RuntimeError(f'The {backend_name.upper()} device module is not registered. '
                            'If you are running on a CPU-only machine, '
                            'please use torch.load with map_location=torch.device(\'cpu\') '
                            'to map your storages to the CPU.')
     device_module = getattr(torch, backend_name)
+    if hasattr(device_module, '_utils') and hasattr(device_module._utils, '_get_device_index'):
+        device_index = device_module._utils._get_device_index(location, True)
+    else:
+        device = torch.device(location)
+        device_index = device.index if device.index else 0
     if hasattr(device_module, 'is_available') and not device_module.is_available():
         raise RuntimeError(f'Attempting to deserialize object on a {backend_name.upper()} '
                            f'device but torch.{backend_name}.is_available() is False. '


### PR DESCRIPTION
**Get device index by torch.privateuse1._utils._get_device_index, if the metched exists.**

Reason:
Can only get device_index 0 if ```location``` such as 'privateuse1' before modify.
Can get accurate deivce index use _get_device_index in this scenario.