### PR TITLE
[1/N] Apply clang-tidy to c10/test/*cpp

### DIFF
--- a/c10/test/core/CompileTimeFunctionPointer_test.cpp
+++ b/c10/test/core/CompileTimeFunctionPointer_test.cpp
@@ -2,42 +2,41 @@
 #include <gtest/gtest.h>
 
 namespace test_is_compile_time_function_pointer {
-static_assert(!c10::is_compile_time_function_pointer<void()>::value, "");
+static_assert(!c10::is_compile_time_function_pointer<void()>::value);
 
 void dummy() {}
 static_assert(
-    c10::is_compile_time_function_pointer<TORCH_FN_TYPE(dummy)>::value,
-    "");
+    c10::is_compile_time_function_pointer<TORCH_FN_TYPE(dummy)>::value);
 } // namespace test_is_compile_time_function_pointer
 
 namespace test_access_through_type {
 void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(dummy);
-static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value, "");
-static_assert(dummy_ptr::func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value, "");
+static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
+static_assert(dummy_ptr::func_ptr() == &dummy);
+static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
 } // namespace test_access_through_type
 
 namespace test_access_through_value {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(dummy);
-static_assert(dummy_ptr.func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value, "");
+static_assert(dummy_ptr.func_ptr() == &dummy);
+static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
 } // namespace test_access_through_value
 
 namespace test_access_through_type_also_works_if_specified_as_pointer {
 void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(&dummy);
-static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value, "");
-static_assert(dummy_ptr::func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value, "");
+static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
+static_assert(dummy_ptr::func_ptr() == &dummy);
+static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
 } // namespace test_access_through_type_also_works_if_specified_as_pointer
 
 namespace test_access_through_value_also_works_if_specified_as_pointer {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(&dummy);
-static_assert(dummy_ptr.func_ptr() == &dummy, "");
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value, "");
+static_assert(dummy_ptr.func_ptr() == &dummy);
+static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
 } // namespace test_access_through_value_also_works_if_specified_as_pointer
 
 namespace test_run_through_type {

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -400,7 +400,7 @@ TEST(DispatchKeySet, TestBackendComponentToString) {
 }
 
 TEST(DispatchKeySet, TestEndOfRuntimeBackendKeysAccurate) {
-  DispatchKey k;
+  DispatchKey k = DispatchKey::Undefined;
 #define SETTER(fullname, prefix) k = DispatchKey::EndOf##fullname##Backends;
   C10_FORALL_FUNCTIONALITY_KEYS(SETTER)
 #undef SETTER

--- a/c10/test/core/impl/InlineDeviceGuard_test.cpp
+++ b/c10/test/core/impl/InlineDeviceGuard_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <initializer_list>
 
 #include <c10/core/impl/FakeGuardImpl.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
@@ -18,7 +19,7 @@ static Device dev(DeviceIndex index) {
 using TestGuard = InlineDeviceGuard<TestGuardImpl>;
 
 TEST(InlineDeviceGuard, Constructor) {
-  for (DeviceIndex i : {-1, 0, 1}) {
+  for (DeviceIndex i : std::initializer_list<DeviceIndex>{-1, 0, 1}) {
     DeviceIndex init_i = 0;
     TestGuardImpl::setDeviceIndex(init_i);
     auto test_body = [&](TestGuard& g) -> void {
@@ -60,9 +61,9 @@ TEST(InlineDeviceGuard, ConstructorError) {
 TEST(InlineDeviceGuard, SetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
-  DeviceIndex i = init_i + 1;
+  DeviceIndex i = 1;
   TestGuard g(i);
-  DeviceIndex i2 = init_i + 2;
+  DeviceIndex i2 = 2;
   g.set_device(dev(i2));
   ASSERT_EQ(g.original_device(), dev(init_i));
   ASSERT_EQ(g.current_device(), dev(i2));
@@ -76,9 +77,9 @@ TEST(InlineDeviceGuard, SetDevice) {
 TEST(InlineDeviceGuard, ResetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
-  DeviceIndex i = init_i + 1;
+  DeviceIndex i = 1;
   TestGuard g(i);
-  DeviceIndex i2 = init_i + 2;
+  DeviceIndex i2 = 2;
   g.reset_device(dev(i2));
   ASSERT_EQ(g.original_device(), dev(init_i));
   ASSERT_EQ(g.current_device(), dev(i2));
@@ -92,9 +93,9 @@ TEST(InlineDeviceGuard, ResetDevice) {
 TEST(InlineDeviceGuard, SetIndex) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
-  DeviceIndex i = init_i + 1;
+  DeviceIndex i = 1;
   TestGuard g(i);
-  DeviceIndex i2 = init_i + 2;
+  DeviceIndex i2 = 2;
   g.set_index(i2);
   ASSERT_EQ(g.original_device(), dev(init_i));
   ASSERT_EQ(g.current_device(), dev(i2));
@@ -111,7 +112,7 @@ TEST(InlineDeviceGuard, SetIndex) {
 using MaybeTestGuard = InlineOptionalDeviceGuard<TestGuardImpl>;
 
 TEST(InlineOptionalDeviceGuard, Constructor) {
-  for (DeviceIndex i : {-1, 0, 1}) {
+  for (DeviceIndex i : std::initializer_list<DeviceIndex>{-1, 0, 1}) {
     DeviceIndex init_i = 0;
     TestGuardImpl::setDeviceIndex(init_i);
     auto test_body = [&](MaybeTestGuard& g) -> void {
@@ -167,7 +168,7 @@ TEST(InlineOptionalDeviceGuard, SetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
   MaybeTestGuard g;
-  DeviceIndex i = init_i + 1;
+  DeviceIndex i = 1;
   g.set_device(dev(i));
   ASSERT_EQ(g.original_device(), make_optional(dev(init_i)));
   ASSERT_EQ(g.current_device(), make_optional(dev(i)));
@@ -181,7 +182,7 @@ TEST(InlineOptionalDeviceGuard, SetDevice) {
 TEST(InlineOptionalDeviceGuard, SetIndex) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
-  DeviceIndex i = init_i + 1;
+  DeviceIndex i = 1;
   MaybeTestGuard g;
   g.set_index(i);
   ASSERT_EQ(g.original_device(), make_optional(dev(init_i)));

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -10,6 +10,7 @@
 using namespace c10;
 using namespace c10::impl;
 
+// NOLINTBEGIN(*conversion*, *multiplication*)
 static void checkData(
     const SizesAndStrides& sz,
     IntArrayRef sizes,
@@ -418,3 +419,4 @@ TEST(SizesAndStridesTest, MoveAssignmentSelf) {
   selfMove(big, big);
   checkBig(big);
 }
+// NOLINTEND(*conversion*, *multiplication*)

--- a/c10/test/util/ConstexprCrc_test.cpp
+++ b/c10/test/util/ConstexprCrc_test.cpp
@@ -13,5 +13,5 @@ static_assert(
 
 // check concrete expected values (for CRC64 with Jones coefficients and an init
 // value of 0)
-static_assert(crc64_t{0} == crc64(""), "");
-static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"), "");
+static_assert(crc64_t{0} == crc64(""));
+static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"));

--- a/c10/test/util/LeftRight_test.cpp
+++ b/c10/test/util/LeftRight_test.cpp
@@ -34,7 +34,7 @@ TEST(LeftRightTest, givenVector_whenWritingReturnsValue_thenValueIsReturned) {
   LeftRight<vector<int>> obj;
 
   auto a = obj.write([](vector<int>&) -> int { return 5; });
-  static_assert(std::is_same<int, decltype(a)>::value, "");
+  static_assert(std::is_same<int, decltype(a)>::value);
   EXPECT_EQ(5, a);
 }
 

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -5,6 +5,7 @@
 
 using namespace c10::guts;
 
+// NOLINTBEGIN(modernize*)
 namespace {
 
 namespace test_function_traits {
@@ -300,3 +301,4 @@ TEST(MetaprogrammingTest, TupleMap_canBeUsedWithAutoLambdas) {
 } // namespace test_tuple_map
 
 } // namespace
+// NOLINTEND(modernize*)

--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -6,6 +6,7 @@ using c10::string_view;
 using c10::util::get_fully_qualified_type_name;
 using c10::util::get_type_index;
 
+// NOLINTBEGIN(modernize-unary-static-assert)
 namespace {
 
 static_assert(get_type_index<int>() == get_type_index<int>(), "");
@@ -211,3 +212,4 @@ TEST(TypeIndex, FunctionArgumentsAndReturns) {
 }
 } // namespace test_function_arguments_and_returns
 } // namespace
+// NOLINTEND(modernize-unary-static-assert)

--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 using namespace c10::guts::typelist;
-
+// NOLINTBEGIN(modernize-unary-static-assert)
 namespace test_size {
 class MyClass {};
 static_assert(0 == size<typelist<>>::value, "");
@@ -377,3 +377,4 @@ static_assert(
         drop_if_nonempty_t<typelist<int64_t, int32_t>, 3>>::value,
     "");
 } // namespace test_drop_if_nonempty
+// NOLINTEND(modernize-unary-static-assert)

--- a/c10/test/util/TypeTraits_test.cpp
+++ b/c10/test/util/TypeTraits_test.cpp
@@ -3,6 +3,7 @@
 
 using namespace c10::guts;
 
+// NOLINTBEGIN(modernize-unary-static-assert)
 namespace {
 
 namespace test_is_equality_comparable {
@@ -191,3 +192,4 @@ void func() {
       !is_stateless_lambda<Func*>::value, "A function pointer is not a lambda");
 }
 } // namespace test_lambda_is_stateless
+// NOLINTEND(modernize-unary-static-assert)

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -41,7 +41,7 @@ TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
 
     // The relative error should be less than 1/(2^7) since BFloat16
     // has 7 bits mantissa.
-    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+    EXPECT_LE(std::fabs(out[i] - in[i]) / in[i], 1.0 / 128);
   }
 }
 
@@ -64,7 +64,7 @@ TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
 
     // The relative error should be less than 1/(2^7) since BFloat16
     // has 7 bits mantissa.
-    EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+    EXPECT_LE(std::fabs(out[i] - in[i]) / in[i], 1.0 / 128);
   }
 }
 

--- a/c10/test/util/either_test.cpp
+++ b/c10/test/util/either_test.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <vector>
 
+// NOLINTBEGIN(*)
 using c10::either;
 using c10::make_left;
 using c10::make_right;
@@ -1250,3 +1251,4 @@ TEST(EitherTestDestructor, RightDestructorIsCalledAfterMoveAssignment) {
       std::move(temp2);
   var1 = std::move(var2);
 }
+// NOLINTEND(*)

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -88,7 +88,7 @@ class NullType2 final {
   }
 };
 SomeClass NullType2::singleton_;
-static_assert(NullType1::singleton() != NullType2::singleton(), "");
+static_assert(NullType1::singleton() != NullType2::singleton());
 } // namespace
 
 static_assert(

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -175,14 +175,13 @@ TEST(OrderedPreservingDictTest, test_range_insert) {
   const int nb_values = 1000;
   std::vector<std::pair<int, int>> values;
   for (const auto i : c10::irange(nb_values)) {
-    // NOLINTNEXTLINE(modernize-use-emplace,performance-inefficient-vector-operation)
-    values.push_back(std::make_pair(i, i + 1));
+    values.emplace_back(i, i + 1);
   }
 
   dict_int_int map = {{-1, 0}, {-2, 0}};
   map.insert(values.begin() + 10, values.end() - 5);
 
-  TORCH_INTERNAL_ASSERT(map.size(), 987);
+  ASSERT_EQUAL_PRIM(map.size(), 987);
 
   ASSERT_EQUAL_PRIM(map.at(-1), 0);
 
@@ -197,7 +196,7 @@ TEST(OrderedPreservingDictTest, test_range_erase_all) {
   // insert x values, delete all
   const std::size_t nb_values = 1000;
   dict_int_int map;
-  for (const auto i : c10::irange(nb_values)) {
+  for (const int64_t i : c10::irange<int64_t>(nb_values)) {
     map[i] = i + 1;
   }
   auto it = map.erase(map.begin(), map.end());
@@ -281,8 +280,8 @@ TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_constructor) {
   HMap map_move(std::move(map));
 
   ASSERT_EQUAL_PRIM(map_move.size(), 3);
-  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
-  ASSERT_EQUAL_PRIM(map.size(), 0);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_TRUE(map.empty());
 
   map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
   TORCH_INTERNAL_ASSERT(
@@ -297,8 +296,8 @@ TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_operator) {
   HMap map_move = std::move(map);
 
   ASSERT_EQUAL_PRIM(map_move.size(), 3);
-  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
-  ASSERT_EQUAL_PRIM(map.size(), 0);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_TRUE(map.empty());
 
   map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
   TORCH_INTERNAL_ASSERT(

--- a/c10/test/util/small_vector_test.cpp
+++ b/c10/test/util/small_vector_test.cpp
@@ -13,9 +13,10 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/SmallVector.h>
 #include <gtest/gtest.h>
-#include <stdarg.h>
+#include <cstdarg>
 #include <list>
 
+// NOLINTBEGIN(*arrays, bugprone-forwarding-reference-overload)
 using c10::SmallVector;
 using c10::SmallVectorImpl;
 
@@ -45,14 +46,14 @@ class Constructable {
     ++numConstructorCalls;
   }
 
-  Constructable(const Constructable& src) : constructed(true) {
-    value = src.value;
+  Constructable(const Constructable& src)
+      : constructed(true), value(src.value) {
     ++numConstructorCalls;
     ++numCopyConstructorCalls;
   }
 
-  Constructable(Constructable&& src) : constructed(true) {
-    value = src.value;
+  Constructable(Constructable&& src) noexcept
+      : constructed(true), value(src.value) {
     src.value = 0;
     ++numConstructorCalls;
     ++numMoveConstructorCalls;
@@ -72,7 +73,7 @@ class Constructable {
     return *this;
   }
 
-  Constructable& operator=(Constructable&& src) {
+  Constructable& operator=(Constructable&& src) noexcept {
     EXPECT_TRUE(constructed);
     value = src.value;
     src.value = 0;
@@ -142,13 +143,10 @@ int Constructable::numCopyAssignmentCalls;
 int Constructable::numMoveAssignmentCalls;
 
 struct NonCopyable {
-  NonCopyable() {}
-  NonCopyable(NonCopyable&&) {}
-  NonCopyable& operator=(NonCopyable&&) {
-    return *this;
-  }
+  NonCopyable() = default;
+  NonCopyable(NonCopyable&&) noexcept = default;
+  NonCopyable& operator=(NonCopyable&&) noexcept = default;
 
- private:
   NonCopyable(const NonCopyable&) = delete;
   NonCopyable& operator=(const NonCopyable&) = delete;
 };
@@ -840,7 +838,7 @@ TYPED_TEST(DualSmallVectorsTest, MoveAssignment) {
   SCOPED_TRACE("MoveAssignTest-DualVectorTypes");
 
   // Set up our vector with four elements.
-  for (unsigned I = 0; I < 4; ++I)
+  for (int I = 0; I < 4; ++I)
     this->otherVector.push_back(Constructable(I));
 
   const Constructable* OrigDataPtr = this->otherVector.data();
@@ -885,16 +883,16 @@ TEST(SmallVectorCustomTest, NoAssignTest) {
   SmallVector<notassignable, 2> vec;
   vec.push_back(notassignable(x));
   x = 42;
-  EXPECT_EQ(42, vec.pop_back_val().x);
+  EXPECT_EQ(x, vec.pop_back_val().x);
 }
 
 struct MovedFrom {
   bool hasValue;
   MovedFrom() : hasValue(true) {}
-  MovedFrom(MovedFrom&& m) : hasValue(m.hasValue) {
+  MovedFrom(MovedFrom&& m) noexcept : hasValue(m.hasValue) {
     m.hasValue = false;
   }
-  MovedFrom& operator=(MovedFrom&& m) {
+  MovedFrom& operator=(MovedFrom&& m) noexcept {
     hasValue = m.hasValue;
     m.hasValue = false;
     return *this;
@@ -920,14 +918,13 @@ template <int I>
 struct EmplaceableArg {
   EmplaceableArgState State;
   EmplaceableArg() : State(EAS_Defaulted) {}
-  EmplaceableArg(EmplaceableArg&& X)
+  EmplaceableArg(EmplaceableArg&& X) noexcept
       : State(X.State == EAS_Arg ? EAS_RValue : EAS_Failure) {}
   EmplaceableArg(EmplaceableArg& X)
       : State(X.State == EAS_Arg ? EAS_LValue : EAS_Failure) {}
 
   explicit EmplaceableArg(bool) : State(EAS_Arg) {}
 
- private:
   EmplaceableArg& operator=(EmplaceableArg&&) = delete;
   EmplaceableArg& operator=(const EmplaceableArg&) = delete;
 };
@@ -967,13 +964,12 @@ struct Emplaceable {
         A3(std::forward<A3Ty>(A3)),
         State(ES_Emplaced) {}
 
-  Emplaceable(Emplaceable&&) : State(ES_Moved) {}
-  Emplaceable& operator=(Emplaceable&&) {
+  Emplaceable(Emplaceable&&) noexcept : State(ES_Moved) {}
+  Emplaceable& operator=(Emplaceable&&) noexcept {
     State = ES_Moved;
     return *this;
   }
 
- private:
   Emplaceable(const Emplaceable&) = delete;
   Emplaceable& operator=(const Emplaceable&) = delete;
 };
@@ -1445,3 +1441,4 @@ TYPED_TEST(SmallVectorInternalReferenceInvalidationTest, EmplaceBack) {
 }
 
 } // end namespace
+// NOLINTEND(*arrays, bugprone-forwarding-reference-overload)

--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gmock/gmock.h>
 
+// NOLINTBEGIN(modernize*, readability*, bugprone-string-constructor)
 using c10::string_view;
 
 namespace {
@@ -50,9 +51,9 @@ static_assert(
 } // namespace test_typedefs
 
 namespace test_default_constructor {
-static_assert(string_view().size() == 0, "");
+static_assert(string_view().empty());
 static_assert(string_view().data() == nullptr, "");
-static_assert(string_view() == string_view(""), "");
+static_assert(string_view() == string_view(""));
 } // namespace test_default_constructor
 
 namespace test_constchar_constructor {
@@ -1665,3 +1666,4 @@ TEST(StringViewTest, testHash) {
 } // namespace test_hash
 
 } // namespace
+// NOLINTEND(modernize*, readability*, bugprone-string-constructor)

--- a/c10/test/util/tempfile_test.cpp
+++ b/c10/test/util/tempfile_test.cpp
@@ -5,20 +5,20 @@
 
 #if !defined(_WIN32)
 static bool file_exists(const char* path) {
-  struct stat st;
+  struct stat st {};
   return stat(path, &st) == 0 && S_ISREG(st.st_mode);
 }
 static bool directory_exists(const char* path) {
-  struct stat st;
+  struct stat st {};
   return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
 }
 #else
 static bool file_exists(const char* path) {
-  struct _stat st;
+  struct _stat st {};
   return _stat(path, &st) == 0 && ((st.st_mode & _S_IFMT) == _S_IFREG);
 }
 static bool directory_exists(const char* path) {
-  struct _stat st;
+  struct _stat st {};
   return _stat(path, &st) == 0 && ((st.st_mode & _S_IFMT) == _S_IFDIR);
 }
 #endif // !defined(_WIN32)


### PR DESCRIPTION
This series of PR enables clang-tidy checks in c10/test. We aim to finally add the path to lintrunner.toml 