### PR TITLE
[Decomposition] clamp_min

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -139,10 +139,6 @@ aten::clamp_max.Tensor_out
 aten::clamp_max.out
 aten::clamp_max_
 aten::clamp_max_.Tensor
-aten::clamp_min
-aten::clamp_min.Tensor
-aten::clamp_min.Tensor_out
-aten::clamp_min.out
 aten::clamp_min_
 aten::clamp_min_.Tensor
 aten::clone

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -227,6 +227,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.binary_cross_entropy_with_logits,
             aten.celu,
             aten.celu_,
+            aten.clamp_min,
             aten.col2im,
             aten.count_nonzero,
             aten.cudnn_batch_norm,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -71,6 +71,7 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 decomps_to_exclude = [
     aten._unsafe_index,
     aten._scaled_dot_product_flash_attention.default,  # See comments in torch/_decomp/decompositions.py
+    aten.clamp_min,
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)


### PR DESCRIPTION
Summary:
Decomp already exists so just add it to core_aten_decompositions

https://www.internalfb.com/code/fbsource/[abda43a5a268e83fef6d62b49531a390ce915ad2]/fbcode/caffe2/torch/_refs/__init__.py?lines=1846

Differential Revision: D48880080




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov