### PR TITLE
[AOTInductor] Initial functionality for Inf and NaN checker

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -135,22 +135,40 @@ class AotInductorTests(TestCase):
         actual = AOTInductorModelRunner.run(model, example_inputs, expected)
         self.assertTrue(same(actual, expected))
 
+    @unittest.skip("Skip this test, only for local test as SIGABRT is produced.")
     def test_inf(self):
         model = SimpleLinear((10, 10))
         x = torch.randn(10, 10, device="cuda")
         x[0][0] = float("Inf")
         example_inputs = (
             x,
-            torch.randn(1, 512, device="cuda"),
+            torch.randn(1, 10, device="cuda"),
         )
         expected = model(*example_inputs)
         actual = AOTInductorModelRunner.run(
             model,
             example_inputs,
             expected,
-            options={"aot_inductor.check_inf_and_nan": True},
+            options={"debug_check_inf_and_nan": True},
         )
         self.assertTrue(same(actual, expected))
+
+    @unittest.skip("Skip this test, only for local test as SIGABRT is produced.")
+    def test_nan(self):
+        model = SimpleLinear((10, 10))
+        x = torch.randn(10, 10, device="cuda")
+        x[0][0] = float("nan")
+        example_inputs = (
+            x,
+            torch.randn(1, 10, device="cuda"),
+        )
+        expected = model(*example_inputs)
+        actual = AOTInductorModelRunner.run(
+            model,
+            example_inputs,
+            expected,
+            options={"debug_check_inf_and_nan": True},
+        )
 
     def test_with_offset(self):
         class Repro(torch.nn.Module):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -482,6 +482,10 @@ class WrapperCodeGen(CodeGen):
     ):
         self.writeline(f"{name} = {kernel}({', '.join(codegen_args)})")
 
+    def generate_inf_and_nan_checker(self, node):
+        # TODO: Add check for python too.
+        pass
+
     @dynamo_timed
     def generate(self):
         result = IndentedBuffer()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -6,6 +6,9 @@ import torch
 # add some debug printouts
 debug = False
 
+# add inf and NaN checkers
+debug_check_inf_and_nan = False
+
 # Whether to disable a progress bar for autotuning
 disable_progress = True
 
@@ -432,7 +435,6 @@ class aot_inductor:
     # If a relative path is specified, it will be used as a subdirectory under the default caching path;
     # If not specified, a temp directory will be created under the default caching path
     output_path = ""
-    check_inf_and_nan = False
 
 
 class cuda:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1788,7 +1788,7 @@ class Scheduler:
                 assert isinstance(node, NopKernelSchedulerNode)
                 node.allocate()
 
-            if config.aot_inductor.check_inf_and_nan:
+            if config.debug_check_inf_and_nan:
                 V.graph.wrapper_code.generate_inf_and_nan_checker(node)
 
             if config.triton.debug_sync_kernel:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109525
* #109524

Summary:
Add initial functionality for Inf and NaN checker for AOTInductor.

Test Plan:
Included in commit. Skipped for CI as SIGABRT can't be captured by pytest.

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @aakhundov