### PR TITLE
Add reference for linalg.vecdot

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -269,7 +269,6 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.leaky_relu_backward,
             aten.lerp,
             aten.lerp_,
-            aten.linalg_vecdot,
             aten.linspace,
             aten.logaddexp,
             aten.logaddexp2,

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -269,6 +269,7 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.leaky_relu_backward,
             aten.lerp,
             aten.lerp_,
+            aten.linalg_vecdot,
             aten.linspace,
             aten.logaddexp,
             aten.logaddexp2,

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -26,9 +26,6 @@ from torch._prims_common.wrappers import (
 )
 
 
-aten = torch._ops.ops.aten
-
-
 __all__ = ["diagonal", "matrix_norm", "norm", "svd", "svdvals", "vector_norm", "vecdot"]
 
 

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -15,12 +15,21 @@ from torch._prims_common import (
     check_is_matrix,
     Dim,
     DimsType,
+    ELEMENTWISE_TYPE_PROMOTION_KIND,
     NumberType,
     TensorLikeType,
 )
-from torch._prims_common.wrappers import _maybe_convert_to_dtype, out_wrapper
+from torch._prims_common.wrappers import (
+    _maybe_convert_to_dtype,
+    elementwise_type_promotion_wrapper,
+    out_wrapper,
+)
 
-__all__ = ["diagonal", "matrix_norm", "norm", "svd", "svdvals", "vector_norm"]
+
+aten = torch._ops.ops.aten
+
+
+__all__ = ["diagonal", "matrix_norm", "norm", "svd", "svdvals", "vector_norm", "vecdot"]
 
 
 def _check_norm_dtype(dtype: Optional[torch.dtype], x_dtype: torch.dtype, fn_name: str):
@@ -257,3 +266,14 @@ def svd(A: TensorLikeType, full_matrices: bool = True) -> Tuple[Tensor, Tensor, 
 @out_wrapper(exact_dtype=True)
 def svdvals(A: TensorLikeType) -> Tensor:
     return svd(A, full_matrices=False)[1]
+
+
+# CompositeImplicitAutograd
+@out_wrapper()
+@elementwise_type_promotion_wrapper(
+    type_promoting_args=("x", "y"),
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+)
+def vecdot(x: Tensor, y: Tensor, dim: int = -1) -> Tensor:
+    check_fp_or_complex(x.dtype, "linalg.vecdot")
+    return (x.conj() * y).sum(dim=dim)

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -2411,6 +2411,11 @@ python_ref_db: List[OpInfo] = [
         supports_out=False,
         op_db=op_db,
     ),
+    PythonRefInfo(
+        "_refs.linalg.vecdot",
+        torch_opinfo_name="linalg.vecdot",
+        op_db=op_db,
+    ),
     ReductionPythonRefInfo(
         "_refs.linalg.vector_norm",
         torch_opinfo_name="linalg.vector_norm",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #108194
* __->__ #108188

Was addressing https://github.com/pytorch/pytorch/issues/108127, but
then I realised that vecdot is already CompositeImplicit. Pushing anyway
as a short-and-sweet PR.

cc @ezyang @mruberry @Lezcano @peterbell10 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov