### PR TITLE
[Quant] Use finite hops to check if the quant nodes are connected with producer

### DIFF
--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -22,7 +22,6 @@ logger.setLevel(logging.WARNING)
 __all__ = ["PortNodeMetaForQDQ"]
 
 _METADATA_TO_PORT = [
-    "nn_module_stack",
     "stack_trace",
     "quantization_tag",
 ]
@@ -167,6 +166,12 @@ class PortNodeMetaForQDQ(_ExportPassBase):
           - Quantized [Q-> DQ -> Conv -> Q -> DQ -> AvgPool -> Q -> DQ -> choose_params -> Q -> DQ -> Linear]
           - Quantized [Q-> [DQ -> Conv -> Q] -> [DQ -> AvgPool -> Q] -> DQ -> [choose_params -> Q -> DQ -> Linear]]
           - Note first Q does not inherit metadata from any nodes
+    NB:
+    - The best place for porting metadata is during observer conversion to q/dq. This is because it precisely
+      knows which quantization spec is converted to q/dq and thus from where the metadata should be ported.
+      However, since FX and PT2E quant workflow are on a common code-base, this hurts readability quite a bit.
+      Doing it via a separate pass, helps readability of the code. Once we are able to refactor PT2E quant
+      code, this pass should like to be integrated in the refactored variant of "convert" step.
     """
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:

--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -44,6 +44,8 @@ def _is_connected(source: torch.fx.Node, dest: torch.fx.Node) -> bool:
     quant_workflow_ops = _QUANTIZE_OPS + _DEQUANTIZE_OPS
     quant_workflow_ops.append(torch.ops.quantized_decomposed.choose_qparams.tensor)
     while dest.target in quant_workflow_ops:
+        if not isinstance(dest.args[0], torch.fx.Node):
+            raise ValueError(f"expected arg[0] of quant workflow ops to be a node but found {dest.args[0]}")
         dest = dest.args[0]
     return (dest == source)
 

--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -37,7 +37,7 @@ _DEQUANTIZE_OPS = [
 
 
 def _is_connected(next_node: torch.fx.Node, target: torch.fx.Node) -> bool:
-    q = queue.Queue()
+    q: queue.Queue = queue.Queue()
     for n in next_node.users.keys():
         q.put(n)
     while not q.empty():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108572

Summary:
Using dfs to check if two nodes are connecgted is making it very slow. Even BFS was the same. So resorted to finite hop checks starting from dq node to find a node that is not inserted by quant workflow.

Test Plan:
https://gist.github.com/leslie-fang-intel/9cd828623f567a3afbf41564d3546398

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D48971710](https://our.internmc.facebook.com/intern/diff/D48971710)