### PR TITLE
Multi-Head Attention: Only require attn_mask if actually needed

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5249,7 +5249,7 @@ def multi_head_attention_forward(
         target_type=query.dtype
     )
 
-    if is_causal and attn_mask is None:
+    if is_causal and attn_mask is None and (key_padding_mask is not None or need_weights):
         raise RuntimeError(
             "Need attn_mask if specifying the is_causal hint. "
             "You may use the Transformer module method "


### PR DESCRIPTION
`torch.nn.MultiheadAttention` internally uses `scaled_dot_product_attention()`. For the common case of causal attention, the latter accepts an `is_causal` flag, which computes causal attention inside the kernel without having to compute an attention mask in memory. Still, `torch.nn.MultiheadAttention` and `torch.nn.functional.multi_head_attention_forward()` ask for an attention mask whenever `is_causal=True` is given:
```python
import torch
mha = torch.nn.MultiheadAttention(100, 4)
x = torch.random(2, 10, 100)
mha(x, x, x, is_causal=True, need_weights=False)  # RuntimeError
```
This short PR tightens the check for a missing attention mask so it is not required when it would be set to `None` 11 lines later anyway.
Disclaimer: I currently do not have a development setup for PyTorch and will rely on the CI, sorry.

As an aside, the docstring of `torch.nn.functional.multi_head_attention_forward()` currently reads:
> is_causal: If specified, applies a causal mask as attention mask, and ignores
>        attn_mask for computing scaled dot product attention.

This suggests that the mask is completely ignored, while it is actually still required when either `need_weights` or `key_padding_mask` is given. This could be fixed either by updating the docstring, or by creating a causal `attn_mask` on the fly when needed, and not ever complaining about a missing mask. The latter would be convenient, but it would hide to the user the opportunity to precompute the mask once and reuse it in the case of fixed sequence lengths or multiple same-size transformer layers.