### PR TITLE
Check results dtype in index_out

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -443,6 +443,9 @@ TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
   const auto& result = maybe_get_output();
 
   if (result.defined()) {
+    TORCH_CHECK(self.scalar_type() == result.scalar_type(),
+                "index_out: self (", self.scalar_type(), ") and result (", result.scalar_type(),
+                ") must have the same scalar type"); 
     at::assert_no_internal_overlap(result);
     at::assert_no_overlap(result, self);
     for (const at::OptionalTensorRef& index : materialized) {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -445,7 +445,7 @@ TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
   if (result.defined()) {
     TORCH_CHECK(self.scalar_type() == result.scalar_type(),
                 "index_out: self (", self.scalar_type(), ") and result (", result.scalar_type(),
-                ") must have the same scalar type"); 
+                ") must have the same scalar type");
     at::assert_no_internal_overlap(result);
     at::assert_no_overlap(result, self);
     for (const at::OptionalTensorRef& index : materialized) {


### PR DESCRIPTION
This logic exists for index_put and index_add, but for some reason not for `index.out`
Skip testing, as this function is not technically exposed on the Python level.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c688cfd</samp>

> _`index_out` checks types_
> _avoiding errors in autumn_
> _complex tensors work_

Fixes https://github.com/pytorch/pytorch/issues/107698

