### PR TITLE
Do not use a specific LOC in link

### DIFF
--- a/docs/source/torch.compiler_guards_overview.rst
+++ b/docs/source/torch.compiler_guards_overview.rst
@@ -100,10 +100,8 @@ The function we have installed is ``convert_frame`` or
 over that nuance for now, let’s take a look at ``convert_frame_assert``,
 as ``convert_frame`` proxies to it.
 
-We can find it on `line 222 of convert_frame.py
-<https://github.com/pytorch/pytorch/blob/0833f475ce7e42b1dd11af577f276b804fc2b158/torch/_dynamo/convert_frame.py#L222>`__,
-
-with a signature as follows:
+We can find the function in ``torch/_dynamo/convert_frame.py`` with a signature
+as follows:
 
 .. code-block:: python
 


### PR DESCRIPTION
The order of LOC can change and so it should not be used in creating a link. Also, a specific LOC is not needed here given the function name as used in general in overall documentaton.
Previously, a fix was provided by updating the line number for the mentioned issue in this PR but the LOC was eventually changed resulting a broken link.

Fixes #102183
