### PR TITLE
Don't call release_lock_on_cudamalloc on ROCm

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -176,6 +176,7 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-build:
+    # To let ROCm job run on PR, to be undo later
     # if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -176,8 +176,7 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-build:
-    # To let ROCm job run on PR, to be undo later
-    # if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -176,7 +176,7 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-build:
-    if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3620,7 +3620,7 @@ class TestCudaMallocAsync(TestCase):
             self.assertTrue(pow2_div2_mem - start_mem == power2_div(nbytes_big, 2))
 
         torch.cuda.memory.empty_cache()
-        if TEST_CUDA:
+        if not TEST_WITH_ROCM:
             # NB: This is not available on ROCm
             torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:True")
         start_mem = torch.cuda.memory_stats()[key_allocated]
@@ -3637,7 +3637,7 @@ class TestCudaMallocAsync(TestCase):
         with self.assertRaises(RuntimeError):
             torch.cuda.memory._set_allocator_settings("max_split_size_mb:2")
 
-        if TEST_CUDA:
+        if not TEST_WITH_ROCM:
             # NB: This is not available on ROCm
             with self.assertRaises(RuntimeError):
                 torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:none")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3620,7 +3620,9 @@ class TestCudaMallocAsync(TestCase):
             self.assertTrue(pow2_div2_mem - start_mem == power2_div(nbytes_big, 2))
 
         torch.cuda.memory.empty_cache()
-        torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:True")
+        if TEST_CUDA:
+            # NB: This is not available on ROCm
+            torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:True")
         start_mem = torch.cuda.memory_stats()[key_allocated]
         w = torch.rand(nelems, device='cuda')
         reg_mem = torch.cuda.memory_stats()[key_allocated]
@@ -3635,8 +3637,10 @@ class TestCudaMallocAsync(TestCase):
         with self.assertRaises(RuntimeError):
             torch.cuda.memory._set_allocator_settings("max_split_size_mb:2")
 
-        with self.assertRaises(RuntimeError):
-            torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:none")
+        if TEST_CUDA:
+            # NB: This is not available on ROCm
+            with self.assertRaises(RuntimeError):
+                torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:none")
 
 
     def test_raises_oom(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3619,14 +3619,14 @@ class TestCudaMallocAsync(TestCase):
             # not supported with the cudaMallocAsync backend
             self.assertTrue(pow2_div2_mem - start_mem == power2_div(nbytes_big, 2))
 
-        torch.cuda.memory.empty_cache()
         if not TEST_WITH_ROCM:
+            torch.cuda.memory.empty_cache()
             # NB: This is not available on ROCm
             torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:True")
-        start_mem = torch.cuda.memory_stats()[key_allocated]
-        w = torch.rand(nelems, device='cuda')
-        reg_mem = torch.cuda.memory_stats()[key_allocated]
-        self.assertTrue(reg_mem - start_mem == nbytes)
+            start_mem = torch.cuda.memory_stats()[key_allocated]
+            w = torch.rand(nelems, device='cuda')
+            reg_mem = torch.cuda.memory_stats()[key_allocated]
+            self.assertTrue(reg_mem - start_mem == nbytes)
 
         with self.assertRaises(RuntimeError):
             torch.cuda.memory._set_allocator_settings("foo:1,bar:2")


### PR DESCRIPTION
This change https://github.com/pytorch/pytorch/pull/108367 breaks ROCm tests in trunk.  This was landed internally, so it might be easier to forward fix the test instead.

The failure https://hud.pytorch.org/pytorch/pytorch/commit/b8af8ac784905ff4d20792959e3920d01acfa8cf is that the new `release_lock_on_cudamalloc` function is not available on ROCm.

### Testing

The test passes on ROCm https://github.com/pytorch/pytorch/actions/runs/6057040907/job/16437921431

Fixes #108476

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang