### PR TITLE
LazyBatchNorm{1-3}d support dict&set

### DIFF
--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -454,6 +454,18 @@ class TestLazyModules(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'shape of an uninitialized'):
             module.load_state_dict(lazy_module.state_dict())
 
+    def _check_lazy_norm_with_dict_input(self, cls, lazy_cls, input_shape):
+        input = {"input": torch.ones(*input_shape)}
+
+        lazy_module = lazy_cls()
+        lazy_output = lazy_module(**input)
+
+        num_features = input_shape[1]
+        module = cls(num_features)
+        expected_output = module(**input)
+
+        self.assertEqual(lazy_output, expected_output)
+
     def test_lazy_batchnorm1d(self):
         self._check_lazy_norm(nn.BatchNorm1d, nn.LazyBatchNorm1d, (16, 3, 6))
         self._check_lazy_norm(nn.BatchNorm1d, nn.LazyBatchNorm1d, (16, 6))
@@ -515,6 +527,11 @@ class TestLazyModules(TestCase):
     def test_lazy_instancenorm3d_state(self):
         self._check_lazy_instancenorm_state(nn.InstanceNorm3d, nn.LazyInstanceNorm3d)
         self._check_lazy_instancenorm_state(nn.InstanceNorm3d, nn.LazyInstanceNorm3d)
+
+    def test_lazy_batchnorm(self):
+        self._check_lazy_norm_with_dict_input(nn.BatchNorm1d, nn.LazyBatchNorm1d, (16, 3, 6))
+        self._check_lazy_norm_with_dict_input(nn.BatchNorm2d, nn.LazyBatchNorm2d, (16, 3, 6, 7))
+        self._check_lazy_norm_with_dict_input(nn.BatchNorm3d, nn.LazyBatchNorm3d, (16, 3, 6, 7, 8))
 
     @suppress_warnings
     def test_materialize_dtype(self):

--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -528,7 +528,7 @@ class TestLazyModules(TestCase):
         self._check_lazy_instancenorm_state(nn.InstanceNorm3d, nn.LazyInstanceNorm3d)
         self._check_lazy_instancenorm_state(nn.InstanceNorm3d, nn.LazyInstanceNorm3d)
 
-    def test_lazy_batchnorm(self):
+    def test_lazy_batchnorm_with_dict_input(self):
         self._check_lazy_norm_with_dict_input(nn.BatchNorm1d, nn.LazyBatchNorm1d, (16, 3, 6))
         self._check_lazy_norm_with_dict_input(nn.BatchNorm2d, nn.LazyBatchNorm2d, (16, 3, 6, 7))
         self._check_lazy_norm_with_dict_input(nn.BatchNorm3d, nn.LazyBatchNorm3d, (16, 3, 6, 7, 8))

--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -15,8 +15,7 @@ class _LazyProtocol(Protocol):
     def _register_load_state_dict_pre_hook(self, hook):
         ...
 
-    def register_forward_pre_hook(self, hook, *, prepend=False,
-                                  with_kwargs=False):
+    def register_forward_pre_hook(self, hook, *, prepend=False, with_kwargs=False):
         ...
 
     def _lazy_load_hook(

--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -15,7 +15,8 @@ class _LazyProtocol(Protocol):
     def _register_load_state_dict_pre_hook(self, hook):
         ...
 
-    def register_forward_pre_hook(self, hook):
+    def register_forward_pre_hook(self, hook, *, prepend=False,
+                                  with_kwargs=False):
         ...
 
     def _lazy_load_hook(
@@ -176,7 +177,7 @@ class LazyModuleMixin:
         # Mypy doesnt like this super call in a mixin
         super().__init__(*args, **kwargs)  # type: ignore[misc]
         self._load_hook = self._register_load_state_dict_pre_hook(self._lazy_load_hook)
-        self._initialize_hook = self.register_forward_pre_hook(self._infer_parameters)
+        self._initialize_hook = self.register_forward_pre_hook(self._infer_parameters, with_kwargs=True)
         warnings.warn('Lazy modules are a new feature under heavy development '
                       'so changes to the API or functionality can happen at any moment.')
 
@@ -237,7 +238,7 @@ class LazyModuleMixin:
                 return True
         return False
 
-    def _infer_parameters(self: _LazyProtocol, module, input):
+    def _infer_parameters(self: _LazyProtocol, module, args, kwargs=None):
         r"""Infers the size and initializes the parameters according to the
         provided input batch.
         Given a module that contains parameters that were declared inferrable
@@ -247,7 +248,8 @@ class LazyModuleMixin:
         The module is set into evaluation mode before running the forward pass in order
         to avoid saving statistics or calculating gradients
         """
-        module.initialize_parameters(*input)
+        kwargs = kwargs if kwargs else {}
+        module.initialize_parameters(*args, **kwargs)
         if module.has_uninitialized_params():
             raise RuntimeError(f'module {self._get_name()} has not been fully initialized')
         module._initialize_hook.remove()


### PR DESCRIPTION
Fixes #105292

As the title shown ,LazyBatchNorm don`t support dict&set, keep consistent with BatchNorm{1-3}d.