### PR TITLE
[ez][inductor][fx passes] quick fix for invalid nodes

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -214,6 +214,8 @@ def is_linear_node_can_be_fused(node):
     weight = get_arg_value(node, 1, "weight")
     return (
         is_node_meta_valid(node)
+        and is_node_meta_valid(input)
+        and is_node_meta_valid(weight)
         and len(input.meta["example_value"].shape) == 2
         and len(weight.meta["example_value"].shape) == 2
     )


### PR DESCRIPTION
Summary: As title.Need to check whether node is valid before fusion

Test Plan: To add test

Differential Revision: D49241525




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov