### PR TITLE
Fix hpu deserialization bug

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -292,9 +292,9 @@ def validate_hpu_device(location):
 
 
 def _hpu_deserialize(obj, location):
-    hpu = getattr(torch, "hpu", None)
-    assert hpu is not None, "HPU device module is not loaded"
     if location.startswith('hpu'):
+        hpu = getattr(torch, "hpu", None)
+        assert hpu is not None, "HPU device module is not loaded"
         device = validate_hpu_device(location)
         if getattr(obj, "_torch_load_uninitialized", False):
             with hpu.device(device):


### PR DESCRIPTION
# Motivation
fix hpu deserialization bug. It should check hpu model if and only if location start with hpu. Otherwise, it always raise an AssertError if hpu is not imported. This break the serialization/desirialization functionality abourt other third-party like IPEX.

# Solution
only assert hpu model when start with hpu
