### PR TITLE
pass inference accuracy check for detectron2_fcos_r_50_fpn

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -145,6 +145,11 @@ REQUIRE_HIGHER_FP16_TOLERANCE = {
     "drq",
 }
 
+
+REQUIRE_HIGHER_BF16_TOLERANCE = {
+    "detectron2_fcos_r_50_fpn",
+}
+
 REQUIRE_COSINE_TOLERACE = {
     # Just keeping it here even though its empty, if we need this in future.
 }
@@ -440,6 +445,11 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             if name in REQUIRE_HIGHER_FP16_TOLERANCE:
                 return 1e-2, cosine
             return 1e-3, cosine
+
+        if self.args.bfloat16:
+            if name in REQUIRE_HIGHER_BF16_TOLERANCE:
+                return 1e-2, cosine
+
         if is_training and current_device == "cuda":
             tolerance = 1e-3
             if name in REQUIRE_COSINE_TOLERACE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108328

We need a higher tolerance to pass the inference accuracy check for detectron2_fcos_r_50_fpn .

Command:
```
python benchmarks/dynamo/torchbench.py --backend inductor --bfloat16 --accuracy --only detectron2_fcos_r_50_fpn --disable-cudagraphs --inference
```


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov