### PR TITLE
Fix for out of bounds read in torch flatbuffer loader

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -753,8 +753,6 @@ mobile::Module parse_and_initialize_mobile_module(
     c10::optional<at::Device>,
     ExtraFilesMap* extra_files,
     bool should_copy_tensor_memory) {
-  TORCH_CHECK(
-      mobile::serialization::ModuleBufferHasIdentifier(data), "Format error");
   // TODO(T128189662): If not copying, enforce that data is aligned to
   // kFlatbufferDataAlignmentBytes, and add unit tests.
 
@@ -763,6 +761,9 @@ mobile::Module parse_and_initialize_mobile_module(
   TORCH_CHECK(
       mobile::serialization::VerifyModuleBuffer(verifier),
       "Malformed Flatbuffer module");
+
+  TORCH_CHECK(
+      mobile::serialization::ModuleBufferHasIdentifier(data), "Format error");
 
   FlatbufferLoader loader;
   loader.setShouldCopyTensorMemory(should_copy_tensor_memory);


### PR DESCRIPTION
Summary:
This diff fixes an out of bounds read issue that was introduced because we were accessing a flatbuffer object before verifying it.

This diff moves the accessing code after the verification call to remove the potential for the out of bounds read condition.

Test Plan: Out of bounds read crash no longer reproduces

Differential Revision: D48875827


