### PR TITLE
[1/N] apply clang-tidy in torch/csrc/autograd

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -127,20 +127,20 @@ at::Tensor pow_backward(
     const at::Tensor& self,
     const at::Scalar& exponent_);
 at::Tensor pow_backward_self(
-    at::Tensor grad,
+    const at::Tensor& grad,
     const at::Tensor& self,
     const at::Tensor& exponent);
 at::Tensor pow_backward_exponent(
-    at::Tensor grad,
+    const at::Tensor& grad,
     const at::Tensor& self,
     const at::Tensor& exponent,
-    at::Tensor result);
+    const at::Tensor& result);
 at::Tensor pow_backward_exponent(
-    at::Tensor grad,
+    const at::Tensor& grad,
     const at::Scalar& base,
     const at::Tensor& exponent,
     at::Tensor result);
-at::Tensor angle_backward(at::Tensor grad, const at::Tensor& self);
+at::Tensor angle_backward(const at::Tensor& grad, const at::Tensor& self);
 template <typename T>
 at::Tensor mul_tensor_backward(Tensor grad, T other, ScalarType self_st);
 template <typename T>
@@ -153,12 +153,12 @@ at::Tensor div_tensor_self_backward(
     ScalarType self_st,
     const c10::optional<c10::string_view>& rounding_mode);
 at::Tensor div_tensor_other_backward(
-    Tensor grad,
-    Tensor self,
+    const Tensor& grad,
+    const Tensor& self,
     Tensor other,
     const c10::optional<c10::string_view>& rounding_mode);
 at::Tensor mvlgamma_backward(
-    at::Tensor grad,
+    const at::Tensor& grad,
     const at::Tensor& self,
     int64_t p);
 at::Tensor permute_backwards(const at::Tensor& grad, at::IntArrayRef fwd_dims);
@@ -337,8 +337,8 @@ at::Tensor repeat_backward(
     at::SymIntArrayRef repeats,
     at::SymIntArrayRef input_shape);
 at::Tensor _fused_dropout_backward(
-    at::Tensor grad,
-    at::Tensor mask,
+    const at::Tensor& grad,
+    const at::Tensor& mask,
     double p1m);
 at::Tensor infinitely_differentiable_native_dropout_backward(
     const at::Tensor& grad,
@@ -350,7 +350,7 @@ at::Tensor native_dropout_double_backward(
     const at::Tensor& mask,
     double scale);
 at::Tensor evenly_distribute_backward(
-    at::Tensor grad,
+    const at::Tensor& grad,
     const at::Tensor& input,
     const at::Tensor& value);
 Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn);
@@ -409,10 +409,10 @@ at::Tensor cholesky_jvp(
     const at::Tensor& L,
     bool upper);
 at::Tensor cholesky_inverse_backward(
-    at::Tensor grad,
-    at::Tensor L,
+    const at::Tensor& grad,
+    const at::Tensor& L,
     bool upper,
-    at::Tensor inverse);
+    const at::Tensor& inverse);
 at::Tensor cholesky_inverse_jvp(
     const at::Tensor& F,
     const at::Tensor& dF,
@@ -433,7 +433,7 @@ at::Tensor _nested_split_with_sizes_backward(
     const Tensor& self);
 at::Tensor split_backward(
     const std::vector<torch::autograd::Variable>& grads,
-    c10::SymInt split_size,
+    const c10::SymInt& split_size,
     int64_t dim,
     c10::SymIntArrayRef sizes,
     const at::TensorOptions& options);
@@ -569,7 +569,7 @@ at::Tensor sparse_constructor_values_backward(
 at::Tensor embedding_dense_double_backward_symint(
     const at::Tensor& grad,
     const at::Tensor& indices,
-    c10::SymInt padding_idx);
+    const c10::SymInt& padding_idx);
 at::Tensor index_backward(
     at::Tensor zeros_like_self,
     const torch::List<c10::optional<Tensor>>& indices,
@@ -720,7 +720,7 @@ Tensor fft_r2c_backward(
     at::IntArrayRef dim,
     int64_t normalization,
     bool onesided,
-    c10::SymInt last_dim_size);
+    const c10::SymInt& last_dim_size);
 Tensor fft_c2r_backward(
     const Tensor& grad,
     IntArrayRef dim,
@@ -748,7 +748,7 @@ infinitely_differentiable_native_group_norm_backward(
     const Tensor& rstd,
     const c10::optional<Tensor>& gamma,
     c10::SymInt N,
-    c10::SymInt C,
+    const c10::SymInt& C,
     c10::SymInt HxW,
     int64_t group,
     double eps,
@@ -763,11 +763,11 @@ Tensor as_strided_backward(
     const TensorGeometry& input_geometry,
     c10::SymIntArrayRef sizes,
     c10::SymIntArrayRef strides,
-    optional<c10::SymInt> storage_offset_);
+    const optional<c10::SymInt>& storage_offset_);
 Tensor as_strided_scatter_backward(
-    Tensor grad,
+    const Tensor& grad,
     const TensorGeometry& input_geometry,
-    TensorGeometry src_geometry,
+    const TensorGeometry& src_geometry,
     c10::SymIntArrayRef sizes,
     c10::SymIntArrayRef strides,
     optional<c10::SymInt> storage_offset);
@@ -860,8 +860,8 @@ Tensor linalg_solve_jvp(
 Tensor lu_unpack_backward(
     const Tensor& L_grad,
     const Tensor& U_grad,
-    const c10::SymInt m,
-    const c10::SymInt n);
+    const c10::SymInt& m,
+    const c10::SymInt& n);
 
 Tensor linalg_det_backward(
     const Tensor& grad,
@@ -988,10 +988,14 @@ Tensor convolution_backward_jvp_grad_bias(
     const Tensor& grad_out_t,
     const Tensor& grad_bias);
 
-Tensor cat_jvp(at::ITensorListRef tensors, int64_t dim);
+Tensor cat_jvp(const at::ITensorListRef& tensors, int64_t dim);
 Tensor block_diag_jvp(at::TensorList tensors);
 Tensor stack_jvp(at::TensorList tensors, int64_t dim);
-Tensor cumprod_jvp(Tensor self_t, Tensor self_p, Tensor result, int dim);
+Tensor cumprod_jvp(
+    const Tensor& self_t,
+    const Tensor& self_p,
+    const Tensor& result,
+    int dim);
 Tensor gather_with_keepdimed_indices(
     const Tensor& input,
     int64_t dim,

--- a/torch/csrc/autograd/TraceTypeManual.cpp
+++ b/torch/csrc/autograd/TraceTypeManual.cpp
@@ -62,7 +62,7 @@ const Tensor& resize_(
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
-    self.resize_(size, std::move(optional_memory_format));
+    self.resize_(size, optional_memory_format);
   }
   return self;
 }
@@ -78,7 +78,7 @@ const Tensor& resize_as_(
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
-    self.resize_as_(the_template, std::move(optional_memory_format));
+    self.resize_as_(the_template, optional_memory_format);
   }
   return self;
 }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -53,7 +53,7 @@ static void _process_forward_mode_AD(
     const optional_variable_list& outputs,
     const std::unordered_set<at::TensorImpl*>& non_differentiable,
     const std::unordered_set<at::TensorImpl*>& dirty_inputs,
-    _jvp_fn_t jvp_user_function) {
+    const _jvp_fn_t& jvp_user_function) {
   // TODO handle multiple levels here
   uint64_t level = 0;
 
@@ -247,7 +247,7 @@ static void _process_forward_mode_AD(
   }
 }
 
-static at::Tensor _view_as_self_with_no_grad(at::Tensor self) {
+static at::Tensor _view_as_self_with_no_grad(const at::Tensor& self) {
   // This is called below in _process_backward_mode_ad in two places:
   //
   // (1) An input has been returned, but it wasn't modified. Return it as a view
@@ -485,7 +485,7 @@ optional_variable_list _wrap_outputs(
 void check_variable_result(
     const at::TensorBase& original,
     const at::TensorBase& result,
-    std::string hook_name) {
+    const std::string& hook_name) {
   if (!original.options().type_equal(result.options())) {
     std::stringstream ss;
     ss << "hook '" << hook_name << "' has changed the type of value (";

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -26,7 +26,7 @@ TORCH_API std::vector<c10::optional<Variable>> _wrap_outputs(
 TORCH_API void check_variable_result(
     const at::TensorBase& original,
     const at::TensorBase& result,
-    std::string hook_name);
+    const std::string& hook_name);
 
 // Get the return type of the forward function of the custom Function class X
 template <typename X, typename... Args>

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -222,8 +222,8 @@ int NodeTask::getReentrantDepth() const {
 }
 
 CheckpointValidGuard::CheckpointValidGuard(
-    const std::shared_ptr<const GraphTask>& graph_task) {
-  prev_checkpoint_valid_state = checkpoint_valid;
+    const std::shared_ptr<const GraphTask>& graph_task)
+    : prev_checkpoint_valid_state(checkpoint_valid) {
   checkpoint_valid =
       graph_task->can_checkpoint() && prev_checkpoint_valid_state;
 }
@@ -383,8 +383,8 @@ void Engine::thread_init(
   }
 }
 
-GraphTaskGuard::GraphTaskGuard(std::shared_ptr<GraphTask> graph_task) {
-  last_graph_task_ = std::move(current_graph_task);
+GraphTaskGuard::GraphTaskGuard(std::shared_ptr<GraphTask> graph_task)
+    : last_graph_task_(std::move(current_graph_task)) {
   current_graph_task = std::move(graph_task);
 }
 GraphTaskGuard::~GraphTaskGuard() {
@@ -671,7 +671,7 @@ void GraphTask::mark_as_completed_and_run_post_processing() {
     // Need to unlock before we call markCompleted to avoid holding locks
     // when the callbacks are called.
     lock.unlock();
-    future_result_->markCompleted(std::move(vars));
+    future_result_->markCompleted(vars);
   } catch (std::exception& e) {
     future_result_->setErrorIfNeeded(std::current_exception());
   }

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -23,8 +23,8 @@ namespace autograd {
 C10_DEFINE_TLS_static(std::shared_ptr<Node>, tls_current_evaluating_node);
 #define current_evaluating_node (tls_current_evaluating_node.get())
 
-NodeGuard::NodeGuard(std::shared_ptr<Node> node) {
-  last_evaluating_node_ = std::move(current_evaluating_node);
+NodeGuard::NodeGuard(std::shared_ptr<Node> node)
+    : last_evaluating_node_(std::move(current_evaluating_node)) {
   current_evaluating_node = std::move(node);
 }
 NodeGuard::~NodeGuard() {

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -274,7 +274,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   // callbacks.
   m.def(
       "_record_function_with_args_enter",
-      [](const std::string& name, py::args args) {
+      [](const std::string& name, const py::args& args) {
         using torch::autograd::profiler::PythonRecordFunction;
         auto python_rec = c10::make_intrusive<PythonRecordFunction>(
             at::RecordScope::USER_SCOPE);
@@ -324,7 +324,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
     return activities;
   });
 
-  m.def("_unsafe_set_version_counter", [](at::Tensor t, int64_t i) {
+  m.def("_unsafe_set_version_counter", [](const at::Tensor& t, int64_t i) {
     auto vc = torch::autograd::impl::version_counter(t);
     vc.set_version(i);
   });
@@ -975,7 +975,7 @@ static PyObject* pop_torch_dispatch_stack(
     PyObject* maybe_mode_key) {
   HANDLE_TH_ERRORS
   c10::optional<c10::impl::TorchDispatchModeKey> mode_key = c10::nullopt;
-  PyObject* r;
+  PyObject* r = nullptr;
   if (maybe_mode_key != Py_None) {
     mode_key = py::cast<c10::impl::TorchDispatchModeKey>(maybe_mode_key);
     auto maybe_mode =

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -64,7 +64,6 @@ inline int64_t getTimeUs() {
 using torch::profiler::impl::ActiveProfilerType;
 using torch::profiler::impl::EventType;
 using torch::profiler::impl::ExtraFields;
-using torch::profiler::impl::get_record_concrete_inputs_enabled;
 using torch::profiler::impl::ivalueListToStr;
 using torch::profiler::impl::op_input_t;
 using torch::profiler::impl::ProfilerStateBase;
@@ -666,7 +665,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
 }
 
 KinetoEvent::KinetoEvent(
-    std::shared_ptr<const torch::profiler::impl::Result> result,
+    const std::shared_ptr<const torch::profiler::impl::Result>& result,
     const bool verbose)
     : result_{result} {
   TORCH_INTERNAL_ASSERT(result != nullptr);

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -23,7 +23,7 @@ using experimental_event_t = std::shared_ptr<torch::profiler::impl::Result>;
 
 struct TORCH_API KinetoEvent {
   KinetoEvent(
-      std::shared_ptr<const torch::profiler::impl::Result>,
+      const std::shared_ptr<const torch::profiler::impl::Result>&,
       const bool verbose);
 
   uint64_t startThreadId() const;

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -301,7 +301,7 @@ class ValueCache {
 
   c10::optional<TensorMetadata> recordIfTensor(py::handle p);
   std::vector<std::pair<std::string, TensorMetadata>> unpackTensorMap(
-      py::dict tensor_map);
+      const py::dict& tensor_map);
   void trimPrefixes();
 
  private:
@@ -354,7 +354,7 @@ c10::optional<TensorMetadata> ValueCache::recordIfTensor(py::handle p) {
 }
 
 std::vector<std::pair<std::string, TensorMetadata>> ValueCache::unpackTensorMap(
-    py::dict tensor_map) {
+    const py::dict& tensor_map) {
   std::vector<std::pair<std::string, TensorMetadata>> out;
   for (auto& it : tensor_map) {
     auto* value = it.second.ptr();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -564,7 +564,7 @@ static void _get_tensors_to_save(
     for (const auto i : c10::irange(num_saved)) {
       PyObject* obj = PyTuple_GET_ITEM(self->to_save, i);
       if (obj == Py_None) {
-        tensors_to_save.push_back(c10::nullopt);
+        tensors_to_save.emplace_back(c10::nullopt);
         continue;
       } else if (THPVariable_Check(obj)) {
         const auto& tensor = THPVariable_Unpack(obj);
@@ -572,7 +572,7 @@ static void _get_tensors_to_save(
           to_save_if_setup_context.insert(tensor.unsafeGetTensorImpl());
         }
         if (is_executable) {
-          tensors_to_save.push_back(tensor);
+          tensors_to_save.emplace_back(tensor);
         }
       } else {
         if (is_executable) {

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -171,7 +171,7 @@ auto PyFunctionPostHook::operator()(
 }
 
 void PyFunctionTensorPreHook::compiled_args(CompiledNodeArgs& args) {
-  PyObject *key, *value;
+  PyObject *key = nullptr, *value = nullptr;
   Py_ssize_t pos = 0;
   while (PyDict_Next(dict, &pos, &key, &value)) {
     Py_INCREF(value);
@@ -182,7 +182,7 @@ void PyFunctionTensorPreHook::compiled_args(CompiledNodeArgs& args) {
 }
 
 void PyFunctionPreHook::compiled_args(CompiledNodeArgs& args) {
-  PyObject *key, *value;
+  PyObject *key = nullptr, *value = nullptr;
   Py_ssize_t pos = 0;
   while (PyDict_Next(dict, &pos, &key, &value)) {
     Py_INCREF(value);
@@ -191,7 +191,7 @@ void PyFunctionPreHook::compiled_args(CompiledNodeArgs& args) {
 }
 
 void PyFunctionPostHook::compiled_args(CompiledNodeArgs& args) {
-  PyObject *key, *value;
+  PyObject *key = nullptr, *value = nullptr;
   Py_ssize_t pos = 0;
   while (PyDict_Next(dict, &pos, &key, &value)) {
     Py_INCREF(value);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -627,7 +627,7 @@ static PyObject* THPVariable_make_subclass(
 
   return THPVariable_NewWithVar(
       (PyTypeObject*)cls,
-      std::move(data),
+      data,
       c10::impl::PyInterpreterStatus::DEFINITELY_UNINITIALIZED);
   END_HANDLE_TH_ERRORS
 }
@@ -722,7 +722,7 @@ static PyObject* THPVariable_make_wrapper_subclass(
         0,
         at::DataPtr{nullptr, r.device(7)},
         /*allocator=*/c10::GetAllocator(c10::kMeta),
-        /*resizeable=*/true};
+        /*resizable=*/true};
 
     auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
     if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
@@ -758,7 +758,7 @@ static PyObject* THPVariable_make_wrapper_subclass(
 
   return THPVariable_NewWithVar(
       (PyTypeObject*)cls,
-      std::move(tensor),
+      tensor,
       c10::impl::PyInterpreterStatus::DEFINITELY_UNINITIALIZED);
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
This PR begins a new series of patches for enabling clang-tidy checks in torch/csrc/augograd