### PR TITLE
When byteorder record is missing load as little endian by default

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -14,6 +14,7 @@ import copy
 import pickle
 import shutil
 import pathlib
+import platform
 from copy import deepcopy
 from itertools import product
 
@@ -3858,6 +3859,47 @@ class TestSerialization(TestCase, SerializationMixin):
             self.assertFalse(torch.equal(tensor_le_no_bom, tensor_be_bom))
             self.assertTrue(torch.equal(tensor_be_no_bom, tensor_le_bom))
             self.assertTrue(torch.equal(tensor_be_no_bom, tensor_be_bom))
+
+    @unittest.skipIf(platform.machine() != 's390x', "s390x-specific test")
+    def test_serialization_warning_s390x(self):
+        data_be_no_bom = (b'PK\x03\x04\x00\x00\x08\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                          b'\x00\x00\x00\x00\x00\x19\x00\t\x00tensor.double.BE/data.pklFB\x05\x00ZZZZZ\x80\x02'
+                          b'ctorch._utils\n_rebuild_tensor_v2\nq\x00((X\x07\x00\x00\x00storageq\x01ctorch\n'
+                          b'DoubleStorage\nq\x02X\x01\x00\x00\x000q\x03X\x03\x00\x00\x00cpuq\x04K\x04tq\x05'
+                          b'QK\x00K\x02K\x02\x86q\x06K\x02K\x01\x86q\x07\x89ccollections\nOrderedDict\nq\x08'
+                          b')Rq\ttq\nRq\x0b.PK\x07\x08S\xd3\xba&\x9b\x00\x00\x00\x9b\x00\x00\x00PK\x03\x04\x00'
+                          b'\x00\x08\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                          b'\x00\x17\x00 \x00tensor.double.BE/data/0FB\x1c\x00ZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'
+                          b'?\xc9^|\xff\xa4v\x97\xbf\xe9\xb0\x8dP\x8c\xbc\xce\xbf\xd3\xdb\xb7[\xef\x0e\xdc?\xde'
+                          b'\x00\xf9Q\x08\xb14PK\x07\x083@\x82/ \x00\x00\x00 \x00\x00\x00PK\x03\x04\x00\x00'
+                          b'\x08\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                          b'\x18\x00\x1a\x00tensor.double.BE/versionFB\x16\x00ZZZZZZZZZZZZZZZZZZZZZZ3\nPK\x07'
+                          b'\x08\xd1\x9egU\x02\x00\x00\x00\x02\x00\x00\x00PK\x01\x02\x00\x00\x00\x00\x08\x08'
+                          b'\x00\x00\x00\x00\x00\x00S\xd3\xba&\x9b\x00\x00\x00\x9b\x00\x00\x00\x19\x00\x00'
+                          b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00tensor.double.BE/da'
+                          b'ta.pklPK\x01\x02\x00\x00\x00\x00\x08\x08\x00\x00\x00\x00\x00\x003@\x82/ '
+                          b'\x00\x00\x00 \x00\x00\x00\x17\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                          b'\xeb\x00\x00\x00tensor.double.BE/data/0PK\x01\x02\x00\x00\x00\x00\x08\x08\x00\x00'
+                          b'\x00\x00\x00\x00\xd1\x9egU\x02\x00\x00\x00\x02\x00\x00\x00\x18\x00\x00\x00\x00'
+                          b'\x00\x00\x00\x00\x00\x00\x00\x00\x00p\x01\x00\x00tensor.double.BE/versionPK\x06\x06'
+                          b',\x00\x00\x00\x00\x00\x00\x00\x1e\x03-\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03'
+                          b'\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\xd2\x00\x00\x00\x00'
+                          b'\x00\x00\x00\xd2\x01\x00\x00\x00\x00\x00\x00PK\x06\x07\x00\x00\x00\x00\xa4\x02\x00'
+                          b'\x00\x00\x00\x00\x00\x01\x00\x00\x00PK\x05\x06\x00\x00\x00\x00\x03\x00\x03\x00'
+                          b'\xd2\x00\x00\x00\xd2\x01\x00\x00\x00\x00')
+
+        current_load_endian = get_default_load_endianness()
+
+        buf_be_no_bom = io.BytesIO(data_be_no_bom)
+
+        try:
+            set_default_load_endianness(None)
+            with self.assertWarnsRegex(UserWarning, "The default load endianness for checkpoints "
+                                       "without a byteorder mark on big endian machines "
+                                       "was changed from 'native' to 'little' endian"):
+                tensor_be_no_bom = torch.load(buf_be_no_bom)
+        finally:
+            set_default_load_endianness(current_load_endian)
 
     @parametrize('weights_only', (True, False))
     @unittest.skipIf(IS_WINDOWS, "NamedTemporaryFile on windows")

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1326,12 +1326,12 @@ def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', overall
         byteorderdata = zip_file.get_record(byteordername)
         if byteorderdata not in [b'little', b'big']:
             raise ValueError('Unknown endianness type: ' + byteorderdata.decode())
-    elif get_default_load_endianness() == LoadEndianness.LITTLE:
+    elif get_default_load_endianness() == LoadEndianness.LITTLE or \
+            get_default_load_endianness() is None:
         byteorderdata = b'little'
     elif get_default_load_endianness() == LoadEndianness.BIG:
         byteorderdata = b'big'
-    elif get_default_load_endianness() == LoadEndianness.NATIVE or \
-            get_default_load_endianness() is None:
+    elif get_default_load_endianness() == LoadEndianness.NATIVE:
         pass
     else:
         raise ValueError('Invalid load endianness type')
@@ -1339,11 +1339,11 @@ def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', overall
     if not zip_file.has_record(byteordername) and \
             get_default_load_endianness() is None and \
             sys.byteorder == 'big':
-        # Default behaviour should be changed in future
+        # Default behaviour was changed
         # See https://github.com/pytorch/pytorch/issues/101688
         warnings.warn("The default load endianness for checkpoints without a byteorder mark "
-                      "on big endian machines will be changed from 'native' to 'little' endian "
-                      "in a future release, to avoid this behavior please use "
+                      "on big endian machines was changed from 'native' to 'little' endian, "
+                      "to avoid this behavior please use "
                       "torch.serialization.set_default_load_endianness to set "
                       "the desired default load endianness",
                       DeprecationWarning)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1346,7 +1346,7 @@ def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', overall
                       "to avoid this behavior please use "
                       "torch.serialization.set_default_load_endianness to set "
                       "the desired default load endianness",
-                      DeprecationWarning)
+                      UserWarning)
 
     def load_tensor(dtype, numel, key, location):
         name = f'data/{key}'


### PR DESCRIPTION
Fixes #101688
