### PR TITLE
[Decomposition] hann_window.periodic [2]

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -791,7 +791,6 @@ aten::hamming_window.periodic_alpha_out
 aten::hamming_window.periodic_out
 aten::hann_window
 aten::hann_window.out
-aten::hann_window.periodic
 aten::hann_window.periodic_out
 aten::hardshrink_backward
 aten::hardshrink_backward.grad_input

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -255,6 +255,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.gelu_,
             aten.gelu_backward,
             aten.glu_backward,
+            aten.hann_window.periodic,
             aten.hardshrink,
             aten.hardsigmoid,
             aten.hardsigmoid_,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4020,6 +4020,31 @@ def scaled_dot_product_flash_attention(
     )
 
 
+@register_decomposition(aten.hann_window.periodic)
+def hann_window_periodic(
+    window_length: int,
+    periodic: bool,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None,
+) -> Tensor:
+    # aten::hann_window.periodic(int window_length, bool periodic, ...) -> Tensor
+    if window_length == 1:
+        hann_window = torch.ones(size=(1,))
+    else:
+        N = window_length + (1 if periodic else 0)
+        hann_window = torch.narrow(
+            torch.pow(torch.sin((torch.arange(0, N) * torch.pi) / (N - 1)), 2),
+            dim=0,
+            start=0,
+            length=window_length,
+        )
+
+    return hann_window.to(dtype=dtype, device=device)
+
+
 def register_inplace(aten_op, outplace_op):
     @register_decomposition(aten_op)
     def inplace_op(*args, **kwargs):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8391,6 +8391,12 @@ def sample_inputs_multi_head_attention_forward(opinfo, device, dtype, requires_g
         yield SampleInput(q, args=sample_args, kwargs=sample_kwargs)
 
 
+def sample_inputs_hann_window(op_info, device, dtype, requires_grad, **kwargs):
+    for window_length in [1, 2, 5, 10]:
+        for periodic in [True, False]:
+            yield SampleInput(window_length, periodic)
+
+
 # Includes some values such that N * N won't be a multiple of 4,
 # which should ensure we test the vectorized and non-vectorized
 # kernel code paths.
@@ -18674,6 +18680,15 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
         ),
+    ),
+    OpInfo(
+        'hann_window',
+        aten_name='hann_window',
+        dtypes=_dispatch_dtypes((torch.int32,)),
+        dtypesIfCUDA=_dispatch_dtypes((torch.int32,)),
+        dtypesIfROCM=_dispatch_dtypes((torch.int32,)),
+        supports_out=False,
+        sample_inputs_func=sample_inputs_hann_window,
     ),
 ]
 op_db += opinfo.definitions.op_db


### PR DESCRIPTION
Summary: Add decomposition for hann_window.periodic and include it in core_aten_decompositions

Test Plan:
Phabricator + OSS Tests
```
EXPECTTEST_ACCEPT=1 python3 test/test_decomp.py -k test_quick_hann_window
```

Differential Revision: D49344987

