### PR TITLE
Update caffe2 with LLVM-18 API change

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -742,7 +742,9 @@ void LLVMCodeGenImpl::emitKernel(
       PM,
       asmStream,
       nullptr,
-#if LLVM_VERSION_MAJOR >= 10
+#if LLVM_VERSION_MAJOR >= 18
+      llvm::CodeGenFileType::AssemblyFile);
+#elif LLVM_VERSION_MAJOR >= 10
       llvm::CodeGenFileType::CGFT_AssemblyFile);
 #else
       llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -101,7 +101,11 @@ static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder(
     c10::optional<std::string> attrs) {
   auto JTMB = triple ? makeJTMBFromTriple(*triple, cpu, attrs)
                      : makeJTMBFromHost(cpu, attrs);
+#if LLVM_VERSION_MAJOR >= 18
+  JTMB.setCodeGenOptLevel(llvm::CodeGenOptLevel::Default);
+#else
   JTMB.setCodeGenOptLevel(llvm::CodeGenOpt::Default);
+#endif
   JTMB.getOptions().AllowFPOpFusion = llvm::FPOpFusion::Fast;
   return JTMB;
 }


### PR DESCRIPTION
Summary: https://github.com/llvm/llvm-project/pull/66295 modified some internal LLVM APIs, update these places with the changes under LLVM version guard

Test Plan: CI

Differential Revision: D49340871




cc @EikanWang @jgong5