### PR TITLE
Use linux.24xlarge for conda linux nightly builds

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -57,6 +57,8 @@ jobs:
       {%- if "aarch64" in build_environment %}
       runs_on: linux.t4g.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
+      {%- elif "conda" in build_environment and config["gpu_arch_type"] == "cuda" %}
+      runs_on: linux.24xlarge
       {%- endif %}
       build_name: !{{ config["build_name"] }}
       build_environment: !{{ build_environment }}

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -107,6 +107,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
       DESIRED_PYTHON: "3.8"
+      runs_on: linux.24xlarge
       build_name: conda-py3_8-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -167,6 +168,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
       DESIRED_PYTHON: "3.8"
+      runs_on: linux.24xlarge
       build_name: conda-py3_8-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -284,6 +286,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
       DESIRED_PYTHON: "3.9"
+      runs_on: linux.24xlarge
       build_name: conda-py3_9-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -344,6 +347,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
       DESIRED_PYTHON: "3.9"
+      runs_on: linux.24xlarge
       build_name: conda-py3_9-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -461,6 +465,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
       DESIRED_PYTHON: "3.10"
+      runs_on: linux.24xlarge
       build_name: conda-py3_10-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -521,6 +526,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
       DESIRED_PYTHON: "3.10"
+      runs_on: linux.24xlarge
       build_name: conda-py3_10-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -638,6 +644,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
       DESIRED_PYTHON: "3.11"
+      runs_on: linux.24xlarge
       build_name: conda-py3_11-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -698,6 +705,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
       DESIRED_PYTHON: "3.11"
+      runs_on: linux.24xlarge
       build_name: conda-py3_11-cuda12_1
       build_environment: linux-binary-conda
     secrets:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/108607
CI test: https://github.com/pytorch/pytorch/pull/108666
Lowering memory limit did not worked: https://github.com/pytorch/pytorch/pull/108669