### PR TITLE
reduce overhead in split and chunk for NestedTensor

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -6,9 +6,10 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_nested_tensor_size_native.h>
-#include <ATen/ops/_nested_tensor_strides_native.h>
 #include <ATen/ops/_nested_tensor_storage_offsets_native.h>
+#include <ATen/ops/_nested_tensor_strides_native.h>
 #include <ATen/ops/chunk_native.h>
+#include <ATen/ops/empty_like_native.h>
 #include <ATen/ops/split_with_sizes_native.h>
 #endif
 
@@ -93,11 +94,11 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   --dim;
   int64_t tensor_dim = sizes.size(1);
   for (const auto split_idx : c10::irange(chunks)) {
-      auto new_sizes = at::empty_like(sizes) ;
+      auto new_sizes = at::native::empty_like(sizes);
       auto new_strides = strides.clone();
-      auto new_offsets = at::empty_like(offsets);
-      int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+      auto new_offsets = at::native::empty_like(offsets);
       int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+      int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
       // Get start val for each split
       int64_t start_val = split_idx * split_size;
       for (int64_t i : c10::irange(n_tensors)) {
@@ -150,9 +151,9 @@ std::vector<Tensor> split_with_sizes_nested(
   int64_t start_val = 0;
   for (const auto split_idx : c10::irange(num_splits)) {
     auto split_size = split_sizes[split_idx];
-    auto new_sizes = at::empty_like(sizes);
+    auto new_sizes = at::native::empty_like(sizes);
     auto new_strides = strides.clone();
-    auto new_offsets = at::empty_like(offsets);
+    auto new_offsets = at::native::empty_like(offsets);
     int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
     int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
 

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -9,7 +9,6 @@
 #include <ATen/ops/_nested_tensor_storage_offsets_native.h>
 #include <ATen/ops/_nested_tensor_strides_native.h>
 #include <ATen/ops/chunk_native.h>
-#include <ATen/ops/empty_like_native.h>
 #include <ATen/ops/split_with_sizes_native.h>
 #endif
 
@@ -94,9 +93,9 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   --dim;
   int64_t tensor_dim = sizes.size(1);
   for (const auto split_idx : c10::irange(chunks)) {
-      auto new_sizes = at::native::empty_like(sizes);
+      auto new_sizes = sizes.clone();
       auto new_strides = strides.clone();
-      auto new_offsets = at::native::empty_like(offsets);
+      auto new_offsets = offsets.clone();
       int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
       int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
       // Get start val for each split
@@ -150,9 +149,9 @@ std::vector<Tensor> split_with_sizes_nested(
   int64_t start_val = 0;
   for (const auto split_idx : c10::irange(num_splits)) {
     auto split_size = split_sizes[split_idx];
-    auto new_sizes = at::native::empty_like(sizes);
+    auto new_sizes = sizes.clone();
     auto new_strides = strides.clone();
-    auto new_offsets = at::native::empty_like(offsets);
+    auto new_offsets = offsets.clone();
     int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
     int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
     // Get start val for each split

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -106,8 +106,7 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
         new_offsets_ptr[i] = offsets_ptr[i] + start_val;
         size_ptr[index] = split_size;
     }
-    splits[split_idx] = create_nested_view_tensor(
-      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+    splits[split_idx] = create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
   }
   return splits;
 }
@@ -164,8 +163,7 @@ std::vector<Tensor> split_with_sizes_nested(
       size_ptr[index] = split_size;
     }
     start_val += split_size;
-    splits[split_idx] = create_nested_view_tensor(
-      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+    splits[split_idx] = create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
   }
   return splits;
 }

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -93,19 +93,21 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   --dim;
   int64_t tensor_dim = sizes.size(1);
   for (const auto split_idx : c10::irange(chunks)) {
-      auto new_sizes = sizes.clone() ;
-      auto new_strides = strides.clone();
-      // This copys offsets so we are safe to move
-      auto new_offsets = offsets.clone();
-      int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
-      // Get start val for each split
-      int64_t start_val = split_idx * split_size;
-      for (int64_t i : c10::irange(n_tensors)) {
-        const int64_t index = i * tensor_dim + dim;
-        new_offsets[i] = offsets_ptr[i] + start_val;
-        size_ptr[index] = split_size;
+    auto new_sizes = at::empty_like(sizes) ;
+    auto new_strides = at::empty_like(strides);
+    // This copys offsets so we are safe to move
+    auto new_offsets = at::empty_like(offsets);
+    int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+    int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+    // Get start val for each split
+    int64_t start_val = split_idx * split_size;
+    for (int64_t i : c10::irange(n_tensors)) {
+      const int64_t index = i * tensor_dim + dim;
+      new_offsets_ptr[i] = offsets_ptr[i] + start_val;
+      size_ptr[index] = split_size;
     }
-    splits[split_idx] = create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
+    splits[split_idx] = create_nested_view_tensor(
+      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }
@@ -149,18 +151,21 @@ std::vector<Tensor> split_with_sizes_nested(
   int64_t start_val = 0;
   for (const auto split_idx : c10::irange(num_splits)) {
     auto split_size = split_sizes[split_idx];
-    auto new_sizes = sizes.clone();
-    auto new_strides = strides.clone();
-    auto new_offsets = offsets.clone();
+    auto new_sizes = at::empty_like(sizes);
+    auto new_strides = at::empty_like(strides);
+    auto new_offsets = at::empty_like(offsets);
     int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+    int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+
     // Get start val for each split
     for (int64_t i : c10::irange(n_tensors)) {
       const int64_t index = i * tensor_dim + dim;
-      new_offsets[i] = offsets_ptr[i] + start_val;
+      new_offsets_ptr[i] = offsets_ptr[i] + start_val;
       size_ptr[index] = split_size;
     }
     start_val += split_size;
-    splits[split_idx] = create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
+    splits[split_idx] = create_nested_view_tensor(
+      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -155,7 +155,6 @@ std::vector<Tensor> split_with_sizes_nested(
     auto new_offsets = at::native::empty_like(offsets);
     int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
     int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
-
     // Get start val for each split
     for (int64_t i : c10::irange(n_tensors)) {
       const int64_t index = i * tensor_dim + dim;

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -94,7 +94,7 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   int64_t tensor_dim = sizes.size(1);
   for (const auto split_idx : c10::irange(chunks)) {
       auto new_sizes = at::empty_like(sizes) ;
-      auto new_strides = at::empty_like(strides);
+      auto new_strides = strides.clone();
       // This copys offsets so we are safe to move
       auto new_offsets = at::empty_like(offsets);
       int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
@@ -150,22 +150,22 @@ std::vector<Tensor> split_with_sizes_nested(
   int64_t tensor_dim = sizes.size(1);
   int64_t start_val = 0;
   for (const auto split_idx : c10::irange(num_splits)) {
-      auto split_size = split_sizes[split_idx];
-      auto new_sizes = at::empty_like(sizes);
-      auto new_strides = at::empty_like(strides);
-      auto new_offsets = at::empty_like(offsets);
-      int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
-      int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+    auto split_size = split_sizes[split_idx];
+    auto new_sizes = at::empty_like(sizes);
+    auto new_strides = at::empty_like(strides);
+    auto new_offsets = at::empty_like(offsets);
+    int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+    int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
 
-      // Get start val for each split
-      for (int64_t i : c10::irange(n_tensors)) {
-        const int64_t index = i * tensor_dim + dim;
-        new_offsets_ptr[i] = offsets_ptr[i] + start_val;
-        size_ptr[index] = split_size;
-      }
-      start_val += split_size;
-      splits[split_idx] = create_nested_view_tensor(
-        self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+    // Get start val for each split
+    for (int64_t i : c10::irange(n_tensors)) {
+      const int64_t index = i * tensor_dim + dim;
+      new_offsets_ptr[i] = offsets_ptr[i] + start_val;
+      size_ptr[index] = split_size;
+    }
+    start_val += split_size;
+    splits[split_idx] = create_nested_view_tensor(
+      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -93,21 +93,21 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   --dim;
   int64_t tensor_dim = sizes.size(1);
   for (const auto split_idx : c10::irange(chunks)) {
-    auto new_sizes = at::empty_like(sizes) ;
-    auto new_strides = at::empty_like(strides);
-    // This copys offsets so we are safe to move
-    auto new_offsets = at::empty_like(offsets);
-    int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
-    int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
-    // Get start val for each split
-    int64_t start_val = split_idx * split_size;
-    for (int64_t i : c10::irange(n_tensors)) {
-      const int64_t index = i * tensor_dim + dim;
-      new_offsets_ptr[i] = offsets_ptr[i] + start_val;
-      size_ptr[index] = split_size;
-    }
-    splits[split_idx] = create_nested_view_tensor(
-      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+      auto new_sizes = at::empty_like(sizes) ;
+      auto new_strides = at::empty_like(strides);
+      // This copys offsets so we are safe to move
+      auto new_offsets = at::empty_like(offsets);
+      int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+      int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+      // Get start val for each split
+      int64_t start_val = split_idx * split_size;
+      for (int64_t i : c10::irange(n_tensors)) {
+        const int64_t index = i * tensor_dim + dim;
+        new_offsets_ptr[i] = offsets_ptr[i] + start_val;
+        size_ptr[index] = split_size;
+      }
+      splits[split_idx] = create_nested_view_tensor(
+        self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }
@@ -150,22 +150,22 @@ std::vector<Tensor> split_with_sizes_nested(
   int64_t tensor_dim = sizes.size(1);
   int64_t start_val = 0;
   for (const auto split_idx : c10::irange(num_splits)) {
-    auto split_size = split_sizes[split_idx];
-    auto new_sizes = at::empty_like(sizes);
-    auto new_strides = at::empty_like(strides);
-    auto new_offsets = at::empty_like(offsets);
-    int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
-    int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
+      auto split_size = split_sizes[split_idx];
+      auto new_sizes = at::empty_like(sizes);
+      auto new_strides = at::empty_like(strides);
+      auto new_offsets = at::empty_like(offsets);
+      int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+      int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
 
-    // Get start val for each split
-    for (int64_t i : c10::irange(n_tensors)) {
-      const int64_t index = i * tensor_dim + dim;
-      new_offsets_ptr[i] = offsets_ptr[i] + start_val;
-      size_ptr[index] = split_size;
-    }
-    start_val += split_size;
-    splits[split_idx] = create_nested_view_tensor(
-      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+      // Get start val for each split
+      for (int64_t i : c10::irange(n_tensors)) {
+        const int64_t index = i * tensor_dim + dim;
+        new_offsets_ptr[i] = offsets_ptr[i] + start_val;
+        size_ptr[index] = split_size;
+      }
+      start_val += split_size;
+      splits[split_idx] = create_nested_view_tensor(
+        self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -95,6 +95,7 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   for (const auto split_idx : c10::irange(chunks)) {
       auto new_sizes = sizes.clone();
       auto new_strides = strides.clone();
+      // This copys offsets so we are safe to move
       auto new_offsets = offsets.clone();
       int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
       int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -95,7 +95,6 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   for (const auto split_idx : c10::irange(chunks)) {
       auto new_sizes = at::empty_like(sizes) ;
       auto new_strides = strides.clone();
-      // This copys offsets so we are safe to move
       auto new_offsets = at::empty_like(offsets);
       int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();
       int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
@@ -152,7 +151,7 @@ std::vector<Tensor> split_with_sizes_nested(
   for (const auto split_idx : c10::irange(num_splits)) {
     auto split_size = split_sizes[split_idx];
     auto new_sizes = at::empty_like(sizes);
-    auto new_strides = at::empty_like(strides);
+    auto new_strides = strides.clone();
     auto new_offsets = at::empty_like(offsets);
     int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
     int64_t *new_offsets_ptr = new_offsets.data_ptr<int64_t>();

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -105,9 +105,9 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
         const int64_t index = i * tensor_dim + dim;
         new_offsets_ptr[i] = offsets_ptr[i] + start_val;
         size_ptr[index] = split_size;
-      }
-      splits[split_idx] = create_nested_view_tensor(
-        self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
+    }
+    splits[split_idx] = create_nested_view_tensor(
+      self, std::move(new_sizes), std::move(new_strides), std::move(new_offsets));
   }
   return splits;
 }


### PR DESCRIPTION
GH first copy of #108207

Uses raw pointers to reduce construction overhead.

cc @jbschlosser @bhosmer @drisspg