### PR TITLE
[dtensor] fix two more requires_grad callsite

### DIFF
--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -202,7 +202,7 @@ class Redistribute(torch.autograd.Function):
             target_spec.placements,
             shape=input.shape,
             dtype=input.dtype,
-            requires_grad=local_tensor.requires_grad,
+            requires_grad=input.requires_grad,
             stride=input.stride(),
         )
 
@@ -239,7 +239,7 @@ class Redistribute(torch.autograd.Function):
             target_spec.placements,
             shape=grad_output.shape,
             dtype=grad_output.dtype,
-            requires_grad=local_tensor.requires_grad,
+            requires_grad=grad_output.requires_grad,
             stride=grad_output.stride(),
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108358

redistribute return a new DTensor and those returned DTensors should
follow the input DTensor requires_grad instead of the input tensor local
tensor's requires_grad