### PR TITLE
Update accuracy checking for nan, floats

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -227,6 +227,7 @@ FORCE_AMP_FOR_FP16_BF16_MODELS = {
     "doctr_reco_predictor",
     "Super_SloMo",
     "tts_angular",
+    "pyhpc_turbulent_kinetic_energy",
 }
 
 # models in canary_models that we should run anyway

--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -129,8 +129,7 @@ class Repro(torch.nn.Module):
 
     def forward(self, arg0_1):
         log1p = torch.ops.aten.log1p.default(arg0_1);  arg0_1 = None
-        gt = torch.ops.aten.gt.Scalar(log1p, 0);  log1p = None
-        return (gt,)""",
+        return (log1p,)""",
         )
 
         # FP accuracy will refuse to promote the logical_not on the outputs,

--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -129,7 +129,8 @@ class Repro(torch.nn.Module):
 
     def forward(self, arg0_1):
         log1p = torch.ops.aten.log1p.default(arg0_1);  arg0_1 = None
-        return (log1p,)""",
+        gt = torch.ops.aten.gt.Scalar(log1p, 0);  log1p = None
+        return (gt,)""",
         )
 
         # FP accuracy will refuse to promote the logical_not on the outputs,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1043,6 +1043,9 @@ def same(
             # Check error from fp64 version
             if fp64_ref.dtype == torch.float64:
                 ref_error = rmse(fp64_ref, ref).item()
+                if math.isnan(ref_error):
+                    return True
+
                 res_error = rmse(fp64_ref, res).item()
                 multiplier = 2.0
 
@@ -1081,7 +1084,7 @@ def same(
             log_error("Accuracy failed (%s): %s != %s", type(ref), ref, res)
         return r
     elif isinstance(ref, float):
-        r = math.isclose(ref, res, rel_tol=tol, abs_tol=tol)
+        r = same(torch.tensor(ref), torch.tensor(res), rel_tol=tol, abs_tol=tol)
         if not r:
             log_error(
                 "Accuracy failed (float): %s != %s (within tol=%s)", ref, res, tol

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1049,8 +1049,10 @@ def same(
             if fp64_ref.dtype == torch.float64:
                 ref_error = rmse(fp64_ref, ref).item()
                 # ref unable to produce this with stable numerics in this precision, ignore
-                if math.isnan(ref_error) and fp64_ref.isnan().sum() == 0:
-                    return True
+                if math.isnan(ref_error):
+                    log.warning(
+                        "Found nan in reference. Consider running in higher precision."
+                    )
 
                 res_error = rmse(fp64_ref, res).item()
                 multiplier = 2.0

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1048,7 +1048,8 @@ def same(
             # Check error from fp64 version
             if fp64_ref.dtype == torch.float64:
                 ref_error = rmse(fp64_ref, ref).item()
-                if math.isnan(ref_error):
+                # ref unable to produce this with stable numerics in this precision, ignore
+                if math.isnan(ref_error) and fp64_ref.isnan().sum() == 0:
                     return True
 
                 res_error = rmse(fp64_ref, res).item()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108202

Fixes inference accuracy for `doctr_reco_predictor` and `pyhpc_turbulent_kinetic_energy`.

For the `same(float, float)` comparison we weren't going through the more rigorous tensor comparison path which takes into account the fp64 base results.

Also return True when fp64 base result are not well formed (nan).

I debugged these models and the source of divergence were innocuous:
`doctr_reco_predictor` - can be fixed by turning off layout optimization, decomp for batch norm

`pyhpc_turbulent_kinetic_energy` - divergence caused because fused kernel keeps precision in fp32 instead of casting back and forth from/to fp32/bf16. Fused kernel is better precision, anyway.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @anijain2305