### PR TITLE
inductor/test_max_autotune serial in CI

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -353,6 +353,7 @@ CI_SERIAL_LIST = [
     "test_autocast",  # OOM
     "test_native_mha",  # OOM
     "test_module_hooks",  # OOM
+    "inductor/test_max_autotune",  # Testing, probably revert later
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Trying to figure out why the this keeps timing out, wondering if its due to parallelization weirdness