### PR TITLE
[memory snapshots] _record_memory_history_legacy bug fix

### DIFF
--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -674,9 +674,9 @@ def _record_memory_history_legacy(
     _C._cuda_record_memory_history_legacy(
         enabled,
         record_context,
-        record_context_cpp,
         trace_alloc_max_entries,
         trace_alloc_record_context,
+        record_context_cpp,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108260

The argment order for the legacy path got swapped in a recent patch.
Because there is still a blog post documenting the legacy interface
people are hitting this pathway.

This patch fixes #108208
I will also update the blog post to the new API so that people are
more likely to use the newer `_record_memory_history` API.