### PR TITLE
Add torch.export.register_dataclass API

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -554,6 +554,7 @@ API Reference
 .. autofunction:: constrain_as_value
 .. autofunction:: save
 .. autofunction:: load
+.. autofunction:: register_dataclass
 .. autoclass:: Constraint
 .. autoclass:: ExportedProgram
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -151,6 +151,7 @@ def get_ignored_functions() -> Set[Callable]:
         torch.export.dynamic_dim,
         torch.export.export,
         torch.export.load,
+        torch.export.register_dataclass,
         torch.export.save,
         torch.eye,
         torch.fft.fftfreq,


### PR DESCRIPTION
`register_dataclass` allows dataclass to be used as valid input/output types of torch.export.export
