### PR TITLE
[dynamo][`__torch_function__` 1/n] Add getset descriptor and `__get__` vars

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1131,6 +1131,30 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 3)
 
+    def test_getset_descriptor(self):
+        def fn(g, x):
+            return g.__get__(x)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fullgraph=True, backend="eager")(fn)
+        g = torch.Tensor.shape
+
+        res = opt_fn(g, torch.ones(2, 2))
+        exp_res = fn(g, torch.ones(2, 2))
+        self.assertEqual(res, exp_res)
+
+    def test_get_attr_function(self):
+        def fn(g, x):
+            return g(x)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        g = torch.Tensor.shape.__get__
+
+        res = opt_fn(g, torch.ones(2, 2))
+        exp_res = fn(g, torch.ones(2, 2))
+        self.assertEqual(res, exp_res)
+
     def test_user_getattribute(self):
         class MyObject:
             def __init__(self):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -114,7 +114,9 @@ from .misc import (
     AutogradFunctionContextVariable,
     AutogradFunctionVariable,
     ComptimeVariable,
+    GetAttrFunctionVariable,
     GetAttrVariable,
+    GetSetDescriptorVariable,
     InspectSignatureVariable,
     LambdaVariable,
     NumpyVariable,
@@ -670,6 +672,17 @@ class VariableBuilder:
             # TODO: this doing it manually is bad
             return self.tx.output.side_effects.track_object_existing(
                 self.source, value, result
+            )
+        elif isinstance(value, types.GetSetDescriptorType):
+            return GetSetDescriptorVariable(
+                value, guards=self.make_guards(GuardBuilder.ID_MATCH)
+            )
+        elif isinstance(value, types.MethodWrapperType) and value.__name__ == "__get__":
+            return GetAttrFunctionVariable(
+                value,
+                value.__self__.__name__,
+                source=self.source,
+                guards=self.make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -678,9 +678,7 @@ class VariableBuilder:
                 value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
             )
         elif isinstance(value, types.MethodWrapperType):
-            return MethodWrapperVariable(
-                value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
-            )
+            return MethodWrapperVariable(value)
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -114,11 +114,11 @@ from .misc import (
     AutogradFunctionContextVariable,
     AutogradFunctionVariable,
     ComptimeVariable,
-    GetAttrFunctionVariable,
     GetAttrVariable,
     GetSetDescriptorVariable,
     InspectSignatureVariable,
     LambdaVariable,
+    MethodWrapperVariable,
     NumpyVariable,
     PythonModuleVariable,
     SkipFilesVariable,
@@ -675,15 +675,10 @@ class VariableBuilder:
             )
         elif isinstance(value, types.GetSetDescriptorType):
             return GetSetDescriptorVariable(
-                value, guards=self.make_guards(GuardBuilder.ID_MATCH)
+                value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
             )
-        elif isinstance(value, types.MethodWrapperType) and value.__name__ == "__get__":
-            return GetAttrFunctionVariable(
-                value,
-                value.__self__.__name__,
-                source=self.source,
-                guards=self.make_guards(GuardBuilder.FUNCTION_MATCH),
-            )
+        elif isinstance(value, types.MethodWrapperType):
+            return MethodWrapperVariable(value)
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -114,11 +114,11 @@ from .misc import (
     AutogradFunctionContextVariable,
     AutogradFunctionVariable,
     ComptimeVariable,
+    GetAttrFunctionVariable,
     GetAttrVariable,
     GetSetDescriptorVariable,
     InspectSignatureVariable,
     LambdaVariable,
-    MethodWrapperVariable,
     NumpyVariable,
     PythonModuleVariable,
     SkipFilesVariable,
@@ -675,10 +675,15 @@ class VariableBuilder:
             )
         elif isinstance(value, types.GetSetDescriptorType):
             return GetSetDescriptorVariable(
-                value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
+                value, guards=self.make_guards(GuardBuilder.ID_MATCH)
             )
-        elif isinstance(value, types.MethodWrapperType):
-            return MethodWrapperVariable(value)
+        elif isinstance(value, types.MethodWrapperType) and value.__name__ == "__get__":
+            return GetAttrFunctionVariable(
+                value,
+                value.__self__.__name__,
+                source=self.source,
+                guards=self.make_guards(GuardBuilder.FUNCTION_MATCH),
+            )
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -678,7 +678,9 @@ class VariableBuilder:
                 value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
             )
         elif isinstance(value, types.MethodWrapperType):
-            return MethodWrapperVariable(value)
+            return MethodWrapperVariable(
+                value, guards=self.make_guards(GuardBuilder.FUNCTION_MATCH)
+            )
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(
                 value,

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -666,6 +666,14 @@ class GetSetDescriptorVariable(VariableTracker):
             return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
                 self.desc.__get__
             )
+        else:
+            return super().var_getattr(tx, name)
+
+    def is_python_constant(self):
+        return True
+
+    def as_python_constant(self):
+        return self.desc
 
 
 class PythonModuleVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -635,6 +635,39 @@ class GetAttrVariable(VariableTracker):
         return super().call_method(tx, name, args, kwargs)
 
 
+class GetAttrFunctionVariable(VariableTracker):
+    def __init__(self, get_fn, name, **kwargs):
+        super().__init__(**kwargs)
+        self.get_fn = get_fn
+        self.name = name
+
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        assert len(args) == 1 and len(kwargs) == 0
+        return args[0].var_getattr(tx, self.name)
+
+    def is_python_constant(self):
+        return True
+
+    def as_python_constant(self):
+        return self.get_fn
+
+
+class GetSetDescriptorVariable(VariableTracker):
+    def __init__(self, desc, **kwargs):
+        super().__init__(**kwargs)
+        self.desc = desc
+
+    def var_getattr(self, tx, name):
+        if name == "__get__":
+            from .builder import VariableBuilder
+
+            return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
+                self.desc.__get__
+            )
+
+
 class PythonModuleVariable(VariableTracker):
     def __init__(self, value: types.ModuleType, **kwargs):
         super().__init__(**kwargs)

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -635,45 +635,27 @@ class GetAttrVariable(VariableTracker):
         return super().call_method(tx, name, args, kwargs)
 
 
-class GetAttrFunctionVariable(VariableTracker):
-    def __init__(self, get_fn, name, **kwargs):
-        super().__init__(**kwargs)
-        self.get_fn = get_fn
-        self.name = name
-
+class MethodWrapperVariable(variables.ConstantVariable):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
-        assert len(args) == 1 and len(kwargs) == 0
-        return args[0].var_getattr(tx, self.name)
+        if self.value.__name__ == "__get__":
+            assert len(args) == 1 and len(kwargs) == 0
+            return args[0].var_getattr(tx, self.value.__self__.__name__)
 
-    def is_python_constant(self):
-        return True
-
-    def as_python_constant(self):
-        return self.get_fn
+        super().call_function(tx, args, kwargs)
 
 
-class GetSetDescriptorVariable(VariableTracker):
-    def __init__(self, desc, **kwargs):
-        super().__init__(**kwargs)
-        self.desc = desc
-
+class GetSetDescriptorVariable(variables.ConstantVariable):
     def var_getattr(self, tx, name):
         if name == "__get__":
             from .builder import VariableBuilder
 
             return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
-                self.desc.__get__
+                self.value.__get__
             )
         else:
             return super().var_getattr(tx, name)
-
-    def is_python_constant(self):
-        return True
-
-    def as_python_constant(self):
-        return self.desc
 
 
 class PythonModuleVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -668,7 +668,7 @@ class GetSetDescriptorVariable(VariableTracker):
         self.desc = desc
 
     def var_getattr(self, tx, name):
-        if name == "__get__":
+        if name == "__get__" and self.source:
             from .builder import VariableBuilder
 
             return VariableBuilder(tx, AttrSource(self.source, "__get__"))(


### PR DESCRIPTION
Adds the MethodWrapperVariable and GetSetDescriptor variable types. These are used in `__torch_function__` tracing to represent attribute reads (`__get__`) and for comparing unbound methods. (the func argument when `__torch_function__` is dispatched from a method call)

towards tracing for https://github.com/pytorch/pytorch/issues/93723

cc @hameerabbasi @rgommers @peterbell10 @ezyang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng