### PR TITLE
Update clang7 CI jobs to clang9

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -181,9 +181,9 @@ case "$image" in
     CONDA_CMAKE=yes
     ONNX=yes
     ;;
-  pytorch-linux-focal-py3-clang7-android-ndk-r19c)
+  pytorch-linux-focal-py3-clang9-android-ndk-r19c)
     ANACONDA_PYTHON_VERSION=3.8
-    CLANG_VERSION=7
+    CLANG_VERSION=9
     LLVMDEV=yes
     PROTOBUF=yes
     ANDROID=yes

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -157,7 +157,7 @@ jobs:
 
           # run gradle buildRelease
           (echo "./.circleci/scripts/build_android_gradle.sh" | docker exec \
-            -e BUILD_ENVIRONMENT="pytorch-linux-focal-py3-clang7-android-ndk-r19c-gradle-build" \
+            -e BUILD_ENVIRONMENT="pytorch-linux-focal-py3-clang9-android-ndk-r19c-gradle-build" \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
             -e PR_NUMBER \

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image-name: pytorch-linux-focal-rocm-n-1-py3
           - docker-image-name: pytorch-linux-focal-rocm-n-py3
           - docker-image-name: pytorch-linux-jammy-cuda11.8-cudnn8-py3.8-clang12
-          - docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
+          - docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
           - docker-image-name: pytorch-linux-jammy-py3.8-gcc11
           - docker-image-name: pytorch-linux-jammy-py3.8-gcc11-inductor-benchmarks
           - docker-image-name: pytorch-linux-jammy-py3-clang12-asan

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -247,12 +247,12 @@ jobs:
           { config: "default", shard: 1, num_shards: 1 },
         ]}
 
-  linux-focal-py3-clang7-mobile-custom-build-static:
-    name: linux-focal-py3-clang7-mobile-custom-build-static
+  linux-focal-py3-clang9-mobile-custom-build-static:
+    name: linux-focal-py3-clang9-mobile-custom-build-static
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-py3-clang7-mobile-custom-build-static
-      docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
+      build-environment: linux-focal-py3-clang9-mobile-custom-build-static
+      docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
       build-generates-artifacts: false
       test-matrix: |
         { include: [
@@ -317,23 +317,23 @@ jobs:
           { config: "default", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },
         ]}
 
-  linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single:
-    name: linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single
+  linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single:
+    name: linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single
     uses: ./.github/workflows/_android-build-test.yml
     with:
-      build-environment: linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single
-      docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
+      build-environment: linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single
+      docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
-  linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit:
-    name: linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit
+  linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single-full-jit:
+    name: linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:
-      build-environment: linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit
-      docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
+      build-environment: linux-focal-py3-clang9-android-ndk-r19c-gradle-custom-build-single-full-jit
+      docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -76,12 +76,12 @@ jobs:
           { config: "default", shard: 1, num_shards: 1 },
         ]}
 
-  pytorch-linux-focal-py3-clang7-android-ndk-r19c-build:
-    name: pytorch-linux-focal-py3-clang7-android-ndk-r19c-build
+  pytorch-linux-focal-py3-clang9-android-ndk-r19c-build:
+    name: pytorch-linux-focal-py3-clang9-android-ndk-r19c-build
     uses: ./.github/workflows/_android-full-build-test.yml
     with:
-      build-environment: pytorch-linux-focal-py3-clang7-android-ndk-r19c-build
-      docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
+      build-environment: pytorch-linux-focal-py3-clang9-android-ndk-r19c-build
+      docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },


### PR DESCRIPTION
This PR updates the remaining clang7 CI job to clang9. However, I have no permission to push the new docker image so Android CI tests would fail.