### PR TITLE
[PyTorch][Vulkan] Add a matrix multiplication performance test binary and fix GPU latency measurement

### DIFF
--- a/aten/src/ATen/test/vulkan_conv_arithmetic_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_conv_arithmetic_perf_test.cpp
@@ -10,12 +10,19 @@
 #include <ATen/native/vulkan/ops/Factory.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
 #include <ATen/native/vulkan/ops/Utils.h>
-
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
 #include <iostream>
+#endif
 
 namespace {
 
 namespace vulkan_api = at::native::vulkan::api;
+
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+static const float NANOSECONDS_IN_SECOND = 1000000000.0;
+#endif
+
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
 void report_pep(const std::string& name, const uint64_t duration) {
   std::stringstream buffer;
   buffer << "PyTorchObserver {\"type\": \"";
@@ -30,7 +37,9 @@ void report_pep(const std::string& name, const uint64_t duration) {
   buffer << "}\n";
   std::cout << buffer.str();
 }
+#endif
 
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
 void report_aibench_res(vulkan_api::QueryPool& qpool) {
   std::unordered_map<std::string, uint64_t> shader_runtimes;
   uint64_t num_additions = 0;
@@ -50,8 +59,21 @@ void report_aibench_res(vulkan_api::QueryPool& qpool) {
     report_pep(name, duration);
   }
 }
+#endif
 
-at::Tensor vulkan_to_cpu(at::Tensor vulkan, at::Tensor in_cpu) {
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+static void extractTotalOpResultsAndSetState(
+    benchmark::State& state,
+    const char* op_name) {
+  at::native::vulkan::api::context()->querypool().extract_results();
+  float total_op_time =
+      at::native::vulkan::api::context()->querypool().get_total_op_ns(op_name) /
+      NANOSECONDS_IN_SECOND;
+  state.SetIterationTime(total_op_time);
+}
+#endif
+
+at::Tensor vulkan_to_cpu(const at::Tensor& vulkan, const at::Tensor& in_cpu) {
   auto q_options = in_cpu.options();
   if (q_options.dtype().toScalarType() == c10::ScalarType::QUInt8) {
     auto output = at::native::empty_affine_quantized(
@@ -108,18 +130,11 @@ static void add_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::add(in_vulkan1, in_vulkan2).cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.add");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("add") / 1000000.0);
 #endif
 }
 
@@ -160,20 +175,13 @@ static void add_op_q_benchmark(benchmark::State& state) {
   const double scale2 = 0.15;
   const int zero_point2 = 15;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_add = at::native::vulkan::ops::quantized_add(
         out_vulkan1, out_vulkan2, scale2, zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_add, out_cpu1);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_add");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_add") / 1000000.0);
 #endif
 }
 
@@ -240,7 +248,6 @@ static void conv2d_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::conv2d(
                                 input_cpu.vulkan(),
                                 weights_cpu,
@@ -250,16 +257,11 @@ static void conv2d_op_benchmark(benchmark::State& state) {
                                 dilation,
                                 groups)
                                 .cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.conv2d");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("conv2d") / 1000000.0);
 #endif
 }
 
@@ -335,7 +337,6 @@ static void conv2d_op_q_benchmark(benchmark::State& state) {
   const int zero_point = 10;
   const auto out_vulkan1 = at::native::vulkan::ops::quantize_per_tensor(
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
   at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
@@ -347,7 +348,6 @@ static void conv2d_op_q_benchmark(benchmark::State& state) {
   const auto shape_match =
       at::rand({1, 1, 64, 199}, at::device(at::kCPU).dtype(at::kFloat)) * 6;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_conv2d = at::native::vulkan::ops::quantized_conv2d(
         out_vulkan1,
         weight_q,
@@ -359,16 +359,10 @@ static void conv2d_op_q_benchmark(benchmark::State& state) {
         scale2,
         zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_conv2d, shape_match);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_conv2d");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_conv2d") / 1000000.0);
 #endif
 }
 
@@ -434,7 +428,6 @@ static void conv2dpw_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::conv2d(
                                 input_cpu.vulkan(),
                                 weights_cpu,
@@ -444,16 +437,10 @@ static void conv2dpw_op_benchmark(benchmark::State& state) {
                                 dilation,
                                 groups)
                                 .cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.conv2d_pw_2x2");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("conv2d_pw_2x2") / 1000000.0);
 #endif
 }
 
@@ -540,7 +527,6 @@ static void conv2dpw_op_q_benchmark(benchmark::State& state) {
   const auto shape_match =
       at::rand({1, 29, 127, 397}, at::device(at::kCPU).dtype(at::kFloat)) * 6;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_conv2d = at::native::vulkan::ops::quantized_conv2d(
         out_vulkan1,
         weight_q,
@@ -552,16 +538,10 @@ static void conv2dpw_op_q_benchmark(benchmark::State& state) {
         scale2,
         zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_conv2d, shape_match);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_conv2d_pw_2x2");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_conv2d_pw_2x2") / 1000000.0);
 #endif
 }
 
@@ -626,7 +606,6 @@ static void conv2ddw_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::conv2d(
                                 input_cpu.vulkan(),
                                 weights_cpu,
@@ -636,17 +615,11 @@ static void conv2ddw_op_benchmark(benchmark::State& state) {
                                 dilation,
                                 groups)
                                 .cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.conv2d_dw");
   at::native::vulkan::api::context()->querypool().print_results();
   report_aibench_res(vulkan_api::context()->querypool());
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("conv2d_dw") / 1000000.0);
 #endif
 }
 
@@ -720,7 +693,6 @@ static void conv2ddw_op_q_benchmark(benchmark::State& state) {
   const int zero_point = 10;
   const auto out_vulkan1 = at::native::vulkan::ops::quantize_per_tensor(
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
   at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
@@ -732,7 +704,6 @@ static void conv2ddw_op_q_benchmark(benchmark::State& state) {
   const auto shape_match =
       at::rand({1, 7, 45, 67}, at::device(at::kCPU).dtype(at::kFloat)) * 6;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_conv2d = at::native::vulkan::ops::quantized_conv2d(
         out_vulkan1,
         weight_q,
@@ -744,16 +715,10 @@ static void conv2ddw_op_q_benchmark(benchmark::State& state) {
         scale2,
         zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_conv2d, shape_match);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_conv2d_dw");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_conv2d_dw") / 1000000.0);
 #endif
 }
 
@@ -784,18 +749,11 @@ static void sub_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::sub(in_vulkan1, in_vulkan2).cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.sub");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("sub") / 1000000.0);
 #endif
 }
 
@@ -836,20 +794,14 @@ static void sub_op_q_benchmark(benchmark::State& state) {
   const double scale2 = 0.15;
   const int zero_point2 = 15;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_sub = at::native::vulkan::ops::quantized_sub(
         out_vulkan1, out_vulkan2, scale2, zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_sub, out_cpu1);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_sub");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_sub") / 1000000.0);
 #endif
 }
 
@@ -880,18 +832,11 @@ static void mul_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::mul(in_vulkan1, in_vulkan2).cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.mul");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("mul") / 1000000.0);
 #endif
 }
 
@@ -932,20 +877,20 @@ static void mul_op_q_benchmark(benchmark::State& state) {
   const double scale2 = 0.15;
   const int zero_point2 = 15;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_mul = at::native::vulkan::ops::quantized_mul(
         out_vulkan1, out_vulkan2, scale2, zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_mul, out_cpu1);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  float total_op_time =
+      at::native::vulkan::api::context()->querypool().get_total_op_ns(
+          "vulkan.quantized_mul") /
+      NANOSECONDS_IN_SECOND;
+  state.SetIterationTime(total_op_time);
+
   at::native::vulkan::api::context()->querypool().extract_results();
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_mul") / 1000000.0);
 #endif
 }
 
@@ -976,18 +921,12 @@ static void div_op_benchmark(benchmark::State& state) {
 
   // Act
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_out = at::div(in_vulkan1, in_vulkan2).cpu();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.div");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("div") / 1000000.0);
 #endif
 }
 
@@ -1018,7 +957,6 @@ static void div_op_q_benchmark(benchmark::State& state) {
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
   const auto out_vulkan2 = at::native::vulkan::ops::quantize_per_tensor(
       in_vulkan2, scale, zero_point, c10::ScalarType::QUInt8);
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
   at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
@@ -1028,20 +966,13 @@ static void div_op_q_benchmark(benchmark::State& state) {
   const double scale2 = 0.15;
   const int zero_point2 = 15;
   for (auto _ : state) {
-    auto start = std::chrono::high_resolution_clock::now();
     const auto vulkan_div = at::native::vulkan::ops::quantized_div(
         out_vulkan1, out_vulkan2, scale2, zero_point2);
     const auto vulkan_out = vulkan_to_cpu(vulkan_div, out_cpu1);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    state.SetIterationTime(elapsed.count());
   }
-
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
-  at::native::vulkan::api::context()->querypool().extract_results();
+  extractTotalOpResultsAndSetState(state, "vulkan.quantized_div");
   at::native::vulkan::api::context()->querypool().print_results();
-  state.SetIterationTime(at::native::vulkan::api::context()->querypool().get_total_op_ns("quantized_div") / 1000000.0);
 #endif
 }
 

--- a/aten/src/ATen/test/vulkan_mm_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_mm_perf_test.cpp
@@ -1,0 +1,240 @@
+#include <unordered_map>
+#ifdef USE_VULKAN_API
+
+#include <benchmark/benchmark.h>
+
+#include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/vulkan/api/api.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Copy.h>
+#include <ATen/native/vulkan/ops/Factory.h>
+#include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+
+namespace {
+
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+static const float NANOSECONDS_IN_SECOND = 1000000000.0;
+#endif
+
+template <class... Inputs>
+inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
+  return {std::forward<Inputs>(inputs)...};
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByHandle(
+    const c10::OperatorHandle& op,
+    Args... args) {
+  auto stack = makeStack(std::forward<Args>(args)...);
+  c10::Dispatcher::singleton().callBoxed(op, &stack);
+  return stack;
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByName(
+    const char* func_name,
+    const char* overload_name,
+    Args... args) {
+  const c10::optional<c10::OperatorHandle> op_handle =
+      c10::Dispatcher::singleton().findSchema({func_name, overload_name});
+  assert(op_handle.has_value());
+  return callOpByHandle(op_handle.value(), std::forward<Args>(args)...);
+}
+
+static void CommonMMBenchmarkSettings(benchmark::internal::Benchmark* b) {
+  b->Unit(benchmark::kMillisecond);
+  b->ArgNames({"N", "M", "P"});
+}
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+static void extractTotalOpResultsAndSetState(
+    benchmark::State& state,
+    const char* op_name) {
+  at::native::vulkan::api::context()->querypool().extract_results();
+  float total_op_time =
+      at::native::vulkan::api::context()->querypool().get_total_op_ns(op_name) /
+      NANOSECONDS_IN_SECOND;
+  state.SetIterationTime(total_op_time);
+}
+#endif
+
+static void mm_benchmark(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
+  at::native::vulkan::api::context()->reset_querypool();
+#endif
+
+  // Arrange
+  const auto n = state.range(0);
+  const auto m = state.range(1);
+  const auto p = state.range(2);
+
+  const auto in_cpu1 = at::rand({n, p}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({p, m}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan1 = in_cpu1.vulkan();
+  // Act
+  for (auto _ : state) {
+    const auto vulkan_out = in_vulkan1.mm(in_cpu2).cpu();
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  extractTotalOpResultsAndSetState(state, "vulkan.mm");
+  at::native::vulkan::api::context()->querypool().print_results();
+#endif
+}
+
+static void addmm_benchmark(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
+  at::native::vulkan::api::context()->reset_querypool();
+#endif
+
+  // Arrange
+  const auto n = state.range(0);
+  const auto m = state.range(1);
+  const auto p = state.range(2);
+
+  const auto in_cpu1 = at::rand({n, p}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({p, m}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan1 = in_cpu1.vulkan();
+  const auto in_vulkan2 = in_cpu2.vulkan();
+
+  const auto bias_vk =
+      at::zeros({n, p}, at::device(at::kCPU).dtype(at::kFloat)).vulkan();
+
+  // Act
+  for (auto _ : state) {
+    const auto vulkan_out =
+        at::addmm(bias_vk, in_vulkan1, in_vulkan2, 1.0, 1.0).cpu();
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  extractTotalOpResultsAndSetState(state, "vulkan.addmm");
+  at::native::vulkan::api::context()->querypool().print_results();
+#endif
+}
+
+static void create_linear_context_benchmark(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
+  at::native::vulkan::api::context()->reset_querypool();
+#endif
+
+  // Arrange
+  const auto n = state.range(0);
+  const auto m = state.range(1);
+  const auto p = state.range(2);
+
+  const auto weight = at::rand({p, m}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias = at::rand({n, p}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  for (auto _ : state) {
+    auto prepack =
+        callOpByName("vulkan_prepack::create_linear_context", "", weight, bias);
+
+    const auto dummy = at::zeros({1}).vulkan();
+    dummy.cpu(); // force sync?
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->querypool().extract_results();
+  float total_op_time =
+      at::native::vulkan::api::context()->querypool().get_total_op_ns(
+          "vulkan.nchw_to_image") /
+      NANOSECONDS_IN_SECOND;
+  total_op_time +=
+      at::native::vulkan::api::context()->querypool().get_total_op_ns(
+          "vulkan.image_to_nchw") /
+      NANOSECONDS_IN_SECOND;
+  state.SetIterationTime(total_op_time);
+
+  at::native::vulkan::api::context()->querypool().print_results();
+#endif
+}
+
+static void run_linear_context_benchmark(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
+  at::native::vulkan::api::context()->reset_querypool();
+#endif
+
+  // Arrange
+  const auto n = state.range(0);
+  const auto m = state.range(1);
+  const auto p = state.range(2);
+
+  const auto input_cpu =
+      at::rand({n, p}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight = at::rand({p, m}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias = at::rand({n, p}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto prepack =
+      callOpByName("vulkan_prepack::create_linear_context", "", weight, bias);
+
+  // Act
+  for (auto _ : state) {
+    auto vulkan_output = callOpByName(
+        "vulkan_prepack::run_linear_context",
+        "",
+        input_cpu.vulkan(),
+        prepack[0]);
+    auto out_vulkan = vulkan_output[0].toTensor().cpu(); // force sync?
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  extractTotalOpResultsAndSetState(state, "vulkan.addmm");
+  at::native::vulkan::api::context()->querypool().print_results();
+#endif
+}
+
+} // namespace
+
+const uint32_t BENCHMARK_MM_N = 500;
+const uint32_t BENCHMARK_MM_M = 500;
+const uint32_t BENCHMARK_MM_P = 500;
+const uint32_t BENCHMARK_ITERATIONS = 5;
+BENCHMARK(mm_benchmark)
+    ->Apply(CommonMMBenchmarkSettings)
+    ->UseManualTime()
+    ->Threads(1)
+    ->Iterations(BENCHMARK_ITERATIONS)
+    ->Args({BENCHMARK_MM_N, BENCHMARK_MM_M, BENCHMARK_MM_P});
+
+BENCHMARK(addmm_benchmark)
+    ->Apply(CommonMMBenchmarkSettings)
+    ->UseManualTime()
+    ->Threads(1)
+    ->Iterations(BENCHMARK_ITERATIONS)
+    ->Args({BENCHMARK_MM_N, BENCHMARK_MM_M, BENCHMARK_MM_P});
+
+BENCHMARK(create_linear_context_benchmark)
+    ->Apply(CommonMMBenchmarkSettings)
+    ->UseManualTime()
+    ->Threads(1)
+    ->Iterations(BENCHMARK_ITERATIONS)
+    ->Args({BENCHMARK_MM_N, BENCHMARK_MM_M, BENCHMARK_MM_P});
+
+BENCHMARK(run_linear_context_benchmark)
+    ->Apply(CommonMMBenchmarkSettings)
+    ->UseManualTime()
+    ->Threads(1)
+    ->Iterations(BENCHMARK_ITERATIONS)
+    ->Args({BENCHMARK_MM_N, BENCHMARK_MM_M, BENCHMARK_MM_P});
+
+BENCHMARK_MAIN();
+
+#endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
- Added a new matmul perf test binary as target `pt_vulkan_mm_perf_test_bin`
- Also renamed the existing `vulkan_perf_test_bin` to `vulkan_conv_arithmetic_perf_test_bin` with associated source file name change
- **Fixed the manual time benchmark measurement for both performance binaries, which was not tracking the correct opnames (e.g. checked for runtime of nonexistent "mm" instead of "vulkan.mm")**

Test Plan:
# pt_vulkan_mm_perf_test_bin

- build the matrix multiplication performance test binary
```
~/fbsource »  buck2 build  -c ndk.debug_info_level=0  -c ndk.static_linking=true -c pt.enable_qpl=0 -c pt.vulkan_use_gpu_diagnostics=1 --target-platforms=ovr_config//platform/android:arm32-fbsource //xplat/caffe2:pt_vulkan_mm_perf_test_binAndroid  --show-output  -c pt.vulkan_full_precision=1
[...]
BUILD SUCCEEDED
fbsource//xplat/caffe2:pt_vulkan_mm_perf_test_binAndroid buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_mm_perf_test_binAndroid__/pt_vulkan_mm_perf_test_binAndroid
```
- test on arm32 android device
```
~/fbsource » adb push buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_mm_perf_test_binAndroid__/pt_vulkan_mm_perf_test_binAndroid /data/local/tmp/
~/fbsource » adb shell /data/local/tmp/pt_vulkan_mm_perf_test_binAndroid
```
- output P817269023, excerpt below
```
Kernel Name              Workgroup Size             Duration (ns)
===========              ==============               ===========
vulkan.nchw_to_image     {500, 500, 1}                    4336072
vulkan.nchw_to_image     {250, 250, 1}                    1106716
vulkan.nchw_to_image     {1, 1, 1}                           7228
vulkan.mm                {250, 250, 1}                  132570256

[...]

vulkan.mm                {250, 250, 1}                   80492152
vulkan.image_to_nchw     {500, 500, 1}                    1420328
-------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                     Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------------------------
mm_benchmark/N:500/M:500/P:500/iterations:5/manual_time/threads:1                         91047 ms          143 ms            5

```

# pt_vulkan_conv_arithmetic_perf_test_bin
- build the convolution and arithmetic performance test binary
```
~/fbsource »  buck2 build  -c ndk.debug_info_level=0  -c ndk.static_linking=true -c pt.enable_qpl=0 -c pt.vulkan_use_gpu_diagnostics=1 --target-platforms=ovr_config//platform/android:arm32-fbsource //xplat/caffe2:pt_vulkan_conv_arithmetic_perf_test_binAndroid  --show-output  -c pt.vulkan_full_precision=1
[...]
BUILD SUCCEEDED
fbsource//xplat/caffe2:pt_vulkan_conv_arithmetic_perf_test_binAndroid buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_conv_arithmetic_perf_test_binAndroid__/pt_vulkan_conv_arithmetic_perf_test_binAndroid
```
- test on arm32 android device
```
~/fbsource » adb push buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_conv_arithmetic_perf_test_binAndroid__/pt_vulkan_conv_arithmetic_perf_test_binAndroid /data/local/tmp/
~/fbsource » adb shell /data/local/tmp/pt_vulkan_conv_arithmetic_perf_test_binAndroid
2023-07-20T20:23:26+00:00

```
- output P817267332, excerpt below

```
Kernel Name              Workgroup Size             Duration (ns)
===========              ==============               ===========
vulkan.add               {193, 221, 30}                  39475696
vulkan.image_to_nchw     {193, 221, 30}                  13463424
vulkan.add               {193, 221, 30}                  72950176
vulkan.image_to_nchw     {193, 221, 30}                  17792684

[...]

vulkan.add               {193, 221, 30}                  72986368
vulkan.image_to_nchw     {193, 221, 30}                  15921672
----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                  Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------------
add_op_benchmark/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1             73242 ms          602 ms          100
libc++abi: terminating due to uncaught exception of type c10::Error: Copy of vulkan quantized tensors to cpu is currently disabled!
```

Reviewed By: yipjustin

Differential Revision: D48798710

