### PR TITLE
[Dev Container][CUDA]Fix linker path

### DIFF
--- a/.devcontainer/scripts/install-dev-tools.sh
+++ b/.devcontainer/scripts/install-dev-tools.sh
@@ -9,3 +9,5 @@ make setup_lint
 
 # Add CMAKE_PREFIX_PATH to bashrc
 echo 'export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}' >> ~/.bashrc
+# Add linker path so that cuda-related libraries can be found
+echo 'export LDFLAGS="-L/opt/conda/lib/ $LDFLAGS"' >> ~/.bashrc

--- a/.devcontainer/scripts/install-dev-tools.sh
+++ b/.devcontainer/scripts/install-dev-tools.sh
@@ -10,4 +10,4 @@ make setup_lint
 # Add CMAKE_PREFIX_PATH to bashrc
 echo 'export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}' >> ~/.bashrc
 # Add linker path so that cuda-related libraries can be found
-echo 'export LDFLAGS="-L/opt/conda/lib/ $LDFLAGS"' >> ~/.bashrc
+echo 'export LDFLAGS="-L${CONDA_PREFIX}/lib/ $LDFLAGS"' >> ~/.bashrc


### PR DESCRIPTION
Building with CUDA in dev container leads to error: `cannot find -lcudart_static`. This is because the libraries are under a custom CUDA_HOME, and `ld` cannot find it.

Updating the `LDFLAGS` environment variable works.