### PR TITLE
[Decomposition] full_like

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -243,10 +243,6 @@ aten::fmod.Tensor
 aten::fmod.Tensor_out
 aten::fmod_.Scalar
 aten::fmod_.Tensor
-aten::full
-aten::full.names
-aten::full.names_out
-aten::full.out
 aten::gcd
 aten::gcd.out
 aten::gcd_

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -765,8 +765,10 @@ aten::frexp.Tensor
 aten::frexp.Tensor_out
 aten::from_file
 aten::from_file.out
-aten::full_like
-aten::full_like.out
+aten::full
+aten::full.names
+aten::full.names_out
+aten::full.out
 aten::gather
 aten::gather.out
 aten::geqrf

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1826,6 +1826,7 @@ class TestRefsOpsInfo(TestCase):
         '_refs.fliplr',
         '_refs.flipud',
         '_refs.float_power',
+        '_refs.full',
         '_refs.hsplit',
         '_refs.hstack',
         '_refs.isclose',

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -249,6 +249,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.eye,
             aten.fill,
             aten.fill_,
+            aten.full_like,
             aten.frac,
             aten.frac_,
             aten._fused_moving_avg_obs_fq_helper,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,28 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition(aten.full_like)
+def full_like(
+    self,
+    fill_value,
+    *,
+    dtype=None,
+    layout=None,
+    device=None,
+    pin_memory=False,
+    requires_grad=False,
+    memory_format=torch.preserve_format,
+):
+    return torch.full(
+        [*self.size()],
+        fill_value,
+        dtype=dtype or self.dtype,
+        layout=layout or self.layout,
+        device=device or self.device,
+        requires_grad=requires_grad,
+    ).to(memory_format=memory_format)
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -71,6 +71,7 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 decomps_to_exclude = [
     aten._unsafe_index,
     aten._scaled_dot_product_flash_attention.default,  # See comments in torch/_decomp/decompositions.py
+    aten.full_like,
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)
@@ -341,28 +342,6 @@ def randn_like(self, *, dtype=None, device=None, **kwargs):
         dtype=dtype or self.dtype,
         device=device or self.device,
         **kwargs,
-    )
-
-
-@register_decomposition(aten.full_like)
-def full_like(
-    self,
-    fill_value,
-    *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=False,
-    requires_grad=False,
-    memory_format=torch.preserve_format,
-):
-    return torch.full(
-        [*self.size()],
-        fill_value,
-        dtype=dtype or self.dtype,
-        layout=layout or self.layout,
-        device=device or self.device,
-        requires_grad=requires_grad,
     )
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5257,7 +5257,6 @@ def eye(
     # result.requires_grad_(requires_grad)
 
 
-@register_decomposition(aten.full)
 @out_wrapper()
 def full(
     shape: ShapeType,


### PR DESCRIPTION
Summary: Moving decomposition from _inductor/decomposition.py and include it in core_aten_decompositions

Test Plan: Phabricator + OSS Tests

Differential Revision: D48939842




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel