### PR TITLE
Move eval_frame global variables into module state

### DIFF
--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -190,7 +190,7 @@ typedef struct {
   PyObject* guard_fail_hook;
   PyObject* guard_error_hook;
   // Points to the extra scratch space on the code object
-  Py_ssize_t extra_index;;
+  Py_ssize_t extra_index;
 } eval_frame_mod_state;
 
 // TODO (kenjin): Check, this might not be multi-interpreter safe.
@@ -1288,7 +1288,7 @@ PyObject* torch_c_dynamo_eval_frame_init(void) {
   if (module == NULL) {
     return NULL;
   }
-  
+
   if (eval_frame_mod_exec(module) < 0) {
     Py_DECREF(module);
     return NULL;

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -1210,33 +1210,29 @@ static int eval_frame_mod_exec(PyObject *mod) {
 
   #if IS_PYTHON_3_11_PLUS
   if (PyType_Ready(&THPPyInterpreterFrameType) < 0) {
-    goto failure;
+    return -1;
   }
   // TODO (kenjin) convert this to heap type. This operation will leak references on interpreter finalization IIRC.
   Py_INCREF(&THPPyInterpreterFrameType);
   if (PyModule_AddObject(mod, "_PyInterpreterFrame", (PyObject*)&THPPyInterpreterFrameType) < 0) {
     // Need to decref on failure as PyModule_AddObject only steals a reference on success.
     Py_DECREF(&THPPyInterpreterFrameType);
-    goto failure;
+    return -1;
   }
 #endif
 
 
   if (PyType_Ready(&CacheEntryType) < 0) {
-    goto failure;
+    return -1;
   }
   // TODO (kenjin) convert this to heap type. This operation will leak references on interpreter finalization IIRC.
   Py_INCREF(&CacheEntryType);
   if (PyModule_AddObject(mod, "_CacheEntry", (PyObject *) &CacheEntryType) < 0) {
-      Py_DECREF(&CacheEntryType);
-      goto failure;
+    Py_DECREF(&CacheEntryType);
+    return -1;
   }
   return 0;
 
-failure:
-  PyThread_tss_delete(&eval_frame_callback_key);
-  Py_DECREF(Py_None);
-  return -1;
 }
 
 static PyModuleDef_Slot eval_frame_module_slots[] = {

--- a/torch/csrc/dynamo/eval_frame.h
+++ b/torch/csrc/dynamo/eval_frame.h
@@ -3,5 +3,7 @@
 
 extern "C" {
 PyObject* torch_c_dynamo_eval_frame_init(void);
-extern bool is_dynamo_compiling;
+
+bool get_is_dynamo_compiling();
+
 }

--- a/torch/csrc/dynamo/eval_frame.h
+++ b/torch/csrc/dynamo/eval_frame.h
@@ -5,5 +5,4 @@ extern "C" {
 PyObject* torch_c_dynamo_eval_frame_init(void);
 
 bool get_is_dynamo_compiling();
-
 }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_torch_function_mode.h>
 #include <torch/csrc/utils/torch_dispatch_mode.h>
+#include <torch/csrc/dynamo/eval_frame.h>
 
 #include <ATen/ATen.h>
 #include <ATen/PythonTorchFunctionTLS.h>
@@ -806,7 +807,7 @@ static bool is_int_list(
     }
 
     // in dynamo, FakeTensor is qualified for INT_LIST
-    if (is_dynamo_compiling && THPVariable_Check(item.ptr())) {
+    if (get_is_dynamo_compiling() && THPVariable_Check(item.ptr())) {
       auto& var = THPVariable_Unpack(item.ptr());
       if (var.numel() != 1 || !var.sizes().empty() ||
           !at::isIntegralType(
@@ -847,8 +848,9 @@ static bool is_int_or_symint(PyObject* obj) {
     return true;
   }
 
+
   // FakeTensor(..., size=()) is qualified for SymInt param
-  if (is_dynamo_compiling && THPVariable_Check(obj)) {
+  if (get_is_dynamo_compiling() && THPVariable_Check(obj)) {
     auto& var = THPVariable_Unpack(obj);
     if (var.numel() == 1 && var.sizes().empty() &&
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -4,11 +4,11 @@
 #include <torch/csrc/Layout.h>
 #include <torch/csrc/MemoryFormat.h>
 #include <torch/csrc/autograd/python_variable.h>
+#include <torch/csrc/dynamo/eval_frame.h>
 #include <torch/csrc/utils/invalid_arguments.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_torch_function_mode.h>
 #include <torch/csrc/utils/torch_dispatch_mode.h>
-#include <torch/csrc/dynamo/eval_frame.h>
 
 #include <ATen/ATen.h>
 #include <ATen/PythonTorchFunctionTLS.h>
@@ -847,7 +847,6 @@ static bool is_int_or_symint(PyObject* obj) {
   if (THPUtils_checkIndex(obj)) {
     return true;
   }
-
 
   // FakeTensor(..., size=()) is qualified for SymInt param
   if (get_is_dynamo_compiling() && THPVariable_Check(obj)) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -549,7 +549,7 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
     return std::vector<c10::SymInt>(size1, si);
   }
 
-  if (is_dynamo_compiling && size1 > 0 && THPVariable_Check(args[i])) {
+  if (get_is_dynamo_compiling() && size1 > 0 && THPVariable_Check(args[i])) {
     auto& var = THPVariable_Unpack(args[i]);
     if (size1 == 1 && var.numel() == 1 && var.sizes().empty() &&
         at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
@@ -966,7 +966,7 @@ inline c10::SymInt PythonArgs::toSymInt(int i) {
   // convert FakeTensor to SymInt
   // expect empty sizes, numel = 1
   // and ScalarType::Int
-  if (is_dynamo_compiling && THPVariable_Check(obj)) {
+  if (get_is_dynamo_compiling() && THPVariable_Check(obj)) {
     auto& var = THPVariable_Unpack(obj);
 
     if (var.numel() != 1 || !var.sizes().empty() ||


### PR DESCRIPTION
Partially addresses https://github.com/pytorch/pytorch/issues/108942

This PR ties global variables in `eval_frame.c` to module state, moving it closer to supporting [PEP 684](https://peps.python.org/pep-0684/), and a side-effect of the GIL, making it thread safe (well at least until nogil gets merged : - ).

This does not enable multi-phase initialization yet, which is required for multiple interpreters (CPython 3.12). The main reason is that getting module state from regular methods is quite cumbersome and I don't really know how we would do it with PEP 523 (the recommended way is https://peps.python.org/pep-0630/#module-state-access-from-regular-methods which doesn't really work for us).

This adds the small overhead of 1 list index to every path that requires getting the state.

This also fixes a few possible memory leaks on error paths.

For more information on what is happening, please see https://peps.python.org/pep-0630/

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng