### PR TITLE
Validate that storage have enough memory allocated

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
@@ -292,9 +292,10 @@ c10::intrusive_ptr<Message> tensorpipeDeserialize(
     picklePos += toCopy;
     return toCopy;
   };
-  auto tensorReadFunc = [&](const std::string& ename) -> at::DataPtr {
+  auto tensorReadFunc =
+      [&](const std::string& ename) -> std::tuple<at::DataPtr, size_t> {
     unsigned long index = std::stoul(ename);
-    return std::move(buffers.tensors.at(index));
+    return std::make_tuple(std::move(buffers.tensors.at(index)), 0);
   };
 
   // No need to pass typeResolver here, as it always processes string and

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -442,7 +442,8 @@ std::pair<std::vector<char>, std::vector<at::Tensor>> wireDeserialize(
       metaDataPos += toCopy;
       return toCopy;
     };
-    auto sectionReadFunc = [&](const std::string& ename) -> at::DataPtr {
+    auto sectionReadFunc =
+        [&](const std::string& ename) -> std::tuple<at::DataPtr, size_t> {
       auto it = sections.find(ename);
       if (it == sections.end()) {
         TORCH_CHECK(false, "Couldn't find entity " + ename);
@@ -452,7 +453,7 @@ std::pair<std::vector<char>, std::vector<at::Tensor>> wireDeserialize(
       if (idat.second != 0) {
         memcpy(dptr.get(), idat.first, idat.second);
       }
-      return dptr;
+      return std::make_tuple(std::move(dptr), idat.second);
     };
 
     // No need to pass typeResolver here, as it always processes string and

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -149,7 +149,7 @@ c10::IValue IValueUnpickler::readArchive(
   auto read_record = [&](const std::string& name) {
     std::stringstream ss;
     ss << archive_name << "/" << name;
-    return std::get<0>(reader_->getRecord(ss.str()));
+    return reader_->getRecord(ss.str());
   };
 
   Unpickler unpickler(

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -37,7 +37,7 @@ IValue readArchiveAndTensors(
 
   auto read_record = [&](const std::string& name) {
     std::string ss = tensor_dir_path + name;
-    return std::get<0>(stream_reader.getRecord(ss));
+    return stream_reader.getRecord(ss);
   };
 
   Unpickler unpickler(

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -593,8 +593,8 @@ PickleOpCode Unpickler::readInstruction() {
           size_t bytes_read;
           std::tie(storage_ptr, bytes_read) = read_record_(key);
           TORCH_CHECK(
-              bytes_read >= numel * dtype.itemsize(),
-              "Tensor unpicklig: read storage with ",
+              bytes_read >= numel * dtype.itemsize() || device.is_meta(),
+              "Unpickle non-meta tensor: read storage with ",
               bytes_read,
               " bytes of data, but tensor expects at least ",
               numel,

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -590,7 +590,17 @@ PickleOpCode Unpickler::readInstruction() {
           // If there are no elements in the tensor, there's no point in
           // reading a zero (0) byte file from the input stream and paying
           // that cost.
-          storage_ptr = read_record_(key);
+          size_t bytes_read;
+          std::tie(storage_ptr, bytes_read) = read_record_(key);
+          TORCH_CHECK(
+              bytes_read >= numel * dtype.itemsize(),
+              "Tensor unpicklig: read storage with ",
+              bytes_read,
+              " bytes of data, but tensor expects at least ",
+              numel,
+              " elements by ",
+              dtype.itemsize(),
+              " bytes each");
         }
 
         storage = at::Storage(

--- a/torch/csrc/jit/serialization/unpickler.h
+++ b/torch/csrc/jit/serialization/unpickler.h
@@ -53,7 +53,8 @@ class TORCH_API Unpickler {
       std::function<size_t(char*, size_t)> reader,
       TypeResolver type_resolver,
       ObjLoader obj_loader,
-      std::function<at::DataPtr(const std::string&)> read_record,
+      std::function<std::tuple<at::DataPtr, size_t>(const std::string&)>
+          read_record,
       c10::optional<at::Device> device,
       bool use_storage_device = false,
       TypeParserT type_parser = defaultTypeParser,
@@ -163,7 +164,8 @@ class TORCH_API Unpickler {
   ObjLoader obj_loader_;
   IValue empty_tuple_;
 
-  std::function<at::DataPtr(const std::string&)> read_record_;
+  std::function<std::tuple<at::DataPtr, size_t>(const std::string&)>
+      read_record_;
   c10::optional<at::Device> device_;
   // When set to true, Unpickler will ignore the pickled device and use the
   // device of the DataPtr returned by the read_record_ function. The default


### PR DESCRIPTION
Check that storage have enough memory allocated to contain all tensor data (according to its metadata).

Fixes #108865


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel