### PR TITLE
[Inductor] Add fused_attention pattern matcher with additional clone

### DIFF
--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -303,6 +303,81 @@ def _sfdp_replacement_12(query, key, value, inv_scale_factor, dropout_p):
     )
 
 
+def _sfdp_pattern_13(query, key, value, inv_scale):
+    # dropout would create a clone() if eval() or p = 0
+    return (
+        torch.matmul(query, key.transpose(-2, -1))
+        .div(inv_scale)
+        .softmax(dim=-1)
+        .clone()
+        .matmul(value)
+    )
+
+
+def _sfdp_replacement_13(query, key, value, inv_scale):
+    counters["inductor"]["fuse_attention"] += 1
+    return aten.scaled_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=1.0 / inv_scale,
+    )
+
+
+def _sfdp_pattern_14(query, key, value, scale_factor):
+    # dropout would create a clone() if eval() or p = 0
+    return (
+        torch.matmul(query, key.transpose(-2, -1))
+        .mul(scale_factor)
+        .softmax(dim=-1)
+        .clone()
+        .matmul(value)
+    )
+
+
+def _sfdp_replacement_14(query, key, value, scale_factor):
+    counters["inductor"]["fuse_attention"] += 1
+    return aten.scaled_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale_factor,
+    )
+
+
+def _sfdp_pattern_15(query, key, value, inv_scale):
+    # dropout would create a clone() if eval() or p = 0
+    q = query.permute(0, 2, 1, 3)
+    k = key.permute(0, 2, 1, 3)
+    v = value.permute(0, 2, 1, 3)
+    return (
+        torch.matmul(q, k.transpose(-2, -1))
+        .div(inv_scale)
+        .softmax(dim=-1)
+        .clone()
+        .matmul(v)
+    )
+
+
+def _sfdp_replacement_15(query, key, value, inv_scale):
+    counters["inductor"]["fuse_attention"] += 1
+    return aten.scaled_dot_product_attention(
+        query.transpose(1, 2),
+        key.transpose(1, 2),
+        value.transpose(1, 2),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=1.0 / inv_scale,
+    )
+
+
 def _sfdp_params_check(match):
     assert all(k in match.kwargs for k in ("query", "key", "value"))
     query = match.kwargs["query"].meta["val"]
@@ -448,6 +523,27 @@ def _sfdp_init():
             _sfdp_replacement_12,
             [g(), g(), g(), c()],
             d,
+            _sfdp_scale_factor_check(aten.div.Tensor),
+        ),
+        (
+            _sfdp_pattern_13,
+            _sfdp_replacement_13,
+            [g(), g(), g(), c()],
+            {},
+            _sfdp_scale_factor_check(aten.div.Tensor),
+        ),
+        (
+            _sfdp_pattern_14,
+            _sfdp_replacement_14,
+            [g(), g(), g(), c()],
+            {},
+            _sfdp_scale_factor_check(aten.mul.Tensor),
+        ),
+        (
+            _sfdp_pattern_15,
+            _sfdp_replacement_15,
+            [g(), g(), g(), c()],
+            {},
             _sfdp_scale_factor_check(aten.div.Tensor),
         ),
     ]:


### PR DESCRIPTION
A previous PR https://github.com/pytorch/pytorch/pull/106274 decomposes `aten.dropout` and would create a `clone()` when `eval()` or `p=0`. This makes many SDPA-related models fail to match fused_attention pattern matchers.

This PR adds new fused_attention pattern matchers with an additional clone to re-enable the SDPA op matching.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov