### PR TITLE
[pytorch-vulkan] move glsl random utils to Random.h

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/random.h
+++ b/aten/src/ATen/native/vulkan/glsl/random.h
@@ -1,0 +1,21 @@
+/*
+ * Random utility functions
+ */
+
+uint pcg_hash(uint v) {
+  // From: https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/
+  uint state = v * 747796405u + 2891336453u;
+  uint word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+  return (word >> 22u) ^ word;
+}
+
+float rand2(ivec4 pos) {
+  uint s =
+      pcg_hash(pos.x) + pcg_hash(pos.y) + pcg_hash(pos.z) + pcg_hash(pos.w);
+  return fract(s / 1234567.0);
+}
+
+float get_uniform(ivec4 pos, float from, float to) {
+  float v = rand2(pos);
+  return from + v * (to - from);
+}

--- a/aten/src/ATen/native/vulkan/glsl/uniform_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/uniform_.glsl
@@ -2,6 +2,8 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+#include "random.h"
+
 layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
@@ -15,33 +17,15 @@ layout(set = 0, binding = 1) uniform PRECISION restrict Block {
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-uint pcg_hash(uint v) {
-  // From: https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering/
-  uint state = v * 747796405u + 2891336453u;
-  uint word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
-  return (word >> 22u) ^ word;
-}
-
-float rand2(ivec4 pos) {
-  uint s =
-      pcg_hash(pos.x) + pcg_hash(pos.y) + pcg_hash(pos.z) + pcg_hash(pos.w);
-  return fract(s / 1234567.0);
-}
-
-float get_uniform(ivec4 pos) {
-  float v = rand2(pos);
-  return uBlock.from + v * (uBlock.to - uBlock.from);
-}
-
 void main() {
   ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size))) {
     vec4 v = vec4(
-        get_uniform(ivec4(pos, -20)),
-        get_uniform(ivec4(pos, 40)),
-        get_uniform(ivec4(pos, -30)),
-        get_uniform(ivec4(pos, 15)));
+        get_uniform(ivec4(pos, -20), uBlock.from, uBlock.to),
+        get_uniform(ivec4(pos, 40), uBlock.from, uBlock.to),
+        get_uniform(ivec4(pos, -30), uBlock.from, uBlock.to),
+        get_uniform(ivec4(pos, 15), uBlock.from, uBlock.to));
     imageStore(uOutput, pos, v);
   }
 }


### PR DESCRIPTION
Summary:
I plan to use the Box-Muller method for sampling from the normal distribution to implement `aten::randn_like`, which can use the existing uniform functions, so I move them out to a `random.h`.

https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform

Test Plan:
```
[ttingchulin@95660.od /data/sandcastle/boxes/fbsource (rand_lib)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*<test>*" eg.  -- --gtest_filter="*uniform*"

BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *uniform*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VulkanAPITest
[ RUN      ] VulkanAPITest.uniform
[       OK ] VulkanAPITest.uniform (120 ms)
[----------] 1 test from VulkanAPITest (120 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (120 ms total)
[  PASSED  ] 1 test.
```

Reviewed By: yipjustin

Differential Revision: D48750679


