### PR TITLE
Revert "[dynamo] Reduce cache size limit to 8 (#108526)"

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1470,14 +1470,13 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(mandelbrot_numpy)
-        n_iter = torch._dynamo.config.cache_size_limit
-        for _ in range(n_iter):
+        for _ in range(10):
             x = random.randint(2, 30)
             ref = mandelbrot_numpy(x)
             res = opt_fn(x)
             self.assertEqual(ref, res)
         # We need to specialise the number as it's in a forloop
-        self.assertEqual(cnts.frame_count, n_iter)
+        self.assertEqual(cnts.frame_count, 10)
 
     def test_numpy_as_global(self):
         global x

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -90,7 +90,6 @@ class TestPatternMatcherBase(TestCase):
         check_quantization=False,
     ):
         counters.clear()
-        torch._dynamo.reset()
         maybe_autocast = contextlib.nullcontext()
         if check_autocast and torch.ops.mkldnn._is_mkldnn_bf16_supported():
             maybe_autocast = torch.cpu.amp.autocast()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -35,7 +35,8 @@ dead_code_elimination = True
 # controls the maximum number of cache entries with a guard on same ID_MATCH'd
 # object. It also controls the maximum size of cache entries if they don't have
 # any ID_MATCH'd guards.
-cache_size_limit = 8
+# TODO(janimesh) - Reduce this value to a smaller number once stability is reached.
+cache_size_limit = 64
 # controls the maximum number of entries for a code object.
 accumulated_cache_size_limit = 64
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1137,7 +1137,7 @@ TestEnvironment.def_flag("TEST_WITH_TORCHDYNAMO", env_var="PYTORCH_TEST_WITH_DYN
 if TEST_WITH_TORCHDYNAMO:
     import torch._dynamo
     # Do not spend time on helper functions that are called with different inputs
-    torch._dynamo.config.accumulated_cache_size_limit = 8
+    torch._dynamo.config.cache_size_limit = 8
     # TODO: Remove this; this is grandfathered in because we suppressed errors
     # on test suite previously
     torch._dynamo.config.suppress_errors = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108795

This reverts commit 29f109789173535a79dc9e8b116878ff7bb72e72.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov