### PR TITLE
Add torchgen path in gen_vulkan_spy

### DIFF
--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -7,6 +7,7 @@ import glob
 import os
 import re
 import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import subprocess
 import textwrap
 import yaml


### PR DESCRIPTION
Fixes the CMake building error
```
    from torchgen.code_template import CodeTemplate
ModuleNotFoundError: No module named 'torchgen'
```
cc @Skylion007 @ezyang 