### PR TITLE
[pytorch] Small fix to docstring of FSDP.optim_state_dict_to_load

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1875,7 +1875,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             >>> )
             >>> model.load_state_dict(state_dict)
             >>> optim_state_dict = FSDP.optim_state_dict_to_load(
-            >>>     optim_state_dict, model, optim
+            >>>     model, optim, optim_state_dict
             >>> )
             >>> optim.load_state_dict(optim_state_dict)
 


### PR DESCRIPTION
Summary: Fix ordering of args in docstring

Test Plan: N/A

Differential Revision: D48889668

