### PR TITLE
Release GIL in torch.cuda ops wherever possible.

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -105,9 +105,8 @@ PyObject* THCPModule_exchangeDevice(PyObject* self, PyObject* arg) {
     return THPUtils_packInt32(-1);
   }
 
-  int current_device = 0;
   torch::utils::cuda_lazy_init();
-  current_device = c10::cuda::ExchangeDevice(device);
+  auto current_device = c10::cuda::ExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS
@@ -121,9 +120,8 @@ PyObject* THCPModule_maybeExchangeDevice(PyObject* self, PyObject* arg) {
     return THPUtils_packInt32(-1);
   }
 
-  int current_device = 0;
   torch::utils::cuda_lazy_init();
-  current_device = c10::cuda::MaybeExchangeDevice(device);
+  auto current_device = c10::cuda::MaybeExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS
@@ -131,10 +129,9 @@ PyObject* THCPModule_maybeExchangeDevice(PyObject* self, PyObject* arg) {
 
 PyObject* THCPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  int32_t device = 0;
   torch::utils::cuda_lazy_init();
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-  device = static_cast<int32_t>(c10::cuda::current_device());
+  auto device = static_cast<int32_t>(c10::cuda::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
@@ -159,9 +156,8 @@ PyObject* THCPModule_canDeviceAccessPeer_wrap(PyObject* self, PyObject* args) {
   int64_t device = THPUtils_unpackLong(arg1);
   int64_t peer_device = THPUtils_unpackLong(arg2);
 
-  bool can_access = false;
   torch::utils::cuda_lazy_init();
-  can_access = at::cuda::canDeviceAccessPeer(device, peer_device);
+  auto can_access = at::cuda::canDeviceAccessPeer(device, peer_device);
   return PyBool_FromLong(can_access);
   END_HANDLE_TH_ERRORS
 }
@@ -169,9 +165,7 @@ PyObject* THCPModule_canDeviceAccessPeer_wrap(PyObject* self, PyObject* args) {
 PyObject* THCPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   poison_fork();
-  uint64_t device_count = 0;
-  device_count = at::cuda::device_count();
-  return THPUtils_packUInt64(device_count);
+  return THPUtils_packUInt64(at::cuda::device_count());
   END_HANDLE_TH_ERRORS
 }
 
@@ -223,9 +217,7 @@ PyObject* THCPModule_getCurrentStream_raw(
   THPUtils_assert(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   int64_t device = THPUtils_unpackLong(device_index);
-  void* stream = nullptr;
-  stream = at::cuda::getCurrentCUDAStream(device).stream();
-  return PyLong_FromVoidPtr(stream);
+  return PyLong_FromVoidPtr(at::cuda::getCurrentCUDAStream(device).stream());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -106,7 +106,7 @@ PyObject* THCPModule_exchangeDevice(PyObject* self, PyObject* arg) {
   }
 
   torch::utils::cuda_lazy_init();
-  auto current_device = c10::cuda::ExchangeDevice(device);
+  int current_device = c10::cuda::ExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS
@@ -121,7 +121,7 @@ PyObject* THCPModule_maybeExchangeDevice(PyObject* self, PyObject* arg) {
   }
 
   torch::utils::cuda_lazy_init();
-  auto current_device = c10::cuda::MaybeExchangeDevice(device);
+  int current_device = c10::cuda::MaybeExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -91,10 +91,7 @@ PyObject* THCPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   int64_t device = THPUtils_unpackLong(arg);
 
   torch::utils::cuda_lazy_init();
-  {
-    pybind11::gil_scoped_release no_gil;
-    THCPModule_setDevice(device);
-  }
+  THCPModule_setDevice(device);
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -110,10 +107,7 @@ PyObject* THCPModule_exchangeDevice(PyObject* self, PyObject* arg) {
 
   int current_device = 0;
   torch::utils::cuda_lazy_init();
-  {
-    pybind11::gil_scoped_release no_gil;
-    current_device = c10::cuda::ExchangeDevice(device);
-  }
+  current_device = c10::cuda::ExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS
@@ -129,10 +123,7 @@ PyObject* THCPModule_maybeExchangeDevice(PyObject* self, PyObject* arg) {
 
   int current_device = 0;
   torch::utils::cuda_lazy_init();
-  {
-    pybind11::gil_scoped_release no_gil;
-    current_device = c10::cuda::MaybeExchangeDevice(device);
-  }
+  current_device = c10::cuda::MaybeExchangeDevice(device);
 
   return THPUtils_packInt32(current_device);
   END_HANDLE_TH_ERRORS
@@ -142,11 +133,8 @@ PyObject* THCPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   int32_t device = 0;
   torch::utils::cuda_lazy_init();
-  {
-    pybind11::gil_scoped_release no_gil;
-    // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-    device = static_cast<int32_t>(c10::cuda::current_device());
-  }
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+  device = static_cast<int32_t>(c10::cuda::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
@@ -173,10 +161,7 @@ PyObject* THCPModule_canDeviceAccessPeer_wrap(PyObject* self, PyObject* args) {
 
   bool can_access = false;
   torch::utils::cuda_lazy_init();
-  {
-    pybind11::gil_scoped_release no_gil;
-    can_access = at::cuda::canDeviceAccessPeer(device, peer_device);
-  }
+  can_access = at::cuda::canDeviceAccessPeer(device, peer_device);
   return PyBool_FromLong(can_access);
   END_HANDLE_TH_ERRORS
 }
@@ -185,10 +170,7 @@ PyObject* THCPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   poison_fork();
   uint64_t device_count = 0;
-  {
-    pybind11::gil_scoped_release no_gil;
-    device_count = at::cuda::device_count();
-  }
+  device_count = at::cuda::device_count();
   return THPUtils_packUInt64(device_count);
   END_HANDLE_TH_ERRORS
 }
@@ -242,10 +224,7 @@ PyObject* THCPModule_getCurrentStream_raw(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   int64_t device = THPUtils_unpackLong(device_index);
   void* stream = nullptr;
-  {
-    pybind11::gil_scoped_release no_gil;
-    stream = at::cuda::getCurrentCUDAStream(device).stream();
-  }
+  stream = at::cuda::getCurrentCUDAStream(device).stream();
   return PyLong_FromVoidPtr(stream);
   END_HANDLE_TH_ERRORS
 }
@@ -295,17 +274,14 @@ PyObject* THCPModule_setStream_wrap(
           &device_type)) {
   }
 
-  {
-    pybind11::gil_scoped_release no_gil;
-    auto stream = at::cuda::CUDAStream::unpack3(
-        stream_id, device_index, static_cast<c10::DeviceType>(device_type));
+  auto stream = at::cuda::CUDAStream::unpack3(
+      stream_id, device_index, static_cast<c10::DeviceType>(device_type));
 
-    auto device = c10::cuda::current_device();
-    if (device != stream.device_index()) {
-      THCPModule_setDevice(stream.device_index());
-    }
-    at::cuda::setCurrentCUDAStream(stream);
+  auto device = c10::cuda::current_device();
+  if (device != stream.device_index()) {
+    THCPModule_setDevice(stream.device_index());
   }
+  at::cuda::setCurrentCUDAStream(stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -489,10 +465,8 @@ PyObject* THCPModule_cudaSynchronize(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THCPModule_cudaIPCCollect(PyObject* _unused, PyObject* noargs) {
-  HANDLE_TH_ERRORS {
-    pybind11::gil_scoped_release no_gil;
-    torch::CudaIPCCollect();
-  }
+  HANDLE_TH_ERRORS
+  torch::CudaIPCCollect();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -574,19 +548,14 @@ PyObject* THCPModule_setMemoryFraction(PyObject* _unused, PyObject* args) {
   double fraction = PyFloat_AsDouble(fraction_o);
   int64_t device = PyLong_AsLongLong(device_o);
 
-  {
-    pybind11::gil_scoped_release no_gil;
-    c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, device);
-  }
+  c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
 
 PyObject* THCPModule_emptyCache(PyObject* _unused, PyObject* noargs) {
-  HANDLE_TH_ERRORS {
-    pybind11::gil_scoped_release no_gil;
-    c10::cuda::CUDACachingAllocator::emptyCache();
-  }
+  HANDLE_TH_ERRORS
+  c10::cuda::CUDACachingAllocator::emptyCache();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -601,11 +570,6 @@ PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   using c10::cuda::CUDACachingAllocator::Stat;
   using c10::cuda::CUDACachingAllocator::StatArray;
   using c10::cuda::CUDACachingAllocator::StatType;
-  c10::cuda::CUDACachingAllocator::DeviceStats stats;
-  {
-    pybind11::gil_scoped_release no_gil;
-    stats = c10::cuda::CUDACachingAllocator::getDeviceStats(device);
-  }
 
   const auto statToDict = [](const Stat& stat) {
     py::dict dict;
@@ -626,6 +590,9 @@ PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
     }
     return dict;
   };
+
+  const DeviceStats stats =
+      c10::cuda::CUDACachingAllocator::getDeviceStats(device);
 
   py::dict result;
   result["num_alloc_retries"] = stats.num_alloc_retries;
@@ -655,10 +622,7 @@ PyObject* THCPModule_resetAccumulatedMemoryStats(
       THPUtils_checkLong(arg),
       "invalid argument to reset_accumulated_memory_stats");
   const int device = (int)THPUtils_unpackLong(arg);
-  {
-    pybind11::gil_scoped_release no_gil;
-    c10::cuda::CUDACachingAllocator::resetAccumulatedStats(device);
-  }
+  c10::cuda::CUDACachingAllocator::resetAccumulatedStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -668,10 +632,7 @@ PyObject* THCPModule_resetPeakMemoryStats(PyObject* _unused, PyObject* arg) {
   THPUtils_assert(
       THPUtils_checkLong(arg), "invalid argument to reset_peak_memory_stats");
   const int device = (int)THPUtils_unpackLong(arg);
-  {
-    pybind11::gil_scoped_release no_gil;
-    c10::cuda::CUDACachingAllocator::resetPeakStats(device);
-  }
+  c10::cuda::CUDACachingAllocator::resetPeakStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -878,28 +839,25 @@ PyObject* THCPModule_cudaSetSyncDebugMode(PyObject* _unused, PyObject* arg) {
   THPUtils_assert(
       THPUtils_checkLong(arg), "invalid argument to set_sync_debug_mode");
   int64_t debug_mode = THPUtils_unpackLong(arg);
-  {
-    pybind11::gil_scoped_release no_gil;
-    TORCH_CHECK(
-        debug_mode >= 0 && debug_mode <= 2,
-        "invalid value of debug_mode, expected one of 0,1,2");
-    c10::cuda::SyncDebugMode l;
-    switch (debug_mode) {
-      case 0:
-        l = c10::cuda::SyncDebugMode::L_DISABLED;
-        break;
-      case 1:
-        l = c10::cuda::SyncDebugMode::L_WARN;
-        break;
-      case 2:
-        l = c10::cuda::SyncDebugMode::L_ERROR;
-        break;
-      default:
-        l = c10::cuda::SyncDebugMode::L_DISABLED;
-        break; // can't happen
-    }
-    c10::cuda::warning_state().set_sync_debug_mode(l);
+  TORCH_CHECK(
+      debug_mode >= 0 && debug_mode <= 2,
+      "invalid value of debug_mode, expected one of 0,1,2");
+  c10::cuda::SyncDebugMode l;
+  switch (debug_mode) {
+    case 0:
+      l = c10::cuda::SyncDebugMode::L_DISABLED;
+      break;
+    case 1:
+      l = c10::cuda::SyncDebugMode::L_WARN;
+      break;
+    case 2:
+      l = c10::cuda::SyncDebugMode::L_ERROR;
+      break;
+    default:
+      l = c10::cuda::SyncDebugMode::L_DISABLED;
+      break; // can't happen
   }
+  c10::cuda::warning_state().set_sync_debug_mode(l);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
Most `torch.cuda` ops (ex: `torch.cuda.synchronize`) do not release GIL in C++ land. This has the potential of causing deadlocks and freeze the python process. For example, `torch.cuda.synchronize` could hold GIL and get blocked on some operation. However, that operation might never complete in python land since GIL is held by `torch.cuda.synchronize`.

In this PR, I've tried to release GIL as much as possible in `torch.cuda` ops.

See https://github.com/pytorch/pytorch/issues/109074 for an example of how holding GIL causes a deadlock.