### PR TITLE
[TEST] Revert "[4/N] fix clang-tidy warnings in torch/csrc (#108305)"

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -11,7 +11,7 @@ namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
 
-inline bool has_names(const ITensorListRef& tensors) {
+inline bool has_names(ITensorListRef tensors) {
   return std::any_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
     return t.has_names();
   });

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -144,15 +144,17 @@ void invoke_parallel(
   const std::function<void(int64_t, int64_t)>& f) {
   at::internal::lazy_init_num_threads();
 
-  size_t num_tasks = 0, chunk_size = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  size_t num_tasks, chunk_size;
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct {
     std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
     std::exception_ptr eptr;
     std::mutex mutex;
-    volatile size_t remaining{0};
+    volatile size_t remaining;
     std::condition_variable cv;
   } state;
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -75,7 +75,7 @@ namespace detail {
       }
     }
     // Structured Tensor[] translates to this case
-    void operator()(const at::ITensorListRef& xs) {
+    void operator()(at::ITensorListRef xs) {
       for (const auto& x : xs) {
         ts = ts | x.key_set();
       }

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -745,7 +745,7 @@ namespace std {
 
 template <>
 struct hash<c10::OperatorHandle> {
-  size_t operator()(const c10::OperatorHandle& op) const noexcept {
+  size_t operator()(c10::OperatorHandle op) const noexcept {
     return std::hash<void*>{}(static_cast<void*>(op.operatorDef_));
   }
 };

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -80,7 +80,8 @@ struct ComplexHolder : c10::intrusive_ptr_target {
 // Similar to ComplexHolder, for StreamData3
 struct StreamData3Holder : c10::intrusive_ptr_target {
   public:
-    StreamData3Holder(struct c10::StreamData3 d):val(d) {
+    StreamData3Holder(struct c10::StreamData3 d) {
+      val = d;
     }
     StreamData3Holder() = delete;
     struct c10::StreamData3 val;
@@ -584,7 +585,7 @@ public:
     payload.u.as_int = i;
   }
 
-  IValue(const c10::SymInt& i) {
+  IValue(c10::SymInt i) {
     if (auto mi = i.maybe_as_int()) {
       tag = Tag::Int;
       payload.u.as_int = *mi;
@@ -601,7 +602,7 @@ public:
   c10::SymInt toSymInt() &&;
   c10::SymInt toSymInt() const&;
 
-  IValue(const c10::SymFloat& i) {
+  IValue(c10::SymFloat i) {
     if (i.is_symbolic()) {
       tag = Tag::SymFloat;
       payload.u.as_intrusive_ptr = i.toSymNodeImpl().release();
@@ -618,7 +619,7 @@ public:
   c10::SymFloat toSymFloat() &&;
   c10::SymFloat toSymFloat() const&;
 
-  IValue(const c10::SymBool& i) {
+  IValue(c10::SymBool i) {
      if (auto mi = i.maybe_as_bool()) {
       tag = Tag::Bool;
       payload.u.as_int = *mi;

--- a/aten/src/ATen/core/type_factory.h
+++ b/aten/src/ATen/core/type_factory.h
@@ -22,7 +22,7 @@ struct TORCH_API TypeFactoryBase<c10::DynamicType> {
             {std::move(ty), std::forward<Args>(args)...})));
   }
   template <typename T>
-  static c10::DynamicTypePtr create(const std::vector<c10::TypePtr>& types) {
+  static c10::DynamicTypePtr create(std::vector<c10::TypePtr> types) {
     return std::make_shared<c10::DynamicType>(
         c10::DynamicTypeTrait<T>::tagValue(),
         c10::DynamicType::Arguments(types));

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -20,17 +20,14 @@ PyObject *THPException_FatalError, *THPException_LinAlgError,
   if (!(cond))            \
   return false
 bool THPException_init(PyObject* module) {
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_FatalError =
           PyErr_NewException("torch.FatalError", nullptr, nullptr));
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       PyModule_AddObject(module, "FatalError", THPException_FatalError) == 0);
 
   // Set the doc string here since _add_docstr throws malloc errors if tp_doc is
   // modified for an error class.
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_LinAlgError = PyErr_NewExceptionWithDoc(
           "torch._C._LinAlgError",
@@ -57,7 +54,6 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(module, "_LinAlgError", THPException_LinAlgError) ==
       0);
 
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_OutOfMemoryError = PyErr_NewExceptionWithDoc(
           "torch.cuda.OutOfMemoryError",
@@ -68,7 +64,6 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_OutOfMemoryError", THPException_OutOfMemoryError) == 0);
 
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistError",
@@ -78,7 +73,6 @@ could not be completed because the input matrix is singular.",
   ASSERT_TRUE(
       PyModule_AddObject(module, "_DistError", THPException_DistError) == 0);
 
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistBackendError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistBackendError",
@@ -89,7 +83,6 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_DistBackendError", THPException_DistBackendError) == 0);
 
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistNetworkError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistNetworkError",
@@ -100,7 +93,6 @@ could not be completed because the input matrix is singular.",
       PyModule_AddObject(
           module, "_DistNetworkError", THPException_DistNetworkError) == 0);
 
-  // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
   ASSERT_TRUE(
       THPException_DistStoreError = PyErr_NewExceptionWithDoc(
           "torch.distributed.DistStoreError",
@@ -225,42 +217,42 @@ void translate_exception_to_python(const std::exception_ptr& e_ptr) {
 }
 
 IndexError::IndexError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 TypeError::TypeError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 ValueError::ValueError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 NotImplementedError::NotImplementedError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 AttributeError::AttributeError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
 }
 
 LinAlgError::LinAlgError(const char* format, ...) {
-  va_list fmt_args{};
+  va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);
   va_end(fmt_args);
@@ -296,7 +288,8 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
   auto& warning_buffer = internal_handler_.warning_buffer_;
 
   if (!warning_buffer.empty()) {
-    PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    PyObject *type, *value, *traceback;
     pybind11::gil_scoped_acquire gil;
     auto result = 0;
     if (in_exception_) {
@@ -320,7 +313,7 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
             /*category=*/map_warning_to_python_type(warning),
             /*message=*/msg.c_str(),
             /*filename=*/source_location.file,
-            /*lineno=*/static_cast<int>(source_location.line),
+            /*lineno=*/source_location.line,
             /*module=*/nullptr,
             /*registry=*/nullptr);
       } else {
@@ -351,6 +344,7 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
       throw python_error();
     }
     if (in_exception_) {
+      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       PyErr_Restore(type, value, traceback);
     }
   }

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -105,8 +105,8 @@ static inline Py_ssize_t doPartialPythonIO(
     size_t nbytes,
     bool is_read) {
   auto rw_flag = is_read ? PyBUF_WRITE : PyBUF_READ;
-  THPObjectPtr memview(PyMemoryView_FromMemory(
-      reinterpret_cast<char*>(buf), static_cast<Py_ssize_t>(nbytes), rw_flag));
+  THPObjectPtr memview(
+      PyMemoryView_FromMemory(reinterpret_cast<char*>(buf), nbytes, rw_flag));
   if (!memview)
     throw python_error();
 
@@ -228,8 +228,8 @@ void THPStorage_writeFileRaw(
   c10::DeviceGuard guard(self->device());
   uint8_t* data{};
   at::Tensor cpu_tensor;
-  size_t size_bytes = self->nbytes();
-  size_t numel = size_bytes / element_size;
+  int64_t size_bytes = self->nbytes();
+  int64_t numel = size_bytes / element_size;
   if (self->device_type() == at::kCPU) {
     // We are using a mutable pointer here because we're ultimately
     // calling into a Python API that requires that, even though it
@@ -239,9 +239,9 @@ void THPStorage_writeFileRaw(
     // Here we use a tensor.to() to impl D2H for all non-CPU device.
     auto device_tensor = at::from_blob(
         self->mutable_data(),
-        {static_cast<int64_t>(size_bytes)},
+        {size_bytes},
         {1},
-        nullptr,
+        NULL,
         at::device(self->device()).dtype(c10::kByte),
         {self->device()});
     cpu_tensor = device_tensor.to(at::kCPU);
@@ -267,11 +267,11 @@ void THPStorage_writeFileRaw(
           torch::utils::THPByteOrder::THP_LITTLE_ENDIAN) {
     doWrite(fd, data, size_bytes);
   } else {
-    size_t buffer_size = std::min(numel, (size_t)5000);
+    int64_t buffer_size = std::min(numel, (int64_t)5000);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     std::unique_ptr<uint8_t[]> le_buffer(
         new uint8_t[buffer_size * element_size]);
-    for (size_t i = 0; i < numel; i += buffer_size) {
+    for (int64_t i = 0; i < numel; i += buffer_size) {
       size_t to_convert = std::min(numel - i, buffer_size);
       // NOLINTNEXTLINE(bugprone-branch-clone)
       if (element_size == 2) {
@@ -325,7 +325,7 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     int64_t tsize = size; // convert little endian storage to big endian cpu
     torch::utils::THP_decodeInt64Buffer(&size, (const uint8_t*)&tsize, true, 1);
   }
-  size_t nbytes = element_size * size;
+  int64_t nbytes = element_size * size;
   if (!storage.defined()) {
     storage = c10::make_intrusive<at::StorageImpl>(
         c10::StorageImpl::use_byte_size_t(),
@@ -333,7 +333,7 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
         c10::GetDefaultCPUAllocator(),
         /*resizable=*/true);
   } else {
-    size_t _storage_nbytes = storage->nbytes();
+    int64_t _storage_nbytes = storage->nbytes();
     TORCH_CHECK(
         _storage_nbytes == nbytes,
         "storage has wrong byte size: expected %ld got %ld",
@@ -341,14 +341,12 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
         _storage_nbytes);
   }
 
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   std::unique_ptr<char[]> cpu_data;
 
   uint8_t* data{};
   if (storage->device_type() == at::kCPU) {
     data = static_cast<uint8_t*>(storage->mutable_data());
   } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     cpu_data = std::unique_ptr<char[]>(new char[nbytes]);
     data = (uint8_t*)cpu_data.get();
   }
@@ -385,14 +383,12 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
   if (storage->device_type() != at::kCPU) {
     // Here we use a tensor.copy_() to impl H2D for all non-CPU device.
     auto cpu_tensor = at::from_blob(
-        (void*)data,
-        {static_cast<int64_t>(nbytes)},
-        at::device(at::kCPU).dtype(c10::kByte));
+        (void*)data, {nbytes}, at::device(at::kCPU).dtype(c10::kByte));
     auto device_tensor = at::from_blob(
         storage->mutable_data(),
-        {static_cast<int64_t>(nbytes)},
+        {nbytes},
         {1},
-        nullptr,
+        NULL,
         at::device(storage->device()).dtype(c10::kByte),
         {storage->device()});
     device_tensor.copy_(cpu_tensor);

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <cstdarg>
-#include <cstring>
 #include <iterator>
 #include <sstream>
 #include <string>
@@ -264,11 +263,12 @@ char* tensor_repr(at::Tensor tensor) {
   PyGILState_STATE gil = PyGILState_Ensure();
   PyObject* pytensor = nullptr;
   PyObject* repr = nullptr;
-  Py_ssize_t bufsize = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  Py_ssize_t bufsize;
   const char* buf = nullptr;
   char* result = nullptr;
 
-  pytensor = THPVariable_Wrap(std::move(tensor));
+  pytensor = THPVariable_Wrap(at::Tensor(std::move(tensor)));
   if (!pytensor)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
@@ -280,16 +280,16 @@ char* tensor_repr(at::Tensor tensor) {
   if (!buf)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
-  // account for the trailing \0
   // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-  result = static_cast<char*>(malloc(bufsize + 1));
+  result =
+      static_cast<char*>(malloc(bufsize + 1)); // account for the trailing \0
   if (!result) {
     fmt::print(stderr, "cannot allocate memory for the result\n");
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;
   }
-  std::strncpy(result, buf, bufsize);
-  result[bufsize] = '\0';
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.strcpy)
+  strcpy(result, buf);
   Py_XDECREF(pytensor);
   Py_XDECREF(repr);
   PyGILState_Release(gil);


### PR DESCRIPTION
This reverts commit a20fac89c8d51900a70a2aef65db7077a1bf8567.

Conda builds are broken, see if this fixes it
