### PR TITLE
[quant] Move dropout replacement to `move_model_to_eval` (#108184)

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -361,7 +361,7 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
         self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
 
         if verify_convert:
-            model_pt2e.eval()
+            torch.ao.quantization.move_model_to_eval(model_pt2e)
             model_pt2e = convert_pt2e(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)
             model_fx.eval()
@@ -2391,6 +2391,39 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             ref_node_occurrence,
             non_ref_node_occurrence
         )
+
+    def test_move_model_to_eval(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dropout = torch.nn.Dropout(0.5)
+
+            def forward(self, x):
+                return self.dropout(x)
+
+        example_inputs = (torch.randn(1),)
+        m = M().train()
+        m = capture_pre_autograd_graph(m, example_inputs)
+        m.graph.eliminate_dead_code()
+        m.recompile()
+
+        # Assert that dropout op exists and is in train mode
+        dropout_node = None
+        for n in m.graph.nodes:
+            if n.target == torch.ops.aten.native_dropout.default:
+                dropout_node = n
+                break
+        self.assertTrue(dropout_node is not None)
+        self.assertTrue(dropout_node.args[2])
+
+        # Do the subgraph rewriting
+        torch.ao.quantization.move_model_to_eval(m)
+
+        # Assert that dropout op is now replaced with a clone op
+        targets = [n.target for n in m.graph.nodes]
+        self.assertTrue(torch.ops.aten.clone.default in targets)
+        self.assertTrue(torch.ops.aten.native_dropout.default not in targets)
+
 
 @skipIfNoQNNPACK
 class TestQuantizePT2EOps(QuantizationTestCase):

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -12,6 +12,7 @@ from .quantization_mappings import *  # type: ignore[no-redef]
 from .quantize import *  # noqa: F403
 from .quantize_jit import *  # noqa: F403
 from .stubs import *  # noqa: F403
+from .pt2e.utils import move_model_to_eval
 from typing import Union, List, Callable, Tuple, Optional
 from torch import Tensor
 import torch
@@ -119,6 +120,7 @@ __all__ = [
     "get_quantized_operator",
     "get_static_quant_module_class",
     "load_observer_state_dict",
+    "move_model_to_eval",
     "no_observer_set",
     "per_channel_weight_observer_range_neg_127_to_127",
     "prepare",

--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -9,7 +9,6 @@ from .pt2e.qat_utils import (
 from .pt2e.utils import (
     _get_node_name_to_scope,
     _fuse_conv_bn_,
-    _replace_dropout_for_eval,
 )
 from .pt2e.representation import reference_representation_rewrite
 from .fx.prepare import prepare as fx_prepare
@@ -95,9 +94,6 @@ def convert_pt2e(
     use_reference_representation: bool = False,
 ) -> GraphModule:
     original_graph_meta = model.meta
-    # TODO: Handle this in export itself, outside of quantization
-    # See https://github.com/pytorch/pytorch/issues/103681.
-    _replace_dropout_for_eval(model)
     model = _convert_to_reference_decomposed_fx(model)
     model = _fold_conv_bn_qat(model)
     if use_reference_representation:


### PR DESCRIPTION
Summary: This commit adds a public facing
`torch.ao.quantization.move_model_to_eval` util function for QAT users. Instead of calling model.eval() on an exported model (which doesn't work, see https://github.com/pytorch/pytorch/issues/103681), the user would call this new util function instead. This ensures special ops such as dropout and batchnorm (not supported yet) will have the right behavior when the graph is later used for inference.

Note: Support for an equivalent `move_model_to_train` will be added in the future. This is difficult to do for dropout currently because the eval pattern of dropout is simply a clone op, which we cannot just match and replace with a dropout op.

Test Plan:
python test/test_quantization.py TestQuantizePT2E.test_move_model_to_eval

Reviewers: jerryzh168, kimishpatel

Subscribers: jerryzh168, kimishpatel, supriyar

Differential Revision: [D48814735](https://our.internmc.facebook.com/intern/diff/D48814735)
Pull Request resolved: https://github.com/pytorch/pytorch/pull/108184
Approved by: https://github.com/jerryzh168