### PR TITLE
MAINT: torch/_numpy: remove stubs raising NIError

### DIFF
--- a/test/torch_np/numpy_tests/lib/test_type_check.py
+++ b/test/torch_np/numpy_tests/lib/test_type_check.py
@@ -6,7 +6,6 @@ import torch._numpy as np
 from pytest import raises as assert_raises
 
 from torch._numpy import (
-    asfarray,
     common_type,
     iscomplex,
     iscomplexobj,
@@ -14,7 +13,6 @@ from torch._numpy import (
     isposinf,
     isreal,
     isrealobj,
-    mintypecode,
     nan_to_num,
     real_if_close,
 )

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -843,10 +843,6 @@ def array_equiv(a1: ArrayLike, a2: ArrayLike):
     return _tensor_equal(a1_t, a2_t)
 
 
-def mintypecode():
-    raise NotImplementedError
-
-
 def nan_to_num(
     x: ArrayLike, copy: NotImplementedType = True, nan=0.0, posinf=None, neginf=None
 ):
@@ -857,14 +853,6 @@ def nan_to_num(
         return re + 1j * im
     else:
         return torch.nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf)
-
-
-def asfarray():
-    raise NotImplementedError
-
-
-def block(*args, **kwds):
-    raise NotImplementedError
 
 
 # ### put/take_along_axis ###


### PR DESCRIPTION
Remove remaining stubs. There is no point raising NotImplementedError, now that a missing function triggers a graph break just by being missing in `torch._numpy` namespace.


cc @mruberry @rgommers