### PR TITLE
Create empty host tensor for MTIA device type.

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -761,6 +761,18 @@ void Reducer::all_reduce_local_used_map() {
         local_used_map_tmp.data_ptr() != local_used_map_.data_ptr());
     local_used_map_tmp.copy_(local_used_map_);
     local_used_map_dev_.copy_(local_used_map_tmp, true);
+  } else if (local_used_map_dev_.is_mtia()) {
+    // MTIA probably will have special logic in the future, following code might
+    // be changed drastically. Therefore, a new if case is created for MTIA, for
+    // now, the implementation is similar to the CUDA one, except for
+    // the pin memory step.
+    auto local_used_map_tmp = at::native::empty_like(
+        local_used_map_,
+        optTypeMetaToScalarType(local_used_map_.options().dtype_opt()),
+        local_used_map_.options().layout_opt(),
+        local_used_map_.options().device_opt());
+    local_used_map_tmp.copy_(local_used_map_);
+    local_used_map_dev_.copy_(local_used_map_tmp, true);
   } else {
     local_used_map_dev_.copy_(local_used_map_, true);
   }


### PR DESCRIPTION
Summary: Before copying tensor from CPU memory to device memory, for MTIA device, it doesn't need to pin the host memory first.

Test Plan: See diff D48761820

Reviewed By: jackm321

Differential Revision: D48456471

