### PR TITLE
[Decomposition] uniform_

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -516,7 +516,6 @@ aten::unbind.int
 aten::unfold
 aten::uniform
 aten::uniform.out
-aten::uniform_
 aten::unsafe_split.Tensor
 aten::unsafe_split_with_sizes
 aten::unsafe_split_with_sizes.out

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -370,6 +370,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.triu_,
             aten.unfold_backward,
             aten.unfold_copy,
+            aten.uniform_,
             aten._unsafe_index,
             aten.upsample_bilinear2d,
             aten.upsample_nearest2d_backward,


### PR DESCRIPTION
Summary:
Include decomp in core_aten_decompositions

Decomp already exists

https://www.internalfb.com/code/fbsource/[03ff511cad587fc27ed8fd6a54b87845246e8e0c]/xplat/caffe2/torch/_decomp/decompositions.py?lines=2178

Test Plan: OSS + Phabricator Tests

Differential Revision: D48940435


