### PR TITLE
[inductor] Add a C shim layer for libtorch

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -500,6 +500,7 @@ lazy_tensor_core_python_sources = [
 ]
 
 inductor_core_resources = [
+    "torch/csrc/inductor/aoti_torch/shim_common.cpp",
     "torch/csrc/inductor/inductor_ops.cpp",
 ]
 
@@ -683,6 +684,7 @@ libtorch_cuda_core_sources = [
     "torch/csrc/CudaIPCTypes.cpp",
     "torch/csrc/cuda/comm.cpp",
     "torch/csrc/cuda/memory_snapshot.cpp",
+    "torch/csrc/inductor/aoti_torch/shim_cuda.cpp",
     "torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp",
     "torch/csrc/profiler/stubs/cuda.cpp",
     "torch/csrc/autograd/functions/comm.cpp",

--- a/setup.py
+++ b/setup.py
@@ -1293,6 +1293,7 @@ def main():
         "include/torch/csrc/dynamo/*.h",
         "include/torch/csrc/inductor/*.h",
         "include/torch/csrc/inductor/aot_runtime/*.h",
+        "include/torch/csrc/inductor/aoti_torch/c/*.h",
         "include/torch/csrc/jit/*.h",
         "include/torch/csrc/jit/backends/*.h",
         "include/torch/csrc/jit/generated/*.h",

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -834,6 +834,12 @@ def get_include_and_linking_paths(
                 )
             else:
                 macros = f"-D{macros}"
+
+        if aot_mode and cuda:
+            if macros is None:
+                macros = ""
+            macros += " -D USE_CUDA"
+
         if cuda:
             if config.is_fbcode():
                 libs += ["cuda"]

--- a/torch/_inductor/codegen/aot_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aot_runtime/interface.cpp
@@ -1,8 +1,9 @@
 #include <torch/csrc/inductor/aot_runtime/interface.h>
 #include <torch/csrc/inductor/aot_runtime/model_container.h>
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <iostream>
 #include <torch/csrc/inductor/aot_runtime/proxy_executor.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+
+#include <iostream>
 #include <stdexcept>
 #include <vector>
 
@@ -53,7 +54,7 @@ AOTInductorError AOTInductorModelContainerDelete(
 
 AOTInductorError AOTInductorModelContainerRun(
     AOTInductorModelContainerHandle container_handle,
-    const AOTInductorTensorHandle inputs_handle,
+    AOTInductorTensorHandle inputs_handle,
     size_t num_inputs,
     AOTInductorTensorHandle outputs_handle,
     size_t num_outputs,
@@ -64,7 +65,7 @@ AOTInductorError AOTInductorModelContainerRun(
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
 
-  const auto* inputs = reinterpret_cast<const at::Tensor*>(inputs_handle);
+  auto* inputs = reinterpret_cast<at::Tensor*>(inputs_handle);
   std::vector<at::Tensor> input_tensors;
   input_tensors.reserve(num_inputs);
   for (size_t i = 0; i < num_inputs; i++) {

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -433,6 +433,9 @@ class aot_inductor:
     # If not specified, a temp directory will be created under the default caching path
     output_path = ""
 
+    # Wether to codegen abi compatible model.so
+    abi_compatible = is_fbcode()
+
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/csrc/inductor/aot_runtime/interface.h
+++ b/torch/csrc/inductor/aot_runtime/interface.h
@@ -64,7 +64,7 @@ AOTInductorError AOTInductorModelContainerDelete(
 // Runs the inference.
 AOTInductorError AOTInductorModelContainerRun(
     AOTInductorModelContainerHandle container_handle,
-    const AOTInductorTensorHandle inputs_handle,
+    AOTInductorTensorHandle inputs_handle,
     size_t num_inputs,
     AOTInductorTensorHandle outputs_handle,
     size_t num_outputs,

--- a/torch/csrc/inductor/aot_runtime/model_container.h
+++ b/torch/csrc/inductor/aot_runtime/model_container.h
@@ -144,7 +144,7 @@ class AOTInductorModelContainer {
   }
 
   void run(
-      const std::vector<at::Tensor>& inputs,
+      std::vector<at::Tensor>& inputs,
       std::vector<at::Tensor>& outputs,
       std::vector<std::vector<int64_t>>** output_shapes,
       cudaStream_t stream,

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -1,0 +1,177 @@
+#ifndef AOTI_TORCH_SHIM
+#define AOTI_TORCH_SHIM
+
+#include <stddef.h>
+#include <stdint.h>
+
+// This header defines a stable C API for certain ATen functionality in
+// libtorch. The AOTInductor compiled model.so will only refer to this header
+// instead of other headers from aten/c10, which means it will NOT be able to
+// directly use any data structures or call functions from libtorch.
+//
+// What problems are we trying to solve here?  Direct use of aten/c10 APIs
+// means use of C++ APIs on a library that doesn't have any ABI compatibility
+// guarantees.  However, we want model.so to remain usable across updates
+// to the PyTorch C++ libraries, which requires a stable ABI.  By introducing
+// a C shim layer, we can minimize the surface that will cause breakage. The
+// corresponding software stack can be illustrated as follows:
+//
+// |--------------------------------|
+// |     inference service code     |
+// |--------------------------------|
+// |           model.so             |
+// |--------------|-----------------|
+// |           <c shim>             |
+// |          libtorch.so           |
+// |--------------------------------|
+//
+// The general guidelines for the C API:
+//
+//  - No exceptions, return an explicit error code to be checked at call site
+//  - Only pointers (AtenTensorHandle counts), integers and floats in headers
+//
+// If you want to make changes to this header, you MUST MAINTAIN ABI
+// compatibility.  Typically, this means you will have to add a _v2 version
+// of a function that you, e.g., want to add a new function parameter to, and
+// maintain the old and new versions of the APIs until all old model.so
+// go out of use.
+
+#ifdef __GNUC__
+#define AOTI_TORCH_EXPORT __attribute__((__visibility__("default")))
+#else // !__GNUC__
+#ifdef _WIN32
+#define AOTI_TORCH_EXPORT __declspec(dllexport)
+#else // !_WIN32
+#define AOTI_TORCH_EXPORT
+#endif // _WIN32
+#endif // __GNUC__
+
+#ifdef __GNUC__
+#define AOTI_TORCH_NOINLINE __attribute__((noinline))
+#elif _MSC_VER
+#define AOTI_TORCH_NOINLINE __declspec(noinline)
+#else
+#define AOTI_TORCH_NOINLINE
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// AtenTensorHandle represents an abstract notion of Tensor that can be passed
+// between model.so and libtorch.so.  The contents of the structure itself
+// are private; model.so is not allowed to access any fields directly, it must
+// go through functions defined in this ABI.  Under the hood, this is
+// represented as at::Tensor*, but we reserve the right to change this (and in
+// fact, we probably should change it to at::TensorImpl* at least).
+//
+// An AtenTensorHandle can be owning (please check the API reference for exact
+// ownership/borrow semantics).  If you have an owning AtenTensorHandle
+// in model.so, you are obligated to aoti_torch_delete_tensor_object when you
+// are done.  You can use the helper C++ class RAIIAtenTensorHandle
+// (see aot_runtime/model.h) to ensure the deallocator is called in RAII style
+// (note that RAIIAtenTensorHandle is private to model.so, and never crosses
+// the ABI boundary.)
+struct AtenTensorOpaque;
+using AtenTensorHandle = AtenTensorOpaque*;
+
+using AOTITorchError = int32_t;
+#define AOTI_TORCH_SUCCESS 0
+#define AOTI_TORCH_FAILURE 1
+
+// Getter functions for retrieving various constants from the runtime, that
+// can subsequently be passed to other aoti_* functions.  By hiding these
+// behind functions, the precise value of device/dtype is NOT part of the
+// ABI contract.  (In practice, aten/c10 is pretty good about not renumbering
+// these, so we probably could later switch to having these in the ABI, if
+// desired for perf reasons.)
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_device_type_cpu();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_device_type_cuda();
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_bfloat16();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_float16();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_float32();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_float64();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_uint8();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_int8();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_int16();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_int32();
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE int32_t aoti_torch_dtype_int64();
+
+// Free the tensor object
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch_delete_tensor_object(AtenTensorHandle tensor);
+
+// Get a pointer to the underlying storage data
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_get_data_ptr(
+    void** ret, // returns borrowed reference
+    AtenTensorHandle tensor);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_get_sizes(
+    int64_t** ret, // returns borrowed reference
+    AtenTensorHandle tensor);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_get_strides(
+    int64_t** ret, // returns borrowed reference
+    AtenTensorHandle tensor);
+
+// This function will create a new tensor object and its pointer is returned
+// through *out. The caller is responsible for wrapping the tensor pointer
+// with RAIIAtenTensorHandle which will call aoti_torch_delete_tensor_object
+// when going out of scope.
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch__reinterpret_tensor(
+    AtenTensorHandle* ret, // returns new reference
+    AtenTensorHandle self,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset);
+
+// This function will create a new tensor object and its pointer is returned
+// through *out. The caller is responsible for wrapping the tensor pointer
+// with RAIIAtenTensorHandle which will call aoti_torch_delete_tensor_object
+// when going out of scope.
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_empty_strided(
+    AtenTensorHandle* ret, // returns new reference
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch_tensor_copy_(AtenTensorHandle src, AtenTensorHandle dst);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_addmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat1,
+    AtenTensorHandle mat2,
+    float beta,
+    float alpha);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_bmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_mm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2);
+
+#ifdef USE_CUDA
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch_get_current_cuda_stream(void** ret, int32_t device_index);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch_set_current_cuda_stream(void* stream, int32_t device_index);
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // AOTI_TORCH_SHIM

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1,0 +1,203 @@
+#include <c10/core/DeviceType.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/Exception.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/inductor/aoti_torch/utils.h>
+#include <torch/csrc/inductor/inductor_ops.h>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+
+#include <ATen/ops/_addmm_activation.h>
+#include <ATen/ops/addmm.h>
+#include <ATen/ops/as_strided.h>
+#include <ATen/ops/bmm.h>
+#include <ATen/ops/convolution.h>
+#include <ATen/ops/empty_strided.h>
+#include <ATen/ops/from_blob.h>
+#include <ATen/ops/mm.h>
+
+#endif
+
+namespace {
+at::Tensor* tensor_handle_to_tensor_pointer(AtenTensorHandle handle) {
+  return reinterpret_cast<at::Tensor*>(handle);
+}
+
+AtenTensorHandle tensor_pointer_to_tensor_handle(at::Tensor* tensor) {
+  return reinterpret_cast<AtenTensorHandle>(tensor);
+}
+} // namespace
+
+int32_t aoti_torch_device_type_cpu() {
+  return (int32_t)c10::DeviceType::CPU;
+}
+
+int32_t aoti_torch_device_type_cuda() {
+  return (int32_t)c10::DeviceType::CUDA;
+}
+
+int32_t aoti_torch_dtype_bfloat16() {
+  return (int32_t)c10::ScalarType::BFloat16;
+}
+
+int32_t aoti_torch_dtype_float16() {
+  return (int32_t)c10::ScalarType::Half;
+}
+
+int32_t aoti_torch_dtype_float32() {
+  return (int32_t)c10::ScalarType::Float;
+}
+
+int32_t aoti_torch_dtype_float64() {
+  return (int32_t)c10::ScalarType::Double;
+}
+
+int32_t aoti_torch_dtype_uint8() {
+  return (int32_t)c10::ScalarType::Byte;
+}
+
+int32_t aoti_torch_dtype_int8() {
+  return (int32_t)c10::ScalarType::Char;
+}
+
+int32_t aoti_torch_dtype_int16() {
+  return (int32_t)c10::ScalarType::Short;
+}
+
+int32_t aoti_torch_dtype_int32() {
+  return (int32_t)c10::ScalarType::Int;
+}
+
+int32_t aoti_torch_dtype_int64() {
+  return (int32_t)c10::ScalarType::Long;
+}
+
+AOTITorchError aoti_torch_delete_tensor_object(AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+    delete t;
+  });
+}
+
+AOTITorchError aoti_torch_get_data_ptr(void** ret, AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+    *ret = t->data_ptr();
+  });
+}
+
+AOTITorchError aoti_torch_get_sizes(int64_t** ret, AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+    *ret = const_cast<int64_t*>(t->sizes().data());
+  });
+}
+
+AOTITorchError aoti_torch_get_strides(int64_t** ret, AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
+    *ret = const_cast<int64_t*>(t->strides().data());
+  });
+}
+
+AOTITorchError aoti_torch__reinterpret_tensor(
+    AtenTensorHandle* ret,
+    AtenTensorHandle self,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t offset_increment) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    c10::IntArrayRef sizes(sizes_ptr, ndim);
+    c10::IntArrayRef strides(strides_ptr, ndim);
+    at::Tensor* out_tensor =
+        new at::Tensor(torch::inductor::_reinterpret_tensor(
+            *self_tensor, sizes, strides, offset_increment));
+    *ret = tensor_pointer_to_tensor_handle(out_tensor);
+  });
+}
+
+// TODO: implement a more efficient version instead of calling into aten
+AOTITorchError aoti_torch_empty_strided(
+    AtenTensorHandle* ret,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    c10::IntArrayRef sizes(sizes_ptr, ndim);
+    c10::IntArrayRef strides(strides_ptr, ndim);
+    c10::Device device{
+        static_cast<c10::DeviceType>(device_type),
+        static_cast<c10::DeviceIndex>(device_index)};
+    c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
+        static_cast<c10::ScalarType>(dtype));
+    at::Tensor* out_tensor =
+        new at::Tensor(at::empty_strided(sizes, strides, options));
+    *ret = tensor_pointer_to_tensor_handle(out_tensor);
+  });
+}
+
+// TODO: implement a more efficient version instead of calling into aten
+AOTITorchError aoti_torch_tensor_copy_(
+    AtenTensorHandle src,
+    AtenTensorHandle dst) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* src_tensor = tensor_handle_to_tensor_pointer(src);
+    at::Tensor* dst_tensor = tensor_handle_to_tensor_pointer(dst);
+    dst_tensor->copy_(*src_tensor);
+  });
+}
+
+// TODO: implement a more efficient version instead of calling into aten
+AOTITorchError aoti_torch_addmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat1,
+    AtenTensorHandle mat2,
+    float beta,
+    float alpha) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    at::Tensor* mat1_tensor = tensor_handle_to_tensor_pointer(mat1);
+    at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
+    at::addmm_out(
+        *out_tensor, *self_tensor, *mat1_tensor, *mat2_tensor, beta, alpha);
+  });
+}
+
+// TODO: implement a more efficient version instead of calling into aten
+AOTITorchError aoti_torch_bmm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
+    at::bmm_out(*out_tensor, *self_tensor, *mat2_tensor);
+  });
+}
+
+// TODO: implement a more efficient version instead of calling into aten
+AOTITorchError aoti_torch_mm_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    AtenTensorHandle mat2) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
+    at::mm_out(*out_tensor, *self_tensor, *mat2_tensor);
+  });
+}

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -1,0 +1,24 @@
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/inductor/aoti_torch/utils.h>
+
+#include <c10/cuda/CUDAStream.h>
+
+AOTITorchError aoti_torch_get_current_cuda_stream(
+    void** ret,
+    int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    cudaStream_t cuda_stream = c10::cuda::getCurrentCUDAStream(device_index);
+    *ret = reinterpret_cast<void*>(cuda_stream);
+  });
+}
+
+AOTITorchError aoti_torch_set_current_cuda_stream(
+    void* stream,
+    int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    c10::cuda::setCurrentCUDAStream(
+        at::cuda::getStreamFromExternal(cuda_stream, device_index));
+  });
+}

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <c10/util/Logging.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+#define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(...)    \
+  try {                                                    \
+    __VA_ARGS__                                            \
+  } catch (const std::exception& e) {                      \
+    LOG(ERROR) << "Exception in aoti_torch: " << e.what(); \
+    return AOTI_TORCH_FAILURE;                             \
+  } catch (...) {                                          \
+    LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";      \
+    return AOTI_TORCH_FAILURE;                             \
+  }                                                        \
+  return AOTI_TORCH_SUCCESS;


### PR DESCRIPTION
Summary:
This PR adds a limited C shim layer for libtorch. The ultimate goal is to ban any direct reference to aten/c10 data structures or functions, to avoid ABI breakage by providing stable C interfaces.

To make the review and landing easier, we broke the changes into several steps. In this PR (a combination of https://github.com/pytorch/pytorch/pull/109022 and https://github.com/pytorch/pytorch/pull/109351), we add C interfaces for certain libtorch functions and modify the wrapper codegen to generate calls to those interfaces. There are a few other items to be addressed in future PRs:

* The AOTInductor runtime interface still takes lists of aten tensors as input and output
* The interaction with ProxyExecutor (general fallback support) needs to move away from aten tensor
* Remove all references to aten/c10 headers in the AOTInductor-generated code

Differential Revision: D49302669




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov