### PR TITLE
Remove det_singular OpInfo

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -9,8 +9,8 @@
 import itertools
 import unittest
 
-from torch.testing._internal.common_utils import TestCase, run_tests, is_iterable_of_tensors, IS_MACOS, \
-    IS_X86, parametrize, TEST_WITH_ASAN, noncontiguous_like
+from torch.testing._internal.common_utils import TestCase, run_tests, is_iterable_of_tensors, \
+     parametrize, TEST_WITH_ASAN, noncontiguous_like
 from torch.testing._internal.common_utils import skipIfRocm, runOnRocm
 import torch
 from torch import Tensor
@@ -37,7 +37,6 @@ from common_utils import (
     is_valid_inplace_sample_input,
     loop,
     loop2,
-    expectedFailureIf,
 )
 from torch.testing._internal.autograd_function_db import (
     autograd_function_db

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -10,7 +10,7 @@ import itertools
 import unittest
 
 from torch.testing._internal.common_utils import TestCase, run_tests, is_iterable_of_tensors, \
-     parametrize, TEST_WITH_ASAN, noncontiguous_like
+    parametrize, TEST_WITH_ASAN, noncontiguous_like
 from torch.testing._internal.common_utils import skipIfRocm, runOnRocm
 import torch
 from torch import Tensor

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -495,8 +495,6 @@ class TestOperators(TestCase):
         xfail('as_strided'),
         xfail('as_strided', 'partial_views'),
         xfail('as_strided_scatter'),
-        decorate('linalg.det', 'singular',
-                 decorator=expectedFailureIf(IS_MACOS and IS_X86)),
     }))
     @opsToleranceOverride('TestOperators', 'test_jvp', (
         tol1('nn.functional.conv_transpose3d',
@@ -701,8 +699,6 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         tol1('linalg.vander',
              {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
-        tol2('linalg.det', 'singular',
-             {torch.float32: tol(atol=2e-05, rtol=2e-05)}),
     ))
     def test_vjpvjp(self, device, dtype, op):
         if not op.supports_autograd:
@@ -1051,9 +1047,6 @@ class TestOperators(TestCase):
         tol1('linalg.householder_product',
              {torch.float32: tol(atol=2e-04, rtol=9e-3)}),
     ))
-    @skipOps('TestOperators', 'test_vmapjvpall', vmapjvpall_fail.union({
-        decorate('linalg.det', 'singular', decorator=expectedFailureIf(IS_MACOS and IS_X86)),
-    }))
     # This is technically a superset of test_vmapjvp. We should either delete test_vmapjvp
     # or figure out if we can split vmapjvpall. It's useful to keep test_vmapjvp intact
     # because that corresponds to "batched forward-mode AD" testing in PyTorch core

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -33,11 +33,9 @@ from torch.testing._internal.common_dtype import (
     all_types_and_complex_and,
     floating_and_complex_types,
     floating_and_complex_types_and,
-    get_all_complex_dtypes,
 )
 from torch.testing._internal.common_utils import (
     GRADCHECK_NONDET_TOL,
-    IS_MACOS,
     make_fullrank_matrices_with_distinct_singular_values,
     skipIfSlowGradcheckEnv,
     slowTest,
@@ -185,37 +183,6 @@ def sample_inputs_householder_product(op_info, device, dtype, requires_grad, **k
     yield SampleInput(make_arg((S, S)), make_arg((S - 2,), low=None, high=None))
     # m = S, n = S -1, k = S - 2
     yield SampleInput(make_arg((S, S - 1)), make_arg((S - 2,), low=None, high=None))
-
-
-def sample_inputs_linalg_det_singular(op_info, device, dtype, requires_grad, **kwargs):
-    make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-    def make_singular_matrix_batch_base(size, rank):
-        assert size[-1] == size[-2]
-        assert rank > 0 and rank < size[-1]
-
-        n = size[-1]
-        a = make_arg(size[:-2] + (n, rank)) / 10
-        b = make_arg(size[:-2] + (rank, n)) / 10
-        x = a @ b
-        lu, pivs, _ = torch.linalg.lu_factor_ex(x)
-        p, l, u = torch.lu_unpack(lu, pivs)
-        u_diag_abs = u.diagonal(0, -2, -1).abs()
-        u_diag_abs_largest = u_diag_abs.max(dim=-1, keepdim=True).values
-        u_diag_abs_smallest_idxs = torch.topk(
-            u_diag_abs, k=(n - rank), largest=False
-        ).indices
-        u.diagonal(0, -2, -1).div_(u_diag_abs_largest)
-        u.diagonal(0, -2, -1)[..., u_diag_abs_smallest_idxs] = torch.finfo(dtype).eps
-        matrix = p @ l @ u
-
-        matrix.requires_grad_(requires_grad)
-        return matrix
-
-    for batch, size in product(((), (2,), (2, 2)), range(6)):
-        shape = batch + (size, size)
-        for rank in range(1, size):
-            yield SampleInput(make_singular_matrix_batch_base(shape, rank))
 
 
 def sample_inputs_linalg_matrix_power(op_info, device, dtype, requires_grad, **kwargs):
@@ -1199,87 +1166,6 @@ op_db: List[OpInfo] = [
         sample_inputs_func=sample_inputs_linalg_det_logdet_slogdet,
         decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
         check_batched_gradgrad=False,
-    ),
-    OpInfo(
-        "linalg.det",
-        aten_name="linalg_det",
-        op=torch.linalg.det,
-        variant_test_name="singular",
-        aliases=("det",),
-        dtypes=floating_and_complex_types(),
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
-        check_batched_gradgrad=False,
-        sample_inputs_func=sample_inputs_linalg_det_singular,
-        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
-        skips=(
-            DecorateInfo(
-                unittest.skip("The backward may give different results"),
-                "TestCommon",
-                "test_noncontiguous_samples",
-            ),
-            DecorateInfo(
-                unittest.skip("Gradients are incorrect on macos"),
-                "TestBwdGradients",
-                "test_fn_grad",
-                device_type="cpu",
-                dtypes=(torch.float64,),
-                active_if=IS_MACOS,
-            ),
-            DecorateInfo(
-                unittest.skip("Gradients are incorrect on macos"),
-                "TestFwdGradients",
-                "test_forward_mode_AD",
-                device_type="cpu",
-                dtypes=(torch.float64,),
-                active_if=IS_MACOS,
-            ),
-            # Both Hessians are incorrect on complex inputs??
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestBwdGradients",
-                "test_fn_gradgrad",
-                dtypes=(torch.complex128,),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestFwdGradients",
-                "test_fn_fwgrad_bwgrad",
-                dtypes=(torch.complex128,),
-            ),
-            DecorateInfo(
-                unittest.skip("Skipped, see https://github.com//issues/84192"),
-                "TestBwdGradients",
-                "test_fn_gradgrad",
-                device_type="cuda",
-            ),
-            DecorateInfo(
-                unittest.skip("Skipped, see https://github.com//issues/84192"),
-                "TestFwdGradients",
-                "test_fn_fwgrad_bwgrad",
-                device_type="cuda",
-            ),
-            DecorateInfo(
-                unittest.skip(
-                    "Flaky on ROCm https://github.com/pytorch/pytorch/issues/93044"
-                ),
-                "TestBwdGradients",
-                "test_fn_grad",
-                device_type="cuda",
-                dtypes=get_all_complex_dtypes(),
-                active_if=TEST_WITH_ROCM,
-            ),
-            DecorateInfo(
-                unittest.skip(
-                    "Flaky on ROCm https://github.com/pytorch/pytorch/issues/93045"
-                ),
-                "TestFwdGradients",
-                "test_forward_mode_AD",
-                device_type="cuda",
-                dtypes=get_all_complex_dtypes(),
-                active_if=TEST_WITH_ROCM,
-            ),
-        ),
     ),
     OpInfo(
         "linalg.diagonal",


### PR DESCRIPTION
Fixes #93045


singular linalg_det test cases are flaky. Consensus seems to be we can remove associated OpInfo according to this:
https://github.com/pytorch/pytorch/issues/93045#issuecomment-1477674083
@lezcano 

This change is a duplicate of a different stale PR: https://github.com/pytorch/pytorch/pull/102581