### PR TITLE
[S362716] turn off constant folding

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -462,6 +462,10 @@ class TestPaternMatcher(TestCase):
         self.assertEqual(count_calls(gm.graph), 2)
 
     def test_pointless_cumsum(self):
+        # Constant folding was explicitly turned off due to issue #108388
+        # Turn it back on for test
+        torch._inductor.config.joint_graph_constant_folding = True
+
         def fn1():
             ones = torch.full(
                 [1, 128], 1, layout=torch.strided, dtype=torch.float32

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3346,6 +3346,10 @@ class CommonTemplate:
         def matmul_with_op(x, y, fn):
             return fn(x @ y)
 
+        # Constant folding was explicitly turned off due to issue #108388
+        # Turn it back on for test
+        torch._inductor.config.joint_graph_constant_folding = True
+
         foo_opt = torch.compile(matmul_with_op)
 
         # test no-op

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -163,16 +163,17 @@ benchmark_kernel = os.environ.get("TORCHINDUCTOR_BENCHMARK_KERNEL", "0") == "1"
 # Enable constant and index_expr folding
 constant_and_index_propagation = True
 
-# constant folding on the joint graph
-joint_graph_constant_folding = True
-
-# Enable indirect_indexing asserts for decompositions and lowerings
-debug_index_asserts = False
-
 
 def is_fbcode():
     return not hasattr(torch.version, "git_version")
 
+
+# constant folding on the joint graph
+# Turn off constant folding due to issue #108388
+joint_graph_constant_folding = not is_fbcode()
+
+# Enable indirect_indexing asserts for decompositions and lowerings
+debug_index_asserts = False
 
 # warnings intended for PyTorch developers, disable for point releases
 is_nightly_or_source = "dev" in torch.__version__ or "git" in torch.__version__


### PR DESCRIPTION
Summary: Constant folding is using a lot of memory and is causing OOM. Turn if off in fbcode. Also filed an issue https://github.com/pytorch/pytorch/issues/108388

Test Plan: Cloned a failed job and it's working now

Differential Revision: D48871102



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov