### PR TITLE
Remove case for `RecursionError` on `try_solve`.

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3357,9 +3357,6 @@ class ShapeEnv:
                     self._set_replacement(cast(sympy.Symbol, free[0]), new_var)
             except NotImplementedError:
                 pass
-            except RecursionError:
-                self.counter["sympy_recursion_error"] += 1
-                self.log.warning("RecursionError in sympy.solve(%s - %s, %s)", lhs, rhs, free[0])
         if expr.has(Mod):
             mod_expr = tuple(expr.atoms(Mod))[0]
             try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108144

This PR removes an `except` clause for `RecursionError`. It used to be there because
`sympy.solve` was being used at the time. Since we are using the simpler `try_solve`, it's
not needed anymore.