### PR TITLE
Draft for adding backend concept to torch.export

### DIFF
--- a/docs/source/onnx_dynamo.rst
+++ b/docs/source/onnx_dynamo.rst
@@ -27,8 +27,8 @@ The exporter is designed to be modular and extensible. It is composed of the fol
   - **ONNX Registry**: :class:`OnnxRegistry` is the registry of ONNX operators and functions.
   - **FX Graph Extractor**: :class:`FXGraphExtractor` extracts the FX graph from the PyTorch model.
   - **Fake Mode**: :class:`ONNXFakeContext` is a context manager that enables fake mode for large scale models.
-  - **ONNX Export Output**: :class:`ExportOutput` is the output of the exporter that contains the exported ONNX graph and diagnostics.
-  - **ONNX Export Output Serializer**: :class:`ExportOutputSerializer` serializes the exported model to a file.
+  - **ONNX Exported Program**: :class:`ONNXExportedProgram` is the output of the exporter that contains the exported ONNX graph and diagnostics.
+  - **ONNX Exported Program Serializer**: :class:`ONNXExportedProgramSerializer` serializes the exported model to a file.
   - **ONNX Diagnostic Options**: :class:`DiagnosticOptions` has a set of options that control the diagnostics emitted by the exporter.
 
 Dependencies
@@ -74,17 +74,17 @@ See below a demonstration of exporter API in action with a simple Multilayer Per
 
   model = MLPModel()
   tensor_x = torch.rand((97, 8), dtype=torch.float32)
-  export_output = torch.onnx.dynamo_export(model, tensor_x)
+  exported_program = torch.onnx.dynamo_export(model, tensor_x)
 
 As the code above shows, all you need is to provide :func:`torch.onnx.dynamo_export` with an instance of the model and its input.
-The exporter will then return an instance of :class:`torch.onnx.ExportOutput` that contains the exported ONNX graph along with extra information.
+The exporter will then return an instance of :class:`torch.onnx.ONNXExportedProgram` that contains the exported ONNX graph along with extra information.
 
-The in-memory model available through ``export_output.model_proto`` is an ``onnx.ModelProto`` object in compliance with the `ONNX IR spec <https://github.com/onnx/onnx/blob/main/docs/IR.md>`_.
-The ONNX model may then be serialized into a `Protobuf file <https://protobuf.dev/>`_ using the :meth:`torch.onnx.ExportOutput.save` API.
+The in-memory model available through ``exported_program.model_proto`` is an ``onnx.ModelProto`` object in compliance with the `ONNX IR spec <https://github.com/onnx/onnx/blob/main/docs/IR.md>`_.
+The ONNX model may then be serialized into a `Protobuf file <https://protobuf.dev/>`_ using the :meth:`torch.onnx.ONNXExportedProgram.save` API.
 
 .. code-block:: python
 
-  export_output.save("mlp.onnx")
+  exported_program.save("mlp.onnx")
 
 Inspecting the ONNX model using GUI
 -----------------------------------
@@ -140,10 +140,10 @@ API Reference
 
 .. autofunction:: torch.onnx.enable_fake_mode
 
-.. autoclass:: torch.onnx.ExportOutput
+.. autoclass:: torch.onnx.ONNXExportedProgram
     :members:
 
-.. autoclass:: torch.onnx.ExportOutputSerializer
+.. autoclass:: torch.onnx.ONNXExportedProgramSerializer
     :members:
 
 .. autoclass:: torch.onnx.OnnxExporterError

--- a/docs/source/scripts/exportdb/generate_example_rst.py
+++ b/docs/source/scripts/exportdb/generate_example_rst.py
@@ -73,7 +73,7 @@ Result:
             model,
             inputs.args,
             inputs.kwargs,
-            constraints=example_case.constraints,
+            options={"constraints": example_case.constraints},
         )
         graph_output = str(exported_program)
         graph_output = re.sub(r"        # File(.|\n)*?\n", "", graph_output)

--- a/test/export/test_db.py
+++ b/test/export/test_db.py
@@ -33,7 +33,7 @@ class ExampleTests(TestCase):
             model,
             inputs.args,
             inputs.kwargs,
-            constraints=case.constraints,
+            options={"constraints": case.constraints},
         )
         exported_program.graph_module.print_readable()
 
@@ -63,7 +63,7 @@ class ExampleTests(TestCase):
                 model,
                 inputs.args,
                 inputs.kwargs,
-                constraints=case.constraints,
+                options={"constraints": case.constraints},
             )
 
     @parametrize(
@@ -86,7 +86,7 @@ class ExampleTests(TestCase):
             rewrite_case.model,
             inputs.args,
             inputs.kwargs,
-            constraints=rewrite_case.constraints,
+            options={"constraints": rewrite_case.constraints},
         )
 
 

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -74,7 +74,7 @@ class TestPasses(TestCase):
 
         x = torch.zeros(2, 2, 3)
 
-        ep = export(M(), (x,), constraints=[dynamic_dim(x, 1) >= 2, dynamic_dim(x, 1) <= 6])
+        ep = export(M(), (x,), options={"constraints": [dynamic_dim(x, 1) >= 2, dynamic_dim(x, 1) <= 6]})
 
         with self.assertRaisesRegex(RuntimeError, "Input arg0_1"):
             ep(torch.zeros(2, 7, 3))
@@ -99,7 +99,7 @@ class TestPasses(TestCase):
             dynamic_dim(x, 0) >= 3
         ]
 
-        ep = export(M(), (x, y), constraints=constraints)
+        ep = export(M(), (x, y), options={"constraints": constraints})
 
         with self.assertRaisesRegex(RuntimeError, "Input arg0_1"):
             ep(torch.zeros(4, 7, 3), torch.ones(5, 5, 5))
@@ -124,7 +124,7 @@ class TestPasses(TestCase):
             dynamic_dim(x, 0) >= 3
         ]
 
-        ep = export(M(), (x, y), constraints=constraints)
+        ep = export(M(), (x, y), options={"constraints": constraints})
 
         with self.assertRaisesRegex(RuntimeError, "Input arg0_1"):
             ep(torch.zeros(4, 7, 3), torch.ones(5, 5, 5))
@@ -155,7 +155,7 @@ class TestPasses(TestCase):
             dynamic_dim(y, 1) <= 6,
         ]
 
-        ep = export(M(), (x, y), constraints=constraints)
+        ep = export(M(), (x, y), options={"constraints": constraints})
 
         with self.assertRaisesRegex(RuntimeError, "Input arg0_1"):
             ep(torch.zeros(4, 7, 3), torch.ones(5, 5, 5))
@@ -253,7 +253,7 @@ class TestPasses(TestCase):
         x = torch.tensor([2, 1, 2, 3, 5, 0])
 
         mod = M()
-        ep = export(mod, (x,), constraints=[dynamic_dim(x, 0) >= 2])
+        ep = export(mod, (x,), options={"constraints": [dynamic_dim(x, 0) >= 2]})
 
         num_assert = count_call_function(ep.graph, torch.ops.aten._assert_async.msg)
         num_scalar_tensor = count_call_function(ep.graph, torch.ops.aten.scalar_tensor.default)
@@ -311,7 +311,7 @@ class TestPasses(TestCase):
         x = torch.rand(3, 4)
         y = torch.rand(3, 4)
         exported = torch._export.export(
-            m, (x, y), constraints=[dynamic_dim(x, 1) == dynamic_dim(y, 1)]
+            m, (x, y), options={"constraints": [dynamic_dim(x, 1) == dynamic_dim(y, 1)]}
         )
 
         x = torch.rand(3, 5)
@@ -341,9 +341,9 @@ class TestPasses(TestCase):
             exactly=True,
         ).run(gm.code)
 
-        # TODO(ycao): ExportedProgram._transform() forbids changes to number
+        # TODO(ycao): DynamoExportedProgram._transform() forbids changes to number
         # of inputs/outputs for now. When it supports that better, change this
-        # back to using ExportedProgram._transform()
+        # back to using DynamoExportedProgram._transform()
         gm = _FunctionalizeSideEffectfulOpsPass()(ep.graph_module).graph_module
 
         with self.assertRaisesRegex(

--- a/test/export/test_upgrade.py
+++ b/test/export/test_upgrade.py
@@ -117,7 +117,7 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
             return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
 
         inputs = (torch.ones([2, 3]) * 4, 2.)
-        ep = export(fn, inputs, {}, [])
+        ep = export(fn, inputs, {}, options={"constraints": []})
         compiler_opset_version = {"aten": 4}
         model_opset_version = {"aten": 3}
         upgrader = GraphModuleOpUpgrader(compiler_opset_version, model_opset_version, TEST_UPGRADERS)

--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -5,12 +5,12 @@ import os
 import onnx
 import torch
 from beartype import roar
-from torch.onnx import dynamo_export, ExportOptions, ExportOutput
+from torch.onnx import dynamo_export, ExportOptions, ONNXExportedProgram
 from torch.onnx._internal import exporter, io_adapter
 from torch.onnx._internal.exporter import (
-    ExportOutputSerializer,
-    LargeProtobufExportOutputSerializer,
-    ProtobufExportOutputSerializer,
+    LargeProtobufONNXExportedProgramSerializer,
+    ONNXExportedProgramSerializer,
+    ProtobufONNXExportedProgramSerializer,
     ResolvedExportOptions,
 )
 from torch.onnx._internal.fx import diagnostics
@@ -61,7 +61,7 @@ class TestExportOptionsAPI(common_utils.TestCase):
 class TestDynamoExportAPI(common_utils.TestCase):
     def test_default_export(self):
         output = dynamo_export(SampleModel(), torch.randn(1, 1, 2))
-        self.assertIsInstance(output, ExportOutput)
+        self.assertIsInstance(output, ONNXExportedProgram)
         self.assertIsInstance(output.model_proto, onnx.ModelProto)
 
     def test_export_with_options(self):
@@ -73,7 +73,7 @@ class TestDynamoExportAPI(common_utils.TestCase):
                     dynamic_shapes=True,
                 ),
             ),
-            ExportOutput,
+            ONNXExportedProgram,
         )
 
     def test_save_to_file_default_serializer(self):
@@ -89,9 +89,11 @@ class TestDynamoExportAPI(common_utils.TestCase):
     def test_save_to_file_using_specified_serializer(self):
         expected_buffer = "I am not actually ONNX"
 
-        class CustomSerializer(ExportOutputSerializer):
+        class CustomSerializer(ONNXExportedProgramSerializer):
             def serialize(
-                self, export_output: ExportOutput, destination: io.BufferedIOBase
+                self,
+                exported_program: ONNXExportedProgram,
+                destination: io.BufferedIOBase,
             ) -> None:
                 destination.write(expected_buffer.encode())
 
@@ -105,12 +107,14 @@ class TestDynamoExportAPI(common_utils.TestCase):
     def test_save_to_file_using_specified_serializer_without_inheritance(self):
         expected_buffer = "I am not actually ONNX"
 
-        # NOTE: Inheritance from `ExportOutputSerializer` is not required.
-        # Because `ExportOutputSerializer` is a Protocol class.
+        # NOTE: Inheritance from `ONNXExportedProgramSerializer` is not required.
+        # Because `ONNXExportedProgramSerializer` is a Protocol class.
         # `beartype` will not complain.
         class CustomSerializer:
             def serialize(
-                self, export_output: ExportOutput, destination: io.BufferedIOBase
+                self,
+                exported_program: ONNXExportedProgram,
+                destination: io.BufferedIOBase,
             ) -> None:
                 destination.write(expected_buffer.encode())
 
@@ -146,7 +150,7 @@ class TestDynamoExportAPI(common_utils.TestCase):
             dynamo_export(ModelWithExportError(), torch.randn(1, 1, 2))
         self.assertTrue(os.path.exists(exporter._DEFAULT_FAILED_EXPORT_SARIF_LOG_PATH))
 
-    def test_export_output_accessible_from_exception_when_export_failed(self):
+    def test_exported_program_accessible_from_exception_when_export_failed(self):
         class ModelWithExportError(torch.nn.Module):
             def forward(self, x):
                 raise RuntimeError("Export error")
@@ -154,9 +158,9 @@ class TestDynamoExportAPI(common_utils.TestCase):
         with self.assertRaises(torch.onnx.OnnxExporterError) as cm:
             dynamo_export(ModelWithExportError(), torch.randn(1, 1, 2))
         self.assertIsInstance(cm.exception, torch.onnx.OnnxExporterError)
-        self.assertIsInstance(cm.exception.export_output, ExportOutput)
+        self.assertIsInstance(cm.exception.exported_program, ONNXExportedProgram)
 
-    def test_access_export_output_model_proto_raises_when_export_output_is_emitted_from_failed_export(
+    def test_access_exported_program_model_proto_raises_when_exported_program_is_emitted_from_failed_export(
         self,
     ):
         class ModelWithExportError(torch.nn.Module):
@@ -165,9 +169,9 @@ class TestDynamoExportAPI(common_utils.TestCase):
 
         with self.assertRaises(torch.onnx.OnnxExporterError) as cm:
             dynamo_export(ModelWithExportError(), torch.randn(1, 1, 2))
-        export_output = cm.exception.export_output
+        exported_program = cm.exception.exported_program
         with self.assertRaises(RuntimeError):
-            export_output.model_proto
+            exported_program.model_proto
 
     def test_raise_from_diagnostic_warning_when_diagnostic_option_warning_as_error_is_true(
         self,
@@ -185,8 +189,8 @@ class TestDynamoExportAPI(common_utils.TestCase):
 
     def test_raise_on_invalid_save_argument_type(self):
         with self.assertRaises(roar.BeartypeException):
-            ExportOutput(torch.nn.Linear(2, 3))  # type: ignore[arg-type]
-        export_output = ExportOutput(
+            ONNXExportedProgram(torch.nn.Linear(2, 3))  # type: ignore[arg-type]
+        exported_program = ONNXExportedProgram(
             onnx.ModelProto(),
             io_adapter.InputAdapter(),
             io_adapter.OutputAdapter(),
@@ -194,30 +198,30 @@ class TestDynamoExportAPI(common_utils.TestCase):
             fake_context=None,
         )
         with self.assertRaises(roar.BeartypeException):
-            export_output.save(None)  # type: ignore[arg-type]
-        export_output.model_proto
+            exported_program.save(None)  # type: ignore[arg-type]
+        exported_program.model_proto
 
 
-class TestProtobufExportOutputSerializerAPI(common_utils.TestCase):
+class TestProtobufONNXExportedProgramSerializerAPI(common_utils.TestCase):
     def test_raise_on_invalid_argument_type(self):
         with self.assertRaises(roar.BeartypeException):
-            serializer = ProtobufExportOutputSerializer()
+            serializer = ProtobufONNXExportedProgramSerializer()
             serializer.serialize(None, None)  # type: ignore[arg-type]
 
     def test_serialize_raises_when_model_greater_than_2gb(self):
-        export_output = torch.onnx.dynamo_export(_LargeModel(), torch.randn(1))
-        serializer = ProtobufExportOutputSerializer()
+        exported_program = torch.onnx.dynamo_export(_LargeModel(), torch.randn(1))
+        serializer = ProtobufONNXExportedProgramSerializer()
         with self.assertRaisesRegex(ValueError, "exceeds maximum protobuf size of 2GB"):
-            serializer.serialize(export_output, io.BytesIO())
+            serializer.serialize(exported_program, io.BytesIO())
 
 
-class TestLargeProtobufExportOutputSerializerAPI(common_utils.TestCase):
+class TestLargeProtobufONNXExportedProgramSerializerAPI(common_utils.TestCase):
     def test_serialize_succeeds_when_model_greater_than_2gb(self):
-        export_output = torch.onnx.dynamo_export(_LargeModel(), torch.randn(1))
+        exported_program = torch.onnx.dynamo_export(_LargeModel(), torch.randn(1))
         with common_utils.TemporaryFileName() as path:
-            serializer = LargeProtobufExportOutputSerializer(path)
+            serializer = LargeProtobufONNXExportedProgramSerializer(path)
             # `io.BytesIO()` is unused, but required by the Protocol interface.
-            serializer.serialize(export_output, io.BytesIO())
+            serializer.serialize(exported_program, io.BytesIO())
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_fx_passes.py
+++ b/test/onnx/test_fx_passes.py
@@ -123,10 +123,10 @@ class TestModularizePass(common_utils.TestCase):
                 unused_relu_result = self.unused_relu(x)
                 return result
 
-        export_output = torch.onnx.dynamo_export(
+        exported_program = torch.onnx.dynamo_export(
             TestModule(), torch.randn(3), torch.randn(3)
         )
-        model_proto = export_output.model_proto
+        model_proto = exported_program.model_proto
         function_proto_names = [function.name for function in model_proto.functions]
         self.assertIn(
             "torch_nn_modules_activation_GELU_used_gelu_1", function_proto_names
@@ -146,10 +146,10 @@ class TestModularizePass(common_utils.TestCase):
                 out = self.relu(out)
                 return out
 
-        export_output = torch.onnx.dynamo_export(
+        exported_program = torch.onnx.dynamo_export(
             TestModule(), torch.randn(3), torch.randn(3)
         )
-        model_proto = export_output.model_proto
+        model_proto = exported_program.model_proto
         function_proto_names = [function.name for function in model_proto.functions]
         self.assertIn("torch_nn_modules_activation_ReLU_relu_1", function_proto_names)
         self.assertIn("torch_nn_modules_activation_ReLU_relu_2", function_proto_names)
@@ -178,10 +178,10 @@ class TestModularizePass(common_utils.TestCase):
                 out = self.inner_module.relu(out)
                 return out
 
-        export_output = torch.onnx.dynamo_export(
+        exported_program = torch.onnx.dynamo_export(
             TestModule(), torch.randn(3), torch.randn(3)
         )
-        model_proto = export_output.model_proto
+        model_proto = exported_program.model_proto
         function_proto_names = [function.name for function in model_proto.functions]
         self.assertIn(
             "torch_nn_modules_activation_ReLU_inner_module_relu_1", function_proto_names

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -120,12 +120,12 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return output
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
-        export_output = dynamo_export(
+        exported_program = dynamo_export(
             MNISTModel(), tensor_x, export_options=ExportOptions(op_level_debug=True)
         )
 
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostic_rule,
             diagnostics.levels.NONE,
             expected_node="aten.convolution.default",
@@ -156,7 +156,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return torch.sum(values)
 
         x = torch.arange(1.0, 6.0, requires_grad=True)
-        export_output = dynamo_export(
+        exported_program = dynamo_export(
             TopKModel(), x, export_options=self.export_options
         )
 
@@ -169,14 +169,14 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         x = torch.randint(4, (4, 3, 2))
         embedding_matrix = torch.rand(10, 3)
 
-        export_output = dynamo_export(
+        exported_program = dynamo_export(
             model,
             x,
             embedding_matrix,
             export_options=ExportOptions(op_level_debug=True),
         )
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostics.rules.op_level_debugging,
             diagnostics.levels.WARNING,
             expected_node="aten.embedding.default",
@@ -190,10 +190,10 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return input.new_zeros(())
 
         x = torch.randn((2, 3), dtype=torch.float32)
-        export_output = dynamo_export(TraceModel(), x)
+        exported_program = dynamo_export(TraceModel(), x)
 
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostics.rules.find_opschema_matched_symbolic_function,
             diagnostics.levels.WARNING,
             expected_node="aten.new_zeros.default",
@@ -213,11 +213,11 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return self.conv2(input)
 
         x = torch.randn(20, 16, 50, 50)
-        export_output = dynamo_export(
+        exported_program = dynamo_export(
             TraceModel(), x, export_options=ExportOptions(op_level_debug=False)
         )
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostics.rules.find_opschema_matched_symbolic_function,
             diagnostics.levels.NONE,
             expected_node="aten.convolution.default",
@@ -242,11 +242,11 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         onnx_registry._registry.pop(aten_add_Tensor)
 
         x = torch.tensor(3)
-        export_output = dynamo_export(
+        exported_program = dynamo_export(
             TraceModel(), x, export_options=ExportOptions(onnx_registry=onnx_registry)
         )
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostics.rules.find_operator_overloads_in_onnx_registry,
             diagnostics.levels.WARNING,
             expected_node="aten.add.Tensor",
@@ -258,9 +258,9 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return torch.ops.aten.clone(input, memory_format=torch.preserve_format)
 
         x = torch.tensor(3)
-        export_output = dynamo_export(CustomModule(), x)
+        exported_program = dynamo_export(CustomModule(), x)
         assert_has_diagnostics(
-            export_output.diagnostic_context,
+            exported_program.diagnostic_context,
             diagnostics.rules.find_opschema_matched_symbolic_function,
             diagnostics.levels.NONE,
             expected_node="aten.clone.default",
@@ -302,8 +302,8 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
 
         model = MNISTModel()
-        export_output = torch.onnx.dynamo_export(model, tensor_x)
-        model_proto = export_output.model_proto
+        exported_program = torch.onnx.dynamo_export(model, tensor_x)
+        model_proto = exported_program.model_proto
         self.assertEqual(
             {initializer.name for initializer in model_proto.graph.initializer},
             {*model.state_dict().keys()},
@@ -323,25 +323,25 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             x = torch.rand(5, 2, 2)
             model = Model()
             export_options = ExportOptions(fake_context=fake_context)
-            export_output = torch.onnx.dynamo_export(
+            exported_program = torch.onnx.dynamo_export(
                 model, x, export_options=export_options
             )
 
         assert (
-            export_output is not None
-        ), "ExportOutput must be created on successful export"
+            exported_program is not None
+        ), "ONNXExportedProgram must be created on successful export"
         assert (
-            export_output.model_proto is not None
+            exported_program.model_proto is not None
         ), "A model protobuf must be created on a successful export"
-        onnx.checker.check_model(export_output.model_proto, full_check=True)
+        onnx.checker.check_model(exported_program.model_proto, full_check=True)
         assert (
-            len(export_output.model_proto.graph.initializer) == 0
+            len(exported_program.model_proto.graph.initializer) == 0
         ), "Initializers cannot exist when fake mode is enabled"
 
         # Variant 1: Save ONNX proto using Model's state_dict()
         with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
             model_state_dict = Model().state_dict()  # Create a state_dict for testing
-            export_output.save(tmp_onnx_file.name, model_state_dict=model_state_dict)
+            exported_program.save(tmp_onnx_file.name, model_state_dict=model_state_dict)
             assert (
                 len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
             ), "Initializers must be present after loading it from model_state_dict"
@@ -355,7 +355,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             torch.save(
                 Model().state_dict(), tmp_checkpoint_file.name
             )  # Create checkpoint file for testing
-            export_output.save(
+            exported_program.save(
                 tmp_onnx_file.name, model_state_dict=tmp_checkpoint_file.name
             )
             assert (
@@ -424,15 +424,15 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             position_ids = position_ids.unsqueeze(0).view(-1, seq)
 
             export_options = torch.onnx.ExportOptions(fake_context=fake_context)
-            export_output = torch.onnx.dynamo_export(
+            exported_program = torch.onnx.dynamo_export(
                 model,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
                 export_options=export_options,
             )
-            onnx.checker.check_model(export_output.model_proto)
-            onnx.shape_inference.infer_shapes(export_output.model_proto)
+            onnx.checker.check_model(exported_program.model_proto)
+            onnx.shape_inference.infer_shapes(exported_program.model_proto)
 
     def test_fake_tensor_mode_huggingface_open_llama(self):
         config = transformers.OpenLlamaConfig(
@@ -448,15 +448,15 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             position_ids = position_ids.unsqueeze(0).view(-1, seq)
 
             export_options = torch.onnx.ExportOptions(fake_context=fake_context)
-            export_output = torch.onnx.dynamo_export(
+            exported_program = torch.onnx.dynamo_export(
                 model,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
                 export_options=export_options,
             )
-            onnx.checker.check_model(export_output.model_proto)
-            onnx.shape_inference.infer_shapes(export_output.model_proto)
+            onnx.checker.check_model(exported_program.model_proto)
+            onnx.shape_inference.infer_shapes(exported_program.model_proto)
 
     @pytorch_test_common.xfail(
         "This is addressed in main branch of transformers."
@@ -476,15 +476,15 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             position_ids = position_ids.unsqueeze(0).view(-1, seq)
 
             export_options = torch.onnx.ExportOptions(fake_context=fake_context)
-            export_output = torch.onnx.dynamo_export(
+            exported_program = torch.onnx.dynamo_export(
                 model,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
                 export_options=export_options,
             )
-            onnx.checker.check_model(export_output.model_proto)
-            onnx.shape_inference.infer_shapes(export_output.model_proto)
+            onnx.checker.check_model(exported_program.model_proto)
+            onnx.shape_inference.infer_shapes(exported_program.model_proto)
 
     @pytorch_test_common.xfail(
         "Not decorated with xfail because CI doesn't have enough memory to run and then fail."
@@ -501,14 +501,14 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             attention_mask = torch.ones(batch, seq, dtype=torch.bool)
 
             export_options = torch.onnx.ExportOptions(fake_context=fake_context)
-            export_output = torch.onnx.dynamo_export(
+            exported_program = torch.onnx.dynamo_export(
                 model,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 export_options=export_options,
             )
-            onnx.checker.check_model(export_output.model_proto)
-            onnx.shape_inference.infer_shapes(export_output.model_proto)
+            onnx.checker.check_model(exported_program.model_proto)
+            onnx.shape_inference.infer_shapes(exported_program.model_proto)
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -141,7 +141,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
         tensor_x = torch.randn(1, 1, 2, dtype=torch.float32)
 
-        export_output = torch.onnx.dynamo_export(
+        exported_program = torch.onnx.dynamo_export(
             func,
             tensor_x,
             8.0,
@@ -150,17 +150,17 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 dynamic_shapes=self.dynamic_shapes,
             ),
         )
-        onnx_test_common.assert_dynamic_shapes(export_output, self.dynamic_shapes)
-        onnx_format_args = export_output.adapt_torch_inputs_to_onnx(tensor_x, 8.0)
-        ref_outputs = export_output.adapt_torch_outputs_to_onnx(func(tensor_x, 8.0))
-        ort_outputs = onnx_test_common.run_ort(export_output, onnx_format_args)
+        onnx_test_common.assert_dynamic_shapes(exported_program, self.dynamic_shapes)
+        onnx_format_args = exported_program.adapt_torch_inputs_to_onnx(tensor_x, 8.0)
+        ref_outputs = exported_program.adapt_torch_outputs_to_onnx(func(tensor_x, 8.0))
+        ort_outputs = onnx_test_common.run_ort(exported_program, onnx_format_args)
         for ref_output, ort_output in zip(ref_outputs, ort_outputs):
             torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
         # test on different non-tensor input - xfail
-        onnx_format_args = export_output.adapt_torch_inputs_to_onnx(tensor_x, 9.0)
-        ref_outputs = export_output.adapt_torch_outputs_to_onnx(func(tensor_x, 9.0))
-        _ = onnx_test_common.run_ort(export_output, onnx_format_args)
+        onnx_format_args = exported_program.adapt_torch_inputs_to_onnx(tensor_x, 9.0)
+        ref_outputs = exported_program.adapt_torch_outputs_to_onnx(func(tensor_x, 9.0))
+        _ = onnx_test_common.run_ort(exported_program, onnx_format_args)
         for ref_output, ort_output in zip(ref_outputs, ort_outputs):
             torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
@@ -690,14 +690,16 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 export_options.fx_tracer = (
                     fx_symbolic_graph_extractor.FXSymbolicTracer()
                 )
-                export_output = torch.onnx.dynamo_export(
+                exported_program = torch.onnx.dynamo_export(
                     fake_model,
                     *fake_args,
                     export_options=export_options,
                 )
-                onnx_model = export_output.model_proto
+                onnx_model = exported_program.model_proto
 
-            onnx_test_common.assert_dynamic_shapes(export_output, self.dynamic_shapes)
+            onnx_test_common.assert_dynamic_shapes(
+                exported_program, self.dynamic_shapes
+            )
 
             # Tasks done by the following block.
             #  1. Iterate through all tensors stored in ctx.paths (the file content is loaded torch.load)
@@ -711,7 +713,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             onnx_model_location = model_name + "_external_data.onnx"
             onnx_initializer_location = model_name + "_initializers"
             # TODO: We are using the internal `save_model_with_external_data` instead of public
-            # `ExportOutput.save` because we need to rename ONNX initializers before saving.
+            # `ONNXExportedProgram.save` because we need to rename ONNX initializers before saving.
             # This is only needed/allowed because we are using `fx_tracer=FXSymbolicTracer`,
             # which is not an official FX tracer.
             fx_serialization.save_model_with_external_data(
@@ -726,11 +728,11 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             args = create_args()
             kwargs = create_pytorch_only_kwargs()
             # Original outputs.
-            ref_outputs = export_output.adapt_torch_outputs_to_onnx(
+            ref_outputs = exported_program.adapt_torch_outputs_to_onnx(
                 model(*args, **kwargs)
             )
             # ORT outputs.
-            args_not_none = export_output.adapt_torch_inputs_to_onnx(*args)
+            args_not_none = exported_program.adapt_torch_inputs_to_onnx(*args)
 
             # Drop Parameters and buffers added by fx_serialization.save_model_with_external_data
             args_not_none = args_not_none[: len(args) - len(kwargs)]
@@ -813,6 +815,59 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_model,
             create_args,
             create_pytorch_only_extra_kwargs,
+        )
+
+    def test_torch_export_simple_function_all_default(self):
+        def func(x):
+            y = x + 1
+            z = y.relu()
+            return (y, z)
+
+        func_args = (torch.randn(1, 1, 2),)
+
+        export_options = torch.onnx.ExportOptions(
+            op_level_debug=self.op_level_debug,
+            dynamic_shapes=self.dynamic_shapes,
+        )
+
+        exported_program = torch.export.export(
+            func,
+            func_args,
+            backend="onnx",
+            options={"export_options": export_options},
+        )
+
+        onnx_test_common._compare_pytorch_onnx_with_exported_program(
+            exported_program, func, func_args, {}
+        )
+
+    def test_torch_export_simple_function_with_options(self):
+        def func(x):
+            y = x + 1
+            z = y.relu()
+            return (y, z)
+
+        func_args = (torch.randn(1, 1, 2),)
+
+        export_options = torch.onnx.ExportOptions(
+            op_level_debug=self.op_level_debug,
+            dynamic_shapes=self.dynamic_shapes,
+        )
+
+        exported_program = torch.export.export(
+            func,
+            func_args,
+            backend="onnx",
+            options={"export_options": export_options},
+        )
+
+        onnxruntime_options = {"providers": ["CPUExecutionProvider"]}
+        onnx_test_common._compare_pytorch_onnx_with_exported_program(
+            exported_program,
+            func,
+            func_args,
+            {},
+            onnxruntime_options=onnxruntime_options,
         )
 
 
@@ -910,7 +965,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 )
 
                 if export_within_fake_mode:
-                    export_output = torch.onnx.dynamo_export(
+                    exported_program = torch.onnx.dynamo_export(
                         fake_model,
                         *fake_args,
                         **fake_kwargs,
@@ -918,14 +973,16 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                     )
 
             if not export_within_fake_mode:
-                export_output = torch.onnx.dynamo_export(
+                exported_program = torch.onnx.dynamo_export(
                     fake_model, *fake_args, **fake_kwargs, export_options=export_options
                 )
 
-            onnx_test_common.assert_dynamic_shapes(export_output, self.dynamic_shapes)
+            onnx_test_common.assert_dynamic_shapes(
+                exported_program, self.dynamic_shapes
+            )
 
             with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
-                export_output.save(
+                exported_program.save(
                     tmp_onnx_file.name, model_state_dict=tmp_checkpoint_file.name
                 )
 
@@ -933,11 +990,11 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 args = create_args()
                 kwargs = create_kwargs()
                 # Original outputs.
-                ref_outputs = export_output.adapt_torch_outputs_to_onnx(
+                ref_outputs = exported_program.adapt_torch_outputs_to_onnx(
                     real_model(*args, **kwargs)
                 )
                 # ORT outputs.
-                args_not_none = export_output.adapt_torch_inputs_to_onnx(
+                args_not_none = exported_program.adapt_torch_inputs_to_onnx(
                     *args, **kwargs
                 )
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -1,3 +1,4 @@
+import builtins
 import copy
 import dataclasses
 import io
@@ -48,7 +49,7 @@ from .exported_program import (
     CallSpec,
     combine_args_kwargs,
     ExportBackwardSignature,
-    ExportedProgram,
+    DynamoExportedProgram,
     ExportGraphSignature,
 )
 from .passes.add_runtime_assertions_for_constraints_pass import (
@@ -182,395 +183,37 @@ def capture_pre_autograd_graph(
         return m
 
 
-def _convert_input_to_fake(gm, args, kwargs):
-    fake_inps: List[torch.Tensor] = []
-    fake_mode = FakeTensorMode(
-        allow_fallback_kernels=False,
-        allow_non_fake_inputs=True,
-        shape_env=ShapeEnv(
-            assume_static_by_default=True,
-        ),
-    )
-
-    for node in gm.graph.nodes:
-        if node.op == "placeholder" and "val" in node.meta:
-            fake_val = node.meta["val"]
-            if fake_val is not None and isinstance(fake_val, torch.Tensor):
-                fake_inps.append(fake_val)
-
-    if detected_fake_mode := detect_fake_mode(fake_inps):
-        fake_mode = detected_fake_mode
-
-    count = 0
-
-    def convert_to_fake(x):
-        nonlocal count
-        val = fake_inps[count]
-        count += 1
-        return val
-
-    fake_args = pytree.tree_map_only(torch.Tensor, convert_to_fake, args)
-    # TODO properly use the cached fake tensor
-    fake_kwargs = pytree.tree_map_only(torch.Tensor, fake_mode.from_tensor, kwargs)
-    return fake_args, fake_kwargs, fake_mode
-
-
-def _safe_to_skip_dynamo(gm: torch.fx.GraphModule):
-    for node in gm.graph.nodes:
-        if "is_torch_exported" in node.meta:
-            return True
-    return False
-
-
-def _replace_param_buffer_names(param_buffer_table, sig):
-    def replace(x):
-        return param_buffer_table.get(x, x)
-
-    sig.parameters = pytree.tree_map(replace, sig.parameters)
-    sig.buffers = pytree.tree_map(replace, sig.buffers)
-    sig.inputs_to_parameters = pytree.tree_map(replace, sig.inputs_to_parameters)
-    sig.inputs_to_buffers = pytree.tree_map(replace, sig.inputs_to_buffers)
-    sig.buffers_to_mutate = pytree.tree_map(replace, sig.buffers_to_mutate)
-    if sig.backward_signature is not None:
-        sig.backward_signature.gradients_to_parameters = pytree.tree_map(
-            replace, sig.backward_signature.gradients_to_parameters
-        )
-
-
-def _normalize_nn_module_stack(gm_torch_level, root_cls):
-    # Append a root module to every nn_module_stack.
-    root = "L['self']"
-    root_key = re.sub(r'[^a-zA-Z0-9]', '_', root)
-    for gm in gm_torch_level.modules():
-        if not isinstance(gm, torch.fx.GraphModule):
-            continue
-        for node in gm.graph.nodes:
-            if node.op in ["placeholder", "output"]:
-                continue
-            add_root = True
-            if nn_module_stack := node.meta.get("nn_module_stack", {}):
-                path, ty = next(iter(nn_module_stack.values()))
-                assert issubclass(ty, torch.nn.Module)
-                # TODO Figure out why sometimes we have root sometimes we don't.
-                if path == root and ty is root_cls:
-                    add_root = False
-            if add_root:
-                def normalize_path(path):
-                    try:
-                        parts = []
-
-                        class Path:
-                            def __getattr__(self, name):
-                                parts.append(name)
-                                return self
-
-                            def __getitem__(self, idx):
-                                parts.append(str(idx))
-                                return self
-
-                        eval(path, {"L": {"self": Path()}})
-                        return ".".join(parts)
-                    except Exception:  # TODO(zhxchen17) Remove this.
-                        return path
-
-                nn_module_stack = {root_key: (root, root_cls), **nn_module_stack}
-                node.meta["nn_module_stack"] = {
-                    key: (normalize_path(path), ty)
-                    for key, (path, ty) in nn_module_stack.items()
-                }
-
 def export(
     f: Callable,
-    args: Tuple[Any, ...],
-    kwargs: Optional[Dict[str, Any]] = None,
-    constraints: Optional[List[Constraint]] = None,
+    f_args: Tuple[Any, ...],
+    f_kwargs: Optional[Dict[str, Any]] = None,
     *,
-    preserve_module_call_signature: Tuple[str, ...] = (),
-) -> ExportedProgram:
+    backend: Union[str, Callable] = "dynamo",
+    options: Optional[Dict[str, Any]] = None,
+) -> DynamoExportedProgram:
     """
     Traces either an nn.Module's forward function or just a callable with PyTorch
-    operations inside and produce a ExportedProgram.
+    operations inside and produce a DynamoExportedProgram.
 
     Args:
-        m: the `nn.Module` or callable to trace.
-
-        args: example positional inputs.
-
-        kwargs: optional example keyword inputs.
-
-        constraints: A optional list of constraints on the dynamic arguments specifying
-            their possible range of their shapes
-
-        preserve_module_call_signature: A list of submodule paths for which the original
-            calling conventions are preserved as metadata.
+        f: the `nn.Module` or callable to trace.
+        f_args: example positional inputs.
+        f_kwargs: optional example keyword inputs.
+        backend: the backend to use for exporting.  See `torch._export.list_backends()`
+        options: A dictionary of options to control ``backend``
 
     Returns:
-        An ExportedProgram containing the traced method.
+        An DynamoExportedProgram containing the traced method.
     """
-    constraints = constraints or []
-    kwargs = kwargs or {}
 
-    if not isinstance(args, tuple):
-        raise UserError(UserErrorType.INVALID_INPUT,
-                        f"Expecting `args` to be a tuple of example positional inputs, got {type(args)}")
-
-    # We convert to nn.Module because __call__ of ExportedProgram
-    # is untracable right now.
-    if isinstance(f, ExportedProgram):
-        if len(constraints) > 0:
-            raise UserError(
-                UserErrorType.INVALID_INPUT,
-                "Cannot provide constraints for already exported program."
-            )
-        f = f.module()
-
-    with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
-        try:
-            module_call_specs: Dict[str, Dict[str, pytree.TreeSpec]] = {}
-            # TODO Horrible hack to skip dynamo
-            if isinstance(f, torch.fx.GraphModule) and _safe_to_skip_dynamo(f):
-                if len(constraints) > 0:
-                    raise UserError(
-                        UserErrorType.INVALID_INPUT,
-                        "Cannot provide constraints for already exported program."
-                    )
-                gm_torch_level = f
-            else:
-                with _wrap_submodules(f, preserve_module_call_signature, module_call_specs):
-                    gm_torch_level, _ = torch._dynamo.export(
-                        f,
-                        constraints=constraints,
-                        assume_static_by_default=True,
-                        tracing_mode="symbolic",
-                    )(
-                        *args,
-                        **kwargs,
-                    )
-        except (ConstraintViolationError, ValueRangeError) as e:
-            raise UserError(UserErrorType.CONSTRAIN_VIOLATION, str(e))
-        except GuardOnDataDependentSymNode as e:
-            raise UserError(
-                UserErrorType.ANTI_PATTERN,
-                f"Consider annotating your code using constrain_as_*(). {str(e)}")
-
-    params_buffers: Dict[str, Union[torch.Tensor, torch.nn.Parameter]] = {}
-    for name, param in gm_torch_level.named_parameters(remove_duplicate=False):
-        params_buffers[name] = param
-
-    for name, buffer in gm_torch_level.named_buffers(remove_duplicate=False):
-        params_buffers[name] = buffer
-
-    fake_args, fake_kwargs, fake_mode = _convert_input_to_fake(gm_torch_level, args, kwargs)
-
-    # First, we want to pass through the graph to try populating
-    # val field for getattr if there is anything missing.
-    # THis can happen when quantization adds extra params and forgets
-    # to update "val"
-    for node in gm_torch_level.graph.nodes:
-        if node.op == "get_attr" and "val" not in node.meta:
-            attr = getattr(gm_torch_level, node.target)
-            # Checks if it is not a HigherOrderOp branch or a module
-            if not isinstance(attr, torch.nn.Module):
-                node.meta["val"] = fake_mode.from_tensor(attr, static_shapes=True)
-
-    # When aot_export lifts the params, we lose the nn_module_stack
-    # and source_fn from the param nodes as they are treated as fresh inputs
-    # Therefore, we manually extract them before calling into aot_export
-    params_buffers_to_node_meta = {}
-    for node in gm_torch_level.graph.nodes:
-        target = node.target
-        meta = node.meta
-        if node.op == "call_module":
-            submodule = getattr(gm_torch_level, target)
-            if isinstance(submodule, torch.nn.Module):
-                for name, _ in submodule.named_parameters(recurse=True, remove_duplicate=False):
-                    params_buffers_to_node_meta[target + "." + name] = meta
-
-                for name, _ in submodule.named_buffers(recurse=True, remove_duplicate=False):
-                    params_buffers_to_node_meta[target + "." + name] = meta
-
-        if node.op == "get_attr":
-            submodule = getattr(gm_torch_level, target)
-            if not isinstance(submodule, torch.fx.GraphModule):
-                params_buffers_to_node_meta[target] = meta
-
-        # If the call_function uses param as input, we also need to update params' meta
-        # with this call_function node's meta.
-        # This is basically the same flow as torch.fx.traceback.preserve_meta()
-        if node.op == "call_function" and not isinstance(node.target, torch._ops.HigherOrderOperator):
-            for arg in node._input_nodes:
-                if arg.op == "get_attr":
-                    for entry in torch.fx.proxy._COPY_META_FIELDS:
-                        if entry in meta:
-                            params_buffers_to_node_meta[arg.target][entry] = meta[entry]
-
-    # Fix the graph output signature to be tuple if scalar
-    out_spec = orig_out_spec = gm_torch_level._out_spec
-    # aot_export expect the return type to always be a tuple.
-    if out_spec.type not in (list, tuple):
-        out_spec = pytree.TreeSpec(tuple, None, [out_spec])
-
-    orig_args = gm_torch_level.graph._codegen.pytree_info.orig_args  # type: ignore[attr-defined]
-
-    gm_torch_level.graph._codegen = _PyTreeCodeGen(
-        _PyTreeInfo(
-            orig_args,
-            gm_torch_level._in_spec,
-            out_spec,
-        )
-    )
-    gm_torch_level.recompile()
-
-    param_buffer_table: Dict[str, str] = {}
-    if isinstance(f, torch.nn.Module):
-        param_lookup: Dict[int, List[str]] = {}
-        buffer_lookup: Dict[int, List[str]] = {}
-        for name, param in f.named_parameters(remove_duplicate=False):
-            param_lookup.setdefault(id(param), []).append(name)
-        for name, buffer in f.named_buffers(remove_duplicate=False):
-            buffer_lookup.setdefault(id(buffer), []).append(name)
-        for dynamo_name, dynamo_param in gm_torch_level.named_parameters(remove_duplicate=False):
-            assert dynamo_name not in param_buffer_table
-            if id(dynamo_param) in param_lookup:
-                param_buffer_table[dynamo_name] = param_lookup[id(dynamo_param)].pop()
-
-        for dynamo_name, dynamo_buffer in gm_torch_level.named_buffers(remove_duplicate=False):
-            assert dynamo_name not in param_buffer_table
-            if id(dynamo_buffer) in buffer_lookup:
-                param_buffer_table[dynamo_name] = buffer_lookup[id(dynamo_buffer)].pop()
-
-    if isinstance(f, torch.nn.Module):
-        _normalize_nn_module_stack(gm_torch_level, type(f))
-
-    # Note: aot_export_module doesn't accept kwargs, we'd like to reorder the kwargs as an OrderedDict
-    # to follow the order in orig_args and correctly call gm_torch_level
-    gm, graph_signature = aot_export_module(
-        gm_torch_level,
-        (*fake_args, *_reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs).values()),
-        decompositions=DECOMP_TABLE,
-        trace_joint=False
-    )
-
-    export_backward_signature = ExportBackwardSignature(
-        gradients_to_parameters=graph_signature.backward_signature.gradients_to_parameters,
-        gradients_to_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs,
-        loss_output=graph_signature.backward_signature.loss_output
-    ) if graph_signature.backward_signature is not None else None
-
-    def to_str_list(sig_component: List[Any]):
-        return [str(v) for v in sig_component]
-
-    def to_str_dict(sig_component: Dict[Any, Any]):
-        return {str(k): str(v) for k, v in sig_component.items()}
-
-    export_graph_signature = ExportGraphSignature(
-        parameters=to_str_list(graph_signature.parameters),
-        buffers=to_str_list(graph_signature.buffers),
-        user_inputs=to_str_list(graph_signature.user_inputs),
-        user_outputs=to_str_list(graph_signature.user_outputs),
-        inputs_to_parameters=to_str_dict(graph_signature.inputs_to_parameters),
-        inputs_to_buffers=to_str_dict(graph_signature.inputs_to_buffers),
-        buffers_to_mutate=to_str_dict(graph_signature.buffers_to_mutate),
-        backward_signature=export_backward_signature
-    )
-
-    # NOTE: aot_export adds symint metadata for placeholders with int values;
-    # since these become specialized, we replace such metadata with the original values
-    flat_args, in_spec = pytree.tree_flatten(combine_args_kwargs(args, kwargs))
-    _, orig_in_spec = pytree.tree_flatten((args, kwargs))
-    index = 0
-    total_param_buffers = len(graph_signature.parameters) + len(graph_signature.buffers)
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            if index >= total_param_buffers:
-                user_arg = flat_args[index - total_param_buffers]
-                if not isinstance(user_arg, torch.Tensor):
-                    node.meta["val"] = user_arg
-            index += 1
-
-    # TODO unfortunately preserving graph-level metadata is not
-    # working well with aot_export. So we manually copy it.
-    # (The node-level meta is addressed above.)
-    gm.meta.update(gm_torch_level.meta)
-
-    # The unbacked symint symbols are updated in aot_export
-    # so we serialize them here instead of inside dynamo
-    gm.meta["inline_constraints"] = {
-        k: v
-        for k, v in fake_mode.shape_env.runtime_var_to_range.items()
-        if re.match(r"^[if]\d+$", str(k))
-    }
-
-    # After aot_export, set the param/buffer metadata back into placeholders
-    # Technically, users can still construct this data from param names
-    # without relying on this metadata
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            if node.target in export_graph_signature.inputs_to_parameters:
-                param_name = export_graph_signature.inputs_to_parameters[node.target]
-                if param_name in params_buffers_to_node_meta:
-                    for k, v in params_buffers_to_node_meta[param_name].items():
-                        node.meta[k] = v
-            if node.target in export_graph_signature.inputs_to_buffers:
-                buffer_name = export_graph_signature.inputs_to_buffers[node.target]
-                if buffer_name in params_buffers_to_node_meta:
-                    for k, v in params_buffers_to_node_meta[buffer_name].items():
-                        node.meta[k] = v
-
-        node.meta["is_torch_exported"] = True
-
-    range_constraints, equality_constraints = _process_constraints(
-        gm,
-        export_graph_signature,
-        flat_args,
-    )
-
-    if isinstance(f, torch.nn.Module):
-        _replace_param_buffer_names(param_buffer_table, export_graph_signature)
-        params_buffers = {param_buffer_table.get(name, name): tensor for name, tensor in params_buffers.items()}
-
-    module_call_signatures = {fqn: ModuleCallSignature(inputs=[], outputs=[], **specs) for fqn, specs in module_call_specs.items()}
-
-    if len(preserve_module_call_signature) > 0:
-        res = CollectTracepointsPass(module_call_signatures)(gm)
-        assert res is not None
-        gm = res.graph_module
-
-    assert orig_out_spec is not None
-    exported_program = ExportedProgram(
-        gm,
-        gm.graph,
-        export_graph_signature,
-        # TODO(zhxchen17) Remove this field.
-        CallSpec(in_spec, orig_out_spec),
-        # TODO(zhxchen17) Return empty state_dict for functions.
-        params_buffers,
-        range_constraints,
-        equality_constraints,
-        [ModuleCallEntry("", ModuleCallSignature(inputs=[], outputs=[], in_spec=orig_in_spec, out_spec=orig_out_spec))] +
-        [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
-        (args, kwargs),
-    )
-
-    if len(range_constraints) > 0 or len(equality_constraints) > 0:
-        exported_program = exported_program._transform(
-            _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
-        )
-    exported_program = lift_constant_tensor_pass(exported_program)
-
-    return exported_program._transform(_ReplaceSymSizeOpPass())
-
-
-def _reorder_kwargs_by_names(arg_names: List[str], args: Tuple[Any], kwargs: Dict[str, Any]):
-    assert len(arg_names) == len(args) + len(kwargs), (
-        f"Total number of arg names is expected to be {len(arg_names)} "
-        f"but got {len(args)} positional args, {len(kwargs)} kwargs."
-    )
-    return OrderedDict({kw_name: kwargs[kw_name] for kw_name in arg_names[len(args):]})
+    if not options:
+        options = {}
+    export_fn = torch.export.backends.registry.lookup_backend(backend)
+    return export_fn(f, f_args, f_kwargs, **options)
 
 
 def save(
-    ep: ExportedProgram,
+    ep: DynamoExportedProgram,
     f: Union[str, pathlib.Path, io.BytesIO],
     *,
     extra_files: Optional[Dict[str, Any]] = None,
@@ -601,7 +244,7 @@ def load(
     *,
     extra_files: Optional[Dict[str, Any]] = None,
     expected_opset_version: Optional[Dict[str, int]] = None,
-) -> ExportedProgram:
+) -> DynamoExportedProgram:
     if isinstance(f, (str, pathlib.Path)):
         f = str(f)
 
@@ -620,7 +263,7 @@ def load(
         serialized_ep = zipf.read('serialized_exported_program.json')
         serialized_state_dict = zipf.read('serialized_state_dict.json')
 
-        # Deserialize ExportedProgram
+        # Deserialize DynamoExportedProgram
         from .serde.serialize import deserialize
         ep = deserialize(serialized_ep, serialized_state_dict, expected_opset_version)
 
@@ -638,7 +281,7 @@ def aot_compile(
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
     options: Optional[Dict[str, Any]] = None,
-) -> Tuple[str, ExportedProgram]:
+) -> Tuple[str, DynamoExportedProgram]:
     """
     Note: this function is not stable yet
 
@@ -665,7 +308,7 @@ def aot_compile(
 
     global DECOMP_TABLE
     DECOMP_TABLE = select_decomp_table()
-    ep = export(f, args, kwargs, constraints)
+    ep = export(f, args, kwargs, options={"constraints": constraints})
     # Reset the global value
     DECOMP_TABLE = core_aten_decompositions()
 
@@ -676,12 +319,12 @@ def aot_compile(
     unlifted_module = ep.module()
     unlifted_module.graph.set_codegen(torch.fx.CodeGen())  # type: ignore[attr-defined]
     unlifted_module.recompile()
-    options = (
+    aot_compile_options = (
         {"from_export": True}
         if options is None
         else {**options, "from_export": True}
     )
-    so_path = torch._inductor.aot_compile(unlifted_module, flat_example_inputs, options)  # type: ignore[arg-type]
+    so_path = torch._inductor.aot_compile(unlifted_module, flat_example_inputs, aot_compile_options)  # type: ignore[arg-type]
 
     user_inputs = []
     user_outputs = []
@@ -691,7 +334,7 @@ def aot_compile(
         elif node.op == "output":
             user_outputs = [arg.name for arg in node.args[0]]
 
-    unlifted_ep = ExportedProgram(
+    unlifted_ep = DynamoExportedProgram(
         unlifted_module,
         unlifted_module.graph,
         ExportGraphSignature(

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -27,7 +27,7 @@ from torch.export import (
     ArgumentSpec,
     ExportBackwardSignature,
     ExportGraphSignature,
-    ExportedProgram,
+    DynamoExportedProgram,
     ModuleCallEntry,
     ModuleCallSignature,
 )
@@ -38,7 +38,7 @@ __all__ = [
     "ArgumentSpec",
     "ExportBackwardSignature",
     "ExportGraphSignature",
-    "ExportedProgram",
+    "DynamoExportedProgram",
     "ModuleCallEntry",
     "ModuleCallSignature",
 ]
@@ -195,7 +195,7 @@ def _unlift(gm, inp_pos_to_param_buffer_name, in_spec, out_spec, state_dict, buf
     return gm
 
 
-def unlift_exported_program_lifted_states(ep: torch.export.ExportedProgram) -> torch.nn.Module:
+def unlift_exported_program_lifted_states(ep: torch.export.DynamoExportedProgram) -> torch.nn.Module:
     new_gm = copy.deepcopy(ep.graph_module)
 
     # TODO Fix the period in params/buffers names later
@@ -262,7 +262,7 @@ def _create_graph_module_for_export(root, graph):
         warnings.warn(
             "Unable to execute the generated python source code from "
             "the graph. The graph module will no longer be directly callable, "
-            "but you can still run the ExportedProgram, and if needed, you can "
+            "but you can still run the DynamoExportedProgram, and if needed, you can "
             "run the graph module eagerly using torch.fx.Interpreter."
         )
         gm = torch.fx.GraphModule(root, torch.fx.Graph())

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -1,9 +1,9 @@
 import torch
-from torch._export import ExportedProgram
+from torch._export import DynamoExportedProgram
 from torch._guards import detect_fake_mode
 
 
-def lift_constant_tensor_pass(ep: ExportedProgram) -> ExportedProgram:
+def lift_constant_tensor_pass(ep: DynamoExportedProgram) -> DynamoExportedProgram:
     if len([node for node in ep.graph.nodes if node.op == "placeholder"]) == 0:
         return ep
 

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -256,6 +256,10 @@ class GraphModule:
 
 @dataclass
 class ExportedProgram:
+    ...
+
+@dataclass
+class DynamoExportedProgram:
     graph_module: GraphModule
     opset_version: Dict[str, int]
     range_constraints: Dict[str, RangeConstraint]

--- a/torch/_export/serde/upgrade.py
+++ b/torch/_export/serde/upgrade.py
@@ -178,7 +178,7 @@ class GraphModuleOpUpgrader:
 
         return upgrader_passes
 
-    def upgrade(self, exported_program: ep.ExportedProgram) -> ep.ExportedProgram:
+    def upgrade(self, exported_program: ep.DynamoExportedProgram) -> ep.DynamoExportedProgram:
         """Run each upgrader pass and then retrace to decompose it. Each upgrader pass replaces the old version of
         operators with a custom operator. The custom operator contains a CompositeImplicitAutograd kernel (the
         upgrading function itself). After retrace, this custom operator will be decomposed into the ops used in the

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 import torch
 
-from torch._export import ExportedProgram
+from torch._export import DynamoExportedProgram
 
 from torch.utils._pytree import (
     _register_pytree_node,
@@ -92,7 +92,7 @@ def register_dataclass_as_pytree_node(
     )
 
 
-def is_param(program: ExportedProgram, node: torch.fx.Node) -> bool:
+def is_param(program: DynamoExportedProgram, node: torch.fx.Node) -> bool:
     """
     Checks if the given node is a parameter within the exported program
     """
@@ -101,7 +101,7 @@ def is_param(program: ExportedProgram, node: torch.fx.Node) -> bool:
 
 
 def get_param(
-    program: ExportedProgram,
+    program: DynamoExportedProgram,
     node: torch.fx.Node,
 ) -> Optional[torch.nn.Parameter]:
     """
@@ -116,7 +116,7 @@ def get_param(
     return None
 
 
-def is_buffer(program: ExportedProgram, node: torch.fx.Node) -> bool:
+def is_buffer(program: DynamoExportedProgram, node: torch.fx.Node) -> bool:
     """
     Checks if the given node is a buffer within the exported program
     """
@@ -125,7 +125,7 @@ def is_buffer(program: ExportedProgram, node: torch.fx.Node) -> bool:
 
 
 def get_buffer(
-    program: ExportedProgram,
+    program: DynamoExportedProgram,
     node: torch.fx.Node,
 ) -> Optional[torch.Tensor]:
     """

--- a/torch/export/backends/__init__.py
+++ b/torch/export/backends/__init__.py
@@ -1,0 +1,17 @@
+from .registry import (
+    InvalidTorchExportBackend,
+    list_backends,
+    lookup_backend,
+    register_backend,
+    register_debug_backend,
+    register_experimental_backend,
+)
+
+__all__ = [
+    "InvalidTorchExportBackend",
+    "list_backends",
+    "lookup_backend",
+    "register_backend",
+    "register_debug_backend",
+    "register_experimental_backend",
+]

--- a/torch/export/backends/dynamo.py
+++ b/torch/export/backends/dynamo.py
@@ -1,0 +1,468 @@
+import dataclasses
+
+import re
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+
+import torch._dynamo
+import torch.fx
+
+import torch.utils._pytree as pytree
+from torch._dynamo.exc import UserError, UserErrorType
+from torch._export import DECOMP_TABLE, DEFAULT_EXPORT_DYNAMO_CONFIG
+from torch._export.exported_program import (
+    _process_constraints,
+    CallSpec,
+    combine_args_kwargs,
+    DynamoExportedProgram,
+    ExportBackwardSignature,
+    ExportGraphSignature,
+    ModuleCallEntry,
+    ModuleCallSignature,
+)
+from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
+    _AddRuntimeAssertionsForInlineConstraintsPass,
+)
+from torch._export.passes.collect_tracepoints_pass import CollectTracepointsPass
+from torch._export.passes.lift_constant_tensor_pass import lift_constant_tensor_pass
+from torch._export.passes.replace_sym_size_ops_pass import _ReplaceSymSizeOpPass
+from torch._export.wrappers import _wrap_submodules
+from torch._functorch.aot_autograd import aot_export_module
+from torch._guards import detect_fake_mode
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from torch.export import Constraint, register_backend
+from torch.fx.experimental.symbolic_shapes import (
+    ConstraintViolationError,
+    GuardOnDataDependentSymNode,
+    ShapeEnv,
+)
+from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
+from torch.utils._sympy.value_ranges import ValueRangeError
+
+
+def _convert_input_to_fake(gm, args, kwargs):
+    fake_inps: List[torch.Tensor] = []
+    fake_mode = FakeTensorMode(
+        allow_fallback_kernels=False,
+        allow_non_fake_inputs=True,
+        shape_env=ShapeEnv(
+            assume_static_by_default=True,
+        ),
+    )
+
+    for node in gm.graph.nodes:
+        if node.op == "placeholder" and "val" in node.meta:
+            fake_val = node.meta["val"]
+            if fake_val is not None and isinstance(fake_val, torch.Tensor):
+                fake_inps.append(fake_val)
+
+    if detected_fake_mode := detect_fake_mode(fake_inps):
+        fake_mode = detected_fake_mode
+
+    count = 0
+
+    def convert_to_fake(x):
+        nonlocal count
+        val = fake_inps[count]
+        count += 1
+        return val
+
+    fake_args = pytree.tree_map_only(torch.Tensor, convert_to_fake, args)
+    # TODO properly use the cached fake tensor
+    fake_kwargs = pytree.tree_map_only(torch.Tensor, fake_mode.from_tensor, kwargs)
+    return fake_args, fake_kwargs, fake_mode
+
+
+def _normalize_nn_module_stack(gm_torch_level, root_cls):
+    # Append a root module to every nn_module_stack.
+    root = "L['self']"
+    root_key = re.sub(r"[^a-zA-Z0-9]", "_", root)
+    for gm in gm_torch_level.modules():
+        if not isinstance(gm, torch.fx.GraphModule):
+            continue
+        for node in gm.graph.nodes:
+            if node.op in ["placeholder", "output"]:
+                continue
+            add_root = True
+            if nn_module_stack := node.meta.get("nn_module_stack", {}):
+                path, ty = next(iter(nn_module_stack.values()))
+                assert issubclass(ty, torch.nn.Module)
+                # TODO Figure out why sometimes we have root sometimes we don't.
+                if path == root and ty is root_cls:
+                    add_root = False
+            if add_root:
+
+                def normalize_path(path):
+                    try:
+                        parts = []
+
+                        class Path:
+                            def __getattr__(self, name):
+                                parts.append(name)
+                                return self
+
+                            def __getitem__(self, idx):
+                                parts.append(str(idx))
+                                return self
+
+                        eval(path, {"L": {"self": Path()}})
+                        return ".".join(parts)
+                    except Exception:  # TODO(zhxchen17) Remove this.
+                        return path
+
+                nn_module_stack = {root_key: (root, root_cls), **nn_module_stack}
+                node.meta["nn_module_stack"] = {
+                    key: (normalize_path(path), ty)
+                    for key, (path, ty) in nn_module_stack.items()
+                }
+
+
+def _reorder_kwargs_by_names(
+    arg_names: List[str], args: Tuple[Any], kwargs: Dict[str, Any]
+):
+    assert len(arg_names) == len(args) + len(kwargs), (
+        f"Total number of arg names is expected to be {len(arg_names)} "
+        f"but got {len(args)} positional args, {len(kwargs)} kwargs."
+    )
+    return OrderedDict({kw_name: kwargs[kw_name] for kw_name in arg_names[len(args) :]})
+
+
+def _replace_param_buffer_names(param_buffer_table, sig):
+    def replace(x):
+        return param_buffer_table.get(x, x)
+
+    sig.parameters = pytree.tree_map(replace, sig.parameters)
+    sig.buffers = pytree.tree_map(replace, sig.buffers)
+    sig.inputs_to_parameters = pytree.tree_map(replace, sig.inputs_to_parameters)
+    sig.inputs_to_buffers = pytree.tree_map(replace, sig.inputs_to_buffers)
+    sig.buffers_to_mutate = pytree.tree_map(replace, sig.buffers_to_mutate)
+    if sig.backward_signature is not None:
+        sig.backward_signature.gradients_to_parameters = pytree.tree_map(
+            replace, sig.backward_signature.gradients_to_parameters
+        )
+
+
+def _safe_to_skip_dynamo(gm: torch.fx.GraphModule):
+    for node in gm.graph.nodes:
+        if "is_torch_exported" in node.meta:
+            return True
+    return False
+
+
+@register_backend  # type: ignore[arg-type]  # TODO: Fix backend type hint
+def dynamo(
+    f: Callable,
+    f_args: Tuple[Any, ...],
+    f_kwargs: Optional[Dict[str, Any]] = None,
+    constraints: Optional[List[Constraint]] = None,
+    preserve_module_call_signature: Tuple[str, ...] = (),
+) -> DynamoExportedProgram:
+    """Dynamic export backend for torch.export.
+
+    Args:
+        constraints: An optional list of constraints on the dynamic arguments
+         that specify their possible range of shapes. By default, shapes of
+         input torch.Tensors are assumed to be static. If an input torch.Tensor
+         is expected to have dynamic shapes, please use :func:`dynamic_dim`
+         to define :class:`Constraint` objects that specify the dynamics and the possible
+         range of shapes. See :func:`dynamic_dim` docstring for examples on
+         how to use it.
+
+        preserve_module_call_signature: A list of submodule paths for which the original
+            calling conventions are preserved as metadata.
+    """
+
+    constraints = constraints or []
+    f_kwargs = f_kwargs or {}
+
+    if not isinstance(f_args, tuple):
+        raise UserError(
+            UserErrorType.INVALID_INPUT,
+            f"Expecting `args` to be a tuple of example positional inputs, got {type(f_args)}",
+        )
+
+    # We convert to nn.Module because __call__ of DynamoExportedProgram
+    # is untraceable right now.
+    if isinstance(f, DynamoExportedProgram):
+        if len(constraints) > 0:
+            raise UserError(
+                UserErrorType.INVALID_INPUT,
+                "Cannot provide constraints for already exported program.",
+            )
+        f = f.module()
+
+    with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
+        try:
+            module_call_specs: Dict[str, Dict[str, pytree.TreeSpec]] = {}
+            # TODO Horrible hack to skip dynamo
+            if isinstance(f, torch.fx.GraphModule) and _safe_to_skip_dynamo(f):
+                if len(constraints) > 0:
+                    raise UserError(
+                        UserErrorType.INVALID_INPUT,
+                        "Cannot provide constraints for already exported program.",
+                    )
+                gm_torch_level = f
+            else:
+                with _wrap_submodules(
+                    f, preserve_module_call_signature, module_call_specs
+                ):
+                    gm_torch_level, _ = torch._dynamo.export(
+                        f,
+                        constraints=constraints,
+                        assume_static_by_default=True,
+                        tracing_mode="symbolic",
+                    )(
+                        *f_args,
+                        **f_kwargs,
+                    )
+        except (ConstraintViolationError, ValueRangeError) as e:
+            raise UserError(UserErrorType.CONSTRAIN_VIOLATION, str(e))
+        except GuardOnDataDependentSymNode as e:
+            raise UserError(
+                UserErrorType.ANTI_PATTERN,
+                f"Consider annotating your code using constrain_as_*(). {str(e)}",
+            )
+
+    params_buffers: Dict[str, Union[torch.Tensor, torch.nn.Parameter]] = {}
+    for name, param in gm_torch_level.named_parameters(remove_duplicate=False):
+        params_buffers[name] = param
+
+    for name, buffer in gm_torch_level.named_buffers(remove_duplicate=False):
+        params_buffers[name] = buffer
+
+    fake_args, fake_kwargs, fake_mode = _convert_input_to_fake(
+        gm_torch_level, f_args, f_kwargs
+    )
+
+    # First, we want to pass through the graph to try populating
+    # val field for getattr if there is anything missing.
+    # This can happen when quantization adds extra params and forgets
+    # to update "val"
+    for node in gm_torch_level.graph.nodes:
+        if node.op == "get_attr" and "val" not in node.meta:
+            attr = getattr(gm_torch_level, node.target)
+            # Checks if it is not a HigherOrderOp branch or a module
+            if not isinstance(attr, torch.nn.Module):
+                node.meta["val"] = fake_mode.from_tensor(attr, static_shapes=True)
+
+    # When aot_export lifts the params, we lose the nn_module_stack
+    # and source_fn from the param nodes as they are treated as fresh inputs
+    # Therefore, we manually extract them before calling into aot_export
+    params_buffers_to_node_meta = {}
+    for node in gm_torch_level.graph.nodes:
+        target = node.target
+        meta = node.meta
+        if node.op == "call_module":
+            submodule = getattr(gm_torch_level, target)
+            if isinstance(submodule, torch.nn.Module):
+                for name, _ in submodule.named_parameters(
+                    recurse=True, remove_duplicate=False
+                ):
+                    params_buffers_to_node_meta[target + "." + name] = meta
+
+                for name, _ in submodule.named_buffers(
+                    recurse=True, remove_duplicate=False
+                ):
+                    params_buffers_to_node_meta[target + "." + name] = meta
+
+        if node.op == "get_attr":
+            submodule = getattr(gm_torch_level, target)
+            if not isinstance(submodule, torch.fx.GraphModule):
+                params_buffers_to_node_meta[target] = meta
+
+        # If the call_function uses param as input, we also need to update params' meta
+        # with this call_function node's meta.
+        # This is basically the same flow as torch.fx.traceback.preserve_meta()
+        if node.op == "call_function" and not isinstance(
+            node.target, torch._ops.HigherOrderOperator
+        ):
+            for arg in node._input_nodes:
+                if arg.op == "get_attr":
+                    for entry in torch.fx.proxy._COPY_META_FIELDS:
+                        if entry in meta:
+                            params_buffers_to_node_meta[arg.target][entry] = meta[entry]
+
+    # Fix the graph output signature to be tuple if scalar
+    out_spec = orig_out_spec = gm_torch_level._out_spec
+    # aot_export expect the return type to always be a tuple.
+    if out_spec.type not in (list, tuple):
+        out_spec = pytree.TreeSpec(tuple, None, [out_spec])
+
+    orig_args = gm_torch_level.graph._codegen.pytree_info.orig_args  # type: ignore[attr-defined]
+
+    gm_torch_level.graph._codegen = _PyTreeCodeGen(
+        _PyTreeInfo(
+            orig_args,
+            gm_torch_level._in_spec,
+            out_spec,
+        )
+    )
+    gm_torch_level.recompile()
+
+    param_buffer_table: Dict[str, str] = {}
+    if isinstance(f, torch.nn.Module):
+        param_lookup: Dict[int, List[str]] = {}
+        buffer_lookup: Dict[int, List[str]] = {}
+        for name, param in f.named_parameters(remove_duplicate=False):
+            param_lookup.setdefault(id(param), []).append(name)
+        for name, buffer in f.named_buffers(remove_duplicate=False):
+            buffer_lookup.setdefault(id(buffer), []).append(name)
+        for dynamo_name, dynamo_param in gm_torch_level.named_parameters(
+            remove_duplicate=False
+        ):
+            assert dynamo_name not in param_buffer_table
+            if id(dynamo_param) in param_lookup:
+                param_buffer_table[dynamo_name] = param_lookup[id(dynamo_param)].pop()
+
+        for dynamo_name, dynamo_buffer in gm_torch_level.named_buffers(
+            remove_duplicate=False
+        ):
+            assert dynamo_name not in param_buffer_table
+            if id(dynamo_buffer) in buffer_lookup:
+                param_buffer_table[dynamo_name] = buffer_lookup[id(dynamo_buffer)].pop()
+
+    if isinstance(f, torch.nn.Module):
+        _normalize_nn_module_stack(gm_torch_level, type(f))
+
+    # Note: aot_export_module doesn't accept kwargs, we'd like to reorder the kwargs as an OrderedDict
+    # to follow the order in orig_args and correctly call gm_torch_level
+    gm, graph_signature = aot_export_module(
+        gm_torch_level,
+        (
+            *fake_args,
+            *_reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs).values(),
+        ),
+        decompositions=DECOMP_TABLE,
+        trace_joint=False,
+    )
+
+    export_backward_signature = (
+        ExportBackwardSignature(
+            gradients_to_parameters=graph_signature.backward_signature.gradients_to_parameters,
+            gradients_to_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs,
+            loss_output=graph_signature.backward_signature.loss_output,
+        )
+        if graph_signature.backward_signature is not None
+        else None
+    )
+
+    def to_str_list(sig_component: List[Any]):
+        return [str(v) for v in sig_component]
+
+    def to_str_dict(sig_component: Dict[Any, Any]):
+        return {str(k): str(v) for k, v in sig_component.items()}
+
+    export_graph_signature = ExportGraphSignature(
+        parameters=to_str_list(graph_signature.parameters),
+        buffers=to_str_list(graph_signature.buffers),
+        user_inputs=to_str_list(graph_signature.user_inputs),
+        user_outputs=to_str_list(graph_signature.user_outputs),
+        inputs_to_parameters=to_str_dict(graph_signature.inputs_to_parameters),
+        inputs_to_buffers=to_str_dict(graph_signature.inputs_to_buffers),
+        buffers_to_mutate=to_str_dict(graph_signature.buffers_to_mutate),
+        backward_signature=export_backward_signature,
+    )
+
+    # NOTE: aot_export adds symint metadata for placeholders with int values;
+    # since these become specialized, we replace such metadata with the original values
+    flat_args, in_spec = pytree.tree_flatten(combine_args_kwargs(f_args, f_kwargs))
+    _, orig_in_spec = pytree.tree_flatten((f_args, f_kwargs))
+    index = 0
+    total_param_buffers = len(graph_signature.parameters) + len(graph_signature.buffers)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if index >= total_param_buffers:
+                user_arg = flat_args[index - total_param_buffers]
+                if not isinstance(user_arg, torch.Tensor):
+                    node.meta["val"] = user_arg
+            index += 1
+
+    # TODO unfortunately preserving graph-level metadata is not
+    # working well with aot_export. So we manually copy it.
+    # (The node-level meta is addressed above.)
+    gm.meta.update(gm_torch_level.meta)
+
+    # The unbacked symint symbols are updated in aot_export
+    # so we serialize them here instead of inside dynamo
+    gm.meta["inline_constraints"] = {
+        k: v
+        for k, v in fake_mode.shape_env.runtime_var_to_range.items()
+        if re.match(r"^[if]\d+$", str(k))
+    }
+
+    # After aot_export, set the param/buffer metadata back into placeholders
+    # Technically, users can still construct this data from param names
+    # without relying on this metadata
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node.target in export_graph_signature.inputs_to_parameters:
+                param_name = export_graph_signature.inputs_to_parameters[node.target]
+                if param_name in params_buffers_to_node_meta:
+                    for k, v in params_buffers_to_node_meta[param_name].items():
+                        node.meta[k] = v
+            if node.target in export_graph_signature.inputs_to_buffers:
+                buffer_name = export_graph_signature.inputs_to_buffers[node.target]
+                if buffer_name in params_buffers_to_node_meta:
+                    for k, v in params_buffers_to_node_meta[buffer_name].items():
+                        node.meta[k] = v
+
+        node.meta["is_torch_exported"] = True
+
+    range_constraints, equality_constraints = _process_constraints(
+        gm,
+        export_graph_signature,
+        flat_args,
+    )
+
+    if isinstance(f, torch.nn.Module):
+        _replace_param_buffer_names(param_buffer_table, export_graph_signature)
+        params_buffers = {
+            param_buffer_table.get(name, name): tensor
+            for name, tensor in params_buffers.items()
+        }
+
+    module_call_signatures = {
+        fqn: ModuleCallSignature(inputs=[], outputs=[], **specs)
+        for fqn, specs in module_call_specs.items()
+    }
+
+    if len(preserve_module_call_signature) > 0:
+        res = CollectTracepointsPass(module_call_signatures)(gm)
+        assert res is not None
+        gm = res.graph_module
+
+    assert orig_out_spec is not None
+    exported_program = DynamoExportedProgram(
+        gm,
+        gm.graph,
+        export_graph_signature,
+        # TODO(zhxchen17) Remove this field.
+        CallSpec(in_spec, orig_out_spec),
+        # TODO(zhxchen17) Return empty state_dict for functions.
+        params_buffers,
+        range_constraints,
+        equality_constraints,
+        [
+            ModuleCallEntry(
+                "",
+                ModuleCallSignature(
+                    inputs=[], outputs=[], in_spec=orig_in_spec, out_spec=orig_out_spec
+                ),
+            )
+        ]
+        + [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
+        (f_args, f_kwargs),
+    )
+
+    if len(range_constraints) > 0 or len(equality_constraints) > 0:
+        exported_program = exported_program._transform(
+            _AddRuntimeAssertionsForInlineConstraintsPass(
+                range_constraints, equality_constraints
+            )
+        )
+    exported_program = lift_constant_tensor_pass(exported_program)
+
+    return exported_program._transform(_ReplaceSymSizeOpPass())

--- a/torch/export/backends/registry.py
+++ b/torch/export/backends/registry.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import functools
+import importlib
+import os
+import sys
+import types
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+ExportFn = Callable[
+    [Callable, List[Any], Optional[Dict[str, Any]], Optional[Any]], "ExportedProgram"  # type: ignore[name-defined]
+]
+_BACKENDS: Dict[str, ExportFn] = dict()
+
+
+class InvalidTorchExportBackend(RuntimeError):
+    def __init__(self, name):
+        super().__init__(
+            f"Invalid backend: {name!r}, see `torch._export.list_backends()` for available backends."
+        )
+
+
+def lookup_backend(export_fn):
+    """Expand backend strings to functions"""
+    if isinstance(export_fn, str):
+        if export_fn not in _BACKENDS:
+            _lazy_import()
+        if export_fn not in _BACKENDS:
+            _lazy_import_entry_point(export_fn)
+        if export_fn not in _BACKENDS:
+            raise InvalidTorchExportBackend(name=export_fn)
+        export_fn = _BACKENDS[export_fn]
+    return export_fn
+
+
+def register_backend(
+    export_fn: Optional[ExportFn] = None,
+    name: Optional[str] = None,
+    tags: Sequence[str] = (),
+):
+    """
+    Decorator to add a given export function to the registry to allow calling
+    `torch.export` with string shorthand.  Note: for projects not
+    imported by default, it might be easier to pass a function directly
+    as a backend and not use a string.
+
+    Args:
+        export_fn: Callable taking a :class:`torch.nn.Module` model, inputs and options
+        name: Optional name, defaults to `export_fn.__name__`
+        tags: Optional set of string tags to categorize backend with
+    """
+    if export_fn is None:
+        # @register_backend(name="") syntax
+        return functools.partial(register_backend, name=name, tags=tags)
+    assert callable(export_fn)
+    name = name or export_fn.__name__
+    assert name not in _BACKENDS, f"duplicate backend name: {name}"
+    _BACKENDS[name] = export_fn
+    export_fn._tags = tuple(tags)  # type: ignore[attr-defined]
+    return export_fn
+
+
+register_debug_backend = functools.partial(register_backend, tags=("debug",))
+register_experimental_backend = functools.partial(
+    register_backend, tags=("experimental",)
+)
+
+
+def list_backends(exclude_tags=("debug", "experimental")) -> List[str]:
+    """
+    Return valid strings that can be passed to `torch.export(..., backend="name")`.
+    """
+    _lazy_import()
+    exclude_tags = set(exclude_tags or ())
+
+    return sorted(
+        [
+            name
+            for name, backend in _BACKENDS.items()
+            if not exclude_tags.intersection(backend._tags)  # type: ignore[attr-defined]
+        ]
+    )
+
+
+@functools.lru_cache(None)
+def _lazy_import_entry_point(backend_name: str):
+    # TODO: Document similar to <torch>/docs/source/torch.compiler_custom_backends.rst
+    from importlib.metadata import entry_points
+
+    export_fn = None
+    group_name = "torch_export_backends"
+    if sys.version_info < (3, 10):
+        backend_eps = entry_points()
+        eps = [ep for ep in backend_eps.get(group_name, ()) if ep.name == backend_name]
+        if len(eps) > 0:
+            export_fn = eps[0].load()
+    else:
+        backend_eps = entry_points(group=group_name)
+        if backend_name in backend_eps.names:
+            export_fn = backend_eps[backend_name].load()
+
+    if export_fn is not None and backend_name not in list_backends():
+        register_backend(export_fn=export_fn, name=backend_name)
+
+
+def import_submodule(mod: types.ModuleType):
+    """
+    Ensure all the files in a given submodule are imported
+    """
+    for filename in sorted(os.listdir(os.path.dirname(mod.__file__))):  # type: ignore[type-var]
+        if filename.endswith(".py") and filename[0] != "_":
+            importlib.import_module(f"{mod.__name__}.{filename[:-3]}")
+
+
+@functools.lru_cache(None)
+def _lazy_import():
+    from .. import backends
+
+    import_submodule(backends)

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -44,8 +44,8 @@ from .utils import (
 
 from ._internal.exporter import (  # usort:skip. needs to be last to avoid circular import
     ExportOptions,
-    ExportOutput,
-    ExportOutputSerializer,
+    ONNXExportedProgram,
+    ONNXExportedProgramSerializer,
     dynamo_export,
     OnnxExporterError,
     enable_fake_mode,
@@ -98,8 +98,8 @@ __all__ = [
     "CheckerError",  # Backwards compatibility
     # Dynamo Exporter
     "ExportOptions",
-    "ExportOutput",
-    "ExportOutputSerializer",
+    "ONNXExportedProgram",
+    "ONNXExportedProgramSerializer",
     "dynamo_export",
     "OnnxExporterError",
     "enable_fake_mode",
@@ -113,8 +113,8 @@ __all__ = [
 ExportTypes.__module__ = "torch.onnx"
 JitScalarType.__module__ = "torch.onnx"
 ExportOptions.__module__ = "torch.onnx"
-ExportOutput.__module__ = "torch.onnx"
-ExportOutputSerializer.__module__ = "torch.onnx"
+ONNXExportedProgram.__module__ = "torch.onnx"
+ONNXExportedProgramSerializer.__module__ = "torch.onnx"
 dynamo_export.__module__ = "torch.onnx"
 OnnxExporterError.__module__ = "torch.onnx"
 enable_fake_mode.__module__ = "torch.onnx"


### PR DESCRIPTION
Fixes #109131
### 🚀 The feature, motivation and pitch

Currently, ONNX exporter is exposed through `torch.onnx.export`, which was the only “export” API on PyTorch repo until PyTorch 2.0 introduced Dynamo and its great backends.

With the introduction of `torch.export` on PyTorch 2.0, there are 2 `export` APIs, namely `torch.onnx.export` and `torch.export.export`, which might confuse users, especially the existing ONNX users.

We propose a way to allow `torch.export.export` to support multiple backends, similar in principle to the `torch.compile` API, which allow backends to produce, for example, either a `GraphModule` with the default backend or an `onnx.ModelProto` when `backend="onnx"` is specified, unifying both FX and ONNX export APIs into one.

Backend implementation are separate as it is today and users could register extra backends through `register_backend` or list the available ones through `list_backends`

Below is an example on how a model would be exported with the new API

```python
import torch

def f(x, y):
    return x[0] + y

inp = ([torch.ones(1, 3)], torch.ones(1, 3))

exported_program = torch.export.export(f, inp, backend="dynamo", options={})  # ``backend`` and ``options`` are optionals
output = exported_program(*inp)
```

The PR https://github.com/pytorch/pytorch/pull/109315 roughly implements this idea for the already existing backend. 

The ONNX exporter could leverage dynamo under the hood and be exported as below:

```python
import torch

def func(x):
    y = x + 1
    z = y.relu()
    return (y, z)
export_options = torch.onnx.ExportOptions()  # TODO: Maybe we can flatten ExportOption in favor of a dict as dynamo?
exported_onnx = torch.export.export(func, (torch.randn(1, 1, 2),), backend="onnx", options={"export_options":  export_options},
)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng