### PR TITLE
Switch to CUDA event based profiling

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from torch._inductor.select_algorithm import TritonTemplateCaller
 
 from . import config
-from .utils import do_bench_using_profiling
+from .utils import do_bench
 from .virtualized import V
 
 CUDA_VISIBLE_DEVICES = "CUDA_VISIBLE_DEVICES"
@@ -408,7 +408,7 @@ class BenchmarkRequest:
             load_elapse = time.time() - start_ts
             start_ts = time.time()
 
-        out = do_bench_using_profiling(fn)
+        out = do_bench(fn)
         torch.cuda.synchronize()  # shake out any CUDA errors
 
         if debug:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -19,7 +19,7 @@ from torch.utils._sympy.value_ranges import ValueRanges
 from .. import metrics
 from ..utils import (
     DeferredLineBase,
-    do_bench_using_profiling,
+    do_bench,
     free_symbol_startswith,
     IndentedBuffer,
     sympy_dot,
@@ -1065,7 +1065,7 @@ class ChoiceCaller:
 
     def benchmark(self, *args, out) -> float:
         algo = self.to_callable()
-        return do_bench_using_profiling(lambda: algo(*args, out=out))
+        return do_bench(lambda: algo(*args, out=out))
 
     def call_name(self) -> str:
         raise NotImplementedError()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -26,7 +26,7 @@ from .codegen.triton import texpr, TritonKernel, TritonPrinter, TritonScheduling
 from .codegen.triton_utils import config_of, signature_to_meta
 from .exc import CUDACompileError
 from .utils import (
-    do_bench_using_profiling,
+    do_bench,
     Placeholder,
     sympy_dot,
     sympy_product,
@@ -645,7 +645,7 @@ class ExternKernelCaller(ChoiceCaller):
                 out_new, tuple(out.size()), tuple(out.stride())
             )
             out.copy_(out_new)  # for correctness checking
-            return do_bench_using_profiling(lambda: algo(*args))
+            return do_bench(lambda: algo(*args))
 
     def to_callable(self):
         fn = self.choice.to_callable()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -25,13 +25,7 @@ from .codegen.cuda.cuda_kernel import CUDATemplateCaller
 from .codegen.triton import texpr, TritonKernel, TritonPrinter, TritonScheduling
 from .codegen.triton_utils import config_of, signature_to_meta
 from .exc import CUDACompileError
-from .utils import (
-    do_bench,
-    Placeholder,
-    sympy_dot,
-    sympy_product,
-    unique,
-)
+from .utils import do_bench, Placeholder, sympy_dot, sympy_product, unique
 from .virtualized import V
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/107901, the CUDA event based
profiling is changed to profiler based profiling to avoid counting CPU-side
kernel launch overhead in final latency numbers. However, it turns out that
torch.profile() is significantly slower than CUDA event which affects model
compilation speed quite significantlly. This PR changes back to CUDA event
based profiling.

Follow-ups:
* Try CUDA event profiling with CUDAGraphs;
* Multi-GPU profiling;

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109338



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov