### PR TITLE
[PyPer][BE] Fix test_scripted_module in StatCollector

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -477,8 +477,8 @@ class MinMaxObserver(UniformQuantizationObserverBase):
             eps=eps,
         )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
-        self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
-        self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
+        self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs).detach())
+        self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs).detach())
         if (
             self.qscheme == torch.per_tensor_symmetric
             and self.reduce_range


### PR DESCRIPTION
Summary: D41985889 removed the cast to int for the inputs to torch.histc below, allowing the inputs to still be tensors. These tensors still have require_grad_ set to True, causing issues with the call to torch.histc.

Test Plan: buck2 test 'fbcode//mode/opt' fbcode//dper3/dper3/modules/low_level_modules/tests:stat_collector_test -- --exact 'dper3/dper3/modules/low_level_modules/tests:stat_collector_test - test_scripted_module (dper3.dper3.modules.low_level_modules.tests.stat_collector_test.StatCollectorTest_1)'

Differential Revision: D48800879

