### PR TITLE
Add support for tolist on AsyncCollectiveTensor

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -516,6 +516,8 @@ class TestOpWaitiness(MultiThreadedTestCase):
         foo.trigger_wait()
         self.assertEqual(0, ft_c_impl._outstanding_wait_count())
 
+        self.assertEqual(foo.tolist(), [[1.0, 1.0], [1.0, 1.0]])
+
     def test_dead_wrapper_triggers_wait(self):
         self.assertEqual(0, ft_c_impl._outstanding_wait_count())
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -332,6 +332,10 @@ class AsyncCollectiveTensor(torch.Tensor):
     def __tensor_flatten__(self):
         return ["elem"], None
 
+    def tolist(self):
+        wait_tensor(self.elem)
+        return self.elem.tolist()
+
     @staticmethod
     def __tensor_unflatten__(inner_tensors, meta):
         assert meta is None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109377

This has to be done by hand because tolist isn't supported on tensor subclasses.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>