### PR TITLE
distinguish arrays and scalars in torch._numpy

### DIFF
--- a/test/torch_np/numpy_tests/lib/test_arraypad.py
+++ b/test/torch_np/numpy_tests/lib/test_arraypad.py
@@ -555,3 +555,7 @@ class TestConstant:
         arr = np.zeros((3, 0, 2))
         result = np.pad(arr, [(0,), (2,), (1,)], mode="constant")
         assert result.shape == (3, 4, 4)
+
+    def test_pad_scalar_width(self):
+        result = np.pad([1, 2, 3], 4)
+        assert_array_equal(result, [0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0])

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -7,6 +7,7 @@ pytorch tensors.
 # where type annotations are used in conjunction with the @normalizer decorator.
 from __future__ import annotations
 
+import math
 import builtins
 import itertools
 import operator
@@ -305,8 +306,8 @@ def linspace(
 
 
 def geomspace(
-    start: ArrayLike,
-    stop: ArrayLike,
+    start: ArrayLikeOrScalar,
+    stop: ArrayLikeOrScalar,
     num=50,
     endpoint=True,
     dtype: Optional[DTypeLike] = None,
@@ -314,11 +315,20 @@ def geomspace(
 ):
     if axis != 0 or not endpoint:
         raise NotImplementedError
-    base = torch.pow(stop / start, 1.0 / (num - 1))
-    logbase = torch.log(base)
+    all_scalars = all(_dtypes_impl.is_scalar_or_symbolic(x) for x in [start, stop, num])
+
+    if all_scalars:
+        power = math.pow
+        log = math.log
+    else:
+        power = torch.pow
+        log = torch.log
+
+    base = power(stop / start, 1.0 / (num - 1))
+    logbase = log(base)
     return torch.logspace(
-        torch.log(start) / logbase,
-        torch.log(stop) / logbase,
+        log(start) / logbase,
+        log(stop) / logbase,
         num,
         base=base,
     )

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -7,9 +7,10 @@ pytorch tensors.
 # where type annotations are used in conjunction with the @normalizer decorator.
 from __future__ import annotations
 
-import math
 import builtins
 import itertools
+
+import math
 import operator
 from typing import Optional, Sequence
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -2040,7 +2040,7 @@ def min_scalar_type(a: ArrayLike, /):
     return DType(dtype)
 
 
-def pad(array: ArrayLike, pad_width: ArrayLikeOrScalar, mode="constant", **kwargs):
+def pad(array: ArrayLike, pad_width: ArrayLike, mode="constant", **kwargs):
     if mode != "constant":
         raise NotImplementedError
     value = kwargs.get("constant_values", 0)
@@ -2048,8 +2048,6 @@ def pad(array: ArrayLike, pad_width: ArrayLikeOrScalar, mode="constant", **kwarg
     typ = _dtypes_impl.python_type_for_torch(array.dtype)
     value = typ(value)
 
-    if not isinstance(pad_width, torch.Tensor):
-        pad_width = torch.as_tensor(pad_width)
     pad_width = torch.broadcast_to(pad_width, (array.ndim, 2))
     pad_width = torch.flip(pad_width, (0,)).flatten()
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -316,22 +316,24 @@ def geomspace(
 ):
     if axis != 0 or not endpoint:
         raise NotImplementedError
-    all_scalars = all(_dtypes_impl.is_scalar_or_symbolic(x) for x in [start, stop, num])
 
+    all_scalars = all(_dtypes_impl.is_scalar_or_symbolic(x) for x in [start, stop])
     if all_scalars:
-        power = math.pow
+        exp = math.exp
         log = math.log
     else:
-        power = torch.pow
+        exp = math.exp
         log = torch.log
 
-    base = power(stop / start, 1.0 / (num - 1))
-    logbase = log(base)
+    logbase = log(stop / start) / (num - 1)
+    base = exp(logbase)
+
     return torch.logspace(
         log(start) / logbase,
         log(stop) / logbase,
         num,
         base=base,
+        dtype=dtype
     )
 
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -288,8 +288,8 @@ def vander(x: ArrayLike, N=None, increasing=False):
 
 
 def linspace(
-    start: ArrayLike,
-    stop: ArrayLike,
+    start: ArrayLikeOrScalar,
+    stop: ArrayLikeOrScalar,
     num=50,
     endpoint=True,
     retstep=False,
@@ -325,8 +325,8 @@ def geomspace(
 
 
 def logspace(
-    start,
-    stop,
+    start: ArrayLikeOrScalar,
+    stop: ArrayLikeOrScalar,
     num=50,
     endpoint=True,
     base=10.0,

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -982,6 +982,13 @@ def clip(
     max: Optional[ArrayLikeOrScalar] = None,
     out: Optional[OutArray] = None,
 ):
+    is_min_scalar = _dtypes_impl.is_scalar_or_symbolic(min)
+    is_max_scalar = _dtypes_impl.is_scalar_or_symbolic(max)
+    if is_min_scalar and not is_max_scalar:
+        min = _util._coerce_to_tensor(min)
+    if is_max_scalar and not is_min_scalar:
+        max = _util._coerce_to_tensor(max)
+
     return torch.clamp(a, min, max)
 
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -1862,7 +1862,7 @@ def common_type(*tensors: ArrayLike):
 
 def histogram(
     a: ArrayLike,
-    bins: ArrayLike = 10,
+    bins: ArrayLikeOrScalar = 10,
     range=None,
     normed=None,
     weights: Optional[ArrayLike] = None,
@@ -2022,7 +2022,7 @@ def min_scalar_type(a: ArrayLike, /):
     return DType(dtype)
 
 
-def pad(array: ArrayLike, pad_width: ArrayLike, mode="constant", **kwargs):
+def pad(array: ArrayLike, pad_width: ArrayLikeOrScalar, mode="constant", **kwargs):
     if mode != "constant":
         raise NotImplementedError
     value = kwargs.get("constant_values", 0)
@@ -2030,6 +2030,8 @@ def pad(array: ArrayLike, pad_width: ArrayLike, mode="constant", **kwargs):
     typ = _dtypes_impl.python_type_for_torch(array.dtype)
     value = typ(value)
 
+    if not isinstance(pad_width, torch.Tensor):
+        pad_width = torch.as_tensor(pad_width)
     pad_width = torch.broadcast_to(pad_width, (array.ndim, 2))
     pad_width = torch.flip(pad_width, (0,)).flatten()
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -978,8 +978,8 @@ def flatnonzero(a: ArrayLike):
 
 def clip(
     a: ArrayLike,
-    min: Optional[ArrayLike] = None,
-    max: Optional[ArrayLike] = None,
+    min: Optional[ArrayLikeOrScalar] = None,
+    max: Optional[ArrayLikeOrScalar] = None,
     out: Optional[OutArray] = None,
 ):
     return torch.clamp(a, min, max)

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -323,11 +323,7 @@ def geomspace(
     base = math.exp(logbase)
 
     return torch.logspace(
-        math.log(start) / logbase,
-        math.log(stop) / logbase,
-        num,
-        base=base,
-        dtype=dtype
+        math.log(start) / logbase, math.log(stop) / logbase, num, base=base, dtype=dtype
     )
 
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -1533,10 +1533,6 @@ def angle(z: ArrayLike, deg=False):
     return result
 
 
-def sinc(x: ArrayLike):
-    return torch.sinc(x)
-
-
 # NB: have to normalize *varargs manually
 def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
     N = f.ndim  # number of dimensions
@@ -1782,10 +1778,6 @@ def isneginf(x: ArrayLike, out: Optional[OutArray] = None):
 
 def isposinf(x: ArrayLike, out: Optional[OutArray] = None):
     return torch.isposinf(x)
-
-
-def i0(x: ArrayLike):
-    return torch.special.i0(x)
 
 
 def isscalar(a):

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -317,20 +317,14 @@ def geomspace(
     if axis != 0 or not endpoint:
         raise NotImplementedError
 
-    all_scalars = all(_dtypes_impl.is_scalar_or_symbolic(x) for x in [start, stop])
-    if all_scalars:
-        exp = math.exp
-        log = math.log
-    else:
-        exp = math.exp
-        log = torch.log
-
-    logbase = log(stop / start) / (num - 1)
-    base = exp(logbase)
+    # XXX: torch.logspace only accepts scalars,
+    # while np.logspace broadcasts array-like arguments
+    logbase = math.log(stop / start) / (num - 1)
+    base = math.exp(logbase)
 
     return torch.logspace(
-        log(start) / logbase,
-        log(stop) / logbase,
+        math.log(start) / logbase,
+        math.log(stop) / logbase,
         num,
         base=base,
         dtype=dtype

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -307,8 +307,8 @@ def linspace(
 
 
 def geomspace(
-    start: ArrayLikeOrScalar,
-    stop: ArrayLikeOrScalar,
+    start,
+    stop,
     num=50,
     endpoint=True,
     dtype: Optional[DTypeLike] = None,

--- a/torch/_numpy/_unary_ufuncs_impl.py
+++ b/torch/_numpy/_unary_ufuncs_impl.py
@@ -24,6 +24,7 @@ from torch import (  # noqa: F401
     exp2,  # noqa: F401
     expm1,  # noqa: F401
     floor,  # noqa: F401
+    i0,  # noqa: F401
     isfinite,  # noqa: F401
     isinf,  # noqa: F401
     isnan,  # noqa: F401
@@ -41,14 +42,13 @@ from torch import (  # noqa: F401
     sign,  # noqa: F401
     signbit,  # noqa: F401
     sin,  # noqa: F401
+    sinc,  # noqa: F401
     sinh,  # noqa: F401
     sqrt,  # noqa: F401
     square,  # noqa: F401
     tan,  # noqa: F401
     tanh,  # noqa: F401
     trunc,  # noqa: F401
-    sinc,  # noqa: F401
-    i0,  # noqa: F401
 )
 
 

--- a/torch/_numpy/_unary_ufuncs_impl.py
+++ b/torch/_numpy/_unary_ufuncs_impl.py
@@ -47,6 +47,8 @@ from torch import (  # noqa: F401
     tan,  # noqa: F401
     tanh,  # noqa: F401
     trunc,  # noqa: F401
+    sinc,  # noqa: F401
+    i0,  # noqa: F401
 )
 
 


### PR DESCRIPTION
We used to convert all scalar into 0D tensors in the torch_np layer; this is apparently sometimes problematic; here's a try to use ArrayOrScalar annotations some more:

- binary ufuncs: just a cleanup, avoid explicit `Union[ArrayLike, Scalar]` since we have a name for this
- i0, sinc : make ufuncs; this is only a drive-by clean-up (or hit-and-run cleanup), can remove
- np.pad : this one is what things would look like, many of these changes would require explicit isinstance checks. Do we want that @lezcano?

cross-ref gh-108082

cc @mruberry @rgommers @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng