### PR TITLE
[Dynamo][Guard]expose guard code

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1146,9 +1146,7 @@ class CheckFunctionManager:
 
         unique_code_parts = list(unique(code_parts))
         make_guard_fn_args = ", ".join(closure_vars.keys())
-        guard_body, pycode, guard_code = build_guard_function(
-            unique_code_parts, make_guard_fn_args
-        )
+        guard_body, pycode = build_guard_function(unique_code_parts, make_guard_fn_args)
 
         if os.environ.get("TORCHDYNAMO_PRINT_GUARDS", None) == "1":
             print("GUARDS\n", guard_body)
@@ -1202,7 +1200,7 @@ class CheckFunctionManager:
         return None
 
 
-def build_guard_function(code_parts, closure_args) -> Tuple[str, str, str]:
+def build_guard_function(code_parts, closure_args) -> Tuple[str, str]:
     from torch._inductor.utils import IndentedBuffer
 
     if HAS_UNPARSE_FUNCTIONS:
@@ -1242,7 +1240,7 @@ def build_guard_function(code_parts, closure_args) -> Tuple[str, str, str]:
         make_guard_fn.splice(guard)
         make_guard_fn.writeline("return guard")
 
-    return guard_body.getvalue(), make_guard_fn.getvalue(), guard.getvalue()
+    return guard_body.getvalue(), make_guard_fn.getvalue()
 
 
 stashed_first_fail_reason = None

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1167,7 +1167,7 @@ class CheckFunctionManager:
         # TODO(whc) maybe '.code_parts' was only kept around for the guard callback? so we don't need both
         guard_fn.args = largs
         guard_fn.code_parts = code_parts
-        guard_fn.src = guard_code
+        guard_fn.src = guard_body
         # Grab only G, but preserve "G" because guards access it as "G"
         guard_fn.global_scope = {
             "G": global_builder.scope["G"],


### PR DESCRIPTION
This is part of ongoing efforts to expose more information to users so that they can check and understand how dynamo works.

This PR exposes the source code of guards to users. Together with the `_debug_get_cache_entry_list` API, users can inspect a compiled function he wants, and look into its guards.

Another proposal is to wire things up so that `inspect.getsource` works for guards. However, `inspect.getsource` works by reading the source code **file**, which does not work for dynamically generated function.

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @jansel 