### PR TITLE
Fix operator precedence

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -883,8 +883,7 @@ class VariableBuilder:
         if (
             source.guard_source().is_nn_module()
             or get_static_address_type(value) is not None
-            and not source.guard_source().is_fsdp_module()
-        ):
+        ) and not source.guard_source().is_fsdp_module():
             return self.tx.output.register_attr_or_module(
                 value,
                 self.name,


### PR DESCRIPTION
Summary: Ensure that modules are only installed if they are not fsdp modules.

Differential Revision: D48810186



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov