### PR TITLE
[export] Fix getattr node issues with custom obj

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -246,6 +246,16 @@ def _create_graph_module_for_export(root, graph):
         gm = torch.fx.GraphModule(root, torch.fx.Graph())
         gm._graph = graph
 
+        # Copy over attrs
+        for k, _ in root.named_children():
+            torch.fx.graph_module._copy_attr(root, gm, k)
+
+        for k, _ in root.named_buffers():
+            torch.fx.graph_module._copy_attr(root, gm, k)
+
+        for k, _ in root.named_parameters():
+            torch.fx.graph_module._copy_attr(root, gm, k)
+
     return gm
 
 


### PR DESCRIPTION
When we recreate a graph module with a custom object, we will run into a SyntaxError due to the python codegen not understanding what to do with the custom in-memory objects. To solve this, we bypass the issue through creating an empty GraphModule and manually set the graph (https://fburl.com/code/5pgtpju8).

However, this runs into an issue when there are attributes on the graph module. torch.fx.GraphModule initialization only copies over the attributes if there is a get_attr node in the graph (https://www.internalfb.com/code/fbsource/[3f79c0a1c045]/fbcode/caffe2/torch/fx/graph_module.py?lines=360-363). Since we don't initialize the graph module with a graph when there's a custom object in the graph, these attributes will never get copied over to the newly created graph module.

Fixes an issue from tensorrt team.
