### PR TITLE
Update CopySlices to not internal assert when grad_output is undefined

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9829,6 +9829,27 @@ class TestAutogradDeviceType(TestCase):
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 s1.mul_(s2)
 
+    def test_inplace_on_view_undefined_grad_output(self, device):
+        a = torch.tensor([1.], requires_grad=True)
+        c = a.clone()
+        v = c[:]
+        b = torch.tensor(1., requires_grad=True)
+
+        class InplaceFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, other):
+                ctx.mark_dirty(x)
+                return x.mul_(2)
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad * 2, None
+
+        out = InplaceFunc.apply(v, b)
+        out.backward()
+        self.assertIsNone(b.grad)
+        self.assertEqual(a.grad.item(), 2)
+
     @skipIfMps  # the test doesn't work on MPS as double types are not supported
     def test_mv_grad_stride_0(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/38315

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -156,7 +156,11 @@ inline variable_list CopySlices::apply_impl(
   variable_list grad_inputs(num_outputs());
   for (const auto i : c10::irange(res.size())) {
     if (task_should_compute_output(i)) {
-      AT_ASSERT(res[i].defined());
+      if (!res[i].defined()) {
+        // If the output is not defined, treat it as if it was a zero tensor.
+        // This can happen if users define a custom Function.
+        continue;
+      }
       if (i == 0) {
         grad_slice.copy_(res[i]);
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108353
* #107349
* #107296

Fixes https://github.com/pytorch/pytorch/issues/107928

cc @ezyang @albanD @zou3519 @gqchen @pearu @nikitaved @Lezcano @Varal7