### PR TITLE
[optim] Make casting to match params a hook (2nd try)

### DIFF
--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -2083,6 +2083,28 @@ class TestOptim(TestCase):
         self.assertTrue(opt.state["ran_load_state_dict_pre_hook2"])
         self.assertTrue(opt.state["ran_load_state_dict_post_hook"])
 
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_get_load_state_dict_cast_hook_handle(self):
+        param = torch.rand(2, 3, requires_grad=True, device="cpu")
+        param.grad = torch.rand_like(param)
+        opt = optim.Adadelta([param], lr=0.001)
+
+        # Simulate saving and loading state_dict after init'ing state with step()
+        opt.step()
+        cpu_state_dict = opt.state_dict()
+
+        param_cuda = torch.rand(2, 3, requires_grad=True, device="cuda")
+        param_cuda.grad = torch.rand_like(param_cuda)
+        opt_cuda = optim.Adadelta([param_cuda], lr=0.001)
+        handle = opt_cuda.get_load_state_dict_cast_hook_handle()
+        handle.remove()
+
+        opt_cuda.load_state_dict(cpu_state_dict)
+
+        # Assert that casting to CUDA did not happen for the param state
+        # since the cast hook has been removed
+        self.assertEqual(opt_cuda.state[param_cuda]["square_avg"].device, torch.device("cpu"))
+
 
 def _diff_fn(p, grad, opt_differentiable_state, opt_class, kwargs, *ignored):
     # Ignored is the list of values in `opt_differentiable_state`, we do this

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -245,8 +245,9 @@ class Optimizer:
         """
 
         if len(groups) != len(saved_groups):
-            raise ValueError("loaded state dict has a different number of "
-                             "parameter groups")
+            raise ValueError(f"loaded state dict has {len(saved_groups)} parameter groups "
+                             f"but the optimizer being loaded into has {len(groups)} "
+                             "parameter groups. They should be equal.")
         param_lens = (len(g['params']) for g in groups)
         saved_lens = (len(g['params']) for g in saved_groups)
         if any(p_len != s_len for p_len, s_len in zip(param_lens, saved_lens)):
@@ -284,8 +285,7 @@ class Optimizer:
                 return value
 
         # Cast state tensors to appropriate types in the state_dict
-        for k in state_dict['state']:
-            v = state_dict['state'][k]
+        for k, v in state_dict['state'].items():
             if k in id_map:
                 param = id_map[k]
                 state_dict['state'][k] = _cast(param, v, param_id=k, param_groups=saved_groups)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -233,8 +233,63 @@ class Optimizer:
     _optimizer_step_post_hooks: Dict[int, OptimizerPostHook]
     _optimizer_state_dict_pre_hooks: 'OrderedDict[int, Callable[["Optimizer"], None]]'
     _optimizer_state_dict_post_hooks: 'OrderedDict[int, Callable[["Optimizer", StateDict], Optional[StateDict]]]'
-    _optimizer_load_state_dict_pre_hooks: 'OrderedDict[int, Callable[["Optimizer", StateDict], Optional[StateDict]]]'
+    # _optimizer_load_state_dict_pre_hooks handled by @property
     _optimizer_load_state_dict_post_hooks: 'OrderedDict[int, Callable[["Optimizer"], None]]'
+
+
+    @staticmethod
+    def _verify_param_groups_align(groups, saved_groups) -> Dict[int, torch.Tensor]:
+        """_verify_param_groups_align is a helper method that verifies the param groups of
+        a saved checkpoint and the current optimizer are aligned and then returns an
+        id map mapping param ID (integer) to a parameter.
+        """
+
+        if len(groups) != len(saved_groups):
+            raise ValueError("loaded state dict has a different number of "
+                             "parameter groups")
+        param_lens = (len(g['params']) for g in groups)
+        saved_lens = (len(g['params']) for g in saved_groups)
+        if any(p_len != s_len for p_len, s_len in zip(param_lens, saved_lens)):
+            raise ValueError("loaded state dict contains a parameter group "
+                             "that doesn't match the size of optimizer's group")
+
+        return dict(zip(chain.from_iterable(g['params'] for g in saved_groups),
+                        chain.from_iterable(g['params'] for g in groups)))
+
+
+    @staticmethod
+    def _cast_state_to_match_params_hook(optimizer, state_dict) -> None:
+        """The following hook is automatically registered to load_state_dict as a pre-hook. This processing
+        used to live within load_state_dict, but, since the introduction of state_dict hooks, we've moved
+        this to be its own hook to allow users flexibility to trigger pre-hook before OR after casting
+        state to match the params' dtype and device.
+        """
+
+        # Validate the state_dict
+        groups = optimizer.param_groups
+        saved_groups = state_dict['param_groups']
+        id_map = Optimizer._verify_param_groups_align(groups, saved_groups)
+
+        def _cast(param, value, param_id=None, param_groups=None, key=None):
+            r"""Make a deep copy of value, casting all tensors to device of param."""
+            if isinstance(value, torch.Tensor):
+                return Optimizer._process_value_according_to_param_policy(param, value, param_id, param_groups, key)
+            elif isinstance(value, dict):
+                return {k: _cast(param, v, param_id=param_id, param_groups=param_groups, key=k)
+                        for k, v in value.items()}
+            elif isinstance(value, Iterable):
+                return type(value)(_cast(param, v, param_id=param_id, param_groups=param_groups)
+                                   for v in value)  # type: ignore[call-arg]
+            else:
+                return value
+
+        # Cast state tensors to appropriate types in the state_dict
+        for k in state_dict['state']:
+            v = state_dict['state'][k]
+            if k in id_map:
+                param = id_map[k]
+                state_dict['state'][k] = _cast(param, v, param_id=k, param_groups=saved_groups)
+
 
     def __init__(self, params: params_t, defaults: Dict[str, Any]) -> None:
         torch._C._log_api_usage_once("python.optimizer")
@@ -243,7 +298,8 @@ class Optimizer:
         self._optimizer_step_post_hooks = OrderedDict()
         self._optimizer_state_dict_pre_hooks = OrderedDict()
         self._optimizer_state_dict_post_hooks = OrderedDict()
-        self._optimizer_load_state_dict_pre_hooks = OrderedDict()
+        # _optimizer_load_state_dict_pre_hooks and _load_state_dict_cast_handle
+        # are handled as managed properties
         self._optimizer_load_state_dict_post_hooks = OrderedDict()
 
         self._patch_step_function()
@@ -270,6 +326,9 @@ class Optimizer:
         # https://github.com/pytorch/pytorch/issues/72948
         self._warned_capturable_if_run_uncaptured = True
 
+    def get_load_state_dict_cast_hook_handle(self) -> RemovableHandle:
+        return self._load_state_dict_cast_handle
+
     def __getstate__(self) -> Dict[str, Any]:
         return {
             'defaults': self.defaults,
@@ -287,8 +346,9 @@ class Optimizer:
             self._optimizer_state_dict_pre_hooks = OrderedDict()
         if '_optimizer_state_dict_post_hooks' not in self.__dict__:
             self._optimizer_state_dict_post_hooks = OrderedDict()
-        if '_optimizer_load_state_dict_pre_hooks' not in self.__dict__:
-            self._optimizer_load_state_dict_pre_hooks = OrderedDict()
+        # Why are _optimizer_load_state_dict_pre_hooks and _load_state_dict_cast_handle
+        # excluded here? We want to have the property lazy initialization be our source
+        # of truth.
         if '_optimizer_load_state_dict_post_hooks' not in self.__dict__:
             self._optimizer_load_state_dict_post_hooks = OrderedDict()
         self._patch_step_function()  # To support multiprocessing pickle/unpickle
@@ -402,6 +462,50 @@ class Optimizer:
         if not hooked:
             self.__class__.step = self.profile_hook_step(self.__class__.step)  # type: ignore[assignment]
             self.__class__.step.hooked = True  # type: ignore[attr-defined]
+
+    def _set_up_load_state_dict_pre_hooks_and_handle(self) -> None:
+        self._optimizer_load_state_dict_pre_hooks_legit: 'OrderedDict[int, Callable[["Optimizer", StateDict], Optional[StateDict]]]' = OrderedDict()  # noqa: B950
+        handle = hooks.RemovableHandle(self._optimizer_load_state_dict_pre_hooks_legit)
+        self._load_state_dict_cast_handle_legit: RemovableHandle = handle
+        self._optimizer_load_state_dict_pre_hooks_legit[handle.id] = Optimizer._cast_state_to_match_params_hook
+
+    @property
+    def _optimizer_load_state_dict_pre_hooks(
+            self) -> 'OrderedDict[int, Callable[["Optimizer", StateDict], Optional[StateDict]]]':
+        if (hasattr(self, "_optimizer_load_state_dict_pre_hooks_legit") and
+                self._optimizer_load_state_dict_pre_hooks_legit is not None):
+            return self._optimizer_load_state_dict_pre_hooks_legit
+        # otherwise, set up the hooks and handle
+        if (hasattr(self, "_load_state_dict_cast_handle_legit") and
+                self._load_state_dict_cast_handle_legit is not None):
+            raise RuntimeError("the load_state_dict pre hooks should always be init'd "
+                               "at the same time as the handle but found an init'd "
+                               "handle with uninit'd hooks")
+        self._set_up_load_state_dict_pre_hooks_and_handle()
+        return self._optimizer_load_state_dict_pre_hooks_legit
+
+    @_optimizer_load_state_dict_pre_hooks.setter
+    def _optimizer_load_state_dict_pre_hooks(
+            self, value) -> None:
+        self._optimizer_load_state_dict_pre_hooks_legit = value
+
+    @property
+    def _load_state_dict_cast_handle(self) -> RemovableHandle:
+        if (hasattr(self, "_load_state_dict_cast_handle_legit") and
+                self._load_state_dict_cast_handle_legit is not None):
+            return self._load_state_dict_cast_handle_legit
+        # otherwise, set up the hooks and handle
+        if (hasattr(self, "_optimizer_load_state_dict_pre_hooks_legit") and
+                self._optimizer_load_state_dict_pre_hooks_legit is not None):
+            raise RuntimeError("the load_state_dict pre hooks should always be init'd "
+                               "at the same time as the handle but found an init'd "
+                               "hooks dictionary with an uninit'd handle")
+        self._set_up_load_state_dict_pre_hooks_and_handle()
+        return self._load_state_dict_cast_handle_legit
+
+    @_load_state_dict_cast_handle.setter
+    def _load_state_dict_cast_handle(self, value) -> None:
+        self._load_state_dict_cast_handle_legit = value
 
     def register_step_pre_hook(self, hook: OptimizerPreHook) -> RemovableHandle:
         r"""Register an optimizer step pre hook which will be called before
@@ -650,6 +754,14 @@ class Optimizer:
         calling ``load_state_dict`` on ``self``. The registered hook can be used to
         perform pre-processing before the ``load_state_dict`` call is made.
 
+        .. note::
+
+            There is an automatically registered load_state_dict pre-hook which
+            casts the state to match the params in dtype and device. Set ``prepend``
+            to True in order to insert the your defined hook before this pre-processing,
+            otherwise, leaving ``prepend`` as False will have your registered hook run
+            after the casting has taken place.
+
         Args:
             hook (Callable): The user defined hook to be registered.
             prepend (bool): If True, the provided pre ``hook`` will be fired before
@@ -720,44 +832,21 @@ class Optimizer:
             if hook_result is not None:
                 state_dict = hook_result
 
-        # Validate the state_dict
-        groups = self.param_groups
-
         # Deepcopy as we write into saved_groups later to update state
         saved_groups = deepcopy(state_dict['param_groups'])
 
-        if len(groups) != len(saved_groups):
-            raise ValueError("loaded state dict has a different number of "
-                             "parameter groups")
-        param_lens = (len(g['params']) for g in groups)
-        saved_lens = (len(g['params']) for g in saved_groups)
-        if any(p_len != s_len for p_len, s_len in zip(param_lens, saved_lens)):
-            raise ValueError("loaded state dict contains a parameter group "
-                             "that doesn't match the size of optimizer's group")
+        # Validate the state_dict
+        groups = self.param_groups
+        id_map = Optimizer._verify_param_groups_align(groups, saved_groups)
 
-        # Update the state
-        id_map = dict(zip(chain.from_iterable(g['params'] for g in saved_groups),
-                      chain.from_iterable(g['params'] for g in groups)))
-
-        def _cast(param, value, param_id=None, param_groups=None, key=None):
-            r"""Make a deep copy of value, casting all tensors to device of param."""
-            if isinstance(value, torch.Tensor):
-                return Optimizer._process_value_according_to_param_policy(param, value, param_id, param_groups, key)
-            elif isinstance(value, dict):
-                return {k: _cast(param, v, param_id=param_id, param_groups=param_groups, key=k) for k, v in value.items()}
-            elif isinstance(value, Iterable):
-                return type(value)(_cast(param, v, param_id=param_id, param_groups=param_groups) for v in value)  # type: ignore[call-arg]
-            else:
-                return value
-
-        # Copy state assigned to params (and cast tensors to appropriate types).
+        # Copy state assigned to params
         # State that is not assigned to params is copied as is (needed for
         # backward compatibility).
         state: DefaultDict[torch.Tensor, Dict[Any, Any]] = defaultdict(dict)
         for k, v in state_dict['state'].items():
             if k in id_map:
                 param = id_map[k]
-                state[param] = _cast(param, v, param_id=k, param_groups=state_dict['param_groups'])
+                state[param] = v
             else:
                 state[k] = v
 
@@ -767,6 +856,7 @@ class Optimizer:
             return new_group
         param_groups = [
             update_group(g, ng) for g, ng in zip(groups, saved_groups)]
+
         self.__setstate__({'state': state, 'param_groups': param_groups})
 
         for post_hook in self._optimizer_load_state_dict_post_hooks.values():


### PR DESCRIPTION
Reland of #106725, but instead of registering the hook in the constructor, do it lazily through @property

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108303

