### PR TITLE
Add CONDA_CMAKE=yes for all ROCm docker configs

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -321,6 +321,9 @@ case "$image" in
       extract_version_from_image_name rocm ROCM_VERSION
       NINJA_VERSION=1.9.0
       TRITON=yes
+      # To ensure that any ROCm config will build using conda cmake
+      # and thus have LAPACK/MKL enabled
+      CONDA_CMAKE=yes
     fi
     if [[ "$image" == *centos7* ]]; then
       NINJA_VERSION=1.10.2


### PR DESCRIPTION
This ensures all BUILD_ENVIRONMENT ROCm configs will have LAPACK/MKL support enabled due to using conda cmake. This should have no impact on pytorch/pytorch CI builds though, since those do not fall in the catch-all condition.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang