### PR TITLE
Fix `ConstantVariable` init method if NumPy is missing

### DIFF
--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -33,7 +33,7 @@ class ConstantVariable(VariableTracker):
             for disallowed_type, reason in _type_to_assert_reason.items():
                 assert not isinstance(value, disallowed_type), reason
 
-        if isinstance(value, np.number):
+        if np is not None and isinstance(value, np.number):
             self.value = value.item()
         else:
             self.value = value


### PR DESCRIPTION
By adding `np is not None` check before `isinstance(value, np.number)`

Partially addresses https://github.com/pytorch/pytorch/issues/109387



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng