### PR TITLE
Fix the example in the extending.func.rst

### DIFF
--- a/docs/source/notes/extending.func.rst
+++ b/docs/source/notes/extending.func.rst
@@ -386,6 +386,7 @@ Example::
 
         @staticmethod
         def backward(ctx, grad_output, _0, _1):
+            ind, ind_inv = ctx.saved_tensors
             return NumpyTake.apply(grad_output, ind_inv, ind, ctx.dim), None
 
         # The signature of the vmap staticmethod is:


### PR DESCRIPTION
As the title shown ,the `backward` function is missing the definition of `ind` and `ind_inv`, which will lead to error when calling backward