### PR TITLE
[Decomposition] exponential_

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -224,7 +224,6 @@ aten::expm1.out
 aten::expm1_
 aten::exponential
 aten::exponential.out
-aten::exponential_
 aten::flip
 aten::flip.out
 aten::floor

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -246,6 +246,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.empty_like,
             aten._euclidean_dist.default,
             aten.expand_as,
+            aten.exponential_,
             aten.eye,
             aten.fill,
             aten.fill_,


### PR DESCRIPTION
Summary:
Include decomp in core_aten_decompositions

Decomp already exists:
https://github.com/pytorch/pytorch/blob/ff38c0e2f9cae35378553c38ccf7188007fed938/torch/_decomp/decompositions_for_rng.py#L229

Test Plan: Phabricator + OSS Tests

Differential Revision: D48939790


