### PR TITLE
[export] Fix export arg type declaration

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -927,7 +927,7 @@ def dynamic_dim(t: torch.Tensor, index: int):
 
 def export(
     f: Callable,
-    args: Tuple[Any],
+    args: Tuple[Any, ...],
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     constraints: Optional[List[Constraint]] = None,


### PR DESCRIPTION
Summary: Its a arbitrary length tuple of anything. Tuple[Any] means 1 element.

Test Plan: ci

Differential Revision: D49161625


