### PR TITLE
Revert "[inductor] let codegen not rely on node order (#107320)"

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -994,10 +994,6 @@ class Kernel(CodeGen):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Note that V.graph.scheduler can be None when codegening triton template
-        kernels.
-        """
         if V.graph.scheduler:
             V.graph.scheduler.remove_kernel_local_buffers()
         super().__exit__(exc_type, exc_val, exc_tb)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1940,6 +1940,9 @@ class TritonKernel(Kernel):
         if config.benchmark_kernel:
             code.splice(self.codegen_kernel_benchmark())
 
+        if name is not None:
+            return code.getvalue()
+
         return code.getvalue()
 
     def codegen_static_numels(self, code):
@@ -2262,7 +2265,8 @@ class TritonScheduling(BaseScheduling):
 
         node_schedule = self.generate_node_schedule(nodes, numel, rnumel)
 
-        schedule_log.debug("Schedule:\n %s", node_schedule)
+        if schedule_log.isEnabledFor(logging.DEBUG):
+            schedule_log.debug("Schedule:\n %s", node_schedule)
 
         return self.codegen_node_schedule(node_schedule, numel, rnumel)
 
@@ -2381,26 +2385,6 @@ class TritonScheduling(BaseScheduling):
         origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
         if origins:
             wrapper.writeline(origins)
-
-        if config.debug_fusion:
-            from torch._inductor.scheduler import (
-                BaseSchedulerNode,
-                ForeachKernelSchedulerNode,
-            )
-
-            if not any(
-                isinstance(n, ForeachKernelSchedulerNode) for n in node_schedule
-            ):
-                # We probablly should look what are the nodes inside a foreach
-                # schedule node
-                node_names = [
-                    n.get_name()
-                    for n in node_schedule
-                    if isinstance(n, BaseSchedulerNode)
-                ]
-                wrapper.writeline(
-                    f"{wrapper.comment} Fused node name list: {', '.join(node_names)}"
-                )
 
     def codegen_node_schedule(self, node_schedule, numel, reduction_numel):
         tiled_groups = self.select_tiling(node_schedule, numel, reduction_numel)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -141,10 +141,6 @@ implicit_fallbacks = True
 # fuse even in cases without common reads
 aggressive_fusion = False
 
-# For each fused kernel in the wrapper, comment with the nodes that get fused.
-# Useful for debugging fusion.
-debug_fusion = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION") == "1"
-
 # how many nodes to allow into a single fusion
 max_fusion_size = 64
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109466

This reverts commit 556bfe7cb547f8073c86982e186c780ba5a53a8a.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel