### PR TITLE
Revert D47848392: Multisect successfully blamed "D47848392: Serialize pytree to json string (#106116)" for test or build failures

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -21,14 +21,7 @@ from torch._export.utils import (
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.utils._pytree import (
-    LeafSpec,
-    tree_flatten,
-    tree_unflatten,
-    TreeSpec,
-    treespec_loads,
-    treespec_dumps
-)
+from torch.utils._pytree import LeafSpec, tree_flatten, tree_unflatten, TreeSpec
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
@@ -401,9 +394,6 @@ class TestExport(TestCase):
         self.assertEqual(orig_dt.y, 4)
         self.assertEqual(orig_dt.z, None)
 
-        roundtrip_spec = treespec_loads(treespec_dumps(spec))
-        self.assertEqual(roundtrip_spec, spec)
-
         # Override the registration with keep none fields
         register_dataclass_as_pytree_node(MyDataClass, return_none_fields=True)
 
@@ -427,9 +417,6 @@ class TestExport(TestCase):
         self.assertEqual(orig_dt.x, 3)
         self.assertEqual(orig_dt.y, 4)
         self.assertEqual(orig_dt.z, None)
-
-        roundtrip_spec = treespec_loads(treespec_dumps(spec))
-        self.assertEqual(roundtrip_spec, spec)
 
     def test_pytree_regster_nested_data_class(self):
 
@@ -456,9 +443,6 @@ class TestExport(TestCase):
 
         unflat = tree_unflatten(flat, spec)
         self.assertEqual(unflat, inp)
-
-        roundtrip_spec = treespec_loads(treespec_dumps(spec))
-        self.assertEqual(roundtrip_spec, spec)
 
     def test_param_util(self):
         class Basic(torch.nn.Module):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -479,6 +479,9 @@ class TestOpVersioning(TestCase):
 unittest.expectedFailure(
     TestDeserialize.test_exportdb_supported_case_tensor_setattr
 )
+unittest.expectedFailure(
+    TestDeserialize.test_exportdb_supported_case_pytree_flatten
+)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -8,9 +8,8 @@ from torch.utils._pytree import (
     tree_unflatten,
     TreeSpec,
     LeafSpec,
-    treespec_dumps,
-    treespec_loads,
-    _register_pytree_node,
+    pytree_to_str,
+    str_to_pytree,
 )
 import unittest
 from torch.utils._pytree import _broadcast_to_and_flatten, tree_map_only, tree_all
@@ -275,28 +274,18 @@ TreeSpec(TupleVariable, None, [*,
             result = _broadcast_to_and_flatten(pytree, to_spec)
             self.assertEqual(result, expected, msg=str([pytree, to_spec, expected]))
 
-    @parametrize("spec", [
-        TreeSpec(list, None, []),
-        TreeSpec(tuple, None, []),
-        TreeSpec(dict, [], []),
-        TreeSpec(list, None, [LeafSpec()]),
-        TreeSpec(list, None, [LeafSpec(), LeafSpec()]),
-        TreeSpec(tuple, None, [LeafSpec(), LeafSpec(), LeafSpec()]),
-        TreeSpec(dict, ['a', 'b', 'c'], [LeafSpec(), LeafSpec(), LeafSpec()]),
-        TreeSpec(OrderedDict, ['a', 'b', 'c'], [
-            TreeSpec(
-                tuple,
-                None,
-                [LeafSpec(), LeafSpec()]
-            ),
-            LeafSpec(),
-            TreeSpec(
-                dict,
-                ['a', 'b', 'c'],
-                [LeafSpec(), LeafSpec(), LeafSpec()]
-            ),
-        ]),
-        TreeSpec(list, None, [
+    @parametrize("spec, str_spec", [
+        (TreeSpec(list, None, []), "L()"),
+        (TreeSpec(tuple, None, []), "T()"),
+        (TreeSpec(dict, [], []), "D()"),
+        (TreeSpec(list, None, [LeafSpec()]), "L(*)"),
+        (TreeSpec(list, None, [LeafSpec(), LeafSpec()]), "L(*,*)"),
+        (TreeSpec(tuple, None, [LeafSpec(), LeafSpec(), LeafSpec()]), "T(*,*,*)"),
+        (
+            TreeSpec(dict, ['a', 'b', 'c'], [LeafSpec(), LeafSpec(), LeafSpec()]),
+            "D(a:*,b:*,c:*)"
+        ),
+        (TreeSpec(list, None, [
             TreeSpec(tuple, None, [
                 LeafSpec(),
                 LeafSpec(),
@@ -305,123 +294,24 @@ TreeSpec(TupleVariable, None, [*,
                     LeafSpec(),
                 ]),
             ]),
-        ]),
-    ],)
-    def test_pytree_serialize(self, spec):
-        serialized_spec = treespec_dumps(spec)
-        self.assertTrue(isinstance(serialized_spec, str))
-        self.assertTrue(spec == treespec_loads(serialized_spec))
+        ]), "L(T(*,*,L(*,*)))"),
+    ], name_fn=lambda _, str_spec: str_spec)
+    def test_pytree_serialize(self, spec, str_spec):
+        self.assertEqual(pytree_to_str(spec), str_spec)
+        self.assertTrue(spec == str_to_pytree(str_spec))
+        self.assertTrue(spec == str_to_pytree(pytree_to_str(spec)))
 
     def test_pytree_serialize_namedtuple(self):
         Point = namedtuple("Point", ["x", "y"])
         spec = TreeSpec(namedtuple, Point, [LeafSpec(), LeafSpec()])
+        str_spec = "N(Point(x, y),*,*)"
 
-        roundtrip_spec = treespec_loads(treespec_dumps(spec))
+        self.assertEqual(pytree_to_str(spec), str_spec)
+
+        roundtrip_spec = str_to_pytree(pytree_to_str(spec))
         # The context in the namedtuple is different now because we recreated
         # the namedtuple type.
         self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
-
-    def test_pytree_custom_type_serialize(self):
-        class DummyType:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
-        _register_pytree_node(
-            DummyType,
-            lambda dummy: ([dummy.x, dummy.y], None),
-            lambda xs, _: Dummy(*xs),
-            to_dumpable_context=lambda context: "moo",
-            from_dumpable_context=lambda dumpable_context: None,
-        )
-        spec = TreeSpec(DummyType, None, [LeafSpec(), LeafSpec()])
-        serialized_spec = treespec_dumps(spec, 1)
-        self.assertTrue("moo" in serialized_spec)
-        roundtrip_spec = treespec_loads(serialized_spec)
-        self.assertEqual(roundtrip_spec, spec)
-
-    def test_pytree_serialize_register_bad(self):
-        class DummyType:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
-        with self.assertRaisesRegex(ValueError, "Both to_dumpable_context and from_dumpable_context"):
-            _register_pytree_node(
-                DummyType,
-                lambda dummy: ([dummy.x, dummy.y], None),
-                lambda xs, _: Dummy(*xs),
-                to_dumpable_context=lambda context: "moo",
-            )
-
-    def test_pytree_context_serialize_bad(self):
-        class DummyType:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
-        _register_pytree_node(
-            DummyType,
-            lambda dummy: ([dummy.x, dummy.y], None),
-            lambda xs, _: Dummy(*xs),
-            to_dumpable_context=lambda context: DummyType,
-            from_dumpable_context=lambda dumpable_context: None,
-        )
-
-        spec = TreeSpec(DummyType, None, [LeafSpec(), LeafSpec()])
-
-        with self.assertRaisesRegex(TypeError, "Object of type type is not JSON serializable"):
-            treespec_dumps(spec)
-
-    def test_pytree_serialize_bad_input(self):
-        with self.assertRaises(AttributeError):
-            treespec_dumps("random_blurb")
-
-    def test_pytree_serialize_bad_protocol(self):
-        import json
-
-        Point = namedtuple("Point", ["x", "y"])
-        spec = TreeSpec(namedtuple, Point, [LeafSpec(), LeafSpec()])
-
-        with self.assertRaisesRegex(ValueError, "Unknown protocol"):
-            treespec_dumps(spec, -1)
-
-        serialized_spec = treespec_dumps(spec)
-        protocol, data = json.loads(serialized_spec)
-        bad_protocol_serialized_spec = json.dumps((-1, data))
-
-        with self.assertRaisesRegex(ValueError, "Unknown protocol"):
-            treespec_loads(bad_protocol_serialized_spec)
-
-    def test_saved_serialized(self):
-        complicated_spec = TreeSpec(OrderedDict, [1, 2, 3], [
-            TreeSpec(
-                tuple,
-                None,
-                [LeafSpec(), LeafSpec()]
-            ),
-            LeafSpec(),
-            TreeSpec(
-                dict,
-                [4, 5, 6],
-                [LeafSpec(), LeafSpec(), LeafSpec()]
-            ),
-        ])
-
-        serialized_spec = treespec_dumps(complicated_spec)
-        saved_spec = (
-            '[1, {"type": "collections.OrderedDict", "context": "[1, 2, 3]", '
-            '"children_spec": [{"type": "builtins.tuple", "context": "null", '
-            '"children_spec": [{"type": null, "context": null, '
-            '"children_spec": []}, {"type": null, "context": null, '
-            '"children_spec": []}]}, {"type": null, "context": null, '
-            '"children_spec": []}, {"type": "builtins.dict", "context": '
-            '"[4, 5, 6]", "children_spec": [{"type": null, "context": null, '
-            '"children_spec": []}, {"type": null, "context": null, "children_spec": '
-            '[]}, {"type": null, "context": null, "children_spec": []}]}]}]'
-        )
-        self.assertEqual(serialized_spec, saved_spec)
-        self.assertEqual(complicated_spec, treespec_loads(saved_spec))
 
 
 instantiate_parametrized_tests(TestPytree)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -494,6 +494,8 @@ def _register_dynamo_dict_to_tree_spec():
         ConstDictVariable,
         _dictvariable_flatten,
         _dictvariable_unflatten,
+        pytree._dict_to_str,
+        pytree._maybe_str_to_dict,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -730,6 +730,8 @@ def _register_dynamo_list_to_tree_spec():
         ListVariable,
         _listvariable_flatten,
         _listvariable_unflatten,
+        pytree._list_to_str,
+        pytree._maybe_str_to_list,
     )
 
     fx_pytree.register_pytree_flatten_spec(
@@ -756,6 +758,8 @@ def _register_dynamo_tuple_to_tree_spec():
         TupleVariable,
         _tuplevariable_flatten,
         _tuplevariable_unflatten,
+        pytree._tuple_to_str,
+        pytree._maybe_str_to_tuple,
     )
 
     fx_pytree.register_pytree_flatten_spec(

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional, Tuple
 
 # NOTE: Please update this value if any modifications are made to the schema
 SCHEMA_VERSION = 1
-TREESPEC_VERSION = 1
 
 # TODO (zhxchen17) Move to a separate file.
 class _Union:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -19,7 +19,7 @@ import torch
 import torch._export.exported_program as ep
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
-from torch.utils._pytree import treespec_dumps, treespec_loads, tree_map_only
+from torch.utils._pytree import pytree_to_str, str_to_pytree, tree_map_only
 
 from .schema import (  # type: ignore[attr-defined]
     _Union,
@@ -51,7 +51,6 @@ from .schema import (  # type: ignore[attr-defined]
     TensorArgument,
     TensorMeta,
     TensorValue,
-    TREESPEC_VERSION,
 )
 
 
@@ -190,15 +189,15 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
 
 def serialize_call_spec(call_spec: ep.CallSpec) -> CallSpec:
     return CallSpec(
-        in_spec=treespec_dumps(call_spec.in_spec, TREESPEC_VERSION) if call_spec.in_spec else "",
-        out_spec=treespec_dumps(call_spec.out_spec, TREESPEC_VERSION) if call_spec.out_spec else "",
+        in_spec=pytree_to_str(call_spec.in_spec) if call_spec.in_spec else "",
+        out_spec=pytree_to_str(call_spec.out_spec) if call_spec.out_spec else "",
     )
 
 
 def deserialize_call_spec(call_spec: CallSpec) -> ep.CallSpec:
     return ep.CallSpec(
-        in_spec=treespec_loads(call_spec.in_spec) if call_spec.in_spec else None,
-        out_spec=treespec_loads(call_spec.out_spec) if call_spec.out_spec else None,
+        in_spec=str_to_pytree(call_spec.in_spec) if call_spec.in_spec else None,
+        out_spec=str_to_pytree(call_spec.out_spec) if call_spec.out_spec else None,
     )
 
 
@@ -660,8 +659,8 @@ class GraphModuleSerializer:
         return ModuleCallSignature(
             inputs=[serialize_argument(x) for x in module_call_signature.inputs],
             outputs=[serialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=treespec_dumps(module_call_signature.in_spec, TREESPEC_VERSION),
-            out_spec=treespec_dumps(module_call_signature.out_spec, TREESPEC_VERSION),
+            in_spec=pytree_to_str(module_call_signature.in_spec),
+            out_spec=pytree_to_str(module_call_signature.out_spec),
         )
 
     def serialize_module_call_graph(self, module_call_graph: List[ep.ModuleCallEntry]) -> List[ModuleCallEntry]:
@@ -1300,8 +1299,8 @@ class GraphModuleDeserializer:
         return ep.ModuleCallSignature(
             inputs=[deserialize_argument(x) for x in module_call_signature.inputs],
             outputs=[deserialize_argument(x) for x in module_call_signature.outputs],
-            in_spec=treespec_loads(module_call_signature.in_spec),
-            out_spec=treespec_loads(module_call_signature.out_spec),
+            in_spec=str_to_pytree(module_call_signature.in_spec),
+            out_spec=str_to_pytree(module_call_signature.out_spec),
         )
 
     def deserialize_module_call_graph(self, module_call_graph: List[ModuleCallEntry]) -> List[ep.ModuleCallEntry]:

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple
 
 import torch
 
@@ -9,32 +9,25 @@ from torch._export import ExportedProgram
 from torch.utils._pytree import (
     _register_pytree_node,
     Context,
-    DumpableContext,
     FlattenFunc,
-    FromDumpableContextFn,
-    ToDumpableContextFn,
+    MaybeFromStrFunc,
+    ToStrFunc,
     UnflattenFunc,
 )
-
-
-SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS: Dict[str, Type[Any]] = {}
 
 
 def register_dataclass_as_pytree_node(
     typ: Any,
     flatten_fn: Optional[FlattenFunc] = None,
     unflatten_fn: Optional[UnflattenFunc] = None,
+    to_str_fn: Optional[ToStrFunc] = None,
+    maybe_from_str_fn: Optional[MaybeFromStrFunc] = None,
     *,
-    to_dumpable_context: Optional[ToDumpableContextFn] = None,
-    from_dumpable_context: Optional[FromDumpableContextFn] = None,
     return_none_fields: bool = False,
 ) -> None:
     assert dataclasses.is_dataclass(
         typ
     ), f"Only dataclasses can be registered with this function: {typ}"
-
-    serialized_type = f"{typ.__module__}.{typ.__name__}"
-    SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS[serialized_type] = typ
 
     def default_flatten_fn(obj: Any) -> Tuple[List[Any], Context]:
         flattened = []
@@ -53,42 +46,15 @@ def register_dataclass_as_pytree_node(
         typ, flat_names, none_names = context
         return typ(**dict(zip(flat_names, values)), **{k: None for k in none_names})
 
-    def default_to_dumpable_context(context: Context) -> DumpableContext:
-        return (serialized_type, context[1], context[2])
-
-    def default_from_dumpable_context(dumpable_context: DumpableContext) -> Context:
-        return (
-            SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS[dumpable_context[0]],
-            dumpable_context[1],
-            dumpable_context[2],
-        )
-
     flatten_fn = flatten_fn if flatten_fn is not None else default_flatten_fn
     unflatten_fn = unflatten_fn if unflatten_fn is not None else default_unflatten_fn
-
-    if (to_dumpable_context is None) ^ (from_dumpable_context is None):
-        raise ValueError(
-            f"Both to_dumpable_context and from_dumpable_context for {typ} must "
-            "be None or registered."
-        )
-
-    to_dumpable_context = (
-        to_dumpable_context
-        if to_dumpable_context is not None
-        else default_to_dumpable_context
-    )
-    from_dumpable_context = (
-        from_dumpable_context
-        if from_dumpable_context is not None
-        else default_from_dumpable_context
-    )
 
     _register_pytree_node(
         typ,
         flatten_fn,
         unflatten_fn,
-        to_dumpable_context=to_dumpable_context,
-        from_dumpable_context=from_dumpable_context,
+        None,
+        None,
     )
 
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1,9 +1,7 @@
 from typing import NamedTuple, Callable, Any, Tuple, List, Dict, Type, cast, Optional, TypeVar, overload, Union
 import functools
 from collections import namedtuple, OrderedDict
-import dataclasses
-import json
-import warnings
+from dataclasses import dataclass
 
 
 T = TypeVar('T')
@@ -28,16 +26,6 @@ This pytree implementation is not very performant due to Python overhead
 To improve the performance we can move parts of the implementation to C++.
 """
 
-DEFAULT_TREESPEC_SERIALIZATION_PROTOCOL = 1
-
-Context = Any
-PyTree = Any
-FlattenFunc = Callable[[PyTree], Tuple[List, Context]]
-UnflattenFunc = Callable[[List, Context], PyTree]
-DumpableContext = Any  # Any json dumpable text
-ToDumpableContextFn = Callable[[Context], DumpableContext]
-FromDumpableContextFn = Callable[[DumpableContext], Context]
-
 # A NodeDef holds two callables:
 # - flatten_fn should take the collection and return a flat list of values.
 #   It can also return some context that is used in reconstructing the
@@ -45,75 +33,75 @@ FromDumpableContextFn = Callable[[DumpableContext], Context]
 # - unflatten_fn should take a flat list of values and some context
 #   (returned by flatten_fn). It returns the collection by reconstructing
 #   it from the list and the context.
+# - to_str_fn takes a TreeSpec with the specific type and a list of its children
+#   TreeSpecs already converted to strings, and returns a string representation
+#   of this TreeSpec
+# - maybe_from_str_fn takes in a string and if this string represents a TreeSpec
+#   of this type, returns the type, the context, and a string representation of
+#   its children specs. Otherwise it returns None.
+Context = Any
+PyTree = Any
+FlattenFunc = Callable[[PyTree], Tuple[List, Context]]
+UnflattenFunc = Callable[[List, Context], PyTree]
+ToStrFunc = Callable[["TreeSpec", List[str]], str]
+MaybeFromStrFunc = Callable[[str], Optional[Tuple[Any, Context, str]]]
+
 class NodeDef(NamedTuple):
     type: Type[Any]
     flatten_fn: FlattenFunc
     unflatten_fn: UnflattenFunc
+    to_str_fn: ToStrFunc
+    maybe_from_str_fn: MaybeFromStrFunc
 
 SUPPORTED_NODES: Dict[Type[Any], NodeDef] = {}
-
-# _SerializeNodeDef holds the following:
-# - typ: the type of the node (e.g., "Dict", "List", etc)
-# - type_fqn: the fully qualified name of the type, e.g. "collections.OrderedDict"
-# - to_dumpable_context takes a TreeSpec, and returns a serialized string format of the
-#   context, and the version number
-# - from_dumpable_context takes in a string representation of the context, and the
-#   version, and returns the deserialized context
-class _SerializeNodeDef(NamedTuple):
-    typ: Type[Any]
-    type_fqn: str
-    to_dumpable_context: Optional[ToDumpableContextFn]
-    from_dumpable_context: Optional[FromDumpableContextFn]
-
-SUPPORTED_SERIALIZED_TYPES: Dict[Type[Any], _SerializeNodeDef] = {}
-SERIALIZED_TYPE_TO_PYTHON_TYPE: Dict[str, Type[Any]] = {}
 
 def _register_pytree_node(
     typ: Any,
     flatten_fn: FlattenFunc,
     unflatten_fn: UnflattenFunc,
-    *,
-    to_dumpable_context: Optional[ToDumpableContextFn] = None,
-    from_dumpable_context: Optional[FromDumpableContextFn] = None,
+    to_str_fn: Optional[ToStrFunc] = None,
+    maybe_from_str_fn: Optional[MaybeFromStrFunc] = None,
 ) -> None:
-    """
-    Args:
-        typ: the type to register
-        flatten_fn: A callable that takes a pytree and returns a flattened
-            representation of the pytree and additional context to represent the
-            flattened pytree.
-        unflatten_fn: A callable that takes a flattened version of the pytree,
-            additional context, and returns an unflattedn pytree.
-        to_dumpable_context: An optional keyword argument to custom specify how
-            to convert the context of the pytree to a custom json dumpable
-            representation. This is used for json serialization, which is being
-            used in torch.export right now.
-        from_dumpable_context: An optional keyword argument to custom specify how
-            to convert the custom json dumpable representation of the context
-            back to the original context. This is used for json deserialization,
-            which is being used in torch.export right now.
-    """
+    if to_str_fn is None:
+        def _raise_error(spec: "TreeSpec", child_strings: List[str]) -> str:
+            raise NotImplementedError(f"Serializing {typ} not implemented")
+        to_str_fn = _raise_error
 
-    node_def = NodeDef(
-        typ,
-        flatten_fn,
-        unflatten_fn,
-    )
+    if maybe_from_str_fn is None:
+        def dummy_to_str(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+            return None
+        maybe_from_str_fn = dummy_to_str
+
+    assert to_str_fn is not None
+    assert maybe_from_str_fn is not None
+    node_def = NodeDef(typ, flatten_fn, unflatten_fn, to_str_fn, maybe_from_str_fn)
     SUPPORTED_NODES[typ] = node_def
 
-    if (to_dumpable_context is None) ^ (from_dumpable_context is None):
-        raise ValueError(
-            f"Both to_dumpable_context and from_dumpable_context for {typ} must "
-            "be None or registered."
-        )
+def _str_to_dict(str_spec: str) -> Tuple[List[str], str]:
+    assert str_spec[1] == "("
+    assert str_spec[-1] == ")"
+    context_and_child_strings = str_spec[2:-1]
 
-    type_fqn = f"{typ.__module__}.{typ.__name__}"
-    serialize_node_def = _SerializeNodeDef(
-        typ, type_fqn, to_dumpable_context, from_dumpable_context
-    )
-    SUPPORTED_SERIALIZED_TYPES[typ] = serialize_node_def
-    SERIALIZED_TYPE_TO_PYTHON_TYPE[type_fqn] = typ
+    child_strings = []
+    context_strings = []
+    nested_parentheses = 0
+    start_index = 0
+    for i, char in enumerate(context_and_child_strings):
+        if char == ":":
+            if nested_parentheses == 0:
+                context_strings.append(context_and_child_strings[start_index:i])
+                start_index = i + 1
+        elif char == "(":
+            nested_parentheses += 1
+        elif char == ")":
+            nested_parentheses -= 1
 
+        if nested_parentheses == 0 and char == ",":
+            child_strings.append(context_and_child_strings[start_index:i])
+            start_index = i + 1
+
+    child_strings.append(context_and_child_strings[start_index:])
+    return context_strings, ','.join(child_strings)
 
 def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
     return list(d.values()), list(d.keys())
@@ -121,11 +109,36 @@ def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
 def _dict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]:
     return dict(zip(context, values))
 
+def _dict_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:
+    assert spec.type == dict
+    context_child_strings = []
+    for key, child_string in zip(spec.context, child_strings):
+        context_child_strings.append(f"{key}:{child_string}")
+    return f"D({','.join(context_child_strings)})"
+
+def _maybe_str_to_dict(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("D"):
+        return None
+    context_strings, child_strings = _str_to_dict(str_spec)
+    return dict, context_strings, child_strings
+
 def _list_flatten(d: List[Any]) -> Tuple[List[Any], Context]:
     return d, None
 
 def _list_unflatten(values: List[Any], context: Context) -> List[Any]:
     return list(values)
+
+def _list_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:
+    assert spec.type == list
+    return f"L({','.join(child_strings)})"
+
+def _maybe_str_to_list(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("L"):
+        return None
+    assert str_spec[1] == "("
+    assert str_spec[-1] == ")"
+    children_string = str_spec[2:-1]
+    return list, None, children_string
 
 def _tuple_flatten(d: Tuple[Any, ...]) -> Tuple[List[Any], Context]:
     return list(d), None
@@ -133,24 +146,48 @@ def _tuple_flatten(d: Tuple[Any, ...]) -> Tuple[List[Any], Context]:
 def _tuple_unflatten(values: List[Any], context: Context) -> Tuple[Any, ...]:
     return tuple(values)
 
+def _tuple_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:
+    assert spec.type == tuple
+    return f"T({','.join(child_strings)})"
+
+def _maybe_str_to_tuple(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("T"):
+        return None
+    assert str_spec[1] == "("
+    assert str_spec[-1] == ")"
+    children_string = str_spec[2:-1]
+    return tuple, None, children_string
+
 def _namedtuple_flatten(d: NamedTuple) -> Tuple[List[Any], Context]:
     return list(d), type(d)
 
 def _namedtuple_unflatten(values: List[Any], context: Context) -> NamedTuple:
     return cast(NamedTuple, context(*values))
 
-def _namedtuple_serialize(context: Context) -> DumpableContext:
-    json_namedtuple = {
-        "class_name": context.__name__,
-        "fields": context._fields,
-    }
-    return json_namedtuple
+def _namedtuple_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:
+    assert spec.type == namedtuple
+    context_type = {spec.context.__name__}
+    context_fields = str(spec.context._fields).replace("'", "")
+    context_type = spec.context.__name__
+    return f"N({context_type}{context_fields},{','.join(child_strings)})"
 
-def _namedtuple_deserialize(dumpable_context: DumpableContext) -> Context:
-    class_name = dumpable_context["class_name"]
-    assert isinstance(class_name, str)
-    context = namedtuple(class_name, dumpable_context["fields"])  # type: ignore[misc]
-    return context
+def _maybe_str_to_namedtuple(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("N"):
+        return None
+    assert str_spec[1] == "("
+    assert str_spec[-1] == ")"
+    context_end_idx = str_spec.find(")") + 1
+    context_str = str_spec[2:context_end_idx]
+    children_string = str_spec[context_end_idx + 1:-1]
+
+    # Create the context namedtuple
+    type_end_idx = context_str.find("(")
+    context_type_str = context_str[:type_end_idx]
+    assert context_str[-1] == ")"
+    namedtuple_fields_str = context_str[type_end_idx + 1:-1]
+    context = namedtuple(context_type_str, namedtuple_fields_str)  # type: ignore[misc]
+
+    return namedtuple, context, children_string
 
 def _odict_flatten(d: 'OrderedDict[Any, Any]') -> Tuple[List[Any], Context]:
     return list(d.values()), list(d.keys())
@@ -158,18 +195,25 @@ def _odict_flatten(d: 'OrderedDict[Any, Any]') -> Tuple[List[Any], Context]:
 def _odict_unflatten(values: List[Any], context: Context) -> 'OrderedDict[Any, Any]':
     return OrderedDict((key, value) for key, value in zip(context, values))
 
+def _odict_to_str(spec: "TreeSpec", child_strings: List[str]) -> str:
+    assert spec.type == OrderedDict
+    context_child_strings = []
+    for key, child_string in zip(spec.context, child_strings):
+        context_child_strings.append(f"{key}:{child_string}")
+    return f"O({','.join(context_child_strings)})"
 
-_register_pytree_node(dict, _dict_flatten, _dict_unflatten)
-_register_pytree_node(list, _list_flatten, _list_unflatten)
-_register_pytree_node(tuple, _tuple_flatten, _tuple_unflatten)
-_register_pytree_node(
-    namedtuple,
-    _namedtuple_flatten,
-    _namedtuple_unflatten,
-    to_dumpable_context=_namedtuple_serialize,
-    from_dumpable_context=_namedtuple_deserialize,
-)
-_register_pytree_node(OrderedDict, _odict_flatten, _odict_unflatten)
+def _maybe_str_to_odict(str_spec: str) -> Optional[Tuple[Any, Context, str]]:
+    if not str_spec.startswith("O"):
+        return None
+    context_strings, child_strings = _str_to_dict(str_spec)
+    return OrderedDict, context_strings, child_strings
+
+
+_register_pytree_node(dict, _dict_flatten, _dict_unflatten, _dict_to_str, _maybe_str_to_dict)
+_register_pytree_node(list, _list_flatten, _list_unflatten, _list_to_str, _maybe_str_to_list)
+_register_pytree_node(tuple, _tuple_flatten, _tuple_unflatten, _tuple_to_str, _maybe_str_to_tuple)
+_register_pytree_node(namedtuple, _namedtuple_flatten, _namedtuple_unflatten, _namedtuple_to_str, _maybe_str_to_namedtuple)
+_register_pytree_node(OrderedDict, _odict_flatten, _odict_unflatten, _odict_to_str, _maybe_str_to_odict)
 
 
 # h/t https://stackoverflow.com/questions/2166818/how-to-check-if-an-object-is-an-instance-of-a-namedtuple
@@ -198,7 +242,7 @@ def _is_leaf(pytree: PyTree) -> bool:
 # context: some context that is useful in unflattening the pytree
 # children_specs: specs for each child of the root Node
 # num_leaves: the number of leaves
-@dataclasses.dataclass
+@dataclass
 class TreeSpec:
     type: Any
     context: Context
@@ -426,114 +470,75 @@ def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[A
     return result
 
 
-"""
-_TreeSpecSchema is the schema used to serialize the TreeSpec
-It contains the following fields:
-- type: A string name of the type. null for the case of a LeafSpec.
-- context: Any format which is json dumpable
-- children_spec: A list of children serialized specs.
-"""
-@dataclasses.dataclass
-class _TreeSpecSchema:
-    type: Optional[str]
-    context: DumpableContext
-    children_spec: List['_TreeSpecSchema']
-
-class _ProtocolFn(NamedTuple):
-    treespec_to_json: Callable[[TreeSpec], DumpableContext]
-    json_to_treespec: Callable[[DumpableContext], TreeSpec]
-
-_SUPPORTED_PROTOCOLS: Dict[int, _ProtocolFn] = {}
-
-
-def _treespec_to_json(spec: TreeSpec) -> _TreeSpecSchema:
+def pytree_to_str(spec: TreeSpec) -> str:
     if isinstance(spec, LeafSpec):
-        return _TreeSpecSchema(None, None, [])
-
-    if spec.type not in SUPPORTED_SERIALIZED_TYPES:
-        raise NotImplementedError(f"Serializing {spec.type} in pytree is not registered.")
-
-    serialize_node_def = SUPPORTED_SERIALIZED_TYPES[spec.type]
-
-    type_fqn = serialize_node_def.type_fqn
-
-    if serialize_node_def.to_dumpable_context is None:
-        try:
-            serialized_context = json.dumps(spec.context)
-        except TypeError as e:
-            raise TypeError(
-                "Unable to serialize context. "
-                "Please make the context json dump-able, or register a "
-                "custom serializer using _register_pytree_node."
-            ) from e
+        return "*"
+    elif spec.type in SUPPORTED_NODES:
+        child_strings = [pytree_to_str(child) for child in spec.children_specs]
+        return SUPPORTED_NODES[spec.type].to_str_fn(spec, child_strings)
     else:
-        serialized_context = serialize_node_def.to_dumpable_context(spec.context)
+        raise NotImplementedError(f"Serializing {spec.type} in pytree not supported yet")
 
-    child_schemas = [_treespec_to_json(child) for child in spec.children_specs]
 
-    return _TreeSpecSchema(type_fqn, serialized_context, child_schemas)
-
-def _json_to_treespec(json_schema: DumpableContext) -> TreeSpec:
-    if (
-        json_schema["type"] is None and
-        json_schema["context"] is None and
-        len(json_schema["children_spec"]) == 0
-    ):
+def str_to_pytree(str_spec: str) -> TreeSpec:
+    if str_spec == "*":
         return LeafSpec()
 
-    if json_schema["type"] not in SERIALIZED_TYPE_TO_PYTHON_TYPE:
-        raise NotImplementedError(f'Deserializing {json_schema["type"]} in pytree is not registered.')
-
-    typ = SERIALIZED_TYPE_TO_PYTHON_TYPE[json_schema["type"]]
-    serialize_node_def = SUPPORTED_SERIALIZED_TYPES[typ]
-
-    if serialize_node_def.from_dumpable_context is None:
-        try:
-            context = json.loads(json_schema["context"])
-        except TypeError:
-            raise TypeError(
-                "Unable to deserialize context. "
-                "Please make the context json load-able, or register a "
-                "custom serializer using _register_pytree_node."
-            )
-    else:
-        context = serialize_node_def.from_dumpable_context(json_schema["context"])
-
-    children_spec = []
-    for child_string in json_schema["children_spec"]:
-        children_spec.append(_json_to_treespec(child_string))
-
-    return TreeSpec(typ, context, children_spec)
+    for node_def in SUPPORTED_NODES.values():
+        res = node_def.maybe_from_str_fn(str_spec)
+        if res is not None:
+            typ, context, child_strings = res
+            children_spec = []
+            for child_string in _split_nested(child_strings):
+                if child_string == "":
+                    continue
+                children_spec.append(str_to_pytree(child_string))
+            return TreeSpec(typ, context, children_spec)
+    raise NotImplementedError(f"Deserializing {str_spec} in pytree not supported yet")
 
 
-_SUPPORTED_PROTOCOLS[1] = _ProtocolFn(_treespec_to_json, _json_to_treespec)
+def _split_nested(string: str) -> List[str]:
+    nested_parentheses = 0
+    splits = []
+    start_index = 0
+
+    for i, char in enumerate(string):
+        if char == "(":
+            nested_parentheses += 1
+        elif char == ")":
+            nested_parentheses -= 1
+
+        if nested_parentheses == 0 and char == ",":
+            splits.append(string[start_index:i])
+            start_index = i + 1
+
+    splits.append(string[start_index:])
+    return splits
 
 
-def treespec_dumps(treespec: TreeSpec, protocol: Optional[int] = None) -> str:
-    if protocol is None:
-        protocol = DEFAULT_TREESPEC_SERIALIZATION_PROTOCOL
+def _parse_dict_children_spec(toplevel_str: str) -> Tuple[List[str], List[TreeSpec]]:
+    assert toplevel_str[1] == "("
+    assert toplevel_str[-1] == ")"
+    children_string = toplevel_str[2:-1]
 
-    if protocol in _SUPPORTED_PROTOCOLS:
-        json_spec = _SUPPORTED_PROTOCOLS[protocol].treespec_to_json(treespec)
-    else:
-        raise ValueError(f"Unknown protocol {protocol}. Available protocols: {list(_SUPPORTED_PROTOCOLS.keys())}")
+    child_strings = []
+    context_strings = []
+    nested_parentheses = 0
+    start_index = 0
+    for i, char in enumerate(children_string):
+        if char == ":":
+            if nested_parentheses == 0:
+                context_strings.append(children_string[start_index:i])
+                start_index = i + 1
+        elif char == "(":
+            nested_parentheses += 1
+        elif char == ")":
+            nested_parentheses -= 1
 
-    str_spec = json.dumps((protocol, dataclasses.asdict(json_spec)))
-    return str_spec
+        if nested_parentheses == 0 and char == ",":
+            child_strings.append(children_string[start_index:i])
+            start_index = i + 1
 
-def treespec_loads(data: str) -> TreeSpec:
-    protocol, json_schema = json.loads(data)
-
-    if protocol in _SUPPORTED_PROTOCOLS:
-        return _SUPPORTED_PROTOCOLS[protocol].json_to_treespec(json_schema)
-    raise ValueError(f"Unknown protocol {protocol}. Available protocols: {list(_SUPPORTED_PROTOCOLS.keys())}")
-
-# TODO(angelayi): remove this function after OSS/internal stabilize
-def pytree_to_str(spec: TreeSpec) -> str:
-    warnings.warn("pytree_to_str is deprecated. Please use treespec_dumps")
-    return treespec_dumps(spec)
-
-# TODO(angelayi): remove this function after OSS/internal stabilize
-def str_to_pytree(json: str) -> TreeSpec:
-    warnings.warn("str_to_pytree is deprecated. Please use treespec_loads")
-    return treespec_loads(json)
+    child_strings.append(children_string[start_index:])
+    children = [str_to_pytree(child_string) for child_string in child_strings]
+    return context_strings, children


### PR DESCRIPTION
Summary:
This diff is reverting D47848392
D47848392: Serialize pytree to json string (#106116) by angelayi has been identified to be causing the following test or build failures:

Tests affected:
- [aps/rec/ir/tests:rec_train_model_serializer_provider_test - aps.rec.ir.tests.rec_train_model_serializer_provider_test.RecTrainModelSerializerProviderTest: test_create_manifold_train_model_serializer](https://www.internalfb.com/intern/test/281475081477866/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2915049
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D48824591



cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov