### PR TITLE
[Dynamo] Fix numpy error in test_numpy_torch_operators

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1314,6 +1314,11 @@ class MiscTests(torch._dynamo.test_case.TestCase):
                 # skip
                 # Did you know that tensor[ndarray_of_floats] works?
                 continue
+            if op is operator.imatmul and (t1_np or t2_np):
+                # skip
+                # in numpy, in place matmul does not work single
+                # dimensional arrays
+                continue
             t1 = torch.rand(5)
             if t1_np:
                 t1 = t1.numpy()


### PR DESCRIPTION
When you inplace matmul two one dimensional numpy arrays, numpy=="1.24.3" gives
```
TypeError: In-place matrix multiplication is not (yet) supported. Use 'a = a @ b' instead of 'a @= b'.
```
but numpy=="1.25.2" gives
```
ValueError: inplace matrix multiplication requires the first operand to have at least one and the second at least two dimensions.
```

This diff makes it so that newer versions of numpy does not fail on this test because we do not catch ValueError.

An alternative solution would be to update the test cases to be 2 dimensional, but that would have impact on other operators being tested.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng