### PR TITLE
Pass S3 credentials to ios upload workflow

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -124,11 +124,19 @@ jobs:
 
       - name: Build PyTorch mobile runtime
         shell: bash
+        # TODO: DEBUG
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         run: |
           set -eux
           # shellcheck disable=SC1091
           export TCLLIBPATH="/usr/local/lib"
           ${CONDA_RUN} scripts/build_ios.sh
+
+          ${CONDA_RUN} pip install awscli
+          # TODO: DEBUG
+          ${CONDA_RUN} aws s3 ls "s3://ossci-ios"
 
       - name: Build TestApp
         if: matrix.ios_platform == 'SIMULATOR'

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -3,10 +3,15 @@ name: ios-build-test
 on:
   workflow_call:
     inputs:
+      trigger-event:
+        type: string
+        default: ""
+        description: |
+          The trigger event from the caller that determines whether or not to upload
       build-environment:
         required: true
         type: string
-        description: Top-level label for what's being built/tested.
+        description: Top-level label for what is being built/tested.
       sync-tag:
         required: false
         type: string
@@ -262,7 +267,7 @@ jobs:
     runs-on: macos-12
     needs: build
     # NB: Only upload release build, if we need it, we could also turn on nightly here
-    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'ios-upload' || '' }}
+    environment: ${{ ((inputs.trigger-event == 'push' || inputs.trigger-event == 'workflow_dispatch') && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'ios-upload' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -292,6 +297,10 @@ jobs:
         shell: bash
         run: |
           set -eux
+
+          echo "DEBUG"
+          echo ${{ github.event_name }}
+          echo ${{ (github.event.ref }}
 
           for ARCH in "arm64" "x86_64"; do
             TMP_DIR="${RUNNER_TEMP}/${ARCH}"
@@ -412,7 +421,7 @@ jobs:
 
       - name: Set DRY_RUN
         # TODO: uncomment me
-        # if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        # if: ${{ (inputs.trigger-event == 'push' || inputs.trigger-event == 'workflow_dispatch') && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
         shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
@@ -449,7 +458,7 @@ jobs:
           # We need to set this secret to upload to cocoapods. However, we might want
           # to NOT set this for PROD release so that we can upload the artifacts manually
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN || '' }}
-        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' && env.COCOAPODS_TRUNK_TOKEN != '' }}
+        if: ${{ (inputs.trigger-event == 'push' || inputs.trigger-event == 'workflow_dispatch') && github.event.ref == 'refs/heads/nightly' && env.COCOAPODS_TRUNK_TOKEN != '' }}
         shell: bash
         working-directory: ${{ runner.temp }}/arm64
         run: |

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -411,7 +411,8 @@ jobs:
           path: ${{ env.DEST_DIR }}/${{ env.SPEC_NAME_WITH_VERSION }}
 
       - name: Set DRY_RUN
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        # TODO: uncomment me
+        # if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
         shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -24,6 +24,8 @@ on:
         required: false
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY:
         required: false
+      COCOAPODS_TRUNK_TOKEN:
+        required: false
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -19,6 +19,11 @@ on:
         type: string
         description: |
           A JSON description of what configs to run later on.
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
+        required: false
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY:
+        required: false
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -298,10 +298,6 @@ jobs:
         run: |
           set -eux
 
-          echo "DEBUG"
-          echo ${{ github.event_name }}
-          echo ${{ (github.event.ref }}
-
           for ARCH in "arm64" "x86_64"; do
             TMP_DIR="${RUNNER_TEMP}/${ARCH}"
             mkdir -p "${TMP_DIR}"
@@ -421,7 +417,7 @@ jobs:
 
       - name: Set DRY_RUN
         # TODO: uncomment me
-        # if: ${{ (inputs.trigger-event == 'push' || inputs.trigger-event == 'workflow_dispatch') && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        # if: ${{ (inputs.trigger-event == 'push' || inputs.trigger-event == 'workflow_dispatch') && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) }}
         shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"

--- a/.github/workflows/build-ios-binaries.yml
+++ b/.github/workflows/build-ios-binaries.yml
@@ -41,6 +41,7 @@ jobs:
     name: ios-build-test
     uses: ./.github/workflows/_ios-build-test.yml
     with:
+      trigger-event: ${{ github.event_name }}
       build-environment: ios-build-test
       sync-tag: ios-build-test
       test-matrix: |

--- a/.github/workflows/build-ios-binaries.yml
+++ b/.github/workflows/build-ios-binaries.yml
@@ -40,7 +40,6 @@ jobs:
   ios-build-test:
     name: ios-build-test
     uses: ./.github/workflows/_ios-build-test.yml
-    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'ios-upload' || '' }}
     with:
       build-environment: ios-build-test
       sync-tag: ios-build-test

--- a/.github/workflows/build-ios-binaries.yml
+++ b/.github/workflows/build-ios-binaries.yml
@@ -40,6 +40,7 @@ jobs:
   ios-build-test:
     name: ios-build-test
     uses: ./.github/workflows/_ios-build-test.yml
+    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'ios-upload' || '' }}
     with:
       build-environment: ios-build-test
       sync-tag: ios-build-test
@@ -68,3 +69,6 @@ jobs:
             use_custom_op_list: ${{ inputs.use_custom_op_list || '' }}
           }
         ]}
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -118,6 +118,7 @@ jobs:
     if: github.event_name != 'schedule' || github.event.schedule == '45 0,8,16 * * 1-5' || github.event.schedule == '45 4 * * 0,6'
     uses: ./.github/workflows/_ios-build-test.yml
     with:
+      trigger-event: ${{ github.event_name }}
       build-environment: ios-build-test
       sync-tag: ios-build-test
       test-matrix: |


### PR DESCRIPTION
This fixes the failed upload to S3 for nightly and release build.  The credentials needs to be passed from the caller workflow.