### PR TITLE
[ROCm] enable BF16 datatype

### DIFF
--- a/aten/src/ATen/cuda/CUDADataType.h
+++ b/aten/src/ATen/cuda/CUDADataType.h
@@ -30,6 +30,9 @@ template<> inline cudaDataType getCudaDataType<c10::complex<float>>() {
 template<> inline cudaDataType getCudaDataType<c10::complex<double>>() {
   return CUDA_C_64F;
 }
+template<> inline cudaDataType getCudaDataType<at::BFloat16>() {
+  return CUDA_R_16BF;
+}
 
 // HIP doesn't define integral types
 #ifndef USE_ROCM
@@ -50,9 +53,6 @@ template<> inline cudaDataType getCudaDataType<int16_t>() {
 }
 template<> inline cudaDataType getCudaDataType<int64_t>() {
   return CUDA_R_64I;
-}
-template<> inline cudaDataType getCudaDataType<at::BFloat16>() {
-  return CUDA_R_16BF;
 }
 #endif
 
@@ -79,13 +79,13 @@ inline cudaDataType ScalarTypeToCudaDataType(const c10::ScalarType& scalar_type)
       return CUDA_C_32F;
     case c10::ScalarType::ComplexDouble:
       return CUDA_C_64F;
+    case c10::ScalarType::BFloat16:
+      return CUDA_R_16BF;
 #if !defined(USE_ROCM)
     case c10::ScalarType::Short:
       return CUDA_R_16I;
     case c10::ScalarType::Long:
       return CUDA_R_64I;
-    case c10::ScalarType::BFloat16:
-      return CUDA_R_16BF;
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
     case c10::ScalarType::Float8_e4m3fn:
       return CUDA_R_8F_E4M3;


### PR DESCRIPTION
This PR is to enable CUDA_R_16BF data type on ROCm. 

This is to fix the PyT unit test errors like below.

```
ERROR [0.008s]: test_addmm_sizes_all_sparse_csr_k_1_n_10_m_25_cuda_bfloat16 (__main__.TestSparseCSRCUDA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/pytorch/torch/testing/_internal/common_utils.py", line 2354, in wrapper
    method(*args, **kwargs)
  File "/root/pytorch/torch/testing/_internal/common_utils.py", line 2354, in wrapper
    method(*args, **kwargs)
  File "/root/pytorch/torch/testing/_internal/common_device_type.py", line 428, in instantiated_test
    raise rte
  File "/root/pytorch/torch/testing/_internal/common_device_type.py", line 415, in instantiated_test
    result = test(self, **param_kwargs)
  File "/root/pytorch/torch/testing/_internal/common_device_type.py", line 945, in dep_fn
    return fn(slf, *args, **kwargs)
  File "test_sparse_csr.py", line 1997, in test_addmm_sizes_all_sparse_csr
    _test_addmm_addmv(self, torch.addmm, M, m1, m2, layout=torch.sparse_csr, mode="all_sparse")
  File "test_sparse_csr.py", line 115, in _test_addmm_addmv
    res1 = f(*map(convert_layout, (t, m, v)), alpha=alpha, beta=beta)
RuntimeError: false INTERNAL ASSERT FAILED at "/root/pytorch/aten/src/ATen/hip/HIPDataType.h":93, please report a bug to PyTorch. Cannot convert ScalarType BFloat16 to hipDataType.

```



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang