### PR TITLE
Allow adding extra dispatch keys to wrapper tensor subclass

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -678,8 +678,9 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // resizable (have to define a custom allocator in that case)
   Tensor tensor;
   if (r.idx == 0) {
-    TORCH_CHECK(!r.toDispatchKeySetOptional(13),
-                "This overload of _make_wrapper_subclass does not support _extra_dispatch_keys");
+    TORCH_CHECK(
+        !r.toDispatchKeySetOptional(13),
+        "This overload of _make_wrapper_subclass does not support _extra_dispatch_keys");
     tensor = at::for_blob(nullptr, r.intlist(1))
                  .strides(r.intlistOptional(2))
                  .storage_offset(r.toInt64Optional(3))

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -630,13 +630,15 @@ static PyObject* THPVariable_make_wrapper_subclass(
       "_make_wrapper_subclass(PyObject* cls, IntArrayRef size, *, IntArrayRef? strides=None, "
       "int64_t? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
-      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False)",
+      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
+      "DispatchKeySet _extra_dispatch_keys=None)",
       "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef strides, "
       "SymInt? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
-      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False)",
+      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
+      "DispatchKeySet _extra_dispatch_keys=None)",
   });
-  ParsedArgs<13> parsed_args{};
+  ParsedArgs<14> parsed_args{};
   auto r = parser.parse(args, kwargs, parsed_args);
   PyObject* cls = r.pyobject(0);
 
@@ -676,6 +678,8 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // resizable (have to define a custom allocator in that case)
   Tensor tensor;
   if (r.idx == 0) {
+    TORCH_CHECK(!r.toDispatchKeySetOptional(13),
+                "This overload of _make_wrapper_subclass does not support _extra_dispatch_keys");
     tensor = at::for_blob(nullptr, r.intlist(1))
                  .strides(r.intlistOptional(2))
                  .storage_offset(r.toInt64Optional(3))
@@ -706,8 +710,12 @@ static PyObject* THPVariable_make_wrapper_subclass(
         /*allocator=*/c10::GetAllocator(c10::kMeta),
         /*resizeable=*/true};
 
+    auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
+    if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
+      keys = keys | *mb_extra_keys;
+    }
     tensor = at::detail::make_tensor<TensorImpl>(
-        std::move(storage), options.computeDispatchKey(), options.dtype());
+        std::move(storage), keys, options.dtype());
 
     auto sym_sizes = r.symintlist(1);
     auto sym_strides = r.symintlist(2);

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -50,6 +50,7 @@ static std::unordered_map<std::string, ParameterType> type_map = {
     {"Dimname", ParameterType::DIMNAME},
     {"DimnameList", ParameterType::DIMNAME_LIST},
     {"ScalarList", ParameterType::SCALAR_LIST},
+    {"DispatchKeySet", ParameterType::DISPATCH_KEY_SET},
 };
 
 // Default arg name translations for compatibility with NumPy.
@@ -989,6 +990,8 @@ auto FunctionParameter::check(
       return is_int_or_symint(obj);
     case ParameterType::SYM_INT_LIST:
       return is_int_or_symint_list(obj, size, failed_idx);
+    case ParameterType::DISPATCH_KEY_SET:
+      return py::isinstance<c10::DispatchKeySet>(py::handle(obj));
     default:
       throw std::runtime_error("unknown parameter type");
   }
@@ -1044,6 +1047,8 @@ std::string FunctionParameter::type_name() const {
       return "tuple of Scalars";
     case ParameterType::SYM_INT_LIST:
       return "tuple of ints";
+    case ParameterType::DISPATCH_KEY_SET:
+      return "DispatchKeySet";
     default:
       throw std::runtime_error("unknown parameter type");
   }
@@ -1165,7 +1170,8 @@ void FunctionParameter::set_default_str(const std::string& str) {
   if (str == "None") {
     allow_none = true;
   }
-  if (type_ == ParameterType::TENSOR) {
+  if (type_ == ParameterType::TENSOR ||
+      type_ == ParameterType::DISPATCH_KEY_SET) {
     if (str != "None") {
       throw std::runtime_error(
           "default value for Tensor must be none, got: " + str);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -74,6 +74,7 @@
 #include <c10/core/SymFloat.h>
 #include <c10/core/SymNodeImpl.h>
 
+#include <c10/core/DispatchKeySet.h>
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -120,7 +121,8 @@ enum class ParameterType {
   QSCHEME,
   FLOAT_LIST,
   SCALAR_LIST,
-  SYM_INT_LIST
+  SYM_INT_LIST,
+  DISPATCH_KEY_SET
 };
 
 struct FunctionParameter;
@@ -298,6 +300,7 @@ struct PythonArgs {
   inline bool toBool(int i);
   inline bool toBoolWithDefault(int i, bool default_bool);
   inline bool isNone(int i);
+  inline c10::optional<c10::DispatchKeySet> toDispatchKeySetOptional(int i);
 
  private:
   at::Tensor tensor_slow(int i);
@@ -725,6 +728,14 @@ inline std::vector<double> PythonArgs::doublelist(int i) {
     return {};
   }
   return this->getDoublelist(i);
+}
+
+inline c10::optional<c10::DispatchKeySet> PythonArgs::toDispatchKeySetOptional(
+    int i) {
+  if (!args[i]) {
+    return {};
+  }
+  return py::cast<c10::DispatchKeySet>(py::handle(args[i]));
 }
 
 inline at::ScalarType PythonArgs::scalartypeWithDefault(

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -561,6 +561,8 @@ void initDispatchBindings(PyObject* module) {
       DEF_ONE(CompositeExplicitAutograd)
       DEF_ONE(CompositeImplicitAutogradNestedTensor)
       DEF_ONE(CompositeImplicitAutograd)
+      // NestedTensor is not a backend key
+      DEF_ONE(AutogradNestedTensor)
       DEF_ONE(AutogradOther)
       DEF_ONE(Autograd)
       DEF_ONE(BackendSelect)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #108316
* #108315
* #108314
* __->__ #108808

Updated version of https://github.com/pytorch/pytorch/pull/108313 which has more review comments