### PR TITLE
[Decomposition] split.Tensor

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -474,7 +474,6 @@ aten::special_zeta.other_scalar_out
 aten::special_zeta.out
 aten::special_zeta.self_scalar
 aten::special_zeta.self_scalar_out
-aten::split.Tensor
 aten::split_with_sizes
 aten::sqrt
 aten::sqrt.out

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -105,7 +105,15 @@ class TestSerialize(TestCase):
 
         serialized, _ = ExportedProgramSerializer().serialize(exported_module)
         node = serialized.graph_module.graph.nodes[-1]
-        self.assertEqual(node.target, "torch.ops.aten.split.Tensor")
+        # split.Tensor gets decomposed into split_with_sizes.default
+        self.assertIn(
+            node.target,
+            {
+                "torch.ops.aten.split.Tensor",
+                "torch.ops.aten.split_with_sizes.default",
+            }
+        )
+
         self.assertEqual(len(node.outputs), 1)
         # Input looks like:
         # tensor([[0, 1],

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -357,6 +357,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.special_entr,
             aten.special_log_ndtr,
             aten.special_xlog1py,
+            aten.split.Tensor,
             aten.std.correction,
             aten.stack,
             aten.t,


### PR DESCRIPTION
Summary:
Include decomp in core_aten_decompositions

Decomp: https://github.com/pytorch/pytorch/blob/1e9b590df989337d809fa33edd7ffc6cb60e70ff/torch/_decomp/decompositions.py#L1198

Test Plan: OSS + Phabricator Tests

Differential Revision: D48871743




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4