### PR TITLE
[dynamo] disable flaky test_unhandled_exception_in_dynamo2

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5407,9 +5407,7 @@ def fn():
         except RuntimeError as e:
             self.assertIn("smoge", traceback.format_exc())
 
-    @unittest.skip(
-        "Not clear why this test would trigger a segfault."
-    )
+    @unittest.skip("Not clear why this test would trigger a segfault.")
     def test_unhandled_exception_in_dynamo2(self):
         # segfaults in python 3.11 if shadow frame is freed improperly
         from torch.testing import make_tensor

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5407,6 +5407,9 @@ def fn():
         except RuntimeError as e:
             self.assertIn("smoge", traceback.format_exc())
 
+    @unittest.skip(
+        "Not clear why this test would trigger a segfault."
+    )
     def test_unhandled_exception_in_dynamo2(self):
         # segfaults in python 3.11 if shadow frame is freed improperly
         from torch.testing import make_tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108906

Fix https://github.com/pytorch/pytorch/issues/106028.

The test `test_unhandled_exception_in_dynamo` should cover most cases. The disabled test `test_unhandled_exception_in_dynamo2` covered some weird case that I found when implementing dynamo 3.11.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng