### PR TITLE
[Pytorch][Vulkan] Add bmm op

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/bmm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/bmm.glsl
@@ -1,0 +1,80 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uM1;
+layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uM2;
+layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
+  ivec4 size;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  ivec3 posx = ivec3(pos.x * 2, pos.y * 2, pos.z);
+
+  if (all(lessThan(posx, uBlock.size.xyz))) {
+    vec4 sum_b1 = vec4(0);
+    vec4 sum_b2 = vec4(0);
+    vec4 sum_b3 = vec4(0);
+    vec4 sum_b4 = vec4(0);
+
+    for (int k = 0; k < uBlock.size.w; ++k) {
+      ivec3 inposx = ivec3(2 * k, 2 * pos.y, pos.z);
+      vec4 intexx = texelFetch(uM1, inposx, 0);
+      ivec3 inposy = ivec3(inposx.x + 1, inposx.y, pos.z);
+      vec4 intexy = texelFetch(uM1, inposy, 0);
+      ivec3 inposz = ivec3(inposx.x, inposx.y + 1, pos.z);
+      vec4 intexz = texelFetch(uM1, inposz, 0);
+      ivec3 inposw = ivec3(inposx.x + 1, inposx.y + 1, pos.z);
+      vec4 intexw = texelFetch(uM1, inposw, 0);
+
+      vec4 texel1_b1 = vec4(intexx.x, intexy.x, intexz.x, intexw.x);
+      vec4 texel1_b2 = vec4(intexx.y, intexy.y, intexz.y, intexw.y);
+      vec4 texel1_b3 = vec4(intexx.z, intexy.z, intexz.z, intexw.z);
+      vec4 texel1_b4 = vec4(intexx.w, intexy.w, intexz.w, intexw.w);
+
+      vec4 texel2_b1 = texelFetch(uM2, ivec3(pos.x, k, 4 * pos.z), 0);
+      vec4 texel2_b2 = texelFetch(uM2, ivec3(pos.x, k, 4 * pos.z + 1), 0);
+      vec4 texel2_b3 = texelFetch(uM2, ivec3(pos.x, k, 4 * pos.z + 2), 0);
+      vec4 texel2_b4 = texelFetch(uM2, ivec3(pos.x, k, 4 * pos.z + 3), 0);
+
+      sum_b1 = fma(texel1_b1.xxzz, texel2_b1.xyxy, sum_b1);
+      sum_b1 = fma(texel1_b1.yyww, texel2_b1.zwzw, sum_b1);
+      sum_b2 = fma(texel1_b2.xxzz, texel2_b2.xyxy, sum_b2);
+      sum_b2 = fma(texel1_b2.yyww, texel2_b2.zwzw, sum_b2);
+      sum_b3 = fma(texel1_b3.xxzz, texel2_b3.xyxy, sum_b3);
+      sum_b3 = fma(texel1_b3.yyww, texel2_b3.zwzw, sum_b3);
+      sum_b4 = fma(texel1_b4.xxzz, texel2_b4.xyxy, sum_b4);
+      sum_b4 = fma(texel1_b4.yyww, texel2_b4.zwzw, sum_b4);
+    }
+
+    const vec4 outx = vec4(sum_b1.x, sum_b2.x, sum_b3.x, sum_b4.x);
+
+    const ivec3 posy = ivec3(posx.x + 1, posx.y, pos.z);
+    const vec4 outy = vec4(sum_b1.y, sum_b2.y, sum_b3.y, sum_b4.y);
+
+    const ivec3 posz = ivec3(posx.x, posx.y + 1, pos.z);
+    const vec4 outz = vec4(sum_b1.z, sum_b2.z, sum_b3.z, sum_b4.z);
+
+    const ivec3 posw = ivec3(posx.x + 1, posx.y + 1, pos.z);
+    const vec4 outw = vec4(sum_b1.w, sum_b2.w, sum_b3.w, sum_b4.w);
+
+    imageStore(uOutput, posx, outx);
+    if (all(lessThan(posy, uBlock.size.xyz))) {
+      imageStore(uOutput, posy, outy);
+    }
+    if (all(lessThan(posz, uBlock.size.xyz))) {
+      imageStore(uOutput, posz, outz);
+    }
+    if (all(lessThan(posw, uBlock.size.xyz))) {
+      imageStore(uOutput, posw, outw);
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -48,6 +48,13 @@ struct Layout final {
     static constexpr size_t height = 0u;
     static constexpr size_t width = 1u;
   };
+
+  // Parameters (Pooling Kernels, Dilation, Padding, Stride, etc.)
+  struct BatchMatrices final {
+    static constexpr size_t batch = 0u;
+    static constexpr size_t height = 1u;
+    static constexpr size_t width = 2u;
+  };
 };
 
 /*

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -17,7 +17,10 @@ class LinearPackedContext final : virtual public VulkanPackedContext,
   c10::impl::GenericList unpacked_;
 
  public:
-  LinearPackedContext(const Tensor& weight, const c10::optional<Tensor>& bias);
+  LinearPackedContext(
+      const Tensor& weight,
+      const c10::optional<Tensor>& bias,
+      const bool use_batch = false);
 
   /*
    * Assigns a name to each index in the unpacked list.

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/vulkan/ops/Convolution.h>
 #include <c10/util/irange.h>
 
+
 // TODO: These functions should move to a common place.
 
 namespace {
@@ -863,6 +864,55 @@ TEST_F(VulkanAPITest, batch_norm_large) {
   }
 
   ASSERT_TRUE(check);
+}
+
+void test_bmm(at::Tensor m1_cpu, at::Tensor m2_cpu) {
+  const auto out_cpu = m1_cpu.bmm(m2_cpu);
+
+  const auto m1_vulkan = m1_cpu.vulkan();
+  const auto out_vulkan = m1_vulkan.bmm(m2_cpu);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+
+}
+
+TEST_F(VulkanAPITest, bmm) {
+  const auto m1_cpu =
+      at::rand({131, 235, 546}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m2_cpu =
+      at::rand({131, 546, 267}, at::device(at::kCPU).dtype(at::kFloat));
+  test_bmm(m1_cpu, m2_cpu);
+}
+
+TEST_F(VulkanAPITest, bmm_small) {
+  const auto m1_cpu =
+      at::rand({2, 6, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m2_cpu =
+      at::rand({2, 5, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  test_bmm(m1_cpu, m2_cpu);
+}
+
+TEST_F(VulkanAPITest, bmm_one) {
+  const auto m1_cpu =
+      at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m2_cpu =
+      at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  test_bmm(m1_cpu, m2_cpu);
+}
+
+TEST_F(VulkanAPITest, bmm_error) {
+  // mismatched dimensions of batch sizes.
+  const auto m1_cpu =
+      at::rand({100, 235, 546}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m2_cpu =
+      at::rand({200, 546, 267}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m1_vulkan = m1_cpu.vulkan();
+  EXPECT_THROW(m1_vulkan.bmm(m2_cpu), ::c10::Error);
 }
 
 TEST_F(VulkanAPITest, clamp) {


### PR DESCRIPTION
Summary:
BMM is developed on top of MM methodology, the main difference is the 1st input matrix changed from a standard Vulkan 2D tensor to a Vulkan 3D tenser, so the indexing changed quite differently. The matrices of a batch are appended on z-dimension and the channel of size 4 (texel).

The 2nd input matrix remains the same as a packed format (fit a `H*W` matrix into a `H/2 * W/2 * 1` 3D image texture by utilizing all 4 values in the texel), but appends more matrices in the batch on z-dimension (only has 1 element in the case of MM).

**Vulkan 2D Basic (1st input of MM & output):**
```
ivec3 pos(j, i, 0);
float v = texelFetch(uInput, pos, 0)[0];
# no batch
```


**Vulkan 3D Basic (1st input of BMM & output):**
```
ivec3 pos(k, j, i/4);
float v = texelFetch(uInput, pos, 0)[i % 4];
# i as batch id
```


**Packed weights (2nd input of MM):**
```
ivec3 pos(k_, j_, 0);
float v = texelFetch(uInput, pos, 0)
# v.xyzw are 4 numbers in one matrix
# no batch
# k_, j_ has only 1/4 of the range as the original matrix size (H*W matrix i=> H/2*W/2*1 3D Image).
```


**Packed weights (2nd input of BMM):**
```
ivec3 pos(k_, j_, i);
float v = texelFetch(uInput, pos, 0)
# v.xyzw are 4 numbers in one matrix
# i as batch id
```


Based on the different indexing of MM & BMM. I modified the MM methodology to produce the desired output image.

Test Plan:
```
[ttingchulin@27298.od /data/sandcastle/boxes/fbsource (bmm)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*<test>*" eg.  -- --gtest_filter="*mm*"
Building: finished in 0.1 sec (100%) 328/3361 jobs, 0/3361 updated
  Total time: 0.1 sec
BUILD SUCCEEDED
Running main() from xplat/third-party/gmock/googletest-1.12.1/googletest/src/gtest_main.cc
Note: Google Test filter = *mm*
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.addmm
[       OK ] VulkanAPITest.addmm (125 ms)
[ RUN      ] VulkanAPITest.addmm_expand
[       OK ] VulkanAPITest.addmm_expand (76 ms)
[ RUN      ] VulkanAPITest.addmm_expand2
[       OK ] VulkanAPITest.addmm_expand2 (0 ms)
[ RUN      ] VulkanAPITest.bmm
[       OK ] VulkanAPITest.bmm (152 ms)
[ RUN      ] VulkanAPITest.bmm_large
[       OK ] VulkanAPITest.bmm_large (4818 ms)
[ RUN      ] VulkanAPITest.bmm_small
[       OK ] VulkanAPITest.bmm_small (4 ms)
[ RUN      ] VulkanAPITest.bmm_one
[       OK ] VulkanAPITest.bmm_one (0 ms)
[ RUN      ] VulkanAPITest.mm
[       OK ] VulkanAPITest.mm (55 ms)
[----------] 8 tests from VulkanAPITest (5233 ms total)


[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (5233 ms total)
[  PASSED  ] 8 tests.

```

Differential Revision: D49306279


