### PR TITLE
[dynamo] Add dynamic shapes support to torch.Size.numel

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2196,6 +2196,17 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         num = torch.Size([10, 8]).numel()
         self.assertEqual(opt_fn(), num)
 
+    def test_torch_size_numel_dynamic(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            return x.size().numel()
+
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+        x = torch.rand(10, 1, 8, 1)
+        expect = fn(x)
+        self.assertEqual(opt_fn(x), expect)
+
     def test_size_dim(self):
         cnts = torch._dynamo.testing.CompileCounter()
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -15,7 +15,7 @@ from ..bytecode_transformation import create_call_function, create_instruction
 from ..exc import unimplemented
 from ..guards import make_dupe_guard
 from ..source import GetItemSource
-from ..utils import check_constant_args, get_fake_value, guard_if_dyn, namedtuple_fields, product
+from ..utils import check_constant_args, get_fake_value, guard_if_dyn, namedtuple_fields
 from .base import MutableLocal, VariableTracker
 from .constant import ConstantVariable
 from .functions import UserFunctionVariable, UserMethodVariable
@@ -541,9 +541,9 @@ class SizeVariable(TupleVariable):
     def unpack_var_sequence(self, tx):
         return [x.add_options(self) for x in self.items]
 
-    def numel(self):
-        from .tensor import SymNodeVariable
+    def numel(self, tx):
         from .builtin import BuiltinVariable
+        from .tensor import SymNodeVariable
 
         const_result = 1
         sym_sizes = []
@@ -582,7 +582,8 @@ class SizeVariable(TupleVariable):
             out = self.get_item_dyn(tx, args[0])
             return out
         elif name == "numel":
-            return self.numel()
+            assert not args and not kwargs
+            return self.numel(tx)
 
         return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #108240
* __->__ #108239

Currently numel only supports static shapes, but this expands it to support
generating symbolic arithmetic into the graph. e.g.
```
# x.size().numel with x.size() = [s0, 1, s1]
size = l_x_.size()
getitem = size[0]
getitem_2 = size[2];  size = None
mul = getitem * getitem_2;  getitem = getitem_2 = None
```

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng