### PR TITLE
[inductor] Enable Mypy Checking for torch/_inductor/codegen/triton_utils.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -216,7 +216,6 @@ exclude_patterns = [
     'torch/_inductor/codegen/triton_foreach.py',
     'torch/_inductor/codegen/__init__.py',
     'torch/_inductor/codegen/cpp.py',
-    'torch/_inductor/codegen/triton_utils.py',
     'torch/_inductor/codegen/triton.py',
     'torch/_inductor/fx_passes/split_cat.py',
     'torch/_inductor/fx_passes/binary_folding.py',

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -1,10 +1,12 @@
+from typing import Dict, List, Union
+
 from .. import config
 from ..utils import instance_descriptor
 from ..virtualized import V
 from .common import SizeArg, TensorArg
 
 
-def signature_of(arg, *, size_dtype: str):
+def signature_of(arg: Union[TensorArg, SizeArg], *, size_dtype: str) -> str:
     from triton.runtime.jit import JITFunction
 
     if isinstance(arg, TensorArg):
@@ -28,14 +30,18 @@ def signature_of(arg, *, size_dtype: str):
     raise NotImplementedError(f"unhandled {type(arg)}: {arg}")
 
 
-def signature_to_meta(signature, *, size_dtype: str):
+def signature_to_meta(
+    signature: List[Union[TensorArg, SizeArg]], *, size_dtype: str
+) -> Dict[int, str]:
     return {
         i: signature_of(arg, size_dtype=size_dtype) for i, arg in enumerate(signature)
     }
 
 
-def config_of(args):
-    def is_aligned(x, alignment, include_tensor):
+def config_of(args: List[Union[TensorArg, SizeArg]]) -> instance_descriptor:
+    def is_aligned(
+        x: Union[TensorArg, SizeArg], alignment: int, include_tensor: bool
+    ) -> bool:
         """
         Roughly follow triton code here:
         https://github.com/openai/triton/blob/5282ed890d453e10b9ee30076ef89115dd197761/python/triton/runtime/jit.py#L208-L222


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #108951

Summary: Used monkeytype to generate the typehints and enabled mypy checking

Test Plan: `lintrunner torch/_inductor/codegen/*.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov