### PR TITLE
Revert D48801487: Multisect successfully blamed "D48801487: [export] Copy gm before calling PassManager" for test or build failures

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -398,7 +398,7 @@ class ExportedProgram:
         )
 
         pm = PassManager(list(passes))
-        res = pm(copy.deepcopy(self.graph_module))
+        res = pm(self.graph_module)
         transformed_gm = res.graph_module if res is not None else self.graph_module
         assert transformed_gm is not None
 


### PR DESCRIPTION
Summary:
This diff is reverting D48801487
D48801487: [export] Copy gm before calling PassManager by digantdesai has been identified to be causing the following test or build failures:

Tests affected:
- [on_device_ai/Assistant/Jarvis/compiler:test_passes - test_calculate_peak_memory_pass (on_device_ai.Assistant.Jarvis.compiler.tests.test_passes.TestMemPlanningPasses)](https://www.internalfb.com/intern/test/844425014917237/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2930767
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D48901081


