### PR TITLE
[ghexport] reintroduce old way of non diff train way of finding oss base

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 --------------------------------------------------------------------------------
 random change
+another random change
 
 PyTorch is a Python package that provides two high-level features:
 - Tensor computation (like NumPy) with strong GPU acceleration


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108769
* #108768

When we introduced diff train to ghexport, it made it such that it did not work with non difftrain prs. Here we reintroduce that logic erased from D39008711

Differential Revision: [D49042620](https://our.internmc.facebook.com/intern/diff/D49042620/)