### PR TITLE
cleanup typos; redundant parentheses

### DIFF
--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -120,7 +120,7 @@ C10_HOST_DEVICE inline double cauchy(double val, double median, double sigma) {
 
 /**
  * Transforms uniformly distributed `val` between 0.0 and 1.0 to
- * exponentialy distributed with `lambda` parameter of the distribution.
+ * exponentially distributed with `lambda` parameter of the distribution.
  */
 template <typename T>
 C10_HOST_DEVICE inline T exponential(T val, T lambda) {
@@ -144,7 +144,7 @@ C10_HOST_DEVICE inline T exponential(T val, T lambda) {
 
 /**
  * Transforms uniformly distributed `val` between 0.0 and 1.0 to
- * geometricaly distributed with success probability `p`.
+ * geometrically distributed with success probability `p`.
  */
 template <typename T>
 C10_HOST_DEVICE inline T geometric(T val, T p) {

--- a/torch/distributed/_tensor/ops/basic_strategy.py
+++ b/torch/distributed/_tensor/ops/basic_strategy.py
@@ -173,9 +173,9 @@ def gen_einsum_strategies(
     # strategies base on the actual tensor shape
     # (i.e. for Shard, tensor dim size must > mesh size)
     all_strategies = []
-    for startegy_comb in strategy_combs:
+    for strategy_comb in strategy_combs:
         spec_list = []
-        for specs in zip(*startegy_comb):
+        for specs in zip(*strategy_comb):
             spec_list.append(DTensorSpec(mesh, tuple(specs)))
         strat = PlacementStrategy(output_spec=spec_list[0], input_specs=spec_list[1:])
         all_strategies.append(strat)

--- a/torch/distributed/_tensor/ops/basic_strategy.py
+++ b/torch/distributed/_tensor/ops/basic_strategy.py
@@ -173,9 +173,9 @@ def gen_einsum_strategies(
     # strategies base on the actual tensor shape
     # (i.e. for Shard, tensor dim size must > mesh size)
     all_strategies = []
-    for strategy_comb in strategy_combs:
+    for startegy_comb in strategy_combs:
         spec_list = []
-        for specs in zip(*strategy_comb):
+        for specs in zip(*startegy_comb):
             spec_list.append(DTensorSpec(mesh, tuple(specs)))
         strat = PlacementStrategy(output_spec=spec_list[0], input_specs=spec_list[1:])
         all_strategies.append(strat)


### PR DESCRIPTION
- minor spelling fixes in `aten/src/ATen/core/TransformationHelper.h`
- remove redundant parentheses in control statements in `torch/distributed/algorithms/_quantization/quantization.py`.
