### PR TITLE
s390x SIMD: update abs() function for complex numbers

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -2410,13 +2410,13 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
     return a.mergee().data();
   }
 
-  vinner_data abs_() const {
-    auto ret = abs_2_();
-    return Vectorized<T>{ret}.real().sqrt().data();
+  static T abs_helper(const T &value)
+  {
+    return T(std::abs(value));
   }
 
   Vectorized<T> abs() const {
-    return Vectorized<T>{abs_()};
+    return mapOrdinary(abs_helper);
   }
 
   Vectorized<T> exp() const {


### PR DESCRIPTION
It propagated NANs when it should have not.
Also, replace it with std::abs due to precision mismatching.

This change fixes test_python_ref__refs_abs_cpu_complex32 test in test/test_ops.py.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10