### PR TITLE
[Decomposition] randint

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -1045,10 +1045,8 @@ aten::rand.names_out
 aten::rand.out
 aten::rand_like
 aten::rand_like.out
-aten::randint
 aten::randint.generator
 aten::randint.generator_out
-aten::randint.low
 aten::randint.low_generator
 aten::randint.low_generator_out
 aten::randint.low_out

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -326,6 +326,8 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten._reshape_alias,
             aten.rad2deg,
             aten.rad2deg_,
+            aten.randint,
+            aten.randint.low,
             aten.renorm,
             aten.renorm_,
             aten.rot90,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,67 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition(aten.randint.default)
+def randint(
+    high,
+    size,
+    *,
+    dtype: Optional[torch.dtype] = torch.long,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None
+) -> Tensor:
+    # aten::randint(
+    #     int high,
+    #     SymInt[] size,
+    #     *,
+    #     ScalarType? dtype=long,
+    #     Layout? layout=None,
+    #     Device? device=None,
+    #     bool? pin_memory=None
+    # ) -> Tensor
+    return aten.randint.low(
+        0,
+        high,
+        size,
+        dtype=dtype,
+        layout=layout,
+        device=device,
+        pin_memory=pin_memory,
+    )
+
+
+@register_decomposition(aten.randint.low)
+def randint_low(
+    low,
+    high,
+    size,
+    *,
+    dtype: Optional[torch.dtype] = torch.long,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None
+) -> Tensor:
+    # aten::randint.low(
+    #     int low,
+    #     int high,
+    #     SymInt[] size,
+    #     *,
+    #     ScalarType? dtype=long,
+    #     Layout? layout=None,
+    #     Device? device=None,
+    #     bool? pin_memory=None
+    # ) -> Tensor
+    return torch.floor(
+        torch.rand(
+            size=size,
+            layout=(layout if layout is not None else torch.strided),
+            device=device,
+            pin_memory=(pin_memory if pin_memory is not None else False),
+        ) * (high - low) + low
+    ).to(dtype=dtype)
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -390,11 +390,6 @@ def randint_like_low(self, low, high, *, dtype=None, device=None, **kwargs):
     )
 
 
-@register_decomposition(aten.randint.default)
-def randint(high, size, **kwargs):
-    return aten.randint.low(0, high, size, **kwargs)
-
-
 # The difference between quantize_per_tensor.default and quantize_per_tensor.tensor is
 # scale and zero_point is scalar or scalar tensor
 @register_decomposition(quantized_decomposed.quantize_per_tensor.default)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1676,7 +1676,6 @@ def warn_triton_random():
 
 fallback_rand = fallback_handler(aten.rand)
 fallback_randn = fallback_handler(aten.randn)
-make_fallback(aten.randint)
 
 
 @register_lowering(aten.rand)


### PR DESCRIPTION
Summary: Moving decomposition from _inductor/decomposition.py and include it in core_aten_decompositions

Test Plan: Phabricator + OSS Tests

Differential Revision: D48940203




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel