### PR TITLE
[4/N] fix clang-tidy warnings in torch/csrc

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -11,7 +11,7 @@ namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
 
-inline bool has_names(ITensorListRef tensors) {
+inline bool has_names(const ITensorListRef& tensors) {
   return std::any_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
     return t.has_names();
   });

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -144,17 +144,15 @@ void invoke_parallel(
   const std::function<void(int64_t, int64_t)>& f) {
   at::internal::lazy_init_num_threads();
 
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  size_t num_tasks, chunk_size;
+  size_t num_tasks = 0, chunk_size = 0;
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct {
     std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
     std::exception_ptr eptr;
     std::mutex mutex;
-    volatile size_t remaining;
+    volatile size_t remaining{0};
     std::condition_variable cv;
   } state;
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -75,7 +75,7 @@ namespace detail {
       }
     }
     // Structured Tensor[] translates to this case
-    void operator()(at::ITensorListRef xs) {
+    void operator()(const at::ITensorListRef& xs) {
       for (const auto& x : xs) {
         ts = ts | x.key_set();
       }

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -745,7 +745,7 @@ namespace std {
 
 template <>
 struct hash<c10::OperatorHandle> {
-  size_t operator()(c10::OperatorHandle op) const noexcept {
+  size_t operator()(const c10::OperatorHandle& op) const noexcept {
     return std::hash<void*>{}(static_cast<void*>(op.operatorDef_));
   }
 };

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -80,8 +80,7 @@ struct ComplexHolder : c10::intrusive_ptr_target {
 // Similar to ComplexHolder, for StreamData3
 struct StreamData3Holder : c10::intrusive_ptr_target {
   public:
-    StreamData3Holder(struct c10::StreamData3 d) {
-      val = d;
+    StreamData3Holder(struct c10::StreamData3 d):val(d) {
     }
     StreamData3Holder() = delete;
     struct c10::StreamData3 val;
@@ -585,7 +584,7 @@ public:
     payload.u.as_int = i;
   }
 
-  IValue(c10::SymInt i) {
+  IValue(const c10::SymInt& i) {
     if (auto mi = i.maybe_as_int()) {
       tag = Tag::Int;
       payload.u.as_int = *mi;
@@ -602,7 +601,7 @@ public:
   c10::SymInt toSymInt() &&;
   c10::SymInt toSymInt() const&;
 
-  IValue(c10::SymFloat i) {
+  IValue(const c10::SymFloat& i) {
     if (i.is_symbolic()) {
       tag = Tag::SymFloat;
       payload.u.as_intrusive_ptr = i.toSymNodeImpl().release();
@@ -619,7 +618,7 @@ public:
   c10::SymFloat toSymFloat() &&;
   c10::SymFloat toSymFloat() const&;
 
-  IValue(c10::SymBool i) {
+  IValue(const c10::SymBool& i) {
      if (auto mi = i.maybe_as_bool()) {
       tag = Tag::Bool;
       payload.u.as_int = *mi;

--- a/aten/src/ATen/core/type_factory.h
+++ b/aten/src/ATen/core/type_factory.h
@@ -22,7 +22,7 @@ struct TORCH_API TypeFactoryBase<c10::DynamicType> {
             {std::move(ty), std::forward<Args>(args)...})));
   }
   template <typename T>
-  static c10::DynamicTypePtr create(std::vector<c10::TypePtr> types) {
+  static c10::DynamicTypePtr create(const std::vector<c10::TypePtr>& types) {
     return std::make_shared<c10::DynamicType>(
         c10::DynamicTypeTrait<T>::tagValue(),
         c10::DynamicType::Arguments(types));

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -20,14 +20,17 @@ PyObject *THPException_FatalError, *THPException_LinAlgError,
   if (!(cond))            \
   return false
 bool THPException_init(PyObject* module) {
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_FatalError =
           PyErr_NewException("torch.FatalError", nullptr, nullptr));
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       PyModule_AddObject(module, "FatalError", THPException_FatalError) == 0);
 
   // Set the doc string here since _add_docstr throws malloc errors if tp_doc is
   // modified for an error class.
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_LinAlgError = PyErr_NewExceptionWithDoc(
           "torch._C._LinAlgError",
@@ -54,6 +57,7 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(module, "_LinAlgError", THPException_LinAlgError) ==
       0);
 
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_OutOfMemoryError = PyErr_NewExceptionWithDoc(
           "torch.cuda.OutOfMemoryError",
@@ -64,6 +68,7 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_OutOfMemoryError", THPException_OutOfMemoryError) == 0);
 
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistError",
@@ -73,6 +78,7 @@ could not be completed because the input matrix is singular.",
   ASSERT_TRUE(
       PyModule_AddObject(module, "_DistError", THPException_DistError) == 0);
 
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistBackendError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistBackendError",
@@ -83,6 +89,7 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_DistBackendError", THPException_DistBackendError) == 0);
 
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistNetworkError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistNetworkError",
@@ -93,6 +100,7 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_DistNetworkError", THPException_DistNetworkError) == 0);
 
+  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistStoreError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistStoreError",
@@ -213,46 +221,46 @@ void translate_exception_to_python(const std::exception_ptr& e_ptr) {
         "called with invalid exception pointer");
     std::rethrow_exception(e_ptr);
   }
-  CATCH_ALL_ERRORS(return )
+  CATCH_ALL_ERRORS(return)
 }
 
 IndexError::IndexError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 TypeError::TypeError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 ValueError::ValueError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 NotImplementedError::NotImplementedError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 AttributeError::AttributeError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 LinAlgError::LinAlgError(const char* format, ...) {
-  va_list fmt_args;
+  va_list fmt_args{};
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
@@ -288,8 +296,7 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
   auto& warning_buffer = internal_handler_.warning_buffer_;
 
   if (!warning_buffer.empty()) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    PyObject *type, *value, *traceback;
+    PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
     pybind11::gil_scoped_acquire gil;
     auto result = 0;
     if (in_exception_) {
@@ -313,7 +320,7 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
             /*category=*/map_warning_to_python_type(warning),
             /*message=*/msg.c_str(),
             /*filename=*/source_location.file,
-            /*lineno=*/source_location.line,
+            /*lineno=*/static_cast<int>(source_location.line),
             /*module=*/nullptr,
             /*registry=*/nullptr);
       } else {
@@ -344,7 +351,6 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
       throw python_error();
     }
     if (in_exception_) {
-      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       PyErr_Restore(type, value, traceback);
     }
   }

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -221,7 +221,7 @@ void translate_exception_to_python(const std::exception_ptr& e_ptr) {
         "called with invalid exception pointer");
     std::rethrow_exception(e_ptr);
   }
-  CATCH_ALL_ERRORS(return)
+  CATCH_ALL_ERRORS(return )
 }
 
 IndexError::IndexError(const char* format, ...) {

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -20,6 +20,7 @@
 #include <c10/util/intrusive_ptr.h>
 #include <fmt/format.h>
 
+// NOLINTBEGIN(*narrowing-conversions*)
 template <>
 void THPPointer<c10::StorageImpl>::free() {
   if (ptr) {
@@ -66,6 +67,7 @@ c10::intrusive_ptr<c10::StorageImpl> make_storage_impl(
   // be created. If you need to create a storageimpl object of a subclass, you
   // need to pass in the device information.
   if (allocator_opt.has_value()) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
     allocator = reinterpret_cast<c10::Allocator*>(allocator_opt.value());
   } else if (device_opt.has_value()) {
     at::Device device = device_opt.value();
@@ -84,6 +86,7 @@ c10::intrusive_ptr<c10::StorageImpl> make_storage_impl(
     } else if (device.type() == at::kMPS) {
       allocator = at::mps::GetMPSAllocator();
 #endif
+      // NOLINTBEGIN(bugprone-branch-clone)
     } else if (device.type() == at::DeviceType::XPU) {
       allocator = c10::GetAllocator(device.type());
     } else if (device.type() == at::DeviceType::HPU) {
@@ -92,8 +95,8 @@ c10::intrusive_ptr<c10::StorageImpl> make_storage_impl(
       allocator = c10::GetAllocator(device.type());
     } else if (device.type() == at::DeviceType::PrivateUse1) {
       allocator = c10::GetAllocator(device.type());
-
     } else {
+      // NOLINTEND(bugprone-branch-clone)
       TORCH_CHECK(
           false,
           THPStorageStr,
@@ -201,7 +204,6 @@ static PyObject* THPStorage_pynew(
     try {
       for (Py_ssize_t i = 0; i < length; i++) {
         item = PySequence_GetItem(sequence, i);
-        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         uint8_t value = THPByteUtils_unpackReal(item.get());
         const auto& storage = THPStorage_Unpack(self);
         if (allocator == c10::GetDefaultCPUAllocator()) {
@@ -256,9 +258,10 @@ static PyObject* THPStorage_get(THPStorage* self, PyObject* index) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Py_ssize_t start, stop, slicelength, step;
     int64_t len = storage.nbytes();
-    if (PySlice_GetIndicesEx(index, len, &start, &stop, &step, &slicelength) !=
-        0)
+    if (PySlice_Unpack(index, &start, &stop, &step) < 0) {
       return nullptr;
+    }
+    slicelength = PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
       THPUtils_setError(
           "Trying to slice with a step of %lld, but only a step of "
@@ -318,11 +321,12 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
     return 0;
   } else if (PySlice_Check(index)) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    Py_ssize_t start, stop, slicelength, step;
+    Py_ssize_t start, stop, step;
     int64_t len = storage.nbytes();
-    if (PySlice_GetIndicesEx(index, len, &start, &stop, &step, &slicelength) !=
-        0)
+    if (PySlice_Unpack(index, &start, &stop, &step) < 0) {
       return -1;
+    }
+    PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
       THPUtils_setError(
           "Trying to slice with a step of %lld, but only a step of "
@@ -493,3 +497,4 @@ void THPStorage_postInit(PyObject* module) {
   if (!THPStorageClass)
     throw python_error();
 }
+// NOLINTEND(*narrowing-conversions*)

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <cstring>
 #include <iterator>
 #include <sstream>
 #include <string>
@@ -287,7 +288,7 @@ char* tensor_repr(at::Tensor tensor) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
   }
-  strncpy(result, buf, bufsize);
+  std::strncpy(result, buf, bufsize);
   result[bufsize] = '\0';
   Py_XDECREF(pytensor);
   Py_XDECREF(repr);

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -263,12 +263,11 @@ char* tensor_repr(at::Tensor tensor) {
   PyGILState_STATE gil = PyGILState_Ensure();
   PyObject* pytensor = nullptr;
   PyObject* repr = nullptr;
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  Py_ssize_t bufsize;
+  Py_ssize_t bufsize = 0;
   const char* buf = nullptr;
   char* result = nullptr;
 
-  pytensor = THPVariable_Wrap(at::Tensor(std::move(tensor)));
+  pytensor = THPVariable_Wrap(std::move(tensor));
   if (!pytensor)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
@@ -280,16 +279,16 @@ char* tensor_repr(at::Tensor tensor) {
   if (!buf)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
+  // account for the trailing \0
   // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-  result =
-      static_cast<char*>(malloc(bufsize + 1)); // account for the trailing \0
+  result = static_cast<char*>(malloc(bufsize + 1));
   if (!result) {
     fmt::print(stderr, "cannot allocate memory for the result\n");
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
   }
-  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.strcpy)
-  strcpy(result, buf);
+  strncpy(result, buf, bufsize);
+  result[bufsize] = '\0';
   Py_XDECREF(pytensor);
   Py_XDECREF(repr);
   PyGILState_Release(gil);


### PR DESCRIPTION
Fixes clang-tidy warnings in torch/csrc.
