### PR TITLE
Release only change, test against test channel

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -90,7 +90,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
       if [[ "\${TORCH_CONDA_BUILD_FOLDER}" == "pytorch-nightly" ]]; then
               PYTORCH_CHANNEL="pytorch-nightly"
       fi
-      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c "\${PYTORCH_CHANNEL}" "pytorch-cuda=\${cu_ver}"
+      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c pytorch-test "pytorch-cuda=\${cu_ver}"
     fi
     conda install \${EXTRA_CONDA_FLAGS} -y "\$pkg" --offline
   )
@@ -98,9 +98,9 @@ elif [[ "$PACKAGE_TYPE" != libtorch ]]; then
   if [[ "$(uname -m)" == aarch64 ]]; then
     # Using "extra-index-url" until all needed aarch64 dependencies are
     # added to "https://download.pytorch.org/whl/nightly/"
-    pip install "\$pkg" --extra-index-url "https://download.pytorch.org/whl/nightly/${DESIRED_CUDA}"
+    pip install "\$pkg" --extra-index-url "https://download.pytorch.org/whl/test/${DESIRED_CUDA}"
   else
-    pip install "\$pkg" --index-url "https://download.pytorch.org/whl/nightly/${DESIRED_CUDA}"
+    pip install "\$pkg" --index-url "https://download.pytorch.org/whl/test/${DESIRED_CUDA}"
   fi
   retry pip install -q numpy protobuf typing-extensions
 fi


### PR DESCRIPTION
Release testing. Test against test channel.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7de5901</samp>

Updated the source of binary packages for testing the 2.1 release branch on Linux. Used the `pytorch-test` channel and the `test` subdirectory for conda and pip respectively in `.circleci/scripts/binary_linux_test.sh`.