### PR TITLE
[dynamo] fix dynamo + DTensor to work with 2d

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -161,13 +161,9 @@ class TestDTensorCompileE2E(DTensorTestBase):
             tp_model, process_group=fsdp_pg, device_id=self.rank, use_orig_params=True
         )
         out = eager_2d(inp)
-        # TODO: once aot autograd support is ready we can just use default backend
         tp_model2 = parallelize_module(
             model_copy, twod_mesh, PairwiseParallel(), tp_mesh_dim=1
         )
-        # TODO: now we first apply torch compile on tp model then use fsdp to wrap it, ideally
-        # we should apply torch.compile after fsdp wrap, but the current graph break approach
-        # have some issues with the tensor subclass compilation, need to dig into this later
         fsdp_2d = FSDP(
             tp_model2,
             process_group=fsdp_pg,
@@ -175,6 +171,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
             use_orig_params=True,
         )
 
+        # TODO: once aot autograd support is ready we can just use default backend
         compiled_2d = torch.compile(fsdp_2d, backend="eager")
         compiled_output = compiled_2d(inp)
 

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -169,6 +169,7 @@ FILENAME_ALLOWLIST |= {
 FILENAME_ALLOWLIST |= {
     _module_dir(torch) + "distributed/tensor/parallel/_utils.py",
     _module_dir(torch) + "distributed/tensor/parallel/style.py",
+    _module_dir(torch) + "distributed/tensor/parallel/_data_parallel_utils.py",
     _module_dir(torch) + "distributed/_tensor/api.py",
     _module_dir(torch) + "distributed/_tensor/device_mesh.py",
 }

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -86,6 +86,7 @@ from .dicts import (
 from .distributed import (
     DeviceMeshVariable,
     PlacementClassVariable,
+    PlacementVariable,
     ProcessGroupVariable,
 )
 from .functions import (
@@ -661,6 +662,14 @@ class VariableBuilder:
             # TODO: see if we need to add custom guard instead
             # of a simple ID_MATCH
             return PlacementClassVariable(
+                value,
+                source=self.source,
+                guards=make_guards(GuardBuilder.ID_MATCH),
+            )
+        elif PlacementVariable.is_placement(value):
+            # TODO: see if we need to add custom guard instead
+            # of a simple ID_MATCH
+            return PlacementVariable(
                 value,
                 source=self.source,
                 guards=make_guards(GuardBuilder.ID_MATCH),

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -92,7 +92,7 @@ class PlacementVariable(DistributedVariable):
 
         from torch.distributed._tensor.placement_types import Placement
 
-        return istype(value, Placement)
+        return isinstance(value, Placement)
 
     def as_python_constant(self):
         return self.value

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -627,9 +627,10 @@ class TensorVariable(VariableTracker):
             # rewrite non-primitive args/kwargs to be included in the on-the-fly prim function
             # and rewrite args to have only proxyable args, then insert call_function
             args_as_value = [x.as_python_constant() for x in args]
+            kwargs_as_value = {k: v.as_python_constant() for k, v in kwargs.items()}
 
             def redistribute_fn_with_prim_types(x):
-                return x.redistribute(*args_as_value)
+                return x.redistribute(*args_as_value, **kwargs_as_value)
 
             # attach the same function name for better debugging
             redistribute_fn_with_prim_types.__name__ = f"prim_{name}"

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -572,6 +572,7 @@ class TorchVariable(VariableTracker):
         elif is_from_local(self.value):
             # rewrite non-primitive args/kwargs to be included in the on-the-fly prim function
             # and rewrite args to have only proxyable args, then insert call_function
+            # TODO: support cases where device_mesh + placements specified as kwargs
             args_as_value = [x.as_python_constant() for x in args[1:]]
 
             def fn_with_prim_types(x, **kwargs):

--- a/torch/distributed/tensor/parallel/_data_parallel_utils.py
+++ b/torch/distributed/tensor/parallel/_data_parallel_utils.py
@@ -16,6 +16,7 @@ from torch.distributed._shard.sharded_tensor import (
 from torch.distributed._shard.sharding_spec import ShardMetadata
 from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
 from torch.distributed._tensor import DTensor as DistributedTensor, Shard as DShard
+
 from torch.distributed._tensor.placement_types import DTensorSpec
 
 from torch.distributed.fsdp._common_utils import _set_fsdp_flattened
@@ -151,8 +152,8 @@ def _flatten_tensor(
 def _unflatten_tensor(tensor: torch.Tensor, spec: DTensorSpec) -> torch.Tensor:
     result = DistributedTensor.from_local(
         tensor,
-        device_mesh=spec.mesh,
-        placements=spec.placements,
+        spec.mesh,
+        spec.placements,
         run_check=False,
     )
 

--- a/torch/distributed/tensor/parallel/_data_parallel_utils.py
+++ b/torch/distributed/tensor/parallel/_data_parallel_utils.py
@@ -16,7 +16,6 @@ from torch.distributed._shard.sharded_tensor import (
 from torch.distributed._shard.sharding_spec import ShardMetadata
 from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
 from torch.distributed._tensor import DTensor as DistributedTensor, Shard as DShard
-
 from torch.distributed._tensor.placement_types import DTensorSpec
 
 from torch.distributed.fsdp._common_utils import _set_fsdp_flattened


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108329

pair debugged with @wconstab and we found some issue in both dynamo and
the TP's fsdp extension side. This PR fixes the dynamo + DTensor integration
so that the current graph break FSDP can work with tensor parallel by moving
the torch.compile after FSDP wrapping.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov