### PR TITLE
[C10D] Push store scalability a bit further.

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -6,6 +6,10 @@
 #include <fcntl.h>
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <fstream>
+#include <random>
+#include <streambuf>
 #include <system_error>
 #include <thread>
 #include <unordered_map>
@@ -299,9 +303,37 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
     // server successfully started
     C10D_DEBUG("The server has started on port = {}.", server_->port());
 
+    std::ifstream maxconnFile("/proc/sys/net/core/somaxconn");
+    if (maxconnFile.good() and numWorkers_.has_value()) {
+      try {
+        std::string str(
+            (std::istreambuf_iterator<char>(maxconnFile)),
+            std::istreambuf_iterator<char>());
+        std::size_t somaxconn = std::stoll(str);
+        if (somaxconn < *numWorkers_) {
+          C10D_WARNING(
+              "Starting store with {} workers but somaxconn is {}."
+              "This might cause instability during bootstrap, consider increasing it.",
+              *numWorkers_,
+              somaxconn);
+        }
+      } catch (std::exception& e) {
+        // ignore
+      }
+    }
+
     addr_.port = server_->port();
   } else {
     addr_.port = opts.port;
+  }
+
+  if (numWorkers_.has_value()) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib(1, *numWorkers_);
+    // stagger connecting to the store when there are too many ranks to
+    // avoid causing a DDoS
+    std::this_thread::sleep_for(std::chrono::milliseconds(distrib(gen)));
   }
 
   client_ = detail::TCPClient::connect(addr_, opts);

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -29,7 +29,7 @@ Other callbacks don't provide exception safety so avoid there.
 
 */
 
-#define DEFAULT_BACKLOG 2048
+#define DEFAULT_BACKLOG 16384
 #define MAX_KEY_COUNT (128 * 1024)
 #define MAX_STRING_LEN (8 * 1024)
 #define MAX_PAYLOAD_LEN (8 * 1024 * 1024)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109200

This is a bunch of small changes to improve store scalability:

- stagger client connection to avoid a stampede.
- warn if somaxconn is too small.
- increase the backlog to 16k.