### PR TITLE
[inductor] Fix CudaStreamGuard in AOTInductor ABI compatible mode

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -163,11 +163,18 @@ AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError aoti_torch_mm_out(
     AtenTensorHandle mat2);
 
 #ifdef USE_CUDA
-AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
-aoti_torch_get_current_cuda_stream(void** ret, int32_t device_index);
+
+struct CUDAStreamGuardOpaque;
+using CUDAStreamGuardHandle = CUDAStreamGuardOpaque*;
 
 AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
-aoti_torch_set_current_cuda_stream(void* stream, int32_t device_index);
+aoti_torch_create_cuda_stream_guard(
+    CUDAStreamGuardHandle* ret_guard, // returns new reference
+    void* stream,
+    int32_t device_index);
+
+AOTI_TORCH_EXPORT AOTI_TORCH_NOINLINE AOTITorchError
+aoti_torch_delete_cuda_stream_guard(CUDAStreamGuardHandle guard);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Summary: Use a RAII class to wrap around at::cuda::CUDAStreamGuard. Previous implementation didn't follow the exact CUDAStreamGuard behavior.

Test Plan: CI

Differential Revision: D49355542


