### PR TITLE
Fix `torch._numpy.random`

### DIFF
--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -3048,6 +3048,8 @@ class TestArgmaxArgminCommon:
     @pytest.mark.parametrize("method", [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
         arr = np.random.normal(size=size)
+        if size is None or size == ():
+            arr = np.asarray(arr)
 
         # contiguous arrays
         if axis is None:

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -36,9 +36,37 @@ def test_uniform_scalar(use_numpy):
     assert isinstance(r, float)
 
 
-def test_shuffle():
-    x = tnp.arange(10)
-    tnp.random.shuffle(x)
+class TestShuffle:
+    @pytest.mark.parametrize("use_numpy", [True, False])
+    def test_list(self, use_numpy):
+        x = [1, 2, 3]
+        ax = tnp.asarray(x)
+
+        tnp.random.seed(1234)
+        tnp.random.shuffle(x)
+
+        tnp.random.seed(1234)
+        tnp.random.shuffle(ax)
+
+        assert isinstance(x, list)
+        assert isinstance(ax, tnp.ndarray)
+        assert_equal(x, ax)
+
+    @pytest.mark.parametrize("use_numpy", [True, False])
+    def test_2d_list(self, use_numpy):
+        # np.shuffle only shuffles the first axis
+        x = [[1, 2, 3], [4, 5, 6]]
+        ax = tnp.asarray(x)
+
+        tnp.random.seed(1234)
+        tnp.random.shuffle(x)
+
+        tnp.random.seed(1234)
+        tnp.random.shuffle(ax)
+
+        assert isinstance(x, list)
+        assert isinstance(ax, tnp.ndarray)
+        assert_equal(x, ax)
 
 
 @pytest.mark.parametrize("use_numpy", [True, False])
@@ -51,28 +79,28 @@ def test_choice(use_numpy):
         assert_equal(x, x_1)
 
 
-def test_numpy_global():
-    with control_stream(use_numpy=True):
-        tnp.random.seed(12345)
-        x = tnp.random.uniform(0, 1, size=11)
+class TestNumpyGlobal:
+    def test_numpy_global(self):
+        with control_stream(use_numpy=True):
+            tnp.random.seed(12345)
+            x = tnp.random.uniform(0, 1, size=11)
 
-    # check that the stream is identical to numpy's
-    _np.random.seed(12345)
-    x_np = _np.random.uniform(0, 1, size=11)
-    assert_equal(x, tnp.asarray(x_np))
+        # check that the stream is identical to numpy's
+        _np.random.seed(12345)
+        x_np = _np.random.uniform(0, 1, size=11)
+        assert_equal(x, tnp.asarray(x_np))
 
-    # switch to the pytorch stream, variates differ
-    with control_stream(use_numpy=False):
-        tnp.random.seed(12345)
-        x_1 = tnp.random.uniform(0, 1, size=11)
+        # switch to the pytorch stream, variates differ
+        with control_stream(use_numpy=False):
+            tnp.random.seed(12345)
+            x_1 = tnp.random.uniform(0, 1, size=11)
 
-    assert not (x_1 == x).all()
+        assert not (x_1 == x).all()
 
-
-def test_wrong_global():
-    with control_stream("oops"):
-        with pytest.raises(ValueError):
-            tnp.random.rand()
+    def test_wrong_global(self):
+        with control_stream("oops"):
+            with pytest.raises(ValueError):
+                tnp.random.rand()
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -13,12 +13,14 @@ from torch._numpy.testing import assert_equal
 
 @contextmanager
 def control_stream(use_numpy=False):
-    oldstate = tnp.random.USE_NUMPY_RANDOM
-    tnp.random.USE_NUMPY_RANDOM = use_numpy
+    import torch._dynamo.config as config
+
+    oldstate = config.use_numpy_random_stream
+    config.use_numpy_random_stream = use_numpy
     try:
         yield
     finally:
-        tnp.random.USE_NUMPY_RANDOM = oldstate
+        config.use_numpy_random_stream = oldstate
 
 
 @pytest.mark.parametrize("use_numpy", [True, False])

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -38,35 +38,37 @@ def test_uniform_scalar(use_numpy):
 
 class TestShuffle:
     @pytest.mark.parametrize("use_numpy", [True, False])
-    def test_list(self, use_numpy):
-        x = [1, 2, 3]
-        ax = tnp.asarray(x)
-
-        tnp.random.seed(1234)
-        tnp.random.shuffle(x)
+    def test_1d(self, use_numpy):
+        ax = tnp.asarray([1, 2, 3, 4, 5, 6])
+        ox = ax.copy()
 
         tnp.random.seed(1234)
         tnp.random.shuffle(ax)
 
-        assert isinstance(x, list)
         assert isinstance(ax, tnp.ndarray)
-        assert_equal(x, ax)
+        assert not (ax == ox).all()
 
     @pytest.mark.parametrize("use_numpy", [True, False])
-    def test_2d_list(self, use_numpy):
+    def test_2d(self, use_numpy):
         # np.shuffle only shuffles the first axis
-        x = [[1, 2, 3], [4, 5, 6]]
-        ax = tnp.asarray(x)
-
-        tnp.random.seed(1234)
-        tnp.random.shuffle(x)
+        ax = tnp.asarray([[1, 2, 3], [4, 5, 6]])
+        ox = ax.copy()
 
         tnp.random.seed(1234)
         tnp.random.shuffle(ax)
 
-        assert isinstance(x, list)
         assert isinstance(ax, tnp.ndarray)
-        assert_equal(x, ax)
+        assert not(ax == ox).all()
+
+    @pytest.mark.parametrize("use_numpy", [True, False])
+    def test_shuffle_list(self, use_numpy):
+        # on eager, we refuse to shuffle lists
+        # under dynamo, we always fall back to numpy
+        # NB: this means that the random stream is different for
+        # shuffling a list or an array when USE_NUMPY_STREAM == False
+        x = [1, 2, 3]
+        with pytest.raises(NotImplementedError):
+            tnp.random.shuffle(x)
 
 
 @pytest.mark.parametrize("use_numpy", [True, False])

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -95,6 +95,7 @@ def test_choice(use_numpy):
     with control_stream(use_numpy):
         tnp.random.seed(12345)
         x = tnp.random.choice(5, **kwds)
+        tnp.random.seed(12345)
         x_1 = tnp.random.choice(tnp.arange(5), **kwds)
         assert_equal(x, x_1)
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -266,6 +266,9 @@ numpy_default_float = "float64"
 numpy_default_complex = "complex128"
 numpy_default_int = "int64"
 
+# use numpy random variates if True, pytorch otherwise
+use_numpy_random_stream = False
+
 
 def is_fbcode():
     return not hasattr(torch.version, "git_version")

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -266,7 +266,7 @@ numpy_default_float = "float64"
 numpy_default_complex = "complex128"
 numpy_default_int = "int64"
 
-# use numpy random variates if True, pytorch otherwise
+# use numpy's PRNG if True, pytorch otherwise
 use_numpy_random_stream = False
 
 

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -85,8 +85,9 @@ def random_sample(size=None):
     return array_or_scalar(values, return_scalar=size == ())
 
 
-@deco_stream
 def rand(*size):
+    if size == ():
+        size = None
     return random_sample(size)
 
 
@@ -107,7 +108,7 @@ def uniform(low=0.0, high=1.0, size=None):
 def randn(*size):
     dtype = _dtypes_impl.default_dtypes().float_dtype
     values = torch.randn(size, dtype=dtype)
-    return array_or_scalar(values, return_scalar=size is None)
+    return array_or_scalar(values, return_scalar=size == ())
 
 
 @deco_stream

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -42,11 +42,10 @@ def deco_stream(func):
         if USE_NUMPY_RANDOM is False:
             return func(*args, **kwds)
         elif USE_NUMPY_RANDOM is True:
-            import numpy as _np
-
+            import numpy
             from ._ndarray import ndarray
 
-            f = getattr(_np.random, func.__name__)
+            f = getattr(numpy.random, func.__name__)
 
             # numpy funcs accept numpy ndarrays, unwrap
             args = tuple(
@@ -59,8 +58,8 @@ def deco_stream(func):
 
             value = f(*args, **kwds)
 
-            # `value` can be either _np.ndarray or python scalar (or None)
-            if value is not None and isinstance(value, _np.ndarray):
+            # `value` can be either numpy.ndarray or python scalar (or None)
+            if isinstance(value, numpy.ndarray):
                 value = ndarray(torch.as_tensor(value))
 
             return value

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -129,14 +129,7 @@ def shuffle(x: ArrayLike):
     elif isinstance(x, ndarray):
         _shuffle_tensor_inplace(x.tensor)
     else:
-        # untyped code path. Apply the permutation in-place
-        # cf https://stackoverflow.com/questions/16501424/algorithm-to-apply-permutation-in-constant-memory-space/41472796#41472796
-        perm = torch.randperm(len(x)).tolist()
-        for i in range(len(x)):
-            idx = perm[i]
-            while idx < i:
-                idx = perm[idx]
-            x[i], x[idx] = x[idx], x[i]
+        raise NotImplementedError("We do not random.shuffle lists in-place")
 
 
 def _shuffle_tensor_inplace(t):

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -42,9 +42,9 @@ def use_numpy_random():
 def deco_stream(func):
     @functools.wraps(func)
     def inner(*args, **kwds):
-        if use_numpy_random() is False:
+        if not use_numpy_random():
             return func(*args, **kwds)
-        elif use_numpy_random() is True:
+        else:
             import numpy
 
             from ._ndarray import ndarray
@@ -67,10 +67,6 @@ def deco_stream(func):
                 value = ndarray(torch.as_tensor(value))
 
             return value
-        else:
-            raise ValueError(
-                f"config.use_numpy_random_stream = {use_numpy_random()} not understood."
-            )
 
     return inner
 
@@ -126,22 +122,20 @@ def normal(loc=0.0, scale=1.0, size=None):
 
 
 @deco_stream
-def shuffle(x: ArrayLike):
-    # no @normalizer because we need to shuffle e.g. lists in-place
+def shuffle(x):
+    # no @normalizer because we do not cast e.g. lists to tensors
     from ._ndarray import ndarray
 
     if isinstance(x, torch.Tensor):
-        _shuffle_tensor_inplace(x)
+        tensor = x
     elif isinstance(x, ndarray):
-        _shuffle_tensor_inplace(x.tensor)
+        tensor = x.tensor
     else:
         raise NotImplementedError("We do not random.shuffle lists in-place")
 
-
-def _shuffle_tensor_inplace(t):
-    perm = torch.randperm(t.shape[0])
-    xp = t[perm]
-    t.copy_(xp)
+    perm = torch.randperm(tensor.shape[0])
+    xp = tensor[perm]
+    tensor.copy_(xp)
 
 
 @deco_stream

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -29,20 +29,24 @@ __all__ = [
     "randint",
     "shuffle",
     "uniform",
-    "USE_NUMPY_RANDOM",
 ]
 
 
-USE_NUMPY_RANDOM = False
+def use_numpy_random():
+    # local import to avoid ref cycles
+    import torch._dynamo.config as config
+
+    return config.use_numpy_random_stream
 
 
 def deco_stream(func):
     @functools.wraps(func)
     def inner(*args, **kwds):
-        if USE_NUMPY_RANDOM is False:
+        if use_numpy_random() is False:
             return func(*args, **kwds)
-        elif USE_NUMPY_RANDOM is True:
+        elif use_numpy_random() is True:
             import numpy
+
             from ._ndarray import ndarray
 
             f = getattr(numpy.random, func.__name__)
@@ -64,7 +68,9 @@ def deco_stream(func):
 
             return value
         else:
-            raise ValueError(f"USE_NUMPY_RANDOM={USE_NUMPY_RANDOM} not understood.")
+            raise ValueError(
+                f"config.use_numpy_random_stream = {use_numpy_random()} not understood."
+            )
 
     return inner
 


### PR DESCRIPTION
Fix several issues with `torch._numpy.random` functions on eager

1. actually return scalars when `size is None`
2. fix dispatch with USE_NUMPY_STREAM
3. make tnp.random functions composable: make numpy functions receive numpy arguments, not `tnp.ndarray`s
4. fix random.shuffle for e.g. lists

The main need for this gymnastics is due to `np.random` functions returning an ndarray or python scalar depending on the `size` argument. We decided a while ago to replicate this behavior in `tnp.random` and not elsewhere where we always return 0D arrays instead.

cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng