### PR TITLE
[unwind.cpp] In process unwind symbolization

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1367,6 +1367,7 @@ if($ENV{TH_BINARY_BUILD})
 endif()
 
 target_link_libraries(torch_cpu PUBLIC c10)
+target_link_libraries(torch_cpu PRIVATE bfd)
 target_link_libraries(torch_cpu PUBLIC ${Caffe2_PUBLIC_DEPENDENCY_LIBS})
 target_link_libraries(torch_cpu PRIVATE ${Caffe2_DEPENDENCY_LIBS})
 target_link_libraries(torch_cpu PRIVATE ${Caffe2_DEPENDENCY_WHOLE_LINK_LIBS})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108469

(WIP to debug build issues)
Replaces the Symbolizer which calls `addr2line` with one that uses
libbfd in process to do the same work. This is a little nicer to deal with
because it doesn't have to fork, which can be a problem for large applications.
It also doesn't keep subprocesses around that might not clean up nicely.

libbfd is the same library addr2line uses, so the results should be equivalent
and take about the same time to generate.

This uses `std::async` to launch threads because libbfd is pretty slow,
and doing so matches the performance of the previous version which launched
processes instead of threads.

Differential Revision: [D48980893](https://our.internmc.facebook.com/intern/diff/D48980893)