### PR TITLE
[functorch] make torch.compile support opt-in

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -287,7 +287,7 @@ _save_config_ignore = {
 capture_autograd_function = True
 
 # enable/disable dynamo tracing for `torch.func` transforms
-capture_func_transforms = True
+capture_func_transforms = False
 
 # simulates what would happen if we didn't have support for BUILD_SET opcode,
 # used for testing


### PR DESCRIPTION
This is an experimental feature and we want to make it opt-in for this release.

Setting this to False will still run the relevant tests.

Note: This PR is for release/2.1

https://github.com/pytorch/pytorch/blob/6d20b39d3f36cdd52ae35d078985b6905a8da550/test/dynamo/test_higher_order_ops.py#L1611-L1617

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov