### PR TITLE
[FSDP][state_dict][optim_state_dict] Log slow optim and model state_dict paths

### DIFF
--- a/torch/distributed/fsdp/_debug_utils.py
+++ b/torch/distributed/fsdp/_debug_utils.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
-from typing import Dict, Iterator, List, Set, Tuple, Union
+from typing import Dict, Iterator, List, Set, Tuple
 
 import torch
 import torch.distributed.fsdp.flat_param as flat_param_file
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class SimpleProfiler:
-    class Type(Enum, str):
+    class Type(str, Enum):
         ALL = "all"
         ALLGATHER = "all_gather"
         ALLGATHER_OBJ = "all_gather_object"

--- a/torch/distributed/fsdp/_debug_utils.py
+++ b/torch/distributed/fsdp/_debug_utils.py
@@ -1,3 +1,8 @@
+import logging
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from enum import Enum
 from typing import Dict, List, Tuple
 
 import torch
@@ -7,6 +12,49 @@ from torch.distributed.fsdp._common_utils import (
     _get_module_fsdp_state,
     clean_tensor_name,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleProfiler:
+    class Type(Enum):
+        ALL = "all"
+        ALLGATHER = "all_gather"
+        ALLGATHER_OBJ = "all_gather_object"
+        RESHARDING = "resharding"
+        H2D = "H2D"
+        D2H = "D2H"
+
+    results = defaultdict(float)
+    profiling = set()
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.results.clear()
+        cls.profiling.clear()
+
+    @classmethod
+    @contextmanager
+    def profile(cls, profile_type: str) -> None:
+        assert profile_type not in cls.profiling, (
+            f"{profile_type} is already being profiled. "
+            "SimpleProfiler does not support profiling multiple instances at "
+            "the same time. "
+        )
+
+        cls.profiling.add(profile_type)
+        begin = time.monotonic()
+        try:
+            yield
+        finally:
+            end = time.monotonic()
+            cls.results[profile_type] += end - begin
+            cls.profiling.remove(profile_type)
+
+    @classmethod
+    def dump_and_reset(cls, msg: str) -> None:
+        logger.warning("%s %s", msg, str(cls.results))
+        cls.reset()
 
 
 def _get_sharded_module_tree_with_module_name_to_fqns(

--- a/torch/distributed/fsdp/_debug_utils.py
+++ b/torch/distributed/fsdp/_debug_utils.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
-from typing import Dict, List, Tuple
+from typing import Dict, Iterator, List, Set, Tuple, Union
 
 import torch
 import torch.distributed.fsdp.flat_param as flat_param_file
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class SimpleProfiler:
-    class Type(Enum):
+    class Type(Enum, str):
         ALL = "all"
         ALLGATHER = "all_gather"
         ALLGATHER_OBJ = "all_gather_object"
@@ -25,8 +25,8 @@ class SimpleProfiler:
         H2D = "H2D"
         D2H = "D2H"
 
-    results = defaultdict(float)
-    profiling = set()
+    results: Dict[str, float] = defaultdict(float)
+    profiling: Set[str] = set()
 
     @classmethod
     def reset(cls) -> None:
@@ -35,7 +35,7 @@ class SimpleProfiler:
 
     @classmethod
     @contextmanager
-    def profile(cls, profile_type: str) -> None:
+    def profile(cls, profile_type: str) -> Iterator[None]:
         assert profile_type not in cls.profiling, (
             f"{profile_type} is already being profiled. "
             "SimpleProfiler does not support profiling multiple instances at "

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1,6 +1,7 @@
 import copy
 import functools
 import warnings
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -33,6 +34,7 @@ from torch.distributed.fsdp._common_utils import (
     _named_parameters_with_duplicates,
     clean_tensor_name,
 )
+from torch.distributed.fsdp._debug_utils import SimpleProfiler
 from torch.distributed.fsdp._fsdp_extensions import (
     _ext_chunk_dtensor,
     _ext_chunk_tensor,
@@ -418,6 +420,8 @@ def _flatten_optim_state_dict(
     Returns:
         Dict[str, Any]: The flattened optimizer state dict.
     """
+    SimpleProfiler.reset()
+
     unflat_osd = optim_state_dict
     if "state" not in unflat_osd and not rank0_only:
         raise ValueError(
@@ -455,11 +459,12 @@ def _flatten_optim_state_dict(
         if fqn in fqn_to_fsdp_param_info:
             fsdp_param_info = fqn_to_fsdp_param_info[fqn]
             if use_orig_params:
-                flat_state = _shard_orig_param_state(
-                    fsdp_param_info,
-                    fqn,
-                    unflat_osd_state[fqn],
-                )
+                with SimpleProfiler.profile(SimpleProfiler.Type.RESHARDING):
+                    flat_state = _shard_orig_param_state(
+                        fsdp_param_info,
+                        fqn,
+                        unflat_osd_state[fqn],
+                    )
             else:
                 flat_state = _flatten_optim_state(
                     fsdp_param_info,
@@ -517,6 +522,7 @@ def _flatten_optim_state_dict(
             user_state = _broadcast_state(fsdp_state, user_state, group=group)
         flat_osd_state[key] = copy.copy(user_state)
 
+    SimpleProfiler.dump_and_reset("FSDP _flatten_optim_state_dict() profiling: ")
     # Construct the "param_groups" part -- copy as is since it will be
     # rekeyed later according to the target rank's optimizer
     # Only copy param_groups if it exists in unflat_osd
@@ -1330,35 +1336,43 @@ def _optim_state_dict(
         :meth:`torch.optim.Optimizer.state_dict`. If ``rank0_only=False``,
         then nonzero ranks return an empty :class:`dict`.
     """
+    SimpleProfiler.reset()
+    cm = ExitStack()
+    cm.enter_context(SimpleProfiler.profile(SimpleProfiler.Type.ALL))
     _reset_flat_param_grad_info_if_needed(traversal_utils._get_fsdp_handles(model))
     to_save = not rank0_only or dist.get_rank(group) == 0 or shard_state
 
-    fsdp_osd: Dict[str, Any] = {"state": {}} if to_save else {}
-    fsdp_osd_state: Dict[str, Any] = fsdp_osd["state"] if to_save else {}
-    param_to_fqns = _get_param_to_fqns(model)
-    flat_param_to_fqn = _get_flat_param_to_fqn(model)
-    is_named_optimizer = _is_named_optimizer(optim_state_dict)
+    with SimpleProfiler.profile("preprocessing"):
+        fsdp_osd: Dict[str, Any] = {"state": {}} if to_save else {}
+        fsdp_osd_state: Dict[str, Any] = fsdp_osd["state"] if to_save else {}
+        param_to_fqns = _get_param_to_fqns(model)
+        flat_param_to_fqn = _get_flat_param_to_fqn(model)
+        is_named_optimizer = _is_named_optimizer(optim_state_dict)
 
-    param_key_to_param = cast(
-        Dict[Union[int, str], nn.Parameter],
+        param_key_to_param = cast(
+            Dict[Union[int, str], nn.Parameter],
+            (
+                _get_param_id_to_param_from_optim_input(model, optim_input)
+                if using_optim_input
+                else _get_param_key_to_param(
+                    optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
+                )
+            ),
+        )
+        fqn_to_fsdp_param_info = _get_fqn_to_fsdp_param_info(model)
+
+    with SimpleProfiler.profile("preprocessing_with_comm"):
         (
-            _get_param_id_to_param_from_optim_input(model, optim_input)
-            if using_optim_input
-            else _get_param_key_to_param(
-                optim, model, is_named_optimizer, param_to_fqns, flat_param_to_fqn
-            )
-        ),
-    )
-    fqn_to_fsdp_param_info = _get_fqn_to_fsdp_param_info(model)
-
-    all_optim_state_keys, optim_state_key_to_param_key = _map_param_key_to_optim_keys(
-        optim_state_dict,
-        group,
-        param_key_to_param,
-        param_to_fqns,
-        fqn_to_fsdp_param_info,
-        merge_keys=use_orig_params,
-    )
+            all_optim_state_keys,
+            optim_state_key_to_param_key,
+        ) = _map_param_key_to_optim_keys(
+            optim_state_dict,
+            group,
+            param_key_to_param,
+            param_to_fqns,
+            fqn_to_fsdp_param_info,
+            merge_keys=use_orig_params,
+        )
 
     # Iterate in rank 0's flat parameter ID order to ensure aligned all-gathers
     # across ranks
@@ -1410,12 +1424,15 @@ def _optim_state_dict(
         elif to_save:
             assert len(optim_state_key.unflat_param_names) == 1
             unflat_param_name = optim_state_key.unflat_param_names[0]
-            fsdp_osd_state[unflat_param_name] = copy.copy(
-                optim_state_dict["state"][param_key]
-            )
-            for state_name, value in sorted_items(fsdp_osd_state[unflat_param_name]):
-                if torch.is_tensor(value):
-                    fsdp_osd_state[unflat_param_name][state_name] = value.cpu()
+            with SimpleProfiler.profile("none_fsdp_managed_copy"):
+                fsdp_osd_state[unflat_param_name] = copy.copy(
+                    optim_state_dict["state"][param_key]
+                )
+                for state_name, value in sorted_items(
+                    fsdp_osd_state[unflat_param_name]
+                ):
+                    if torch.is_tensor(value):
+                        fsdp_osd_state[unflat_param_name][state_name] = value.cpu()
 
     # At this point, communication is complete and ranks can return early if nothing
     # will be saved on that rank.
@@ -1447,6 +1464,9 @@ def _optim_state_dict(
         fsdp_osd["param_groups"] = _unflatten_param_groups(
             optim_state_dict, param_key_to_param, param_to_fqns
         )
+
+    cm.close()
+    SimpleProfiler.dump_and_reset("FSDP _optim_state_dict() profiling: ")
 
     return fsdp_osd
 
@@ -1535,7 +1555,10 @@ def _all_gather_optim_state(
     object_list: List[StateInfo] = [
         processed_state for _ in range(fsdp_state.world_size)
     ]
-    dist.all_gather_object(object_list, processed_state, group=fsdp_state.process_group)
+    with SimpleProfiler.profile(SimpleProfiler.Type.ALLGATHER_OBJ):
+        dist.all_gather_object(
+            object_list, processed_state, group=fsdp_state.process_group
+        )
 
     # Convert the gathered, pre-processed state of each rank to the original one.
     gathered_state: Dict[str, Any] = {}
@@ -1544,6 +1567,8 @@ def _all_gather_optim_state(
         {n for state in object_list for n in state.tensors.keys()}
     )
     empty_ranks: Set[int] = set()
+    cm = ExitStack()
+    cm.enter_context(SimpleProfiler.profile(SimpleProfiler.Type.ALLGATHER))
     for name in all_tensor_states:
         numels = []
         dtype = torch.float
@@ -1604,6 +1629,7 @@ def _all_gather_optim_state(
                 if rank_numel > 0
             ]
         )
+    cm.close()
 
     return gathered_state
 
@@ -1630,31 +1656,33 @@ def _gather_orig_param_state(
     ):
         return optim_state
 
-    gathered_state = _all_gather_optim_state(fsdp_state, optim_state)
+    with SimpleProfiler.profile(SimpleProfiler.Type.RESHARDING):
+        gathered_state = _all_gather_optim_state(fsdp_state, optim_state)
 
     # Unflatten state values.
-    for state_name, value in list(gathered_state.items()):
-        if not torch.is_tensor(value) or value.dim() == 0:
-            continue
+    with SimpleProfiler.profile(SimpleProfiler.Type.H2D):
+        for state_name, value in list(gathered_state.items()):
+            if not torch.is_tensor(value) or value.dim() == 0:
+                continue
 
-        value = value[: flat_param._numels[param_idx]].reshape(
-            flat_param._shapes[param_idx]
-        )
-        if shard_state:
-            if not fsdp_state._optim_state_dict_config.use_dtensor:
-                assert fsdp_state.process_group is not None
-                value = _ext_chunk_tensor(
-                    value,
-                    fsdp_state.rank,
-                    fsdp_state.world_size,
-                    fsdp_state._device_handle.device_count(),
-                    fsdp_state.process_group,
-                )
-            else:
-                assert fsdp_state._device_mesh is not None
-                value = _ext_chunk_dtensor(
-                    value, fsdp_state.rank, fsdp_state._device_mesh
-                )
-        value = value.cpu()
-        gathered_state[state_name] = value
+            value = value[: flat_param._numels[param_idx]].reshape(
+                flat_param._shapes[param_idx]
+            )
+            if shard_state:
+                if not fsdp_state._optim_state_dict_config.use_dtensor:
+                    assert fsdp_state.process_group is not None
+                    value = _ext_chunk_tensor(
+                        value,
+                        fsdp_state.rank,
+                        fsdp_state.world_size,
+                        fsdp_state._device_handle.device_count(),
+                        fsdp_state.process_group,
+                    )
+                else:
+                    assert fsdp_state._device_mesh is not None
+                    value = _ext_chunk_dtensor(
+                        value, fsdp_state.rank, fsdp_state._device_mesh
+                    )
+            value = value.cpu()
+            gathered_state[state_name] = value
     return gathered_state

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -36,7 +36,6 @@ from torch.distributed.fsdp._runtime_utils import (
     _lazy_init,
     _reset_flat_param_grad_info_if_needed,
 )
-from torch.distributed.fsdp._shard_utils import SimpleProfiler
 from torch.distributed.fsdp.api import (
     FullStateDictConfig,
     ShardingStrategy,

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -29,12 +29,14 @@ from torch.distributed.fsdp._common_utils import (
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
 )
+from torch.distributed.fsdp._debug_utils import SimpleProfiler
 from torch.distributed.fsdp._runtime_utils import (
     _cast_buffers_to_dtype_and_device,
     _get_orig_buffer_dtypes,
     _lazy_init,
     _reset_flat_param_grad_info_if_needed,
 )
+from torch.distributed.fsdp._shard_utils import SimpleProfiler
 from torch.distributed.fsdp.api import (
     FullStateDictConfig,
     ShardingStrategy,
@@ -353,7 +355,8 @@ def _full_pre_load_state_dict_hook(
         _is_composable(fsdp_state)
         and fsdp_state.sharding_strategy == ShardingStrategy.NO_SHARD
     ):
-        _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
+        with SimpleProfiler.profile("_enter_unshard_params_ctx"):
+            _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
     # Add FSDP_PREFIX only for wrapper-based FSDP.
     if not _is_composable(fsdp_state):
         _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")
@@ -366,7 +369,8 @@ def _full_post_load_state_dict_hook(
         _is_composable(fsdp_state)
         and fsdp_state.sharding_strategy == ShardingStrategy.NO_SHARD
     ):
-        _exit_unshard_params_ctx(module, fsdp_state)
+        with SimpleProfiler.profile("_exit_unshard_params_ctx"):
+            _exit_unshard_params_ctx(module, fsdp_state)
 
 
 def _local_pre_state_dict_hook(
@@ -566,7 +570,8 @@ def _sharded_post_load_state_dict_hook(
     module: nn.Module, fsdp_state: _FSDPState, *args, **kwargs
 ) -> None:
     if _has_fsdp_params(fsdp_state, module):
-        _exit_unshard_params_ctx(module, fsdp_state)
+        with SimpleProfiler.profile("_exit_unshard_params_ctx"):
+            _exit_unshard_params_ctx(module, fsdp_state)
 
 
 @no_type_check
@@ -620,7 +625,8 @@ def _sharded_pre_load_state_dict_hook(
                 local_tensor = shards[0].tensor.flatten()
                 pg_device = _get_pg_default_device(fsdp_state.process_group)
                 if local_tensor.device.type != pg_device.type:
-                    local_tensor = local_tensor.to(pg_device)
+                    with SimpleProfiler.profile(SimpleProfiler.Type.H2D):
+                        local_tensor = local_tensor.to(pg_device)
                 num_padding = chunk_size - local_tensor.numel()
                 if num_padding > 0:
                     local_tensor = F.pad(local_tensor, [0, num_padding])
@@ -635,18 +641,22 @@ def _sharded_pre_load_state_dict_hook(
                 # Tensor could be on FSDP GPU compute device, while local_tensor is on CPU.
                 # Convert to CPU so all_gather can work.
                 tensor_dev = tensor.device
-                tensor = tensor.cpu()
+                with SimpleProfiler.profile(SimpleProfiler.Type.H2D):
+                    tensor = tensor.cpu()
                 tensor_list = list(
                     torch.chunk(tensor, dist.get_world_size(fsdp_state.process_group))
                 )
-                dist.all_gather(
-                    tensor_list, local_tensor, group=fsdp_state.process_group
-                )
-                tensor.to(tensor_dev)
+                with SimpleProfiler.profile(SimpleProfiler.Type.ALLGATHER):
+                    dist.all_gather(
+                        tensor_list, local_tensor, group=fsdp_state.process_group
+                    )
+                with SimpleProfiler.profile(SimpleProfiler.Type.D2H):
+                    tensor.to(tensor_dev)
             else:
-                dist.all_gather_into_tensor(
-                    tensor, local_tensor, group=fsdp_state.process_group
-                )
+                with SimpleProfiler.profile(SimpleProfiler.Type.ALLGATHER):
+                    dist.all_gather_into_tensor(
+                        tensor, local_tensor, group=fsdp_state.process_group
+                    )
             tensor = tensor.narrow(0, 0, param_numel).reshape(param.size())
             state_dict[fqn_from_global_root] = tensor
         else:
@@ -658,7 +668,8 @@ def _sharded_pre_load_state_dict_hook(
             )
             state_dict[fqn_from_global_root] = param.to_local()
 
-    _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
+    with SimpleProfiler.profile("_enter_unshard_params_ctx"):
+        _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
 
 
 @contextlib.contextmanager
@@ -789,6 +800,10 @@ def _pre_load_state_dict_hook(
     else:
         context = contextlib.nullcontext()
 
+    _lazy_init(fsdp_state, module)
+    if fsdp_state._is_root:
+        SimpleProfiler.reset()
+
     with context:
         _pre_load_state_dict_hook_fn = {
             StateDictType.FULL_STATE_DICT: _full_pre_load_state_dict_hook,
@@ -830,6 +845,9 @@ def _post_load_state_dict_hook(
         # Dispatch into state_dict type specific implementation of post-hook for
         # loading state_dict.
         _post_load_state_dict_hook_fn[fsdp_state._state_dict_type](module, fsdp_state)
+
+    if fsdp_state._is_root:
+        SimpleProfiler.dump_and_reset("FSDP model load_state_dict profiling: ")
 
 
 def _register_all_state_dict_hooks(state: _FSDPState):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #108298
* __->__ #108290

This PR adds SimpleProfiler for FSDP state_dict/load_state_dict logging purpose. SimpleProfiler use class variables to record profiling results and it does everything in the Python which can be slow. So it is only suitable for logging slow actions such as initialization and state_dict/load_state_dict.

This PR uses SimpleProfiler to log some critical/slow paths of the model and optimizer state_dict/load_state_dict.

Differential Revision: [D48774406](https://our.internmc.facebook.com/intern/diff/D48774406/)