### PR TITLE
Properly skip fast path in TransformerEncoder/MHA if autocast is enabled on CPU

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -406,6 +406,7 @@ TORCH_LIBRARY_IMPL(aten, AutocastCPU, m) {
   KERNEL_CPU2(conv_transpose2d, input, lower_precision_fp)
   KERNEL_CPU2(conv_transpose3d, input, lower_precision_fp)
   KERNEL_CPU(prelu, lower_precision_fp)
+  KERNEL_CPU(scaled_dot_product_attention, lower_precision_fp)
 
   // fp32 cast policy
   KERNEL_CPU(avg_pool3d, fp32)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1198,6 +1198,18 @@ class TestTransformers(NNTestCase):
 
         torch.jit.script(mha)
 
+    @onlyCPU
+    def test_transformer_encoder_cpu_autocast(self):
+        # make sure cpu autocast runs without error #107663
+        encoder_layer = torch.nn.TransformerEncoderLayer(d_model=128, nhead=8, batch_first=True)
+        model = torch.nn.TransformerEncoder(encoder_layer, num_layers=2, enable_nested_tensor=True)
+        model.eval()
+
+        src_rand = torch.rand(16, 8, 128)
+        mask_rand = torch.zeros(16, 8)
+        with torch.no_grad(), torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+            out = model(src_rand, src_key_padding_mask=mask_rand)
+
 
 class TestSDPAFailureModes(NNTestCase):
     """ Used to test the failure modes of scaled_dot_product_attention

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1164,7 +1164,7 @@ class MultiheadAttention(Module):
         elif query.is_nested and (key_padding_mask is not None or attn_mask is not None):
             why_not_fast_path = "supplying both src_key_padding_mask and src_mask at the same time \
                                  is not supported with NestedTensor input"
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled() or (query.is_cpu and torch.is_autocast_cpu_enabled()):
             why_not_fast_path = "autocast is enabled"
 
         if not why_not_fast_path:

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -347,7 +347,7 @@ class TransformerEncoder(Module):
             why_not_sparsity_fast_path = "NestedTensor input is not supported"
         elif mask is not None:
             why_not_sparsity_fast_path = "src_key_padding_mask and mask were both supplied"
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled() or (src.is_cpu and torch.is_autocast_cpu_enabled()):
             why_not_sparsity_fast_path = "autocast is enabled"
 
         if not why_not_sparsity_fast_path:
@@ -642,7 +642,7 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "neither src_key_padding_mask nor src_mask are not supported with NestedTensor input"
         elif self.self_attn.num_heads % 2 == 1:
             why_not_sparsity_fast_path = "num_head is odd"
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled() or (src.is_cpu and torch.is_autocast_cpu_enabled()):
             why_not_sparsity_fast_path = "autocast is enabled"
         if not why_not_sparsity_fast_path:
             tensor_args = (


### PR DESCRIPTION
Fix #107663

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108178
