### PR TITLE
Added a flag is_cpu to the AOTInductor runtime

### DIFF
--- a/torch/_inductor/codegen/aot_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aot_runtime/interface.cpp
@@ -22,14 +22,15 @@ extern "C" {
 
 AOTInductorError AOTInductorModelContainerCreate(
     AOTInductorModelContainerHandle* container_handle,
-    size_t num_models) {
+    size_t num_models,
+    bool is_cpu) {
   if (num_models == 0) {
     LOG(ERROR) << "num_models must be positive, but got 0";
     return AOTInductorError::Failure;
   }
   CONVERT_EXCEPTION_TO_ERROR_CODE({
     auto* container =
-        new torch::aot_inductor::AOTInductorModelContainer(num_models);
+        new torch::aot_inductor::AOTInductorModelContainer(num_models, is_cpu);
     *container_handle =
         reinterpret_cast<AOTInductorModelContainerHandle>(container);
   })

--- a/torch/csrc/inductor/aot_runtime/interface.h
+++ b/torch/csrc/inductor/aot_runtime/interface.h
@@ -53,7 +53,8 @@ extern "C" {
 // the same input model.
 AOTInductorError AOTInductorModelContainerCreate(
     AOTInductorModelContainerHandle* container_handle,
-    size_t num_models);
+    size_t num_models,
+    bool is_cpu = false);
 
 // Deletes the AOTInductor model container.
 AOTInductorError AOTInductorModelContainerDelete(


### PR DESCRIPTION
Summary:
added a flag is_cpu that can be specified by the user to
indicate whether the AOTInductor runtime is for CPU. It's
false by default.

Test Plan: ci

Reviewed By: hl475, aakhundov

Differential Revision: D49253826




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @aakhundov