### PR TITLE
[Decomposition] _unsafe_index.Tensor

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -371,6 +371,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.unfold_backward,
             aten.unfold_copy,
             aten._unsafe_index,
+            aten._unsafe_index.Tensor,
             aten.upsample_bilinear2d,
             aten.upsample_nearest2d_backward,
             aten.view_as_complex,


### PR DESCRIPTION
Summary:
Decomp already exists so just add it to core_aten_decompositions

https://www.internalfb.com/code/fbsource/[1e085b346f4112247e2aac6f720ae1358acbb14d]/xplat/caffe2/torch/_decomp/decompositions.py?lines=3096

Differential Revision: D48618937


