### PR TITLE
Use ctypes to serialize raw content for tensors.

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -89,6 +89,24 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
+    def test_large(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.randn(250112, 512, device="cuda")
+
+            def forward(self, x, y):
+                return x + torch.nn.functional.linear(y, self.weight)
+
+        model = Repro()
+        example_inputs = (
+            torch.randn(1, 250112, device="cuda"),
+            torch.randn(1, 512, device="cuda"),
+        )
+        expected = model(*example_inputs)
+        actual = AOTInductorModelRunner.run(model, example_inputs, expected)
+        self.assertTrue(same(actual, expected))
+
     def test_with_offset(self):
         class Repro(torch.nn.Module):
             def __init__(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -981,6 +981,8 @@ class AotCodeCache:
         aot_constants = b""
 
         def _to_bytes(t: torch.Tensor) -> bytes:
+            # This serializes the tensor's untyped_storage to bytes by accessing
+            # the raw data of the underlying structure.
             import ctypes
 
             t_cpu = t.untyped_storage().cpu()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -979,8 +979,19 @@ class AotCodeCache:
         )
 
         aot_constants = b""
-        for tensor in graph.constants.values():
-            aot_constants += bytes(tensor.untyped_storage().cpu())
+
+        def _to_bytes(t: torch.Tensor) -> bytes:
+            import ctypes
+
+            t_cpu = t.untyped_storage().cpu()
+            raw_array = ctypes.cast(
+                t_cpu.data_ptr(), ctypes.POINTER(ctypes.c_ubyte * t_cpu.nbytes())
+            )
+
+            return bytes(raw_array.contents)
+
+        for idx, tensor in enumerate(graph.constants.values()):
+            aot_constants += _to_bytes(tensor)
 
         consts_key, consts_path = write(
             aot_constants,


### PR DESCRIPTION
Summary:
There's a deadlock in current storage's implementation if the size of tensor is too large. Use ctypes to do serialization.

Test Plan:
python benchmarks/dynamo/huggingface.py --bfloat16 --accuracy --inference --device cuda --export-aot-inductor --only MT5ForConditionalGeneration

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @aakhundov