### PR TITLE
Remove unneeded linking in CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 
 # One variable that determines whether the current cmake process is being run
 # with the main Caffe2 library. This is useful for building modules - if

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -45,10 +45,6 @@ set(ATEN_INSTALL_LIB_SUBDIR "lib" CACHE PATH "ATen install library subdirectory"
 set(ATEN_INSTALL_INCLUDE_SUBDIR "include" CACHE PATH "ATen install include subdirectory")
 set(MEM_EFF_ATTENTION_CUDA_SOURCES)
 
-if(USE_CUDA)
-  list(APPEND ATen_CUDA_INCLUDE ${CUDA_INCLUDE_DIRS})
-endif()
-
 set(TH_LINK_STYLE STATIC)
 set(TH_CPU_INCLUDE
   ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -446,7 +446,6 @@ if(USE_CUDA AND NOT USE_ROCM)
     list(APPEND ATen_CUDA_DEPENDENCY_LIBS
       ${CUDA_LIBRARIES}
       CUDA::cusparse_static
-      CUDA::curand_static
       CUDA::cufft_static_nocallback
     )
    if(NOT BUILD_LAZY_CUDA_LINALG)
@@ -466,7 +465,6 @@ if(USE_CUDA AND NOT USE_ROCM)
     list(APPEND ATen_CUDA_DEPENDENCY_LIBS
       ${CUDA_LIBRARIES}
       CUDA::cusparse
-      CUDA::curand
       CUDA::cufft
     )
    if(NOT BUILD_LAZY_CUDA_LINALG)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -631,8 +631,7 @@ if(USE_CUDA)
     set(DELAY_LOAD_FLAGS "")
   endif()
 
-  target_link_libraries(caffe2_nvrtc ${CUDA_NVRTC} ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB} ${DELAY_LOAD_FLAGS})
-  target_include_directories(caffe2_nvrtc PRIVATE ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(caffe2_nvrtc ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB} ${DELAY_LOAD_FLAGS})
   install(TARGETS caffe2_nvrtc DESTINATION "${TORCH_INSTALL_LIB_DIR}")
   if(USE_NCCL)
     list(APPEND Caffe2_GPU_SRCS

--- a/test/cpp/aot_inductor/CMakeLists.txt
+++ b/test/cpp/aot_inductor/CMakeLists.txt
@@ -31,14 +31,6 @@ target_link_libraries(test_aot_inductor PRIVATE
 )
 
 if(USE_CUDA)
-  target_link_libraries(test_aot_inductor PRIVATE
-    ${C10_CUDA_BUILD_SHARED_LIBS}
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES}
-  )
-
   target_include_directories(test_aot_inductor PRIVATE ${ATen_CUDA_INCLUDE})
 
   target_compile_definitions(test_aot_inductor PRIVATE USE_CUDA)

--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -57,12 +57,6 @@ if(NOT MSVC)
 endif()
 
 if(USE_CUDA)
-  target_link_libraries(test_api PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
-
   target_compile_definitions(test_api PRIVATE "USE_CUDA")
 endif()
 

--- a/test/cpp/dist_autograd/CMakeLists.txt
+++ b/test/cpp/dist_autograd/CMakeLists.txt
@@ -10,12 +10,6 @@ if(USE_DISTRIBUTED AND NOT WIN32)
   target_link_libraries(test_dist_autograd PRIVATE torch gtest)
 
   if(USE_CUDA)
-    target_link_libraries(test_dist_autograd PRIVATE
-      ${CUDA_LIBRARIES}
-      ${CUDA_NVRTC_LIB}
-      ${CUDA_CUDA_LIB}
-      ${TORCH_CUDA_LIBRARIES})
-
     target_compile_definitions(test_dist_autograd PRIVATE "USE_CUDA")
   endif()
 

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -139,12 +139,6 @@ if(LINUX)
 endif()
 
 if(USE_CUDA)
-  target_link_libraries(test_jit PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
-
   target_compile_definitions(test_jit PRIVATE USE_CUDA)
   # Suppress sign compare checks for NVFUSER JIT tests
   if(NOT MSVC)

--- a/test/cpp/lazy/CMakeLists.txt
+++ b/test/cpp/lazy/CMakeLists.txt
@@ -33,12 +33,6 @@ target_link_libraries(test_lazy PRIVATE ${LAZY_TEST_DEPENDENCIES})
 target_include_directories(test_lazy PRIVATE ${ATen_CPU_INCLUDE})
 
 if(USE_CUDA)
-  target_link_libraries(test_lazy PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
-
   target_compile_definitions(test_lazy PRIVATE USE_CUDA)
 elseif(USE_ROCM)
   target_link_libraries(test_lazy PRIVATE

--- a/test/cpp/rpc/CMakeLists.txt
+++ b/test/cpp/rpc/CMakeLists.txt
@@ -33,12 +33,6 @@ target_include_directories(
 target_link_libraries(test_cpp_rpc PRIVATE ${TORCH_RPC_TEST_DEPENDENCY_LIBS})
 
 if(USE_CUDA)
-  target_link_libraries(test_cpp_rpc PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
-
   target_compile_definitions(test_cpp_rpc PRIVATE "USE_CUDA")
 endif()
 

--- a/test/cpp/tensorexpr/CMakeLists.txt
+++ b/test/cpp/tensorexpr/CMakeLists.txt
@@ -57,18 +57,7 @@ if(USE_PTHREADPOOL)
   target_link_libraries(test_tensorexpr PRIVATE pthreadpool_interface)
 endif()
 if(USE_CUDA)
-  target_link_libraries(test_tensorexpr PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
   target_compile_definitions(test_tensorexpr PRIVATE USE_CUDA)
-
-  target_link_libraries(tutorial_tensorexpr PRIVATE
-    ${CUDA_LIBRARIES}
-    ${CUDA_NVRTC_LIB}
-    ${CUDA_CUDA_LIB}
-    ${TORCH_CUDA_LIBRARIES})
   target_compile_definitions(tutorial_tensorexpr PRIVATE USE_CUDA)
 elseif(USE_ROCM)
   target_link_libraries(test_tensorexpr PRIVATE


### PR DESCRIPTION
This PR removes unused library dependencies, help refactoring in the future.
cc @ezyang @huydhn