### PR TITLE
Revert PR-107951 to only support new graph capture API in Quantization

### DIFF
--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -47,12 +47,6 @@ def fold_bn_weights_into_conv_node(
     conv_w = _get_tensor_constant_from_node(conv_weight_node, m)
     conv_b = _get_tensor_constant_from_node(conv_bias_node, m)
     transpose = not (conv_node.target == torch.ops.aten.conv2d.default)
-    # TODO(Leslie): WA to support both graph capture of `torch._export.capture_pre_autograd_graph`
-    # and `torch._dynamo_export` for 2.1 release, remove it after formal support of new graph capture
-    # API in Inductor for X86.
-    if conv_node.target == torch.ops.aten.convolution.default:
-        assert type(conv_node.args[6]) is bool
-        transpose = conv_node.args[6]
 
     # eval bn args: input, weight, bias, running mean, running var, momentum, eps
     # train bn args: input, weight, bias, running mean, running var, training, momentum, eps
@@ -74,10 +68,8 @@ def fold_bn_weights_into_conv_node(
 
     # update the weight and bias for conv
     conv_args = list(conv_node.args)
-    # TODO(Leslie): Remove the check of node target after formal support of new graph capture
-    # API `torch._export.capture_pre_autograd_graph` in Inductor for X86.
     # filling in the default bias argument
-    if len(conv_args) == 2 and (conv_node.target == torch.ops.aten.conv2d.default):
+    if len(conv_args) == 2:
         conv_args.append(None)
 
     # calling data since the fused_weight and fused_bias are nn.Parameter
@@ -121,12 +113,7 @@ def _fuse_conv_bn_(m: GraphModule) -> None:
             continue
         bn_node = n
         n = bn_node.args[0]
-        # TODO(Leslie): Remove the check of node target torch.ops.aten.convolution.default after formal
-        # support of new graph capture API `torch._export.capture_pre_autograd_graph` in Inductor for X86.
-        if n.op != "call_function" or (
-            n.target != torch.ops.aten.conv2d.default
-            and n.target != torch.ops.aten.convolution.default
-        ):
+        if n.op != "call_function" or n.target != torch.ops.aten.conv2d.default:
             continue
         conv_node = n
         conv_weight_node = conv_node.args[1]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108317
* #108214

**Summary**
Revert the changes in https://github.com/pytorch/pytorch/pull/107951 to make the utils function only support graph captured by `capture_pre_autograd_graph`.
