### PR TITLE
[Decomposition] bernoulli

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -647,12 +647,6 @@ aten::batch_norm_stats
 aten::batch_norm_stats.out
 aten::batch_norm_update_stats
 aten::batch_norm_update_stats.out
-aten::bernoulli
-aten::bernoulli.Tensor
-aten::bernoulli.Tensor_out
-aten::bernoulli.float_out
-aten::bernoulli.out
-aten::bernoulli.p
 aten::bernoulli_.Tensor
 aten::bernoulli_.float
 aten::bincount

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -222,6 +222,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.arange.default,
             aten.arange.start,
             aten.avg_pool2d_backward,
+            aten.bernoulli,
             aten.binary_cross_entropy,
             aten.binary_cross_entropy_backward,
             aten.binary_cross_entropy_with_logits,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3907,6 +3907,12 @@ def multilabel_margin_loss_forward(
     return z, is_target
 
 
+@register_decomposition([aten.bernoulli])
+def bernoulli(self, *, generator=None):
+    assert generator is None
+    return torch.rand_like(self, dtype=torch.float32) < self
+
+
 # scaled_dot_product_attention used to be decomposed in pre-autograd, given that
 # it calls _scaled_dot_product_attention_math and
 # _scaled_dot_product_attention_math only has a CompositeImplicitAutograd

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -288,12 +288,6 @@ def lift(self):
     return self
 
 
-@register_decomposition([aten.bernoulli.default])
-def bernoulli(self, *, generator=None):
-    assert generator is None
-    return torch.rand_like(self, dtype=torch.float32) < self
-
-
 @register_decomposition([aten.fmin, prims.fmin])
 def fmin(self, other):
     return torch.where(torch.isnan(other) | (other > self), self, other)


### PR DESCRIPTION
Summary: Moving decomposition of bernoulli from _inductor/decomposition.py and include it in core_aten_decompositions

Test Plan: Phabricator + OSS Tests

Differential Revision: D48878434




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel