### PR TITLE
Fix std_mean f16 opinfo test by using reference_in_float

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -275,7 +275,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "randn_like": {f16, f32, f64},
     ("round", "decimals_3"): {f16},
     "sparse.sampled_addmm": {f32, f64},
-    ("std_mean", "unbiased"): {f16},
     "to_sparse": {f16, f32, f64},
     "uniform": {f16, f32, f64},
 }
@@ -374,6 +373,7 @@ inductor_override_kwargs = {
     ("softmax", "cuda", f16): {"atol": 1e-4, "rtol": 0.02},
     ("softmax", "cpu", f16): {"atol": 1e-4, "rtol": 0.02},
     ("_softmax_backward_data", "cuda", f16): {"atol": 0.008, "rtol": 0.002},
+    ("std_mean.unbiased", "cuda", f16): {"atol": 4e-5, "rtol": 0.002},
     "gradient": {"check_gradient": False},  # segfault on check_gradient
     # Following tests failed, and causing subsequent tests failing with unrecoverable CUDA error
     "linalg.solve_triangular": {"check_gradient": False},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -373,7 +373,7 @@ inductor_override_kwargs = {
     ("softmax", "cuda", f16): {"atol": 1e-4, "rtol": 0.02},
     ("softmax", "cpu", f16): {"atol": 1e-4, "rtol": 0.02},
     ("_softmax_backward_data", "cuda", f16): {"atol": 0.008, "rtol": 0.002},
-    ("std_mean.unbiased", "cuda", f16): {"atol": 4e-5, "rtol": 0.002},
+    ("std_mean.unbiased", "cuda", f16): {"reference_in_float": True},
     "gradient": {"check_gradient": False},  # segfault on check_gradient
     # Following tests failed, and causing subsequent tests failing with unrecoverable CUDA error
     "linalg.solve_triangular": {"check_gradient": False},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #109128
* #109089
* __->__ #109081

It seems that the compiled f16 op is more accurate than the eager f16
op:

**Compiled float16 vs Eager float64**

    Mismatched elements: 25 / 25 (100.0%)
    Greatest absolute difference: 3.718038455710615e-05 at index (1, 0) (up to 1e-07 allowed)
    Greatest relative difference: 0.0018021699903143316 at index (0, 4) (up to 1e-07 allowed)

**Eager float16 vs Eager float64**

    Mismatched elements: 25 / 25 (100.0%)
    Greatest absolute difference: 7.280254198286512e-05 at index (3, 3) (up to 1e-07 allowed)
    Greatest relative difference: 0.004104326045245938 at index (0, 4) (up to 1e-07 allowed)

**Compiled float16 vs Eager float16**

    Mismatched elements: 7 / 25 (28.0%)
    Greatest absolute difference: 7.62939453125e-05 at index (3, 3) (up to 1e-05 allowed)
    Greatest relative difference: 0.00588226318359375 at index (0, 4) (up to 0.001 allowed)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov