### PR TITLE
Use `torch.cumsum` instead of numpy one

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -3,8 +3,6 @@ import logging
 import operator
 from typing import Callable, List, Sequence, Tuple, Union
 
-import numpy
-
 import torch
 from torch._dynamo.utils import counters
 
@@ -454,8 +452,7 @@ class SplitCatSimplifier:
                 for user_input in user_inputs
                 if isinstance(user_input, tuple)
             }
-
-        cumulative_sizes = [0] + list(numpy.cumsum(split_sections))
+        cumulative_sizes = [0] + torch.cumsum(torch.tensor(split_sections), 0).tolist()
         split_ranges = sorted(
             [(cumulative_sizes[r[0]], cumulative_sizes[r[1] + 1]) for r in ranges]
         )
@@ -578,7 +575,7 @@ class SplitCatSimplifier:
                     for i in range(len(split_ranges))
                 ]
         # Now assign the right getitem to the right input
-        cumulative_sizes = [0] + list(numpy.cumsum(split_sections))
+        cumulative_sizes = [0] + torch.cumsum(torch.tensor(split_sections), 0).tolist()
         new_user_inputs_list = []
         for user_inputs in user_inputs_list:
             new_user_inputs = []


### PR DESCRIPTION
`s/list(numpy.cumsum(foo))/torch.cumsum(torch.tensor(foo), 0).tolist()/`

Test plan: ` python3 ../test/inductor/test_split_cat_fx_passes.py -v`

Partially addresses https://github.com/pytorch/pytorch/issues/109387




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov