### PR TITLE
Add Drq to BF16 Higher Tolernace

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -148,6 +148,7 @@ REQUIRE_HIGHER_FP16_TOLERANCE = {
 
 REQUIRE_HIGHER_BF16_TOLERANCE = {
     "detectron2_fcos_r_50_fpn",
+    "drq",
 }
 
 REQUIRE_COSINE_TOLERACE = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108368

This passes for me on aws gpu but not devgpu, and was already in the `REQUIRE_HIGHER_FP16_TOLERANCE` set.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov