### PR TITLE
[Test][pytree] Fix pytree tests

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -192,24 +192,24 @@ class TestPytree(TestCase):
             def f(x):
                 return x * 3
 
-            sm1 = sum(map(tree_flatten(pytree)[0], f))
-            sm2 = tree_flatten(tree_map(f, pytree))[0]
+            sm1 = sum(map(f, tree_flatten(pytree)[0]))
+            sm2 = sum(tree_flatten(tree_map(f, pytree))[0])
             self.assertEqual(sm1, sm2)
 
             def invf(x):
                 return x // 3
 
-            self.assertEqual(tree_flatten(tree_flatten(pytree, f), invf), pytree)
+            self.assertEqual(tree_map(invf, tree_map(f, pytree)), pytree)
 
-            cases = [
-                [()],
-                ([],),
-                {"a": ()},
-                {"a": 1, "b": [{"c": 2}]},
-                {"a": 0, "b": [2, {"c": 3}, 4], "c": (5, 6)},
-            ]
-            for case in cases:
-                run_test(case)
+        cases = [
+            [()],
+            ([],),
+            {"a": ()},
+            {"a": 1, "b": [{"c": 2}]},
+            {"a": 0, "b": [2, {"c": 3}, 4], "c": (5, 6)},
+        ]
+        for case in cases:
+            run_test(case)
 
     def test_tree_only(self):
         self.assertEqual(tree_map_only(int, lambda x: x + 2, [0, "a"]), [2, "a"])

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -359,7 +359,7 @@ TreeSpec(TupleVariable, None, [*,
         _register_pytree_node(
             DummyType,
             lambda dummy: ([dummy.x, dummy.y], None),
-            lambda xs, _: Dummy(*xs),
+            lambda xs, _: DummyType(*xs),
             to_dumpable_context=lambda context: "moo",
             from_dumpable_context=lambda dumpable_context: None,
         )
@@ -381,7 +381,7 @@ TreeSpec(TupleVariable, None, [*,
             _register_pytree_node(
                 DummyType,
                 lambda dummy: ([dummy.x, dummy.y], None),
-                lambda xs, _: Dummy(*xs),
+                lambda xs, _: DummyType(*xs),
                 to_dumpable_context=lambda context: "moo",
             )
 
@@ -394,7 +394,7 @@ TreeSpec(TupleVariable, None, [*,
         _register_pytree_node(
             DummyType,
             lambda dummy: ([dummy.x, dummy.y], None),
-            lambda xs, _: Dummy(*xs),
+            lambda xs, _: DummyType(*xs),
             to_dumpable_context=lambda context: DummyType,
             from_dumpable_context=lambda dumpable_context: None,
         )

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -147,17 +147,17 @@ class TestPytree(TestCase):
         self.assertEqual(result, expected)
 
     def test_flatten_unflatten_dict(self):
-        def run_test(tup):
+        def run_test(dct):
             expected_spec = TreeSpec(
-                dict, list(tup.keys()), [LeafSpec() for _ in tup.values()]
+                dict, list(dct.keys()), [LeafSpec() for _ in dct.values()]
             )
-            values, treespec = tree_flatten(tup)
+            values, treespec = tree_flatten(dct)
             self.assertTrue(isinstance(values, list))
-            self.assertEqual(values, list(tup.values()))
+            self.assertEqual(values, list(dct.values()))
             self.assertEqual(treespec, expected_spec)
 
             unflattened = tree_unflatten(values, treespec)
-            self.assertEqual(unflattened, tup)
+            self.assertEqual(unflattened, dct)
             self.assertTrue(isinstance(unflattened, dict))
 
         run_test({})

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -184,6 +184,8 @@ class TestPytree(TestCase):
             {"a": 0, "b": [{"c": 1}]},
             {"a": 0, "b": [1, {"c": 2}, torch.randn(3)], "c": (torch.randn(2, 3), 1)},
         ]
+        for case in cases:
+            run_test(case)
 
     def test_treemap(self):
         def run_test(pytree):


### PR DESCRIPTION
Fix some tests for the pytree utilities.

Changes in details (each for one commit):

- add missing `run_test` for `test_flatten_unflatten_nested`
- fix untested `test_treemap`
- fix missing variable `Dummy` -> `DummyType`

The first commit only contains style change (run `ufmt`).

See also https://github.com/pytorch/pytorch/pull/93139#discussion_r1328368273