### PR TITLE
Fallback to eager for float8 ops in inductor

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -11,9 +11,9 @@ from torch.testing._internal.inductor_utils import HAS_CUDA
 
 torch.set_float32_matmul_precision("high")
 
+
 @instantiate_parametrized_tests
 class TestFP8Types(TestCase):
-
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_eager_fallback(self, dtype: torch.dtype):
         x_shape = (16, 16)
@@ -24,7 +24,9 @@ class TestFP8Types(TestCase):
             b_scale = torch.Tensor([1.0]).to(device="cuda")
             output_scale = None
             input_bias = torch.rand(32, device="cuda", dtype=dtype)
-            weight = torch.rand(*weight_shape, device="cuda", dtype=dtype).T.to(torch.float8_e4m3fn)
+            weight = torch.rand(*weight_shape, device="cuda", dtype=dtype).T.to(
+                torch.float8_e4m3fn
+            )
             a_inverse_scale = 1 / a_scale
             b_inverse_scale = 1 / b_scale
             output, updated_amax = torch._scaled_mm(
@@ -39,7 +41,7 @@ class TestFP8Types(TestCase):
             return output
 
         x = torch.rand(*x_shape, device="cuda", dtype=dtype).to(torch.float8_e4m3fn)
-        compiled_fp8_matmul = torch.compile(fp8_matmul_unwrapped, backend="inductor", dynamic=False)
+        compiled_fp8_matmul = torch.compile(fp8_matmul_unwrapped, backend="inductor")
         y_fp8 = compiled_fp8_matmul(x)
 
 

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1,13 +1,23 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
-
 from torch.testing._internal.inductor_utils import HAS_CUDA
+
+isSM90orLaterDevice = (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_capability()
+    >= (
+        9,
+        0,
+    )
+)
 
 torch.set_float32_matmul_precision("high")
 
@@ -15,6 +25,7 @@ torch.set_float32_matmul_precision("high")
 @instantiate_parametrized_tests
 class TestFP8Types(TestCase):
     @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @unittest.skipIf(not isSM90orLaterDevice, "Requires SM90 device")
     def test_eager_fallback(self, dtype: torch.dtype):
         x_shape = (16, 16)
         weight_shape = (32, 16)

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1,0 +1,48 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+torch.set_float32_matmul_precision("high")
+
+@instantiate_parametrized_tests
+class TestFP8Types(TestCase):
+
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_eager_fallback(self, dtype: torch.dtype):
+        x_shape = (16, 16)
+        weight_shape = (32, 16)
+
+        def fp8_matmul_unwrapped(x):
+            a_scale = torch.Tensor([1.0]).to(device="cuda")
+            b_scale = torch.Tensor([1.0]).to(device="cuda")
+            output_scale = None
+            input_bias = torch.rand(32, device="cuda", dtype=dtype)
+            weight = torch.rand(*weight_shape, device="cuda", dtype=dtype).T.to(torch.float8_e4m3fn)
+            a_inverse_scale = 1 / a_scale
+            b_inverse_scale = 1 / b_scale
+            output, updated_amax = torch._scaled_mm(
+                x,
+                weight,
+                bias=input_bias,
+                out_dtype=dtype,
+                scale_a=a_inverse_scale,
+                scale_b=b_inverse_scale,
+                scale_result=output_scale,
+            )
+            return output
+
+        x = torch.rand(*x_shape, device="cuda", dtype=dtype).to(torch.float8_e4m3fn)
+        compiled_fp8_matmul = torch.compile(fp8_matmul_unwrapped, backend="inductor", dynamic=False)
+        y_fp8 = compiled_fp8_matmul(x)
+
+
+if __name__ == "__main__":
+    if HAS_CUDA:
+        run_tests()

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -7,6 +7,7 @@ from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
@@ -24,8 +25,12 @@ torch.set_float32_matmul_precision("high")
 
 @instantiate_parametrized_tests
 class TestFP8Types(TestCase):
+    @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+        "FP8 is only supported on H100+",
+    )
     @parametrize("dtype", (torch.float16, torch.bfloat16))
-    @unittest.skipIf(not isSM90orLaterDevice, "Requires SM90 device")
     def test_eager_fallback(self, dtype: torch.dtype):
         x_shape = (16, 16)
         weight_shape = (32, 16)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -146,6 +146,12 @@ def is_boolean_type(x):
     else:
         return isinstance(x, bool)
 
+# def is_float8_type(x):
+#     if isinstance(x, TensorBox):
+#         return is_float8_type(x.get_dtype())
+#     else:
+#         return is_iuns
+
 
 def get_promoted_dtype(*args, type_promotion_kind: ELEMENTWISE_TYPE_PROMOTION_KIND):
     def construct_input(inp):
@@ -2013,6 +2019,11 @@ make_fallback(aten.zeros.names)
 
 make_fallback(torch._prims.rng_prims.run_and_save_rng_state)
 make_fallback(torch._prims.rng_prims.run_with_rng_state)
+
+# Need to add support to codegen for float8 types, for now fallback
+make_fallback(aten._scaled_mm.default)
+make_fallback(torch.ops.prims.convert_element_type.default)
+make_fallback(aten.clone.default)
 
 # fails accuracy on test_torch.py, and explicit fallback required to avoid warn=True on implicit
 make_fallback(aten.exponential.default, warn=False)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -146,6 +146,7 @@ def is_boolean_type(x):
     else:
         return isinstance(x, bool)
 
+
 # def is_float8_type(x):
 #     if isinstance(x, TensorBox):
 #         return is_float8_type(x.get_dtype())


### PR DESCRIPTION
# Summary
As a stop gap to supporting the FP8 Dtype within inductor we would like to fallback to eager. Currently there are 3 ops that are needed for this:
`_scaled_mm` ( matmul for fp8 types)
`clone` (for creating new copies of fp8 tensors)
`to` ( for converting to and from fp8 types).

This PR registers a fallback for _scaled_mm. And adds fp8 to trigger `unsupported_input_tensor`

Prior to these changes this was failing with:
``` Shell
  File "/home/drisspg/meta/pytorch/torch/_inductor/codegen/triton_utils.py", line 11, in signature_of
    tye = JITFunction._type_of(arg.dtype)
  File "/home/drisspg/miniconda3/envs/dev/lib/python3.10/site-packages/triton/runtime/jit.py", line 229, in _type_of
    return key if isinstance(key, str) else f"*{tys[dtype_str]}"
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
KeyError: 'float8_e4m3fn'
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov