### PR TITLE
[docs] Properly link register_post_accumulate_grad_hook docs

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -179,6 +179,7 @@ Tensor autograd functions
    torch.Tensor.detach
    torch.Tensor.detach_
    torch.Tensor.register_hook
+   torch.Tensor.register_post_accumulate_grad_hook
    torch.Tensor.retain_grad
 
 :hidden:`Function`

--- a/docs/source/name_inference.rst
+++ b/docs/source/name_inference.rst
@@ -185,6 +185,7 @@ If you don't see an operation listed here, but it would help your use case, plea
    :meth:`Tensor.reciprocal_`,None
    :meth:`Tensor.refine_names`,See documentation
    :meth:`Tensor.register_hook`,None
+   :meth:`Tensor.register_post_accumulate_grad_hook`,None
    :meth:`Tensor.rename`,See documentation
    :meth:`Tensor.rename_`,See documentation
    :attr:`Tensor.requires_grad`,None

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -575,6 +575,7 @@ Tensor class reference
     Tensor.reciprocal_
     Tensor.record_stream
     Tensor.register_hook
+    Tensor.register_post_accumulate_grad_hook
     Tensor.remainder
     Tensor.remainder_
     Tensor.renorm


### PR DESCRIPTION
it shows up now

![image](https://github.com/pytorch/pytorch/assets/31798555/0aa86839-b9c5-4b4b-b1b1-aa1c0c0abbab)


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108157

