### PR TITLE
[fx][split][testing] Add testing for #107981

### DIFF
--- a/test/fx/test_fx_split.py
+++ b/test/fx/test_fx_split.py
@@ -34,6 +34,11 @@ class TestFXSplit(TestCase):
                     self.assertIn("name", n.meta)
                     self.assertEqual(n.meta["name"], n.name)
 
+        # Validate that metadata is copied correctly for graph placeholder nodes
+        for node in split_gm.graph.nodes:
+            if node.op == "placeholder":
+                self.assertIn("name", node.meta)
+                self.assertEqual(node.meta["name"], node.name)
 
 class TestSplitByTags(TestCase):
     class TestModule(torch.nn.Module):


### PR DESCRIPTION
- Follow-up to #107981, adding testing for metadata copying in placeholder nodes within the `split_by_tags` utility
- Validation included in the test from #107248, since both tests are relevant to the same aspect of the utility