### PR TITLE
Enable pickling model prepared with QAT qconfig

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1,5 +1,5 @@
 # Owner(s): ["oncall: quantization"]
-
+import pickle
 from collections import OrderedDict
 import contextlib
 import torch
@@ -9714,6 +9714,18 @@ class TestQuantizeFxModels(QuantizationTestCase):
             out_ref = converted_ref(inp)
 
             torch.testing.assert_close(out, out_ref)
+
+    @override_qengines
+    def test_qat_pickle(self):
+        model = torch.nn.Sequential(nn.Conv2d(3, 32, 5), nn.BatchNorm2d(32), nn.ReLU())
+        example_inputs = torch.randn(1, 3, 128, 128)
+
+        qengine = torch.backends.quantized.engine
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
+        model = prepare_qat_fx(model, qconfig_dict, example_inputs)
+        pickle.dumps(model)
+
+
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
                        "\tpython test/test_quantization.py TESTNAME\n\n"


### PR DESCRIPTION
Summary:
Resolving error:

AttributeError: Can't pickle local object '_add_module_to_qconfig_obs_ctr.<locals>.get_factory_kwargs_based_on_module_device'

by moving nested function out to the main module

Test Plan: Added test to CI

Reviewed By: andrewor14

Differential Revision: D49187352


