### PR TITLE
[POC] Avoid `recordStream` for `_allgather_base`

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -130,6 +130,7 @@ class ReduceOptions:
 
 class AllGatherOptions:
     timeout: timedelta
+    recordStream: bool
 
 class GatherOptions:
     rootRank: int

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY(c10d, m) {
   m.def(
       "allgather_(Tensor[][] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int timeout) -> (Tensor[][], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "_allgather_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group) -> (Tensor, __torch__.torch.classes.c10d.Work)");
+      "_allgather_base_(Tensor output_tensor, Tensor input_tensor, bool record_stream, __torch__.torch.classes.c10d.ProcessGroup process_group) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
       "allgather_coalesced_(Tensor[][] output_lists, Tensor[] input_list, __torch__.torch.classes.c10d.ProcessGroup process_group) -> __torch__.torch.classes.c10d.Work");
   m.def(
@@ -231,9 +231,11 @@ IMPL_ALLGATHER(PrivateUse1)
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV( \
       at::Tensor& output_tensor,                                          \
       at::Tensor& input_tensor,                                           \
+      bool record_stream,                                                  \
       const c10::intrusive_ptr<ProcessGroup>& process_group) {            \
+    AllgatherOptions opts = AllgatherOptions{std::chrono::milliseconds(-1), record_stream}; \
     auto work = process_group->getBackend(c10::DeviceType::DEV)           \
-                    ->_allgather_base(output_tensor, input_tensor);       \
+                    ->_allgather_base(output_tensor, input_tensor, opts); \
     return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \
         output_tensor, work);                                             \
   }

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -231,9 +231,10 @@ IMPL_ALLGATHER(PrivateUse1)
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV( \
       at::Tensor& output_tensor,                                          \
       at::Tensor& input_tensor,                                           \
-      bool record_stream,                                                  \
+      bool record_stream,                                                 \
       const c10::intrusive_ptr<ProcessGroup>& process_group) {            \
-    AllgatherOptions opts = AllgatherOptions{std::chrono::milliseconds(-1), record_stream}; \
+    AllgatherOptions opts =                                               \
+        AllgatherOptions{std::chrono::milliseconds(-1), record_stream};   \
     auto work = process_group->getBackend(c10::DeviceType::DEV)           \
                     ->_allgather_base(output_tensor, input_tensor, opts); \
     return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -247,11 +247,13 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
             .typed<std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(
                 at::Tensor&,
                 at::Tensor&,
+                bool,
                 const c10::intrusive_ptr<::c10d::ProcessGroup>&)>();
 
     return std::get<1>(op.call(
         outputBuffer,
         inputBuffer,
+        opts.recordStream,
         c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this)));
   }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -536,7 +536,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       std::vector<at::Tensor>& output,
       Fn fn,
       OpType opType,
-      const char* profilingTitle = nullptr);
+      const char* profilingTitle = nullptr,
+      bool recordStream = true);
   template <typename Fn, typename PreProcess, typename PostProcess>
   c10::intrusive_ptr<Work> collective(
       std::vector<at::Tensor>& input,
@@ -545,7 +546,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       PreProcess pre,
       PostProcess post,
       OpType opType,
-      const char* profilingTitle = nullptr);
+      const char* profilingTitle = nullptr,
+      bool recordStream = true);
 
   // Helper that encapsulates work shared across point-to-point communication
   // primitives. It is the same structure as the helper used for collective

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -137,6 +137,7 @@ struct ReduceOptions {
 
 struct AllgatherOptions {
   std::chrono::milliseconds timeout = kUnsetTimeout;
+  bool recordStream = true;
 };
 
 struct GatherOptions {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -826,7 +826,8 @@ This class does not support ``__members__`` property.)");
 
   py::class_<::c10d::AllgatherOptions>(module, "AllgatherOptions")
       .def(py::init<>())
-      .def_readwrite("timeout", &::c10d::AllgatherOptions::timeout);
+      .def_readwrite("timeout", &::c10d::AllgatherOptions::timeout)
+      .def_readwrite("recordStream", &::c10d::AllgatherOptions::recordStream);
 
   py::class_<::c10d::GatherOptions>(module, "GatherOptions")
       .def(py::init<>())

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union, List
 
 import torch
 from torch._C._distributed_c10d import (
+    AllgatherOptions,
     AllreduceCoalescedOptions,
     AllreduceOptions,
     AllToAllOptions,
@@ -2814,7 +2815,7 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
 
 
 @_exception_logger
-def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=False):
+def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=False, record_stream=True):
     """
     Gather tensors from all ranks and put them in a single output tensor.
 
@@ -2894,7 +2895,9 @@ def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=Fal
         else:
             return None
 
-    work = group._allgather_base(output_tensor, input_tensor)
+    opts = AllgatherOptions()
+    opts.recordStream = record_stream
+    work = group._allgather_base(output_tensor, input_tensor, opts)
 
     if async_op:
         return work


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #108591
* __->__ #108590

This is needed for implementing FSDP memory management without ever using `recordStream` (without setting `TORCH_NCCL_AVOID_RECORD_STREAMS=1`). Another option is to always avoid `recordStream` if `async_op=False`.