### PR TITLE
[exir] Add lift constant tensors passes after aten_to_edge

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -228,6 +228,7 @@ class ExportedProgram:
         equality_constraints: List[Tuple[Any, Any]],
         module_call_graph: List[ModuleCallEntry],
         example_inputs: Optional[Tuple[Tuple[Any, ...], Dict[str, Any]]] = None,
+        dialect: Optional[str] = None,
     ):
         from torch._export.exported_program import (
             _create_graph_module_for_export,
@@ -253,6 +254,7 @@ class ExportedProgram:
         ] = equality_constraints
         self._module_call_graph: List[ModuleCallEntry] = module_call_graph
         self._example_inputs = example_inputs
+        self._dialect = dialect or "ATEN"
 
     @property
     @compatibility(is_backward_compatible=False)
@@ -332,6 +334,10 @@ class ExportedProgram:
     @compatibility(is_backward_compatible=False)
     def example_inputs(self):
         return self._example_inputs
+
+    @property
+    def dialect(self):
+        return self._dialect
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         import torch._export.error as error
@@ -518,6 +524,7 @@ class ExportedProgram:
             copy.deepcopy(self.equality_constraints),
             copy.deepcopy(self._module_call_graph),
             self.example_inputs,
+            self.dialect,
         )
         transformed_ep.graph_module.meta.update(self.graph_module.meta)
         transformed_ep.graph_module.meta.update(res.graph_module.meta)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/359

When exporting using enable_aot (through the torch.export path), we want to lift all constant tensors as buffers to the exported program. The ScalarToTensor pass in EXIR's aten_to_edge passes will create some constant tensors in the graph, so we will need to run a lift_constant_tensors pass afterwards.

Note that this only needs to be applied when exporting using the torch.export path because in the original path, nothing is lifted.

Test Plan: CI

Differential Revision: D49207492


