### PR TITLE
 Inductor cpp wrapper: fix codegen of positional args with default value

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -193,6 +193,7 @@ if RUN_CPU:
         BaseTest("test_relu"),  # multiple inputs
         BaseTest("test_repeat_interleave", "", test_cpu_repro.CPUReproTests()),
         BaseTest("test_scalar_input"),
+        BaseTest("test_scaled_dot_product_attention"),
         BaseTest("test_scatter1"),
         BaseTest("test_scatter2"),
         BaseTest("test_scatter3"),
@@ -264,6 +265,7 @@ if RUN_CUDA:
         BaseTest("test_reduction1"),  # Reduction
         BaseTest("test_relu"),  # multiple inputs
         BaseTest("test_scalar_input"),
+        BaseTest("test_scaled_dot_product_attention"),
         BaseTest("test_scaled_dot_product_efficient_attention"),
         BaseTest("test_sort"),
         BaseTest("test_silu"),  # single input, single output

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -44,7 +44,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn import functional as F
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FUSED_SDPA,
     SM80OrLater,
     TEST_CUDNN,
 )
@@ -6750,7 +6750,7 @@ class CommonTemplate:
         self.common(fn, (torch.randn(26),))
 
     def test_scaled_dot_product_attention(self):
-        if self.device == "cuda" and not PLATFORM_SUPPORTS_FLASH_ATTENTION:
+        if self.device == "cuda" and not PLATFORM_SUPPORTS_FUSED_SDPA:
             raise unittest.SkipTest("Can't run flash attention on this platform")
 
         def fn(q, k, v):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -43,7 +43,11 @@ from torch._inductor.virtualized import V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn import functional as F
 from torch.testing import FileCheck, make_tensor
-from torch.testing._internal.common_cuda import SM80OrLater, TEST_CUDNN
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    SM80OrLater,
+    TEST_CUDNN,
+)
 from torch.testing._internal.common_device_type import _has_sufficient_memory
 from torch.testing._internal.common_dtype import all_types
 from torch.testing._internal.common_utils import (
@@ -6744,6 +6748,29 @@ class CommonTemplate:
             return x < y
 
         self.common(fn, (torch.randn(26),))
+
+    def test_scaled_dot_product_attention(self):
+        if self.device == "cuda" and not PLATFORM_SUPPORTS_FLASH_ATTENTION:
+            raise unittest.SkipTest("Can't run flash attention on this platform")
+
+        def fn(q, k, v):
+            return torch.nn.functional.scaled_dot_product_attention(
+                q.transpose(1, 2).contiguous(),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                scale=0.125,
+            )[:2]
+
+        self.common(
+            fn,
+            (
+                torch.randn(4, 2, 4, 2),
+                torch.randn(4, 2, 4, 2),
+                torch.randn(4, 2, 4, 2),
+            ),
+            atol=2e-4,  # to pass lowp check on GPU
+            rtol=1e-2,  # to pass lowp check on GPU
+        )
 
     @skipIfRocm
     def test_scaled_dot_product_efficient_attention(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3603,6 +3603,11 @@ class FallbackKernel(ExternKernelAlloc):
                 else f"aten.{kernel.__name__}"
             )
             if schema is not None:
+                self.args_default_value = [
+                    {"type": x.real_type, "value": x.default_value}
+                    for x in schema.arguments
+                    if not x.kwarg_only
+                ]
                 self.ordered_kwargs_for_cpp_kernel = [
                     x.name for x in schema.arguments if x.kwarg_only
                 ]
@@ -3661,6 +3666,24 @@ class FallbackKernel(ExternKernelAlloc):
             x.name for x in kernel._schema.arguments if x.kwarg_only
         ]
 
+    def get_arg_default_value(self, pos):
+        assert hasattr(
+            self, "args_default_value"
+        ), "self.args_default_value has to be provided"
+        assert pos < len(
+            self.args_default_value
+        ), f"expected the index {pos} to be smaller than len(self.args_default_value): {len(self.args_default_value)}"
+        v = self.args_default_value[pos]["value"]
+        if v is None:
+            arg_type = self.args_default_value[pos]["type"]
+            # TODO: extend the support here
+            assert (
+                str(arg_type) in default_value_map
+            ), f"unsupported default_value arg_type: {str(arg_type)}"
+            return default_value_map[str(arg_type)]()
+        else:
+            return v
+
     def codegen_args(self):
         @dataclasses.dataclass
         class Shim:
@@ -3672,6 +3695,17 @@ class FallbackKernel(ExternKernelAlloc):
         tensor_args = [Shim(x.codegen_reference()) for x in self.inputs]
         args, kwargs = self.unflatten_args(tensor_args, self.constant_args)
         args = [V.graph.wrapper_code.val_to_arg_str(x) for x in args]
+        if V.graph.cpp_wrapper and hasattr(self, "args_default_value"):
+            n_args = len(args)
+            n_pos_args = len(self.args_default_value)
+            # Some positional args are not provided, need to use their default value in cpp wrapper
+            if n_args < n_pos_args:
+                pos_args = [
+                    self.get_arg_default_value(i) for i in range(n_args, n_pos_args)
+                ]
+                pos_args = [V.graph.wrapper_code.val_to_arg_str(x) for x in pos_args]
+                args.extend(pos_args)
+
         # let self.codegen_kwargs handle kwargs
         self.kwargs.update(kwargs)
         return args

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -906,11 +906,18 @@ def blue_text(msg):
     return _color_text(msg, "blue")
 
 
-PYTHON_TYPE_TO_SCHEMA_TYPE = {
-    torch.dtype: "int",
-    torch.device: "Device",
-    bool: "bool",
-}
+@functools.lru_cache(None)
+def python_type_to_schema_type():
+    from . import ir
+
+    PYTHON_TYPE_TO_SCHEMA_TYPE = {
+        torch.dtype: "int",
+        torch.device: "Device",
+        bool: "bool",
+        float: "float",
+        ir.TensorBox: "Tensor",
+    }
+    return PYTHON_TYPE_TO_SCHEMA_TYPE
 
 
 def may_get_optional_schema_type(schema_type, is_optional_arg):
@@ -931,8 +938,8 @@ def type_match(arg, arg_type, is_optional_arg):
             # TODO: add support here
             return False
 
-    if arg.__class__ in PYTHON_TYPE_TO_SCHEMA_TYPE:
-        schema_type = PYTHON_TYPE_TO_SCHEMA_TYPE[arg.__class__]
+    if arg.__class__ in python_type_to_schema_type():
+        schema_type = python_type_to_schema_type()[arg.__class__]
         may_optional_schema_type = may_get_optional_schema_type(
             schema_type, is_optional_arg
         )
@@ -965,6 +972,9 @@ def schema_match(schema, args, kwargs):
     def is_optional(arg):
         return "Optional" in str(arg.type)
 
+    def allow_none(arg):
+        return is_optional(arg) or arg.has_default_value()
+
     assert len(args) <= max_pos_args, args_error_message(
         len(args), max_pos_args, min_args
     )
@@ -981,7 +991,7 @@ def schema_match(schema, args, kwargs):
                 obj = kwargs[argument.name]
                 is_kwd = True
 
-        if obj is None and not is_optional(argument):
+        if obj is None and not allow_none(argument):
             return False
 
         if obj is not None:


### PR DESCRIPTION
Cherry-picks https://github.com/pytorch/pytorch/pull/108552 for release branch.
One extra commit is added to change a function name in an UT back to an older name since https://github.com/pytorch/pytorch/pull/105602 which adds the new function is not on `release/2.1` branch.

Inductor CPP wrapper is a new feature that will be introduced in the 2.1 release.
Due to the recent pattern match fix of flash attention in https://github.com/pytorch/pytorch/pull/108327, a new OP `torch.ops.aten._scaled_dot_product_flash_attention` will be on the inductor IR, where CPP wrapper will fail to run, resulting in 16 model failures in the huggingface suite, 2 model failures in torchbench and 1 model failure in timm_models.
This PR will fix the failure of these models, which is a critical fix for this new feature.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov