### PR TITLE
Avoid cuda stubs libraries being RPATHed

### DIFF
--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -56,7 +56,8 @@ endif()
 
 if(USE_CUDA)
   caffe2_binary_target("inspect_gpu.cc")
-  target_link_libraries(inspect_gpu ${CUDA_LIBRARIES})
+  include(${Torch_SOURCE_DIR}/cmake/LinkCudaLibraries.cmake)
+  link_cuda_libraries(inspect_gpu ${CUDA_LIBRARIES})
   caffe2_binary_target("print_core_object_sizes_gpu.cc")
 
   if(BUILD_TEST)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -624,14 +624,13 @@ endif()
 if(USE_CUDA)
   list(APPEND Caffe2_GPU_CU_SRCS ${Caffe2_GPU_HIP_JIT_FUSERS_SRCS})
   add_library(caffe2_nvrtc SHARED ${ATen_NVRTC_STUB_SRCS})
+  include(${Torch_SOURCE_DIR}/cmake/LinkCudaLibraries.cmake)
+  link_cuda_libraries(caffe2_nvrtc ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB})
   if(MSVC)
     # Delay load nvcuda.dll so we can import torch compiled with cuda on a CPU-only machine
-    set(DELAY_LOAD_FLAGS "-DELAYLOAD:nvcuda.dll;delayimp.lib")
-  else()
-    set(DELAY_LOAD_FLAGS "")
+    target_link_libraries(caffe2_nvrtc "-DELAYLOAD:nvcuda.dll;delayimp.lib")
   endif()
 
-  target_link_libraries(caffe2_nvrtc ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB} ${DELAY_LOAD_FLAGS})
   install(TARGETS caffe2_nvrtc DESTINATION "${TORCH_INSTALL_LIB_DIR}")
   if(USE_NCCL)
     list(APPEND Caffe2_GPU_SRCS
@@ -1512,6 +1511,7 @@ endif()
 
 # ---[ CUDA library.
 if(USE_CUDA)
+  include(${Torch_SOURCE_DIR}/cmake/LinkCudaLibraries.cmake)
   # FIXME: If kineto is linked with CUPTI it pollutes torch_cpu with CUDA dependencies
   # Even worse, it never declares that it depends on cudart, but calls the API, see
   # https://github.com/pytorch/kineto/blob/aef2f5c0f15e3be52406ac0b885e8689de6bc9f6/libkineto/src/CudaDeviceProperties.cpp#L24
@@ -1525,13 +1525,13 @@ if(USE_CUDA)
       torch_cuda INTERFACE $<INSTALL_INTERFACE:include>)
   target_include_directories(
       torch_cuda PRIVATE ${Caffe2_GPU_INCLUDE})
-  target_link_libraries(
+  link_cuda_libraries(
       torch_cuda PRIVATE ${Caffe2_CUDA_DEPENDENCY_LIBS})
 
   # These public dependencies must go after the previous dependencies, as the
   # order of the libraries in the linker call matters here when statically
   # linking; libculibos and cublas must be last.
-  target_link_libraries(torch_cuda PUBLIC torch_cpu_library ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
+  link_cuda_libraries(torch_cuda PUBLIC torch_cpu_library ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
 endif()
 
 # ---[ Metal(OSX) modification

--- a/cmake/LinkCudaLibraries.cmake
+++ b/cmake/LinkCudaLibraries.cmake
@@ -1,0 +1,33 @@
+# Link CUDA libraries to the given target, i.e.: `target_link_libraries(target <args>)`
+#
+# Additionally makes sure CUDA stub libs don't end up being in RPath
+#
+# Example: link_cuda_libraries(mytarget PRIVATE ${CUDA_LIBRARIES})
+function(link_cuda_libraries target)
+  set(libs ${ARGN})
+  set(install_rpath "$ORIGIN")
+  set(filtered FALSE)
+  foreach(lib IN LISTS libs)
+    # CUDA stub libs are in form /prefix/lib/stubs/libcuda.so
+    # So extract the name of the parent folder, to check against "stubs"
+    # And the parent path which we need to add to the INSTALL_RPATH for non-stubs
+    get_filename_component(parent_path "${lib}" DIRECTORY)
+    get_filename_component(parent_name "${parent_path}" NAME)
+    if(parent_name STREQUAL "stubs")
+      message(STATUS "Filtering ${lib} from being set in ${target}'s RPATH, "
+                     "because it appears to point to the CUDA stubs directory.")
+      set(filtered TRUE)
+    elseif(parent_path)
+      list(APPEND install_rpath ${parent_path})
+    endif()
+  endforeach()
+
+  # Regular link command
+  target_link_libraries(${target} ${libs})
+  # Manually set INSTALL_RPATH when there were any stub libs
+  if(filtered)
+    list(REMOVE_DUPLICATES install_rpath)
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH "${install_rpath}")
+  endif()
+endfunction()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9659,6 +9659,21 @@ def add_neg_dim_tests():
         assert not hasattr(TestTorch, test_name), "Duplicated test name: " + test_name
         setattr(TestTorch, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
+class TestRPATH(TestCase):
+    @unittest.skipIf(not sys.platform.startswith('linux'), "linux-only test")
+    def test_rpath(self):
+        """
+        Make sure RPATH (or RUNPATH) in nvrtc does not contain a cuda stubs directory
+        issue gh-35418
+        """
+        libdir = os.path.join(os.path.dirname(torch._C.__file__), 'lib')
+        caffe2_nvrtc = os.path.join(libdir, 'libcaffe2_nvrtc.so')
+        if os.path.exists(caffe2_nvrtc):
+            output = subprocess.check_output(['objdump', '-x', caffe2_nvrtc])
+            for line in output.split(b'\n'):
+                if b'RPATH' in line or b'RUNPATH' in line:
+                    self.assertFalse(b'stubs' in line)
+
 # TODO: these empy classes are temporarily instantiated for XLA compatibility
 #   once XLA updates their test suite it should be removed
 class TestViewOps(TestCase):


### PR DESCRIPTION
Rebase of #87593 which is a continuation of #68912

The new function `link_cuda_libraries` is a drop-in replacement for `target_link_libraries` which calls the latter and does the check and manual-rpath-setting on the libraries.
I also made it to work on CMake prior to 3.20 by using `get_filename_component` instead of `cmake_path`

Fixes #35418

@kumpera in the other PR you mentioned that some changes should/need to be split off. How would this need to look like? The changes depend on each other: The 3 CMakeLists.txt require the new module/file in the `cmake` folder and the `test_torch.py` will fail without those changes.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen