### PR TITLE
Dynamo support for autograd.Function w/ once_differentiable

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -379,6 +379,29 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         after = compiled_model(*args, **kwargs)
         self.assertEqual(before, after)
 
+    def test_once_differentiable(self):
+        from torch.autograd.function import once_differentiable
+
+        class ScaleGradient(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            @once_differentiable
+            def backward(ctx, grad):
+                return grad * 0.5
+
+        x = torch.randn([], requires_grad=True)
+
+        def f(x):
+            return ScaleGradient.apply(x)
+
+        opt_f = torch._dynamo.optimize("eager", nopython=True)(f)
+        output = opt_f(x)
+        gx, = torch.autograd.grad(output, x)
+        self.assertEqual(gx, torch.tensor(0.5))
+
     # I pulled all of these test cases from test_autograd.py
     # In the future, we should make the Dynamo test suite actually
     # run on test_autograd.py (it's disabled right now) and delete these.

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -399,7 +399,7 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
 
         opt_f = torch._dynamo.optimize("eager", nopython=True)(f)
         output = opt_f(x)
-        gx, = torch.autograd.grad(output, x)
+        (gx,) = torch.autograd.grad(output, x)
         self.assertEqual(gx, torch.tensor(0.5))
 
     # I pulled all of these test cases from test_autograd.py

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2224,23 +2224,6 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 # Known sound
                 return
 
-            """
-            # Function returned by torch.autograd.function.once_differentiable is known sound
-            if (
-                isinstance(func, UserFunctionVariable) and
-                func.get_filename().endswith('torch/autograd/function.py') and
-                not func.fn.__module__.startswith('torch.autograd.function')
-            ):
-                return
-            # Function wrapped by torch.autograd.function.once_differentiable is known sound
-            if (
-                isinstance(func, NestedUserFunctionVariable) and
-                func.get_filename().endswith('torch/autograd/function.py') and
-                func.fn_name.value == 'once_differentiable.<locals>.wrapper.<locals>.<genexpr>'
-            ):
-                retuorn
-            """
-
             unimplemented(
                 f"inline in skipfiles: {func.fn.__qualname__}  | {func.get_name()} {func.get_filename()}"
             )

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 import torch
 import torch._logging
-from torch._dynamo_utils import compiler_should_force_inline
+from torch._dynamo.utils import should_force_inline
 from torch._guards import Checkpointable, tracing, TracingContext
 
 from . import (
@@ -2185,7 +2185,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     @staticmethod
     def check_inlineable(func):
-        if compiler_should_force_inline(func):
+        if should_force_inline(func):
             return True
 
         if func.has_self():

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -61,6 +61,7 @@ import torch._functorch.config
 import torch.fx.experimental.symbolic_shapes
 from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
+from torch._dynamo_utils import DYNAMO_FORCE_INLINE
 from torch._subclasses.fake_tensor import FakeTensor, is_fake
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._pytree import tree_map
@@ -90,6 +91,13 @@ def tabulate(rows, headers):
         return "\n".join(
             ", ".join(map(str, row)) for row in itertools.chain([headers], rows)
         )
+
+
+def should_force_inline(func):
+    from .variables.functions import NestedUserFunctionVariable, UserFunctionVariable
+
+    assert isinstance(func, (UserFunctionVariable, NestedUserFunctionVariable))
+    return func.get_code() in DYNAMO_FORCE_INLINE
 
 
 def dynamo_profiled(func):

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -198,7 +198,7 @@ class VariableTracker(metaclass=HasPostInit):
         return self.clone(guards=set.union(self.guards, {guard}))
 
     def add_guards(self, guards):
-        if guards is None:
+        if not guards:
             return self
         assert isinstance(guards, set)
         return self.clone(guards=set.union(self.guards, guards))

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -151,7 +151,9 @@ def speculate_subgraph(
             )
 
             autograd_ctx = (
-                dynamo_enable_grad(tx, enable_grad) if enable_grad is not None else contextlib.nullcontext()
+                dynamo_enable_grad(tx, enable_grad)
+                if enable_grad is not None
+                else contextlib.nullcontext()
             )
 
             if restore_side_effects:
@@ -970,7 +972,9 @@ class AutogradFunctionMethodHigherOrderVariable(TorchHigherOrderOperatorVariable
         # then the grad_mode is False during the backward pass.
         # torch.compile assumes that we only compute first-order gradients,
         # so we want to speculate the backward pass with the grad mode disabled.
-        enable_grad = False if self.value.__name__ == "trampoline_autograd_bwd" else None
+        enable_grad = (
+            False if self.value.__name__ == "trampoline_autograd_bwd" else None
+        )
 
         # TODO: Support kwargs
         (

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -42,12 +42,12 @@ def safe_or_raise_always_restore(tx, graph_checkpoint, checkpoint, f, sub_args):
 
 
 @contextlib.contextmanager
-def dynamo_enable_grad(tx):
+def dynamo_enable_grad(tx, enable=True):
     from . import GradModeVariable
 
     org_value = torch.is_grad_enabled()
     try:
-        GradModeVariable.create(tx, True)
+        GradModeVariable.create(tx, enable)
         yield
     finally:
         GradModeVariable.create(tx, org_value)
@@ -120,7 +120,7 @@ def speculate_subgraph(
     description,
     *,
     always_restore=False,
-    enable_grad=False,
+    enable_grad=None,
     # NOTE [Temporary argument `manually_set_subgraph_inputs`]
     # If manually_set_subgraph_inputs=True, then we manually add
     # the `sub_args` to `subgraph`, if False then we rely
@@ -151,7 +151,7 @@ def speculate_subgraph(
             )
 
             autograd_ctx = (
-                dynamo_enable_grad(tx) if enable_grad else contextlib.nullcontext()
+                dynamo_enable_grad(tx, enable_grad) if enable_grad is not None else contextlib.nullcontext()
             )
 
             if restore_side_effects:
@@ -966,6 +966,11 @@ class AutogradFunctionMethodHigherOrderVariable(TorchHigherOrderOperatorVariable
         checkpoint = tx.copy_graphstate()
         pre_guards = tx.output.guards
         graph_checkpoint = tx.output.graph
+        # In eager-mode PyTorch, if we only compute first-order gradients,
+        # then the grad_mode is False during the backward pass.
+        # torch.compile assumes that we only compute first-order gradients,
+        # so we want to speculate the backward pass with the grad mode disabled.
+        enable_grad = False if self.value.__name__ == "trampoline_autograd_bwd" else None
 
         # TODO: Support kwargs
         (
@@ -985,6 +990,7 @@ class AutogradFunctionMethodHigherOrderVariable(TorchHigherOrderOperatorVariable
             # Backwards should never, ever be stored!
             always_restore=always_restore,
             restore_side_effects=False,
+            enable_grad=enable_grad,
         )
         post_guards = tx.output.guards
         if body_lifted_freevars:

--- a/torch/_dynamo_utils.py
+++ b/torch/_dynamo_utils.py
@@ -1,0 +1,29 @@
+import weakref
+from typing import Any
+
+"""
+Helper utilities for Dynamo that do not require a full import of torch._dynamo.
+The motivation for this file is to avoid circular dependencies.
+"""
+
+DYNAMO_FORCE_INLINE: Any = weakref.WeakKeyDictionary()
+
+
+def compiler_force_inline(f):
+    """Forces inline on all functions that have the same __code__ as f,
+    bypassing things like the SKIPFILES check.
+
+    This matters for lambdas and nested functions: each new instance
+    has a different __code__.
+
+    This API is a short-term hack to avoid design flaws in SKIPFILES:
+    there was not an easy way to mark a single API in a file that is
+    in SKIPFILES for inlining. We should rework the SKIPFILES design
+    (and this API).
+    """
+    DYNAMO_FORCE_INLINE[f.__code__] = True
+    return f
+
+
+def compiler_should_force_inline(func):
+    return func.get_code() in DYNAMO_FORCE_INLINE

--- a/torch/_dynamo_utils.py
+++ b/torch/_dynamo_utils.py
@@ -1,3 +1,4 @@
+import inspect
 import weakref
 from typing import Any
 
@@ -9,7 +10,7 @@ The motivation for this file is to avoid circular dependencies.
 DYNAMO_FORCE_INLINE: Any = weakref.WeakKeyDictionary()
 
 
-def compiler_force_inline(f):
+def force_inline(f):
     """Forces inline on all functions that have the same __code__ as f,
     bypassing things like the SKIPFILES check.
 
@@ -21,9 +22,9 @@ def compiler_force_inline(f):
     in SKIPFILES for inlining. We should rework the SKIPFILES design
     (and this API).
     """
+    if not (inspect.isfunction(f) and hasattr(f, "__code__")):
+        raise ValueError(
+            "force_inline(f): Expected f to be a Python function with .__code__"
+        )
     DYNAMO_FORCE_INLINE[f.__code__] = True
     return f
-
-
-def compiler_should_force_inline(func):
-    return func.get_code() in DYNAMO_FORCE_INLINE

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -8,6 +8,7 @@ import torch._C as _C
 import torch._functorch as _functorch
 import torch.utils.hooks as hooks
 from torch._C import _functions
+from torch._dynamo_utils import compiler_force_inline
 from torch._functorch.autograd_function import custom_function_call
 
 __all__ = [
@@ -550,7 +551,9 @@ class Function(_SingleLevelFunction):
 
 
 def once_differentiable(fn):
+    @compiler_force_inline
     @functools.wraps(fn)
+    @compiler_force_inline
     def wrapper(ctx, *args):
         with torch.no_grad():
             outputs = fn(ctx, *args)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -5,10 +5,10 @@ from typing import Any, List, Optional, Tuple
 
 import torch
 import torch._C as _C
+import torch._dynamo_utils
 import torch._functorch as _functorch
 import torch.utils.hooks as hooks
 from torch._C import _functions
-from torch._dynamo_utils import compiler_force_inline
 from torch._functorch.autograd_function import custom_function_call
 
 __all__ = [
@@ -551,9 +551,14 @@ class Function(_SingleLevelFunction):
 
 
 def once_differentiable(fn):
-    @compiler_force_inline
+    # In order for the function returned by once_differentiable to work with Dynamo,
+    # Dynamo needs to be able to inline through its return to prove safety.
+    # However, Dynamo thinks the function returned by once_differentiable is in a
+    # SKIPFILES, because this file is in SKIPFILES, which prevents inlining. We apply
+    # the following decorator (once per function) to force inlines.
+    @torch._dynamo_utils.force_inline
     @functools.wraps(fn)
-    @compiler_force_inline
+    @torch._dynamo_utils.force_inline
     def wrapper(ctx, *args):
         with torch.no_grad():
             outputs = fn(ctx, *args)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108686

Fixes #106893

There are two main changes:
- Before this PR, the function returned by once_differentiable was
included in skipfiles (because its .co_code is
torch/autograd/function.py). This PR adds a mechanism to tell Dynamo
to inline a function, no matter if it is included in skipfiles.
- A bugfix: when we are introspecting the backward, we need to turn the
grad mode off. This is to accurately model the eager-mode semantics:
In eager-mode PyTorch, if second-order gradients were not requested, then
the grad mode is off. torch.compile does not work with higher-order
gradients and just assumes we do first-order gradients, so this is OK.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng

Differential Revision: [D49064185](https://our.internmc.facebook.com/intern/diff/D49064185)