### PR TITLE
[AOTInductor] Update performance benchmark code

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -694,7 +694,9 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
 
     with maybe_profile(args.export_profiler_trace) as p:
         if args.export_aot_inductor:
-            frozen_model_iter_fn = export_aot_inductor(model_iter_fn)
+            frozen_model_iter_fn = export_aot_inductor(
+                model, example_inputs, model_iter_fn
+            )
         else:
             frozen_model_iter_fn = torch._dynamo.run(model_iter_fn)
 
@@ -1167,20 +1169,17 @@ class AOTInductorModelCache:
         )
 
 
-def export_aot_inductor(forward: Callable):
-    eager_forward = forward
+def export_aot_inductor(model, example_inputs, eager_forward):
+    module, exported, output_tensors, output_spec = AOTInductorModelCache.load(
+        model, example_inputs, eager_forward
+    )
 
-    def opt_aot_inductor(model, example_inputs, collect_outputs=False):
-        module, exported, output_tensors, output_spec = AOTInductorModelCache.load(
-            model, example_inputs, eager_forward
-        )
-        param_buffer_values = list(exported.state_dict.values())
+    def opt_aot_inductor(_, example_inputs, collect_outputs=False):
         example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
         flat_example_inputs = fx_pytree.tree_flatten_spec(
             (example_args, example_kwargs), exported.call_spec.in_spec
         )
-        all_args = (*param_buffer_values, *flat_example_inputs)
-        module.run(all_args, output_tensors)
+        module.run(flat_example_inputs, output_tensors)
         return pytree.tree_unflatten(output_tensors, output_spec)
 
     return opt_aot_inductor
@@ -2400,6 +2399,9 @@ class BenchmarkRunner:
         print(msg, flush=True)
 
         start_stats = get_dynamo_stats()
+
+        if self.args.export_aot_inductor:
+            optimize_ctx = functools.partial(optimize_ctx, model, example_inputs)
 
         if self.args.accuracy:
             status = self.check_accuracy(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1182,9 +1182,9 @@ aot_inductor_launcher = """
     #include <torch/csrc/inductor/aot_runtime/interface.h>
     #include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
 
-    class AOTInductorModelContainer {
+    class RAIIModelContainer {
     public:
-        AOTInductorModelContainer() {
+        RAIIModelContainer() {
             AOTI_RUNTIME_ERROR_CODE_CHECK(AOTInductorModelContainerCreate(
                 &container_handle,
                 1 /*num_models*/,
@@ -1192,7 +1192,7 @@ aot_inductor_launcher = """
                 nullptr /*cubin_dir*/));
         }
 
-        ~AOTInductorModelContainer() {
+        ~RAIIModelContainer() {
             AOTI_RUNTIME_ERROR_CODE_CHECK(AOTInductorModelContainerDelete(container_handle));
         }
 
@@ -1205,7 +1205,7 @@ aot_inductor_launcher = """
     };
 
     // Global instance
-    AOTInductorModelContainer aot_inductor_container;
+    RAIIModelContainer model_container;
 
     void run(
         std::vector<at::Tensor>& input_tensors,
@@ -1227,7 +1227,7 @@ aot_inductor_launcher = """
         AOTIProxyExecutorHandle proxy_executor_handle = nullptr;
 
         AOTI_RUNTIME_ERROR_CODE_CHECK(AOTInductorModelContainerRun(
-            container_handle,
+            model_container.get(),
             input_handles.data(),
             input_tensors.size(),
             output_handles.data(),


### PR DESCRIPTION
Previously during performance benchmark testing, we would create an AOTInductorModelContainerHandle every time the compiled function is run with new inputs. However after https://github.com/pytorch/pytorch/pull/108473 we now load the constants needed in the runtime when initializing the AOTInductorModelContainerHandle. This resulted in our benchmarks displaying a ~0.4x speedup. 

This diff moves the initialization of AOTInductorModelContainerHandle outside of the code where we run the compiled function with different inputs. 

For example,
```
python benchmarks/dynamo/huggingface.py --performance --cold-start-latency --inference --bfloat16 --export-aot-inductor --disable-cudagraphs --device cuda --total-partitions 3 --partition-id 0 --only AlbertForMaskedLM
```
results in `1.359x` speedup.

Specifically, this adds a `create_container_handle` and `delete_container_handle` function which need to called before `run`. We call `create_container_handle` to initialize the AOTInductorModelContainerHandle, call `run` to run the compiled .so with different inputs, and then `delete_container_handle` to delete it.

[Updated dashboard results](https://hud.pytorch.org/benchmark/compilers?startTime=Wed%2C%2013%20Sep%202023%2021%3A03%3A55%20GMT&stopTime=Wed%2C%2020%20Sep%202023%2021%3A03%3A55%20GMT&granularity=hour&suite=torchbench&mode=inference&dtype=bfloat16&lBranch=angelayi/aot_inductor_benchmark&lCommit=f9aa49c4c9a1a140b6f0c4520d1d6d99b57e12fa&rBranch=main&rCommit=015be4cedba357eb931e24bf188479235db7c5c8)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov