### PR TITLE
Remaining replacement of  c10::stoi with std::stoi

### DIFF
--- a/binaries/benchmark_helper.cc
+++ b/binaries/benchmark_helper.cc
@@ -163,7 +163,7 @@ int loadInput(
         vector<string> input_dims_str = caffe2::split(',', input_dims_list[i]);
         vector<int> input_dims;
         for (const string& s : input_dims_str) {
-          input_dims.push_back(c10::stoi(s));
+          input_dims.push_back(std::stoi(s));
         }
         caffe2::Blob* blob = workspace->GetBlob(input_names[i]);
         if (blob == nullptr) {

--- a/binaries/compare_models_torch.cc
+++ b/binaries/compare_models_torch.cc
@@ -170,7 +170,7 @@ std::vector<c10::IValue> create_inputs(
     std::vector<int64_t> input_dims;
     input_dims.reserve(input_dims_str.size());
     for (const auto& s : input_dims_str) {
-      input_dims.push_back(c10::stoi(s));
+      input_dims.push_back(std::stoi(s));
     }
 
     at::ScalarType input_type;

--- a/binaries/speed_benchmark.cc
+++ b/binaries/speed_benchmark.cc
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
         vector<string> input_dims_str = caffe2::split(',', input_dims_list[i]);
         vector<int> input_dims;
         for (const string& s : input_dims_str) {
-          input_dims.push_back(c10::stoi(s));
+          input_dims.push_back(std::stoi(s));
         }
         caffe2::Blob* blob = workspace->GetBlob(input_names[i]);
         if (blob == nullptr) {

--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -119,7 +119,7 @@ std::vector<c10::IValue> create_inputs() {
     auto input_dims_str = split(',', input_dims_list[i]);
     std::vector<int64_t> input_dims;
     for (const auto& s : input_dims_str) {
-      input_dims.push_back(c10::stoi(s));
+      input_dims.push_back(std::stoi(s));
     }
 
     at::ScalarType input_type;

--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -60,7 +60,7 @@ static int iter = 10;
     auto input_dims_str = caffe2::split(',', input_dims_list[i]);
     std::vector<int64_t> input_dims;
     for (const auto& s : input_dims_str) {
-      input_dims.push_back(c10::stoi(s));
+      input_dims.push_back(std::stoi(s));
     }
     if (input_type_list[i] == "float") {
       inputs.push_back(torch::ones(input_dims, at::ScalarType::Float));


### PR DESCRIPTION
PR #109179 replaced c10::stoi with std::stoi. However, there were some files forgotten to change. This patch fixes them.

cc @vfdev-5 
