### PR TITLE
[AOTInductor] Skip pre_grad_passes for exported graph.

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -997,9 +997,11 @@ def compile_fx(
                 recursive_compile_fx,
             )
 
-        # Since handle_dynamo_export_graph will trigger compile_fx again,
-        # Move these passes after handle_dynamo_export_graph to avoid repeated calls.
-        model_ = pre_grad_passes(model_, example_inputs_)
+        if not config.from_export:
+            # Since handle_dynamo_export_graph will trigger compile_fx again,
+            # Move these passes after handle_dynamo_export_graph to avoid repeated calls.
+            # If we come from export, the graph is already in aten IR, so pre-grad passes is no-op.
+            model_ = pre_grad_passes(model_, example_inputs_)
 
     if any(isinstance(x, (list, tuple, dict)) for x in example_inputs_):
         return flatten_graph_inputs(


### PR DESCRIPTION
Summary:
We skip pre_grad_passes if graph comes from export (aten IR) since
pre_grad_passes (i.e. remove_identity) would not preserve meta["val"] in aten IR.


Differential Revision: D49246374



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @aakhundov