### PR TITLE
[Decomposition] div.Tensor_mode

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -181,14 +181,6 @@ aten::digamma.out
 aten::digamma_
 aten::dist
 aten::dist.out
-aten::div.Scalar
-aten::div.Scalar_mode
-aten::div.Scalar_mode_out
-aten::div.Scalar_out
-aten::div.Tensor
-aten::div.Tensor_mode
-aten::div.out
-aten::div.out_mode
 aten::div_.Scalar
 aten::div_.Scalar_mode
 aten::div_.Tensor

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -730,6 +730,13 @@ aten::dequantize.tensors_out
 aten::detach_
 aten::detach_copy
 aten::detach_copy.out
+aten::div.Scalar
+aten::div.Scalar_mode
+aten::div.Scalar_mode_out
+aten::div.Scalar_out
+aten::div.Tensor
+aten::div.out
+aten::div.out_mode
 aten::embedding_renorm
 aten::embedding_renorm.out
 aten::embedding_renorm_

--- a/test/export/test_upgrade.py
+++ b/test/export/test_upgrade.py
@@ -133,9 +133,9 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
         custom_op_count = count_op(upgraded_ep.graph, "aten::div__Scalar_mode_0_3")
         self.assertEqual(custom_op_count, 0)
 
-        # div__Scalar_mode_0_3 decomposes into div.Tensor.
+        # op isn't decomposed into div.Tensor_mode anymore.
         decomposed_op_count = count_op(upgraded_ep.graph, "aten::div.Tensor_mode")
-        self.assertEqual(decomposed_op_count, 1)
+        self.assertEqual(decomposed_op_count, 0)
 
 
 if __name__ == '__main__':

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -236,6 +236,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.detach,
             aten.diag_embed,
             aten.diagonal_backward,
+            aten.div.Tensor_mode,
             aten.dot,
             aten.vdot,
             aten.elu,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,22 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition([aten.div.Tensor_mode])
+def div_tensor_mode(self: Tensor, other: Tensor, *, rounding_mode: Optional[str]) -> Tensor:
+    # aten::div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor
+    quotient = torch.div(self, other)
+    if rounding_mode is None:
+        return quotient
+    elif rounding_mode == "trunc":
+        return torch.trunc(quotient)
+    elif rounding_mode == "floor":
+        return torch.floor(quotient)
+    else:
+        raise RuntimeError(
+            f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found '{rounding_mode}'"
+        )
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -71,6 +71,7 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 decomps_to_exclude = [
     aten._unsafe_index,
     aten._scaled_dot_product_flash_attention.default,  # See comments in torch/_decomp/decompositions.py
+    aten.div.Tensor,
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1147,7 +1147,6 @@ def copysign(
 # complex =  _make_elementwise_binary_reference(prims.complex, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT)
 
 
-@register_decomposition(aten.div)
 @out_wrapper()
 def div(
     a: Union[TensorLikeType, NumberType],


### PR DESCRIPTION
Summary:
Decomp already exists so just add it to core_aten_decompositions

https://www.internalfb.com/code/fbsource/[b15dc20207e33abb49621994196f2ee063724d2a]/xplat/caffe2/torch/_refs/__init__.py?lines=1114

Differential Revision: D48880486




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov