### PR TITLE
[not for land] Cherry-pick of "Trace through `pytree` API with dynamo."

### DIFF
--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -46,6 +46,7 @@ from .misc import (
     PythonModuleVariable,
     SuperVariable,
     UnknownVariable,
+    TreeSpecVariable,
 )
 from .nn_module import NNModuleVariable, UnspecializedNNModuleVariable
 from .tensor import (

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -21,7 +21,7 @@ from ..exc import (
 )
 from ..guards import GuardBuilder
 from ..replay_record import DummyModule
-from ..source import AttrSource, is_constant_source, SuperSource, TypeSource
+from ..source import AttrSource, GetItemSource, is_constant_source, SuperSource, TypeSource
 from ..utils import (
     build_checkpoint_variable,
     check_constant_args,
@@ -1106,6 +1106,24 @@ class BuiltinVariable(VariableTracker):
                 unimplemented("tensor grad")
             else:
                 unimplemented("tensor grad")
+        elif name == "__bases__" and (
+                (
+                    isinstance(obj, variables.BuiltinVariable)
+                    and obj.python_type() is type
+                )
+                or isinstance(obj, variables.UserDefinedClassVariable)
+        ):
+            value = obj.as_python_constant()
+            bases = value.__bases__
+            if source is None:
+                assert len(bases) == 1 and bases[0] is object
+                tuple_args = [BuiltinVariable(object)]
+            else:
+                tuple_args = [
+                    VariableBuilder(tx, GetItemSource(source, i))(b)
+                    for i, b in enumerate(bases)
+                ]
+            return variables.TupleVariable(tuple_args, **options)
         elif isinstance(
             obj,
             (
@@ -1306,6 +1324,11 @@ class BuiltinVariable(VariableTracker):
             mod = tx.output.get_submodule(nn_mod_variable.module_key)
             return variables.ConstantVariable(id(mod))
         else:
+            try:
+                value = args[0].as_python_constant()
+                return variables.ConstantVariable(id(value))
+            except:
+                pass
             unimplemented(f"call_id with args {args}")
 
     def _comparison(self, tx, left, right):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -15,12 +15,12 @@ import torch._C
 import torch.fx
 import torch.nn
 import torch.onnx.operators
-from torch._dynamo.variables import UserFunctionVariable
+from torch._dynamo.variables import TreeSpecVariable, UserFunctionVariable
 
 from .. import config, variables
 from ..allowed_functions import torch_get_name
 from ..exc import unimplemented
-from ..source import GeneratorStateSource
+from ..source import AttrSource, GeneratorStateSource
 from ..utils import (
     check_constant_args,
     check_unspec_python_args,
@@ -601,68 +601,77 @@ class TorchVariable(VariableTracker):
             return UserFunctionVariable(
                 torch.nn.init._calculate_correct_fan, **options
             ).call_function(tx, args, {})
-        elif self.value == torch.utils._pytree.tree_flatten:
-            if len(args) != 1:
-                unimplemented("Unsupported flatten with len(args) != 1")
+        elif self.value.__module__ == "torch.utils._pytree":
+            if isinstance(self.value, types.FunctionType):
+                return tx.inline_user_function_return(
+                    variables.UserFunctionVariable(self.value, **options),
+                    args,
+                    kwargs,
+                )
+            else:
+                return TreeSpecVariable.create(self.value, args, options)
+        # elif self.value == torch.utils._pytree.tree_flatten:
+        #     if len(args) != 1:
+        #         unimplemented("Unsupported flatten with len(args) != 1")
 
-            flattened, spec = torch.utils._pytree.tree_flatten(args[0])
-            return TupleVariable(
-                [ListVariable(flattened), ConstantVariable(spec)], **options
-            )
-        elif self.value == torch.utils._pytree.tree_unflatten:
-            if len(args) != 2:
-                unimplemented("Unsupported unflatten with len(args) != 2")
+        #     flattened, spec = torch.utils._pytree.tree_flatten(args[0])
+        #     return TupleVariable(
+        #         [ListVariable(flattened), ConstantVariable(spec)], **options
+        #     )
+        # elif self.value == torch.utils._pytree.tree_unflatten:
+        #     if len(args) != 2:
+        #         unimplemented("Unsupported unflatten with len(args) != 2")
 
-            unflattened = torch.utils._pytree.tree_unflatten(args[0], args[1].value)
+        #     unflattened = torch.utils._pytree.tree_unflatten(args[0], args[1].value)
 
-            def _wrap_in_dynamo_variables(container):
-                if isinstance(container, VariableTracker):
-                    return container
+        #     def _wrap_in_dynamo_variables(container):
+        #         if isinstance(container, VariableTracker):
+        #             return container
 
-                if isinstance(container, list):
-                    return ListVariable(
-                        [_wrap_in_dynamo_variables(elem) for elem in container],
-                        **options,
-                    )
+        #         if isinstance(container, list):
+        #             return ListVariable(
+        #                 [_wrap_in_dynamo_variables(elem) for elem in container],
+        #                 **options,
+        #             )
 
-                if isinstance(container, tuple):
-                    return TupleVariable(
-                        [_wrap_in_dynamo_variables(elem) for elem in container],
-                        **options,
-                    )
+        #         if isinstance(container, tuple):
+        #             return TupleVariable(
+        #                 [_wrap_in_dynamo_variables(elem) for elem in container],
+        #                 **options,
+        #             )
 
-                if isinstance(container, dict):
-                    return ConstDictVariable(
-                        {k: _wrap_in_dynamo_variables(v) for k, v in container.items()},
-                        type(container),
-                        **options,
-                    )
+        #         if isinstance(container, dict):
+        #             return ConstDictVariable(
+        #                 {k: _wrap_in_dynamo_variables(v) for k, v in container.items()},
+        #                 type(container),
+        #                 **options,
+        #             )
 
-            return _wrap_in_dynamo_variables(unflattened)
+        #     return _wrap_in_dynamo_variables(unflattened)
 
-        elif self.value == torch.fx._pytree.tree_flatten_spec:
-            if len(args) != 2:
-                unimplemented("Unsupported flatten_spec with len(args) != 2")
+        # elif self.value == torch.fx._pytree.tree_flatten_spec:
+        #     if len(args) != 2:
+        #         unimplemented("Unsupported flatten_spec with len(args) != 2")
 
-            flattened, spec = torch.fx._pytree.tree_flatten_spec(args[0], args[1].value)
-            return TupleVariable(
-                [ListVariable(flattened), ConstantVariable(spec)], **options
-            )
-        elif self.value == torch.utils._pytree.tree_map_only:
-            if len(args) != 3:
-                unimplemented("Unsupported tree_map_only with len(args) != 3")
+        #     flattened, spec = torch.fx._pytree.tree_flatten_spec(args[0], args[1].value)
+        #     return TupleVariable(
+        #         [ListVariable(flattened), ConstantVariable(spec)], **options
+        #     )
+        # elif self.value == torch.utils._pytree.tree_map_only:
+        #     if len(args) != 3:
+        #         unimplemented("Unsupported tree_map_only with len(args) != 3")
 
-            ty = args[0].value  # type
-            fn = args[1]  # map fn
-            tree = args[2]  # tree
+        #     ty = args[0].value  # type
+        #     fn = args[1]  # map fn
+        #     tree = args[2]  # tree
 
-            def map_fn(v):
-                if ty == v.python_type():
-                    return fn.call_function(tx, [v], {})
-                else:
-                    return v
+        #     def map_fn(v):
+        #         if ty == v.python_type():
+        #             return fn.call_function(tx, [v], {})
+        #         else:
+        #             return v
 
-            return torch.utils._pytree.tree_map(map_fn, tree)
+        #     return torch.utils._pytree.tree_map(map_fn, tree)
         elif self.value is torch.nn.utils.rnn.pack_padded_sequence:
             unimplemented("workaround https://github.com/pytorch/pytorch/issues/93501")
         elif isinstance(self.value, types.ModuleType):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -212,6 +212,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             inner = str(getattr(self.value, "__name__", None))
         return f"{self.__class__.__name__}({inner})"
 
+    def as_python_constant(self):
+        return self.value
+
     def python_type(self):
         return self.value_type
 


### PR DESCRIPTION
Fix: #107315

This PR enables dynamo to trace through the `pytree` API by inlining its functions. In
order to do so, a few details of `pytree` had to be changed.

In summary, this PR:

- Introduces `TreeSpecVariable` for representing `TreeSpec` instances
- Specializes `<type>.__bases__` call, returning a `TupleVariable`
- Enables the call to `id` builtin function for every variable that implements
  `as_python_constant` method
- Specializes `ConstantVariable.call_method` for its (un)flatten functions
- Implements `UserDefinedObjectVariable.as_python_constant`
- Modifies `pytree` by:
    - Make `SUPPORTED_NODES` a map of ids (instead of types) to `NodeDef`
    - Removed `functools.wraps` function, since it can't be inlined

[ghstack-poisoned]

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng