### PR TITLE
Fix permuted sum precision issue for lower precision on CPU

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1172,13 +1172,13 @@ std::vector<Tensor> gradient(const Tensor& self, IntArrayRef dim, int64_t edge_o
 
 inline bool should_use_acc_buffer(at::TensorIterator& iter) {
   const auto ndim = iter.ndim();
-  if (!iter.device().is_cpu()) {
+  if (!iter.device().is_cpu() || iter.noutputs() != 1) {
     return false;
   }
   if (!at::isReducedFloatingType(iter.common_dtype())) {
     return false;
   }
-  if (ndim < 2 || iter.noutputs() != 1) {
+  if (ndim < 3) {
     return false;
   }
   auto out_strides = iter.strides(0);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1170,6 +1170,25 @@ std::vector<Tensor> gradient(const Tensor& self, IntArrayRef dim, int64_t edge_o
 
 // ALL REDUCE #################################################################
 
+inline bool should_use_acc_buffer(at::TensorIterator& iter) {
+  const auto ndim = iter.ndim();
+  if (!iter.device().is_cpu()) {
+    return false;
+  }
+  if (!at::isReducedFloatingType(iter.common_dtype())) {
+    return false;
+  }
+  if (ndim < 2 || iter.noutputs() != 1) {
+    return false;
+  }
+  auto out_strides = iter.strides(0);
+  for (const auto dim : c10::irange(0, 2)) {
+      if (out_strides[dim] != 0) {
+        return false;
+      }
+  }
+  return true;
+}
 
 TORCH_IMPL_FUNC(sum_out)
 (const Tensor& self,
@@ -1181,7 +1200,19 @@ TORCH_IMPL_FUNC(sum_out)
   if (iter.numel() == 0) {
     result.zero_();
   } else {
-    sum_stub(iter.device_type(), iter);
+    // Here is a limitation of TensorIterator reductions for permuted input with lower precision on CPU.
+    // Consider the case: TensorIterator coalesces such input and output to >= 3 dims tensors,
+    // and the output stride is [0, 0, x, x, ...] with x >= 0 (two reduced dimensions and non-reduced dims).
+    // Since the reduction loop only operates on two dimensions at a time,
+    // the intermediate sums is forced to do accumulation in the second reduced dim with lower precision.
+    // See https://github.com/pytorch/pytorch/issues/83149
+    if (should_use_acc_buffer(iter)) {
+      auto tmp_output = at::empty(result.sizes(), result.options().dtype(kFloat));
+      at::sum_outf(self.to(ScalarType::Float), opt_dim, keepdim, /*dtype=*/c10::nullopt, tmp_output);
+      result.copy_(tmp_output);
+    } else{
+      sum_stub(iter.device_type(), iter);
+    }
   }
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1178,7 +1178,7 @@ inline bool should_use_acc_buffer(at::TensorIterator& iter) {
   if (!at::isReducedFloatingType(iter.common_dtype())) {
     return false;
   }
-  if (ndim < 3) {
+  if (ndim < 2) {
     return false;
   }
   auto out_strides = iter.strides(0);
@@ -1201,7 +1201,7 @@ TORCH_IMPL_FUNC(sum_out)
     result.zero_();
   } else {
     // Here is a limitation of TensorIterator reductions for permuted input with lower precision on CPU.
-    // Consider the case: TensorIterator coalesces such input and output to >= 3 dims tensors,
+    // Consider the case: TensorIterator coalesces such input and output to >= 2 dims tensors,
     // and the output stride is [0, 0, x, x, ...] with x >= 0 (two reduced dimensions and non-reduced dims).
     // Since the reduction loop only operates on two dimensions at a time,
     // the intermediate sums is forced to do accumulation in the second reduced dim with lower precision.

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1347,32 +1347,24 @@ class TestReductions(TestCase):
     @dtypes(torch.bfloat16, torch.float16)
     def test_sum_noncontig_lowp(self, device, dtype) -> None:
         dim_sequences = {
-            2: [0, 1],
             3: [0, 1, 2],
             4: [0, 1, 2, 3],
             5: [0, 1, 2, 3, 4],
         }
 
         def helper(self, shape, reduce_dims, device, dtype):
-            permute_list = dim_sequences[len(shape)]
-            random.shuffle(permute_list)
-            x = torch.ones(shape, device=device, dtype=dtype)
-            x_trans = x.permute(permute_list)
-            x_sum = torch.sum(x_trans, reduce_dims)
-            x_trans_ref = x_trans.float()
-            x_sum_ref = torch.sum(x_trans_ref, reduce_dims)
-            self.assertEqual(x_sum, x_sum_ref.to(dtype=dtype))
+            for permute_list in list(permutations(dim_sequences[len(shape)], len(shape))):
+                x = torch.ones(shape, device=device, dtype=dtype)
+                x_trans = x.permute(permute_list)
+                x_sum = torch.sum(x_trans, reduce_dims)
+                x_trans_ref = x_trans.float()
+                x_sum_ref = torch.sum(x_trans_ref, reduce_dims)
+                self.assertEqual(x_sum, x_sum_ref.to(dtype=dtype))
 
         shapes = [
-            (10, 20),
-            (5, 2, 57),
-            (10, 55, 600),
-            (1, 7, 24, 6),
+            (10, 10, 10),
             (10, 13, 3, 3),
-            (10, 1, 77, 77),
-            (1, 1, 1, 1, 1),
-            (1, 1, 10, 6, 7),
-            (10, 55, 10, 66, 7),
+            (10, 5, 10, 20, 7),
         ]
         for shape in shapes:
             for i in range(1, len(shape)):


### PR DESCRIPTION
Fixes #83149
There is a limitation of `TensorIterator` reductions:
The non-permuted input tensor will be coalesced down to a 2-d tensor by `TensorIterator` whereas the permuted case may become a >2d operation (for example, two reduced dimensions and non-reduced dim). 
Since the cpu reduction loop of `TensorIterator` only operates on two dimensions at a time, this means the intermediate sums will be truncated to lower precision.
