### PR TITLE
[dynamo] Fix return type of Tensor.shape

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2211,13 +2211,10 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         cnts = torch._dynamo.testing.CompileCounter()
 
         def fn(x):
-            if type(x.shape) == torch.Size:
-                return 1
-            else:
-                return 0
+            return x + (type(x.shape) == torch.Size)
 
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
-        x = torch.rand(())
+        x = torch.zeros(())
         self.assertEqual(opt_fn(x), fn(x))
 
     def test_size_dim(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2207,6 +2207,19 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         expect = fn(x)
         self.assertEqual(opt_fn(x), expect)
 
+    def test_shape_type(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            if type(x.shape) == torch.Size:
+                return 1
+            else:
+                return 0
+
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+        x = torch.rand(())
+        self.assertEqual(opt_fn(x), fn(x))
+
     def test_size_dim(self):
         cnts = torch._dynamo.testing.CompileCounter()
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -595,15 +595,6 @@ class SizeVariable(TupleVariable):
             return self.items[index].add_options(arg, self)
 
 
-class ShapeVariable(TupleVariable):
-    """
-    Represents tensor.shape(...) and helps differentiate between a constant
-    TupleVariable and ShapeVariable.
-    """
-
-    pass
-
-
 class NamedTupleVariable(TupleVariable):
     def __init__(self, items, tuple_cls, **kwargs):
         super().__init__(items, **kwargs)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -35,7 +35,7 @@ from ..utils import (
 )
 from .base import VariableTracker
 from .constant import ConstantVariable
-from .lists import ShapeVariable, SizeVariable
+from .lists import SizeVariable
 
 supported_tensor_comparison_ops = {
     ">": operator.gt,
@@ -228,7 +228,7 @@ class TensorVariable(VariableTracker):
             result = ConstantVariable(self.device.type == "cuda", **options)
         elif name == "shape" and self.size is not None:
             sizes = [variables.ConstantVariable(x) for x in self.size]
-            result = ShapeVariable(sizes, **options)
+            result = SizeVariable(sizes, **options)
         elif name == "requires_grad" and self.requires_grad is not None:
             result = ConstantVariable(self.requires_grad, **options)
         elif name == "is_quantized" and self.is_quantized is not None:
@@ -649,7 +649,7 @@ class TensorVariable(VariableTracker):
             if (
                 name == "new"
                 and len(args) == 1
-                and isinstance(args[0], (SizeVariable, ShapeVariable))
+                and isinstance(args[0], SizeVariable)
             ):
                 name = "new_empty"
             return wrap_fx_proxy(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108240
* #108239

This should be `torch.Size` but was returning a plain tuple under dynamo.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng