### PR TITLE
Add torch_lazy_enable_device_data_cache to disable lazy device data cache

### DIFF
--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -28,11 +28,6 @@ C10_DEFINE_bool(
     "Use thread pool to schedule backend execution");
 
 C10_DEFINE_bool(
-    torch_lazy_enable_compilation_cache,
-    true,
-    "Enable or disable compilation cache (turns cache on or off), does not change cache state");
-
-C10_DEFINE_bool(
     torch_lazy_enable_device_data_cache,
     true,
     "Enable or disable device data cache (turns cache on or off), does not change cache state");    

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -27,6 +27,16 @@ C10_DEFINE_bool(
     false,
     "Use thread pool to schedule backend execution");
 
+C10_DEFINE_bool(
+    torch_lazy_enable_compilation_cache,
+    true,
+    "Enable or disable compilation cache (turns cache on or off), does not change cache state");
+
+C10_DEFINE_bool(
+    torch_lazy_enable_device_data_cache,
+    true,
+    "Enable or disable device data cache (turns cache on or off), does not change cache state");    
+
 C10_DEFINE_int(
     torch_lazy_compilation_cache_size,
     1024,

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -30,7 +30,7 @@ C10_DEFINE_bool(
 C10_DEFINE_bool(
     torch_lazy_enable_device_data_cache,
     true,
-    "Enable or disable device data cache (turns cache on or off), does not change cache state");    
+    "Enable or disable device data cache (turns cache on or off), does not change cache state");
 
 C10_DEFINE_int(
     torch_lazy_compilation_cache_size,

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -8,7 +8,6 @@ C10_DECLARE_bool(torch_lazy_all_numbers_special_scalars);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
 C10_DECLARE_bool(torch_lazy_reuse_ir);
 C10_DECLARE_bool(torch_lazy_use_thread_pool);
-C10_DECLARE_bool(torch_lazy_enable_compilation_cache);
 C10_DECLARE_bool(torch_lazy_enable_device_data_cache);
 
 C10_DECLARE_int(torch_lazy_compilation_cache_size);

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -8,6 +8,8 @@ C10_DECLARE_bool(torch_lazy_all_numbers_special_scalars);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
 C10_DECLARE_bool(torch_lazy_reuse_ir);
 C10_DECLARE_bool(torch_lazy_use_thread_pool);
+C10_DECLARE_bool(torch_lazy_enable_compilation_cache);
+C10_DECLARE_bool(torch_lazy_enable_device_data_cache);
 
 C10_DECLARE_int(torch_lazy_compilation_cache_size);
 C10_DECLARE_int(torch_lazy_device_data_cache_size);

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -330,13 +330,20 @@ bool LazyGraphExecutor::DataCacheArena::TensorComparer::operator()(
 
 auto LazyGraphExecutor::DataCacheArena::GetDataCache(
     const BackendDevice& device) -> DataCache* {
+  
   std::lock_guard<std::mutex> lock(mutex_);
-  auto it = device_caches_.find(device);
-  if (it == device_caches_.end()) {
-    std::unique_ptr<DataCache> cache(new DataCache(max_cache_size_));
-    it = device_caches_.emplace(device, std::move(cache)).first;
+  if (FLAGS_torch_lazy_enable_device_data_cache) {
+    auto it = device_caches_.find(device);
+    if (it == device_caches_.end()) {
+      std::unique_ptr<DataCache> cache(new DataCache(max_cache_size_));
+      it = device_caches_.emplace(device, std::move(cache)).first;
+    }
+    return it->second.get();
+  } else {
+      // If cache is disabled then always return a zero size cache
+      static std::unique_ptr<DataCache> s_empty_cache(new DataCache(0));
+      return s_empty_cache.get();
   }
-  return it->second.get();
 }
 
 void LazyGraphExecutor::Register(LazyGraphExecutor* executor) {

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -330,7 +330,6 @@ bool LazyGraphExecutor::DataCacheArena::TensorComparer::operator()(
 
 auto LazyGraphExecutor::DataCacheArena::GetDataCache(
     const BackendDevice& device) -> DataCache* {
-  
   std::lock_guard<std::mutex> lock(mutex_);
   if (FLAGS_torch_lazy_enable_device_data_cache) {
     auto it = device_caches_.find(device);
@@ -340,9 +339,9 @@ auto LazyGraphExecutor::DataCacheArena::GetDataCache(
     }
     return it->second.get();
   } else {
-      // If cache is disabled then always return a zero size cache
-      static std::unique_ptr<DataCache> s_empty_cache(new DataCache(0));
-      return s_empty_cache.get();
+    // If cache is disabled then always return a zero size cache
+    static std::unique_ptr<DataCache> s_empty_cache(new DataCache(0));
+    return s_empty_cache.get();
   }
 }
 


### PR DESCRIPTION
- Add logic to enable and disable the lazy device tensor cache without modifying it
- Remove as yet unused compilation cache enable/disable global
- Lint fixes
