### PR TITLE
[pt2] Turn on cudagraph tree in fbcode

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -321,7 +321,7 @@ class triton:
     cudagraphs = False
 
     # Use cudagraph trees for memory pooling if `cudagraphs` is True
-    cudagraph_trees = not is_fbcode()
+    cudagraph_trees = True
 
     # assertions not on the fast path, steady state
     slow_path_cudagraph_asserts = True


### PR DESCRIPTION
Summary:
cudagraph tree will significantly reduce the memory usage>
Memory consumption wise: {F1081833757}

with cudagraph tree: 65GB
w/o cudagraph tree: 83GB

Differential Revision: D48907239




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov