### PR TITLE
Don't use cpuinfo on s390x

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -89,7 +89,9 @@ if(${USE_GLOG})
 endif()
 target_link_libraries(c10 PRIVATE fmt::fmt-header-only)
 
-target_link_libraries(c10 PRIVATE cpuinfo)
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x")
+    target_link_libraries(c10 PRIVATE cpuinfo)
+endif()
 
 find_package(Backtrace)
 if(Backtrace_FOUND)

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,15 +1,20 @@
 #include <c10/core/thread_pool.h>
 #include <c10/util/Logging.h>
+#if !defined(__s390x__)
 #include <cpuinfo.h>
+#endif
 
 namespace c10 {
 
 size_t TaskThreadPoolBase::defaultNumThreads() {
+  size_t num_threads = 0;
+#if !defined(__s390x__)
   cpuinfo_initialize();
-  size_t num_threads = cpuinfo_get_processors_count();
+  num_threads = cpuinfo_get_processors_count();
   if (num_threads > 0) {
     return num_threads;
   }
+#endif
   num_threads = std::thread::hardware_concurrency();
   if (num_threads == 0) {
     num_threads = 1;


### PR DESCRIPTION
It doesn't support s390x and just crashes pytorch on init.
