### PR TITLE
[inductor] Generalize pointless_cumsum_replacement pattern

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -474,7 +474,15 @@ class TestPaternMatcher(TestCase):
             ).to(torch.int64)
             return torch.cumsum(ones, 1)
 
-        for fn in (fn1, fn2):
+        def fn3():
+            twos = torch.full([5, 4, 3], 2, dtype=torch.int64)
+            return torch.cumsum(twos, 0)
+
+        def fn4():
+            x = torch.full([100], 0.1, dtype=torch.float32)
+            return torch.cumsum(x, 0)
+
+        for fn in (fn1, fn2, fn3, fn4):
             result, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True))
             self.assertNotIn("aten.cumsum", code)
             self.assertEqual(result, fn())

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -259,31 +259,34 @@ def mixed_mm(match: Match, mat1, mat2, mat2_dtype):
         aten.cumsum.default,
         CallFunction(
             torch.ops.aten.full.default,
-            [Arg(), Arg()],
-            1,
+            KeywordArg("shape"),
+            KeywordArg("fill_value"),
             dtype=KeywordArg("dtype"),
             layout=Ignored(),
             device=KeywordArg("device"),
             pin_memory=False,
             _users=MULTIPLE,
         ),
-        1,
+        KeywordArg("dim"),
         _users=MULTIPLE,
     ),
     pass_dict=pass_patterns[1],
 )
-def pointless_cumsum_replacement(match: Match, size0, size1, device, dtype):
+def pointless_cumsum_replacement(match: Match, shape, fill_value, device, dtype, dim):
     """Based on a pattern in OPTForCausalLM"""
 
-    def repl(size0, size1):
-        return torch.arange(1, size1 + 1, device=device, dtype=dtype).expand(
-            size0, size1
-        )
+    def repl(*shape):
+        dim_size = shape[dim]
+        idx = torch.arange(1, dim_size + 1, device=device, dtype=dtype)
+
+        inter_shape = [1] * len(shape)
+        inter_shape[dim] = dim_size
+        return (idx * fill_value).view(inter_shape).expand(shape)
 
     # only replace the output node, not all nodes
     match.nodes = [match.output_node()]
     with V.fake_mode:
-        match.replace_by_example(repl, [size0, size1])
+        match.replace_by_example(repl, list(shape))
 
 
 def shape_of_mm(a, b):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108373

The current pattern transforms:
```
ones([x, y]).cumsum(1) -> arange(1, 1 + y).expand([x, y])
```
but this generalizes it to
```
full(shape, fill_value).cumsum(d) ->
    (fill_value * arange(1, 1 + shape[d])).view([1..., shape[d], 1...]).expand(shape)
```

So we handle any fill value, any number of dimensions, and broadcasting to any dimension.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov