### PR TITLE
Document Triton dependency for the release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -368,4 +368,4 @@ However for release we have following :
 * Wheel builds, depend only triton pypi package: https://pypi.org/project/triton/ for both test and release
 * Rocm wheel builds, depend on : https://download.pytorch.org/whl/test/pytorch-triton-rocm/ for test and https://download.pytorch.org/whl/pytorch-triton-rocm/ for release
 
-Important: The release of https://pypi.org/project/triton/ needs to be requested from OpenAI one branch cut is completed. Please include the PIN hash in the request: https://github.com/pytorch/pytorch/blob/main/.ci/docker/ci_commit_pins/triton.txt
+Important: The release of https://pypi.org/project/triton/ needs to be requested from OpenAI once branch cut is completed. Please include the release PIN hash in the request: https://github.com/pytorch/pytorch/blob/release/2.1/.ci/docker/ci_commit_pins/triton.txt .

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@
 - [Submitting Tutorials](#submitting-tutorials)
 - [Special Topics](#special-topics)
   - [Updating submodules for a release](#updating-submodules-for-a-release)
+  - [Triton dependency for the release](#triton-dependency-for-the-release)
 
 <!-- tocstop -->
 
@@ -352,3 +353,19 @@ git config --file=.gitmodules -e
 An example of this process can be found here:
 
 * https://github.com/pytorch/pytorch/pull/48312
+
+## Triton dependency for the release
+
+In nightly builds for conda and wheels pytorch depend on Triton build by this workflow: https://hud.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=Build%20Triton%20Wheel. The pinned version of triton used by this workflow is specified here:  https://github.com/pytorch/pytorch/blob/main/.ci/docker/ci_commit_pins/triton.txt .
+
+In Nightly builds we have following configuration:
+* Conda builds, depend on: https://anaconda.org/pytorch-nightly/torchtriton
+* Wheel builds, depend on : https://download.pytorch.org/whl/nightly/pytorch-triton/
+* Rocm wheel builds, depend on : https://download.pytorch.org/whl/nightly/pytorch-triton-rocm/
+
+However for release we have following :
+* Conda builds, depend on: https://anaconda.org/pytorch-test/torchtriton for test and https://anaconda.org/pytorch/torchtriton for release
+* Wheel builds, depend only triton pypi package: https://pypi.org/project/triton/ for both test and release
+* Rocm wheel builds, depend on : https://download.pytorch.org/whl/test/pytorch-triton-rocm/ for test and https://download.pytorch.org/whl/pytorch-triton-rocm/ for release
+
+Important: The release of https://pypi.org/project/triton/ needs to be requested from OpenAI one branch cut is completed. Please include the PIN hash in the request: https://github.com/pytorch/pytorch/blob/main/.ci/docker/ci_commit_pins/triton.txt


### PR DESCRIPTION
Document triton dependency for the Pytorch Release

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9773f0</samp>

Add documentation for Triton dependency in `RELEASE.md`. The documentation covers how to install and use Triton for various PyTorch builds and platforms.
