### PR TITLE
Fix constant folding of arithmetic operations with symbolic values.

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -243,14 +243,17 @@ class TestInductorDynamic(TestCase):
 
         def add(x):
             return x + torch.zeros(3)
+
         test(add)
 
         def mul(x):
             return x * torch.ones(3)
+
         test(mul)
 
         def div(x):
             return x / torch.ones(3)
+
         test(div)
 
     @onlyCPU

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -11,6 +11,7 @@ import torch
 from torch._dynamo.testing import make_test_cls_with_patches
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyCPU,
     onlyCUDA,
 )
 from torch.testing._internal.common_utils import (
@@ -230,6 +231,38 @@ class TestInductorDynamic(TestCase):
         b = torch.randn(2, 16, device=device)
         expect = fn(a, b)
         actual = cfn(a, b)
+        self.assertEqual(expect, actual)
+
+    @onlyCPU
+    def test_arithmetic_constant_folding(self, device):
+        def test(fn):
+            cfn = self.compile_fn(fn)
+            expect = fn(3)
+            actual = cfn(3)
+            self.assertEqual(expect, actual)
+
+        def add(x):
+            return x + torch.zeros(3)
+        test(add)
+
+        def mul(x):
+            return x * torch.ones(3)
+        test(mul)
+
+        def div(x):
+            return x / torch.ones(3)
+        test(div)
+
+    @onlyCPU
+    @unittest.expectedFailure
+    # Ref: https://github.com/pytorch/pytorch/issues/108159
+    def test_sub_constant_folding(self, device):
+        def sub(x):
+            return x - torch.zeros(3)
+
+        cfn = self.compile_fn(sub)
+        expect = sub(3)
+        actual = cfn(3)
         self.assertEqual(expect, actual)
 
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -38,6 +38,8 @@ def remove_no_ops(
     graph = gm.graph
 
     def fake_tensors_eq(t1, t2, fields=("shape", "dtype", "device")):
+        if any(not isinstance(t, torch.Tensor) for t in (t1, t2)):
+            return False
         for field in fields:
             if getattr(t1, field) != getattr(t2, field):
                 return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108160

Partial fix: #108067

This PR fixes an inductor bug where it assumed the type of arithmetic nodes arguments were
all `Tensor`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov