### PR TITLE
Fix the issue described by #106769

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1552,7 +1552,7 @@ std::tuple<Tensor, Tensor> lstm_cell(
   check_rnn_cell_forward_input(input, w_ih.sym_size(1));
   auto hidden_size = w_hh.sym_size(1);
   check_rnn_cell_forward_hidden(input, hx[0], hidden_size, 0);
-  check_rnn_cell_forward_hidden(input, hx[1], std::move(hidden_size), 0);
+  check_rnn_cell_forward_hidden(input, hx[1], std::move(hidden_size), 1);
   static at::Tensor undefined;
   return LSTMCell<CellParams>{}(input, std::make_tuple(hx[0], hx[1]), CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -4373,6 +4373,35 @@ TEST_F(ModulesTest, RNNCell) {
   output = rnn(input, hx);
   expected = torch::tensor({0.2808, 0.6505});
   ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
+
+  {
+    auto input = torch::randn({3, 2});
+    auto hx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        rnn(input, hx), "input has inconsistent input_size: got 2 expected 1");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1});
+    ASSERT_THROWS_WITH(
+        rnn(input, hx),
+        "hidden0 has inconsistent hidden_size: got 1, expected 2");
+  }
+
+  {
+    auto input = torch::randn({3, 1, 1, 1, 1});
+    auto hx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        rnn(input, hx), "Expected input to be 1D or 2D, got 5D instead");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1, 1, 1, 2});
+    ASSERT_THROWS_WITH(
+        rnn(input, hx), "Expected hidden to be 1D or 2D, got 5D instead");
+  }
 }
 
 TEST_F(ModulesTest, LSTMCell) {
@@ -4412,6 +4441,60 @@ TEST_F(ModulesTest, LSTMCell) {
   expected_cx = torch::tensor({-0.1195, 0.2144});
   ASSERT_TRUE(torch::allclose(output_hx, expected_hx, 1e-05, 2e-04));
   ASSERT_TRUE(torch::allclose(output_cx, expected_cx, 1e-05, 2e-04));
+
+  {
+    auto input = torch::randn({3, 2});
+    auto hx = torch::randn({3, 2});
+    auto cx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "input has inconsistent input_size: got 2 expected 1");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1});
+    auto cx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "hidden0 has inconsistent hidden_size: got 1, expected 2");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 2});
+    auto cx = torch::randn({3, 1});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "hidden1 has inconsistent hidden_size: got 1, expected 2");
+  }
+
+  {
+    auto input = torch::randn({3, 1, 1, 1, 1});
+    auto hx = torch::randn({3, 1});
+    auto cx = torch::randn({3, 1});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "Expected input to be 1D or 2D, got 5D instead");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1, 1, 1, 2});
+    auto cx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "Expected hx[0] to be 1D or 2D, got 5D instead");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 2});
+    auto cx = torch::randn({3, 1, 1, 1, 2});
+    ASSERT_THROWS_WITH(
+        lstm(input, std::make_tuple(hx, cx)),
+        "Expected hx[1] to be 1D or 2D, got 5D instead");
+  }
 }
 
 TEST_F(ModulesTest, GRUCell) {
@@ -4435,6 +4518,35 @@ TEST_F(ModulesTest, GRUCell) {
   output = gru(input, hx);
   expected = torch::tensor({-1.0058, -0.3025});
   ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
+
+  {
+    auto input = torch::randn({3, 2});
+    auto hx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        gru(input, hx), "input has inconsistent input_size: got 2 expected 1");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1});
+    ASSERT_THROWS_WITH(
+        gru(input, hx),
+        "hidden0 has inconsistent hidden_size: got 1, expected 2");
+  }
+
+  {
+    auto input = torch::randn({3, 1, 1, 1, 1});
+    auto hx = torch::randn({3, 2});
+    ASSERT_THROWS_WITH(
+        gru(input, hx), "Expected input to be 1D or 2D, got 5D instead");
+  }
+
+  {
+    auto input = torch::randn({3, 1});
+    auto hx = torch::randn({3, 1, 1, 1, 2});
+    ASSERT_THROWS_WITH(
+        gru(input, hx), "Expected hidden to be 1D or 2D, got 5D instead");
+  }
 }
 
 TEST_F(ModulesTest, PrettyPrintLinear) {

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -4355,6 +4355,7 @@ TEST_F(ModulesTest, CrossMapLRN2d) {
 TEST_F(ModulesTest, RNNCell) {
   torch::manual_seed(0);
   auto rnn = RNNCell(1, 2);
+
   auto input = torch::randn({3, 1});
   auto hx = torch::randn({3, 2});
   auto output = rnn(input, hx);
@@ -4366,15 +4367,22 @@ TEST_F(ModulesTest, RNNCell) {
   expected =
       torch::tensor({{-0.0775, 0.6688}, {-0.0734, 0.4759}, {-0.0725, 0.4225}});
   ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
+
+  input = torch::randn({1});
+  hx = torch::randn({2});
+  output = rnn(input, hx);
+  expected = torch::tensor({0.2808, 0.6505});
+  ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
 }
 
 TEST_F(ModulesTest, LSTMCell) {
   torch::manual_seed(0);
-  auto rnn = LSTMCell(1, 2);
+  auto lstm = LSTMCell(1, 2);
+
   auto input = torch::randn({3, 1});
   auto hx = torch::randn({3, 2});
   auto cx = torch::randn({3, 2});
-  auto output = rnn(input, std::make_tuple(hx, cx));
+  auto output = lstm(input, std::make_tuple(hx, cx));
   auto output_hx = std::get<0>(output);
   auto output_cx = std::get<1>(output);
   auto expected_hx =
@@ -4384,7 +4392,7 @@ TEST_F(ModulesTest, LSTMCell) {
   ASSERT_TRUE(torch::allclose(output_hx, expected_hx, 1e-05, 2e-04));
   ASSERT_TRUE(torch::allclose(output_cx, expected_cx, 1e-05, 2e-04));
 
-  output = rnn(input);
+  output = lstm(input);
   output_hx = std::get<0>(output);
   output_cx = std::get<1>(output);
   expected_hx =
@@ -4393,21 +4401,39 @@ TEST_F(ModulesTest, LSTMCell) {
       torch::tensor({{-0.2679, 0.2180}, {-0.3049, 0.3493}, {-0.2896, 0.2853}});
   ASSERT_TRUE(torch::allclose(output_hx, expected_hx, 1e-05, 2e-04));
   ASSERT_TRUE(torch::allclose(output_cx, expected_cx, 1e-05, 2e-04));
+
+  input = torch::randn({1});
+  hx = torch::randn({2});
+  cx = torch::randn({2});
+  output = lstm(input, std::make_tuple(hx, cx));
+  output_hx = std::get<0>(output);
+  output_cx = std::get<1>(output);
+  expected_hx = torch::tensor({-0.0443, 0.1537});
+  expected_cx = torch::tensor({-0.1195, 0.2144});
+  ASSERT_TRUE(torch::allclose(output_hx, expected_hx, 1e-05, 2e-04));
+  ASSERT_TRUE(torch::allclose(output_cx, expected_cx, 1e-05, 2e-04));
 }
 
 TEST_F(ModulesTest, GRUCell) {
   torch::manual_seed(0);
-  auto rnn = GRUCell(1, 2);
+  auto gru = GRUCell(1, 2);
+
   auto input = torch::randn({3, 1});
   auto hx = torch::randn({3, 2});
-  auto output = rnn(input, hx);
+  auto output = gru(input, hx);
   auto expected =
       torch::tensor({{1.0243, 0.3227}, {-0.5659, 0.0330}, {-0.4030, -0.2800}});
   ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
 
-  output = rnn(input);
+  output = gru(input);
   expected =
       torch::tensor({{-0.0085, 0.1095}, {-0.1291, 0.2675}, {-0.1339, 0.2725}});
+  ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
+
+  input = torch::randn({1});
+  hx = torch::randn({2});
+  output = gru(input, hx);
+  expected = torch::tensor({-1.0058, -0.3025});
   ASSERT_TRUE(torch::allclose(output, expected, 1e-05, 2e-04));
 }
 

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -277,11 +277,7 @@ class TORCH_API RNNCellImplBase : public torch::nn::Cloneable<Derived> {
   Tensor bias_hh;
 
  protected:
-  void check_forward_input(const Tensor& input) const;
-  void check_forward_hidden(
-      const Tensor& input,
-      const Tensor& hx,
-      std::string hidden_label) const;
+  void check_forward_input(const Tensor& input, const std::string name) const;
   virtual std::string get_nonlinearity_str() const;
 };
 } // namespace detail

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -864,37 +864,16 @@ void RNNCellImplBase<Derived>::pretty_print(std::ostream& stream) const {
 }
 
 template <typename Derived>
-void RNNCellImplBase<Derived>::check_forward_input(const Tensor& input) const {
-  TORCH_CHECK(
-      input.size(1) == options_base.input_size(),
-      "input has inconsistent input_size: got ",
-      input.size(1),
-      " expected ",
-      options_base.input_size());
-}
-
-template <typename Derived>
-void RNNCellImplBase<Derived>::check_forward_hidden(
+void RNNCellImplBase<Derived>::check_forward_input(
     const Tensor& input,
-    const Tensor& hx,
-    std::string hidden_label) const {
+    const string name) const {
   TORCH_CHECK(
-      input.size(0) == hx.size(0),
-      "Input batch size ",
-      input.size(0),
-      " doesn't match hidden",
-      hidden_label,
-      " batch size ",
-      hx.size(0));
-
-  TORCH_CHECK(
-      hx.size(1) == options_base.hidden_size(),
-      "hidden",
-      hidden_label,
-      " has inconsistent hidden_size: got ",
-      hx.size(1),
-      ", expected ",
-      options_base.hidden_size());
+      input.dim() == 1 || input.dim() == 2,
+      "Expected ",
+      name.c_str(),
+      " to be 1D or 2D, got ",
+      input.dim(),
+      "D instead");
 }
 
 template <typename Derived>
@@ -919,26 +898,39 @@ RNNCellImpl::RNNCellImpl(const RNNCellOptions& options_)
       options(options_) {}
 
 Tensor RNNCellImpl::forward(const Tensor& input, Tensor hx) {
-  this->check_forward_input(input);
+  this->check_forward_input(input, "input");
+  this->check_forward_input(hx, "hidden");
+
+  Tensor r_hx, ret;
+
+  bool is_batched = input.dim() == 2;
+  Tensor r_input = is_batched ? input : input.unsqueeze(0);
+
   if (!hx.defined()) {
-    hx = torch::zeros(
+    r_hx = torch::zeros(
         {input.size(0), options.hidden_size()},
         torch::dtype(input.dtype()).device(input.device()));
+  } else {
+    r_hx = is_batched ? hx : hx.unsqueeze(0);
   }
-  this->check_forward_hidden(input, hx, "");
-  Tensor ret;
+
   if (c10::get_if<enumtype::kTanh>(&options.nonlinearity())) {
-    ret =
-        torch::rnn_tanh_cell(input, hx, weight_ih, weight_hh, bias_ih, bias_hh);
+    ret = torch::rnn_tanh_cell(
+        r_input, r_hx, weight_ih, weight_hh, bias_ih, bias_hh);
   } else if (c10::get_if<enumtype::kReLU>(&options.nonlinearity())) {
-    ret =
-        torch::rnn_relu_cell(input, hx, weight_ih, weight_hh, bias_ih, bias_hh);
+    ret = torch::rnn_relu_cell(
+        r_input, r_hx, weight_ih, weight_hh, bias_ih, bias_hh);
   } else {
     TORCH_CHECK(
         false,
         "Unknown nonlinearity: ",
         torch::enumtype::get_enum_name(options.nonlinearity()));
   }
+
+  if (!is_batched) {
+    ret = ret.squeeze(0);
+  }
+
   return ret;
 }
 
@@ -960,28 +952,46 @@ LSTMCellImpl::LSTMCellImpl(const LSTMCellOptions& options_)
 std::tuple<Tensor, Tensor> LSTMCellImpl::forward(
     const Tensor& input,
     torch::optional<std::tuple<Tensor, Tensor>> hx_opt) {
-  this->check_forward_input(input);
+  this->check_forward_input(input, "input");
+  if (hx_opt.has_value()) {
+    this->check_forward_input(std::get<0>(hx_opt.value()), "hx[0]");
+    this->check_forward_input(std::get<1>(hx_opt.value()), "hx[1]");
+  }
 
-  std::tuple<Tensor, Tensor> hx;
+  std::tuple<Tensor, Tensor> r_hx, ret;
+
+  bool is_batched = input.dim() == 2;
+  Tensor r_input = is_batched ? input : input.unsqueeze(0);
+
   if (!hx_opt.has_value()) {
     auto zeros = torch::zeros(
         {input.size(0), options.hidden_size()},
         torch::dtype(input.dtype()).device(input.device()));
-    hx = std::make_tuple(zeros, zeros);
+    r_hx = std::make_tuple(zeros, zeros);
   } else {
-    hx = hx_opt.value();
+    if (!is_batched) {
+      r_hx = std::make_tuple(
+          std::get<0>(hx_opt.value()).unsqueeze(0),
+          std::get<1>(hx_opt.value()).unsqueeze(0));
+    } else {
+      r_hx = hx_opt.value();
+    }
   }
 
-  this->check_forward_hidden(input, std::get<0>(hx), "[0]");
-  this->check_forward_hidden(input, std::get<1>(hx), "[1]");
-
-  return torch::lstm_cell(
-      input,
-      {std::get<0>(hx), std::get<1>(hx)},
+  ret = torch::lstm_cell(
+      r_input,
+      {std::get<0>(r_hx), std::get<1>(r_hx)},
       weight_ih,
       weight_hh,
       bias_ih,
       bias_hh);
+
+  if (!is_batched) {
+    ret = std::make_tuple(
+        std::get<0>(ret).squeeze(0), std::get<1>(ret).squeeze(0));
+  }
+
+  return ret;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRUCell
@@ -996,14 +1006,29 @@ GRUCellImpl::GRUCellImpl(const GRUCellOptions& options_)
       options(options_) {}
 
 Tensor GRUCellImpl::forward(const Tensor& input, Tensor hx) {
-  this->check_forward_input(input);
+  this->check_forward_input(input, "input");
+  this->check_forward_input(hx, "hidden");
+
+  Tensor r_hx, ret;
+
+  bool is_batched = input.dim() == 2;
+  Tensor r_input = is_batched ? input : input.unsqueeze(0);
+
   if (!hx.defined()) {
-    hx = torch::zeros(
+    r_hx = torch::zeros(
         {input.size(0), options.hidden_size()},
         torch::dtype(input.dtype()).device(input.device()));
+  } else {
+    r_hx = is_batched ? hx : hx.unsqueeze(0);
   }
-  this->check_forward_hidden(input, hx, "");
-  return torch::gru_cell(input, hx, weight_ih, weight_hh, bias_ih, bias_hh);
+
+  ret = torch::gru_cell(r_input, r_hx, weight_ih, weight_hh, bias_ih, bias_hh);
+
+  if (!is_batched) {
+    ret = ret.squeeze(0);
+  }
+
+  return ret;
 }
 
 } // namespace nn


### PR DESCRIPTION
Fixes #106769

Align the behavior of the C++ interface with the Python interface

1. Remove some checks in C++ frontend api ,which duplicate with below 
https://github.com/pytorch/pytorch/blob/50fa5880e831c0a1d5e0c2469dacfd0b0b8ff85d/aten/src/ATen/native/RNN.cpp#L676-L690
3. Add some checks
4. support 1D
5. Add Test