### PR TITLE
Back out "Faster gc_count update for CUDACachingAllocator"

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -185,18 +185,10 @@ struct BlockPool {
         unmapped(BlockComparatorAddress),
         is_small(small),
         owner_PrivatePool(private_pool) {}
-
-  // Do not insert a Block to blocks directly; use insert_into_blocks(),
-  // instead.
   std::set<Block*, Comparison> blocks;
   std::set<Block*, Comparison> unmapped;
   const bool is_small;
   PrivatePool* owner_PrivatePool;
-  int64_t get_free_blocks_call_count{0};
-
-  // Add a Block into blocks set with updating gc counter.
-  std::pair<std::set<Block*, Comparison>::iterator, bool> insert_into_blocks(
-      Block* block);
 };
 
 struct ExpandableSegment;
@@ -218,7 +210,8 @@ struct Block {
   Block* prev{nullptr}; // prev block if split from a larger allocation
   Block* next{nullptr}; // next block if split from a larger allocation
   int event_count{0}; // number of outstanding CUDA events
-  int64_t gc_count_base{0}; // get_free_blocks_call_count when Block is inserted
+  int gc_count{0}; // counter for prioritizing older / less useful blocks for
+                   // garbage collection
   std::shared_ptr<GatheredContext> context_when_allocated;
   // only set for the first block in the segment (when prev == null)
   // this records the frame information when cudaMalloc was called
@@ -240,8 +233,7 @@ struct Block {
         size(size),
         requested_size(0),
         pool(pool),
-        ptr(ptr),
-        gc_count_base(pool->get_free_blocks_call_count) {}
+        ptr(ptr) {}
 
   // constructor for search key
   Block(int device, cudaStream_t stream, size_t size)
@@ -250,10 +242,6 @@ struct Block {
         stream_uses(),
         size(size),
         requested_size(0) {}
-
-  size_t gc_count() {
-    return static_cast<int>(pool->get_free_blocks_call_count - gc_count_base);
-  }
 
   bool is_split() const {
     return (prev != nullptr) || (next != nullptr);
@@ -271,12 +259,6 @@ struct Block {
     next = after;
   }
 };
-
-std::pair<std::set<Block*, Comparison>::iterator, bool> BlockPool::
-    insert_into_blocks(Block* block) {
-  block->gc_count_base = get_free_blocks_call_count;
-  return blocks.insert(block);
-}
 
 struct SegmentRange {
   char* ptr;
@@ -589,7 +571,7 @@ struct BlockState {
   size_t size = 0;
   void* ptr = nullptr;
   bool allocated = false;
-  int gc_count_base = 0;
+  int gc_count = 0;
   // maintain invariant that event_count == 0 ;
   // history will be left alone in checkpoint
 
@@ -752,7 +734,7 @@ BlockState::BlockState(Block* block)
       size(block->size),
       ptr(block->ptr),
       allocated(block->allocated),
-      gc_count_base(block->gc_count_base) {
+      gc_count(block->gc_count) {
   TORCH_CHECK(
       block->event_count == 0,
       "Events should have synchronized when checkpointing block");
@@ -1531,7 +1513,7 @@ class DeviceCachingAllocator {
       remaining->prev = block;
       remaining->ptr = static_cast<char*>(remaining->ptr) + size;
       remaining->size -= size;
-      bool inserted = pool->insert_into_blocks(remaining).second;
+      bool inserted = pool->blocks.insert(remaining).second;
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inserted);
 
       if (already_split && !block->expandable_segment_) {
@@ -2332,7 +2314,7 @@ class DeviceCachingAllocator {
     try_merge_blocks(to_map, to_map->prev, pool);
     try_merge_blocks(to_map, to_map->next, pool);
 
-    pool.insert_into_blocks(to_map);
+    pool.blocks.insert(to_map);
 
     // update statistics
     total_allocated_memory += mapped_range.size;
@@ -2424,7 +2406,7 @@ class DeviceCachingAllocator {
     active_blocks.erase(block);
     // Makes sure the Block* isn't already present in the pool we're freeing it
     // back into.
-    bool inserted = pool.insert_into_blocks(block).second;
+    bool inserted = pool.blocks.insert(block).second;
     TORCH_INTERNAL_ASSERT(inserted);
 
     if (block->is_split()) {
@@ -2554,7 +2536,9 @@ class DeviceCachingAllocator {
             set_fraction &&
             CachingAllocatorConfig::garbage_collection_threshold() > 0.0)) {
       // Track block reuse interval only when garbage collection is enabled.
-      ++pool.get_free_blocks_call_count;
+      for (auto& b : pool.blocks) {
+        ++b->gc_count;
+      }
     }
     auto it = pool.blocks.lower_bound(&p.search_key);
     if (it == pool.blocks.end() || (*it)->stream != p.stream())
@@ -2602,6 +2586,7 @@ class DeviceCachingAllocator {
         ((*it)->size >= p.size() + kLargeBuffer))
       return false;
     p.block = *it;
+    (*it)->gc_count = 0; // Denote this block has been used
     pool.blocks.erase(it);
     return true;
   }
@@ -2636,7 +2621,7 @@ class DeviceCachingAllocator {
     int freeable_block_count = 0;
     for (auto& b : large_blocks.blocks) {
       if (!b->is_split()) {
-        total_age += b->gc_count();
+        total_age += b->gc_count;
         ++freeable_block_count;
       }
     }
@@ -2660,10 +2645,10 @@ class DeviceCachingAllocator {
       while (it != large_blocks.blocks.end()) {
         Block* block = *it;
         ++it;
-        if (!block->is_split() && block->gc_count() >= age_threshold) {
+        if (!block->is_split() && block->gc_count >= age_threshold) {
           block_freed = true;
           gc_reclaimed += block->size;
-          total_age -= block->gc_count(); // Decrement the age
+          total_age -= block->gc_count; // Decrement the age
           freeable_block_count--; // One less block that can be freed
           release_block(block);
         }
@@ -2913,7 +2898,7 @@ class DeviceCachingAllocator {
           block->device, block->stream, before_size, block->pool, block->ptr);
       before_free->expandable_segment_ = block->expandable_segment_;
       before_free->splice(block->prev, block);
-      block->pool->insert_into_blocks(before_free);
+      block->pool->blocks.insert(before_free);
     }
 
     auto after_size = block->size - (before_size + unmapped.size);
@@ -2927,7 +2912,7 @@ class DeviceCachingAllocator {
           static_cast<char*>(unmapped.ptr) + unmapped.size);
       after_free->expandable_segment_ = block->expandable_segment_;
       after_free->splice(block, block->next);
-      block->pool->insert_into_blocks(after_free);
+      block->pool->blocks.insert(after_free);
     }
 
     block->ptr = unmapped.ptr;


### PR DESCRIPTION
Summary:
Original commit changeset: 1d04ae368fd8

Original Phabricator Diff: D48481557

Test Plan: llm inference service can encounter a segfault underload. it no longer does after backing out the diff.

Reviewed By: houseroad

Differential Revision: D49003404


