### PR TITLE
[autotuning] move logging logic into logging function

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -292,11 +292,10 @@ class PersistentCache(CacheBase):
 
                 self.update_local_cache(local_cache)
 
-                if use_global_cache():
-                    timings_to_log = {
-                        choice.hash_key(): timings[choice] for choice in choices
-                    }
-                    log_vals(timings_to_log)
+                timings_to_log = {
+                    choice.hash_key(): timings[choice] for choice in choices
+                }
+                log_vals(timings_to_log)
         elif use_global_cache():
             # only check global cache, not local one
             check_cache(self.get_global_cache(), callback=log_stats)


### PR DESCRIPTION
Summary: move check for use_global_cache into logging functions

Test Plan: sandcastle/ci

Differential Revision: D49211797




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov