### PR TITLE
Eliminate calls of c10::guts::conjunction,c10::guts::disjunction,c10::guts::negation,c10::guts::void_t, c10::invoke and c10::guts::apply

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -6,6 +6,7 @@
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/TypeList.h>
+#include <type_traits>
 
 namespace c10 {
 
@@ -17,7 +18,7 @@ class KernelFunction;
 
 template <typename T>
 using has_symint =
-  guts::disjunction<
+  std::disjunction<
     std::is_same<c10::SymInt, T>,
     std::is_same<c10::SymIntArrayRef, T>,
     std::is_same<at::OptionalSymIntArrayRef, T>,

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -3,6 +3,8 @@
 #include <ATen/core/boxing/impl/WrapFunctionIntoFunctor.h>
 #include <ATen/core/boxing/impl/WrapFunctionIntoRuntimeFunctor.h>
 
+#include <type_traits>
+
 namespace c10 {
 
 inline KernelFunction::KernelFunction()
@@ -84,7 +86,7 @@ C10_ALWAYS_INLINE Return KernelFunction::call(const OperatorHandle& opHandle, Di
     // want callers to explicitly specify the Args.
 
     // This should get inlined by compiler
-    if (guts::disjunction<has_symint<Args>...>::value) {
+    if constexpr (std::disjunction_v<has_symint<Args>...>) {
       if (sym_unboxed_kernel_func_ != nullptr) {
         auto *functor = boxed_kernel_func_.getFunctor();
         return callUnboxedKernelFunction<Return, Args...>(

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -10,6 +10,7 @@
 #include <ATen/core/boxing/BoxedKernel.h>
 
 #include <c10/util/Metaprogramming.h>
+#include <type_traits>
 
 namespace c10 {
 namespace impl {
@@ -38,7 +39,7 @@ template <class T, class Enable = void>
 struct has_ivalue_to : std::false_type {};
 
 template <class T>
-struct has_ivalue_to<T, guts::void_t<decltype(std::declval<IValue>().to<T>())>>
+struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
 : std::true_type
 {};
 
@@ -49,7 +50,7 @@ struct has_ivalue_to<T, guts::void_t<decltype(std::declval<IValue>().to<T>())>>
 // A boxable arg type is one that IValue has a constructor for.
 template <typename T>
 using can_box =
-  guts::disjunction<
+  std::disjunction<
     std::is_constructible<IValue, std::decay_t<T>>,
     // TensorOptions are not directly constructible into IValue,
     // but torch::jit::push knows how to handle them
@@ -57,18 +58,18 @@ using can_box =
   >;
 
 template <typename... Ts>
-using can_box_all = guts::conjunction<can_box<Ts>...>;
+using can_box_all = std::conjunction<can_box<Ts>...>;
 
 // an unboxable result is one that can be extracted from an IValue
 template <typename T>
 using can_unbox =
-  guts::conjunction<
-    guts::disjunction<
+   std::conjunction<
+    std::disjunction<
       has_ivalue_to<T>,
       // void returns are ok
       std::is_same<void, T>
     >,
-    guts::negation<std::is_lvalue_reference<T>>
+    std::negation<std::is_lvalue_reference<T>>
   >;
 
 //

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1069,7 +1069,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
     addCallback([childFut,
                  cb = std::move(callback)](Future& parentFut) mutable {
       try {
-        if constexpr (::std::is_convertible_v<typename c10::invoke_result_t<T &&, Future&>, IValueWithStorages>) {
+        if constexpr (::std::is_convertible_v<typename std::invoke_result_t<T &&, Future&>, IValueWithStorages>) {
           auto [ivalue, storages] = cb(parentFut);
           childFut->markCompleted(::std::move(ivalue), ::std::move(storages));
         } else {
@@ -2121,7 +2121,7 @@ template <
             std::negation<std::is_constructible<IValue, Args>>...>::value,
         std::nullptr_t>>
 inline IValue::IValue(const std::tuple<Args...>& t)
-    : IValue(c10::guts::apply(c10::ivalue::Tuple::create<const Args&...>, t)) {
+    : IValue(std::apply(c10::ivalue::Tuple::create<const Args&...>, t)) {
 }
 
 template <
@@ -2132,7 +2132,7 @@ template <
             std::negation<std::is_constructible<IValue, Args>>...>::value,
         std::nullptr_t>>
 inline IValue::IValue(std::tuple<Args...>&& t)
-    : IValue(c10::guts::apply(c10::ivalue::Tuple::create<Args&&...>, std::move(t))) {
+    : IValue(std::apply(c10::ivalue::Tuple::create<Args&&...>, std::move(t))) {
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::ConstantString> v)

--- a/aten/src/ATen/core/op_registration/infer_schema.h
+++ b/aten/src/ATen/core/op_registration/infer_schema.h
@@ -37,10 +37,10 @@ template <class... Types>
 constexpr int checkStaticTypes() {
  // Give nice error messages for some of the common error cases.
  // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
- static_assert(guts::conjunction<
+ static_assert(std::conjunction<
      bool_t<!std::is_integral<Types>::value || std::is_same<Types, int8_t>::value || std::is_same<Types, int64_t>::value || std::is_same<Types, bool>::value>...
    >::value, "INVALID TYPE: Only int8_t, int64_t and bool are supported as an integral argument type");
- static_assert(guts::conjunction<
+ static_assert(std::conjunction<
      bool_t<!std::is_same<Types, float>::value>...
    >::value, "INVALID TYPE: float is not supported as an argument type, use double instead");
  return 0;

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -36,6 +36,7 @@
 #include <ATen/native/TensorIteratorDynamicCasting.h>
 #include <ATen/cpu/vec/vec.h>
 
+#include <functional>
 #include <utility>
 
 namespace at { namespace native { inline namespace CPU_CAPABILITY {
@@ -88,7 +89,7 @@ execute_op(char* C10_RESTRICT data[], const int64_t* strides, int64_t i, int64_t
   using result_type = typename traits::result_type;
   for (; i < n; i++) {
     result_type* out_ptr = (result_type*)(data[0] + i * strides[0]);
-    *out_ptr = c10::guts::apply(std::forward<func_t>(op), dereference<traits>(
+    *out_ptr = std::apply(std::forward<func_t>(op), dereference<traits>(
         &data[1],
         &strides[1],
         i));
@@ -101,7 +102,7 @@ static inline void
 execute_op(char* C10_RESTRICT data[], const int64_t* strides, int64_t i, int64_t n, func_t&& op) {
   using traits = function_traits<func_t>;
   for (; i < n; i++) {
-    c10::guts::apply(std::forward<func_t>(op), dereference<traits>(
+    std::apply(std::forward<func_t>(op), dereference<traits>(
         &data[0],
         &strides[0],
         i));
@@ -161,7 +162,7 @@ void handle_tuple_outputs(char* C10_RESTRICT data[],
 }
 
 // Loop operation for `cpu_kernel_multiple_outputs`.
-// 1. Use `c10::guts::apply` to make dynamic method invocation
+// 1. Use `std::apply` to make dynamic method invocation
 //    for the lambda passed in `cpu_kernel_multiple_outputs`.
 // 2. Iterate over the members of the returned tuple, set the corresponding
 //    output tensor by the tuple member in `handle_tuple_outputs` function.
@@ -182,7 +183,7 @@ multiple_outputs_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_
   }
 
   for (; i < n; i++) {
-    auto output = c10::guts::apply(op, dereference<traits>(
+    auto output = std::apply(op, dereference<traits>(
       &data[num_outputs],
       &strides[num_outputs],
       i));
@@ -212,8 +213,8 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
   for (; i <= n - 2 * Vec::size(); i += 2 * Vec::size()) {
     auto args1 = dereference_vec<traits>(&data[1], opt_scalar, S, i);
     auto args2 = dereference_vec<traits>(&data[1], opt_scalar, S, i + Vec::size());
-    auto out1 = c10::guts::apply(std::forward<vec_func_t>(vop), std::move(args1));
-    auto out2 = c10::guts::apply(std::forward<vec_func_t>(vop), std::move(args2));
+    auto out1 = std::apply(std::forward<vec_func_t>(vop), std::move(args1));
+    auto out2 = std::apply(std::forward<vec_func_t>(vop), std::move(args2));
     out1.store(data[0] + i * sizeof(scalar_t));
     out2.store(data[0] + (i + Vec::size()) * sizeof(scalar_t));
   }

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -7,6 +7,7 @@
 #include <c10/util/irange.h>
 
 #include <sstream>
+#include <type_traits>
 
 namespace at { namespace native { inline namespace CPU_CAPABILITY {
 
@@ -154,7 +155,7 @@ static void set_results(const std::tuple<res_t...>& result, const TensorIterator
 }
 
 template <typename T, typename... Args>
-struct all_same : guts::conjunction<
+struct all_same : std::conjunction<
   std::is_same<T, Args>...
 > {};
 

--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -8,6 +8,7 @@
 #include <c10/core/TensorImpl.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <functional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 
@@ -193,7 +194,8 @@ struct NestedNode {
   // NestedNode(NestedNode&) = delete;
   // NestedNode(const NestedNode&) = delete;
   // NestedNode& operator=(NestedNode) = delete;
-  explicit NestedNode(T payload) : _is_leaf(true), _payload(std::move(payload)) {}
+  explicit NestedNode(T payload)
+      : _is_leaf(true), _payload(std::move(payload)) {}
   inline bool is_leaf() const {
     return _is_leaf;
   }
@@ -274,7 +276,7 @@ class _map<F, A, c10::guts::typelist::typelist<Args...>> {
             TORCH_CHECK(a.degree() > 0, "Internal assert.");
             return a.children(i);
           });
-      c10::guts::apply(
+      std::apply(
           [&result, &fn](Args... filtered) {
             result.emplace_back(function_one(std::forward<F>(fn), filtered...));
           },
@@ -366,7 +368,8 @@ inline Tensor wrap_tensor_node(
                   // for a certain tensor
                   if (tensor_node.children(i).numel() > 0) {
                     memcpy(
-                        nt_buffer.mutable_data_ptr<scalar_t>() + start_offsets[i],
+                        nt_buffer.mutable_data_ptr<scalar_t>() +
+                            start_offsets[i],
                         tensor_node.children(i).data_ptr<scalar_t>(),
                         tensor_node.children(i).numel() * sizeof(scalar_t));
                   }


### PR DESCRIPTION
C++17 provides alternations. 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @kiukchung @d4l3k @lucasllc
@huydhn  @Skylion007 