### PR TITLE
Adding T4 GPUs to inductor nightly benchmarks

### DIFF
--- a/.github/workflows/inductor-a100-perf-test.yml
+++ b/.github/workflows/inductor-a100-perf-test.yml
@@ -1,0 +1,125 @@
+name: inductor-A100-perf-nightly
+
+on:
+  workflow_call:
+    inputs:
+      training:
+        description: Run training?
+        required: false
+        type: boolean
+        default: true
+      inference:
+        description: Run inference?
+        required: false
+        type: boolean
+        default: false
+      default:
+        description: Run inductor_default?
+        required: false
+        type: boolean
+        default: true
+      dynamic:
+        description: Run inductor_dynamic_shapes?
+        required: false
+        type: boolean
+        default: true
+      cudagraphs:
+        description: Run inductor_cudagraphs?
+        required: false
+        type: boolean
+        default: true
+      cppwrapper:
+        description: Run inductor_cpp_wrapper for inference?
+        required: false
+        type: boolean
+        default: false
+      freezing_cudagraphs:
+        description: Run inductor_cudagraphs with freezing for inference?
+        required: false
+        type: boolean
+        default: false
+      aotinductor:
+        description: Run aot_inductor for inference?
+        required: false
+        type: boolean
+        default: false
+      maxautotune:
+        description: Run inductor_max_autotune?
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-sm80-py3-gcc9-inductor-benchmarks
+      cuda-arch-list: '8.0'
+      test-matrix: |
+        { include: [
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+        ]}
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 1-6'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 0'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 1440
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event_name == 'workflow_dispatch'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/inductor-a100-perf-test.yml
+++ b/.github/workflows/inductor-a100-perf-test.yml
@@ -50,7 +50,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-a100
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/inductor-a100-perf-test.yml
+++ b/.github/workflows/inductor-a100-perf-test.yml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-sm80-py3-gcc9-inductor-benchmarks
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -1,4 +1,4 @@
-name: inductor-A100-perf-nightly
+name: inductor-perf-nightly
 
 on:
   schedule:
@@ -57,72 +57,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
-    name: cuda12.1-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-build.yml
+  inductor-perf-test-on-a100-nvidia-gpu:
+    name: inductor-perf-test-on-a100-nvidia-gpu
+    uses: ./.github/workflows/inductor-a100-perf-test.yml
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
-      cuda-arch-list: '8.0'
-      test-matrix: |
-        { include: [
-          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
-        ]}
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+      training: ${{ inputs.training }}
+      inference: ${{ inputs.inference }}
+      default: ${{ inputs.default }}
+      dynamic: ${{ inputs.dynamic }}
+      cudagraphs: ${{ inputs.cudagraphs }}
+      cppwrapper: ${{ inputs.cppwrapper }}
+      freezing_cudagraphs: ${{ inputs.freezing_cudagraphs }}
+      aotinductor: ${{ inputs.aotinductor }}
+      maxautotune: ${{ inputs.maxautotune }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
-    name: cuda12.1-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
-    if: github.event.schedule == '0 7 * * 1-6'
+  inductor-perf-test-on-t4-nvidia-gpu:
+    name: inductor-perf-test-on-t4-nvidia-gpu
+    uses: ./.github/workflows/inductor-t4-perf-test.yml
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
-      timeout-minutes: 720
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+      training: ${{ inputs.training }}
+      inference: ${{ inputs.inference }}
+      default: ${{ inputs.default }}
+      dynamic: ${{ inputs.dynamic }}
+      cudagraphs: ${{ inputs.cudagraphs }}
+      cppwrapper: ${{ inputs.cppwrapper }}
+      freezing_cudagraphs: ${{ inputs.freezing_cudagraphs }}
+      aotinductor: ${{ inputs.aotinductor }}
+      maxautotune: ${{ inputs.maxautotune }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
-    name: cuda12.1-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
-    if: github.event.schedule == '0 7 * * 0'
-    with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
-      timeout-minutes: 1440
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
-    name: cuda12.1-py3.10-gcc9-sm80
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
-    if: github.event_name == 'workflow_dispatch'
-    with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
-      timeout-minutes: 720
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -58,7 +58,7 @@ on:
         default: 'nvidia_a100,nvidia_t4'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ inputs.devices }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -51,6 +51,16 @@ on:
         required: false
         type: boolean
         default: false
+      nvidia_a100:
+        description: Run test on Nvidia A100 GPU?
+        required: false
+        type: boolean
+        default: true
+      nvidia_t4:
+        description: Run test on Nvidia T4 GPU?
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -60,6 +70,7 @@ jobs:
   inductor-perf-test-on-a100-nvidia-gpu:
     name: inductor-perf-test-on-a100-nvidia-gpu
     uses: ./.github/workflows/inductor-a100-perf-test.yml
+    if: ${{ inputs.nvidia_a100 == true }}
     with:
       training: ${{ inputs.training }}
       inference: ${{ inputs.inference }}
@@ -74,6 +85,7 @@ jobs:
   inductor-perf-test-on-t4-nvidia-gpu:
     name: inductor-perf-test-on-t4-nvidia-gpu
     uses: ./.github/workflows/inductor-t4-perf-test.yml
+    if: ${{ inputs.nvidia_t4 == true }}
     with:
       training: ${{ inputs.training }}
       inference: ${{ inputs.inference }}

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -51,16 +51,11 @@ on:
         required: false
         type: boolean
         default: false
-      nvidia_a100:
-        description: Run test on Nvidia A100 GPU?
+      devices:
+        description: Comma separated list of devices
         required: false
-        type: boolean
-        default: true
-      nvidia_t4:
-        description: Run test on Nvidia T4 GPU?
-        required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'nvidia_a100,nvidia_t4'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -70,7 +65,7 @@ jobs:
   inductor-perf-test-on-a100-nvidia-gpu:
     name: inductor-perf-test-on-a100-nvidia-gpu
     uses: ./.github/workflows/inductor-a100-perf-test.yml
-    if: ${{ inputs.nvidia_a100 == true }}
+    if: contains(inputs.devices, 'nvidia_a100')
     with:
       training: ${{ inputs.training }}
       inference: ${{ inputs.inference }}
@@ -85,7 +80,7 @@ jobs:
   inductor-perf-test-on-t4-nvidia-gpu:
     name: inductor-perf-test-on-t4-nvidia-gpu
     uses: ./.github/workflows/inductor-t4-perf-test.yml
-    if: ${{ inputs.nvidia_t4 == true }}
+    if: contains(inputs.devices, 'nvidia_t4')
     with:
       training: ${{ inputs.training }}
       inference: ${{ inputs.inference }}
@@ -96,5 +91,3 @@ jobs:
       freezing_cudagraphs: ${{ inputs.freezing_cudagraphs }}
       aotinductor: ${{ inputs.aotinductor }}
       maxautotune: ${{ inputs.maxautotune }}
-
-

--- a/.github/workflows/inductor-t4-perf-test.yml
+++ b/.github/workflows/inductor-t4-perf-test.yml
@@ -1,0 +1,125 @@
+name: inductor-T4-perf-nightly
+
+on:
+  workflow_call:
+    inputs:
+      training:
+        description: Run training?
+        required: false
+        type: boolean
+        default: true
+      inference:
+        description: Run inference?
+        required: false
+        type: boolean
+        default: false
+      default:
+        description: Run inductor_default?
+        required: false
+        type: boolean
+        default: true
+      dynamic:
+        description: Run inductor_dynamic_shapes?
+        required: false
+        type: boolean
+        default: true
+      cudagraphs:
+        description: Run inductor_cudagraphs?
+        required: false
+        type: boolean
+        default: true
+      cppwrapper:
+        description: Run inductor_cpp_wrapper for inference?
+        required: false
+        type: boolean
+        default: false
+      freezing_cudagraphs:
+        description: Run inductor_cudagraphs with freezing for inference?
+        required: false
+        type: boolean
+        default: false
+      aotinductor:
+        description: Run aot_inductor for inference?
+        required: false
+        type: boolean
+        default: false
+      maxautotune:
+        description: Run inductor_max_autotune?
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
+    name: cuda12.1-py3.10-gcc9-sm75
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm75
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-sm75-py3-gcc9-inductor-benchmarks
+      cuda-arch-list: '7.5'
+      test-matrix: |
+        { include: [
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.g4dn.4xlarge" },
+          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.g4dn.4xlarge" },
+        ]}
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
+    name: cuda12.1-py3.10-gcc9-sm75
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 1-6'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm75
+      dashboard-tag: inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
+    name: cuda12.1-py3.10-gcc9-sm75
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 0'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm75
+      dashboard-tag: inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 1440
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
+    name: cuda12.1-py3.10-gcc9-sm75
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event_name == 'workflow_dispatch'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm75
+      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/inductor-t4-perf-test.yml
+++ b/.github/workflows/inductor-t4-perf-test.yml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm75
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-sm75-py3-gcc9-inductor-benchmarks
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
       cuda-arch-list: '7.5'
       test-matrix: |
         { include: [

--- a/.github/workflows/inductor-t4-perf-test.yml
+++ b/.github/workflows/inductor-t4-perf-test.yml
@@ -50,7 +50,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-t4
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/inductor-t4-perf-test.yml
+++ b/.github/workflows/inductor-t4-perf-test.yml
@@ -7,12 +7,12 @@ on:
         description: Run training?
         required: false
         type: boolean
-        default: true
+        default: false
       inference:
         description: Run inference?
         required: false
         type: boolean
-        default: false
+        default: true
       default:
         description: Run inductor_default?
         required: false

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -2,7 +2,7 @@ name: Upload torch dynamo performance stats
 
 on:
   workflow_run:
-    workflows: [inductor-A100-perf-nightly]
+    workflows: [inductor-perf-nightly]
     types:
       - completed
 


### PR DESCRIPTION
1. Forks the nightly benchmarks workflow to support multiple hardware types.
2. Adds g4dn instances with T4 Turing GPUs to the list of tested devices (Inference only)

