### PR TITLE
cuda.cmake: Fix Identity Check

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -60,11 +60,15 @@ find_package(CUDAToolkit REQUIRED)
 
 cmake_policy(POP)
 
+# resolve symlinks: GH-108931
+file(REAL_PATH CUDA_INCLUDE_DIRS _inc_cuda)
+file(REAL_PATH CUDAToolkit_INCLUDE_DIR _inc_ctk)
 if(NOT CMAKE_CUDA_COMPILER_VERSION STREQUAL CUDAToolkit_VERSION OR
-    NOT CUDA_INCLUDE_DIRS STREQUAL CUDAToolkit_INCLUDE_DIR)
-  message(FATAL_ERROR "Found two conflicting CUDA installs:\n"
-                      "V${CMAKE_CUDA_COMPILER_VERSION} in '${CUDA_INCLUDE_DIRS}' and\n"
-                      "V${CUDAToolkit_VERSION} in '${CUDAToolkit_INCLUDE_DIR}'")
+   NOT _inc_cuda STREQUAL _inc_ctk)
+      message(FATAL_ERROR "Found two conflicting CUDA installs:\n"
+                          "V${CMAKE_CUDA_COMPILER_VERSION} in '${CUDA_INCLUDE_DIRS}' (${_inc_cuda}) and\n"
+                          "V${CUDAToolkit_VERSION} in '${CUDAToolkit_INCLUDE_DIR}' (${_inc_ctk})")
+  endif()
 endif()
 
 if(NOT TARGET CUDA::nvToolsExt)


### PR DESCRIPTION
Resolve symlinks to avoid breaking legit installs of CUDA and/or HPCToolkit.

Fixes #108931

Please backport to 2.1.0-rc4 (or following).

cc @malfet @seemethere @ptrblck