### PR TITLE
[inductor][easy] Enable Mypy Checking for torch/_inductor/decomposition.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -197,7 +197,6 @@ exclude_patterns = [
     'torch/_inductor/coordinate_descent_tuner.py',
     'torch/_inductor/debug.py',
     'torch/_inductor/hooks.py',
-    'torch/_inductor/decomposition.py',
     'torch/_inductor/bounds.py',
     'torch/_inductor/config.py',
     'torch/_inductor/ir.py',

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -180,7 +180,7 @@ def get_decompositions(
 
 
 def remove_decompositions(
-    decompositions: Dict[OpOverload, Callable],
+    decompositions: Dict[torch._ops.OperatorBase, Callable],
     aten_ops: Sequence[Union[OpOverload, OpOverloadPacket]],
 ) -> None:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108682

Summary: Looks like one simple type mismatch between `get_decompositions()` and `remove_decompositions()`

Test Plan: `lintrunner torch/_inductor/decomposition.py`