### PR TITLE
Allow cond to have more dynamo cache beyond limit

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2,6 +2,7 @@
 import functools
 import unittest
 
+from torch.testing._internal.common_utils import TEST_WITH_TORCHDYNAMO
 import torch
 import torch.utils._pytree as pytree
 from torch._functorch.aot_autograd import from_fun, to_fun
@@ -1466,7 +1467,9 @@ def forward(self, arg0_1, arg1_1):
         new_source_fns = collect_meta_for_filtered_nodes(new_gm, checked_ops, checked_meta)
         self.assertEqual(all_source_fns, new_source_fns)
 
+    @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "triggers cache limit for foo and changes unique_graphs count.")
     def test_cond_no_dynamo_cache_limit(self):
+        torch._dynamo.reset()
         counters = torch._dynamo.utils.counters
         counters.clear()
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -8,6 +8,7 @@ import torch.utils._pytree as pytree
 
 from torch._C import _ExcludeDispatchKeyGuard, DispatchKey, DispatchKeySet
 from torch._dynamo.exc import CondOpArgsMismatchError
+from torch._dynamo.utils import disable_cache_limit
 
 from torch._functorch.eager_transforms import (
     _unwrap_all_tensors_from_functional,
@@ -151,9 +152,10 @@ def cond(pred, true_fn, false_fn, operands):
         raise RuntimeError("torch.cond requires dynamo support.")
 
     with _set_compilation_env():
-        return torch.compile(cond_op, backend="eager", fullgraph=True)(
-            pred, true_fn, false_fn, operands
-        )
+        with disable_cache_limit():
+            return torch.compile(cond_op, backend="eager", fullgraph=True)(
+                pred, true_fn, false_fn, operands
+            )
 
 
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109318

This is short term workaround for https://github.com/pytorch/pytorch/issues/108500. In the long term, we should have separate caches if cond appears at different places in user code or per true_fn/false_fn cache.


Test Plan:
see added test. It tests cond can go beyond cache limit.
