### PR TITLE
[export] Lift constant tensors as buffers

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -53,6 +53,7 @@ from .exported_program import (
 from .passes.add_runtime_assertions_for_constraints_pass import (
     _AddRuntimeAssertionsForInlineConstraintsPass,
 )
+from .passes.lift_constant_tensor_pass import lift_constant_tensor_pass
 from .passes.replace_sym_size_ops_pass import _ReplaceSymSizeOpPass
 from .passes.replace_view_ops_with_view_copy_ops_pass import (
     ReplaceViewOpsWithViewCopyOpsPass,
@@ -523,6 +524,7 @@ def export(
         exported_program = exported_program._transform(
             _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
         )
+    exported_program = lift_constant_tensor_pass(exported_program)
 
     return exported_program._transform(_ReplaceSymSizeOpPass())
 

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -1,0 +1,47 @@
+import copy
+from typing import Dict
+
+import torch
+from torch._guards import detect_fake_mode
+from torch._export import ExportedProgram
+
+def lift_constant_tensor_pass(ep: ExportedProgram) -> ExportedProgram:
+    graph_signature = ep.graph_signature
+    inputs_to_buffers = graph_signature.inputs_to_buffers
+    buffers = graph_signature.buffers
+
+    fake_mode = detect_fake_mode(tuple(node.meta["val"] for node in ep.graph.nodes if node.op == "placeholder"))
+    assert fake_mode is not None
+
+    first_user_input = None
+    for node in ep.graph.nodes:
+        if (
+            node.op == "placeholder" and
+            node.name in graph_signature.user_inputs
+        ):
+            first_user_input = node
+            break
+
+    for node in ep.graph.nodes:
+        if node.op == "get_attr":
+            constant_tensor = getattr(ep.graph_module, node.target)
+            if not isinstance(constant_tensor, torch.Tensor):
+                continue
+
+            constant_tensor_fqn = node.target
+
+            with ep.graph.inserting_before(first_user_input):
+                # Insert the constant node before the first user input
+                const_placeholder_node = ep.graph.placeholder(constant_tensor_fqn)
+                const_placeholder_node.meta = copy.deepcopy(node.meta)
+                const_placeholder_node.meta["val"] = fake_mode.from_tensor(constant_tensor)
+                node.replace_all_uses_with(const_placeholder_node)
+                ep.graph.erase_node(node)
+
+                # Add the constant as a buffer to the graph signature
+                inputs_to_buffers[const_placeholder_node.name] = constant_tensor_fqn
+                buffers.append(constant_tensor_fqn)
+                ep.state_dict[constant_tensor_fqn] = constant_tensor
+
+    ep.graph_module.recompile()
+    return ep

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -533,9 +533,11 @@ class GraphModuleSerializer:
                 attr = getattr(arg.graph.owning_module, arg.target)
 
                 if isinstance(attr, torch.Tensor):
-                    self.graph_state.constants[arg.name] = attr
-                    return Argument.create(as_tensor=TensorArgument(name=arg.name))
-                elif isinstance(attr, torch.fx.GraphModule):
+                    raise SerializeError(
+                        "Unsupported getattr on a tensor. Constant tensors "
+                        "should be lifted as buffers inside export."
+                    )
+                if isinstance(attr, torch.fx.GraphModule):
                     with self.save_graph_state():
                         graph = self.serialize_graph(attr)
                     return Argument.create(as_graph=GraphArgument(name=arg.target, graph=graph))
@@ -597,10 +599,10 @@ class GraphModuleSerializer:
                 arguments = []
                 for a in arg:
                     if a.op == "get_attr":
-                        assert isinstance(a.target, str)
-                        attr = getattr(a.graph.owning_module, a.target)
-                        assert isinstance(attr, torch.Tensor)
-                        self.graph_state.constants[a.name] = attr
+                        raise SerializeError(
+                            "Unsupported getattr on a tensor. Constant tensors "
+                            "should be lifted as buffers inside export."
+                        )
                     arguments.append(TensorArgument(name=a.name))
                 return Argument.create(as_tensors=arguments)
             elif all(isinstance(a, (torch.fx.Node, type(None))) for a in arg):


### PR DESCRIPTION
When we retrace the graph containing constant tensors, they get lifted as buffer inputs.
AotInductor also wants to lift all the constants as inputs.
If we separate the constants as a separate thing, then it adds an additional complexity where we now have to keep track of 3 inputs (params, buffers, constants).

Cons: People might care about specifically what buffers are/are not buffers? 

If people want to know specifically which buffers are constants, we can add an additional field in the graph signature to mark this.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108592