### PR TITLE
[dynamo] Avoid recompilation when the PyTorch function accepts scalars

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1366,6 +1366,24 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 2)
 
+    def test_numpy_recompilation_scalar(self):
+        def fn(x, a):
+            return np.where(x < 0.5, a, x)
+
+        x = np.random.randn(8)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, dynamic=True)(fn)
+
+        ref = fn(x, 3)
+        res = opt_fn(x, 3)
+        self.assertEqual(ref, res)
+
+        ref = fn(x, 4)
+        res = opt_fn(x, 4)
+        self.assertEqual(ref, res)
+
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_tensor_interacts_with_numpy_ndarray(self):
         def fn(x, y):
             a = x.numpy()

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -82,6 +82,7 @@ def python_type_for_torch(dtyp):
 
 _SCALAR_TYPES = {int, bool, float, complex, torch.SymInt, torch.SymFloat, torch.SymBool}
 
+
 def is_scalar(x):
     return isinstance(x, _SCALAR_TYPES)
 

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -80,7 +80,10 @@ def python_type_for_torch(dtyp):
 
 # ### NEP 50 helpers ###
 
-SCALAR_TYPES = {int, bool, float, complex}
+_SCALAR_TYPES = {int, bool, float, complex, torch.SymInt, torch.SymFloat, torch.SymBool}
+
+def is_scalar(x):
+    return isinstance(x, _SCALAR_TYPES)
 
 
 def _dtype_for_scalar(py_type):

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -82,11 +82,17 @@ def python_type_for_torch(dtyp):
 
 _SCALAR_TYPES = (int, bool, float, complex)
 
-_SCALAR_AND_SYMBOLIC_TYPES = (*_SCALAR_TYPES, torch.SymInt, torch.SymFloat, torch.SymBool)
+_SCALAR_AND_SYMBOLIC_TYPES = (
+    *_SCALAR_TYPES,
+    torch.SymInt,
+    torch.SymFloat,
+    torch.SymBool,
+)
 
 
 def is_scalar(x):
     return isinstance(x, _SCALAR_TYPES)
+
 
 def is_scalar_or_symbolic(x):
     return isinstance(x, _SCALAR_AND_SYMBOLIC_TYPES)

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -80,18 +80,26 @@ def python_type_for_torch(dtyp):
 
 # ### NEP 50 helpers ###
 
-_SCALAR_TYPES = {int, bool, float, complex, torch.SymInt, torch.SymFloat, torch.SymBool}
+_SCALAR_TYPES = (int, bool, float, complex)
+
+_SCALAR_AND_SYMBOLIC_TYPES = (*_SCALAR_TYPES, torch.SymInt, torch.SymFloat, torch.SymBool)
 
 
 def is_scalar(x):
     return isinstance(x, _SCALAR_TYPES)
 
+def is_scalar_or_symbolic(x):
+    return isinstance(x, _SCALAR_AND_SYMBOLIC_TYPES)
+
 
 def _dtype_for_scalar(py_type):
     return {
         bool: torch.bool,
+        torch.SymBool: torch.bool,
         int: torch.int64,
+        torch.SymInt: torch.int64,
         float: torch.float64,
+        torch.SymFloat: torch.float64,
         complex: torch.complex128,
     }[py_type]
 
@@ -99,16 +107,19 @@ def _dtype_for_scalar(py_type):
 def _category(dtype):
     return {
         torch.bool: 0,
+        torch.SymBool: 0,
         # int
         torch.uint8: 1,
         torch.int8: 1,
         torch.int16: 1,
         torch.int32: 1,
         torch.int64: 1,
+        torch.SymInt: 1,
         # float
         torch.float16: 2,
         torch.float32: 2,
         torch.float64: 2,
+        torch.SymFloat: 2,
         # complex
         torch.complex64: 3,
         torch.complex128: 3,

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -452,7 +452,7 @@ class ndarray:
         index = _util.ndarrays_to_tensors(index)
         index = _upcast_int_indices(index)
 
-        if type(value) not in _dtypes_impl.SCALAR_TYPES:
+        if not _dtypes_impl.is_scalar(value):
             value = normalize_array_like(value)
             value = _util.cast_if_needed(value, self.tensor.dtype)
 

--- a/torch/_numpy/_normalizations.py
+++ b/torch/_numpy/_normalizations.py
@@ -47,9 +47,15 @@ def normalize_array_like(x, parm=None):
 
 
 def normalize_array_like_or_scalar(x, parm=None):
-    if type(x) in _dtypes_impl.SCALAR_TYPES:
+    if _dtypes_impl.is_scalar(x):
         return x
     return normalize_array_like(x, parm)
+
+
+def normalize_optional_array_like_or_scalar(x, parm=None):
+    if x is None:
+        return None
+    return normalize_array_like_or_scalar(x, parm)
 
 
 def normalize_optional_array_like(x, parm=None):
@@ -118,9 +124,10 @@ def normalize_casting(arg, parm=None):
 
 normalizers = {
     "ArrayLike": normalize_array_like,
-    "Union[ArrayLike, Scalar]": normalize_array_like_or_scalar,
+    "ArrayLikeOrScalar": normalize_array_like_or_scalar,
     "Optional[ArrayLike]": normalize_optional_array_like,
     "Sequence[ArrayLike]": normalize_seq_array_like,
+    "Optional[ArrayLikeOrScalar]": normalize_optional_array_like_or_scalar,
     "Optional[NDArray]": normalize_ndarray,
     "Optional[OutArray]": normalize_outarray,
     "NDArray": normalize_ndarray,

--- a/torch/_numpy/_normalizations.py
+++ b/torch/_numpy/_normalizations.py
@@ -47,7 +47,7 @@ def normalize_array_like(x, parm=None):
 
 
 def normalize_array_like_or_scalar(x, parm=None):
-    if _dtypes_impl.is_scalar(x):
+    if _dtypes_impl.is_scalar_or_symbolic(x):
         return x
     return normalize_array_like(x, parm)
 

--- a/torch/_numpy/_ufuncs.py
+++ b/torch/_numpy/_ufuncs.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
 from . import _binary_ufuncs_impl, _dtypes_impl, _unary_ufuncs_impl, _util
 from ._normalizations import (
     ArrayLike,
+    ArrayLikeOrScalar,
     CastingModes,
     DTypeLike,
     normalizer,
     NotImplementedType,
     OutArray,
-    Scalar,
 )
 
 
@@ -71,8 +71,8 @@ def deco_binary_ufunc(torch_func):
 
     @normalizer
     def wrapped(
-        x1: Union[ArrayLike, Scalar],
-        x2: Union[ArrayLike, Scalar],
+        x1: ArrayLikeOrScalar,
+        x2: ArrayLikeOrScalar,
         /,
         out: Optional[OutArray] = None,
         *,
@@ -145,8 +145,8 @@ def matmul(
 # ldexp casting is special : the dtype of the result == dtype of the 1st arg
 @normalizer
 def ldexp(
-    x1: Union[ArrayLike, Scalar],
-    x2: Union[ArrayLike, Scalar],
+    x1: ArrayLikeOrScalar,
+    x2: ArrayLikeOrScalar,
     /,
     out: Optional[OutArray] = None,
     *,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108162

Before, it would create a 0D tensor with the input, which would incur in
a guard and specialisation.

It's not clear whether the guard and specialisation is the right behaviour
when we create 0D tensors, but that's a story for another day.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov