### PR TITLE
[codemod] Del `(object)` from 10 inc caffe2/fb/nas_profiler/lookups/xtensa_lookup.py

### DIFF
--- a/test/jit/test_dataclasses.py
+++ b/test/jit/test_dataclasses.py
@@ -117,7 +117,7 @@ class TestDataclasses(JitTestCase):
 
     def test_default_factories(self):
         @dataclass
-        class Foo(object):
+        class Foo:
             x: List[int] = field(default_factory=list)
 
         with self.assertRaises(NotImplementedError):

--- a/torch/_appdirs.py
+++ b/torch/_appdirs.py
@@ -445,7 +445,7 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
     return path
 
 
-class AppDirs(object):
+class AppDirs:
     """Convenience wrapper for getting application dirs."""
 
     def __init__(


### PR DESCRIPTION
Summary: Python3 makes the use of `(object)` in class inheritance unnecessary. Let's modernize our code by eliminating this.

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D48957985


