### PR TITLE
Revert D49284640: Multisect successfully blamed "D49284640: [inductor][Optimus]Improve logging for group batch fusion" for test or build failures

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -12,9 +12,6 @@ from ..pattern_matcher import (
     stable_topological_sort,
 )
 
-if config.is_fbcode():
-    from torch._inductor.fb.utils import get_everpaste_url
-
 try:
     # importing this will register fbgemm lowerings for inductor
     import deeplearning.fbgemm.fbgemm_gpu.fb.inductor_lowerings  # noqa: F401
@@ -557,13 +554,7 @@ def apply_group_batch_fusion(graph, rule):
                 )
 
 
-def print_graph(graph: torch.fx.Graph, msg: str):
-    if config.is_fbcode():
-        log.info("%s Print graph: %s", msg, get_everpaste_url(str(graph)))
-
-
 def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
-    print_graph(graph, "Before group_batch fusion in post grads pass.")
     fusions = []
 
     if config.group_fusion and has_fbgemm:
@@ -571,11 +562,9 @@ def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
 
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)
-        print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")
 
 
 def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
-    print_graph(graph, "Before group_batch fusion in pre grads pass.")
     fusions = []
     if config.batch_fusion:
         fusions += [
@@ -586,4 +575,3 @@ def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
         ]
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)
-        print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")


### PR DESCRIPTION
Summary:
This diff is reverting D49284640
D49284640: [inductor][Optimus]Improve logging for group batch fusion by jackiexu1992 has been identified to be causing the following test or build failures:

Tests affected:
- [aps_models/examples/dlrm/tests:deterministic_ne_test - test_determinitic_ne (aps_models.examples.dlrm.tests.deterministic_ne_test.TestDLRMDeterministicNE)](https://www.internalfb.com/intern/test/281475072657704/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3056925
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: mengluy

Differential Revision: D49338482




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel