### PR TITLE
[XNNPACK] Enable XX kernels

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1905,7 +1905,6 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-DXNN_NO_U8_OPERATORS",
             "-DXNN_NO_X32_OPERATORS",
             "-DXNN_NO_X8_OPERATORS",
-            "-DXNN_NO_XX_OPERATORS",
             "-DXNN_ENABLE_MEMOPT",
             "-DXNN_ENABLE_SPARSE=0",
             "-DXNN_ENABLE_JIT=0",


### PR DESCRIPTION
Summary: Enables copy, pad, fill etc. kernels in XNNPACK library. This shouldn't be too bad size implication.

Test Plan: CI

Differential Revision: D48915384


