### PR TITLE
Re-enable some Windows tests

### DIFF
--- a/.ci/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.ci/pytorch/win-test-helpers/test_libtorch.bat
@@ -1,6 +1,6 @@
 :: Skip LibTorch tests when building a GPU binary and testing on a CPU machine
 :: because LibTorch tests are not well designed for this use case.
-if "%USE_CUDA%" == "0" IF NOT "%CUDA_VERSION%" == "cpu" exit /b 0
+::if "%USE_CUDA%" == "0" IF NOT "%CUDA_VERSION%" == "cpu" exit /b 0
 
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 if errorlevel 1 exit /b 1
@@ -34,17 +34,9 @@ set CPP_TESTS_DIR=%TMP_DIR_WIN%\build\torch\test
 :: Skip verify_api_visibility as it a compile level test
 if "%~1" == "verify_api_visibility" goto :eof
 
-:: See https://github.com/pytorch/pytorch/issues/25161
-if "%~1" == "c10_metaprogramming_test" goto :eof
 if "%~1" == "module_test" goto :eof
 :: See https://github.com/pytorch/pytorch/issues/25312
 if "%~1" == "converter_nomigraph_test" goto :eof
-:: See https://github.com/pytorch/pytorch/issues/35636
-if "%~1" == "generate_proposals_op_gpu_test" goto :eof
-:: See https://github.com/pytorch/pytorch/issues/35648
-if "%~1" == "reshape_op_gpu_test" goto :eof
-:: See https://github.com/pytorch/pytorch/issues/35651
-if "%~1" == "utility_ops_gpu_test" goto :eof
 
 echo Running "%~2"
 if "%~1" == "c10_intrusive_ptr_benchmark" (


### PR DESCRIPTION
The tests were disabled long before. It should be fine to enable them. 
Fixes #35651, fixes #35636, fixes #35648.
cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @malfet 