### PR TITLE
MAINT: do not test numpy funcs in torch._numpy

### DIFF
--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -5,7 +5,6 @@ import re
 import sys
 import warnings
 
-# from numpy.core._multiarray_tests import array_indexing  # numpy implements this in C
 from itertools import product
 
 import pytest

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -23,8 +23,6 @@ import pytest
 import torch._numpy as np
 from pytest import raises as assert_raises
 
-# from numpy.core._rational_tests import rational
-
 from torch._numpy.testing import (
     assert_,
     assert_allclose,  # IS_PYPY, IS_PYSTON, HAS_REFCOUNT,
@@ -45,9 +43,6 @@ HAS_REFCOUNT = True
 
 from numpy.core.tests._locales import CommaDecimalPointLocale
 from numpy.testing._private.utils import _no_tracing, requires_memory
-
-# Need to test an object that does not fully implement math interface
-# from datetime import timedelta, datetime
 
 
 # #### stubs to make pytest pass the collections stage ####

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -9,7 +9,6 @@ import warnings
 import pytest
 
 import torch._numpy as np
-from numpy.core import umath
 from torch._numpy.random import rand, randint, randn
 from torch._numpy.testing import (
     assert_,
@@ -599,22 +598,6 @@ class TestSeterr:
         finally:
             np.seterrobj(olderrobj)
             del self.called
-
-    def test_errobj_noerrmask(self):
-        # errmask = 0 has a special code path for the default
-        olderrobj = np.geterrobj()
-        try:
-            # set errobj to something non default
-            np.seterrobj([umath.UFUNC_BUFSIZE_DEFAULT, umath.ERR_DEFAULT + 1, None])
-            # call a ufunc
-            np.isnan(np.array([6]))
-            # same with the default, lots of times to get rid of possible
-            # pre-existing stack in the code
-            for i in range(10000):
-                np.seterrobj([umath.UFUNC_BUFSIZE_DEFAULT, umath.ERR_DEFAULT, None])
-            np.isnan(np.array([6]))
-        finally:
-            np.seterrobj(olderrobj)
 
 
 @pytest.mark.xfail(reason="TODO")

--- a/test/torch_np/numpy_tests/lib/test_index_tricks.py
+++ b/test/torch_np/numpy_tests/lib/test_index_tricks.py
@@ -4,7 +4,6 @@ import pytest
 
 import torch._numpy as np
 
-from numpy.lib.index_tricks import ix_, mgrid, ndenumerate, ndindex, ogrid, r_
 from pytest import raises as assert_raises  # , assert_raises_regex,
 
 from torch._numpy import diag_indices, diag_indices_from, fill_diagonal, index_exp, s_
@@ -190,6 +189,7 @@ class TestRavelUnravelIndex:
             np.unravel_index([1], (2, 1, 0))
 
 
+@pytest.mark.xfail(reason="mgrid not implemented")
 class TestGrid:
     def test_basic(self):
         a = mgrid[-1:1:10j]
@@ -306,8 +306,8 @@ class TestGrid:
         assert_array_equal(grid64_a, grid64_b)
 
 
+@pytest.mark.xfail(reason="r_ not implemented")
 class TestConcatenator:
-    @pytest.mark.xfail(reason="r_ not implemented")
     def test_1d(self):
         assert_array_equal(r_[1, 2, 3, 4, 5, 6], np.array([1, 2, 3, 4, 5, 6]))
         b = np.ones(5)
@@ -318,12 +318,10 @@ class TestConcatenator:
         g = r_[10.1, 1:10]
         assert_(g.dtype == "f8")
 
-    @pytest.mark.xfail(reason="r_ not implemented")
     def test_more_mixed_type(self):
         g = r_[-10.1, np.array([1]), np.array([2, 3, 4]), 10.0]
         assert_(g.dtype == "f8")
 
-    @pytest.mark.xfail(reason="r_ not implemented")
     def test_complex_step(self):
         # Regression test for #12262
         g = r_[0:36:100j]
@@ -333,7 +331,6 @@ class TestConcatenator:
         g = r_[0 : 36 : np.complex64(100j)]
         assert_(g.shape == (100,))
 
-    @pytest.mark.xfail(reason="r_ not implemented")
     def test_2d(self):
         b = np.random.rand(5, 5)
         c = np.random.rand(5, 5)
@@ -346,13 +343,13 @@ class TestConcatenator:
         assert_array_equal(d[:5, :], b)
         assert_array_equal(d[5:, :], c)
 
-    @pytest.mark.xfail(reason="r_ not implemented")
     def test_0d(self):
         assert_equal(r_[0, np.array(1), 2], [0, 1, 2])
         assert_equal(r_[[0, 1, 2], np.array(3)], [0, 1, 2, 3])
         assert_equal(r_[np.array(0), [1, 2, 3]], [0, 1, 2, 3])
 
 
+@pytest.mark.xfail(reason="ndenumerate not implemented")
 class TestNdenumerate:
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
@@ -375,8 +372,8 @@ class TestIndexExpression:
         assert_equal(a[:, :3, [1, 2]], a[s_[:, :3, [1, 2]]])
 
 
+@pytest.mark.xfail(reason="ix_ not implemented")
 class TestIx_:
-    @pytest.mark.xfail(reason="ix_ not implemented")
     def test_regression_1(self):
         # Test empty untyped inputs create outputs of indexing type, gh-5804
         (a,) = ix_(range(0))
@@ -389,7 +386,6 @@ class TestIx_:
         (a,) = ix_(np.array([], dtype=np.float32))
         assert_equal(a.dtype, np.float32)
 
-    @pytest.mark.xfail(reason="ix_ not implemented")
     def test_shape_and_dtype(self):
         sizes = (4, 5, 3, 2)
         # Test both lists and arrays
@@ -543,6 +539,7 @@ class TestDiagIndicesFrom:
             diag_indices_from(x)
 
 
+@pytest.mark.xfail(reason="ndindex not implemented")
 def test_ndindex():
     x = list(ndindex(1, 2, 3))
     expected = [ix for ix, e in ndenumerate(np.zeros((1, 2, 3)))]

--- a/test/torch_np/numpy_tests/lib/test_shape_base_.py
+++ b/test/torch_np/numpy_tests/lib/test_shape_base_.py
@@ -7,7 +7,6 @@ import pytest
 
 import torch._numpy as np
 
-from numpy.lib.shape_base import apply_along_axis, apply_over_axes
 from pytest import raises as assert_raises
 from torch._numpy import (
     array_split,
@@ -131,6 +130,7 @@ class TestPutAlongAxis:
         assert_equal(take_along_axis(a, ai, axis=1), 20)
 
 
+@pytest.mark.xfail(reason="apply_along_axis not implemented")
 class TestApplyAlongAxis:
     def test_simple(self):
         a = np.ones((20, 10), "d")
@@ -140,21 +140,18 @@ class TestApplyAlongAxis:
         a = np.ones((10, 101), "d")
         assert_array_equal(apply_along_axis(len, 0, a), len(a) * np.ones(a.shape[1]))
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_3d(self):
         a = np.arange(27).reshape((3, 3, 3))
         assert_array_equal(
             apply_along_axis(np.sum, 0, a), [[27, 30, 33], [36, 39, 42], [45, 48, 51]]
         )
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_scalar_array(self, cls=np.ndarray):
         a = np.ones((6, 3)).view(cls)
         res = apply_along_axis(np.sum, 0, a)
         assert_(isinstance(res, cls))
         assert_array_equal(res, np.array([6, 6, 6]).view(cls))
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_0d_array(self, cls=np.ndarray):
         def sum_to_0d(x):
             """Sum x, returning a 0d array of the same class"""
@@ -170,7 +167,6 @@ class TestApplyAlongAxis:
         assert_(isinstance(res, cls))
         assert_array_equal(res, np.array([3, 3, 3, 3, 3, 3]).view(cls))
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_axis_insertion(self, cls=np.ndarray):
         def f1to2(x):
             """produces an asymmetric non-square matrix from x"""
@@ -209,7 +205,6 @@ class TestApplyAlongAxis:
         assert_equal(type(actual), type(expected))
         assert_equal(actual, expected)
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_axis_insertion_ma(self):
         def f1to2(x):
             """produces an asymmetric non-square matrix from x"""
@@ -225,7 +220,6 @@ class TestApplyAlongAxis:
         assert_array_equal(res[:, :, 1].mask, f1to2(a[:, 1]).mask)
         assert_array_equal(res[:, :, 2].mask, f1to2(a[:, 2]).mask)
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_tuple_func1d(self):
         def sample_1d(x):
             return x[1], x[0]
@@ -233,7 +227,6 @@ class TestApplyAlongAxis:
         res = np.apply_along_axis(sample_1d, 1, np.array([[1, 2], [3, 4]]))
         assert_array_equal(res, np.array([[2, 1], [4, 3]]))
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_empty(self):
         # can't apply_along_axis when there's no chance to call the function
         def never_call(x):
@@ -253,7 +246,6 @@ class TestApplyAlongAxis:
         assert_equal(actual, np.ones(10))
         assert_raises(ValueError, np.apply_along_axis, empty_to_1, 0, a)
 
-    @pytest.mark.xfail(reason="TODO: implement")
     def test_with_iterable_object(self):
         # from issue 5248
         d = np.array([[{1, 11}, {2, 22}, {3, 33}], [{4, 44}, {5, 55}, {6, 66}]])
@@ -267,7 +259,7 @@ class TestApplyAlongAxis:
             assert_equal(type(actual[i]), type(expected[i]))
 
 
-@pytest.mark.xfail(reason="TODO: implement")
+@pytest.mark.xfail(reason="apply_over_axes not implemented")
 class TestApplyOverAxes:
     def test_simple(self):
         a = np.arange(24).reshape(2, 3, 4)

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -16,9 +16,6 @@ from torch._numpy.testing import assert_allclose, assert_equal
 from torch.testing._internal.common_cuda import TEST_CUDA
 
 
-from torch.testing._internal.common_cuda import TEST_CUDA
-
-
 # These function receive one array_like arg and return one array_like result
 one_arg_funcs = [
     w.asarray,

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -16,17 +16,17 @@ from torch.testing._internal.common_utils import TestCase
 
 
 def test_fail_freefunc():
-    assert False
+    raise AssertionError()
 
 
 class TestFailInherit(TestCase):
     def test_fail_inherit(self):
-        assert False
+        raise AssertionError()
 
 
 class TestFailNoInhertit:
     def test_fail_noinherit(self):
-        assert False
+        raise AssertionError()
 
 
 from torch.testing._internal.common_cuda import TEST_CUDA

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -13,6 +13,8 @@ import torch._numpy._util as _util
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_allclose, assert_equal
 
+from torch.testing._internal.common_cuda import TEST_CUDA
+
 
 from torch.testing._internal.common_cuda import TEST_CUDA
 

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -12,21 +12,6 @@ import torch._numpy._ufuncs as _ufuncs
 import torch._numpy._util as _util
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_allclose, assert_equal
-from torch.testing._internal.common_utils import TestCase
-
-
-def test_fail_freefunc():
-    raise AssertionError()
-
-
-class TestFailInherit(TestCase):
-    def test_fail_inherit(self):
-        raise AssertionError()
-
-
-class TestFailNoInhertit:
-    def test_fail_noinherit(self):
-        raise AssertionError()
 
 
 from torch.testing._internal.common_cuda import TEST_CUDA

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -12,6 +12,22 @@ import torch._numpy._ufuncs as _ufuncs
 import torch._numpy._util as _util
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_allclose, assert_equal
+from torch.testing._internal.common_utils import TestCase
+
+
+def test_fail_freefunc():
+    assert False
+
+
+class TestFailInherit(TestCase):
+    def test_fail_inherit(self):
+        assert False
+
+
+class TestFailNoInhertit:
+    def test_fail_noinherit(self):
+        assert False
+
 
 from torch.testing._internal.common_cuda import TEST_CUDA
 


### PR DESCRIPTION
Remove testing of numpy functions which torch._numpy does not implement. 


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng