### PR TITLE
Enable Mypy Checking in torch/_inductor/scheduler.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -205,7 +205,6 @@ exclude_patterns = [
     'torch/_inductor/codecache.py',
     'torch/_inductor/test_operators.py',
     'torch/_inductor/inductor_prims.py',
-    'torch/_inductor/scheduler.py',
     'torch/_inductor/__init__.py',
     'torch/_inductor/exc.py',
     'torch/_inductor/sizevars.py',


### PR DESCRIPTION
Fixes #105230 

Summary:

As suggested in https://github.com/pytorch/pytorch/issues/105230 mypy checking is enabled in torch/_inductor/kernel/scheduler.py

After Fix:

mypy --follow-imports=skip torch/_inductor/kernel/scheduler.py Success: no issues found in 1 source file

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov