### PR TITLE
Add aten::trunc to core IR

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5978,7 +5978,7 @@
   dispatch:
     SparseCPU, SparseCUDA: trunc_sparse
     SparseCsrCPU, SparseCsrCUDA: trunc_sparse_csr
-  tags: pointwise
+  tags: [core, pointwise]
 
 - func: trunc_(Tensor(a!) self) -> Tensor(a!)
   structured_delegate: trunc.out


### PR DESCRIPTION
Summary:
floor, ceil is core.
Libraries like XNNPACK and MKL supports it.
Decomp takes multiple ops (possibly `torch.floor(a) * (a > 0) + torch.ceil(a) * (a < 0)`)

Test Plan: CI

Differential Revision: D48989685


