### PR TITLE
[dtensor] quick fix to #109306

### DIFF
--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -198,11 +198,10 @@ class OpSchema:
         if is_tensor:
             return True
 
-        is_list_like = isinstance(arg, list)
-        if not is_list_like:
+        if not isinstance(arg, list):
             return False
 
-        return all(isinstance(e, DTensorSpec) or e is None for e in self.args_schema)
+        return all(isinstance(e, DTensorSpec) or e is None for e in arg)
 
     def __hash__(self) -> int:
         # Only hash args and kwargs that op indicates to hash

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -142,7 +142,7 @@ class RuntimeSchemaInfo:
     # args/kwargs which would affect sharding propagation results. All args after this
     # index would be hashed to our sharding cache.
     # Note that only a few ops need this information, e.g. view, transpose, var.dim, etc.
-    static_argnum: int = -1
+    static_argnum: int = 100
     # This static_kwargkey records static kwarg names which would affect sharding prop
     static_kwargkey: Optional[List[str]] = None
     # TODO: make use of this field
@@ -193,20 +193,16 @@ class OpSchema:
         )
 
     def arg_type_tensor_or_tensor_list_like(self, arg_idx: int) -> bool:
-        op_arg_type = self.op._schema.arguments[arg_idx].type
-        is_tensor = isinstance(op_arg_type, torch.TensorType)
+        arg = self.args_schema[arg_idx]
+        is_tensor = isinstance(arg, DTensorSpec)
         if is_tensor:
             return True
 
-        is_list_like = isinstance(op_arg_type, torch.ListType)
+        is_list_like = isinstance(arg, list)
         if not is_list_like:
             return False
 
-        elem_type = op_arg_type.getElementType()
-        return isinstance(elem_type, torch.TensorType) or (
-            isinstance(elem_type, torch.OptionalType)
-            and isinstance(elem_type.getElementType(), torch.TensorType)
-        )
+        return all(isinstance(e, DTensorSpec) or e is None for e in self.args_schema)
 
     def __hash__(self) -> int:
         # Only hash args and kwargs that op indicates to hash


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109428

Looks like the op argument schema type check is not reliable.. for
things like aten.div.Tensor(Tensor, Tensor), the second argument can still be
a float/scalar for some reason, switch to check with the instance type
directly