### PR TITLE
[inductor] Handle aten.full's dtype in the decomposition

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -270,7 +270,7 @@ class TestInductorDynamic(TestCase):
 
     def test_full(self, device):
         def fn(a):
-            return torch.full((3,), a)
+            return torch.full((3,), a), torch.full((3,), torch.sym_float(a))
 
         cfn = self.compile_fn(fn)
         expect = fn(5)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -119,9 +119,10 @@ def clamp(x, min=None, max=None):
 
 @register_decomposition([aten.full])
 def full(size, fill_value, **kwargs):
-    if "dtype" not in kwargs:
-        dtype = type_to_dtype(type(fill_value))
-        return aten.full(size, fill_value, dtype=dtype, **kwargs)
+    dtype = kwargs.get("dtype")
+    if dtype is None:
+        kwargs["dtype"] = type_to_dtype(type(fill_value))
+        return aten.full(size, fill_value, **kwargs)
     return NotImplemented
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -18,6 +18,7 @@ from torch._decomp.decompositions import (
 )
 from torch._decomp.decompositions_for_rng import extra_random_decomps
 from torch._higher_order_ops.out_dtype import out_dtype
+from torch._prims_common import type_to_dtype
 
 from . import config
 
@@ -114,6 +115,14 @@ def clamp(x, min=None, max=None):
     if max is not None:
         x = x.clamp_max(max)
     return x
+
+
+@register_decomposition([aten.full])
+def full(size, fill_value, **kwargs):
+    if "dtype" not in kwargs:
+        dtype = type_to_dtype(type(fill_value))
+        return aten.full(size, fill_value, dtype=dtype, **kwargs)
+    return NotImplemented
 
 
 # TorchInductor-only decomposition. It should not be taken to core.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2450,7 +2450,7 @@ def copy_strided(x, stride):
 
 @register_lowering([torch.full, aten.full])
 def full(size, fill_value, **kwargs):
-    assert "dtype" in kwargs, "dtype should be handled by decomposition"
+    assert kwargs.get("dtype") is not None, "dtype should be handled by decomposition"
     return tensor_constructor(fill_value)(size, **kwargs)
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -23,7 +23,6 @@ from torch._prims_common import (
     is_float_dtype,
     is_integer_dtype,
     Number,
-    type_to_dtype,
 )
 from torch.fx.experimental.symbolic_shapes import magic_methods, method_to_operator
 from torch.utils._pytree import tree_flatten
@@ -129,15 +128,6 @@ def decode_dtype(dtype: int):
     assert dtype in DTYPE_ID_LOOKUP, f"id {dtype} missing from DTYPE_ID_LOOKUP"
     dtype = DTYPE_ID_LOOKUP[dtype]
     return dtype
-
-
-def value_to_dtype(value: Any) -> torch.dtype:
-    if isinstance(value, sympy.Expr):
-        if value.is_integer:  # type: ignore[attr-defined]
-            return torch.long
-        if value.is_real:
-            return torch.get_default_dtype()
-    return type_to_dtype(type(value))
 
 
 def is_integer_type(x):
@@ -2460,8 +2450,7 @@ def copy_strided(x, stride):
 
 @register_lowering([torch.full, aten.full])
 def full(size, fill_value, **kwargs):
-    dtype = kwargs.get("dtype")
-    kwargs["dtype"] = dtype if dtype is not None else value_to_dtype(fill_value)
+    assert "dtype" in kwargs, "dtype should be handled by decomposition"
     return tensor_constructor(fill_value)(size, **kwargs)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108443

In the lowering we don't have `SymFloat` and `SymInt`, we just have `sympy.Expr`
so it is impossible to accurately determine the expected dtype of a `full` call.
For example, `sym_float(int_expr)` has `is_integer=True` but should be treated
as a float. In the decomposition though, we can get this right.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov