### PR TITLE
assign var for "not populated" str

### DIFF
--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -349,9 +349,10 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
     #   vmap(vmap( but not completely sure if it is a problem. If we
     #   assigned those fields to the ctx object, the worry is that they
     #   get overwritten.
-    out_dims = "not populated"
-    input_shapes: Any = "not populated"
-    saved_tensors_bdims: Any = "not populated"
+    init_val = "not populated"
+    out_dims = init_val
+    input_shapes: Any = init_val
+    saved_tensors_bdims: Any = init_val
 
     def forward(*operands):
         nonlocal out_dims
@@ -395,8 +396,8 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
         saved_tensors_bdims = saved_tensors_bdims_
 
     def jvp(ctx, *tangents):
-        assert out_dims != "not populated"
-        assert saved_tensors_bdims != "not populated"
+        assert out_dims != init_val
+        assert saved_tensors_bdims != init_val
 
         def jvp_no_context(saved_tensors, tangents):
             wrapped_ctx = CtxWithSavedTensors(ctx, saved_tensors)
@@ -411,9 +412,9 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
         return result
 
     def backward(ctx, *grad_outputs):
-        assert out_dims != "not populated"
-        assert input_shapes != "not populated"
-        assert saved_tensors_bdims != "not populated"
+        assert out_dims != init_val
+        assert input_shapes != init_val
+        assert saved_tensors_bdims != init_val
 
         def backward_no_context(inputs):
             saved_tensors, grad_outputs = inputs
@@ -440,7 +441,7 @@ def vmapify_autograd_function(autograd_function, in_dims, batch_size, randomness
     )
 
     def get_out_dims():
-        assert out_dims != "not populated"
+        assert out_dims != init_val
         return out_dims
 
     return Generated, get_out_dims


### PR DESCRIPTION
minor cleanup of assigning a variable to the 'not populated' string value referenced in several places in `vmapify_autograd_function`.
