### PR TITLE
BUG: gracefully fall back to numpy.random if asked in dynamo.config

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2033,6 +2033,17 @@ utils_device.CURRENT_DEVICE == None""",
 
             self.assertEqual(cnts.frame_count, 1)  # no graph break
 
+    def test_numpy_random_config_to_numpy(self):
+        # setting the config value makes the PRNG identical to numpy's
+        # NB this may involve a graph break
+        torch._dynamo.config.use_numpy_random_stream = True
+
+        @torch.compile
+        def fn():
+            return np.random.uniform(size=13)
+
+        self.assertEqual(fn().shape, (13,))
+
     def test_inplace_view_on_graph_input(self):
         # graph break when calling methods with inplace_view tag on graph input
         func_args_map = {

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -985,6 +985,14 @@ class NumpyVariable(VariableTracker):
                     " Please file an issue to request support for this function."
                 )
 
+            if (
+                func.__module__ == "torch._numpy.random"
+                and config.use_numpy_random_stream
+            ):
+                msg = f"delegate '{func.__qualname__}' to NumPy itself via "
+                msg += f"confg.use_numpy_random_stream={config.use_numpy_random_stream}"
+                unimplemented(msg)
+
             # TODO(larryliu0820): currently assuming all numpy.* functions are returning a ndarray that can be
             #  wrapped by NumpyNdarrayVariable which is wrong!
             proxy = tx.output.create_proxy(


### PR DESCRIPTION
Graph break if `config.use_numpy_random_stream=True` instead of a hard failure in inductor.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @Xia-Weiwen