### PR TITLE
[Decomposition] randn_like

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -1062,8 +1062,6 @@ aten::randn.generator_with_names
 aten::randn.generator_with_names_out
 aten::randn.names
 aten::randn.names_out
-aten::randn_like
-aten::randn_like.out
 aten::random
 aten::random.from
 aten::random.from_out

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -326,6 +326,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten._reshape_alias,
             aten.rad2deg,
             aten.rad2deg_,
+            aten.randn_like,
             aten.renorm,
             aten.renorm_,
             aten.rot90,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,16 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition(aten.randn_like)
+def randn_like(self, *, dtype=None, device=None, **kwargs):
+    return torch.randn(
+        [*self.size()],
+        dtype=dtype or self.dtype,
+        device=device or self.device,
+        **kwargs,
+    ).as_strided(self.size(), self.stride())
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -334,16 +334,6 @@ def rand_like(self, *, dtype=None, device=None, **kwargs):
     )
 
 
-@register_decomposition(aten.randn_like)
-def randn_like(self, *, dtype=None, device=None, **kwargs):
-    return torch.randn(
-        [*self.size()],
-        dtype=dtype or self.dtype,
-        device=device or self.device,
-        **kwargs,
-    )
-
-
 @register_decomposition(aten.full_like)
 def full_like(
     self,


### PR DESCRIPTION
Summary: Moving decomposition from _inductor/decomposition.py and include it in core_aten_decompositions

Test Plan: Phabricator + OSS Tests

Differential Revision: D48940304




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel