### PR TITLE
MAINT: np.unique works with f16 directly

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1544,6 +1544,15 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(r.dtype, torch.int64)
         self.assertEqual(cnts.frame_count, 1)
 
+    def test_numpy_unique_f16(self):
+        @torch.compile
+        def fn():
+            x = np.asarray([1, 1, 2, 2, 3], dtype=np.float16)
+            return np.unique(x)
+
+        result = fn()
+        self.assertEqual(result, np.array([1, 2, 3], dtype=np.float16))
+
     def test_inplace_view_on_graph_input(self):
         # graph break when calling methods with inplace_view tag on graph input
         func_args_map = {

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1545,13 +1545,16 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
 
     def test_numpy_unique_f16(self):
-        @torch.compile
         def fn():
             x = np.asarray([1, 1, 2, 2, 3], dtype=np.float16)
             return np.unique(x)
 
-        result = fn()
-        self.assertEqual(result, np.array([1, 2, 3], dtype=np.float16))
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+
+        r = opt_fn()
+        self.assertEqual(r.dtype, np.float16)
+        self.assertEqual(cnts.frame_count, 1)
 
     def test_inplace_view_on_graph_input(self):
         # graph break when calling methods with inplace_view tag on graph input

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -956,19 +956,9 @@ def unique(
     (ar,), axis = _util.axis_none_flatten(ar, axis=axis)
     axis = _util.normalize_axis_index(axis, ar.ndim)
 
-    is_half = ar.dtype == torch.float16
-    if is_half:
-        ar = ar.to(torch.float32)
-
     result = torch.unique(
         ar, return_inverse=return_inverse, return_counts=return_counts, dim=axis
     )
-
-    if is_half:
-        if isinstance(result, tuple):
-            result = (result[0].to(torch.float16),) + result[1:]
-        else:
-            result = result.to(torch.float16)
 
     return result
 


### PR DESCRIPTION
(follow up on gh-107768)

Remove a f16->f32 workaround from np.unique, since torch.unique and np.unique seem to just work with float16 tensors.

cc @mruberry @rgommers @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov