### PR TITLE
[DTensor] Replace usage of compute_local_offset by compute_local_shape_and_global_offset

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -530,13 +530,15 @@ class DTensorMeshTest(DTensorTestBase):
             ),
         ]
 
-        from torch.distributed._tensor._utils import compute_local_offset
+        from torch.distributed._tensor._utils import (
+            compute_local_shape_and_global_offset,
+        )
 
         # loop through all sharding specs and check local shard offsets
         logical_tensor = torch.randn(tensor_shape)
         for shard_spec, expected_shard_offsets in shard_spec_and_offsets:
             dtensor = distribute_tensor(logical_tensor, device_mesh, shard_spec)
-            offset = compute_local_offset(
+            _, offset = compute_local_shape_and_global_offset(
                 dtensor.shape, device_mesh, dtensor.placements
             )
             self.assertEqual(expected_shard_offsets, offset)

--- a/test/distributed/_tensor/test_random_ops.py
+++ b/test/distributed/_tensor/test_random_ops.py
@@ -8,7 +8,7 @@ import torch.distributed._functional_collectives as funcol
 import torch.distributed._tensor.random as random
 
 from torch.distributed._tensor import DeviceMesh, DTensor
-from torch.distributed._tensor._utils import compute_local_offset
+from torch.distributed._tensor._utils import compute_local_shape_and_global_offset
 from torch.distributed._tensor.api import distribute_tensor
 from torch.distributed._tensor.placement_types import Replicate, Shard
 from torch.distributed._tensor.random import is_rng_supported_mesh, manual_seed
@@ -243,7 +243,7 @@ class DistTensorRandomOpTest(DTensorTestBase):
             self.assertEqual(shard_linear_idx, shard_index[self.rank])
 
             # compute local size and offset
-            local_shard_offset = compute_local_offset(
+            _, local_shard_offset = compute_local_shape_and_global_offset(
                 dtensor.shape, device_mesh, placements
             )
 

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -5,7 +5,6 @@ import itertools
 import torch
 from torch.distributed._tensor import distribute_tensor
 from torch.distributed._tensor._utils import (
-    compute_local_offset,
     compute_local_shape,
     compute_local_shape_and_global_offset,
 )
@@ -23,53 +22,6 @@ class UtilTest(DTensorTestBase):
     @property
     def world_size(self):
         return 8
-
-    @with_comms
-    def test_compute_local_offset_1d(self):
-        # mesh: 8 * 1
-        mesh_tensor = torch.arange(self.world_size)
-        device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-        my_rank = device_mesh.get_rank()
-        size = torch.Size([10])
-
-        placement = [Shard(0)]
-        local_size = compute_local_shape(size, device_mesh, placement)
-        local_offset = compute_local_offset(size, device_mesh, placement)
-
-        tensor = torch.ones([10])
-        tensor_lists = list(torch.chunk(tensor, self.world_size, dim=0))
-        # chunk_sizes = [2, 2, 2, 2, 2, 0, 0, 0]
-        chunk_sizes = [
-            tensor_lists[idx].size(dim=0) if idx < len(tensor_lists) else 0
-            for idx, tensor in enumerate(range(self.world_size))
-        ]
-
-        self.assertEqual(local_size[0], chunk_sizes[my_rank])
-        # Offset for empty shard on the current dimension is equal to
-        # global tensor dim size on the current dimension.
-        self.assertEqual(local_offset[0], sum(chunk_sizes[:my_rank]))
-
-    @with_comms
-    def test_compute_local_shape_2d(self):
-        # mesh: 4 * 2
-        mesh_tensor = torch.arange(self.world_size).reshape(4, 2)
-        mesh = DeviceMesh(self.device_type, mesh_tensor)
-        size = torch.Size([8, 6])
-
-        # replicate, replicate
-        placements1 = [Replicate(), Replicate()]
-        local_size1 = compute_local_shape(size, mesh, placements1)
-        self.assertEqual(local_size1, torch.Size([8, 6]))
-
-        # replicate, shard
-        placements2 = [Replicate(), Shard(0)]
-        local_size2 = compute_local_shape(size, mesh, placements2)
-        self.assertEqual(local_size2, torch.Size([4, 6]))
-
-        # shard, shard
-        placements3 = [Shard(0), Shard(1)]
-        local_size3 = compute_local_shape(size, mesh, placements3)
-        self.assertEqual(local_size3, torch.Size([2, 3]))
 
     @with_comms
     def test_compute_local_shape_2d_uneven(self):


### PR DESCRIPTION
This PR removes four usages of compute_local_offset() in PyTorch repo and replaces it with the new API compute_local_shape_and_global_offset().

We will be removing compute_local_offset() API in the next diff, as there are usages internally. 