### PR TITLE
Use fmt::print to format exception messages

### DIFF
--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -147,10 +147,9 @@ static PyObject* THPGenerator_manualSeed(PyObject* _self, PyObject* seed) {
   HANDLE_TH_ERRORS
   auto self = (THPGenerator*)_self;
   auto generator = self->cdata;
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(seed),
-      "manual_seed expected a long, "
-      "but got %s",
+      "manual_seed expected a long, but got {}",
       THPUtils_typename(seed));
   uint64_t unsigned_seed = unpack_uint64(seed);
   // See Note [Acquire lock when using random generators]
@@ -165,10 +164,9 @@ static PyObject* THPGenerator_setOffset(PyObject* _self, PyObject* offset) {
   HANDLE_TH_ERRORS
   auto self = (THPGenerator*)_self;
   auto generator = self->cdata;
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(offset),
-      "manual_offset expected a long, "
-      "but got %s",
+      "manual_offset expected a long, but got {}",
       THPUtils_typename(offset));
   uint64_t unsigned_offset = unpack_uint64(offset);
   // See Note [Acquire lock when using random generators]

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -127,13 +127,13 @@ static PyObject* THPModule_initNames(PyObject* self, PyObject* arg) {
   names.reserve(names.size() + num_classes);
   for (Py_ssize_t i = 0; i < num_classes; i++) {
     PyObject* obj = PySequence_Fast_GET_ITEM(types.get(), i);
-    THPUtils_assert(PyType_Check(obj), "expected a PyTypeObject");
+    THPUtils_assert_ext(PyType_Check(obj), "expected a PyTypeObject");
     PyTypeObject* type = (PyTypeObject*)obj;
 
     THPObjectPtr module_name(PyObject_GetAttrString(obj, "__module__"));
     if (!module_name)
       return nullptr;
-    THPUtils_assert(
+    THPUtils_assert_ext(
         THPUtils_checkString(module_name.get()),
         "expected __module__ to be a string");
     std::string name = THPUtils_unpackString(module_name.get());
@@ -206,10 +206,9 @@ static PyObject* THPModule_initExtension(
 // checks if our build environment is misconfigured.
 
 static PyObject* THPModule_crashIfCsrcASAN(PyObject* module, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
-      "crash_if_csrc_asan expects an int, "
-      "but got %s",
+      "crash_if_csrc_asan expects an int, but got {}",
       THPUtils_typename(arg));
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
   volatile char x[3];
@@ -219,10 +218,9 @@ static PyObject* THPModule_crashIfCsrcASAN(PyObject* module, PyObject* arg) {
 }
 
 static PyObject* THPModule_crashIfCsrcUBSAN(PyObject* module, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
-      "crash_if_csrc_ubsan expects an int, "
-      "but got %s",
+      "crash_if_csrc_ubsan expects an int, but got {}",
       THPUtils_typename(arg));
   int32_t x = THPUtils_unpackInt(arg);
   double y = 1.0 / x;
@@ -249,10 +247,10 @@ static PyObject* THPModule_crashIfvptrUBSAN(PyObject* module, PyObject* noarg) {
 }
 
 static PyObject* THPModule_crashIfATenASAN(PyObject* module, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
       "crash_if_aten_asan expects an int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   return THPUtils_packInt32(at::_crash_if_asan(THPUtils_unpackInt(arg)));
 }
@@ -265,10 +263,9 @@ static PyObject* THPModule_abort(PyObject* module, PyObject* noargs) {
 static PyObject* THPModule_crashIfDebugAssertsFail(
     PyObject* module,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
-      "crash_if_debug_asserts_fail expects an int, "
-      "but got %s",
+      "crash_if_debug_asserts_fail expects an int, but got {}",
       THPUtils_typename(arg));
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       THPUtils_unpackInt(arg) != 424242,
@@ -282,13 +279,12 @@ static PyObject* THPModule_getNumThreads(PyObject* module, PyObject* noargs) {
 
 static PyObject* THPModule_setNumThreads(PyObject* module, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
-      "set_num_threads expects an int, "
-      "but got %s",
+      "set_num_threads expects an int, but got {}",
       THPUtils_typename(arg));
   int nthreads = (int)THPUtils_unpackLong(arg);
-  THPUtils_assert(nthreads > 0, "set_num_threads expects a positive integer");
+  THPUtils_assert_ext(nthreads > 0, "set_num_threads expects a positive integer");
   at::set_num_threads(nthreads);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -304,13 +300,13 @@ static PyObject* THPModule_setNumInteropThreads(
     PyObject* module,
     PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
       "set_num_interop_threads expects an int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   int nthreads = (int)THPUtils_unpackLong(arg);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       nthreads > 0, "set_num_interop_threads expects a positive integer");
   at::set_num_interop_threads(nthreads);
   Py_RETURN_NONE;
@@ -419,11 +415,11 @@ PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
 PyObject* THPModule_inferSize(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   Py_ssize_t num_args = args ? (Py_ssize_t)PyTuple_Size(args) : 0;
-  THPUtils_assert(num_args == 2, "expected exactly 2 arguments");
+  THPUtils_assert_ext(num_args == 2, "expected exactly 2 arguments");
   PyObject* arg1 = PyTuple_GET_ITEM(args, 0);
-  THPUtils_assert(THPSize_Check(arg1), "expected a torch.Size as argument 1");
+  THPUtils_assert_ext(THPSize_Check(arg1), "expected a torch.Size as argument 1");
   PyObject* arg2 = PyTuple_GET_ITEM(args, 1);
-  THPUtils_assert(THPSize_Check(arg2), "expected a torch.Size as argument 2");
+  THPUtils_assert_ext(THPSize_Check(arg2), "expected a torch.Size as argument 2");
 
   auto size1 = THPUtils_unpackLongs(arg1);
   auto size2 = THPUtils_unpackLongs(arg2);
@@ -435,10 +431,10 @@ PyObject* THPModule_inferSize(PyObject* _unused, PyObject* args) {
 static PyObject* THPModule_setBackcompatBroadcastWarn(
     PyObject* module,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_backcompat_broadcast_warn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   setBackCompatBroadcastWarn(arg == Py_True);
   Py_RETURN_NONE;
@@ -456,10 +452,10 @@ static PyObject* THPModule_getBackcompatBroadcastWarn(
 static PyObject* THPModule_setBackcompatKeepdimWarn(
     PyObject* module,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_backcompat_keepdim_warn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   setBackCompatKeepdimWarn(arg == Py_True);
   Py_RETURN_NONE;
@@ -530,7 +526,7 @@ void DLPack_Capsule_Destructor(PyObject* data) {
 
 PyObject* THPModule_toDLPack(PyObject* _unused, PyObject* data) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(THPVariable_Check(data), "data must be a Tensor");
+  THPUtils_assert_ext(THPVariable_Check(data), "data must be a Tensor");
   DLManagedTensor* dlMTensor = at::toDLPack(THPVariable_Unpack(data));
   return PyCapsule_New(dlMTensor, "dltensor", DLPack_Capsule_Destructor);
   END_HANDLE_TH_ERRORS
@@ -561,10 +557,9 @@ static PyObject* THModule_rename_privateuse1_backend(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkString(arg),
-      "_rename_privateuse1_backend expects a str, "
-      "but got %s",
+      "_rename_privateuse1_backend expects a str, but got {}",
       THPUtils_typename(arg));
   const std::string backend_name = THPUtils_unpackString(arg);
   c10::register_privateuse1_backend(backend_name);
@@ -581,10 +576,10 @@ static PyObject* THModule_get_privateuse1_backend_name(
 }
 
 PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_allow_tf32_cublas expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setAllowTF32CuDNN(arg == Py_True);
   Py_RETURN_NONE;
@@ -600,10 +595,10 @@ PyObject* THPModule_allowTF32CuDNN(PyObject* _unused, PyObject* noargs) {
 PyObject* THPModule_setFloat32MatmulPrecision(
     PyObject* _unused,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkString(arg),
       "set_float32_matmul_precision expects a str, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   std::string s = THPUtils_unpackString(arg);
   at::globalContext().setFloat32MatmulPrecision(s);
@@ -623,10 +618,10 @@ PyObject* THPModule_float32MatmulPrecision(
   return THPUtils_packString(s);
 }
 PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_sdp_use_math expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setSDPUseFlash(arg == Py_True);
   Py_RETURN_NONE;
@@ -638,10 +633,10 @@ PyObject* THPModule_userEnabledFlashSDP(PyObject* _unused, PyObject* noargs) {
     Py_RETURN_FALSE;
 }
 PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_sdp_use_math expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setSDPUseMemEfficient(arg == Py_True);
   Py_RETURN_NONE;
@@ -653,10 +648,10 @@ PyObject* userEnabledMemEfficientSDP(PyObject* _unused, PyObject* noargs) {
     Py_RETURN_FALSE;
 }
 PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_sdp_use_math expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setSDPUseMath(arg == Py_True);
   Py_RETURN_NONE;
@@ -668,10 +663,10 @@ PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
     Py_RETURN_FALSE;
 }
 PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_enabled_cudnn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setUserEnabledCuDNN(arg == Py_True);
   Py_RETURN_NONE;
@@ -685,10 +680,10 @@ PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_enabled_mkldnn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setUserEnabledMkldnn(arg == Py_True);
   Py_RETURN_NONE;
@@ -703,10 +698,10 @@ PyObject* THPModule_userEnabledMkldnn(PyObject* _unused, PyObject* noargs) {
 
 PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_deterministic_cudnn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setDeterministicCuDNN(arg == Py_True);
   Py_RETURN_NONE;
@@ -758,8 +753,8 @@ PyObject* THPModule_setDeterministicFillUninitializedMemory(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
-      PyBool_Check(arg), "expected a bool, but got %s", THPUtils_typename(arg));
+  THPUtils_assert_ext(
+      PyBool_Check(arg), "expected a bool, but got {}", THPUtils_typename(arg));
   at::globalContext().setDeterministicFillUninitializedMemory(arg == Py_True);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -775,7 +770,7 @@ PyObject* THPModule_deterministicFillUninitializedMemory(
 }
 
 PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_enabled_NNPACK expects a bool, "
       "but got %s",
@@ -792,10 +787,10 @@ PyObject* THPModule_userEnabledNNPACK(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THPModule_setWarnAlways(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "setWarnOnlyOnce expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   c10::WarningUtils::set_warnAlways(arg == Py_True);
   Py_RETURN_NONE;
@@ -825,10 +820,10 @@ PyObject* THPModule_warnDeprecation(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THPModule_setBenchmarkCuDNN(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_benchmark_cudnn expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setBenchmarkCuDNN(arg == Py_True);
   Py_RETURN_NONE;
@@ -842,10 +837,10 @@ PyObject* THPModule_benchmarkCuDNN(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_allow_tf32_cublas expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setAllowTF32CuBLAS(arg == Py_True);
   Py_RETURN_NONE;
@@ -861,10 +856,10 @@ PyObject* THPModule_allowTF32CuBLAS(PyObject* _unused, PyObject* noargs) {
 PyObject* THPModule_setAllowFP16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_allow_fp16_reduction_cublas expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setAllowFP16ReductionCuBLAS(arg == Py_True);
   Py_RETURN_NONE;
@@ -882,10 +877,10 @@ PyObject* THPModule_allowFP16ReductionCuBLAS(
 PyObject* THPModule_setAllowBF16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_allow_bf16_reduction_cublas expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setAllowBF16ReductionCuBLAS(arg == Py_True);
   Py_RETURN_NONE;
@@ -901,10 +896,10 @@ PyObject* THPModule_allowBF16ReductionCuBLAS(
 }
 
 PyObject* THPModule_setFlushDenormal(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "flush_denormal expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   if (!at::globalContext().setFlushDenormal(arg == Py_True)) {
     Py_RETURN_FALSE;
@@ -930,10 +925,10 @@ PyObject* THPModule_getDefaultDevice(PyObject* _unused, PyObject* arg) {
 }
 
 PyObject* THPModule_setQEngine(PyObject* /* unused */, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
       "set_qengine expects an int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   HANDLE_TH_ERRORS
   auto qengine = THPUtils_unpackLong(arg);
@@ -972,10 +967,10 @@ PyObject* THPModule_isEnabledXNNPACK(PyObject* _unused, PyObject* noargs) {
 PyObject* THPModule_setCheckSparseTensorInvariants(
     PyObject* _unused,
     PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "set_check_sparse_tensor_invariants expects a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setCheckSparseTensorInvariants(arg == Py_True);
   Py_RETURN_NONE;
@@ -994,13 +989,13 @@ PyObject* THPModule_willEngineExecuteNode(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   bool isTHPFunction = THPFunction_Check(arg);
   bool isTHPCppFunction = torch::autograd::THPCppFunction_Check(arg);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       isTHPFunction || isTHPCppFunction,
       "_will_engine_execute_node expects an grad_fn, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   const auto exec_info = torch::autograd::get_current_graph_task_exec_info();
-  THPUtils_assert(
+  THPUtils_assert_ext(
       exec_info,
       "_get_should_execute_nodes should only be called during the backward pass");
   torch::autograd::Node* node = nullptr;
@@ -1106,10 +1101,10 @@ static PyObject* THPModule_set_display_vmap_fallback_warnings_mode(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyBool_Check(arg),
       "enabled must be a bool, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
   at::globalContext().setDisplayVmapFallbackWarnings(arg == Py_True);
   Py_RETURN_NONE;

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -458,10 +458,10 @@ static PyObject* THPStorage_pynew(
         }
       }
     } catch (const std::exception& e) {
-      THPUtils_setError(
+      THPUtils_setError_ext(
           THPStorageStr
-          "(): tried to construct a storage from a sequence (%s), "
-          "but one of the items was of type %s instead of int",
+          "(): tried to construct a storage from a sequence ({}), "
+          "but one of the items was of type {} instead of int",
           THPUtils_typename(sequence),
           THPUtils_typename(item.get()));
       return nullptr;
@@ -507,10 +507,10 @@ static PyObject* THPStorage_get(THPStorage* self, PyObject* index) {
     }
     slicelength = PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
-      THPUtils_setError(
-          "Trying to slice with a step of %lld, but only a step of "
+      THPUtils_setError_ext(
+          "Trying to slice with a step of {}, but only a step of "
           "1 is supported",
-          (long long)step);
+          step);
       return nullptr;
     }
 
@@ -555,9 +555,9 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   if (!THPByteUtils_checkReal(value)) {
-    THPUtils_setError(
+    THPUtils_setError_ext(
         "can only set storage content with a int types, but got "
-        "%s instead",
+        "{} instead",
         THPUtils_typename(value));
     return -1;
   }
@@ -577,10 +577,10 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
     }
     PySlice_AdjustIndices(len, &start, &stop, step);
     if (step != 1) {
-      THPUtils_setError(
-          "Trying to slice with a step of %lld, but only a step of "
+      THPUtils_setError_ext(
+          "Trying to slice with a step of {}, but only a step of "
           "1 is supported",
-          (long long)step);
+          step);
       return 0;
     }
     // TODO: check the bounds only once
@@ -589,8 +589,8 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
       storage_set(storage, start, rvalue);
     return 0;
   }
-  THPUtils_setError(
-      "can't index a " THPStorageStr " with %s", THPUtils_typename(index));
+  THPUtils_setError_ext(
+      "can't index a " THPStorageStr " with {}", THPUtils_typename(index));
   return -1;
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -127,10 +127,10 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
       storage.sym_nbytes() != 0;
   TORCH_CHECK(
       !invalid, "Attempted to call resize_() on an invalid python storage.")
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(number_arg),
       "resize_ expects an int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(number_arg));
   int64_t newsize = THPUtils_unpackLong(number_arg);
   c10::DeviceType device_type = storage.device_type();
@@ -198,10 +198,10 @@ static PyObject* THPStorage_fill_(PyObject* self, PyObject* number_arg) {
       storage.sym_nbytes() != 0;
   TORCH_CHECK(
       !invalid, "Attempted to call fill_() on an invalid python storage.")
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPByteUtils_checkReal(number_arg),
       "fill_ expects int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(number_arg));
   storage_fill(storage, THPByteUtils_unpackReal(number_arg));
   Py_INCREF(self);
@@ -459,7 +459,7 @@ PyObject* THPStorage_writeFile(PyObject* self, PyObject* args) {
   bool save_size = PyTuple_GetItem(args, 2) == Py_True;
   PyObject* element_size_obj = PyTuple_GET_ITEM(args, 3);
 
-  THPUtils_assert(
+  THPUtils_assert_ext(
       element_size_obj != Py_None, "_write_file: need to specify element size");
   uint64_t element_size = THPUtils_unpackUInt64(element_size_obj);
 
@@ -470,7 +470,7 @@ PyObject* THPStorage_writeFile(PyObject* self, PyObject* args) {
   }
 
   int fd = PyObject_AsFileDescriptor(file);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       fd != -1,
       "_write_file couldn't retrieve a file descriptor "
       "from given object");
@@ -485,12 +485,12 @@ PyObject* THPStorage_newWithFile(PyObject* _unused, PyObject* args) {
   TORCH_CHECK(
       PyTuple_Size(args) == 2, "_new_with_file takes exactly two arguments");
   int fd = PyObject_AsFileDescriptor(PyTuple_GetItem(args, 0));
-  THPUtils_assert(
+  THPUtils_assert_ext(
       fd != -1,
       "_new_with_file couldn't retrieve a file "
       "descriptor from given object");
   PyObject* element_size_obj = PyTuple_GET_ITEM(args, 1);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       element_size_obj != Py_None,
       "_new_with_file: need to specify element size");
   uint64_t element_size = THPUtils_unpackUInt64(element_size_obj);
@@ -512,7 +512,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
 
   PyObject* element_size_obj = PyTuple_GET_ITEM(args, 3);
 
-  THPUtils_assert(
+  THPUtils_assert_ext(
       element_size_obj != Py_None,
       "_set_from_file: need to specify element size");
   uint64_t element_size = THPUtils_unpackUInt64(element_size_obj);
@@ -520,7 +520,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
   if (!is_real_file) {
     // offset can be implemented with a call to the Python object's seek()
     // but it is currently unnecessary to support this.
-    THPUtils_assert(
+    THPUtils_assert_ext(
         offset == Py_None,
         "_set_from_file: offset is NYI for filelike objects");
 
@@ -541,7 +541,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
   if (offset != Py_None) {
     LSEEK(fd, THPUtils_unpackLong(offset), SEEK_SET);
   }
-  THPUtils_assert(
+  THPUtils_assert_ext(
       fd != -1,
       "_set_from_file couldn't retrieve a file "
       "descriptor from given object");
@@ -572,10 +572,10 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
 PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
   HANDLE_TH_ERRORS
   auto self = (THPStorage*)_self;
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(new_cdata),
       "given an invalid argument to "
-      "_set_cdata - expected an int or long, but got %s",
+      "_set_cdata - expected an int or long, but got {}",
       THPUtils_typename(new_cdata));
   c10::StorageImpl* ptr = (c10::StorageImpl*)PyLong_AsVoidPtr(new_cdata);
   self->cdata.~MaybeOwned<c10::Storage>();
@@ -588,12 +588,12 @@ PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
 
 PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(PyTuple_GET_SIZE(args) == 1, "tuple of 1 item expected");
+  THPUtils_assert_ext(PyTuple_GET_SIZE(args) == 1, "tuple of 1 item expected");
   PyObject* _elem_size = PyTuple_GET_ITEM(args, 0);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(_elem_size), "_byteswap(): arg must be an 'int'");
   auto elem_size = THPUtils_unpackLong(_elem_size);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       elem_size == 1 || elem_size == 2 || elem_size == 4 || elem_size == 8,
       "elem_size must be 1, 2, 4, or 8");
 
@@ -604,9 +604,9 @@ PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
   if (elem_size == 1) {
     Py_RETURN_NONE;
   }
-  THPUtils_assert(
+  THPUtils_assert_ext(
       nbytes % elem_size == 0,
-      "the length of data is not a multiple of %ld",
+      "the length of data is not a multiple of {}",
       elem_size);
 
   if (elem_size == 2) {

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -204,23 +204,22 @@ PyObject* THPEngine_run_backward(
           &allow_unreachable,
           &accumulate_grad))
     return nullptr;
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyTuple_Check(tensors),
       "tensors argument is expected to "
-      "be a tuple, but got %s",
+      "be a tuple, but got {}",
       THPUtils_typename(tensors));
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyTuple_Check(grad_tensors),
       "grad_tensors argument is "
-      "expected to be a tuple, but got %s",
+      "expected to be a tuple, but got {}",
       THPUtils_typename(grad_tensors));
 
   Py_ssize_t num_tensors = PyTuple_GET_SIZE(tensors);
   Py_ssize_t num_gradients = PyTuple_GET_SIZE(grad_tensors);
-  THPUtils_assert(
+  THPUtils_assert_ext(
       num_tensors == num_gradients,
-      "got %ld tensors and %ld "
-      "gradients",
+      "got {} tensors and {} gradients",
       num_tensors,
       num_gradients);
 
@@ -239,9 +238,9 @@ PyObject* THPEngine_run_backward(
   grads.reserve(num_tensors);
   for (const auto i : c10::irange(num_tensors)) {
     PyObject* _tensor = PyTuple_GET_ITEM(tensors, i);
-    THPUtils_assert(
+    THPUtils_assert_ext(
         THPVariable_Check(_tensor),
-        "element %d of tensors "
+        "element {} of tensors "
         "tuple is not a Tensor",
         i);
     const auto& variable = THPVariable_Unpack(_tensor);
@@ -255,9 +254,9 @@ PyObject* THPEngine_run_backward(
         "call autograd.grad() outside torch.vmap or file a bug report "
         "with your use case.")
     auto gradient_edge = torch::autograd::impl::gradient_edge(variable);
-    THPUtils_assert(
+    THPUtils_assert_ext(
         gradient_edge.function,
-        "element %d of tensors does not require grad and does not have a grad_fn",
+        "element {} of tensors does not require grad and does not have a grad_fn",
         i);
     roots.push_back(std::move(gradient_edge));
 
@@ -274,13 +273,13 @@ PyObject* THPEngine_run_backward(
       }
       grads.push_back(grad_var);
     } else {
-      THPUtils_assert(
+      THPUtils_assert_ext(
           grad == Py_None,
-          "element %d of gradients tuple is not a Tensor or None",
+          "element {} of gradients tuple is not a Tensor or None",
           i);
-      THPUtils_assert(
+      THPUtils_assert_ext(
           !variable.requires_grad(),
-          "element %d of gradients tuple is None, but the corresponding Tensor requires grad",
+          "element {} of gradients tuple is None, but the corresponding Tensor requires grad",
           i);
     }
   }
@@ -312,7 +311,7 @@ PyObject* THPEngine_run_backward(
         if (accumulate_grad) {
           tensor.retain_grad();
         }
-        THPUtils_assert(
+        THPUtils_assert_ext(
             tensor.requires_grad(),
             "One of the differentiated Tensors does not require grad");
         if (!grad_fn) {
@@ -330,10 +329,10 @@ PyObject* THPEngine_run_backward(
         auto node = PyTuple_GetItem(input, 0);
         bool isTHPFunction = THPFunction_Check(node);
         bool isTHPCppFunction = THPCppFunction_Check(node);
-        THPUtils_assert(
+        THPUtils_assert_ext(
             isTHPFunction || isTHPCppFunction,
             "GradientEdge first object must be an autograd.graph.Node "
-            "but got %s",
+            "but got {}",
             THPUtils_typename(node));
         std::shared_ptr<torch::autograd::Node> node_sp;
         if (isTHPFunction) {
@@ -345,9 +344,9 @@ PyObject* THPEngine_run_backward(
         auto output_nr = THPUtils_unpackUInt32(PyTuple_GetItem(input, 1));
         output_edges.emplace_back(node_sp, output_nr);
       } else {
-        THPUtils_assert(
+        THPUtils_assert_ext(
             false,
-            "all inputs have to be Tensors or GradientEdges, but got %s",
+            "all inputs have to be Tensors or GradientEdges, but got {}",
             THPUtils_typename(input));
       }
     }
@@ -367,7 +366,7 @@ PyObject* THPEngine_run_backward(
     if (!py_outputs)
       return nullptr;
     for (const auto i : c10::irange(num_inputs)) {
-      THPUtils_assert(
+      THPUtils_assert_ext(
           allow_unreachable || outputs[i].defined(),
           "One of the "
           "differentiated Tensors appears to not have been used "

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -49,7 +49,7 @@ PyObject* THPGradientEdgeClass = nullptr;
 
 #define THPFunction_assert(condition, ...) \
   if (!(condition)) {                      \
-    THPUtils_setError(__VA_ARGS__);        \
+    THPUtils_setError_ext(__VA_ARGS__);    \
     throw python_error();                  \
   }
 
@@ -374,7 +374,7 @@ static std::unordered_set<at::TensorImpl*> _mark_dirty(THPFunction* self) {
       PyTuple_Check(self->dirty_tensors),
       "autograd "
       "internal error: dirty_tensors attribute is expected to be a tuple "
-      "but is %s",
+      "but is {}",
       THPUtils_typename(self->dirty_tensors));
   Py_ssize_t num_dirty = PyTuple_GET_SIZE(self->dirty_tensors);
   dirty_inputs.reserve(num_dirty);
@@ -383,7 +383,7 @@ static std::unordered_set<at::TensorImpl*> _mark_dirty(THPFunction* self) {
     THPFunction_assert(
         THPVariable_Check(obj),
         "mark_dirty can "
-        "only accept variables, but argument %d is of type %s",
+        "only accept variables, but argument {} is of type {}",
         i,
         THPUtils_typename(obj));
 
@@ -564,7 +564,7 @@ static void _get_tensors_to_save(
     THPFunction_assert(
         PyTuple_Check(self->saved_for_forward),
         "autograd internal "
-        "error: saved_for_forward attribute is expected to be a tuple but is %s",
+        "error: saved_for_forward attribute is expected to be a tuple but is {}",
         THPUtils_typename(self->saved_for_forward));
     Py_ssize_t num_saved_for_forward =
         PyTuple_GET_SIZE(self->saved_for_forward);
@@ -580,7 +580,7 @@ static void _get_tensors_to_save(
     THPFunction_assert(
         PyTuple_Check(self->to_save),
         "autograd internal "
-        "error: to_save attribute is expected to be a tuple but is %s",
+        "error: to_save attribute is expected to be a tuple but is {}",
         THPUtils_typename(self->to_save));
 
     Py_ssize_t num_saved = PyTuple_GET_SIZE(self->to_save);
@@ -645,7 +645,7 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
       PyTuple_Check(self->non_differentiable),
       "autograd "
       "internal error: non_differentiable attribute is expected to be a "
-      "tuple but is %s",
+      "tuple but is {}",
       THPUtils_typename(self->non_differentiable));
   Py_ssize_t num_nondiff = PyTuple_GET_SIZE(self->non_differentiable);
   set.reserve(num_nondiff);
@@ -654,7 +654,7 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
     THPFunction_assert(
         THPVariable_Check(t),
         "mark_non_differentiable "
-        "only accepts variable arguments, but got %s",
+        "only accepts variable arguments, but got {}",
         THPUtils_typename(t));
     set.insert(THPVariable_Unpack(t).unsafeGetTensorImpl());
   }
@@ -692,7 +692,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject* args) {
       // Python
       if (enforce_variables) {
         THPUtils_setError(
-            "expected a Tensor argument, but got %s", THPUtils_typename(arg));
+            "expected a Tensor argument, but got {}", THPUtils_typename(arg));
         throw python_error();
       }
       Py_INCREF(Py_False);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -88,7 +88,7 @@ void THCPModule_setDevice(int device) {
 
 PyObject* THCPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to setDevice");
+  THPUtils_assert_ext(THPUtils_checkLong(arg), "invalid argument to setDevice");
   int64_t device = THPUtils_unpackLong(arg);
 
   torch::utils::cuda_lazy_init();
@@ -150,9 +150,9 @@ PyObject* THCPModule_canDeviceAccessPeer_wrap(PyObject* self, PyObject* args) {
         "(int device, int peer_device);");
     return nullptr;
   }
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg1), "invalid argument to canDeviceAccessPeer");
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg2), "invalid argument to canDeviceAccessPeer");
   int64_t device = THPUtils_unpackLong(arg1);
   int64_t peer_device = THPUtils_unpackLong(arg2);
@@ -192,7 +192,7 @@ PyObject* THCPModule_getCurrentStream_wrap(
     PyObject* /* unused */,
     PyObject* device_index) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   int64_t device = THPUtils_unpackLong(device_index);
   auto stream = at::cuda::getCurrentCUDAStream(device);
@@ -215,7 +215,7 @@ PyObject* THCPModule_getCurrentStream_raw(
     PyObject* /* unused */,
     PyObject* device_index) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   int64_t device = THPUtils_unpackLong(device_index);
   return PyLong_FromVoidPtr(at::cuda::getCurrentCUDAStream(device).stream());
@@ -226,7 +226,7 @@ PyObject* THCPModule_getDefaultStream_wrap(
     PyObject* /* unused */,
     PyObject* device_index) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(device_index), "invalid argument to getDefaultStream");
   int64_t device = THPUtils_unpackLong(device_index);
   auto stream = at::cuda::getDefaultCUDAStream(device);
@@ -372,19 +372,19 @@ PyObject* THCPModule_cudaJiteratorCompileAndLaunchKernel(
   const bool return_by_ref = THPUtils_unpackBool(return_by_ref_o);
   const int num_outputs = static_cast<int>(THPUtils_unpackLong(num_outputs_o));
 
-  THPUtils_assert(
+  THPUtils_assert_ext(
       PyTuple_Check(tensors_o),
       "tensors argument is expected to "
-      "be a tuple, but got %s",
+      "be a tuple, but got {}",
       THPUtils_typename(tensors_o));
   Py_ssize_t num_tensors = PyTuple_GET_SIZE(tensors_o);
 
   c10::SmallVector<at::Tensor> tensors;
   for (const auto i : c10::irange(num_tensors)) {
     PyObject* _tensor = PyTuple_GET_ITEM(tensors_o, i);
-    THPUtils_assert(
+    THPUtils_assert_ext(
         THPVariable_Check(_tensor),
-        "%d of input tensors tuple is not a Tensor",
+        "{} of input tensors tuple is not a Tensor",
         i);
 
     tensors.emplace_back(THPVariable_Unpack(_tensor));
@@ -466,7 +466,7 @@ PyObject* THCPModule_cudaIPCCollect(PyObject* _unused, PyObject* noargs) {
 
 PyObject* THCPModule_cudaSleep(PyObject* _unused, PyObject* cycles) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(cycles), "torch.cuda._sleep(): expected 'int'");
   int64_t unpacked_cycles = THPUtils_unpackLong(cycles);
   {
@@ -514,7 +514,7 @@ PyObject* THCPModule_cudaUnlockMutex(PyObject* module, PyObject* noargs) {
 
 PyObject* THCPModule_hasPrimaryContext(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg), "invalid argument to has_primary_context");
   int64_t device_index = static_cast<int64_t>(THPUtils_unpackLong(arg));
   if (c10::cuda::hasPrimaryContext(device_index)) {
@@ -555,7 +555,7 @@ PyObject* THCPModule_emptyCache(PyObject* _unused, PyObject* noargs) {
 
 PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg), "invalid argument to memory_allocated");
   const int device = (int)THPUtils_unpackLong(arg);
 
@@ -611,7 +611,7 @@ PyObject* THCPModule_resetAccumulatedMemoryStats(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
       "invalid argument to reset_accumulated_memory_stats");
   const int device = (int)THPUtils_unpackLong(arg);
@@ -622,7 +622,7 @@ PyObject* THCPModule_resetAccumulatedMemoryStats(
 
 PyObject* THCPModule_resetPeakMemoryStats(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg), "invalid argument to reset_peak_memory_stats");
   const int device = (int)THPUtils_unpackLong(arg);
   c10::cuda::CUDACachingAllocator::resetPeakStats(device);
@@ -831,7 +831,7 @@ PyObject* THCPModule_cudaSetSyncDebugMode(PyObject* _unused, PyObject* arg) {
   TORCH_WARN_ONCE(
       "Synchronization debug mode is a prototype feature and does not yet detect all "
       "synchronizing operations");
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg), "invalid argument to set_sync_debug_mode");
   int64_t debug_mode = THPUtils_unpackLong(arg);
   TORCH_CHECK(
@@ -1350,10 +1350,10 @@ static PyObject* THCPModule_isCurrentStreamCapturing_wrap(
 }
 
 PyObject* THCPModule_setBenchmarkLimitCuDNN(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  THPUtils_assert_ext(
       THPUtils_checkLong(arg),
       "set_benchmark_limit_cudnn expects an int, "
-      "but got %s",
+      "but got {}",
       THPUtils_typename(arg));
 #if defined(USE_ROCM)
   TORCH_WARN_ONCE(


### PR DESCRIPTION
This PR replaces printf based way of constructing exceptions with fmt::print which is more easy to use and removes redundant code. Our use of fmt::print also provides compile time check of formatting.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225