### PR TITLE
[HSDP] Fix Node 1 unable receive parameters from Node 0

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -244,9 +244,9 @@ class TestFSDPHybridShard(FSDPTest):
         model = fsdp_ctor(model)
 
         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
-            assert (model.lin1.weight == 0).all()
-            assert (model.lin2.weight == 0).all()
-            assert (model.lin3.weight == 0).all()
+            self.assertTrue((model.lin1.weight == 0).all())
+            self.assertTrue((model.lin2.weight == 0).all())
+            self.assertTrue((model.lin3.weight == 0).all())
 
     @skip_if_lt_x_gpu(2)
     def test_invalid_pg_specification_raises(self):

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -206,6 +206,48 @@ class TestFSDPHybridShard(FSDPTest):
             FSDP.optim_state_dict_to_load(load_model, load_optim, osd)
         load_optim.load_state_dict(osd)
 
+    @skip_if_lt_x_gpu(4)    
+    def test_hsdp_sync_module_state(self):
+        model = MyModel().cuda()
+        num_node_devices = torch.cuda.device_count()
+        shard_rank_lists = list(range(0, num_node_devices // 2)), list(
+            range(num_node_devices // 2, num_node_devices)
+        )
+        shard_groups = (
+            dist.new_group(shard_rank_lists[0]),
+            dist.new_group(shard_rank_lists[1]),
+        )
+        my_shard_group = (
+            shard_groups[0] if self.rank in shard_rank_lists[0] else shard_groups[1]
+        )
+        my_replicate_group = None
+        my_rank = self.rank
+        # Create groups like (0, 4), (1, 5), (2, 6) etc and assign appropriately
+        shard_factor = len(shard_rank_lists[0])
+        for i in range(num_node_devices // 2):
+            replicate_group_ranks = list(range(i, num_node_devices, shard_factor))
+            replicate_group = dist.new_group(replicate_group_ranks)
+            if my_rank in replicate_group_ranks:
+                my_replicate_group = replicate_group
+
+        nn.init.constant_(model.lin1.weight, self.rank)
+        nn.init.constant_(model.lin2.weight, self.rank)
+        nn.init.constant_(model.lin3.weight, self.rank)
+
+        fsdp_ctor = partial(
+            FSDP,
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+            use_orig_params=True,
+            sync_module_states=True,
+            process_group=(my_shard_group, my_replicate_group),
+        )
+        model = fsdp_ctor(model)
+
+        with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
+            assert (model.lin1.weight == 0).all()
+            assert (model.lin2.weight == 0).all()
+            assert (model.lin3.weight == 0).all()
+
     @skip_if_lt_x_gpu(2)
     def test_invalid_pg_specification_raises(self):
         pol = ModuleWrapPolicy({nn.Linear})

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -206,7 +206,7 @@ class TestFSDPHybridShard(FSDPTest):
             FSDP.optim_state_dict_to_load(load_model, load_optim, osd)
         load_optim.load_state_dict(osd)
 
-    @skip_if_lt_x_gpu(4)    
+    @skip_if_lt_x_gpu(4)
     def test_hsdp_sync_module_state(self):
         model = MyModel().cuda()
         num_node_devices = torch.cuda.device_count()

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -572,7 +572,7 @@ def _init_param_handle_from_module(
         _sync_module_params_and_buffers(
             fully_sharded_module, managed_params, state.process_group
         )
-        if getattr(state, "_inter_node_pg", None) is not None:
+        if state.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
             _sync_module_params_and_buffers(
                 fully_sharded_module, managed_params, state._inter_node_pg
             )

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -572,7 +572,7 @@ def _init_param_handle_from_module(
         _sync_module_params_and_buffers(
             fully_sharded_module, managed_params, state.process_group
         )
-        if hasattr(state, '_inter_node_pg'):
+        if getattr(state, '_inter_node_pg', None) is not None:
             _sync_module_params_and_buffers(
                 fully_sharded_module, managed_params, state._inter_node_pg
             )

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -569,8 +569,9 @@ def _init_param_handle_from_module(
 
     managed_params = list(_get_orig_params(fully_sharded_module, state._ignored_params))
     if sync_module_states:
+        default_group = _get_default_group()
         _sync_module_params_and_buffers(
-            fully_sharded_module, managed_params, state.process_group
+            fully_sharded_module, managed_params, default_group
         )
     _init_param_handle_from_params(state, managed_params, fully_sharded_module)
     return state

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -569,10 +569,13 @@ def _init_param_handle_from_module(
 
     managed_params = list(_get_orig_params(fully_sharded_module, state._ignored_params))
     if sync_module_states:
-        default_group = _get_default_group()
         _sync_module_params_and_buffers(
             fully_sharded_module, managed_params, default_group
         )
+        if hasattr(state, '_inter_node_pg'):
+            _sync_module_params_and_buffers(
+                fully_sharded_module, managed_params, state._inter_node_pg
+            )
     _init_param_handle_from_params(state, managed_params, fully_sharded_module)
     return state
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -572,7 +572,7 @@ def _init_param_handle_from_module(
         _sync_module_params_and_buffers(
             fully_sharded_module, managed_params, state.process_group
         )
-        if getattr(state, '_inter_node_pg', None) is not None:
+        if getattr(state, "_inter_node_pg", None) is not None:
             _sync_module_params_and_buffers(
                 fully_sharded_module, managed_params, state._inter_node_pg
             )

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -570,7 +570,7 @@ def _init_param_handle_from_module(
     managed_params = list(_get_orig_params(fully_sharded_module, state._ignored_params))
     if sync_module_states:
         _sync_module_params_and_buffers(
-            fully_sharded_module, managed_params, default_group
+            fully_sharded_module, managed_params, state.process_group
         )
         if hasattr(state, '_inter_node_pg'):
             _sync_module_params_and_buffers(


### PR DESCRIPTION
When use hybrid_shard mode FSDP, 
state.process_group means gpu_0,1,,,~,7 on node 0，so gpus on node 1 cannot receive parameters, setting process_group to default_group（global_group）can fix this issue

Fixes #ISSUE_NUMBER
