### PR TITLE
quantized module serialization through prepack function registration

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -340,6 +340,8 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
     engines.push_back(at::kONEDNN);
 #endif
 
+    engines.push_back(at::kQXPU);
+
 #ifdef USE_FBGEMM
     if (fbgemm::fbgemmSupportedCPU()) {
       engines.push_back(at::kX86);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7539,7 +7539,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA, Meta, MPS: set_
+    CPU, CUDA, QuantizedCPU, Meta, MPS: set_
   autogen: set.source_Storage, set.source_Storage_out
 
 - func: set_.source_Storage_storage_offset(Tensor(a!) self, Storage source, SymInt storage_offset, SymInt[] size, SymInt[] stride=[]) -> Tensor(a!)

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -177,9 +177,9 @@ Tensor& set_storage_quantized_(
   auto* self_ = self.unsafeGetTensorImpl();
   self_->set_storage_keep_dtype(std::move(storage));
   self_->set_storage_offset(storage_offset);
-  if(strides.data() == nullptr){
+  if (strides.data() == nullptr) {
     self_->set_sizes_contiguous(sizes);
-  }else{
+  } else {
     self_->set_sizes_and_strides(sizes, strides);
   }
   return self;

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -177,7 +177,11 @@ Tensor& set_storage_quantized_(
   auto* self_ = self.unsafeGetTensorImpl();
   self_->set_storage_keep_dtype(std::move(storage));
   self_->set_storage_offset(storage_offset);
-  self_->set_sizes_and_strides(sizes, strides);
+  if(strides.data() == nullptr){
+    self_->set_sizes_contiguous(sizes);
+  }else{
+    self_->set_sizes_and_strides(sizes, strides);
+  }
   return self;
 }
 

--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -338,7 +338,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> deserialize_conv(
 
   auto& ctx = at::globalContext();
   auto eng = ctx.qEngine();
-  if(eng == at::QEngine::X86 || eng == at::QEngine::FBGEMM){
+  if (eng == at::QEngine::X86) {
   #if AT_MKLDNN_ENABLED()
     bool use_onednn = onednn_utils::should_use_onednn_quant(
         weight.value(), transpose, groups, output_padding);

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -681,6 +681,6 @@ static C10_UNUSED auto embedding_params = register_embedding_params();
 
 static C10_UNUSED auto conv2d_prepack = init_conv2d_prepack();
 static C10_UNUSED auto conv3d_prepack = init_conv3d_prepack();
-static C10_UNUSED auto linear_preapck = init_linear_prepack();
+static C10_UNUSED auto linear_prepack = init_linear_prepack();
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -679,8 +679,8 @@ static C10_UNUSED auto conv3d_params = register_conv_params<3>();
 static C10_UNUSED auto linear_params = register_linear_params();
 static C10_UNUSED auto embedding_params = register_embedding_params();
 
-static auto sel_2d = init_conv2d_prepack();
-static auto sel_3d = init_conv3d_prepack();
-static auto sel_linear = init_linear_prepack();
+static C10_UNUSED auto conv2d_prepack = init_conv2d_prepack();
+static C10_UNUSED auto conv3d_prepack = init_conv3d_prepack();
+static C10_UNUSED auto linear_preapck = init_linear_prepack();
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -565,26 +565,26 @@ TORCH_API int init_conv3d_prepack(){
   register_prepack<3>(at::QEngine::X86, (PackedConvWeight<3>::prepack));
 #endif
 
-#if AT_MKLDNN_ENABLED()
-  register_prepack<3>(at::QEngine::ONEDNN, (PackedConvWeightsOnednn<3>::prepack));
-#endif
-
 #ifdef USE_PYTORCH_QNNPACK
   register_prepack<3>(at::QEngine::QNNPACK, (PackedConvWeightsQnnp<3>::prepack));
+#endif
+
+#if AT_MKLDNN_ENABLED()
+  register_prepack<3>(at::QEngine::ONEDNN, (PackedConvWeightsOnednn<3>::prepack));
 #endif
 
   return 0;
 }
 
 int init_linear_prepack(){
-#ifdef USE_PYTORCH_QNNPACK
+#ifdef USE_FBGEMM
   register_linear_prepack(at::QEngine::FBGEMM, PackedLinearWeight::prepack);
   register_linear_prepack_fp16(at::QEngine::FBGEMM, PackedLinearWeightFp16::prepack);
   register_linear_prepack(at::QEngine::X86, PackedLinearWeight::prepack);
   register_linear_prepack_fp16(at::QEngine::X86, PackedLinearWeightFp16::prepack);
 #endif
 
-#ifdef USE_PYTORCH_QNN_PACK
+#ifdef USE_PYTORCH_QNNPACK
  register_linear_prepack(at::QEngine::QNNPACK, PackedLinearWeightsQnnp::prepack);
 #endif
 

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -17,6 +17,7 @@ enum class QEngine : uint8_t {
   QNNPACK = 2,
   ONEDNN = 3,
   X86 = 4,
+  QXPU= 5,
 };
 
 constexpr auto kNoQEngine = QEngine::NoQEngine;
@@ -24,6 +25,7 @@ constexpr auto kFBGEMM = QEngine::FBGEMM;
 constexpr auto kQNNPACK = QEngine::QNNPACK;
 constexpr auto kONEDNN = QEngine::ONEDNN;
 constexpr auto kX86 = QEngine::X86;
+constexpr auto kQXPU = QEngine::QXPU;
 
 inline std::string toString(QEngine qengine) {
   switch (qengine) {
@@ -37,6 +39,8 @@ inline std::string toString(QEngine qengine) {
       return "ONEDNN";
     case kX86:
       return "X86";
+    case kQXPU:
+      return "QXPU";
     default:
       TORCH_CHECK(
           false, "Unrecognized Quantized Engine: ", static_cast<int>(qengine));

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -17,7 +17,7 @@ enum class QEngine : uint8_t {
   QNNPACK = 2,
   ONEDNN = 3,
   X86 = 4,
-  QXPU= 5,
+  QXPU = 5,
 };
 
 constexpr auto kNoQEngine = QEngine::NoQEngine;

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -17,7 +17,7 @@ def _get_qengine_id(qengine: str) -> int:
         ret = 3
     elif qengine == "x86":
         ret = 4
-    elif qengine == 'qxpu':
+    elif qengine == "qxpu":
         ret = 5
     else:
         ret = -1

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -17,6 +17,8 @@ def _get_qengine_id(qengine: str) -> int:
         ret = 3
     elif qengine == "x86":
         ret = 4
+    elif qengine == 'qxpu':
+        ret = 5
     else:
         ret = -1
         raise RuntimeError(f"{qengine} is not a valid value for quantized engine")

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -726,28 +726,28 @@ WriteableTensorData getWriteableTensorData(
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.
-    if(tensor.is_quantized()){
+    if (tensor.is_quantized()) {
       result.tensor_ =
-        at::empty_quantized({0}, tensor)
-            .set_(
-                tensor.storage(),
-                /* storage_offset = */ 0,
-                /* size = */
-                {static_cast<int64_t>(
-                    tensor.storage().nbytes() / tensor.element_size())},
-                /* stride = */ {1})
-            .cpu();
-    }else{
+          at::empty_quantized({0}, tensor)
+              .set_(
+                  tensor.storage(),
+                  /* storage_offset = */ 0,
+                  /* size = */
+                  {static_cast<int64_t>(
+                      tensor.storage().nbytes() / tensor.element_size())},
+                  /* stride = */ {1})
+              .cpu();
+    } else {
       result.tensor_ =
-        at::empty({0}, tensor.options())
-            .set_(
-                tensor.storage(),
-                /* storage_offset = */ 0,
-                /* size = */
-                {static_cast<int64_t>(
-                    tensor.storage().nbytes() / tensor.element_size())},
-                /* stride = */ {1})
-            .cpu();
+          at::empty({0}, tensor.options())
+              .set_(
+                  tensor.storage(),
+                  /* storage_offset = */ 0,
+                  /* size = */
+                  {static_cast<int64_t>(
+                      tensor.storage().nbytes() / tensor.element_size())},
+                  /* stride = */ {1})
+              .cpu();
     }
     TORCH_CHECK(
         result.tensor_.storage().nbytes() == result.size_,

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -606,8 +606,7 @@ PickleOpCode Unpickler::readInstruction() {
 
       at::Tensor tensor;
       if (options.backend() == c10::Backend::QuantizedCPU) {
-        tensor = at::_empty_affine_quantized({}, options, 0, 0)
-                     .set_(storage, 0, {}, {});
+        tensor = at::_empty_affine_quantized({}, options, 0, 0).set_(storage);
       } else {
         tensor = at::empty({0}, options).set_(storage);
       }


### PR DESCRIPTION
Fixes #108399

# Motivation

PyTorch only can serialize&deserialize parameters in quantized model for official supported QEngine now. There's no chance to extend it to achieve this goal for out-of-tree QEngine based on current code structure.  `torch.save/torch.load` would fail with a ScriptModule on QuantizedXPU backend.

Serializing quantized module (e.g. `ConvPackedParamsBase, LinearPrepackParamsBase`) depends on specific `prepack&unpack` implementation with regard to each QEngine.  We want to propose a mechanism that allows out-of-tree QEngines register their `prepack` implementation in PyTorch to finish the overall serialization process.

# Modification 
1. Add `register_prepack` `get_device_prepack_fn` utils pair for `qconv`, `qlinear` to register and query the pointer to prepacking function of each QEngine.
2. Add qengine `QXPU`, which is the engine for quantized XPU

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10