### PR TITLE
[Decomposition] unsafe_split.Tensor

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -517,7 +517,6 @@ aten::unfold
 aten::uniform
 aten::uniform.out
 aten::uniform_
-aten::unsafe_split.Tensor
 aten::unsafe_split_with_sizes
 aten::unsafe_split_with_sizes.out
 aten::unsqueeze

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -371,6 +371,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.unfold_backward,
             aten.unfold_copy,
             aten._unsafe_index,
+            aten.unsafe_split.Tensor,
             aten.upsample_bilinear2d,
             aten.upsample_nearest2d_backward,
             aten.view_as_complex,


### PR DESCRIPTION
Summary:
Include decomp in core_aten_decompositions

Decomp already exists

https://www.internalfb.com/code/fbsource/[03ff511cad587fc27ed8fd6a54b87845246e8e0c]/fbcode/caffe2/torch/_decomp/decompositions.py?lines=1209

Test Plan: OSS + Phabricator Tests

Differential Revision: D48940445


