### PR TITLE
Add support for event_tracer in KernelContext and codegen layer

### DIFF
--- a/test/edge/event_tracer.h
+++ b/test/edge/event_tracer.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdlib.h>
+#include <cstdint>
+
+#pragma once
+
+namespace torch {
+namespace executor {
+
+/// Represents an allocator id returned by track_allocator.
+typedef uint32_t AllocatorID;
+/// Represents the chain id that will be passed in by the user during
+/// event logging.
+typedef int32_t ChainID;
+/// Represents the debug handle that is generally associated with each
+/// op executed in the runtime.
+typedef uint32_t DebugHandle;
+
+/// Default id's for chain id and debug handle.
+constexpr ChainID kUnsetChainId = -1;
+constexpr DebugHandle kUnsetDebugHandle = 0;
+
+/// Different types of delegate debug identifiers that are supported currently.
+enum class DelegateDebugIdType {
+  /// Default value, indicates that it's not a delegate event.
+  kNone,
+  /// Indicates a delegate event logged using an integer delegate debug
+  /// identifier.
+  kInt,
+  /// Indicates a delegate event logged using a string delegate debug
+  /// identifier i.e. the delegate debug id is a pointer to a string table
+  /// managed by the class implementing EventTracer functionality.
+  kStr
+};
+
+/**
+ * This is the struct which should be returned when a profiling event is
+ * started. This is used to uniquely identify that profiling event and will be
+ * required to be passed into the end_profiling call to signal that the event
+ * identified by this struct has completed.
+ **/
+struct EventTracerEntry {
+  /// An event id to uniquely identify this event that was generated during a
+  /// call to start the tracking of an event.
+  int64_t event_id;
+  /// The chain to which this event belongs to.
+  ChainID chain_id;
+  /// The debug handle corresponding to this event.
+  DebugHandle debug_handle;
+  /// The time at which this event was started to be tracked.
+  uint64_t start_time;
+  /// When delegate_event_id_type != DelegateDebugIdType::kNone it indicates
+  /// that event_id represents a delegate event. If delegate_event_id_type is:
+  /// 1) kInt then event_id contains an integer delegate debug id.
+  /// 2) kStr then event_id contains a string table index into a string table
+  /// maintained by the class implementing EventTracer functionality that will
+  /// give us the string identifier of this delegate event. For more details
+  /// refer to the DelegateMappingBuilder library present in
+  /// executorch/exir/backend/utils.py.
+  DelegateDebugIdType delegate_event_id_type;
+};
+/**
+ * EventTracer is a class that users can inherit and implement to
+ * log/serialize/stream etc. the profiling and debugging events that are
+ * generated at runtime for a model. An example of this is the ETDump
+ * implementation in the SDK codebase that serializes these events to a
+ * flatbuffer.
+ */
+class EventTracer {
+ public:
+  /**
+   * Start a new event block (can consist of profiling and/or debugging events.)
+   * identified by this name. A block is conceptually a set of events that we
+   * want to group together. e.g. all the events that occur during the call to
+   * execute() (i.e. model inference) could be categorized as a block.
+   *
+   * @param[in] name A human readable identifier for the event block. Users
+   * calling this interface do not need to keep the memory pointed to by this
+   * pointer around. The string must be copied over into internal memory during
+   * this call.
+   */
+  virtual void create_event_block(const char* name) = 0;
+
+  /**
+   * Start the profiling of the event identified by name and debug_handle.
+   * The user can pass in a chain_id and debug_handle to this call, or leave
+   * them empty (default values) which would then result in the chain_id and
+   * debug handle stored within (set by set_chain_debug_handle) this class to be
+   * used.
+   * @param[in] name Human readable name for the profiling event. Users calling
+   * this interface do not need to keep the memory pointed to by this pointer
+   * around. The string must be copied over into internal memory during this
+   * call.
+   * @param[in] chain_id The id of the chain to which this event belongs to. If
+   * kUnsetChainId is passed in the chain_id and kUnsetDebugHandle for
+   * debug_handle then the values stored in the class internally for these
+   * properties will be used.
+   * @param[in] debug_handle Debug handle generated ahead-of-time during model
+   * compilation.
+   *
+   * @return Returns an instance of EventTracerEntry which should be passed back
+   * into the end_profiling() call.
+   */
+  virtual EventTracerEntry start_profiling(
+      const char* name,
+      ChainID chain_id = kUnsetChainId,
+      DebugHandle debug_handle = kUnsetDebugHandle) = 0;
+
+  /**
+   * Start the profiling of a delegate event. Similar to start_profiling it will
+   * return an instance of EventTracerEntry that contains the details of this
+   * event.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   */
+  virtual EventTracerEntry start_profiling_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index) = 0;
+
+  /**
+   * Signal the end of the delegate profiling event contained in
+   * event_tracer_entry. Users also have the option to log some some free-from
+   * string based metadata along with this.
+   *
+   * @param[in] event_tracer_entry The EventTracerEntry returned by a call to
+   * start_profiling_delegate().
+   * @param[in] metadata Optional free-form metadata associated with the
+   * delegate event. This should be a null terminated ASCII string. Users
+   * calling this interface do not need to keep the memory pointed to by this
+   * pointer around. The string must be copied over into internal memory during
+   * this call.
+   */
+  virtual void end_profiling_delegate(
+      EventTracerEntry event_tracer_entry,
+      const char* metadata = nullptr) = 0;
+
+  /**
+   * Some delegates get access to the profiling details only after the complete
+   * graph has been executed. This interface is to support such use cases. It
+   * can be called in a loop etc. to log any number of profiling events that are
+   * part of this delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] start_time The timestamp when the delegate event started.
+   * @param[in] end_time The timestamp when the delegate event finished.
+   * @param[in] metadata Optional data relevant to the execution that the user
+   * wants to log along with this event. Pointer to metadata doesn't need to be
+   * valid after the call to this function. This should be a null terminated
+   * ASCII string.
+   */
+  virtual void log_profiling_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      uint64_t start_time,
+      uint64_t end_time,
+      const char* metadata = nullptr) = 0;
+
+  /**
+   * End the profiling of the event identified by prof_entry
+   *
+   * @param[in] prof_entry Value returned by a call to start_profiling
+   */
+  virtual void end_profiling(EventTracerEntry prof_entry) = 0;
+
+  /**
+   * Track this allocation done via a MemoryAllocator which had profiling
+   * enabled on it.
+   *
+   * @param[in] id Allocator id generated by a call to track_allocator.
+   * @param[in] size The size of the allocation done, in bytes.
+   */
+  virtual void track_allocation(AllocatorID id, size_t size) = 0;
+
+  /**
+   * Generate an allocator id for this memory allocator that will be used in the
+   * future to identify all the allocations done by this allocator.
+   *
+   * @param[in] name Human readable name for the allocator. Users calling
+   * this interface do not need to keep the memory pointed to by this pointer
+   * around. The string should be copied over into internal memory during this
+   * call.
+   *
+   * @return Identifier to uniquely identify this allocator.
+   */
+  virtual AllocatorID track_allocator(const char* name) = 0;
+
+  /**
+   * Helper function to set the chain id ands debug handle. Users have two
+   * options, the first is that they can directly pass in the chain id and debug
+   * handle to start_profiling or they can explicitly set them through this
+   * helper before calling start_profiling.
+   *
+   * The reason this helper exists is to
+   * solve a specific problem. We want to do profiling logging inside the
+   * codegen layer which calls the kernels. The problem though is that the
+   * codegen layer doesn't have access to these ids when calling
+   * start_profiling.
+   *
+   * Users should ideally use these within a RAII scope interface to make sure
+   * that these values are unset after the end_profiling call. If non-default
+   * values are passed into the start_profiling call they will always be given
+   * precedence over the values set by this interface.
+   *
+   * So what we do is call this helper in method.cpp before
+   * we hit the codegen layer and in the codegen layer we do a start_profiling
+   * call without passing in a chain_id or debug_handle. This ensures that the
+   * values set via this helper are the ones associated with that call.
+   *
+   * @param[in] chain_id Chain id of the current instruction being exectuted.
+   * @param[in] debug_handle Debug handle of the current instruction being
+   * executed. In this context debug handle and instruction id are the same
+   * thing.
+   */
+  void set_chain_debug_handle(ChainID chain_id, DebugHandle debug_handle) {
+    chain_id_ = chain_id;
+    debug_handle_ = debug_handle;
+  }
+
+  ChainID get_current_chain_id() {
+    return chain_id_;
+  }
+
+  DebugHandle get_current_debug_handle() {
+    return debug_handle_;
+  }
+
+  virtual ~EventTracer() {}
+
+ protected:
+  ChainID chain_id_ = kUnsetChainId;
+  DebugHandle debug_handle_ = kUnsetDebugHandle;
+};
+
+} // namespace executor
+} // namespace torch

--- a/test/edge/event_tracer_hooks.h
+++ b/test/edge/event_tracer_hooks.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <event_tracer.h>
+
+/**
+ * @file
+ *
+ * This file contains the hooks that are inserted across various parts of the
+ * core runtime code to call into the EventTracer class for logging of profiling
+ * and debugging events. Any calls made to the EventTracer from the runtime must
+ * be made via these hooks.
+ * Users shouldn't directly add these hooks in their code and it's meant only
+ * for usage in ExecuTorch internal code.
+ *
+ * The benefit of defining these hooks is that we can easily control whether or
+ * not we want to compile in the EventTracer code based on the status of the
+ * ET_EVENT_TRACER_ENABLED flag.
+ */
+
+namespace torch {
+namespace executor {
+namespace internal {
+
+/**
+ * This class enables scope based profiling where needed using RAII.
+ * Profiling will be started when the object is created and will end
+ * when the object goes out of scope.
+ */
+class EventTracerProfileScope final {
+ public:
+  EventTracerProfileScope(EventTracer* event_tracer, const char* name) {
+    event_tracer_ = event_tracer;
+    if (event_tracer_ == nullptr) {
+      return;
+    }
+    event_entry_ = event_tracer->start_profiling(name);
+  }
+
+  ~EventTracerProfileScope() {
+    if (event_tracer_ == nullptr) {
+      return;
+    }
+    event_tracer_->end_profiling(event_entry_);
+  }
+
+ private:
+  EventTracer* event_tracer_;
+  EventTracerEntry event_entry_;
+};
+
+/**
+ * This class helps us set and then clear out the chain id and debug handle
+ * values stored in the event tracer class using RAII. This is typically called
+ * in the executor loop before entering the codegen layer to configure the chain
+ * id and debug handle of the current instruction being executed.
+ * After we return from the kernel execution we can then reset the chain id and
+ * debug handle to defaults when this object goes out of scope.
+ */
+class EventTracerProfileInstructionScope final {
+ public:
+  EventTracerProfileInstructionScope(
+      EventTracer* event_tracer,
+      ChainID chain_idx,
+      DebugHandle debug_handle) {
+    event_tracer_ = event_tracer;
+    if (event_tracer_ == nullptr) {
+      return;
+    }
+    event_tracer_->set_chain_debug_handle(chain_idx, debug_handle);
+  }
+
+  ~EventTracerProfileInstructionScope() {
+    if (event_tracer_ == nullptr) {
+      return;
+    }
+    event_tracer_->set_chain_debug_handle(kUnsetChainId, kUnsetDebugHandle);
+  }
+
+ private:
+  EventTracer* event_tracer_;
+};
+
+/**
+ * Create a new event block with the specified name. Any events logged
+ * after this will be associated with this new event block.
+ */
+inline void event_tracer_create_event_block(
+    EventTracer* event_tracer,
+    char const* name) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  if (event_tracer) {
+    event_tracer->create_event_block(name);
+  }
+#else //! ET_EVENT_TRACER_ENABLED
+  (void)event_tracer;
+  (void)name;
+#endif
+}
+
+/**
+ * Explicitly mark the beginning of a new profiling event. This returns
+ * an instance of an EventTracerEntry object that the user needs to keep
+ * around and pass into the corresponding event_tracer_end_profiling_event
+ * call.
+ */
+inline EventTracerEntry event_tracer_begin_profiling_event(
+    EventTracer* event_tracer,
+    char const* name) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  if (event_tracer) {
+    return event_tracer->start_profiling(name);
+  }
+#else //! ET_EVENT_TRACER_ENABLED
+  (void)event_tracer;
+  (void)name;
+#endif
+  // There is no active tracer; this value will be ignored.
+  return EventTracerEntry();
+}
+
+/**
+ * Mark the end of a profiling event passing in the entry token
+ * returned by a previous call to ET_EVENT_TRACER_BEGIN_PROFILING_EVENT.
+ */
+inline void event_tracer_end_profiling_event(
+    EventTracer* event_tracer,
+    EventTracerEntry event) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  if (event_tracer) {
+    event_tracer->end_profiling(event);
+  }
+#else //! ET_EVENT_TRACER_ENABLED
+  (void)event_tracer;
+  (void)event;
+#endif
+}
+
+/**
+ * Start the tracking of the allocator represented by this name and returns
+ * an AllocatorID that will be used to track all subsequent allocations done by
+ * this allocator.
+ */
+inline AllocatorID event_tracer_track_allocator(
+    EventTracer* event_tracer,
+    const char* name) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  if (event_tracer) {
+    return event_tracer->track_allocator(name);
+  }
+#else //! ET_EVENT_TRACER_ENABLED
+  (void)event_tracer;
+  (void)name;
+#endif
+  // There is no active tracer; this value will be ignored.
+  return 0;
+}
+
+/// Log the allocation event done via the allocator represented by id.
+inline void event_tracer_track_allocation(
+    EventTracer* event_tracer,
+    AllocatorID id,
+    size_t size) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  if (event_tracer) {
+    event_tracer->track_allocation(id, size);
+  }
+#else //! ET_EVENT_TRACER_ENABLED
+  (void)event_tracer;
+  (void)id;
+  (void)size;
+#endif
+}
+
+} // namespace internal
+} // namespace executor
+} // namespace torch

--- a/test/edge/kernel_runtime_context.h
+++ b/test/edge/kernel_runtime_context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "event_tracer.h"
+
 namespace torch {
 namespace executor {
 
@@ -15,7 +17,28 @@ namespace executor {
  * operators that need more then constant space, and a TensorResizer for dynamic
  * shape tensors allowing programs to be more flexible with Tensor shape.
  */
-class KernelRuntimeContext {};
+class KernelRuntimeContext {
+     public:
+  /**
+   * Construct a new kernel runtime context along with an optional event tracer.
+   */
+  KernelRuntimeContext(EventTracer* event_tracer = nullptr)
+      : event_tracer_(event_tracer) {}
+
+  /**
+   * INTERNAL ONLY
+   *
+   * Returns a pointer to an instance of EventTracer to do profiling/debugging
+   * logging inside the codegen layer. This is only for internal usage inside
+   * the codegen layer and users should not be accessing this.
+   */
+  EventTracer* internal_event_tracer() {
+    return event_tracer_;
+  }
+
+   private:
+  EventTracer* event_tracer_;
+};
 
 } // namespace executor
 } // namespace torch

--- a/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
+++ b/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
@@ -1,8 +1,11 @@
 #include <operator_registry.h>
+#include <event_tracer_hooks.h>
 #include "${fn_header}" // Generated Function import headers
 
 namespace torch {
 namespace executor {
+
+using namespace internal;
 
 namespace {
 using KernelArrayRef = ::at::ArrayRef<::torch::executor::Kernel>;

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -467,6 +467,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 
@@ -552,6 +553,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 
@@ -586,6 +588,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -234,6 +234,7 @@ Kernel(
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_{f.func.name}");
         EXECUTORCH_SCOPE_PROF("native_call_{f.func.name}");
         {ret_prefix}{kernel_call}(context, {args_str});
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/344

This diff does a couple of things:
- Adds a pointer to an instance of EventTracer inside `KernelRuntimeContext`
- Adds an instance of `EventTracerProfileScope` inside the codegen layer.

Currently calls to both `EventTracerProfileScope` and `EXECUTORCH_SCOPE_PROF` are present inside the codegen layer. This is a temporary state. Once EventTracer and ETDump has been fully integrated, the call to `EXECUTORCH_SCOPE_PROF` will be removed everywhere. `EventTracerProfileScope` should be a no-op for now.

Test Plan: CI

Reviewed By: dbort

Differential Revision: D48975975


