### PR TITLE
add packaging to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ jinja2
 fsspec
 # setuptools was removed from default python install
 setuptools ; python_version >= "3.12"
+packaging


### PR DESCRIPTION
As stated in this https://github.com/pytorch/pytorch/pull/107207#issuecomment-1700674065, packaging is not a built-in python module and need to add it to requirements.txt.