### PR TITLE
Deprecate torch.cross default behaviour

### DIFF
--- a/aten/src/ATen/native/Cross.cpp
+++ b/aten/src/ATen/native/Cross.cpp
@@ -59,6 +59,13 @@ static int64_t _default_cross_dim(const c10::optional<int64_t> &dimension, SymIn
 }
 
 Tensor cross(const Tensor & input, const Tensor & other, const c10::optional<int64_t> dimension) {
+  if (!dimension) {
+    TORCH_WARN_ONCE(
+      "Using torch.cross without specifying the dim arg is deprecated.\n",
+      "Please either pass the dim explicitly or simply use linalg.cross.\n",
+      "The default value of dim will change to agree with that of linalg.cross in a future release."
+    );
+  }
   auto dim = _default_cross_dim(dimension, input.sym_sizes());
   return at::linalg_cross(input, other, dim);
 }

--- a/aten/src/ATen/native/Cross.cpp
+++ b/aten/src/ATen/native/Cross.cpp
@@ -62,7 +62,7 @@ Tensor cross(const Tensor & input, const Tensor & other, const c10::optional<int
   if (!dimension) {
     TORCH_WARN_ONCE(
       "Using torch.cross without specifying the dim arg is deprecated.\n",
-      "Please either pass the dim explicitly or simply use linalg.cross.\n",
+      "Please either pass the dim explicitly or simply use torch.linalg.cross.\n",
       "The default value of dim will change to agree with that of linalg.cross in a future release."
     );
   }

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3202,15 +3202,16 @@ Supports input of float, double, cfloat and cdouble dtypes. Also supports batche
 of vectors, for which it computes the product along the dimension :attr:`dim`.
 In this case, the output has the same batch dimensions as the inputs.
 
-If :attr:`dim` is not given, it defaults to the first dimension found with the
-size 3. Note that this might be unexpected.
+.. warning::
+    If :attr:`dim` is not given, it defaults to the first dimension found
+    with the size 3. Note that this might be unexpected.
+
+    This behavior is deprecated and will be changed to match that of :func:`torch.linalg.cross`
+    in a future release.
 
 .. seealso::
-        :func:`torch.linalg.cross` which requires specifying dim (defaulting to -1).
+        :func:`torch.linalg.cross` which has dim=-1 as default.
 
-.. warning:: This function may change in a future PyTorch release to match
-        the default behaviour in :func:`torch.linalg.cross`. We recommend using
-        :func:`torch.linalg.cross`.
 
 Args:
     {input}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108760

Long overdue this one. We may be able to change it in a few years :hopeful:.

**BC-breaking note**

This PR deprecates `torch.cross`'s default dim in favor of
`torch.linalg.cross`.
A upgrade guide is added to the documentation for `torch.cross`.

Note this PR DOES NOT remove `torch.cross`.

Fixes https://github.com/pytorch/pytorch/issues/108664

cc @jianyuh @nikitaved @pearu @mruberry @walterddr @IvanYashchuk @xwang233 @Lezcano