### PR TITLE
fix(test): `test_ops::test_out` previous uncaught error

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -659,6 +659,7 @@ class TestCommon(TestCase):
     # Cases test here:
     #   - out= with the correct dtype and device, but the wrong shape
     @ops(_ops_and_refs, dtypes=OpDTypes.none)
+    @patch.object(torch, "manual_seed", deterministic_torch_manual_seed)
     def test_out_warning(self, device, op):
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         supported_dtypes = op.supported_dtypes(self.device_type)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -861,17 +861,17 @@ class TestCommon(TestCase):
                     self.assertEqual(original_ptrs, final_ptrs)
 
             # Case 0: out= with the correct shape, dtype, and device
-            #   but NaN values for floating point and complex tensors, and
-            #   maximum values for integer tensors.
+            #   but NaN values for floating point and complex tensors,
+            #   maximum values for integer tensors, and True for bool tensors.
             #   Expected behavior: out= values have no effect on the computation.
             def _case_zero_transform(t):
-                try:
+                if t.dtype == torch.bool:
+                    return torch.full_like(t, True)
+                elif t.dtype.is_floating_point or t.dtype.is_complex:
+                    return torch.zeros_like(t)
+                else:
                     info = torch.iinfo(t.dtype)
                     return torch.full_like(t, info.max)
-                except TypeError as te:
-                    # for non-integer types fills with NaN
-                    return torch.full_like(t, float("nan"))
-
 
             _compare_out(_case_zero_transform)
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3836,7 +3836,7 @@ class FallbackKernel(ExternKernelAlloc):
             elif isinstance(output, int):
                 return output
             else:
-                assert output is None, "FallbackKernel output type is not supported"
+                assert output is None, f"FallbackKernel output type is not supported, {type(output)}"
                 return None
 
         return generate_output(example_output, [])

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -56,7 +56,7 @@ PyObject* THPFInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
       return PyErr_Format(
           PyExc_TypeError,
           "torch.finfo() requires a floating point input type. Use torch.iinfo to handle '%s'",
-          type->tp_name);
+          toString(scalar_type));
     }
   }
   return THPFInfo_New(scalar_type);
@@ -82,7 +82,7 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
     return PyErr_Format(
         PyExc_TypeError,
         "torch.iinfo() requires an integer input type. Use torch.finfo to handle '%s'",
-        type->tp_name);
+        toString(scalar_type));
   }
   return THPIInfo_New(scalar_type);
   END_HANDLE_TH_ERRORS


### PR DESCRIPTION
As explained in https://github.com/pytorch/pytorch/issues/109001
 
TorchDynamo will early exit on the `_case_zero_transform` when encountering an exception, thus returning the original tensor.

This PR fixes this test, thus revealing issues with `torch.compile` with `_refs.isreal` and `_refs.fft.iffthn`

Repro:
```
PYTORCH_TEST_WITH_INDUCTOR=1 python -m pytest test/test_ops.py::TestCommonCUDA -k test_out__refs_fft_ihfftn_cuda_float32 -vv -s
PYTORCH_TEST_WITH_INDUCTOR=1 python -m pytest test/test_ops.py::TestCommonCUDA -k test_out__refs_isreal_cuda_float32 -vv -s
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel