### PR TITLE
Fix the max pool kernel with channels_last memory layout

### DIFF
--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -391,12 +391,12 @@ EXPECTED_SKIPS_OR_FAILS: Tuple[onnx_test_common.DecorateMeta, ...] = (
     ),
     xfail(
         "nn.functional.max_pool2d",
-        dtypes=onnx_test_common.BOOL_TYPES + onnx_test_common.INT_TYPES,
+        dtypes=onnx_test_common.BOOL_TYPES + (torch.uint8, torch.int16, torch.int32, torch.int64),
         reason=onnx_test_common.reason_onnx_does_not_support("Max_pool2d"),
     ),
     xfail(
         "nn.functional.max_pool3d",
-        dtypes=onnx_test_common.BOOL_TYPES + onnx_test_common.INT_TYPES,
+        dtypes=(torch.uint8, torch.int16, torch.int32, torch.int64),
         reason=onnx_test_common.reason_onnx_does_not_support("Max_pool3d"),
     ),
     xfail(

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -575,8 +575,6 @@ def mps_ops_modifier(ops):
         'nn.functional.interpolatebicubic': None,
         'nn.functional.interpolatelinear': None,
         'nn.functional.interpolatetrilinear': None,
-        # TODO: max_pool2d for integral types fails the numerical test
-        'nn.functional.max_pool2d': [torch.int16, torch.int32, torch.int64, torch.uint8, torch.int8],
         'nn.functional.max_unpool1dgrad': None,
         'nn.functional.max_unpool2dgrad': None,
         'nn.functional.max_unpool3dgrad': None,


### PR DESCRIPTION
Fixes #109586

In the kernel for the `channels_last` memory layout pytorch doesn't set the initial value correctly for integer inputs (setting the it to zero rather than the actual minimum value). This causes us to get the wrong value out for max pool if all the inputs are negative.

This fixes the onnx test (for int8) because the onnx test checks that the value returned by onnx is the same as the value pytorch computes and it is now computed correctly in pytorch.

ps: This is not related to ONNX. An ONNX test was fixed as the result of fixing a pytorch kernel

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10