### PR TITLE
`torch.load`: Replaced multiple one byte read() calls during the `_is_zipfile` check with a single call

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -114,19 +114,11 @@ def _is_zipfile(f) -> bool:
     # collisions and assume the zip has only 1 file.
     # See bugs.python.org/issue28494.
 
-    # Read the first 4 bytes of the file
-    read_bytes = []
     start = f.tell()
-
-    byte = f.read(1)
-    while byte != b"":
-        read_bytes.append(byte)
-        if len(read_bytes) == 4:
-            break
-        byte = f.read(1)
+    # Read the first few bytes and match against the ZIP file signature
+    local_header_magic_number = b'PK\x03\x04'
+    read_bytes = f.read(len(local_header_magic_number))
     f.seek(start)
-
-    local_header_magic_number = [b'P', b'K', b'\x03', b'\x04']
     return read_bytes == local_header_magic_number
 
 


### PR DESCRIPTION
Fixes #108955. 

Right now, the `_is_zipfile` check in `torch.load` performs multiple `read()` calls, reading 1 byte at a time in a loop. This is rather wasteful and leads to performance problems when accessing files on a network share (see #108955) .
This PR replaces those 1 byte calls with a single big call. Functionally, this is equivalent as `read(n)` only reads up to `n` bytes, so even if the file is shorter there should not be any problems.