### PR TITLE
[Not for merge][Repro] Unbacked symint in Inductor size_hint output

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -102,11 +102,6 @@ def functional_assert_async_msg_decomp(tensor, msg):
     return
 
 
-@register_decomposition([aten.sym_constrain_range_for_size.default])
-def sym_constrain_range_for_size(symbol, *, min=None, max=None):
-    return
-
-
 @register_decomposition([aten.clamp])
 @pw_cast_for_opmath
 def clamp(x, min=None, max=None):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3766,22 +3766,6 @@ class DynamicScalar(ExternKernelAlloc):
             inputs=[x],
         )
 
-    # TODO: add more operations (see sympy.Integer)
-    def __add__(self, other):
-        return self.symbol + other
-
-    def __mul__(self, other):
-        return self.symbol * other
-
-    def __rmul__(self, other):
-        return self.symbol * other
-
-    def __truediv__(self, other):
-        return self.symbol / other
-
-    def __sub__(self, other):
-        return self.symbol - other
-
 
 @dataclasses.dataclass
 class ExternKernelNode:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2271,7 +2271,6 @@ def long_tensor(data):
 def _local_scalar_dense(data):
     symbol = V.graph.current_node.meta['val'].node.expr
     ret = ir.DynamicScalar.create(data, symbol)
-    # V.graph.sizevars.shape_env.unbacked_symint_to_buf[symbol] = ret.get_name()
     return ret
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -43,7 +43,6 @@ from .ir import (
     TensorBox,
     validate_ir,
     View,
-    DynamicScalar,
 )
 from .utils import ceildiv, decode_device, pad_listlike, sympy_product
 from .virtualized import ops, V
@@ -2327,7 +2326,7 @@ def tensor_constructor(fill_value):
         dtype = dtype or torch.get_default_dtype()
         if len(size) == 1 and isinstance(size[0], (list, tuple, torch.Size)):
             size = tuple(size[0])
-        size = [sympy.expand(s.symbol) if isinstance(s, DynamicScalar) else sympy.expand(s) for s in size]
+        size = [sympy.expand(s.symbol) if isinstance(s, ir.DynamicScalar) else sympy.expand(s) for s in size]
         return _full(fill_value, device, dtype, size)
 
     return inner
@@ -4751,7 +4750,7 @@ register_inplace(aten.__ixor__, aten.__xor__)
 def sym_constrain_range(a, min, max):
     tracing_context = torch._guards.TracingContext.get()
     assert tracing_context is not None
-    if isinstance(a, DynamicScalar):
+    if isinstance(a, ir.DynamicScalar):
         assert a.symbol in tracing_context.fake_mode.shape_env.var_to_range
     else:
         assert a in tracing_context.fake_mode.shape_env.var_to_range

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -376,6 +376,7 @@ class SizeVarAllocator:
         try:
             return int(out)
         except Exception:
+            print(f"out: {out}")
             log.debug("failed on: %s", out)
             raise
 


### PR DESCRIPTION
Repro script:
```python
# Test 1: tolist -> zeros -> cat

import torch
import torch.export
import torch._dynamo.config

def f(x):
    a, b = x.tolist()
    torch.export.constrain_as_size(a)
    torch.export.constrain_as_size(b)
    return torch.cat([torch.zeros(a, device="cuda"), torch.zeros(b, device="cuda")])

with (
    torch._dynamo.config.patch(
        dynamic_shapes=True,
        capture_dynamic_output_shape_ops=True,
        capture_scalar_outputs=True,
    ),
):
    compiled = torch.compile(f, fullgraph=True, dynamic=True)
    x = torch.tensor([1, 4], device="cuda")
    ref = f(x)
    actual = compiled(x)
    print(f"ref: {ref}, actual: {actual}")
    assert torch.allclose(ref, actual)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @Xia-Weiwen @ngimel