### PR TITLE
[dtensor] Fix and improve the sharding cache behavior

### DIFF
--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -231,6 +231,8 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             stride=spec.tensor_meta.stride,
         )
 
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
     @classmethod
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -168,13 +168,13 @@ def _operator_dispatch(
             flat_local_kwargs.append(kwarg)
 
     assert mesh is not None, "found no DeviceMesh from dtensor args!"
-
     op_info = OpInfo(
         mesh,
         OpSchema(
             op_call,
             tree_unflatten(flat_args_schema, args_spec),
             tree_unflatten(flat_kwargs_schema, kwargs_spec),
+            schema_info=sharding_propagator.op_to_schema_info.get(op_call, None),
         ),
         flat_args_schema,
         flat_kwargs_schema,

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -138,10 +138,12 @@ class RuntimeSchemaInfo:
     whether to re-run sharding prop or not 2. to determine if we need pytree
     """
 
-    # This static_argnum records static arg starting index for ops that have non-tensor
-    # args/kwargs which would affect sharding propagation results.
-    # only a few ops need this information, e.g. view, transpose, var.dim, etc.
+    # This static_argnum records static arg "starting index" for ops that have non-tensor
+    # args/kwargs which would affect sharding propagation results. All args after this
+    # index would be hashed to our sharding cache.
+    # Note that only a few ops need this information, e.g. view, transpose, var.dim, etc.
     static_argnum: int = -1
+    # This static_kwargkey records static kwarg names which would affect sharding prop
     static_kwargkey: Optional[List[str]] = None
     # TODO: make use of this field
     needs_pytree: bool = True

--- a/torch/distributed/_tensor/ops/pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/pointwise_ops.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 import torch
+from torch.distributed._tensor.op_schema import RuntimeSchemaInfo
 
 from torch.distributed._tensor.ops.common_rules import (
     linear_pointwise_rule,
@@ -371,4 +372,6 @@ for op in linear_pointwise_ops:
 
 
 for op in pointwise_ops:
-    register_prop_rule(op)(pointwise_rule)
+    register_prop_rule(op, schema_info=RuntimeSchemaInfo(static_kwargkey=["out"]))(
+        pointwise_rule
+    )

--- a/torch/distributed/_tensor/ops/utils.py
+++ b/torch/distributed/_tensor/ops/utils.py
@@ -11,27 +11,27 @@ from torch.distributed._tensor.placement_types import DTensorSpec, Shard
 # convenient wrapper to register sharding propagation rules
 # pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def register_prop_rule(op):
+def register_prop_rule(op, schema_info=None):
     # pyre-fixme[53]: Captured variable `func` is not annotated.
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def wrapper(impl):
         overloads = op if isinstance(op, list) else [op]
         for overload in overloads:
-            DTensor._propagator.register_sharding_prop_rule(overload, impl)
+            DTensor._propagator.register_sharding_prop_rule(overload, impl, schema_info)
         return impl
 
     return wrapper
 
 
-def register_op_strategy(op):
+def register_op_strategy(op, schema_info=None):
     # pyre-fixme[53]: Captured variable `func` is not annotated.
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def wrapper(impl):
         overloads = op if isinstance(op, list) else [op]
         for overload in overloads:
-            DTensor._propagator.register_op_strategy(overload, impl)
+            DTensor._propagator.register_op_strategy(overload, impl, schema_info)
         return impl
 
     return wrapper


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109306

resolves https://github.com/pytorch/pytorch/issues/109101

The problem is essentially because we were hashing all the arguments, including
the scalar too (i.e. aten.div(tensor, scalar)), in the optimizer, the scalar might
change everytime we call the op, thus cache miss everytime we call the op

This PR improves the sharding cache behavior by introducing a
RuntimeSchemaInfo, used to record some runtime necessary hashing
information during op registration time. This enable us to:
* only hash arguments that are tensor or have static_argnum, this is to
enable many cases like aten.div.Tensor(tensor, 0.23231) hit the cache.
as we currently hashing all args which exclude those cases
* with the correct cache behavior, optimizers will hit the cache again
and resolve the high cpu overhead issue.

simple MLP shows all cache hit and for a single addmm -> 0.319ms (from 0.341ms), shows some hashing improvements:
<img width="1172" alt="Screenshot 2023-09-14 at 11 06 07 AM" src="https://github.com/pytorch/pytorch/assets/9443650/3406d673-dd8d-4ad9-9b80-9d4721c430e3">


Adam optimizer shows aten.div hit sharding cache again
<img width="1016" alt="Screenshot 2023-09-14 at 11 02 10 AM" src="https://github.com/pytorch/pytorch/assets/9443650/4280e8e3-af44-4fc2-8360-ea80b768f1d9">

