### PR TITLE
[export] Fix duplicated params for AOTInductor.

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -180,6 +180,22 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
+    def test_duplicated_params(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p = torch.nn.Parameter(torch.rand(6))
+                self.q = self.p
+
+            def forward(self, x):
+                return self.p * x + self.q
+
+        model = Model()
+        example_inputs = (torch.rand(6),)
+        expected = model(*example_inputs)
+        actual = torch._export.export(model, example_inputs)(*example_inputs)
+        self.assertTrue(same(actual, expected))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Summary:

Test Plan:
python benchmarks/dynamo/huggingface.py --bfloat16 --accuracy
--inference --device cuda --export --only  BertForMaskedLM

python benchmarks/dynamo/huggingface.py --bfloat16 --accuracy --inference --device cuda --export-aot-inductor --only  BertForMaskedLM

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov