### PR TITLE
[Decomposition] rand_like

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -1043,8 +1043,6 @@ aten::rand.generator_with_names_out
 aten::rand.names
 aten::rand.names_out
 aten::rand.out
-aten::rand_like
-aten::rand_like.out
 aten::randint
 aten::randint.generator
 aten::randint.generator_out

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -326,6 +326,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten._reshape_alias,
             aten.rad2deg,
             aten.rad2deg_,
+            aten.rand_like,
             aten.renorm,
             aten.renorm_,
             aten.rot90,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,28 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition(aten.rand_like)
+def rand_like(
+    self: Tensor,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None,
+    memory_format: Optional[torch.memory_format] = None,
+):
+    rand_output = torch.rand(
+        [*self.size()],
+        dtype=dtype or self.dtype,
+        device=device or self.device,
+    )
+
+    if memory_format is not None:
+        rand_output = rand_output.to(memory_format=memory_format)
+
+    return memory_format.as_strided(self.size(), self.stride())
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -324,16 +324,6 @@ def view_copy_dtype(self, dtype):
     return self.to(dtype).clone()
 
 
-@register_decomposition(aten.rand_like)
-def rand_like(self, *, dtype=None, device=None, **kwargs):
-    return torch.rand(
-        [*self.size()],
-        dtype=dtype or self.dtype,
-        device=device or self.device,
-        **kwargs,
-    )
-
-
 @register_decomposition(aten.randn_like)
 def randn_like(self, *, dtype=None, device=None, **kwargs):
     return torch.randn(


### PR DESCRIPTION
Summary: Move decomp from _inductor and include it in core_aten_decompositions

Differential Revision: D48940164




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel