### PR TITLE
[export] Fix autogenerated stacktrace

### DIFF
--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -42,7 +42,7 @@ class _ExportPassBase(PassBase):
 
     @staticmethod
     def _create_dummy_node_metadata():
-        return NodeMetadata({"stack_trace": traceback.format_exc(-1)})
+        return NodeMetadata({"stack_trace": "".join(traceback.format_stack(limit=1))})
 
 
     class ExportTracer(PythonKeyTracer):

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -141,8 +141,8 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBase):
 
         # Populate the stack trace with dummy vals to respect IR
         for node in val.graph_module.graph.nodes:
-            if not hasattr(node.meta, "stack_trace"):
-                node.meta["stack_trace"] = traceback.format_exc(-1)
+            if not node.meta.get("stack_trace", None):
+                node.meta["stack_trace"] = "".join(traceback.format_stack(limit=1))
 
         return PassResult(val.graph_module, val.modified)
 


### PR DESCRIPTION
Summary: Existing code is incorrectly overwriting the stacktrace to be None because since there is no exception happening, `traceback.format_exc` is None. Also we should only populate the stack trace if it not there in the first place.

Test Plan: CI

Differential Revision: D48818478

