### PR TITLE
[TD] Emit metrics to compare heuristic quality

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1627,14 +1627,16 @@ def main():
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)
         aggregated_heuristics = get_test_prioritizations(selected_tests)
+
+    test_prioritizations = aggregated_heuristics.get_ranked_tests()
+
+    if IS_CI:
         metrics_dict = {
             "high_relevance_tests": test_prioritizations.get_high_relevance_tests(),
             "probable_relevance_tests": test_prioritizations.get_probable_relevance_tests(),
             "unranked_relevance_tests": test_prioritizations.get_unranked_relevance_tests(),
             "cpp": options.cpp,
         }
-
-    test_prioritizations = aggregated_heuristics.get_ranked_tests()
 
     class TestBatch:
         """Defines a set of tests with similar priority that should be run together on the current shard"""

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -42,8 +42,8 @@ sys.path.insert(0, str(REPO_ROOT))
 from tools.stats.export_test_times import TEST_TIMES_FILE
 from tools.stats.upload_metrics import emit_metric
 from tools.testing.target_determination.determinator import (
+    AggregatedHeuristics,
     get_test_prioritizations,
-    TestPrioritizations,
 )
 from tools.testing.test_selections import (
     calculate_shards,
@@ -1474,11 +1474,11 @@ def run_test_module(
 ) -> Optional[TestFailure]:
     maybe_set_hip_visible_devies()
 
+    test_name = test.name if isinstance(test, ShardedTest) else test
+
     # Printing the date here can help diagnose which tests are slow
     print_to_stderr(f"Running {str(test)} ... [{datetime.now()}]")
-    handler = CUSTOM_HANDLERS.get(
-        test.name if isinstance(test, ShardedTest) else test, run_test
-    )
+    handler = CUSTOM_HANDLERS.get(test_name, run_test)
     return_code = handler(test, test_directory, options)
     assert isinstance(return_code, int) and not isinstance(
         return_code, bool
@@ -1492,7 +1492,7 @@ def run_test_module(
         # return code -N, where N is the signal number.
         signal_name = SIGNALS_TO_NAMES_DICT[-return_code]
         message += f" Received signal: {signal_name}"
-    return TestFailure(test, message)
+    return TestFailure(test_name, message)
 
 
 def run_tests(
@@ -1619,21 +1619,22 @@ def main():
     if options.coverage and not PYTORCH_COLLECT_COVERAGE:
         shell(["coverage", "erase"])
 
-    test_prioritization: TestPrioritizations = TestPrioritizations(
-        tests_being_ranked=selected_tests
+    aggregated_heuristics: AggregatedHeuristics = AggregatedHeuristics(
+        unranked_tests=selected_tests
     )
     metrics_dict = {}
     if IS_CI:
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)
-        test_prioritization = get_test_prioritizations(selected_tests)
-
+        aggregated_heuristics = get_test_prioritizations(selected_tests)
         metrics_dict = {
-            "high_relevance_tests": test_prioritization.get_high_relevance_tests(),
-            "probable_relevance_tests": test_prioritization.get_probable_relevance_tests(),
-            "unranked_relevance_tests": test_prioritization.get_unranked_relevance_tests(),
+            "high_relevance_tests": test_prioritizations.get_high_relevance_tests(),
+            "probable_relevance_tests": test_prioritizations.get_probable_relevance_tests(),
+            "unranked_relevance_tests": test_prioritizations.get_unranked_relevance_tests(),
             "cpp": options.cpp,
         }
+
+    test_prioritizations = aggregated_heuristics.get_ranked_tests()
 
     class TestBatch:
         """Defines a set of tests with similar priority that should be run together on the current shard"""
@@ -1655,16 +1656,16 @@ def main():
     # Each batch will be run sequentially
     test_batches = [
         TestBatch(
-            "high_relevance", test_prioritization.get_high_relevance_tests(), False
+            "high_relevance", test_prioritizations.get_high_relevance_tests(), False
         ),
         TestBatch(
             "probable_relevance",
-            test_prioritization.get_probable_relevance_tests(),
+            test_prioritizations.get_probable_relevance_tests(),
             False,
         ),
         TestBatch(
             "unranked_relevance",
-            test_prioritization.get_unranked_relevance_tests(),
+            test_prioritizations.get_unranked_relevance_tests(),
             True,
         ),
     ]
@@ -1713,8 +1714,14 @@ def main():
 
     all_failures = [failure for batch in test_batches for failure in batch.failures]
 
-    if len(all_failures) != 0:
-        for _, err in all_failures:
+    num_tests = len(selected_tests)
+    if len(all_failures):
+        for test, err in all_failures:
+            test_stats = aggregated_heuristics.get_test_stats(test)
+            test_stats["num_total_tests"] = num_tests
+
+            emit_metric("td_test_failure_stats", test_stats)
+
             print_to_stderr(err)
 
         # A disabled test is expected to fail, so there is no need to report a failure here

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1628,7 +1628,7 @@ def main():
         get_test_case_configs(dirpath=test_directory)
         aggregated_heuristics = get_test_prioritizations(selected_tests)
 
-    test_prioritizations = aggregated_heuristics.get_ranked_tests()
+    test_prioritizations = aggregated_heuristics.get_aggregated_priorities()
 
     if IS_CI:
         metrics_dict = {

--- a/tools/test/test_heuristics.py
+++ b/tools/test/test_heuristics.py
@@ -80,12 +80,7 @@ class TestParsePrevTests(unittest.TestCase):
         "tools.testing.target_determination.heuristics.correlated_with_historical_failures._get_file_rating_tests",
         return_value=["test1"],
     )
-    def test_get_reordered_tests(
-        self,
-        mock_get_prev_failing_tests: Any,
-        mock_get_modified_tests: Any,
-        mock_get_file_rating_tests: Any,
-    ) -> None:
+    def test_get_reordered_tests(self, *args: Any) -> None:
         tests = ["test1", "test2", "test3", "test4", "test5"]
 
         expected_prioritizations = TestPrioritizations(
@@ -95,7 +90,9 @@ class TestParsePrevTests(unittest.TestCase):
             unranked_relevance=["test3", "test5"],
         )
 
-        test_prioritizations = get_test_prioritizations(tests)
+        test_prioritizations = get_test_prioritizations(
+            tests
+        ).get_aggregated_priorities()
 
         self.assertTupleEqual(
             expected_prioritizations.get_high_relevance_tests(),

--- a/tools/testing/target_determination/determinator.py
+++ b/tools/testing/target_determination/determinator.py
@@ -1,22 +1,21 @@
 from typing import List
 
-from tools.stats.upload_metrics import emit_metric
-
 from tools.testing.target_determination.heuristics import (
+    AggregatedHeuristics as AggregatedHeuristics,
     HEURISTICS,
     TestPrioritizations as TestPrioritizations,
 )
 
 
-def get_test_prioritizations(tests: List[str]) -> TestPrioritizations:
-    rankings = TestPrioritizations(tests_being_ranked=tests)
+def get_test_prioritizations(tests: List[str]) -> AggregatedHeuristics:
+    aggregated_results = AggregatedHeuristics(unranked_tests=tests)
     print(f"Received {len(tests)} tests to prioritize")
     for test in tests:
         print(f"  {test}")
 
     for heuristic in HEURISTICS:
-        new_rankings = heuristic.get_test_priorities(tests)
-        rankings.integrate_priorities(new_rankings)
+        new_rankings: TestPrioritizations = heuristic.get_test_priorities(tests)
+        aggregated_results.add_heuristic_results(str(heuristic), new_rankings)
 
         num_tests_found = len(new_rankings.get_prioritized_tests())
         print(
@@ -27,12 +26,4 @@ def get_test_prioritizations(tests: List[str]) -> TestPrioritizations:
         if num_tests_found:
             new_rankings.print_info()
 
-    emit_metric(
-        "test_reordering_prioritized_tests",
-        {
-            "high_relevance_tests": rankings.get_high_relevance_tests(),
-            "probable_relevance_tests": rankings.get_probable_relevance_tests(),
-            "unranked_relevance_tests": rankings.get_unranked_relevance_tests(),
-        },
-    )
-    return rankings
+    return aggregated_results

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -6,6 +6,7 @@ from tools.testing.target_determination.heuristics.correlated_with_historical_fa
 from tools.testing.target_determination.heuristics.edited_by_pr import EditedByPR
 
 from tools.testing.target_determination.heuristics.interface import (
+    AggregatedHeuristics as AggregatedHeuristics,
     HeuristicInterface as HeuristicInterface,
     TestPrioritizations as TestPrioritizations,
 )

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -263,7 +263,7 @@ class AggregatedHeuristics:
             metrics["heuristic_name"] = heuristic_name
             heuristics.append(metrics)
 
-            if metrics[METRIC_ORDER_OVERALL] > highest_ranking_heuristic_order:
+            if metrics[METRIC_ORDER_OVERALL] < highest_ranking_heuristic_order:
                 highest_ranking_heuristic = heuristic_name
                 highest_ranking_heuristic_order = metrics[METRIC_ORDER_OVERALL]
 

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -251,7 +251,7 @@ class AggregatedHeuristics:
         }
         heuristics = []
 
-        # Figure out which heuristic prioritizes this test the most
+        # Figure out which heuristic gave this test the highest priority
         highest_ranking_heuristic = None
         highest_ranking_heuristic_order: int = sys.maxsize
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108192
* #108117

When a test fails, we will now emit fine grained details about how accurately heuristics predicted the relevance of that test.

## Context
Why only look at failing tests? Our only signal that a PR is most likely relevant to a test is whether or not a test fails on it. Green tests don't tell us if the success was due to the code being good vs being irrelevant.  This isn't a perfect measure, since it can miscategorize unstable and flaky failures as having been "missed" by the heuristics, but it's a reasonable approximation.

## What's measured?
The metrics this PR collects are designed to answer the following questions

### How comprehensive are the heuristics?
- What's the false negative rate, the % of failures that ideally should have been prioritized but weren't? (Both at an aggregate level and at a per heuristic level)

### How precise are the heuristics?
- What % of failed tests were prioritized by a given heuristic? What % was prioritized overall?
- How relevant was a failed test was considered to be? (Both a aggregate level and at a per heuristic level)
- What % of time was a given heuristic prioritizing a failing test higher than any other heuristic?

