### PR TITLE
Use the correct channel token when uploading nightly triton conda

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -131,7 +131,7 @@ jobs:
     needs: build-wheel
     container:
       image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
+    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -244,7 +244,7 @@ jobs:
     needs: build-conda
     container:
       image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
+    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -283,7 +283,7 @@ jobs:
         run: |
           set -ex
 
-          if [[ "${UPLOAD_CHANNEL}" = "nightly" ]]; then
+          if [[ "${UPLOAD_CHANNEL:-nightly}" == "nightly" ]]; then
             export ANACONDA_API_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"
           else
             export ANACONDA_API_TOKEN="${CONDA_PYTORCHBOT_TOKEN_TEST}"


### PR DESCRIPTION
This fixes 2 bugs on triton build workflow:

* Use the wrong conda credential when `UPLOAD_CHANNEL` is not set https://github.com/pytorch/pytorch/actions/runs/6129675580/job/16691419329#step:7:18
* Upload wheel and conda packages when pushing to main in addition to nightly.  This is needed because the binary wheel build on trunk also looks for torchtriton package after the triton pin is updated.

### Testing 

https://github.com/pytorch/pytorch/actions/runs/6152447684/job/16694843862?pr=109073#step:7:38 looks correct now.
