### PR TITLE
[dynamo] Support pytree flattening data structures with KJT.

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -225,10 +225,10 @@ class TestPytree(TestCase):
         _, spec = tree_flatten(pytree)
         self.assertExpectedInline(repr(spec),
                                   """\
-TreeSpec(TupleVariable, None, [*,
-  TreeSpec(ListVariable, None, [*,
+TreeSpec(tuple, None, [*,
+  TreeSpec(list, None, [*,
     *,
-    TreeSpec(ListVariable, None, [*])])])""")
+    TreeSpec(list, None, [*])])])""")
 
     def test_broadcast_to_and_flatten(self):
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1387,6 +1387,8 @@ class TorchPatcher:
         torch._dynamo.variables.lists._register_dynamo_list_to_tree_spec()
         torch._dynamo.variables.lists._register_dynamo_tuple_to_tree_spec()
         torch._dynamo.variables.dicts._register_dynamo_dict_to_tree_spec()
+        # TODO Short term solution for KJT to be traced by dynamo.
+        torch._dynamo.variables.user_defined._register_dynamo_kjt_to_tree_spec()
 
     @staticmethod
     def suppress_torch_distributed_warnings(fn):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -63,6 +63,7 @@ from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
 from torch._subclasses.fake_tensor import FakeTensor, is_fake
 from torch.nn.modules.lazy import LazyModuleMixin
+from torch.utils import _pytree as pytree
 from torch.utils._pytree import tree_map
 
 
@@ -788,6 +789,7 @@ def is_safe_constant(v):
             type(type),
             torch.device,
             torch.dtype,
+            pytree.TreeSpec,
         ),
     )
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -17,7 +17,7 @@ from ..exc import unimplemented
 from ..source import AttrSource, GlobalWeakRefSource
 from ..utils import global_key_name, istensor
 from .base import MutableLocal, VariableTracker
-from .constant import ConstantVariable
+from .constant import ConstantVariable, register_dynamo_pytree_spec_type
 from .tensor import TensorVariable
 
 
@@ -500,3 +500,4 @@ def _register_dynamo_dict_to_tree_spec():
         ConstDictVariable,
         _dictvariable_flatten,
     )
+    register_dynamo_pytree_spec_type(ConstDictVariable, dict)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -17,7 +17,7 @@ from ..guards import make_dupe_guard
 from ..source import GetItemSource
 from ..utils import check_constant_args, get_fake_value, guard_if_dyn, namedtuple_fields
 from .base import MutableLocal, VariableTracker
-from .constant import ConstantVariable
+from .constant import ConstantVariable, register_dynamo_pytree_spec_type
 from .functions import UserFunctionVariable, UserMethodVariable
 
 
@@ -736,6 +736,7 @@ def _register_dynamo_list_to_tree_spec():
         ListVariable,
         _listvariable_flatten,
     )
+    register_dynamo_pytree_spec_type(ListVariable, list)
 
 
 def _tuplevariable_flatten(d: TupleVariable) -> Tuple[List[Any], pytree.Context]:
@@ -762,6 +763,7 @@ def _register_dynamo_tuple_to_tree_spec():
         TupleVariable,
         _tuplevariable_flatten,
     )
+    register_dynamo_pytree_spec_type(TupleVariable, tuple)
 
 
 class SetVariable(VariableTracker):


### PR DESCRIPTION
Summary: Register the rule for flattening KJT in dynamo so that we can unblock torch.export() for some important server use cases.

Test Plan: buck2 run mode/opt sigmoid/frontend:unflatten_test -- -r kjt_dynamo_flatten

Differential Revision: D48833738



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov