### PR TITLE
Torchbench model tolerance changes

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -14,7 +14,7 @@ cm3leon_generate,pass,6
 dcgan,pass,0
 dlrm,pass,0
 doctr_det_predictor,pass,2
-doctr_reco_predictor,fail_accuracy,4
+doctr_reco_predictor,pass,4
 drq,pass,0
 fastNLP_Bert,pass,4
 functorch_dp_cifar10,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -14,7 +14,7 @@ cm3leon_generate,pass,6
 dcgan,pass,0
 dlrm,pass,0
 doctr_det_predictor,pass,2
-doctr_reco_predictor,fail_accuracy,4
+doctr_reco_predictor,pass,4
 drq,pass,0
 fastNLP_Bert,pass,4
 functorch_dp_cifar10,pass,0

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -142,6 +142,7 @@ REQUIRE_EVEN_HIGHER_TOLERANCE = {
 }
 
 REQUIRE_HIGHER_FP16_TOLERANCE = {
+    "doctr_reco_predictor",
     "drq",
 }
 

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -147,7 +147,7 @@ REQUIRE_HIGHER_FP16_TOLERANCE = {
 
 
 REQUIRE_HIGHER_BF16_TOLERANCE = {
-    "detectron2_fcos_r_50_fpn",
+    "doctr_reco_predictor",
     "drq",
 }
 
@@ -234,6 +234,7 @@ FORCE_AMP_FOR_FP16_BF16_MODELS = {
     "Super_SloMo",
     "tts_angular",
     "pyhpc_turbulent_kinetic_energy",
+    "detectron2_fcos_r_50_fpn",
 }
 
 # models in canary_models that we should run anyway


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108598


Move detectron2_fcos_r_50_fpn to amp. The minifier showed the following snippet as causing the divergence, where inductor has better numerics than eager:

```
import torch

def foo(x):
    return x > .2

inp = torch.tensor([.2002], device="cuda", dtype=torch.bfloat16)
print(foo(inp))

print(torch.compile(foo)(inp))
```

doctr_reco_predictor had very minimal divergence (.002 vs .001 required), bumping tolerance here.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng