### PR TITLE
Fix registering jit decompositions for jvp for out wrapped decomps

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -96,6 +96,8 @@ def _convert_out_params(f):
         for o in out_params:
             _fn.__annotations__[o.name] = o.annotation
 
+        # Propagate that this function is wrapped by `out_wrapper`
+        _fn._torch_decompositions_out_wrapper = f._torch_decompositions_out_wrapper  # type: ignore[attr-defined]
         fn = _fn
 
     return fn

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 import torch
 import torch._decomp
 from torch import Tensor
+from torch._prims_common.wrappers import _maybe_remove_out_wrapper
 
 decomposition_table = torch._decomp.decomposition_table
 decomposition_table_for_jvp: Dict[torch._ops.OperatorBase, Callable] = {}
@@ -62,6 +63,12 @@ def _register_jit_decomposition_for_jvp(decomp, use_python=False):
     else:
         raise RuntimeError(f"could not find decomposition for {decomp}")
     decomp_fn = decomposition_table_used[decomp]
+
+    # `out_wrapper` extends a decompositions signature with
+    # an `out` parameter. However jit will use the unwrapped function's
+    # signature instead so we need to unwrap here to prevent an error
+    decomp_fn = _maybe_remove_out_wrapper(decomp_fn)
+
     if use_python:
         decomp_fn = torch.jit.ignore(decomp_fn)
         sig = inspect.signature(decomp_fn)

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -285,9 +285,22 @@ def out_wrapper(*out_names: str, exact_dtype: bool = False):
         _fn.__annotations__ = fn.__annotations__
         _fn.__annotations__["out"] = out_type
         _fn.__annotations__["return"] = return_type
+
+        # Add an indicator attribute that can be used in special cases
+        # where having a function wrapped by `out_wrapper` is not desirable e.g.
+        # jit
+        _fn._torch_decompositions_out_wrapper = f"This function is wrapped by {out_wrapper.__module__}.out_wrapper"  # type: ignore[attr-defined]
+
         return _fn
 
     return _out_wrapper
+
+
+def _maybe_remove_out_wrapper(fn: Callable):
+    return inspect.unwrap(
+        fn,
+        stop=lambda f: not hasattr(f, "_torch_decompositions_out_wrapper"),
+    )
 
 
 def backwards_not_supported(prim):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5543,6 +5543,7 @@ def norm(
 
 
 @register_decomposition(aten.trace)
+@out_wrapper()
 def trace(self: TensorLikeType) -> TensorLikeType:
     torch._check(
         self.ndim == 2, lambda: "expected a matrix, but got tensor with dim {self.ndim}"


### PR DESCRIPTION
Python decompositions wrapped by `out_wrapper` need to be unwrapped before compiling with TorchScript since:
- `out_wrapper` extends the decompositions signature with an out parameter, however this `out` parameter is not present in the source code of the original decomposition so the resulting `ScriptFunction` will not have an `out` parameter
- `out_wrapper` is in the `torch._prims_common.wrappers` module so its `globals()` are different to the globals of the decomposition to be wrapped. This may cause symbol resolution to fail with the TorchScript compiler since it is compiling the unwrapped decomps source code rather than the wrapper

The python decomposition for `aten.trace` is wrapped as an example, other decompositions are to be fixed in https://github.com/pytorch/pytorch/pull/107707