### PR TITLE
[quant][executorch] Support inception_v4 in examples

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2583,7 +2583,7 @@ class TestQuantizePT2EOps(QuantizationTestCase):
             model_graph = convert_pt2e(model_graph)
             self.assertEqual(model_fx(*example_inputs), model_graph(*example_inputs))
 
-# TODO: express this using self._test_quantizer
+# TODO: express this using self._test_quantizer, add test for inception_v4
 class TestQuantizePT2EModels(PT2EQuantizationTestCase):
     @skip_if_no_torchvision
     @skipIfNoQNNPACK

--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -345,6 +345,7 @@ def _get_share_qparams_ops_configs() -> List[BackendPatternConfig]:
         executorch_default_op_quint8_dtype_config,
     ]
     share_qparams_ops = [
+        torch.nn.Flatten,
         F.adaptive_avg_pool2d,
         F.elu,
         F.hardtanh,

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -333,6 +333,7 @@ class XNNPACKQuantizer(Quantizer):
         self._annotate_add_patterns(model, config, filter_fn)
         OP_TO_ANNOTATOR["mul_relu"](model, config, filter_fn)
         OP_TO_ANNOTATOR["mul"](model, config, filter_fn)
+        OP_TO_ANNOTATOR["cat"](model, config, filter_fn)
         self._annotate_adaptive_avg_pool2d(model, config, filter_fn)
         self._annotate_gru_io_only(model, config, filter_fn)
         return model


### PR DESCRIPTION
Summary: Verified that pt2e quant flow matches the fx flow with executorch backend config

Test Plan:
with-proxy buck2 run executorch/examples/quantization:example -- -m=ic4 --verify

```
[INFO 2023-08-31 16:08:06,923 example.py:77] prepare sqnr: inf
[INFO 2023-08-31 16:08:06,932 example.py:81] quant diff max: 0.0
[INFO 2023-08-31 16:08:06,936 example.py:85] quant sqnr: inf
```

full output: https://www.internalfb.com/intern/paste/P818520579/

Differential Revision: D48889075

