### PR TITLE
Improve IDE Type Hinting for torch.Tensor class methods

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1289,6 +1289,14 @@ def gen_pyi(
             **env,
         },
     )
+    fm.write_with_template(
+        "torch/_tensor.pyi",
+        "torch/_C/_tensor.pyi.in",
+        lambda: {
+            "generated_comment": "@" + "generated from torch/_C/_tensor.pyi.in",
+            **env,
+        }
+    )
     gen_nn_functional(fm)
 
 

--- a/torch/_C/_tensor.pyi.in
+++ b/torch/_C/_tensor.pyi.in
@@ -1,0 +1,75 @@
+# ${generated_comment}
+
+import builtins
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Any,
+    AnyStr,
+    BinaryIO,
+    Callable,
+    ContextManager,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    overload,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+
+import torch
+from torch import Tensor
+from torch.types import (
+    _bool,
+    _complex,
+    _device,
+    _dispatchkey,
+    _dtype,
+    _float,
+    _int,
+    _layout,
+    _qscheme,
+    _size,
+    Device,
+    Number,
+    Storage,
+    SymInt,
+)
+
+class Tensor(torch._C._TensorBase):
+    requires_grad: _bool
+    retains_grad: _bool
+    shape: Size
+    data: Tensor
+    names: List[str]
+    device: _device
+    dtype: _dtype
+    layout: _layout
+    real: Tensor
+    imag: Tensor
+    T: Tensor
+    H: Tensor
+    mT: Tensor
+    mH: Tensor
+    ndim: _int
+    output_nr: _int
+    _version: _int
+    _base: Optional[Tensor]
+    _cdata: _int
+    grad_fn: Optional[_Node]
+    _grad_fn: Any
+    _grad: Optional[Tensor]
+    grad: Optional[Tensor]
+    _backward_hooks: Optional[Dict[_int, Callable[[Tensor], Optional[Tensor]]]]
+    nbytes: _int
+    itemsize: _int
+    ${tensor_method_hints}


### PR DESCRIPTION
By adding _tensor.pyi to the torch package, IDEs such as PyCharm will pick up type hinting information that was previously not found as it was contained in torch._C.__init__.pyi

This commit will enable autocomplete for all torch.Tensor class methods for the PyCharm IDE

Fixes #109438
