### PR TITLE
[2D][2/N][DeviceMesh] Add get_parent_mesh_dim() in _MeshEnv class

### DIFF
--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -271,6 +271,24 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         self.assertEqual(mesh_resources.get_parent_mesh(mesh_2d["DP"]), mesh_2d)
         self.assertEqual(mesh_resources.get_parent_mesh(mesh_2d["TP"]), mesh_2d)
 
+    @with_comms
+    def test_get_parent_mesh_dim_exist(self):
+        mesh_shape = (2, 4)
+        mesh_dim_names = ("DP", "TP")
+        mesh_2d = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+
+        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh_2d["DP"]), 0)
+        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh_2d["TP"]), 1)
+
+    @with_comms
+    def test_get_parent_mesh_dim_not_exist(self):
+        mesh_shape = (self.world_size,)
+        mesh = init_device_mesh(self.device_type, mesh_shape)
+
+        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh), None)
+
 
 class DeviceMeshCollectiveTest(DTensorTestBase):
     @property


### PR DESCRIPTION
Adding some additional APIs that are needed for 2D workflow.

Since each parallelism is only aware of its own mesh when we are constructing 2D state_dict. We need to know the mesh_dim of the child mesh in the parent mesh. So, we can use it to create DTensor that is 2D sound. 