### PR TITLE
[FSDP] New rate limiter and memory reuse system

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -141,7 +141,7 @@ class TestCommunication(FSDPTest):
             and sharding_strategy == ShardingStrategy.FULL_SHARD
         ):
             # Root does not free the full parameters at the end of the
-            # forward pass
+            # forward pass; neither does the last two FSDP modules
             num_all_gathers = max(num_fsdp - 3, 0)
         elif (
             pass_type == PassType.BWD

--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -142,7 +142,7 @@ class TestCommunication(FSDPTest):
         ):
             # Root does not free the full parameters at the end of the
             # forward pass
-            num_all_gathers = num_fsdp - 1
+            num_all_gathers = max(num_fsdp - 3, 0)
         elif (
             pass_type == PassType.BWD
             and sharding_strategy == ShardingStrategy.SHARD_GRAD_OP

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -183,11 +183,11 @@ class TestFSDPMemory(FSDPTest):
                 expected[f"iter {iteration}: start"] = sharded_model_size_mb + 1
                 # it is hard to calculate this memory size, get it from printed memory usage
                 if ckpt == "ckpt":
-                    expected[f"iter {iteration}: after fwd"] = 51
-                    expected[f"iter {iteration}: after loss"] = 51
+                    expected[f"iter {iteration}: after fwd"] = 55
+                    expected[f"iter {iteration}: after loss"] = 55
                 else:
-                    expected[f"iter {iteration}: after fwd"] = 340
-                    expected[f"iter {iteration}: after loss"] = 340
+                    expected[f"iter {iteration}: after fwd"] = 344
+                    expected[f"iter {iteration}: after loss"] = 344
                 # sharded model size + sharded grad size + 1M temp memory
                 expected[f"iter {iteration}: after bwd"] = 2 * sharded_model_size_mb + 1
             else:
@@ -196,17 +196,17 @@ class TestFSDPMemory(FSDPTest):
                 expected[f"iter {iteration}: start"] = 2 * sharded_model_size_mb + 1
                 if ckpt == "ckpt":
                     expected[f"iter {iteration}: after fwd"] = (
-                        51 + sharded_model_size_mb
+                        55 + sharded_model_size_mb
                     )
                     expected[f"iter {iteration}: after loss"] = (
-                        51 + sharded_model_size_mb
+                        55 + sharded_model_size_mb
                     )
                 else:
                     expected[f"iter {iteration}: after fwd"] = (
-                        340 + sharded_model_size_mb
+                        344 + sharded_model_size_mb
                     )
                     expected[f"iter {iteration}: after loss"] = (
-                        340 + sharded_model_size_mb
+                        344 + sharded_model_size_mb
                     )
                 expected[f"iter {iteration}: after bwd"] = 3 * sharded_model_size_mb + 1
 

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -289,6 +289,8 @@ class TestUnshardParams(TestUnshardParamsBase):
         model = FSDP(
             nn.Sequential(
                 FSDP(nn.Linear(5, 5, bias=False, device=self.device), **fsdp_kwargs),
+                FSDP(nn.Linear(5, 5, bias=False, device=self.device), **fsdp_kwargs),
+                FSDP(nn.Linear(5, 5, bias=False, device=self.device), **fsdp_kwargs),
                 nn.Linear(5, 3, bias=False, device=self.device),
             ),
             **fsdp_kwargs,

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -366,7 +366,8 @@ class TestFSDPWrap(FSDPTest):
         for module in modules_in_fsdp_graph_order:
             self.assertTrue(isinstance(module, FSDP))
             self._check_cpu_offload(module, cpu_offload)
-            self._check_backward_prefetch(module, backward_prefetch)
+            # Note: BACKWARD_POST and BACKWARD_PRE are now consolidated as BACKWARD_POST.
+            self._check_backward_prefetch(module, BackwardPrefetch.BACKWARD_POST)
             self._check_forward_prefetch(module, forward_prefetch)
 
         # Run model a few times for sanity check.

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -547,16 +547,16 @@ class TestAutoWrap(TestCase):
             if use_uniform_kwargs
             else ShardingStrategy.NO_SHARD
         )
-        bn_prefetch = BackwardPrefetch.BACKWARD_PRE
+        bn_prefetch = BackwardPrefetch.BACKWARD_POST
         encoder_strategy = root_strategy = ShardingStrategy.FULL_SHARD
-        encoder_prefetch = root_prefetch = BackwardPrefetch.BACKWARD_PRE
+        encoder_prefetch = root_prefetch = BackwardPrefetch.BACKWARD_POST
         decoder_strategy = (
             ShardingStrategy.FULL_SHARD
             if use_uniform_kwargs
             else ShardingStrategy.SHARD_GRAD_OP
         )
         decoder_prefetch = (
-            BackwardPrefetch.BACKWARD_PRE
+            BackwardPrefetch.BACKWARD_POST
             if use_uniform_kwargs
             else BackwardPrefetch.BACKWARD_POST
         )

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3032,7 +3032,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
   // stream so that the caching allocator can reuse memory pool for this stream
   // in a clever way. This setting is added for libraries like FSDP which uses
   // `reduce_scatter_tensor`.
-  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
+  bool avoidRecordStreams = !opts.asyncOp;
 
   return collective(
       inputs,
@@ -3721,7 +3721,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
   // stream so that the caching allocator can reuse memory pool for this stream
   // in a clever way. This setting is added for libraries like FSDP which uses
   // `all_gather_into_tensor`.
-  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
+  bool avoidRecordStreams = !opts.asyncOp;
 
   return collective(
       inputs,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3032,7 +3032,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
   // stream so that the caching allocator can reuse memory pool for this stream
   // in a clever way. This setting is added for libraries like FSDP which uses
   // `reduce_scatter_tensor`.
-  bool avoidRecordStreams = !opts.asyncOp;
+  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
 
   return collective(
       inputs,
@@ -3721,7 +3721,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
   // stream so that the caching allocator can reuse memory pool for this stream
   // in a clever way. This setting is added for libraries like FSDP which uses
   // `all_gather_into_tensor`.
-  bool avoidRecordStreams = !opts.asyncOp;
+  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
 
   return collective(
       inputs,

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -32,6 +32,7 @@ from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
 )
+from torch.distributed.fsdp._limiter_utils import _FreeEventQueue
 from torch.distributed.utils import _apply_to_tensors
 from torch.utils._mode_utils import no_dispatch
 
@@ -138,6 +139,7 @@ class _FSDPState(_State):
         # Abstract device handle for fsdp compute device. For now,
         # the compute device must implement cuda semantics used by fsdp
         self._device_handle: _FSDPDeviceHandle = _UninitializedDeviceHandle()
+        self._free_event_queue: Optional[_FreeEventQueue] = None
         # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -141,6 +141,8 @@ class _FSDPState(_State):
         # the compute device must implement cuda semantics used by fsdp
         self._device_handle: _FSDPDeviceHandle = _UninitializedDeviceHandle()
         self._free_event_queue: Optional[_FreeEventQueue] = None
+        # Defaults to true per PyTorch module convention
+        self._is_training: bool = True
         # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -58,6 +58,7 @@ FSDP_FLATTENED = "_fsdp_flattened"
 # heuristic like this to predict the desired output dtype.
 _MODULE_TO_INP_DTYPE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
+DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS = 2
 
 class _FSDPDeviceHandle:
     """

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -60,6 +60,7 @@ _MODULE_TO_INP_DTYPE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS = 2
 
+
 class _FSDPDeviceHandle:
     """
     This is a simple abstraction for FSDP computing devices,

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -144,6 +144,8 @@ class _FSDPState(_State):
         self._free_event_queue: Optional[_FreeEventQueue] = None
         # Defaults to true per PyTorch module convention
         self._is_training: bool = True
+        # Defaults rate limiting to true; may be changed in `_init_core_state`
+        self.limit_all_gathers: bool = True
         # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -142,6 +142,8 @@ class _FSDPState(_State):
         # the compute device must implement cuda semantics used by fsdp
         self._device_handle: _FSDPDeviceHandle = _UninitializedDeviceHandle()
         self._free_event_queue: Optional[_FreeEventQueue] = None
+        # Free event queue for unsharded grad reduce-scatter
+        self._free_event_queue_rs: Optional[_FreeEventQueue] = None
         # Defaults to true per PyTorch module convention
         self._is_training: bool = True
         # Defaults rate limiting to true; may be changed in `_init_core_state`

--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
-from torch.distributed.fsdp._common_utils import _FSDPState, _get_param_to_fqns
+from torch.distributed.fsdp._common_utils import _FSDPState, _get_param_to_fqns, DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS
 from torch.distributed.fsdp._flat_param import FlatParamHandle
 
 
@@ -97,7 +97,7 @@ class _ExecOrderData:
         current_index = current_handle._post_forward_index
         if current_index is None:
             return None
-        target_index = current_index - 1
+        target_index = current_index - DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS if current_handle._limit_all_gathers else 1
         target_handle: Optional[FlatParamHandle] = None
         for _ in range(self._backward_prefetch_limit):
             if target_index < 0:

--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -7,7 +7,11 @@ import torch
 import torch.distributed as dist
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
-from torch.distributed.fsdp._common_utils import _FSDPState, _get_param_to_fqns, DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS
+from torch.distributed.fsdp._common_utils import (
+    _FSDPState,
+    _get_param_to_fqns,
+    DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS,
+)
 from torch.distributed.fsdp._flat_param import FlatParamHandle
 
 
@@ -97,7 +101,11 @@ class _ExecOrderData:
         current_index = current_handle._post_forward_index
         if current_index is None:
             return None
-        target_index = current_index - DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS if current_handle._limit_all_gathers else 1
+        target_index = (
+            current_index - DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS
+            if current_handle._limit_all_gathers
+            else 1
+        )
         target_handle: Optional[FlatParamHandle] = None
         for _ in range(self._backward_prefetch_limit):
             if target_index < 0:

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1312,7 +1312,8 @@ class FlatParamHandle:
             padded_unsharded_flat_param = self._all_gather_flat_param(
                 unsharded_flat_param
             )
-            self._use_unsharded_flat_param(padded_unsharded_flat_param)
+
+        self._use_unsharded_flat_param(padded_unsharded_flat_param)
 
     def _unshard_in_backward(
         self,
@@ -1332,7 +1333,8 @@ class FlatParamHandle:
             padded_unsharded_flat_param = self._all_gather_flat_param(
                 unsharded_flat_param
             )
-            self._use_unsharded_flat_param(padded_unsharded_flat_param)
+
+        self._use_unsharded_flat_param(padded_unsharded_flat_param)
 
     def needs_unshard(self) -> bool:
         """Returns if the handle's flat parameter needs to be unsharded."""

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -526,7 +526,7 @@ class FlatParamHandle:
         self._needs_pre_forward_unshard = False
         # Used for guarding against mistargeted backward prefetches
         self._needs_pre_backward_unshard = False
-        # Was the handle prefetched? Set on successful _prefetch_handle and unshard
+        # Was the handle prefetched? Set on successful _prefetch_next_handle and unshard
         self._prefetched = False
         # Optimistically assume a valid input `params` and set dtype attributes
         # before `_init_flat_param()`, which performs the actual validation

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -53,6 +53,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
+RANK = int(os.environ.get("RANK", "0"))
 """
 [Note: Fully Sharded Module]
 We define the "fully sharded module" to be the original ``nn.Module`` that owns
@@ -1263,6 +1264,8 @@ class FlatParamHandle:
                 else self.flat_param
             )
             self._use_unsharded_flat_param(unsharded_flat_param)
+            if RANK == 0:
+                print(f"Handle {self._handle_index} does not need unshard")
             return
 
         if self._limit_all_gathers:
@@ -1283,6 +1286,8 @@ class FlatParamHandle:
         unsharded_flat_param = self._alloc_padded_unsharded_flat_param()
         padded_unsharded_flat_param = self._all_gather_flat_param(unsharded_flat_param)
         self._use_unsharded_flat_param(padded_unsharded_flat_param)
+        if RANK == 0:
+            print(f"Unshard handle {self._handle_index}")
 
     def needs_unshard(self) -> bool:
         """Returns if the handle's flat parameter needs to be unsharded."""

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -455,6 +455,9 @@ class FlatParamHandle:
             from ``named_parameters()``.
     """
 
+    # Attributes for rate limiting
+    _free_event_queue: _FreeEventQueue
+
     ##################
     # INITIALIZATION #
     ##################
@@ -539,14 +542,14 @@ class FlatParamHandle:
             params, fully_sharded_module, self._aligned_numel, use_orig_params  # type: ignore[arg-type]
         )
         self._use_unsharded_views(as_params=False)
-        # Attributes for wait system for rate limiting
-        self._free_event_queue: Optional[_FreeEventQueue] = None
+        # Attributes for rate limiting
         self._limit_all_gathers: Optional[bool] = None
 
-    def init_wait_system(self,
+    def init_wait_system(
+        self,
         free_event_queue: _FreeEventQueue,
         limit_all_gathers: bool,
-    ):
+    ) -> None:
         self._free_event_queue = free_event_queue
         self._limit_all_gathers = limit_all_gathers
 

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -550,6 +550,9 @@ class FlatParamHandle:
         free_event_queue: _FreeEventQueue,
         limit_all_gathers: bool,
     ) -> None:
+        """
+        Get a reference to the free event queue of root FSDP.
+        """
         self._free_event_queue = free_event_queue
         self._limit_all_gathers = limit_all_gathers
 

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1758,7 +1758,7 @@ class FlatParamHandle:
             # If it is, unstash it from queue
             self._free_event_queue.pop(unsharded_flat_param)
             # Then direct free
-            self._free_unsharded_flat_param()
+            _free_storage(unsharded_flat_param)
 
     def post_reshard(self):
         """

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1721,6 +1721,7 @@ class FlatParamHandle:
         unsharded_flat_param = self._get_padded_unsharded_flat_param()
         self._check_storage_allocated(unsharded_flat_param)
         self._check_on_compute_device(unsharded_flat_param)
+        # Do not free the memory until all ops in the current stream finish
         _no_dispatch_record_stream(
             unsharded_flat_param, self._device_handle.current_stream()
         )

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -504,10 +504,9 @@ def _init_prefetching_state(
 ) -> _FSDPState:
     if backward_prefetch == BackwardPrefetch.BACKWARD_PRE:
         warnings.warn(
-            "The `BACKWARD_PRE` option for FSDP parameter `backward_prefetch` "
-            "has been consolidated with `BACKWARD_POST`. FSDP now supports `BACKWARD_POST` (prefetch "
-            "after an earlier instance's backward) or `None` (no prefetch at "
-            "all). Setting it to default value `BACKWARD_POST` now."
+            "The `BACKWARD_PRE` and `BACKWARD_POST` options for FSDP parameter "
+            "`backward_prefetch` has been consolidated. Both options would "
+            "perform the same prefetch during backward. "
         )
         backward_prefetch = BackwardPrefetch.BACKWARD_POST
     state.backward_prefetch = backward_prefetch

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -34,8 +34,8 @@ from torch.distributed.fsdp._common_utils import (
     _is_fsdp_flattened,
     _named_parameters_with_duplicates,
     clean_tensor_name,
-    TrainingState,
     DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS,
+    TrainingState,
 )
 from torch.distributed.fsdp._flat_param import (
     _FSDP_USE_FULL_PREC_IN_EVAL,

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -460,6 +460,9 @@ def _init_core_state(
     state.training_state = TrainingState.IDLE
     state._is_root = None
     state._free_event_queue = _FreeEventQueue(DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS)
+    # Free event queue for unsharded grad reduce-scatter; reusing the same max
+    # inflight as all gather
+    state._free_event_queue_rs = _FreeEventQueue(DEFAULT_MAX_IN_FLIGHT_ALL_GATHERS)
     state._debug_level = dist.get_debug_level()
     state._exec_order_data = exec_order_utils._ExecOrderData(
         state._debug_level,

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -47,7 +47,3 @@ class _FreeEventQueue:
             event = self._queue.popleft()
             return event
         return None
-
-    def clear(self) -> None:
-        """Clear queue."""
-        self._queue.clear()

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -5,6 +5,12 @@ import torch
 
 
 class EventWithTensor:
+    """
+    This data structure pairs the resharding event (i.e. forward done) with the
+    all-gather buffer being resharded. The purpose is to free the all-gather
+    buffer when we ask a new all-gather to wait for a resharding event (hence
+    avoiding OOM).
+    """
     def __init__(
         self,
         event: torch.cuda.Event,

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -1,4 +1,5 @@
 import collections
+from enum import Enum, auto
 from typing import Deque, Optional
 
 import torch
@@ -21,6 +22,11 @@ class EventWithTensor:
         self.tensor = tensor
 
 
+class _QueueDirection(Enum):
+    POP_LEFT = auto()
+    POP_RIGHT = auto()
+
+
 class _FreeEventQueue:
     """
     This tracks all pending frees corresponding to inflight all-gathers. The
@@ -31,10 +37,14 @@ class _FreeEventQueue:
     def __init__(self) -> None:
         self._queue: Deque[EventWithTensor] = collections.deque()
         self._max_num_inflight_all_gathers = 2  # empirically chosen
+        self._direction: _QueueDirection = _QueueDirection.POP_LEFT
 
     def enqueue(self, free_event: EventWithTensor) -> None:
         """Enqueues a free event."""
-        self._queue.append(free_event)
+        if self._direction == _QueueDirection.POP_LEFT:
+            self._queue.append(free_event)
+        else:
+            self._queue.appendleft(free_event)
 
     def dequeue_if_needed(self) -> Optional[EventWithTensor]:
         """Dequeues a single event if the limit is reached."""
@@ -45,6 +55,15 @@ class _FreeEventQueue:
     def dequeue(self) -> Optional[EventWithTensor]:
         """Dequeues a free event if possible."""
         if self._queue:
-            event = self._queue.popleft()
+            if self._direction == _QueueDirection.POP_LEFT:
+                event = self._queue.popleft()
+            else:
+                event = self._queue.pop()
             return event
         return None
+
+    def use_backward_direction(self) -> None:
+        self._direction = _QueueDirection.POP_RIGHT
+
+    def use_forward_direction(self) -> None:
+        self._direction = _QueueDirection.POP_LEFT

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -11,6 +11,7 @@ class EventWithTensor:
     buffer when we ask a new all-gather to wait for a resharding event (hence
     avoiding OOM).
     """
+
     def __init__(
         self,
         event: torch.cuda.Event,

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -32,10 +32,10 @@ class _FreeEventQueue:
     def dequeue_if_needed(self) -> Optional[EventWithTensor]:
         """Dequeues a single event if the limit is reached."""
         if len(self._queue) >= self._max_num_inflight_all_gathers:
-            return self._dequeue()
+            return self.dequeue()
         return None
 
-    def _dequeue(self) -> Optional[EventWithTensor]:
+    def dequeue(self) -> Optional[EventWithTensor]:
         """Dequeues a free event if possible."""
         if self._queue:
             event = self._queue.popleft()

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -41,3 +41,7 @@ class _FreeEventQueue:
             event = self._queue.popleft()
             return event
         return None
+
+    def clear(self) -> None:
+        """Clear queue."""
+        self._queue.clear()

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -4,23 +4,6 @@ from typing import Optional, Tuple
 import torch
 
 
-class EventWithTensor:
-    """
-    This data structure pairs the resharding event (i.e. forward done) with the
-    all-gather buffer being resharded. The purpose is to free the all-gather
-    buffer when we ask a new all-gather to wait for a resharding event (hence
-    avoiding OOM).
-    """
-
-    def __init__(
-        self,
-        event: torch.cuda.Event,
-        tensor: torch.Tensor,
-    ) -> None:
-        self.event = event
-        self.tensor = tensor
-
-
 class _FreeEventQueue:
     """
     This tracks all pending frees corresponding to inflight all-gathers. The

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -60,9 +60,6 @@ class _FreeEventQueue:
             return self._queue.popitem(last=False)
         return None
 
-    def erase(
-        self,
-        tensor: torch.Tensor
-    ) -> Optional[torch.cuda.Event]:
+    def pop(self, tensor: torch.Tensor) -> Optional[torch.cuda.Event]:
         """Erase tensor-event pair from queue"""
-        self._queue.pop(tensor, None)
+        return self._queue.pop(tensor, None)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -327,8 +327,8 @@ def _unshard(
         ran_pre_unshard = handle.pre_unshard()
     if ran_pre_unshard:
         unshard_stream.wait_stream(pre_unshard_stream)
+    handle.unshard(unshard_stream)
     with state._device_handle.stream(unshard_stream):
-        handle.unshard()
         handle.post_unshard()
 
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -443,7 +443,7 @@ def _pre_forward_unshard(
     with torch.profiler.record_function(
         "FullyShardedDataParallel._pre_forward_prefetch"
     ):
-        _prefetch_handle(state, handle, _PrefetchMode.FORWARD)
+        _prefetch_next_handle(state, handle, _PrefetchMode.FORWARD)
 
 
 @no_type_check
@@ -688,7 +688,7 @@ def _pre_backward_hook(
         with torch.profiler.record_function(
             "FullyShardedDataParallel._pre_backward_prefetch"
         ):
-            _prefetch_handle(state, handle, _PrefetchMode.BACKWARD)
+            _prefetch_next_handle(state, handle, _PrefetchMode.BACKWARD)
         handle.prepare_gradient_for_backward()
         handle._ran_pre_backward_hook = True
 
@@ -781,7 +781,7 @@ def _post_backward_reshard(
     with torch.profiler.record_function(
         "FullyShardedDataParallel._post_backward_prefetch"
     ):
-        _prefetch_handle(state, handle, _PrefetchMode.BACKWARD)
+        _prefetch_next_handle(state, handle, _PrefetchMode.BACKWARD)
 
 
 @no_type_check
@@ -1174,7 +1174,7 @@ def _finalize_params(
 
 
 @no_type_check
-def _prefetch_handle(
+def _prefetch_next_handle(
     state: _FSDPState,
     current_handle: Optional[FlatParamHandle],
     prefetch_mode: _PrefetchMode,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -258,7 +258,6 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
-        fsdp_state._device_mesh = root_state._device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -234,6 +234,12 @@ def _share_state_and_init_handle_attrs(
                 f"FSDP state missing attribute {attr_name}",
             )
             attr_name_to_values[attr_name].add(getattr(fsdp_state, attr_name))
+        handle = fsdp_state._handle
+        if handle:
+            handle.init_wait_system(
+                root_state._free_event_queue,
+                root_state.limit_all_gathers,
+            )
         if fsdp_state is root_state:
             continue
         # Relax the assert for non-root FSDP instances in case the nested
@@ -252,13 +258,10 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
+        fsdp_state._device_mesh = root_state._device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()
-            handle.init_wait_system(
-                root_state._free_event_queue,
-                root_state.limit_all_gathers,
-            )
 
         # TODO: remove this if check after we integrate device_mesh in Composable APIs.
         # Currently, it is needed since root_state of composable APIs doesn't have DeviceMesh passed in yet.

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -780,6 +780,12 @@ def _post_backward_reshard(
     handle: FlatParamHandle,
     *unused: Any,
 ) -> None:
+    if state.limit_all_gathers:
+        # If limit_all_gather is on, we ask the unshard stream to wait for the
+        # default stream, before we free the unshard buffer (because it was
+        # allocated in the unshard stream)
+        state._unshard_stream.wait_stream(state._device_handle.current_stream())
+
     free_unsharded_flat_param = _should_free_in_backward(state, handle)
     _reshard(state, handle, free_unsharded_flat_param)
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -878,7 +878,7 @@ def _reduce_grad(state: _FSDPState, handle: FlatParamHandle) -> torch.cuda.Event
                     state, handle, new_sharded_grad
                 )
                 _post_reduce_grad_callback(state, handle, grad_to_offload)
-                return
+                return unsharded_grad_consumed_event
         _div_if_needed(new_sharded_grad, state._gradient_postdivide_factor)
     else:
         state._comm_hook(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -934,7 +934,9 @@ def _accumulate_sharded_grad(
 
 
 @no_type_check
-def _reduce_grad_no_shard(state: _FSDPState, handle: FlatParamHandle) -> torch.cuda.Event:
+def _reduce_grad_no_shard(
+    state: _FSDPState, handle: FlatParamHandle
+) -> torch.cuda.Event:
     """
     For no-shard, this runs gradient reduction (which directly covers any
     gradient accumulation implicitly) and the post-reduction callback.

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -775,6 +775,7 @@ def _post_backward_hook(
             )
 
 
+@no_type_check
 def _post_backward_reshard(
     state: _FSDPState,
     handle: FlatParamHandle,

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -298,7 +298,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             This configures explicit backward prefetching of all-gathers. If
             ``None``, then FSDP does not backward prefetch, and there is no
             communication and computation overlap in the backward pass. See
-            :class:`BackwardPrefetch` for details. (Default: ``BACKWARD_PRE``)
+            :class:`BackwardPrefetch` for details. (Default: ``BACKWARD_POST``)
         mixed_precision (Optional[MixedPrecision]):
             This configures native mixed precision for FSDP. If this is set to
             ``None``, then no mixed precision is used. Otherwise, parameter,
@@ -414,7 +414,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         auto_wrap_policy: Optional[
             Union[Callable, ModuleWrapPolicy, CustomPolicy]
         ] = None,
-        backward_prefetch: Optional[BackwardPrefetch] = BackwardPrefetch.BACKWARD_PRE,
+        backward_prefetch: Optional[BackwardPrefetch] = BackwardPrefetch.BACKWARD_POST,
         mixed_precision: Optional[MixedPrecision] = None,
         ignored_modules: Optional[Iterable[torch.nn.Module]] = None,
         param_init_fn: Optional[Callable[[nn.Module], None]] = None,


### PR DESCRIPTION
### 1. Motivation
Today's FSDP uses CPU-GPU synchronization to limit issuance rate of all-gather. This stalls the CPU thread from issuance new tasks when waiting for GPU computation to finish. See "CPU Thread Activities".
<img width="910" alt="Screenshot 2023-09-28 at 1 08 16 AM" src="https://github.com/pytorch/pytorch/assets/6676466/1d07138f-b8fc-4e06-8bfb-69b8575c2df4">

And when the CPU thread resumes, there is an 235 us overhead between the time the synchronization is met and the time a new all-gather is launched. See "Overhead (zoomed in)". This overhead would turn into GPU utilization gap.

<img width="1011" alt="Screenshot 2023-09-28 at 1 12 24 AM" src="https://github.com/pytorch/pytorch/assets/6676466/d381ea12-c5b3-4c2b-aa96-deb33475f409">

### 2. Proposal
Replace CPU synchronization with stream wait in limitation of all-gather issuance. 

We ask the unshard stream to wait for the resharding event of the "-2" all-gather, which marks the compute completion of the "-2" FSDP instance.

In order for the CUDA caching allocator to work with the stream wait, we ask it to hold the all-gather buffer till the "+2" all-gather. We do so by stashing the all-gather buffer into the existing "free event queue", and free it only when we are about to issue the "+2" all-gather (after "+2" all-gather has established wait relationship).

CPU timeline as follows:
![fsdp_rate_limiter](https://github.com/pytorch/pytorch/assets/6676466/a5089bc0-d9ab-4345-b12e-7ae3c4a62b43)

### 2.1 Additional Changes
**2.1.1 Moved `_free_storage` from reshard to +2 unshard.**
![free_storage](https://github.com/pytorch/pytorch/assets/6676466/7b912f65-95bf-4494-bbaf-fd7f2945e5b4)

**2.1.2 Consolidated `BACKWARD_PRE` and `BACKWARD_POST` options for backward prefetch.**
i.e. we would just use BACKWARD_POST, for example, the completion of layer 12 backward would trigger all-gather of layer 10 (with a stream wait, of course)

### 2.2 Backward wait system
The backward wait is implemented as follows:
![backward](https://github.com/pytorch/pytorch/assets/6676466/47e9e5fc-ff2b-4494-968f-4f0d75086dbc)

Location 1:
We need to allocate two buffers to achieve compute-communication overlap. This is auto-satisfied by the state of the free-event queue at the end of forward -- which still has two last layers stashed. In fact, by such stashing, we save two all-gathers (for the last two layers) compared to today's FSDP. 

Location 2:
What happen here are:
Compute on unshard buffer B done -> Unshard stream wait for compute stream -> Free unshard buffer B -> Switch to unshard stream -> Allocate unshard buffer B+1 -> Perform all-gather on B+1

Location 3:
Switch back to default stream, call `split_and_view` to get individual parameter -> Default stream wait for unshard stream. We switch back to default stream so that the backward op for `split_and_view` would be also on default stream. Otherwise, autograd would use a separate stream for this backward op and call `record_stream` on the param tensors.

### 3. Evaluation
![380210060_682184966891666_4956717331232594368_n](https://github.com/pytorch/pytorch/assets/6676466/7b67e75e-068b-49d7-bf18-e0ff7206b6ea)

Cc: @awgu @albanD @janeyx99 