### PR TITLE
Fix setitem with SymInt

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -372,7 +372,7 @@ static inline Tensor scalarToTensor(
     const Scalar& v,
     const TensorOptions& options,
     const at::Device& self_device) {
-  if (self_device == at::kCPU) {
+  if (self_device == at::kCPU && !v.isSymbolic()) {
     return at::detail::scalar_tensor_static(
         v, options.dtype_opt()->toScalarType(), self_device);
   } else {

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1055,6 +1055,25 @@ def forward(self, a_1):
     return empty"""  # noqa: B950
         )
 
+
+    def test_setitem_symint(self):
+        # from moco
+        # https://github.com/pytorch/pytorch/issues/101939
+        def f(x):
+            x[0] = x.size(0)
+            return x
+
+        r = str(make_fx(f, tracing_mode="symbolic")(torch.randn(10)).code).strip()
+        self.assertExpectedInline(
+            r, """\
+def forward(self, x_1):
+    sym_size = torch.ops.aten.sym_size(x_1, 0)
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(sym_size, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'));  sym_size = None
+    select = torch.ops.aten.select.int(x_1, 0, 0)
+    copy_ = torch.ops.aten.copy_.default(select, scalar_tensor);  select = scalar_tensor = None
+    return x_1"""  # noqa: B950
+        )
+
     def test_dynamic_pointwise_scalar(self):
         def f(gravity, mask):
             gravity[mask, 0] = gravity[mask, 0] * -1

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1314,6 +1314,7 @@ class FakeTensorMode(TorchDispatchMode):
 
     def dispatch(self, func, types, args=(), kwargs=None):
         kwargs = kwargs if kwargs else {}
+        log.debug("%s %s %s", func, args, kwargs)
 
         if func == torch.ops.prim.device.default:
             # NB: Don't use is_our_fake, just serve the fake information
@@ -1370,7 +1371,7 @@ class FakeTensorMode(TorchDispatchMode):
         ):
             assert all(
                 t.constant is not None for t in flat_arg_fake_tensors
-            ), "f{func} should not have fake inputs without constants"
+            ), f"{func} should not have fake inputs without constants"
             const_args, const_kwargs = pytree.tree_map_only(
                 FakeTensor,
                 lambda t: t.constant if self.is_our_fake(t) else t,

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -117,6 +117,12 @@ inline Variable valueToTensor(
     scalar = Scalar(THPUtils_unpackDouble(value));
   } else if (PyComplex_Check(value)) {
     scalar = Scalar(THPUtils_unpackComplexDouble(value));
+  } else if (torch::is_symint(value)) {
+    scalar = Scalar(py::cast<SymInt>(value));
+  } else if (torch::is_symfloat(value)) {
+    scalar = Scalar(py::cast<SymFloat>(value));
+  } else if (torch::is_symbool(value)) {
+    scalar = Scalar(py::cast<SymBool>(value));
   } else {
     throw TypeError(
         "can't assign a %s to a %s",
@@ -126,7 +132,7 @@ inline Variable valueToTensor(
   // lift_fresh is supposed to be used in situations where you are guaranteed to
   // get a plain Tensor which is not true for cpu device but not for non cpu
   // device
-  if (device == at::kCPU) {
+  if (device == at::kCPU && !scalar.isSymbolic()) {
     return at::lift_fresh(
         at::indexing::scalarToTensor(scalar, options, device));
   } else {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -119,11 +119,11 @@ inline Variable valueToTensor(
   } else if (PyComplex_Check(value)) {
     scalar = Scalar(THPUtils_unpackComplexDouble(value));
   } else if (torch::is_symint(value)) {
-    scalar = Scalar(py::cast<c10::SymInt>(value));
+    scalar = Scalar(py::cast<c10::SymInt>(py::handle(value)));
   } else if (torch::is_symfloat(value)) {
-    scalar = Scalar(py::cast<c10::SymFloat>(value));
+    scalar = Scalar(py::cast<c10::SymFloat>(py::handle(value)));
   } else if (torch::is_symbool(value)) {
-    scalar = Scalar(py::cast<c10::SymBool>(value));
+    scalar = Scalar(py::cast<c10::SymBool>(py::handle(value)));
   } else {
     throw TypeError(
         "can't assign a %s to a %s",

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/python_numbers.h>
@@ -118,11 +119,11 @@ inline Variable valueToTensor(
   } else if (PyComplex_Check(value)) {
     scalar = Scalar(THPUtils_unpackComplexDouble(value));
   } else if (torch::is_symint(value)) {
-    scalar = Scalar(py::cast<SymInt>(value));
+    scalar = Scalar(py::cast<c10::SymInt>(value));
   } else if (torch::is_symfloat(value)) {
-    scalar = Scalar(py::cast<SymFloat>(value));
+    scalar = Scalar(py::cast<c10::SymFloat>(value));
   } else if (torch::is_symbool(value)) {
-    scalar = Scalar(py::cast<SymBool>(value));
+    scalar = Scalar(py::cast<c10::SymBool>(value));
   } else {
     throw TypeError(
         "can't assign a %s to a %s",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108873

Fixes https://github.com/pytorch/pytorch/issues/101939

Several fixes bundled together:

1. When we valueToTensor, we only handled non-symbolic inputs and not symbolic inputs. We support symbolic Scalar, so also handle symbolic values.
2. In the symbolic case, we MUST NOT lift_fresh, as you're not going to inline a constant into the graph, it's going to be from a `scalar_tensor` call (so no need to clone it to avoid mutations)
3. In indexing scalarToTensor, must not do the static, directly read out the scalar contents logic with the scalar is symbolic

Signed-off-by: Edward Z. Yang <ezyang@meta.com>