### PR TITLE
Add test/onnx_caffe2 to ONNX Exporter merge rule

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -10,6 +10,7 @@
   - docs/source/_static/img/onnx/**
   - scripts/onnx/**
   - test/onnx/**
+  - test/onnx_caffe2/**
   - tools/onnx/**
   - torch/_dynamo/backends/onnxrt.py
   - torch/_C/__init__.pyi.in


### PR DESCRIPTION
As we deprecate the TorchScript ONNX exporter we need to refactor the onnx caffe2 tests to start using private functions instead of public ones

That requires changes to the merge rules to allow ONNX exporter to drive deprecation