### PR TITLE
[inductor] update fbcode skips for AOTInductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -104,6 +104,7 @@ class AOTInductorModelRunner:
         return list_output_tensors
 
 
+@unittest.skipIf(IS_FBCODE, "cpp extension doesn't work in fbcode CI")
 class AotInductorTests(TestCase):
     def test_simple(self):
         class Repro(torch.nn.Module):
@@ -470,5 +471,5 @@ if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
     # cpp_extension N/A in fbcode
-    if HAS_CUDA and not TEST_WITH_ROCM and not IS_FBCODE:
+    if HAS_CUDA and not TEST_WITH_ROCM:
         run_tests(needs="filelock")


### PR DESCRIPTION
Summary: seems like the `if __name__ == "__main__":` part doesn't run in fbcode; instead, just add skips

Differential Revision: D49258492




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov