### PR TITLE
[export] Lift constant tensors as buffes (reland)

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -54,6 +54,7 @@ from .exported_program import (
 from .passes.add_runtime_assertions_for_constraints_pass import (
     _AddRuntimeAssertionsForInlineConstraintsPass,
 )
+from .passes.lift_constant_tensor_pass import lift_constant_tensor_pass
 from .passes.replace_sym_size_ops_pass import _ReplaceSymSizeOpPass
 from .passes.replace_view_ops_with_view_copy_ops_pass import (
     ReplaceViewOpsWithViewCopyOpsPass,
@@ -524,6 +525,7 @@ def export(
         exported_program = exported_program._transform(
             _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
         )
+    exported_program = lift_constant_tensor_pass(exported_program)
 
     return exported_program._transform(_ReplaceSymSizeOpPass())
 

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -1,0 +1,51 @@
+import copy
+
+import torch
+from torch._export import ExportedProgram
+from torch._guards import detect_fake_mode
+
+
+def lift_constant_tensor_pass(ep: ExportedProgram) -> ExportedProgram:
+    if len([node for node in ep.graph.nodes if node.op == "placeholder"]) == 0:
+        return ep
+
+    graph_signature = ep.graph_signature
+    inputs_to_buffers = graph_signature.inputs_to_buffers
+    buffers = graph_signature.buffers
+
+    fake_mode = detect_fake_mode(
+        tuple(node.meta["val"] for node in ep.graph.nodes if node.op == "placeholder")
+    )
+    assert fake_mode is not None
+
+    first_user_input = None
+    for node in ep.graph.nodes:
+        if node.op == "placeholder" and node.name in graph_signature.user_inputs:
+            first_user_input = node
+            break
+
+    for node in ep.graph.nodes:
+        if node.op == "get_attr":
+            constant_tensor = getattr(ep.graph_module, node.target)
+            if not isinstance(constant_tensor, torch.Tensor):
+                continue
+
+            constant_tensor_fqn = node.target
+
+            with ep.graph.inserting_before(first_user_input):
+                # Insert the constant node before the first user input
+                const_placeholder_node = ep.graph.placeholder(constant_tensor_fqn)
+                const_placeholder_node.meta = copy.deepcopy(node.meta)
+                const_placeholder_node.meta["val"] = fake_mode.from_tensor(
+                    constant_tensor
+                )
+                node.replace_all_uses_with(const_placeholder_node)
+                ep.graph.erase_node(node)
+
+                # Add the constant as a buffer to the graph signature
+                inputs_to_buffers[const_placeholder_node.name] = constant_tensor_fqn
+                buffers.append(constant_tensor_fqn)
+                ep.state_dict[constant_tensor_fqn] = constant_tensor
+
+    ep.graph_module.recompile()
+    return ep


### PR DESCRIPTION
Summary:
When we retrace the graph containing constant tensors, they get lifted as buffer inputs.
AotInductor also wants to lift all the constants as inputs.
If we separate the constants as a separate thing, then it adds an additional complexity where we now have to keep track of 3 inputs (params, buffers, constants).

Cons: People might care about specifically what buffers are/are not buffers?

If people want to know specifically which buffers are constants, we can add an additional field in the graph signature to mark this.

Test Plan: CI

Differential Revision: D49153367


