### PR TITLE
[caffe2] Remove cxx override to c++17

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -186,9 +186,7 @@ def third_party(name):
 
 def get_pt_compiler_flags():
     return select({
-        "DEFAULT": _PT_COMPILER_FLAGS + [
-            "-std=gnu++17",  #to accommodate for eigen
-        ],
+        "DEFAULT": _PT_COMPILER_FLAGS,
         "ovr_config//compiler:cl": windows_convert_gcc_clang_flags(_PT_COMPILER_FLAGS),
     })
 


### PR DESCRIPTION
Summary: Allow the user to specify the cxx version to use when compiling. For applications that compile with C++20, we wish to also compile this library with C++20 to avoid subtle ODR violations with using different library standards.

Test Plan: Built the project successfully.

Reviewed By: smeenai

Differential Revision: D48636406

