### PR TITLE
[dynamorunner] init FSDP on meta device to fix OOM on large models

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -396,7 +396,9 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         if self.args.trace_on_xla:
             # work around for: https://github.com/pytorch/xla/issues/4174
             import torch_xla  # noqa: F401
-        self.validate_model(model, example_inputs)
+        # TODO: skip initial validation for model if it is on meta device for now
+        if next(model.parameters()).device != torch.device("meta"):
+            self.validate_model(model, example_inputs)
         return device, benchmark.name, model, example_inputs, batch_size
 
     def iter_model_names(self, args):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108359

By default init models with `meta` device when using FSDP.

Example command (use own HF token):
```
HUGGING_FACE_HUB_TOKEN=hf_xxx python benchmarks/dynamo/torchbench.py --float16 -dcuda --output=./performance.csv --training --backend=eager --only llama_v2_7b_16h --fsdp --performance --timing --print-memory --multiprocess
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 @Xia-Weiwen