### PR TITLE
[lintrunner] Capture mypy internal error

### DIFF
--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -55,6 +55,18 @@ RESULTS_RE: Pattern[str] = re.compile(
     """
 )
 
+# torch/_dynamo/variables/tensor.py:363: error: INTERNAL ERROR
+INTERNAL_ERROR_RE: Pattern[str] = re.compile(
+    r"""(?mx)
+    ^
+    (?P<file>.*?):
+    (?P<line>\d+):
+    \s(?P<severity>\S+?):?
+    \s(?P<message>INTERNAL\sERROR.*)
+    $
+    """
+)
+
 
 def run_command(
     args: List[str],
@@ -131,7 +143,8 @@ def check_files(
             )
         ]
     stdout = str(proc.stdout, "utf-8").strip()
-    return [
+    stderr = str(proc.stderr, "utf-8").strip()
+    rc = [
         LintMessage(
             path=match["file"],
             name=match["code"],
@@ -146,7 +159,21 @@ def check_files(
             replacement=None,
         )
         for match in RESULTS_RE.finditer(stdout)
+    ] + [
+        LintMessage(
+            path=match["file"],
+            name="INTERNAL ERROR",
+            description=match["message"],
+            line=int(match["line"]),
+            char=None,
+            code=code,
+            severity=severities.get(match["severity"], LintSeverity.ERROR),
+            original=None,
+            replacement=None,
+        )
+        for match in INTERNAL_ERROR_RE.finditer(stderr)
     ]
+    return rc
 
 
 def main() -> None:


### PR DESCRIPTION
Mypy internal errors are reported to stderr rather than stdout and does not contain column number

This should prevent internal errors from creeping into the code and occlude other legitimate errors

Test plan: Checkout https://github.com/pytorch/pytorch/commit/5cd861fcf7e0c626315d73fb3978d3d6a286f86c apply this change and see `lintrunner` run to report internal error

Fixes https://github.com/pytorch/pytorch/issues/104940

