### PR TITLE
[Doc] Move Dynamo IPEX backend to training/inference category

### DIFF
--- a/docs/source/torch.compiler.rst
+++ b/docs/source/torch.compiler.rst
@@ -54,6 +54,8 @@ Some of the most commonly used backends include:
      - Uses the TorchInductor backend. `Read more <https://dev-discuss.pytorch.org/t/torchinductor-a-pytorch-native-compiler-with-define-by-run-ir-and-symbolic-shapes/747>`__
    * - ``torch.compile(m, backend="cudagraphs")``
      - CUDA graphs with AOT Autograd. `Read more <https://github.com/pytorch/torchdynamo/pull/757>`__
+   * - ``torch.compile(m, backend="ipex")``
+     - Uses IPEX on CPU. `Read more <https://github.com/intel/intel-extension-for-pytorch>`__
 
 **Inference-only backends**
 
@@ -67,8 +69,6 @@ Some of the most commonly used backends include:
      - Uses ONNXRT for inference on CPU/GPU. `Read more <https://onnxruntime.ai/>`__
    * - ``torch.compile(m, backend="tensorrt")``
      - Uses ONNXRT to run TensorRT for inference optimizations. `Read more <https://github.com/onnx/onnx-tensorrt>`__
-   * - ``torch.compile(m, backend="ipex")``
-     - Uses IPEX for inference on CPU. `Read more <https://github.com/intel/intel-extension-for-pytorch>`__
    * - ``torch.compile(m, backend="tvm")``
      - Uses Apache TVM for inference optimizations. `Read more <https://tvm.apache.org/>`__
 


### PR DESCRIPTION
As title.
Since dynamo IPEX backend supports training, move it to the category above.