### PR TITLE
[BE]: Replace undocumented constant in logging

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -10,7 +10,7 @@ from weakref import WeakSet
 
 log = logging.getLogger(__name__)
 
-DEFAULT_LOG_LEVEL = logging.WARN
+DEFAULT_LOG_LEVEL = logging.WARNING
 LOG_ENV_VAR = "TORCH_LOGS"
 
 


### PR DESCRIPTION
Replaces the undocumented alias with the proper constant WARNING
