### PR TITLE
[PyTorch][Coreml] Bubble up NSError from loadModel

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable MLModel*)loadModel:(const std::string)modelID
                        backend:(const std::string)backend
-             allowLowPrecision:(BOOL)allowLowPrecision;
+             allowLowPrecision:(BOOL)allowLowPrecision
+                         error:(NSError**)error;
 
 @end
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -55,11 +55,10 @@ static NSString *gVersionExtension = @"version";
   return [PTMCoreMLCompiler _compileModel:modelName atPath:modelPath];
 }
 
-+ (nullable MLModel*)loadModel:(const std::string)modelID backend:(const std::string)backend allowLowPrecision:(BOOL)allowLowPrecision {
++ (nullable MLModel*)loadModel:(const std::string)modelID backend:(const std::string)backend allowLowPrecision:(BOOL)allowLowPrecision error:(NSError**)error {
   NSString *modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
   NSURL *modelURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
 
-  NSError *error;
   MLModel *model;
   if (@available(iOS 12.0, macOS 10.14, *)) {
     MLModelConfiguration* config = [[MLModelConfiguration alloc] init];
@@ -71,12 +70,12 @@ static NSString *gVersionExtension = @"version";
     }
     config.computeUnits = computeUnits;
     config.allowLowPrecisionAccumulationOnGPU = allowLowPrecision;
-    model = [MLModel modelWithContentsOfURL:modelURL configuration:config error:&error];
+    model = [MLModel modelWithContentsOfURL:modelURL configuration:config error:error];
   } else {
-    model = [MLModel modelWithContentsOfURL:modelURL error:&error];
+    model = [MLModel modelWithContentsOfURL:modelURL error:error];
   }
 
-  if (error) {
+  if (error && *error) {
     [PTMCoreMLCompiler _cleanupCachedModel:modelName];
     return nil;
   }


### PR DESCRIPTION
Summary: This can help debug issues esp fc/bc issues with coreml tools, when a model fails to load.

Test Plan:
On a macbook fbsource,
```
arc focus2 -b pp-ios -a ModelRunner -a //xplat/caffe2/c10:c10Apple -a //xplat/caffe2/fb/dynamic_pytorch:dynamic_pytorch_implApple -a //xplat/caffe2:coreml_delegateApple --auto-test-schemes --force-with-wrong-xcode
```
It builds and runs the Playground app using a bunch of coreml models on my iPhone. Here is one for example,
https://pxl.cl/3nSPn

Also forcefully triggering MLModel ctor failure to test this code by setting a `modelURL=nil`, and as expected got this,
```
libc++abi: terminating due to uncaught exception of type c10::Error: Error loading MLModel Error details:  Localized_description: nil value for URL Domain: com.apple.CoreML Code: 3 User Info: {
    NSLocalizedDescription = "nil value for URL";
} Input Shapes: N/A


Exception raised from compile at xplat/caffe2/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm:162 (most recent call first):
(no backtrace available)
```

Instead of a previous message would have been,
```
Loading MLModel failed
```

Unrelated issues
* P829736691 - with running MaskRCNN on Coreml with the Playground app. Only happens some times.
* P829741377 - with Metal Operator Tests with the Playground app.

Differential Revision: D49349726


