### PR TITLE
[TGIF Inplace] [xlv2][1/n]  Expose a couple APIs from inline_container that will be used for chunk read

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -95,6 +95,29 @@ namespace serialize {
 
 static constexpr const char* kSerializationIdRecordName = ".data/serialization_id";
 
+struct MzZipReaderIterWrapper;
+
+class ChunkRecordIterator {
+ public:
+  ~ChunkRecordIterator();
+
+  // Read at most `chunkSize` into `buf`. Return the number of actual bytes read.
+  size_t next(void* buf);
+
+ private:
+ ChunkRecordIterator(
+      size_t recordSize,
+      size_t chunkSize,
+      std::unique_ptr<MzZipReaderIterWrapper> iter);
+
+  const size_t recordSize_;
+  const size_t chunkSize_;
+  size_t offset_;
+  std::unique_ptr<MzZipReaderIterWrapper> iter_;
+
+  friend class PyTorchStreamReader;
+};
+
 class TORCH_API PyTorchStreamReader final {
  public:
   explicit PyTorchStreamReader(const std::string& file_name);
@@ -111,10 +134,18 @@ class TORCH_API PyTorchStreamReader final {
       size_t n,
       size_t chunk_size,
       void* buf,
-      const std::function<void(void*, const void*, size_t)>& memcpy_func);
+      const std::function<void(void*, const void*, size_t)>& memcpy_func = nullptr);
+
+  size_t getRecordSize(const std::string& name);
+
   size_t getRecordOffset(const std::string& name);
   bool hasRecord(const std::string& name);
   std::vector<std::string> getAllRecords();
+
+  ChunkRecordIterator createChunkReaderIter(
+      const std::string& name,
+      const size_t recordSize,
+      const size_t chunkSize);
 
   ~PyTorchStreamReader();
   uint64_t version() const {


### PR DESCRIPTION
Summary: Expose APIs needed for chunk read. Tested together with stacked diff.

Test Plan:
unit test
```
buck test //caffe2/caffe2/serialize:inline_container_test  --  --run-disabled --print-passing-details
```

Integration test is done together with stacked diff.

Differential Revision: D48544397


// Temporarily adding to unblock shipIt:
@diff-train-skip-merge