### PR TITLE
Print restart attempt as part of Dynamo log context

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -480,6 +480,7 @@ def _compile(
     ) -> Optional[GuardedCode]:
         nonlocal output
         for attempt in itertools.count():
+            CompileContext.get().attempt = attempt
             try:
                 out_code = transform_code_object(code, transform)
                 orig_code_map[out_code] = code

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -53,6 +53,19 @@ class CompileId(NamedTuple):
         return f"{self.frame_id}/{self.frame_compile_id}"
 
 
+class TraceId(NamedTuple):
+    compile_id: CompileId
+    # This starts off as 0, and every time we restart analysis it goes
+    # up by one
+    attempt: int
+
+    def __str__(self):
+        if self.attempt == 0:
+            return str(self.compile_id)
+        else:
+            return f"{self.compile_id}_{self.attempt}"
+
+
 class GuardSource(enum.Enum):
     LOCAL = 0
     GLOBAL = 1
@@ -534,7 +547,8 @@ class CompileContext:
 
     def __init__(self, compile_id):
         assert compile_id is None or isinstance(compile_id, CompileId)
-        self.compile_id = compile_id
+        self.compile_id: Optional[CompileId] = compile_id
+        self.attempt = 0
 
     @staticmethod
     def current_compile_id():
@@ -542,6 +556,15 @@ class CompileContext:
         if self is None:
             return None
         return self.compile_id
+
+    @staticmethod
+    def current_trace_id():
+        self = CompileContext.get()
+        if self is None:
+            return None
+        if self.compile_id is None:
+            return None
+        return TraceId(self.compile_id, self.attempt)
 
 
 class TracingContext:

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -643,13 +643,11 @@ class TorchLogsFormatter(logging.Formatter):
         if dist.is_available() and dist.is_initialized():
             record.rankprefix = f"[rank{dist.get_rank()}]:"
 
-        record.compileid = ""
-        if (
-            compile_id := torch._guards.CompileContext.current_compile_id()
-        ) is not None:
-            record.compileid = f" [{compile_id}]"
+        record.traceid = ""
+        if (trace_id := torch._guards.CompileContext.current_trace_id()) is not None:
+            record.traceid = f" [{trace_id}]"
 
-        prefix = f"{record.rankprefix}[{record.asctime}]{record.compileid} {record.name}: [{record.levelname}]"
+        prefix = f"{record.rankprefix}[{record.asctime}]{record.traceid} {record.name}: [{record.levelname}]"
         return "\n".join(f"{prefix} {l}" for l in lines)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108864

Now looks like:

```
[2023-09-08 06:04:48,532] [0/0] torch._dynamo.symbolic_convert: [DEBUG] TRACE STORE_ATTR foo [ConstantVariable(int), NNModule
Variable()]
[2023-09-08 06:04:48,532] [0/0] torch._dynamo.convert_frame: [INFO]
Restarting analysis due to _dynamo/variables/nn_module.py
:138 in convert_to_unspecialized
[2023-09-08 06:04:48,533] [0/0_1] torch._dynamo.symbolic_convert: [INFO] Step 1: torchdynamo start tracing f /data/users/ezyang/c/pytorch/a.py:6
[2023-09-08 06:04:48,533] [0/0_1] torch._dynamo.symbolic_convert.__trace_source: [DEBUG] TRACE starts_line f /data/users/ezyang/c/pytorch/a.py:6
```

I'm happy to bikeshed the exact formatting of the attempt number if you
want.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng