### PR TITLE
[dynamo] Move global state guards to C++

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5735,6 +5735,56 @@ def fn():
         torch._dynamo.optimize(counter)(my_dyn_fn)(x012)
         self.assertEqual(counter.frame_count, 3)
 
+    def test_recompile_on_global_state_change(self):
+        last_state = []
+        cnt = 0
+
+        def my_compiler(gm, _):
+            nonlocal cnt
+            cnt += 1
+            state = read_state()
+
+            def inner(*args):
+                last_state[:] = state
+                return gm(*args)
+
+            return inner
+
+        def read_state():
+            return [
+                torch.is_grad_enabled(),
+                torch.are_deterministic_algorithms_enabled(),
+                torch._C._get_cublas_allow_tf32(),
+            ]
+
+        def write_state(state):
+            torch.set_grad_enabled(state[0]),
+            torch.use_deterministic_algorithms(state[1])
+            torch._C._set_cublas_allow_tf32(state[2]),
+
+        @torch.compile(backend=my_compiler)
+        def fn(x):
+            return x + 1
+
+        initial_state = read_state()
+        y = torch.randn(10)
+        try:
+            for round in range(3):
+                for i in range(len(initial_state)):
+                    new_state = [False] * len(initial_state)
+                    new_state[i] = True
+                    write_state(new_state)
+                    assert read_state() == new_state
+                    last_state.clear()
+                    fn(y)
+                    assert last_state == new_state
+                    if round == 0:
+                        assert cnt == i + 1
+                    else:
+                        assert cnt == len(initial_state)
+        finally:
+            write_state(initial_state)
+
     def test_torch_compile_ctx_on_forward_and_training_step(self):
         class MyModel(torch.nn.Module):
             def forward(self):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -77,6 +77,7 @@ from .utils import (
 log = logging.getLogger(__name__)
 bytecode_log = torch._logging.getArtifactLogger(__name__, "bytecode")
 recompiles_log = torch._logging.getArtifactLogger(__name__, "recompiles")
+GlobalStateGuard = torch._C._dynamo.guards.GlobalStateGuard
 
 
 class Tracker:
@@ -102,10 +103,6 @@ class Tracker:
 input_codes = Tracker()
 output_codes = Tracker()
 
-
-initial_grad_state = None
-initial_deterministic_algorithms_state = None
-initial_torch_function_state = None
 initial_global_state = None
 
 
@@ -129,7 +126,9 @@ def wrap_convert_context(fn):
 
     @functools.wraps(fn)
     def _fn(*args, **kwargs):
+        guards = GlobalStateGuard()
         prior_grad_mode = torch.is_grad_enabled()
+        prior_deterministic = torch.are_deterministic_algorithms_enabled()
         py_rng_state = random.getstate()
         torch_rng_state = torch.random.get_rng_state()
         if torch.cuda.is_available():
@@ -142,11 +141,15 @@ def wrap_convert_context(fn):
         finally:
             cleanup.close()
             torch._C._set_grad_enabled(prior_grad_mode)
+            torch.use_deterministic_algorithms(prior_deterministic)
             random.setstate(py_rng_state)
             torch.random.set_rng_state(torch_rng_state)
             if torch.cuda.is_available():
                 torch.cuda.set_rng_state(cuda_rng_state)
             torch.fx.graph_module._forward_from_src = prior_fwd_from_src
+            assert (
+                guards.check()
+            ), "Global state changed while dynamo tracing, please report a bug"
 
     _fn._torchdynamo_orig_callable = fn  # type: ignore[attr-defined]
     return _fn
@@ -346,19 +349,8 @@ def convert_frame_assert(
         if not has_tensor_in_frame(frame):
             return None
 
-        global initial_grad_state
-        initial_grad_state = torch.is_grad_enabled()
-
-        global initial_deterministic_algorithms_state
-        initial_deterministic_algorithms_state = (
-            torch.are_deterministic_algorithms_enabled()
-        )
-
-        global initial_torch_function_state
-        initial_torch_function_state = torch._C._is_torch_function_enabled()
-
         global initial_global_state
-        initial_global_state = torch._C._dynamo.guards.GlobalStateGuard()
+        initial_global_state = GlobalStateGuard()
 
         global FRAME_COUNTER
         if "_id" not in frame_state:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -106,6 +106,7 @@ output_codes = Tracker()
 initial_grad_state = None
 initial_deterministic_algorithms_state = None
 initial_torch_function_state = None
+initial_global_state = None
 
 
 @functools.wraps(original_forward_from_src)
@@ -355,6 +356,9 @@ def convert_frame_assert(
 
         global initial_torch_function_state
         initial_torch_function_state = torch._C._is_torch_function_enabled()
+
+        global initial_global_state
+        initial_global_state = torch._C._dynamo.guards.GlobalStateGuard()
 
         global FRAME_COUNTER
         if "_id" not in frame_state:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1114,6 +1114,10 @@ class CheckFunctionManager:
             convert_frame.initial_torch_function_state
             == torch._C._is_torch_function_enabled()
         ), "dynamo tracing should not mutate global state"
+        assert (
+            convert_frame.initial_global_state is not None
+            and convert_frame.initial_global_state.check()
+        ), "dynamo tracing should not mutate global state"
 
         closure_vars = collections.OrderedDict(
             [

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1101,16 +1101,16 @@ class CheckFunctionManager:
                 add_code_part(code, gcl.guard)
 
         assert not global_builder.shape_env_code
-        assert convert_frame.initial_global_state is not None
+        global_state = convert_frame.initial_global_state
+        if global_state is None:
+            # we should only hit this case in NopTests()
+            global_state = convert_frame.GlobalStateGuard()
         closure_vars = collections.OrderedDict(
             [
                 ("___guarded_code", self),
                 ("___check_tensors", check_tensors_fn),
                 ("___check_tensors_verbose", check_tensors_verbose_fn),
-                (
-                    "___check_global_state",
-                    convert_frame.initial_global_state.check,
-                ),
+                ("___check_global_state", global_state.check),
                 ("tensor_check_names", tensor_check_names),
             ]
             + list(SYMPY_INTERP.items())

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -88,12 +88,6 @@ CLOSURE_VARS = collections.OrderedDict(
     [
         ("___check_type_id", check_type_id),
         ("___check_obj_id", check_obj_id),
-        ("___is_grad_enabled", torch.is_grad_enabled),
-        (
-            "___are_deterministic_algorithms_enabled",
-            torch.are_deterministic_algorithms_enabled,
-        ),
-        ("___is_torch_function_enabled", torch._C._is_torch_function_enabled),
         ("___odict_getitem", collections.OrderedDict.__getitem__),
         ("___dict_param_key_ids", dict_param_key_ids),
         ("___dict_const_keys", dict_const_keys),
@@ -537,34 +531,13 @@ class GuardBuilder(GuardBuilderBase):
         mutation_guard.watch(self.get(guard.name), self.check_fn_manager)
 
     def GRAD_MODE(self, guard: Guard):
-        """Guard on the initial grad state"""
-        assert guard.name == ""
-        assert guard.source is GuardSource.GLOBAL
-        code = None
-        if convert_frame.initial_grad_state:
-            code = "___is_grad_enabled()"
-        else:
-            code = "not ___is_grad_enabled()"
-        self._produce_guard_code(guard, [code])
+        pass  # we always guard on grad mode via GlobalStateGuard()
 
     def DETERMINISTIC_ALGORITHMS(self, guard: Guard):
-        """Guard on the initial determinism algorithms state"""
-        assert guard.source is GuardSource.GLOBAL
-        code = None
-        if convert_frame.initial_deterministic_algorithms_state:
-            code = "___are_deterministic_algorithms_enabled()"
-        else:
-            code = "not ___are_deterministic_algorithms_enabled()"
-        self._produce_guard_code(guard, [code])
+        pass  # we always guard on grad mode via GlobalStateGuard()
 
     def TORCH_FUNCTION_STATE(self, guard: Guard):
-        assert guard.source is GuardSource.GLOBAL
-        code = None
-        if convert_frame.initial_torch_function_state:
-            code = "___is_torch_function_enabled()"
-        else:
-            code = "not ___is_torch_function_enabled()"
-        self._produce_guard_code(guard, [code])
+        pass  # we always guard on grad mode via GlobalStateGuard()
 
     def DEFAULT_DEVICE(self, guard: Guard):
         """Guard on CURRENT_DEVICE per torch.utils._device"""
@@ -977,13 +950,11 @@ class CheckFunctionManager:
         # see parallel handling of ".0" / "___implicit0" in _eval_frame.c
         largs = local_builder.argnames
         largs += ["**___kwargs_ignored"]
-        args = ",".join(largs)
 
         guards_log.debug("GUARDS:")
 
         # Don't report this guard, it's always the same, useless!
-        code_parts = ["___guarded_code.valid"]
-        base = os.path.dirname(__file__)
+        code_parts = ["___guarded_code.valid", "___check_global_state()"]
 
         def add_code_part(code, guard, log_only=False):
             if guards_log.isEnabledFor(logging.DEBUG):
@@ -1045,8 +1016,6 @@ class CheckFunctionManager:
                 local_builder.tensor_check_examples
                 + global_builder.tensor_check_examples
             )
-            dynamic_dims_sizes = None
-            dynamic_dims_strides = None
 
             def convert(size_or_stride):
                 converted: List[Optional[int]] = []
@@ -1133,11 +1102,28 @@ class CheckFunctionManager:
 
         assert not global_builder.shape_env_code
 
+        # I am a bit horrified that these `initial_*` variables exist since it indicates a hacky workaround to a
+        # pretty terrible bug.  I want to see if these asserts ever get hit, and if they do delete the variables.
+        assert (
+            convert_frame.initial_grad_state == torch.is_grad_enabled()
+        ), "dynamo tracing should not mutate global state"
+        assert convert_frame.initial_deterministic_algorithms_state == (
+            torch.are_deterministic_algorithms_enabled()
+        ), "dynamo tracing should not mutate global state"
+        assert (
+            convert_frame.initial_torch_function_state
+            == torch._C._is_torch_function_enabled()
+        ), "dynamo tracing should not mutate global state"
+
         closure_vars = collections.OrderedDict(
             [
                 ("___guarded_code", self),
                 ("___check_tensors", check_tensors_fn),
                 ("___check_tensors_verbose", check_tensors_verbose_fn),
+                (
+                    "___check_global_state",
+                    torch._C._dynamo.guards.GlobalStateGuard().check,
+                ),
                 ("tensor_check_names", tensor_check_names),
             ]
             + list(SYMPY_INTERP.items())

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -424,7 +424,7 @@ static PyMethodDef TensorGuards_methods[] = {
 
 static PyTypeObject TensorGuardsType = {PyVarObject_HEAD_INIT(nullptr, 0)};
 
-typedef struct {
+struct GlobalStateGuard {
   PyObject_HEAD;
 
   inline void init() {
@@ -450,7 +450,6 @@ typedef struct {
         _num_threads == at::get_num_threads());
   }
 
- private:
   bool _grad_mode;
   bool _torch_function;
   bool _deterministic_algorithms;
@@ -459,7 +458,7 @@ typedef struct {
   bool _allow_bf16_reduce;
   int _num_threads;
   // TODO(jansel): we should guard on more state as inductor starts using it
-} GlobalStateGuard;
+};
 
 int GlobalStateGuard_init(
     GlobalStateGuard* self,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -433,6 +433,8 @@ typedef struct {
     _torch_function = torch::torch_function_enabled();
     _deterministic_algorithms = ctx.deterministicAlgorithms();
     _allow_tf32 = ctx.allowTF32CuBLAS();
+    _allow_fp16_reduce = ctx.allowFP16ReductionCuBLAS();
+    _allow_bf16_reduce = ctx.allowBF16ReductionCuBLAS();
     _num_threads = at::get_num_threads();
   }
 
@@ -443,6 +445,8 @@ typedef struct {
         _torch_function == torch::torch_function_enabled() &&
         _deterministic_algorithms == ctx.deterministicAlgorithms() &&
         _allow_tf32 == ctx.allowTF32CuBLAS() &&
+        _allow_fp16_reduce == ctx.allowFP16ReductionCuBLAS() &&
+        _allow_bf16_reduce == ctx.allowBF16ReductionCuBLAS() &&
         _num_threads == at::get_num_threads());
   }
 
@@ -451,6 +455,8 @@ typedef struct {
   bool _torch_function;
   bool _deterministic_algorithms;
   bool _allow_tf32;
+  bool _allow_fp16_reduce;
+  bool _allow_bf16_reduce;
   int _num_threads;
   // TODO(jansel): we should guard on more state as inductor starts using it
 } GlobalStateGuard;
@@ -476,10 +482,6 @@ PyObject* GlobalStateGuard_check(
 
 static PyMethodDef GlobalStateGuard_methods[] = {
     {"check",
-     (PyCFunction)(void*)GlobalStateGuard_check,
-     METH_NOARGS,
-     "Return true if global state was the same as at creation time"},
-    {"__bool__",
      (PyCFunction)(void*)GlobalStateGuard_check,
      METH_NOARGS,
      "Return true if global state was the same as at creation time"},

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1,6 +1,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <c10/util/flat_hash_map.h>
+#include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/dynamo/guards.h>
+#include <torch/csrc/utils/disable_torch_function.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/extension.h>
 #include <sstream>
@@ -422,6 +424,67 @@ static PyMethodDef TensorGuards_methods[] = {
 
 static PyTypeObject TensorGuardsType = {PyVarObject_HEAD_INIT(nullptr, 0)};
 
+typedef struct {
+  PyObject_HEAD;
+
+  inline void init() {
+    auto& ctx = at::globalContext();
+    _grad_mode = at::GradMode::is_enabled();
+    _torch_function = torch::torch_function_enabled();
+    _deterministic_algorithms = ctx.deterministicAlgorithms();
+    _allow_tf32 = ctx.allowTF32CuBLAS();
+    _num_threads = at::get_num_threads();
+  }
+
+  inline bool check() {
+    auto& ctx = at::globalContext();
+    return (_grad_mode == at::GradMode::is_enabled() &&
+                _torch_function == torch::torch_function_enabled() &&
+                _deterministic_algorithms == ctx.deterministicAlgorithms() &&
+                _allow_tf32 == ctx.allowTF32CuBLAS() &&
+                _num_threads == at::get_num_threads(););
+  }
+
+ private:
+  bool _grad_mode;
+  bool _torch_function;
+  bool _deterministic_algorithms;
+  bool _allow_tf32;
+  int _num_threads;
+  // TODO(jansel): we should guard on more state as inductor starts using it
+} GlobalStateGuard;
+
+int GlobalStateGuard_init(
+    GlobalStateGuard* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  self->init();
+  return 0;
+}
+
+PyObject* GlobalStateGuard_check(
+    GlobalStateGuard* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  if (self->check()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
+static PyMethodDef GlobalStateGuard_methods[] = {
+    {"check",
+     (PyCFunction)(void*)GlobalStateGuard_check,
+     METH_NOARGS,
+     "Return true if global state was the same as at creation time"},
+    {"__bool__",
+     (PyCFunction)(void*)GlobalStateGuard_check,
+     METH_NOARGS,
+     "Return true if global state was the same as at creation time"},
+    {nullptr}};
+static PyTypeObject GlobalStateGuardType = {PyVarObject_HEAD_INIT(nullptr, 0)};
+
 static PyObject* check_type_id(PyObject* dummy, PyObject* args) {
   // faster `lambda obj, expected: id(type(obj)) == expected`
   PyObject* obj = nullptr;
@@ -526,6 +589,18 @@ PyObject* torch_c_dynamo_guards_init() {
   if (PyType_Ready(&TensorGuardsType) < 0)
     return nullptr;
 
+  GlobalStateGuardType.tp_name = "torch._C._dynamo.guards.GlobalStateGuard";
+  GlobalStateGuardType.tp_basicsize = sizeof(GlobalStateGuard);
+  GlobalStateGuardType.tp_itemsize = 0;
+  GlobalStateGuardType.tp_flags = Py_TPFLAGS_DEFAULT;
+  GlobalStateGuardType.tp_doc = "Guard on PyTorch global flags such as no_grad";
+  GlobalStateGuardType.tp_methods = GlobalStateGuard_methods;
+  GlobalStateGuardType.tp_init = (initproc)GlobalStateGuard_init;
+  GlobalStateGuardType.tp_new = PyType_GenericNew;
+
+  if (PyType_Ready(&GlobalStateGuardType) < 0)
+    return nullptr;
+
   auto m = PyModule_Create(&_module);
   if (m == nullptr)
     return nullptr;
@@ -533,6 +608,14 @@ PyObject* torch_c_dynamo_guards_init() {
   Py_INCREF(&TensorGuardsType);
   if (PyModule_AddObject(m, "TensorGuards", (PyObject*)&TensorGuardsType) < 0) {
     Py_DECREF(&TensorGuardsType);
+    Py_DECREF(m);
+    return nullptr;
+  }
+
+  Py_INCREF(&GlobalStateGuardType);
+  if (PyModule_AddObject(
+          m, "GlobalStateGuard", (PyObject*)&GlobalStateGuardType) < 0) {
+    Py_DECREF(&GlobalStateGuardType);
     Py_DECREF(m);
     return nullptr;
   }

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -438,11 +438,12 @@ typedef struct {
 
   inline bool check() {
     auto& ctx = at::globalContext();
-    return (_grad_mode == at::GradMode::is_enabled() &&
-                _torch_function == torch::torch_function_enabled() &&
-                _deterministic_algorithms == ctx.deterministicAlgorithms() &&
-                _allow_tf32 == ctx.allowTF32CuBLAS() &&
-                _num_threads == at::get_num_threads(););
+    return (
+        _grad_mode == at::GradMode::is_enabled() &&
+        _torch_function == torch::torch_function_enabled() &&
+        _deterministic_algorithms == ctx.deterministicAlgorithms() &&
+        _allow_tf32 == ctx.allowTF32CuBLAS() &&
+        _num_threads == at::get_num_threads());
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108624

This combines a bunch of python global state guards into a single C++ guard and switches to checking them 100% of the time.  It also adds a few new guards for things that change inductor's behavior.   Even though we are checking more things, I expect this to be much faster.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng