### PR TITLE
Fix triton upload channel detection

### DIFF
--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -121,7 +121,7 @@ jobs:
         shell: bash -e -l {0}
         run: |
           # reference ends with an RC suffix
-          if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -132,6 +132,7 @@ jobs:
     container:
       image: continuumio/miniconda3:4.12.0
     environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
+    shell: bash
     steps:
       - uses: actions/checkout@v3
 
@@ -148,6 +149,7 @@ jobs:
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
         # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        shell: bash
         run: |
           set -eux
 
@@ -167,6 +169,7 @@ jobs:
           # When running these on pull_request events these should be blank
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
+        shell: bash
         run: |
           set -ex
           bash .circleci/scripts/binary_upload.sh
@@ -242,6 +245,7 @@ jobs:
     container:
       image: continuumio/miniconda3:4.12.0
     environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
+    shell: bash
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -132,7 +132,6 @@ jobs:
     container:
       image: continuumio/miniconda3:4.12.0
     environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
-    shell: bash
     steps:
       - uses: actions/checkout@v3
 
@@ -144,6 +143,7 @@ jobs:
 
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
@@ -171,7 +171,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
-          set -ex
+          set -eux
           bash .circleci/scripts/binary_upload.sh
 
   build-conda:
@@ -245,7 +245,6 @@ jobs:
     container:
       image: continuumio/miniconda3:4.12.0
     environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
-    shell: bash
     steps:
       - uses: actions/checkout@v3
 
@@ -257,11 +256,13 @@ jobs:
 
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
         # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        shell: bash
         run: |
           set -eux
 
@@ -278,8 +279,9 @@ jobs:
           # When running these on pull_request events these should be blank
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
           CONDA_PYTORCHBOT_TOKEN_TEST: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}
+        shell: bash
         run: |
-          set -ex
+          set -eux
 
           if [[ "${UPLOAD_CHANNEL}" = "nightly" ]]; then
             export ANACONDA_API_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -148,7 +148,7 @@ jobs:
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         shell: bash
         run: |
           set -ex
@@ -261,7 +261,7 @@ jobs:
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -149,6 +149,8 @@ jobs:
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
+          set -eux
+
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -151,7 +151,7 @@ jobs:
         # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          set -eux
+          set -ex
 
           # reference ends with an RC suffix
           if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
@@ -171,7 +171,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
-          set -eux
+          set -ex
           bash .circleci/scripts/binary_upload.sh
 
   build-conda:
@@ -264,7 +264,7 @@ jobs:
         # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          set -eux
+          set -ex
 
           # reference ends with an RC suffix
           if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
@@ -281,7 +281,7 @@ jobs:
           CONDA_PYTORCHBOT_TOKEN_TEST: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}
         shell: bash
         run: |
-          set -eux
+          set -ex
 
           if [[ "${UPLOAD_CHANNEL}" = "nightly" ]]; then
             export ANACONDA_API_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -152,7 +152,7 @@ jobs:
           set -eux
 
           # reference ends with an RC suffix
-          if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
           fi
 
@@ -262,7 +262,7 @@ jobs:
           set -eux
 
           # reference ends with an RC suffix
-          if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -147,7 +147,7 @@ jobs:
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
           set -eux
 
@@ -257,8 +257,10 @@ jobs:
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
 
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        # if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
+          set -eux
+
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"


### PR DESCRIPTION
This should be nightly for nightly and test for release candidates.  There are 2 bugs:

* The shell needs to set to `bash` explicitly, otherwise, GHA uses `sh` which doesn't recognized `[[` as shown in https://github.com/pytorch/pytorch/actions/runs/6030476858/job/16362717792#step:6:10
*`${GITHUB_REF_NAME}` is un-quoted.  This is basically https://www.shellcheck.net/wiki/SC2248 but this wasn't captured by actionlint, and shellcheck doesn't work with workflow YAML file.  I will think about how to add a lint rule for this later then.

### Testing

https://github.com/pytorch/pytorch/actions/runs/6031330411 to confirm that setting the channel is performed correctly.
