### PR TITLE
fix(test, inductor): use deterministic manual seed

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -659,6 +659,7 @@ class TestCommon(TestCase):
     # Cases test here:
     #   - out= with the correct dtype and device, but the wrong shape
     @ops(_ops_and_refs, dtypes=OpDTypes.none)
+    @patch.object(torch, "manual_seed", deterministic_torch_manual_seed)
     def test_out_warning(self, device, op):
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         supported_dtypes = op.supported_dtypes(self.device_type)


### PR DESCRIPTION
Workaround: https://github.com/pytorch/pytorch/issues/108990

This seems to be unveiled by https://github.com/pytorch/pytorch/pull/108873 fixing https://github.com/pytorch/pytorch/issues/101939.

As a workaound, we can just use a deterministic seed. 

Edit: relevant tests are currently disabled due to unrelated `complex`+`out=` bug; let's keep it open / fix {symptoms, root cause} for when tests are renabled.
