### PR TITLE
Lower MEMORY_LIMIT_MAX_JOBS to avoid oom during conda builds

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 source /env
 
 # Because most Circle executors only have 20 CPUs, using more causes OOMs w/ Ninja and nvcc parallelization
-MEMORY_LIMIT_MAX_JOBS=8
+MEMORY_LIMIT_MAX_JOBS=4
 NUM_CPUS=$(( $(nproc) - 2 ))
 
 # Defaults here for **binary** linux builds so they can be changed in one place

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 source /env
 
 # Because most Circle executors only have 20 CPUs, using more causes OOMs w/ Ninja and nvcc parallelization
-MEMORY_LIMIT_MAX_JOBS=18
+MEMORY_LIMIT_MAX_JOBS=8
 NUM_CPUS=$(( $(nproc) - 2 ))
 
 # Defaults here for **binary** linux builds so they can be changed in one place

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -156,7 +156,7 @@ EOL
 # nproc doesn't exist on darwin
 if [[ "$(uname)" != Darwin ]]; then
   # This was lowered from 18 to 12 to avoid OOMs when compiling FlashAttentionV2
-  MEMORY_LIMIT_MAX_JOBS=8
+  MEMORY_LIMIT_MAX_JOBS=4
   NUM_CPUS=$(( $(nproc) - 2 ))
 
   # Defaults here for **binary** linux builds so they can be changed in one place

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -156,7 +156,7 @@ EOL
 # nproc doesn't exist on darwin
 if [[ "$(uname)" != Darwin ]]; then
   # This was lowered from 18 to 12 to avoid OOMs when compiling FlashAttentionV2
-  MEMORY_LIMIT_MAX_JOBS=12
+  MEMORY_LIMIT_MAX_JOBS=10
   NUM_CPUS=$(( $(nproc) - 2 ))
 
   # Defaults here for **binary** linux builds so they can be changed in one place

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -156,7 +156,7 @@ EOL
 # nproc doesn't exist on darwin
 if [[ "$(uname)" != Darwin ]]; then
   # This was lowered from 18 to 12 to avoid OOMs when compiling FlashAttentionV2
-  MEMORY_LIMIT_MAX_JOBS=10
+  MEMORY_LIMIT_MAX_JOBS=8
   NUM_CPUS=$(( $(nproc) - 2 ))
 
   # Defaults here for **binary** linux builds so they can be changed in one place


### PR DESCRIPTION
Trying to address nightly failure: https://github.com/pytorch/pytorch/issues/108607