### PR TITLE
[inductor] Move test_inductor_sequence_nr out of test_aot_inductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -132,7 +132,6 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
-    @requires_cpp_extension()
     def test_output_misaligned(self):
         class Repro(torch.nn.Module):
             def __init__(self):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1,9 +1,7 @@
 # Owner(s): ["module: inductor"]
 import copy
 import functools
-import re
 import unittest
-from unittest.mock import patch
 
 import torch
 import torch._export
@@ -12,16 +10,12 @@ import torch._inductor
 import torch.fx._pytree as fx_pytree
 from torch._dynamo.testing import same
 
-from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import IS_FBCODE, TEST_WITH_ROCM, TestCase
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.utils import _pytree as pytree
 
 aten = torch.ops.aten
 requires_cuda = functools.partial(unittest.skipIf, not HAS_CUDA, "requires cuda")
-requires_cpp_extension = functools.partial(
-    unittest.skipIf, IS_FBCODE, "cpp_extension N/A in fbcode"
-)
 
 
 class AOTInductorModelRunner:
@@ -77,7 +71,6 @@ class AOTInductorModelRunner:
 
 
 class AotInductorTests(TestCase):
-    @requires_cpp_extension()
     def test_simple(self):
         class Repro(torch.nn.Module):
             def __init__(self):
@@ -96,7 +89,6 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
-    @requires_cpp_extension()
     def test_with_offset(self):
         class Repro(torch.nn.Module):
             def __init__(self):
@@ -120,7 +112,6 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
-    @requires_cpp_extension()
     def test_missing_output(self):
         class Repro(torch.nn.Module):
             def __init__(self):
@@ -165,64 +156,6 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
-    @requires_cuda()
-    @patch("torch._inductor.config.comment_origin", True)
-    def test_inductor_sequence_nr(self):
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv1 = torch.nn.Conv2d(
-                    in_channels=16,
-                    out_channels=16,
-                    kernel_size=(1, 1),
-                    stride=1,
-                    padding="same",
-                    bias=True,
-                )
-                self.bn1 = torch.nn.BatchNorm2d(num_features=16)
-                self.relu1 = torch.nn.ReLU()
-                self.loss_fn = torch.nn.L1Loss()
-
-            def forward(self, x, target):
-                y = x
-                x = self.conv1(x)
-                x = self.bn1(x)
-                x = self.relu1(x)
-                x = x + y
-                x = torch.flatten(x)
-                output = self.loss_fn(x, target)
-                return (output,)
-
-        def get_triton_codegen(optimized_module, args):
-            def run_with_backward():
-                result = optimized_module(*args)
-                result[0].backward()
-                return result
-
-            res, (fwd_code, bwd_code) = run_and_get_code(run_with_backward)
-            return fwd_code, bwd_code
-
-        x = torch.rand(100, 16, 32, 32, requires_grad=True, device="cuda")
-        target = torch.rand(1, device="cuda")
-        args = [x, target]
-        model = Model().cuda()
-        opt_model = torch.compile(model)
-        fwd_code, bwd_code = get_triton_codegen(opt_model, args)
-
-        bwd_seq_nr_set = set()
-        fwd_seq_nr_set = set()
-        for idx, code in enumerate([fwd_code, bwd_code]):
-            seq_nr_set = bwd_seq_nr_set if idx > 0 else fwd_seq_nr_set
-            prefix = "BWD" if idx > 0 else "FWD"
-            for line in code.split("\n"):
-                if "seq_nr" in line:
-                    res = re.search(r"seq_nr:(\d+)", line)
-                    if res:
-                        seq_nr_set.add(int(res.group(1)))
-
-        self.assertTrue(bwd_seq_nr_set.issubset(fwd_seq_nr_set))
-
-    @requires_cpp_extension()
     def test_dynamic_smem_above_default_limit(self):
         class Repro(torch.nn.Module):
             def forward(self, x, y):
@@ -248,7 +181,6 @@ class AotInductorTests(TestCase):
         )
         self.assertTrue(same(actual, expected))
 
-    @requires_cpp_extension()
     def test_addmm(self):
         class Model(torch.nn.Module):
             def __init__(self, n, k):
@@ -274,5 +206,6 @@ class AotInductorTests(TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if HAS_CUDA and not TEST_WITH_ROCM:
+    # cpp_extension N/A in fbcode
+    if HAS_CUDA and not TEST_WITH_ROCM and not IS_FBCODE:
         run_tests(needs="filelock")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7586,6 +7586,62 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 "first_arg 2 False True",
             )
 
+        @patch("torch._inductor.config.comment_origin", True)
+        def test_inductor_sequence_nr(self):
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.conv1 = torch.nn.Conv2d(
+                        in_channels=16,
+                        out_channels=16,
+                        kernel_size=(1, 1),
+                        stride=1,
+                        padding="same",
+                        bias=True,
+                    )
+                    self.bn1 = torch.nn.BatchNorm2d(num_features=16)
+                    self.relu1 = torch.nn.ReLU()
+                    self.loss_fn = torch.nn.L1Loss()
+
+                def forward(self, x, target):
+                    y = x
+                    x = self.conv1(x)
+                    x = self.bn1(x)
+                    x = self.relu1(x)
+                    x = x + y
+                    x = torch.flatten(x)
+                    output = self.loss_fn(x, target)
+                    return (output,)
+
+            def get_triton_codegen(optimized_module, args):
+                def run_with_backward():
+                    result = optimized_module(*args)
+                    result[0].backward()
+                    return result
+
+                res, (fwd_code, bwd_code) = run_and_get_code(run_with_backward)
+                return fwd_code, bwd_code
+
+            x = torch.rand(100, 16, 32, 32, requires_grad=True, device="cuda")
+            target = torch.rand(1, device="cuda")
+            args = [x, target]
+            model = Model().cuda()
+            opt_model = torch.compile(model)
+            fwd_code, bwd_code = get_triton_codegen(opt_model, args)
+
+            bwd_seq_nr_set = set()
+            fwd_seq_nr_set = set()
+            for idx, code in enumerate([fwd_code, bwd_code]):
+                seq_nr_set = bwd_seq_nr_set if idx > 0 else fwd_seq_nr_set
+                prefix = "BWD" if idx > 0 else "FWD"
+                for line in code.split("\n"):
+                    if "seq_nr" in line:
+                        res = re.search(r"seq_nr:(\d+)", line)
+                        if res:
+                            seq_nr_set.add(int(res.group(1)))
+
+            self.assertTrue(bwd_seq_nr_set.issubset(fwd_seq_nr_set))
+
     class RNNTest(TestCase):
         class Model(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108237

Summary: The initial PR that added test_inductor_sequence_nr (https://github.com/pytorch/pytorch/pull/103129) seems to think test_aot_inductor is to test aot_autograd + inductor. Move the test to test_torchinductor instead, which can simplify the logic for test_aot_inductor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov