### PR TITLE
Add check for out of range pointer. (#107510)

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -85,7 +85,7 @@ class FlatbufferLoader final {
   void registerIValueParser(
       mobile::serialization::IValueUnion ivalue_type,
       IValueParser parser);
-  mobile::Module parseModule(mobile::serialization::Module* module);
+  mobile::Module parseModule(mobile::serialization::Module* module, char* end);
 
   void extractJitSourceAndConstants(
       ExtraFilesMap* jit_sources,
@@ -281,7 +281,8 @@ void FlatbufferLoader::parseAndPopulate(
 }
 
 mobile::Module FlatbufferLoader::parseModule(
-    mobile::serialization::Module* module) {
+    mobile::serialization::Module* module,
+    char* end) {
   module_ = module;
   all_ivalues_.clear();
   all_types_.clear();
@@ -291,6 +292,8 @@ mobile::Module FlatbufferLoader::parseModule(
 
   const auto* ivalues = module->ivalues();
   TORCH_CHECK(ivalues != nullptr, "Corrupted ivalues field")
+  TORCH_CHECK(
+      reinterpret_cast<const char*>(ivalues) < end, "Corrupted ivalues field")
   all_ivalues_.resize(ivalues->size());
   all_types_.resize(module->object_types()->size());
   storages_.resize(module->storage_data_size());
@@ -303,6 +306,8 @@ mobile::Module FlatbufferLoader::parseModule(
 
   for (uint32_t i = 0; i < mobile_ivalue_size_; i++) {
     const auto* ival = ivalues->Get(i);
+    TORCH_CHECK(
+        reinterpret_cast<const char*>(ival) < end, "Corrupted ivalue item")
     parseAndPopulate(i, ival);
   }
   IValue& module_ivalue = getIValue(module->state_obj());
@@ -765,7 +770,8 @@ mobile::Module parse_and_initialize_mobile_module(
   // Flatbuffer doesn't seem to have a way to provide the buffer size when
   // interacting with the buffer.
   auto* flatbuffer_module = mobile::serialization::GetMutableModule(data);
-  mobile::Module m = loader.parseModule(flatbuffer_module);
+  auto* end = static_cast<char*>(data) + size;
+  mobile::Module m = loader.parseModule(flatbuffer_module, end);
   if (extra_files != nullptr) {
     parseExtraFiles(flatbuffer_module, *extra_files);
   }
@@ -807,7 +813,8 @@ mobile::Module parse_and_initialize_mobile_module_for_jit(
 
   FlatbufferLoader loader;
   auto* flatbuffer_module = mobile::serialization::GetMutableModule(data);
-  mobile::Module m = loader.parseModule(flatbuffer_module);
+  auto* end = static_cast<char*>(data) + size;
+  mobile::Module m = loader.parseModule(flatbuffer_module, end);
   if (extra_files != nullptr) {
     parseExtraFiles(flatbuffer_module, *extra_files);
   }
@@ -925,7 +932,8 @@ mobile::Module parse_flatbuffer_no_object(
         return static_cast<c10::IValue>(obj);
       });
 
-  mobile::Module m = loader.parseModule(flatbuffer_module);
+  auto* end = data.get() + size;
+  mobile::Module m = loader.parseModule(flatbuffer_module, end);
   m.set_delete_memory(std::move(data));
   return m;
 }


### PR DESCRIPTION
### Summary

Hi! We've been fuzzing pytorch with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) and found an error of accessing arbitary address while parsing flatbuffer format using `torch::load` function.

pytorch version: 18bcf62bbcf7ffd47e3bcf2596f72aa07a07d65f (the last commit at the moment of reporting the issue)

### Details
The vulnerability appears while loading arbitrary user input using `torch::load` function. To detect the error the input must correspond to FlatbufferFileFormat, so the part of parsing flatbuffer in `import_ir_module` function must be executed.

Firstly error can occur in `GetMutableRoot` in `module.h`, where we add pointer to input data buffer with the value, got from dereference of this pointer (which data fully depends on the user input and can be arbitrary). so the resulting `flatbuffer_module` address can be corrupted.

Moreover, we can get the arbitrary address later at `flatbuffer_loader.cpp:305`, when we get `ival` pointer with `Get` method. There in `IndirectHelper::Read` function we add pointer with the offset got from the dereference of this pointer, so the address can be corrupted again.

The corrupted `ival` pointer is dereferenced at `table.h` in flatbuffers project, where is used to get another address, which is later dereferenced again at `table.h` in flatbuffers project. The resulting corrupted address is written to `func` pointer at `flatbuffer_loader.cpp:274`, which is then used in `parseFunction`, where write access to the address occurs.

To fix the problem we can compute the end of memory area in `parse_and_initialize_mobile_module` function like this:
```
auto* end = static_cast<char*>(data) + size;
```
And then pass it to all the callees and insert corresponding checks.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/107510
Approved by: https://github.com/albanD

Fixes #ISSUE_NUMBER
