### PR TITLE
Fix cumprod f16 opinfo test via ref-in-float + increasing tolerances

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -239,7 +239,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "bernoulli": {f16, f32, f64},
     "cauchy": {f16},
     "cholesky": {f32, f64},
-    "cumprod": {f16},
     "exponential": {f16},
     "fft.ihfft2": {f16, f32, f64},
     "fft.ihfftn": {f16, f32, f64},
@@ -271,7 +270,6 @@ inductor_gradient_expected_failures_single_sample = defaultdict(dict)
 
 inductor_gradient_expected_failures_single_sample["cuda"] = {
     "atanh": {f32},
-    "cumprod": {f16},
     "nanquantile": {f32, f64},
     "nn.functional.normalize": {f16},
 }
@@ -349,6 +347,7 @@ inductor_override_kwargs = {
     ("atanh", "cuda", f16): {"reference_in_float": True},
     ("cauchy", "cuda"): {"reference_in_float": True},
     ("cummax", "cuda", f16): {"atol": 5e-4, "rtol": 0.002},
+    ("cumprod", "cuda"): {"reference_in_float": True, "atol": 7e-5, "rtol": 0.002},
     ("exponential", "cuda"): {"reference_in_float": True},
     ("geometric", "cuda"): {"reference_in_float": True},
     ("kron", "cuda", f16): {"reference_in_float": True},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109128
* #109089
* #109081

Without setting `reference_in_float`, cumprod's single sample case
passes (i.e. the compiled f16 result matches the eager mode f16 result;
in fact they are identical because they both call into aten). However,
the grad calculation does not line up.

Turning on `reference_in_float` causes the grad check to pass (i.e. we
are closer to the more accurate f64 grad calculation) but causes the
single sample case to fail. Since the compiled f16 case is no less
accurate than the eager f16 case for the single sample, relaxing the
tolerances here seems fine.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov