### PR TITLE
Add TORCH_CHECK_ALWAYS_SHOW_CPP_STACKTRACE

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -590,8 +590,7 @@ bool TensorImpl::has_storage() const {
 #endif
 
 void TensorImpl::throw_cannot_call_with_symbolic(const char* meth) const {
-  // TODO: force backtrace to be printed on this error
-  TORCH_CHECK(
+  TORCH_CHECK_ALWAYS_SHOW_CPP_STACKTRACE(
       false, "Cannot call ", meth, "() on tensor with symbolic sizes/strides");
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109373
* #109372

Unlike TORCH_CHECK, these always show C++ stacktrace on error.  Put it
on errors where you frequently seem to need this information.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>