### PR TITLE
MAINT/TST: pytorch-ify torch._numpy tests (added tests only, not vendored)

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -2,6 +2,7 @@
 
 import functools
 import inspect
+from unittest import expectedFailure as xfail
 
 import numpy as _np
 import pytest
@@ -14,6 +15,12 @@ from pytest import raises as assert_raises
 from torch._numpy.testing import assert_allclose, assert_equal
 
 from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 # These function receive one array_like arg and return one array_like result
@@ -58,49 +65,32 @@ ufunc_names.remove("bitwise_not")
 one_arg_funcs += [getattr(_ufuncs, name) for name in ufunc_names]
 
 
-@pytest.mark.parametrize("func", one_arg_funcs)
-class TestOneArr:
+class TestOneArr(TestCase):
     """Base for smoke tests of one-arg functions: (array_like) -> (array_like)
 
     Accepts array_likes, torch.Tensors, w.ndarays; returns an ndarray
     """
 
+    @parametrize("func", one_arg_funcs)
     def test_asarray_tensor(self, func):
         t = torch.Tensor([[1.0, 2, 3], [4, 5, 6]])
         ta = func(t)
 
         assert isinstance(ta, w.ndarray)
 
+    @parametrize("func", one_arg_funcs)
     def test_asarray_list(self, func):
         lst = [[1.0, 2, 3], [4, 5, 6]]
         la = func(lst)
 
         assert isinstance(la, w.ndarray)
 
+    @parametrize("func", one_arg_funcs)
     def test_asarray_array(self, func):
         a = w.asarray([[1.0, 2, 3], [4, 5, 6]])
         la = func(a)
 
         assert isinstance(la, w.ndarray)
-
-
-class _TestOneArrAndAxis:
-    """Smoke test of functions (array_like, axis) -> array_like"""
-
-    def test_tensor(self, func, axis):
-        t = torch.Tensor([[1.0, 2, 3], [4, 5, 6]])
-        ta = func(t, axis=axis)
-        assert isinstance(ta, w.ndarray)
-
-    def test_list(self, func, axis):
-        t = [[1.0, 2, 3], [4, 5, 6]]
-        ta = func(t, axis=axis)
-        assert isinstance(ta, w.ndarray)
-
-    def test_array(self, func, axis):
-        t = w.asarray([[1.0, 2, 3], [4, 5, 6]])
-        ta = func(t, axis=axis)
-        assert isinstance(ta, w.ndarray)
 
 
 one_arg_axis_funcs = [
@@ -118,35 +108,33 @@ one_arg_axis_funcs = [
 ]
 
 
-@pytest.mark.parametrize("func", one_arg_axis_funcs)
-@pytest.mark.parametrize("axis", [0, 1, -1, None])
-class TestOneArrAndAxis(_TestOneArrAndAxis):
-    pass
+class TestOneArrAndAxis(TestCase):
+    @parametrize("func", one_arg_axis_funcs)
+    @parametrize("axis", [0, 1, -1, None])
+    def test_andaxis_tensor(self, func, axis):
+        t = torch.Tensor([[1.0, 2, 3], [4, 5, 6]])
+        ta = func(t, axis=axis)
+        assert isinstance(ta, w.ndarray)
+
+    @parametrize("func", one_arg_axis_funcs)
+    @parametrize("axis", [0, 1, -1, None])
+    def test_andaxis_list(self, func, axis):
+        t = [[1.0, 2, 3], [4, 5, 6]]
+        ta = func(t, axis=axis)
+        assert isinstance(ta, w.ndarray)
+
+    @parametrize("func", one_arg_axis_funcs)
+    @parametrize("axis", [0, 1, -1, None])
+    def test_andaxis_array(self, func, axis):
+        t = w.asarray([[1.0, 2, 3], [4, 5, 6]])
+        ta = func(t, axis=axis)
+        assert isinstance(ta, w.ndarray)
 
 
-one_arg_axis_funcs_not_none = one_arg_axis_funcs[:]
-one_arg_axis_funcs_not_none += [
-    w.expand_dims,
-]
-
-
-@pytest.mark.parametrize("func", one_arg_axis_funcs_not_none)
-@pytest.mark.parametrize(
-    "axis",
-    [
-        0,
-        1,
-        -1,
-    ],
-)
-class TestOneArrAndAxisNotNone(_TestOneArrAndAxis):
-    pass
-
-
-@pytest.mark.parametrize("func", [w.transpose])
-@pytest.mark.parametrize("axes", [(0, 2, 1), (1, 2, 0), None])
-class TestOneArrAndAxesTuple:
-    def test_tensor(self, func, axes):
+class TestOneArrAndAxesTuple(TestCase):
+    @parametrize("func", [w.transpose])
+    @parametrize("axes", [(0, 2, 1), (1, 2, 0), None])
+    def test_andtuple_tensor(self, func, axes):
         t = torch.ones((1, 2, 3))
         ta = func(t, axes=axes)
         assert isinstance(ta, w.ndarray)
@@ -158,12 +146,16 @@ class TestOneArrAndAxesTuple:
             newshape = tuple(t.shape[axes[i]] for i in range(w.ndim(t)))
         assert ta.shape == newshape
 
-    def test_list(self, func, axes):
+    @parametrize("func", [w.transpose])
+    @parametrize("axes", [(0, 2, 1), (1, 2, 0), None])
+    def test_andtuple_list(self, func, axes):
         t = [[[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]  # shape = (1, 2, 3)
         ta = func(t, axes=axes)
         assert isinstance(ta, w.ndarray)
 
-    def test_array(self, func, axes):
+    @parametrize("func", [w.transpose])
+    @parametrize("axes", [(0, 2, 1), (1, 2, 0), None])
+    def test_andtuple_array(self, func, axes):
         t = w.asarray([[[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]])
         ta = func(t, axes=axes)
         assert isinstance(ta, w.ndarray)
@@ -177,7 +169,6 @@ class TestOneArrAndAxesTuple:
 
 arr_shape_funcs = [
     w.reshape,
-    w.ones_like,
     w.empty_like,
     w.ones_like,
     functools.partial(w.full_like, fill_value=42),
@@ -185,16 +176,18 @@ arr_shape_funcs = [
 ]
 
 
-@pytest.mark.parametrize("func", arr_shape_funcs)
-class TestOneArrAndShape:
+# XXX: errs with redefinition, why?
+class TestOneArrAndShape(TestCase):
     """Smoke test of functions (array_like, shape_like) -> array_like"""
 
-    shape = (2, 3)
-    shape_arg_name = {
-        w.reshape: "newshape",
-    }  # reshape expects `newshape`
+    def setUp(self):
+        self.shape = (2, 3)
+        self.shape_arg_name = {
+            w.reshape: "newshape",
+        }  # reshape expects `newshape`
 
-    def test_tensor(self, func):
+    @parametrize("func", arr_shape_funcs)
+    def test_andshape_tensor(self, func):
         t = torch.Tensor([[1, 2, 3], [4, 5, 6]])
 
         shape_dict = {self.shape_arg_name.get(func, "shape"): self.shape}
@@ -202,7 +195,8 @@ class TestOneArrAndShape:
         assert isinstance(ta, w.ndarray)
         assert ta.shape == self.shape
 
-    def test_list(self, func):
+    @parametrize("func", arr_shape_funcs)
+    def test_andshape_list(self, func):
         t = [[1, 2, 3], [4, 5, 6]]
 
         shape_dict = {self.shape_arg_name.get(func, "shape"): self.shape}
@@ -210,7 +204,8 @@ class TestOneArrAndShape:
         assert isinstance(ta, w.ndarray)
         assert ta.shape == self.shape
 
-    def test_array(self, func):
+    @parametrize("func", arr_shape_funcs)
+    def test_andshape_array(self, func):
         t = w.asarray([[1, 2, 3], [4, 5, 6]])
 
         shape_dict = {self.shape_arg_name.get(func, "shape"): self.shape}
@@ -222,11 +217,11 @@ class TestOneArrAndShape:
 one_arg_scalar_funcs = [(w.size, _np.size), (w.shape, _np.shape), (w.ndim, _np.ndim)]
 
 
-@pytest.mark.parametrize("func, np_func", one_arg_scalar_funcs)
-class TestOneArrToScalar:
+class TestOneArrToScalar(TestCase):
     """Smoke test of functions (array_like) -> scalar or python object."""
 
-    def test_tensor(self, func, np_func):
+    @parametrize("func, np_func", one_arg_scalar_funcs)
+    def test_toscalar_tensor(self, func, np_func):
         t = torch.Tensor([[1, 2, 3], [4, 5, 6]])
         ta = func(t)
         tn = np_func(_np.asarray(t))
@@ -234,7 +229,8 @@ class TestOneArrToScalar:
         assert not isinstance(ta, w.ndarray)
         assert ta == tn
 
-    def test_list(self, func, np_func):
+    @parametrize("func, np_func", one_arg_scalar_funcs)
+    def test_toscalar_list(self, func, np_func):
         t = [[1, 2, 3], [4, 5, 6]]
         ta = func(t)
         tn = np_func(t)
@@ -242,7 +238,8 @@ class TestOneArrToScalar:
         assert not isinstance(ta, w.ndarray)
         assert ta == tn
 
-    def test_array(self, func, np_func):
+    @parametrize("func, np_func", one_arg_scalar_funcs)
+    def test_toscalar_array(self, func, np_func):
         t = w.asarray([[1, 2, 3], [4, 5, 6]])
         ta = func(t)
         tn = np_func(t)
@@ -254,12 +251,12 @@ class TestOneArrToScalar:
 shape_funcs = [w.zeros, w.empty, w.ones, functools.partial(w.full, fill_value=42)]
 
 
-@pytest.mark.parametrize("func", shape_funcs)
-class TestShapeLikeToArray:
+class TestShapeLikeToArray(TestCase):
     """Smoke test (shape_like) -> array."""
 
     shape = (3, 4)
 
+    @parametrize("func", shape_funcs)
     def test_shape(self, func):
         a = func(self.shape)
 
@@ -270,10 +267,10 @@ class TestShapeLikeToArray:
 seq_funcs = [w.atleast_1d, w.atleast_2d, w.atleast_3d, w.broadcast_arrays]
 
 
-@pytest.mark.parametrize("func", seq_funcs)
-class TestSequenceOfArrays:
+class TestSequenceOfArrays(TestCase):
     """Smoke test (sequence of arrays) -> (sequence of arrays)."""
 
+    @parametrize("func", seq_funcs)
     def test_single_tensor(self, func):
         t = torch.Tensor([[1, 2, 3], [4, 5, 6]])
         ta = func(t)
@@ -285,6 +282,7 @@ class TestSequenceOfArrays:
 
         assert isinstance(res, w.ndarray)
 
+    @parametrize("func", seq_funcs)
     def test_single_list(self, func):
         lst = [[1, 2, 3], [4, 5, 6]]
         la = func(lst)
@@ -294,6 +292,7 @@ class TestSequenceOfArrays:
 
         assert isinstance(res, w.ndarray)
 
+    @parametrize("func", seq_funcs)
     def test_single_array(self, func):
         a = w.asarray([[1, 2, 3], [4, 5, 6]])
         la = func(a)
@@ -303,6 +302,7 @@ class TestSequenceOfArrays:
 
         assert isinstance(res, w.ndarray)
 
+    @parametrize("func", seq_funcs)
     def test_several(self, func):
         arys = (
             torch.Tensor([[1, 2, 3], [4, 5, 6]]),
@@ -327,10 +327,10 @@ seq_to_single_funcs = [
 ]
 
 
-@pytest.mark.parametrize("func", seq_to_single_funcs)
-class TestSequenceOfArraysToSingle:
+class TestSequenceOfArraysToSingle(TestCase):
     """Smoke test (sequence of arrays) -> (array)."""
 
+    @parametrize("func", seq_to_single_funcs)
     def test_several(self, func):
         arys = (
             torch.Tensor([[1, 2, 3], [4, 5, 6]]),
@@ -351,10 +351,10 @@ single_to_seq_funcs = (
 )
 
 
-@pytest.mark.parametrize("func", single_to_seq_funcs)
-class TestArrayToSequence:
+class TestArrayToSequence(TestCase):
     """Smoke test array -> (tuple of arrays)."""
 
+    @parametrize("func", single_to_seq_funcs)
     def test_asarray_tensor(self, func):
         t = torch.Tensor([[1, 2, 3], [4, 5, 6]])
         ta = func(t)
@@ -362,6 +362,7 @@ class TestArrayToSequence:
         assert isinstance(ta, tuple)
         assert all(isinstance(x, w.ndarray) for x in ta)
 
+    @parametrize("func", single_to_seq_funcs)
     def test_asarray_list(self, func):
         lst = [[1, 2, 3], [4, 5, 6]]
         la = func(lst)
@@ -369,6 +370,7 @@ class TestArrayToSequence:
         assert isinstance(la, tuple)
         assert all(isinstance(x, w.ndarray) for x in la)
 
+    @parametrize("func", single_to_seq_funcs)
     def test_asarray_array(self, func):
         a = w.asarray([[1, 2, 3], [4, 5, 6]])
         la = func(a)
@@ -391,16 +393,16 @@ funcs_and_args = [
 ]
 
 
-@pytest.mark.parametrize("func, args", funcs_and_args)
-class TestPythonArgsToArray:
+class TestPythonArgsToArray(TestCase):
     """Smoke_test (sequence of scalars) -> (array)"""
 
-    def test_simple(self, func, args):
+    @parametrize("func, args", funcs_and_args)
+    def test_argstoarray_simple(self, func, args):
         a = func(*args)
         assert isinstance(a, w.ndarray)
 
 
-class TestNormalizations:
+class TestNormalizations(TestCase):
     """Smoke test generic problems with normalizations."""
 
     def test_unknown_args(self):
@@ -428,14 +430,14 @@ class TestNormalizations:
             w.eye()
 
 
-class TestCopyTo:
-    def test_basic(self):
+class TestCopyTo(TestCase):
+    def test_copyto_basic(self):
         dst = w.empty(4)
         src = w.arange(4)
         w.copyto(dst, src)
         assert (dst == src).all()
 
-    def test_bcast(self):
+    def test_copytobcast(self):
         dst = w.empty((4, 2))
         src = w.arange(4)
 
@@ -448,7 +450,7 @@ class TestCopyTo:
         w.copyto(dst, src)
         assert (dst == src).all()
 
-    def test_typecast(self):
+    def test_copyto_typecast(self):
         dst = w.empty(4, dtype=int)
         src = w.arange(4, dtype=float)
 
@@ -460,7 +462,7 @@ class TestCopyTo:
         assert (dst == src).all()
 
 
-class TestDivmod:
+class TestDivmod(TestCase):
     def test_divmod_out(self):
         x1 = w.arange(8, 15)
         x2 = w.arange(4, 11)
@@ -487,7 +489,7 @@ class TestDivmod:
         assert quot is out[0]
         assert rem is out[1]
 
-    @pytest.mark.xfail(reason="out1, out2 not implemented")
+    @xfail  # ("out1, out2 not implemented")
     def test_divmod_pos_only(self):
         x1 = [4, 5, 6]
         x2 = [2, 1, 2]
@@ -514,15 +516,15 @@ class TestDivmod:
             w.divmod(1, 2, o, o, out=(o, o))
 
 
-class TestSmokeNotImpl:
-    def test_basic(self):
+class TestSmokeNotImpl(TestCase):
+    def test_nimpl_basic(self):
         # smoke test that the "NotImplemented" annotation is picked up
         with assert_raises(NotImplementedError):
             w.empty(3, like="ooops")
 
 
-class TestDefaultDtype:
-    def test_defaults(self):
+class TestDefaultDtype(TestCase):
+    def test_defaultdtype_defaults(self):
         # by default, both floats and ints 64 bit
         x = w.empty(3)
         z = x + 1j * x
@@ -532,7 +534,7 @@ class TestDefaultDtype:
 
         assert w.arange(3).dtype.torch_dtype == torch.int64
 
-    @pytest.mark.parametrize("dt", ["pytorch", "float32", torch.float32])
+    @parametrize("dt", ["pytorch", "float32", torch.float32])
     def test_set_default_float(self, dt):
         try:
             w.set_default_dtype(fp_dtype=dt)
@@ -551,7 +553,7 @@ class TestDefaultDtype:
 @pytest.mark.skipif(
     _np.__version__ <= "1.23", reason="from_dlpack is new in NumPy 1.23"
 )
-class TestExport:
+class TestExport(TestCase):
     def test_exported_objects(self):
         exported_fns = (
             x
@@ -564,35 +566,46 @@ class TestExport:
         assert len(diff) == 0, str(diff)
 
 
-class TestCtorNested:
+class TestCtorNested(TestCase):
     def test_arrays_in_lists(self):
         lst = [[1, 2], [3, w.array(4)]]
         assert_equal(w.asarray(lst), [[1, 2], [3, 4]])
 
 
-def test_ndarrays_to_tensors():
-    out = _util.ndarrays_to_tensors(((w.asarray(42), 7), 3))
-    assert len(out) == 2
-    assert isinstance(out[0], tuple) and len(out[0]) == 2
-    assert isinstance(out[0][0], torch.Tensor)
+class TestMisc(TestCase):
+    def test_ndarrays_to_tensors(self):
+        out = _util.ndarrays_to_tensors(((w.asarray(42), 7), 3))
+        assert len(out) == 2
+        assert isinstance(out[0], tuple) and len(out[0]) == 2
+        assert isinstance(out[0][0], torch.Tensor)
+
+    @pytest.mark.skipif(not TEST_CUDA, reason="requires cuda")
+    def test_f16_on_cuda(self):
+        # make sure operations with float16 tensors give same results on CUDA and on CPU
+        t = torch.arange(5, dtype=torch.float16)
+        assert_allclose(w.vdot(t.cuda(), t.cuda()), w.vdot(t, t))
+        assert_allclose(w.inner(t.cuda(), t.cuda()), w.inner(t, t))
+        assert_allclose(w.matmul(t.cuda(), t.cuda()), w.matmul(t, t))
+        assert_allclose(w.einsum("i,i", t.cuda(), t.cuda()), w.einsum("i,i", t, t))
+
+        assert_allclose(w.mean(t.cuda()), w.mean(t))
+
+        assert_allclose(w.cov(t.cuda(), t.cuda()), w.cov(t, t).tensor.cuda())
+        assert_allclose(w.corrcoef(t.cuda()), w.corrcoef(t).tensor.cuda())
 
 
-@pytest.mark.skipif(not TEST_CUDA, reason="requires cuda")
-def test_f16_on_cuda():
-    # make sure operations with float16 tensors give same results on CUDA and on CPU
-    t = torch.arange(5, dtype=torch.float16)
-    assert_allclose(w.vdot(t.cuda(), t.cuda()), w.vdot(t, t))
-    assert_allclose(w.inner(t.cuda(), t.cuda()), w.inner(t, t))
-    assert_allclose(w.matmul(t.cuda(), t.cuda()), w.matmul(t, t))
-    assert_allclose(w.einsum("i,i", t.cuda(), t.cuda()), w.einsum("i,i", t, t))
-
-    assert_allclose(w.mean(t.cuda()), w.mean(t))
-
-    assert_allclose(w.cov(t.cuda(), t.cuda()), w.cov(t, t).tensor.cuda())
-    assert_allclose(w.corrcoef(t.cuda()), w.corrcoef(t).tensor.cuda())
+instantiate_parametrized_tests(TestOneArr)
+instantiate_parametrized_tests(TestOneArrAndAxis)
+instantiate_parametrized_tests(TestOneArrAndAxesTuple)
+instantiate_parametrized_tests(TestOneArrAndShape)
+instantiate_parametrized_tests(TestShapeLikeToArray)
+instantiate_parametrized_tests(TestOneArrToScalar)
+instantiate_parametrized_tests(TestSequenceOfArrays)
+instantiate_parametrized_tests(TestSequenceOfArraysToSingle)
+instantiate_parametrized_tests(TestArrayToSequence)
+instantiate_parametrized_tests(TestPythonArgsToArray)
+instantiate_parametrized_tests(TestDefaultDtype)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    subtest,
     TestCase,
 )
 
@@ -217,6 +218,11 @@ class TestOneArrAndShape(TestCase):
 
 
 one_arg_scalar_funcs = [(w.size, _np.size), (w.shape, _np.shape), (w.ndim, _np.ndim)]
+one_arg_scalar_funcs_xfail = [
+    (w.size, _np.size),
+    subtest((w.shape, _np.shape), decorators=[xfail]),  # XXX fails under dynamo
+    (w.ndim, _np.ndim),
+]
 
 
 @instantiate_parametrized_tests
@@ -232,7 +238,7 @@ class TestOneArrToScalar(TestCase):
         assert not isinstance(ta, w.ndarray)
         assert ta == tn
 
-    @parametrize("func, np_func", one_arg_scalar_funcs)
+    @parametrize("func, np_func", one_arg_scalar_funcs_xfail)
     def test_toscalar_list(self, func, np_func):
         t = [[1, 2, 3], [4, 5, 6]]
         ta = func(t)

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
 
@@ -220,7 +221,9 @@ class TestOneArrAndShape(TestCase):
 one_arg_scalar_funcs = [(w.size, _np.size), (w.shape, _np.shape), (w.ndim, _np.ndim)]
 one_arg_scalar_funcs_xfail = [
     (w.size, _np.size),
-    subtest((w.shape, _np.shape), decorators=[xfail]),  # XXX fails under dynamo
+    subtest(
+        (w.shape, _np.shape), decorators=[xfail] if TEST_WITH_TORCHDYNAMO else []
+    ),  # XXX fails under dynamo
     (w.ndim, _np.ndim),
 ]
 

--- a/test/torch_np/test_binary_ufuncs.py
+++ b/test/torch_np/test_binary_ufuncs.py
@@ -6,87 +6,80 @@ import numpy as np
 
 from torch._numpy._ufuncs import *  # noqa: F403
 from torch._numpy.testing import assert_allclose
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TestCase,
-)
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestBinaryUfuncBasic(TestCase):
-
     def test_add(self):
         assert_allclose(np.add(0.5, 0.6), add(0.5, 0.6), atol=1e-7, check_dtype=False)
-
 
     def test_arctan2(self):
         assert_allclose(
             np.arctan2(0.5, 0.6), arctan2(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_bitwise_and(self):
         assert_allclose(
             np.bitwise_and(5, 6), bitwise_and(5, 6), atol=1e-7, check_dtype=False
         )
 
-
     def test_bitwise_or(self):
-        assert_allclose(np.bitwise_or(5, 6), bitwise_or(5, 6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.bitwise_or(5, 6), bitwise_or(5, 6), atol=1e-7, check_dtype=False
+        )
 
     def test_bitwise_xor(self):
         assert_allclose(
             np.bitwise_xor(5, 6), bitwise_xor(5, 6), atol=1e-7, check_dtype=False
         )
 
-
     def test_copysign(self):
         assert_allclose(
             np.copysign(0.5, 0.6), copysign(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_divide(self):
-        assert_allclose(np.divide(0.5, 0.6), divide(0.5, 0.6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.divide(0.5, 0.6), divide(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
     def test_equal(self):
-        assert_allclose(np.equal(0.5, 0.6), equal(0.5, 0.6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.equal(0.5, 0.6), equal(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
     def test_float_power(self):
         assert_allclose(
-            np.float_power(0.5, 0.6), float_power(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.float_power(0.5, 0.6),
+            float_power(0.5, 0.6),
+            atol=1e-7,
+            check_dtype=False,
         )
-
 
     def test_floor_divide(self):
         assert_allclose(
-            np.floor_divide(0.5, 0.6), floor_divide(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.floor_divide(0.5, 0.6),
+            floor_divide(0.5, 0.6),
+            atol=1e-7,
+            check_dtype=False,
         )
-
 
     def test_fmax(self):
         assert_allclose(np.fmax(0.5, 0.6), fmax(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-
     def test_fmin(self):
         assert_allclose(np.fmin(0.5, 0.6), fmin(0.5, 0.6), atol=1e-7, check_dtype=False)
-
 
     def test_fmod(self):
         assert_allclose(np.fmod(0.5, 0.6), fmod(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-
     def test_gcd(self):
         assert_allclose(np.gcd(5, 6), gcd(5, 6), atol=1e-7, check_dtype=False)
-
 
     def test_greater(self):
         assert_allclose(
             np.greater(0.5, 0.6), greater(0.5, 0.6), atol=1e-7, check_dtype=False
         )
-
 
     def test_greater_equal(self):
         assert_allclose(
@@ -96,120 +89,110 @@ class TestBinaryUfuncBasic(TestCase):
             check_dtype=False,
         )
 
-
     def test_heaviside(self):
         assert_allclose(
             np.heaviside(0.5, 0.6), heaviside(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_hypot(self):
-        assert_allclose(np.hypot(0.5, 0.6), hypot(0.5, 0.6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.hypot(0.5, 0.6), hypot(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
     def test_lcm(self):
         assert_allclose(np.lcm(5, 6), lcm(5, 6), atol=1e-7, check_dtype=False)
 
-
     def test_ldexp(self):
         assert_allclose(np.ldexp(0.5, 6), ldexp(0.5, 6), atol=1e-7, check_dtype=False)
 
-
     def test_left_shift(self):
-        assert_allclose(np.left_shift(5, 6), left_shift(5, 6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.left_shift(5, 6), left_shift(5, 6), atol=1e-7, check_dtype=False
+        )
 
     def test_less(self):
         assert_allclose(np.less(0.5, 0.6), less(0.5, 0.6), atol=1e-7, check_dtype=False)
-
 
     def test_less_equal(self):
         assert_allclose(
             np.less_equal(0.5, 0.6), less_equal(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_logaddexp(self):
         assert_allclose(
             np.logaddexp(0.5, 0.6), logaddexp(0.5, 0.6), atol=1e-7, check_dtype=False
         )
-
 
     def test_logaddexp2(self):
         assert_allclose(
             np.logaddexp2(0.5, 0.6), logaddexp2(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_logical_and(self):
         assert_allclose(
-            np.logical_and(0.5, 0.6), logical_and(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.logical_and(0.5, 0.6),
+            logical_and(0.5, 0.6),
+            atol=1e-7,
+            check_dtype=False,
         )
-
 
     def test_logical_or(self):
         assert_allclose(
             np.logical_or(0.5, 0.6), logical_or(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_logical_xor(self):
         assert_allclose(
-            np.logical_xor(0.5, 0.6), logical_xor(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.logical_xor(0.5, 0.6),
+            logical_xor(0.5, 0.6),
+            atol=1e-7,
+            check_dtype=False,
         )
-
 
     def test_matmul(self):
         assert_allclose(
             np.matmul([0.5], [0.6]), matmul([0.5], [0.6]), atol=1e-7, check_dtype=False
         )
 
-
     def test_maximum(self):
         assert_allclose(
             np.maximum(0.5, 0.6), maximum(0.5, 0.6), atol=1e-7, check_dtype=False
         )
-
 
     def test_minimum(self):
         assert_allclose(
             np.minimum(0.5, 0.6), minimum(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_remainder(self):
         assert_allclose(
             np.remainder(0.5, 0.6), remainder(0.5, 0.6), atol=1e-7, check_dtype=False
         )
-
 
     def test_multiply(self):
         assert_allclose(
             np.multiply(0.5, 0.6), multiply(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_nextafter(self):
         assert_allclose(
             np.nextafter(0.5, 0.6), nextafter(0.5, 0.6), atol=1e-7, check_dtype=False
         )
-
 
     def test_not_equal(self):
         assert_allclose(
             np.not_equal(0.5, 0.6), not_equal(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
-
     def test_power(self):
-        assert_allclose(np.power(0.5, 0.6), power(0.5, 0.6), atol=1e-7, check_dtype=False)
-
+        assert_allclose(
+            np.power(0.5, 0.6), power(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
     def test_right_shift(self):
         assert_allclose(
             np.right_shift(5, 6), right_shift(5, 6), atol=1e-7, check_dtype=False
         )
-
 
     def test_subtract(self):
         assert_allclose(

--- a/test/torch_np/test_binary_ufuncs.py
+++ b/test/torch_np/test_binary_ufuncs.py
@@ -6,212 +6,216 @@ import numpy as np
 
 from torch._numpy._ufuncs import *  # noqa: F403
 from torch._numpy.testing import assert_allclose
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+)
 
 
-def test_add():
-    assert_allclose(np.add(0.5, 0.6), add(0.5, 0.6), atol=1e-7, check_dtype=False)
+class TestBinaryUfuncBasic(TestCase):
 
+    def test_add(self):
+        assert_allclose(np.add(0.5, 0.6), add(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_arctan2():
-    assert_allclose(
-        np.arctan2(0.5, 0.6), arctan2(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_arctan2(self):
+        assert_allclose(
+            np.arctan2(0.5, 0.6), arctan2(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_bitwise_and():
-    assert_allclose(
-        np.bitwise_and(5, 6), bitwise_and(5, 6), atol=1e-7, check_dtype=False
-    )
 
+    def test_bitwise_and(self):
+        assert_allclose(
+            np.bitwise_and(5, 6), bitwise_and(5, 6), atol=1e-7, check_dtype=False
+        )
 
-def test_bitwise_or():
-    assert_allclose(np.bitwise_or(5, 6), bitwise_or(5, 6), atol=1e-7, check_dtype=False)
 
+    def test_bitwise_or(self):
+        assert_allclose(np.bitwise_or(5, 6), bitwise_or(5, 6), atol=1e-7, check_dtype=False)
 
-def test_bitwise_xor():
-    assert_allclose(
-        np.bitwise_xor(5, 6), bitwise_xor(5, 6), atol=1e-7, check_dtype=False
-    )
 
+    def test_bitwise_xor(self):
+        assert_allclose(
+            np.bitwise_xor(5, 6), bitwise_xor(5, 6), atol=1e-7, check_dtype=False
+        )
 
-def test_copysign():
-    assert_allclose(
-        np.copysign(0.5, 0.6), copysign(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_copysign(self):
+        assert_allclose(
+            np.copysign(0.5, 0.6), copysign(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_divide():
-    assert_allclose(np.divide(0.5, 0.6), divide(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_divide(self):
+        assert_allclose(np.divide(0.5, 0.6), divide(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_equal():
-    assert_allclose(np.equal(0.5, 0.6), equal(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_equal(self):
+        assert_allclose(np.equal(0.5, 0.6), equal(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_float_power():
-    assert_allclose(
-        np.float_power(0.5, 0.6), float_power(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_float_power(self):
+        assert_allclose(
+            np.float_power(0.5, 0.6), float_power(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_floor_divide():
-    assert_allclose(
-        np.floor_divide(0.5, 0.6), floor_divide(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_floor_divide(self):
+        assert_allclose(
+            np.floor_divide(0.5, 0.6), floor_divide(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_fmax():
-    assert_allclose(np.fmax(0.5, 0.6), fmax(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_fmax(self):
+        assert_allclose(np.fmax(0.5, 0.6), fmax(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_fmin():
-    assert_allclose(np.fmin(0.5, 0.6), fmin(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_fmin(self):
+        assert_allclose(np.fmin(0.5, 0.6), fmin(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_fmod():
-    assert_allclose(np.fmod(0.5, 0.6), fmod(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_fmod(self):
+        assert_allclose(np.fmod(0.5, 0.6), fmod(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_gcd():
-    assert_allclose(np.gcd(5, 6), gcd(5, 6), atol=1e-7, check_dtype=False)
 
+    def test_gcd(self):
+        assert_allclose(np.gcd(5, 6), gcd(5, 6), atol=1e-7, check_dtype=False)
 
-def test_greater():
-    assert_allclose(
-        np.greater(0.5, 0.6), greater(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_greater(self):
+        assert_allclose(
+            np.greater(0.5, 0.6), greater(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_greater_equal():
-    assert_allclose(
-        np.greater_equal(0.5, 0.6),
-        greater_equal(0.5, 0.6),
-        atol=1e-7,
-        check_dtype=False,
-    )
 
+    def test_greater_equal(self):
+        assert_allclose(
+            np.greater_equal(0.5, 0.6),
+            greater_equal(0.5, 0.6),
+            atol=1e-7,
+            check_dtype=False,
+        )
 
-def test_heaviside():
-    assert_allclose(
-        np.heaviside(0.5, 0.6), heaviside(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_heaviside(self):
+        assert_allclose(
+            np.heaviside(0.5, 0.6), heaviside(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_hypot():
-    assert_allclose(np.hypot(0.5, 0.6), hypot(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_hypot(self):
+        assert_allclose(np.hypot(0.5, 0.6), hypot(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_lcm():
-    assert_allclose(np.lcm(5, 6), lcm(5, 6), atol=1e-7, check_dtype=False)
 
+    def test_lcm(self):
+        assert_allclose(np.lcm(5, 6), lcm(5, 6), atol=1e-7, check_dtype=False)
 
-def test_ldexp():
-    assert_allclose(np.ldexp(0.5, 6), ldexp(0.5, 6), atol=1e-7, check_dtype=False)
 
+    def test_ldexp(self):
+        assert_allclose(np.ldexp(0.5, 6), ldexp(0.5, 6), atol=1e-7, check_dtype=False)
 
-def test_left_shift():
-    assert_allclose(np.left_shift(5, 6), left_shift(5, 6), atol=1e-7, check_dtype=False)
 
+    def test_left_shift(self):
+        assert_allclose(np.left_shift(5, 6), left_shift(5, 6), atol=1e-7, check_dtype=False)
 
-def test_less():
-    assert_allclose(np.less(0.5, 0.6), less(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_less(self):
+        assert_allclose(np.less(0.5, 0.6), less(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_less_equal():
-    assert_allclose(
-        np.less_equal(0.5, 0.6), less_equal(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_less_equal(self):
+        assert_allclose(
+            np.less_equal(0.5, 0.6), less_equal(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_logaddexp():
-    assert_allclose(
-        np.logaddexp(0.5, 0.6), logaddexp(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_logaddexp(self):
+        assert_allclose(
+            np.logaddexp(0.5, 0.6), logaddexp(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_logaddexp2():
-    assert_allclose(
-        np.logaddexp2(0.5, 0.6), logaddexp2(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_logaddexp2(self):
+        assert_allclose(
+            np.logaddexp2(0.5, 0.6), logaddexp2(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_logical_and():
-    assert_allclose(
-        np.logical_and(0.5, 0.6), logical_and(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_logical_and(self):
+        assert_allclose(
+            np.logical_and(0.5, 0.6), logical_and(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_logical_or():
-    assert_allclose(
-        np.logical_or(0.5, 0.6), logical_or(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_logical_or(self):
+        assert_allclose(
+            np.logical_or(0.5, 0.6), logical_or(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_logical_xor():
-    assert_allclose(
-        np.logical_xor(0.5, 0.6), logical_xor(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_logical_xor(self):
+        assert_allclose(
+            np.logical_xor(0.5, 0.6), logical_xor(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_matmul():
-    assert_allclose(
-        np.matmul([0.5], [0.6]), matmul([0.5], [0.6]), atol=1e-7, check_dtype=False
-    )
 
+    def test_matmul(self):
+        assert_allclose(
+            np.matmul([0.5], [0.6]), matmul([0.5], [0.6]), atol=1e-7, check_dtype=False
+        )
 
-def test_maximum():
-    assert_allclose(
-        np.maximum(0.5, 0.6), maximum(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_maximum(self):
+        assert_allclose(
+            np.maximum(0.5, 0.6), maximum(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_minimum():
-    assert_allclose(
-        np.minimum(0.5, 0.6), minimum(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_minimum(self):
+        assert_allclose(
+            np.minimum(0.5, 0.6), minimum(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_remainder():
-    assert_allclose(
-        np.remainder(0.5, 0.6), remainder(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_remainder(self):
+        assert_allclose(
+            np.remainder(0.5, 0.6), remainder(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_multiply():
-    assert_allclose(
-        np.multiply(0.5, 0.6), multiply(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_multiply(self):
+        assert_allclose(
+            np.multiply(0.5, 0.6), multiply(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_nextafter():
-    assert_allclose(
-        np.nextafter(0.5, 0.6), nextafter(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_nextafter(self):
+        assert_allclose(
+            np.nextafter(0.5, 0.6), nextafter(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_not_equal():
-    assert_allclose(
-        np.not_equal(0.5, 0.6), not_equal(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
 
+    def test_not_equal(self):
+        assert_allclose(
+            np.not_equal(0.5, 0.6), not_equal(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
-def test_power():
-    assert_allclose(np.power(0.5, 0.6), power(0.5, 0.6), atol=1e-7, check_dtype=False)
 
+    def test_power(self):
+        assert_allclose(np.power(0.5, 0.6), power(0.5, 0.6), atol=1e-7, check_dtype=False)
 
-def test_right_shift():
-    assert_allclose(
-        np.right_shift(5, 6), right_shift(5, 6), atol=1e-7, check_dtype=False
-    )
 
+    def test_right_shift(self):
+        assert_allclose(
+            np.right_shift(5, 6), right_shift(5, 6), atol=1e-7, check_dtype=False
+        )
 
-def test_subtract():
-    assert_allclose(
-        np.subtract(0.5, 0.6), subtract(0.5, 0.6), atol=1e-7, check_dtype=False
-    )
+
+    def test_subtract(self):
+        assert_allclose(
+            np.subtract(0.5, 0.6), subtract(0.5, 0.6), atol=1e-7, check_dtype=False
+        )
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_dtype.py
+++ b/test/torch_np/test_dtype.py
@@ -5,6 +5,13 @@ import pytest
 
 import torch._numpy as tnp
 
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+)
+
+
+
 dtype_names = [
     "bool_",
     *[f"int{w}" for w in [8, 16, 32, 64]],
@@ -54,6 +61,4 @@ def test_convert_np_dtypes(name, np_dtype):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_dtype.py
+++ b/test/torch_np/test_dtype.py
@@ -5,11 +5,7 @@ import pytest
 
 import torch._numpy as tnp
 
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TestCase,
-)
-
+from torch.testing._internal.common_utils import run_tests
 
 
 dtype_names = [

--- a/test/torch_np/test_function_base.py
+++ b/test/torch_np/test_function_base.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import (
 )
 
 
+@instantiate_parametrized_tests
 class TestArange(TestCase):
     def test_infinite(self):
         assert_raises(
@@ -101,8 +102,6 @@ class TestAppend(TestCase):
         with pytest.raises((RuntimeError, ValueError)):
             np.append([[1, 2, 3], [4, 5, 6]], [7, 8, 9], axis=0)
 
-
-instantiate_parametrized_tests(TestArange)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_function_base.py
+++ b/test/torch_np/test_function_base.py
@@ -1,13 +1,22 @@
 # Owner(s): ["module: dynamo"]
 
+from unittest import expectedFailure as xfail
+
 import pytest
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_array_equal, assert_equal
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
-class TestArange:
+
+class TestArange(TestCase):
     def test_infinite(self):
         assert_raises(
             (RuntimeError, ValueError), np.arange, 0, np.inf
@@ -31,7 +40,7 @@ class TestArange:
         assert_raises(TypeError, np.arange, step=3)
         assert_raises(TypeError, np.arange, dtype="int64")
 
-    @pytest.mark.xfail(reason="XXX: arange(start=0, stop, step=1)")
+    @xfail  #(reason="XXX: arange(start=0, stop, step=1)")
     def test_require_range_2(self):
         assert_raises(TypeError, np.arange, start=4)
 
@@ -45,7 +54,7 @@ class TestArange:
         assert len(keyword_start_stop) == 6
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
-    @pytest.mark.xfail(reason="XXX: arange(..., dtype=bool)")
+    @xfail #(reason="XXX: arange(..., dtype=bool)")
     def test_arange_booleans(self):
         # Arange makes some sense for booleans and works up to length 2.
         # But it is weird since `arange(2, 4, dtype=bool)` works.
@@ -66,7 +75,7 @@ class TestArange:
         with pytest.raises(TypeError):
             np.arange(3, dtype="bool")
 
-    @pytest.mark.parametrize("which", [0, 1, 2])
+    @parametrize("which", [0, 1, 2])
     def test_error_paths_and_promotion(self, which):
         args = [0, 10, 2]  # start, stop, and step
         args[which] = np.float64(2.0)  # should ensure float64 output
@@ -79,7 +88,7 @@ class TestArange:
             np.arange(*args)
 
 
-class TestAppend:
+class TestAppend(TestCase):
     # tests taken from np.append docstring
     def test_basic(self):
         result = np.append([1, 2, 3], [[4, 5, 6], [7, 8, 9]])
@@ -93,7 +102,7 @@ class TestAppend:
             np.append([[1, 2, 3], [4, 5, 6]], [7, 8, 9], axis=0)
 
 
-if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
+instantiate_parametrized_tests(TestArange)
 
+if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_function_base.py
+++ b/test/torch_np/test_function_base.py
@@ -40,7 +40,7 @@ class TestArange(TestCase):
         assert_raises(TypeError, np.arange, step=3)
         assert_raises(TypeError, np.arange, dtype="int64")
 
-    @xfail  #(reason="XXX: arange(start=0, stop, step=1)")
+    @xfail  # (reason="XXX: arange(start=0, stop, step=1)")
     def test_require_range_2(self):
         assert_raises(TypeError, np.arange, start=4)
 
@@ -54,7 +54,7 @@ class TestArange(TestCase):
         assert len(keyword_start_stop) == 6
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
-    @xfail #(reason="XXX: arange(..., dtype=bool)")
+    @xfail  # (reason="XXX: arange(..., dtype=bool)")
     def test_arange_booleans(self):
         # Arange makes some sense for booleans and works up to length 2.
         # But it is weird since `arange(2, 4, dtype=bool)` works.

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import itertools
+from unittest import expectedFailure as xfail
 
 import pytest
 
@@ -10,8 +11,15 @@ import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_equal
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
-class TestIndexing:
+
+class TestIndexing(TestCase):
     def test_indexing_simple(self):
         a = np.array([[1, 2, 3], [4, 5, 6]])
 
@@ -26,7 +34,7 @@ class TestIndexing:
         assert_equal(a, [[8, 2, 3], [4, 5, 6]])
 
 
-class TestReshape:
+class TestReshape(TestCase):
     def test_reshape_function(self):
         arr = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
         tgt = [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]]
@@ -75,7 +83,7 @@ class TestReshape:
 #
 
 
-class TestTranspose:
+class TestTranspose(TestCase):
     def test_transpose_function(self):
         arr = [[1, 2], [3, 4], [5, 6]]
         tgt = [[1, 3, 5], [2, 4, 6]]
@@ -95,7 +103,7 @@ class TestTranspose:
         assert a.transpose().tensor._base is a.tensor
 
 
-class TestRavel:
+class TestRavel(TestCase):
     def test_ravel_function(self):
         a = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
         tgt = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -111,7 +119,7 @@ class TestRavel:
         assert a.ravel().tensor._base is a.tensor
 
 
-class TestNonzero:
+class TestNonzero(TestCase):
     def test_nonzero_trivial(self):
         assert_equal(np.nonzero(np.array([])), ([],))
         assert_equal(np.array([]).nonzero(), ([],))
@@ -161,7 +169,7 @@ class TestNonzero:
         assert_equal(m.nonzero(), tgt)
 
 
-class TestArgmaxArgminCommon:
+class TestArgmaxArgminCommon: #(TestCase): FIXME
     sizes = [
         (),
         (3,),
@@ -179,7 +187,7 @@ class TestArgmaxArgminCommon:
         (256,),
     ]
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "size, axis",
         itertools.chain(
             *[
@@ -188,7 +196,7 @@ class TestArgmaxArgminCommon:
             ]
         ),
     )
-    @pytest.mark.parametrize("method", [np.argmax, np.argmin])
+    @parametrize("method", [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
         # arr = np.random.normal(size=size)
         arr = np.empty(shape=size)
@@ -258,7 +266,7 @@ class TestArgmaxArgminCommon:
                 method(arr.T, axis=axis, out=wrong_outarray, keepdims=True)
 
     @pytest.mark.skipif(reason="XXX: need ndarray.chooses")
-    @pytest.mark.parametrize("method", ["max", "min"])
+    @parametrize("method", ["max", "min"])
     def test_all(self, method):
         # a = np.random.normal(0, 1, (4, 5, 6, 7, 8))
         a = np.arange(4 * 5 * 6 * 7 * 8).reshape((4, 5, 6, 7, 8))
@@ -271,7 +279,7 @@ class TestArgmaxArgminCommon:
             axes.remove(i)
             assert np.all(a_maxmin == aarg_maxmin.choose(*a.transpose(i, *axes)))
 
-    @pytest.mark.parametrize("method", ["argmax", "argmin"])
+    @parametrize("method", ["argmax", "argmin"])
     def test_output_shape(self, method):
         # see also gh-616
         a = np.ones((10, 5))
@@ -296,8 +304,8 @@ class TestArgmaxArgminCommon:
         arg_method(-1, out=out)
         assert_equal(out, arg_method(-1))
 
-    @pytest.mark.parametrize("ndim", [0, 1])
-    @pytest.mark.parametrize("method", ["argmax", "argmin"])
+    @parametrize("ndim", [0, 1])
+    @parametrize("method", ["argmax", "argmin"])
     def test_ret_is_out(self, ndim, method):
         a = np.ones((4,) + (256,) * ndim)
         arg_method = getattr(a, method)
@@ -305,7 +313,7 @@ class TestArgmaxArgminCommon:
         ret = arg_method(axis=0, out=out)
         assert ret is out
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "arr_method, np_method", [("argmax", np.argmax), ("argmin", np.argmin)]
     )
     def test_np_vs_ndarray(self, arr_method, np_method):
@@ -335,7 +343,7 @@ class TestArgmaxArgminCommon:
         assert_equal(out1, out2)
 
 
-class TestArgmax:
+class TestArgmax(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 0),
         ([3, 3, 3, 3, 2, 2, 2, 2], 0),
@@ -398,7 +406,7 @@ class TestArgmax:
         ([True, False, True, False, False], 0),
     ]
 
-    @pytest.mark.parametrize("data", nan_arr)
+    @parametrize("data", nan_arr)
     def test_combinations(self, data):
         arr, pos = data
         #      with suppress_warnings() as sup:
@@ -406,6 +414,7 @@ class TestArgmax:
         #                      "invalid value encountered in reduce")
         if np.asarray(arr).dtype.kind in "c":
             pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
+            from unittest import 
 
         val = np.max(arr)
 
@@ -438,7 +447,7 @@ class TestArgmax:
         assert_equal(np.argmax(a), 1)
 
 
-class TestArgmin:
+class TestArgmin(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 8),
         ([3, 3, 3, 3, 2, 2, 2, 2], 4),
@@ -501,7 +510,7 @@ class TestArgmin:
         ([False, True, False, True, True], 0),
     ]
 
-    @pytest.mark.parametrize("data", nan_arr)
+    @parametrize("data", nan_arr)
     def test_combinations(self, data):
         arr, pos = data
 
@@ -541,7 +550,7 @@ class TestArgmin:
         assert_equal(np.argmin(a), 1)
 
 
-class TestAmax:
+class TestAmax(TestCase):
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amax(a), 10.0)
@@ -553,7 +562,7 @@ class TestAmax:
         assert_equal(np.amax(arr), arr.max())
 
 
-class TestAmin:
+class TestAmin(TestCase):
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amin(a), -5.0)
@@ -565,22 +574,28 @@ class TestAmin:
         assert_equal(np.amin(arr), arr.min())
 
 
-def test_contains():
-    a = np.arange(12).reshape(3, 4)
-    assert 2 in a
-    assert 42 not in a
+class TestContains(TestCase):
+    def test_contains(self):
+        a = np.arange(12).reshape(3, 4)
+        assert 2 in a
+        assert 42 not in a
 
 
-# make sure ndarray does not carry extra methods/attributes
-# >>> set(dir(a)) - set(dir(a.tensor.numpy()))
-@pytest.mark.parametrize("name", ["fn", "ivar", "method", "name", "plain", "rvar"])
-def test_extra_methods(name):
-    a = np.ones(3)
-    with pytest.raises(AttributeError):
-        getattr(a, name)
+class TestNoExtraMethods(TestCase):
+    # make sure ndarray does not carry extra methods/attributes
+    # >>> set(dir(a)) - set(dir(a.tensor.numpy()))
+    @parametrize("name", ["fn", "ivar", "method", "name", "plain", "rvar"])
+    def test_extra_methods(self, name):
+        a = np.ones(3)
+        with pytest.raises(AttributeError):
+            getattr(a, name)
+
+
+#instantiate_parametrized_tests(TestArgmaxArgminCommon)
+instantiate_parametrized_tests(TestArgmax)
+instantiate_parametrized_tests(TestArgmin)
+instantiate_parametrized_tests(TestNoExtraMethods)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import itertools
-from unittest import expectedFailure as xfail
+from unittest import expectedFailure as xfail, skipIf as skip
 
 import pytest
 
@@ -15,8 +15,8 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TestCase,
     subtest,
+    TestCase,
 )
 
 
@@ -170,7 +170,7 @@ class TestNonzero(TestCase):
         assert_equal(m.nonzero(), tgt)
 
 
-class TestArgmaxArgminCommon: #(TestCase): FIXME
+class TestArgmaxArgminCommon:  # (TestCase): FIXME
     sizes = [
         (),
         (3,),
@@ -266,7 +266,7 @@ class TestArgmaxArgminCommon: #(TestCase): FIXME
             with pytest.raises(ValueError):
                 method(arr.T, axis=axis, out=wrong_outarray, keepdims=True)
 
-    @pytest.mark.skipif(reason="XXX: need ndarray.chooses")
+    @skip(True, reason="XXX: need ndarray.chooses")
     @parametrize("method", ["max", "min"])
     def test_all(self, method):
         # a = np.random.normal(0, 1, (4, 5, 6, 7, 8))
@@ -395,9 +395,18 @@ class TestArgmax(TestCase):
         subtest(([0, 1, 2, complex(0, np.nan), 3], 3), decorators=[xfail]),
         subtest(([complex(0, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
         subtest(([complex(np.nan, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0), decorators=[xfail]),
+        subtest(
+            ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
+            decorators=[xfail],
+        ),
+        subtest(
+            ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
+            decorators=[xfail],
+        ),
+        subtest(
+            ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
+            decorators=[xfail],
+        ),
         subtest(([complex(0, 0), complex(0, 2), complex(0, 1)], 1), decorators=[xfail]),
         subtest(([complex(1, 0), complex(0, 2), complex(0, 1)], 0), decorators=[xfail]),
         subtest(([complex(1, 0), complex(0, 2), complex(1, 1)], 2), decorators=[xfail]),
@@ -498,9 +507,18 @@ class TestArgmin(TestCase):
         subtest(([0, 1, 2, complex(0, np.nan), 3], 3), decorators=[xfail]),
         subtest(([complex(0, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
         subtest(([complex(np.nan, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
-        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0), decorators=[xfail]),
+        subtest(
+            ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
+            decorators=[xfail],
+        ),
+        subtest(
+            ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
+            decorators=[xfail],
+        ),
+        subtest(
+            ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
+            decorators=[xfail],
+        ),
         subtest(([complex(0, 0), complex(0, 2), complex(0, 1)], 0), decorators=[xfail]),
         subtest(([complex(1, 0), complex(0, 2), complex(0, 1)], 2), decorators=[xfail]),
         subtest(([complex(1, 0), complex(0, 2), complex(1, 1)], 1), decorators=[xfail]),
@@ -591,7 +609,7 @@ class TestNoExtraMethods(TestCase):
             getattr(a, name)
 
 
-#instantiate_parametrized_tests(TestArgmaxArgminCommon)
+# instantiate_parametrized_tests(TestArgmaxArgminCommon)
 instantiate_parametrized_tests(TestArgmax)
 instantiate_parametrized_tests(TestArgmin)
 instantiate_parametrized_tests(TestNoExtraMethods)

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -414,7 +414,7 @@ class TestArgmax(TestCase):
         #                      "invalid value encountered in reduce")
         if np.asarray(arr).dtype.kind in "c":
             pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
-            from unittest import 
+            from unittest import
 
         val = np.max(arr)
 

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -191,12 +191,17 @@ class TestArgmaxArgminCommon(TestCase):
 
     @parametrize(
         "size, axis",
-        list(itertools.chain(
-            *[
-                [(size, axis) for axis in list(range(-len(size), len(size))) + [None]]
-                for size in sizes
-            ]
-        )),
+        list(
+            itertools.chain(
+                *[
+                    [
+                        (size, axis)
+                        for axis in list(range(-len(size), len(size))) + [None]
+                    ]
+                    for size in sizes
+                ]
+            )
+        ),
     )
     @parametrize("method", [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
@@ -424,8 +429,8 @@ class TestArgmax(TestCase):
         #      with suppress_warnings() as sup:
         #          sup.filter(RuntimeWarning,
         #                      "invalid value encountered in reduce")
-#        if np.asarray(arr).dtype.kind in "c":
-#            pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
+        #        if np.asarray(arr).dtype.kind in "c":
+        #            pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
 
         val = np.max(arr)
 
@@ -611,7 +616,6 @@ class TestNoExtraMethods(TestCase):
         a = np.ones(3)
         with pytest.raises(AttributeError):
             getattr(a, name)
-
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -170,7 +170,8 @@ class TestNonzero(TestCase):
         assert_equal(m.nonzero(), tgt)
 
 
-class TestArgmaxArgminCommon:  # (TestCase): FIXME
+@instantiate_parametrized_tests
+class TestArgmaxArgminCommon(TestCase):
     sizes = [
         (),
         (3,),
@@ -190,12 +191,12 @@ class TestArgmaxArgminCommon:  # (TestCase): FIXME
 
     @parametrize(
         "size, axis",
-        itertools.chain(
+        list(itertools.chain(
             *[
                 [(size, axis) for axis in list(range(-len(size), len(size))) + [None]]
                 for size in sizes
             ]
-        ),
+        )),
     )
     @parametrize("method", [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
@@ -330,7 +331,7 @@ class TestArgmaxArgminCommon:  # (TestCase): FIXME
         assert_equal(arg_method(out=out1, axis=0), np_method(a, out=out2, axis=0))
         assert_equal(out1, out2)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "arr_method, np_method", [("argmax", np.argmax), ("argmin", np.argmin)]
     )
     def test_np_vs_ndarray_positional(self, arr_method, np_method):
@@ -344,6 +345,7 @@ class TestArgmaxArgminCommon:  # (TestCase): FIXME
         assert_equal(out1, out2)
 
 
+@instantiate_parametrized_tests
 class TestArgmax(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 0),
@@ -422,8 +424,8 @@ class TestArgmax(TestCase):
         #      with suppress_warnings() as sup:
         #          sup.filter(RuntimeWarning,
         #                      "invalid value encountered in reduce")
-        if np.asarray(arr).dtype.kind in "c":
-            pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
+#        if np.asarray(arr).dtype.kind in "c":
+#            pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
 
         val = np.max(arr)
 
@@ -456,6 +458,7 @@ class TestArgmax(TestCase):
         assert_equal(np.argmax(a), 1)
 
 
+@instantiate_parametrized_tests
 class TestArgmin(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 8),
@@ -599,6 +602,7 @@ class TestContains(TestCase):
         assert 42 not in a
 
 
+@instantiate_parametrized_tests
 class TestNoExtraMethods(TestCase):
     # make sure ndarray does not carry extra methods/attributes
     # >>> set(dir(a)) - set(dir(a.tensor.numpy()))
@@ -608,11 +612,6 @@ class TestNoExtraMethods(TestCase):
         with pytest.raises(AttributeError):
             getattr(a, name)
 
-
-# instantiate_parametrized_tests(TestArgmaxArgminCommon)
-instantiate_parametrized_tests(TestArgmax)
-instantiate_parametrized_tests(TestArgmin)
-instantiate_parametrized_tests(TestNoExtraMethods)
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TestCase,
+    subtest,
 )
 
 
@@ -388,18 +389,18 @@ class TestArgmax(TestCase):
         )
     ]
     nan_arr = darr + [
-        ([0, 1, 2, 3, complex(0, np.nan)], 4),
-        ([0, 1, 2, 3, complex(np.nan, 0)], 4),
-        ([0, 1, 2, complex(np.nan, 0), 3], 3),
-        ([0, 1, 2, complex(0, np.nan), 3], 3),
-        ([complex(0, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
-        ([complex(0, 0), complex(0, 2), complex(0, 1)], 1),
-        ([complex(1, 0), complex(0, 2), complex(0, 1)], 0),
-        ([complex(1, 0), complex(0, 2), complex(1, 1)], 2),
+        subtest(([0, 1, 2, 3, complex(0, np.nan)], 4), decorators=[xfail]),
+        subtest(([0, 1, 2, 3, complex(np.nan, 0)], 4), decorators=[xfail]),
+        subtest(([0, 1, 2, complex(np.nan, 0), 3], 3), decorators=[xfail]),
+        subtest(([0, 1, 2, complex(0, np.nan), 3], 3), decorators=[xfail]),
+        subtest(([complex(0, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0), decorators=[xfail]),
+        subtest(([complex(0, 0), complex(0, 2), complex(0, 1)], 1), decorators=[xfail]),
+        subtest(([complex(1, 0), complex(0, 2), complex(0, 1)], 0), decorators=[xfail]),
+        subtest(([complex(1, 0), complex(0, 2), complex(1, 1)], 2), decorators=[xfail]),
         ([False, False, False, False, True], 4),
         ([False, False, False, True, False], 3),
         ([True, False, False, False, False], 0),
@@ -414,7 +415,6 @@ class TestArgmax(TestCase):
         #                      "invalid value encountered in reduce")
         if np.asarray(arr).dtype.kind in "c":
             pytest.xfail(reason="'max_values_cpu' not implemented for 'ComplexDouble'")
-            from unittest import
 
         val = np.max(arr)
 
@@ -492,18 +492,18 @@ class TestArgmin(TestCase):
         )
     ]
     nan_arr = darr + [
-        ([0, 1, 2, 3, complex(0, np.nan)], 4),
-        ([0, 1, 2, 3, complex(np.nan, 0)], 4),
-        ([0, 1, 2, complex(np.nan, 0), 3], 3),
-        ([0, 1, 2, complex(0, np.nan), 3], 3),
-        ([complex(0, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
-        ([complex(0, 0), complex(0, 2), complex(0, 1)], 0),
-        ([complex(1, 0), complex(0, 2), complex(0, 1)], 2),
-        ([complex(1, 0), complex(0, 2), complex(1, 1)], 1),
+        subtest(([0, 1, 2, 3, complex(0, np.nan)], 4), decorators=[xfail]),
+        subtest(([0, 1, 2, 3, complex(np.nan, 0)], 4), decorators=[xfail]),
+        subtest(([0, 1, 2, complex(np.nan, 0), 3], 3), decorators=[xfail]),
+        subtest(([0, 1, 2, complex(0, np.nan), 3], 3), decorators=[xfail]),
+        subtest(([complex(0, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, np.nan), 0, 1, 2, 3], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0), decorators=[xfail]),
+        subtest(([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0), decorators=[xfail]),
+        subtest(([complex(0, 0), complex(0, 2), complex(0, 1)], 0), decorators=[xfail]),
+        subtest(([complex(1, 0), complex(0, 2), complex(0, 1)], 2), decorators=[xfail]),
+        subtest(([complex(1, 0), complex(0, 2), complex(1, 1)], 1), decorators=[xfail]),
         ([True, True, True, True, False], 4),
         ([True, True, True, False, True], 3),
         ([False, True, True, True, True], 0),

--- a/test/torch_np/test_nep50_examples.py
+++ b/test/torch_np/test_nep50_examples.py
@@ -85,6 +85,7 @@ examples = {
     "True + uint8(2)": (uint8(3), unchanged),
 }
 
+
 @pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
 class TestNEP50Table(TestCase):
     @parametrize("example", examples)
@@ -149,12 +150,9 @@ corners = {
 }
 
 
-
 @pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
 class TestCompareToNumpy(TestCase):
-    @parametrize(
-        "scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes)
-    )
+    @parametrize("scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes))
     def test_direct_compare(self, scalar, array, dtype):
         # compare to NumPy w/ NEP 50.
         try:
@@ -177,7 +175,6 @@ class TestCompareToNumpy(TestCase):
 
         finally:
             _np._set_promotion_state(state)
-
 
     @parametrize("name", tnp._ufuncs._binary)
     @parametrize("scalar, array", itertools.product(weaks, non_weaks))

--- a/test/torch_np/test_nep50_examples.py
+++ b/test/torch_np/test_nep50_examples.py
@@ -3,7 +3,7 @@
 """Test examples for NEP 50."""
 
 import itertools
-from unittest import SkipTest, skipIf as skipif
+from unittest import skipIf as skipif, SkipTest
 
 try:
     import numpy as _np
@@ -45,7 +45,6 @@ uint16 = uint8  # can be anything here, see below
 # import numpy as np
 # np._set_promotion_state('weak')
 
-import pytest
 from pytest import raises as assert_raises
 
 unchanged = None

--- a/test/torch_np/test_nep50_examples.py
+++ b/test/torch_np/test_nep50_examples.py
@@ -28,6 +28,14 @@ from torch._numpy import (  # noqa: F401
 )
 from torch._numpy.testing import assert_allclose
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
 uint16 = uint8  # can be anything here, see below
 
 
@@ -77,23 +85,24 @@ examples = {
     "True + uint8(2)": (uint8(3), unchanged),
 }
 
+@pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
+class TestNEP50Table(TestCase):
+    @parametrize("example", examples)
+    def test_nep50_exceptions(self, example):
+        old, new = examples[example]
 
-@pytest.mark.parametrize("example", examples)
-def test_nep50_exceptions(example):
-    old, new = examples[example]
+        if new == Exception:
+            with assert_raises(OverflowError):
+                eval(example)
 
-    if new == Exception:
-        with assert_raises(OverflowError):
-            eval(example)
+        else:
+            result = eval(example)
 
-    else:
-        result = eval(example)
+            if new is unchanged:
+                new = old
 
-        if new is unchanged:
-            new = old
-
-        assert_allclose(result, new, atol=1e-16)
-        assert result.dtype == new.dtype
+            assert_allclose(result, new, atol=1e-16)
+            assert result.dtype == new.dtype
 
 
 # ### Directly compare to numpy ###
@@ -127,34 +136,6 @@ else:
     dtypes = (None,)
 
 
-@pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
-@pytest.mark.parametrize(
-    "scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes)
-)
-def test_direct_compare(scalar, array, dtype):
-    # compare to NumPy w/ NEP 50.
-    try:
-        state = _np._get_promotion_state()
-        _np._set_promotion_state("weak")
-
-        if dtype is not None:
-            kwargs = {"dtype": dtype}
-        try:
-            result_numpy = _np.add(scalar, array.tensor.numpy(), **kwargs)
-        except Exception:
-            return
-
-        kwargs = {}
-        if dtype is not None:
-            kwargs = {"dtype": getattr(tnp, dtype.__name__)}
-        result = tnp.add(scalar, array, **kwargs).tensor.numpy()
-        assert result.dtype == result_numpy.dtype
-        assert result == result_numpy
-
-    finally:
-        _np._set_promotion_state(state)
-
-
 # ufunc name: [array.dtype]
 corners = {
     "true_divide": ["bool_", "uint8", "int8", "int16", "int32", "int64"],
@@ -168,45 +149,75 @@ corners = {
 }
 
 
+
 @pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
-@pytest.mark.parametrize("name", tnp._ufuncs._binary)
-@pytest.mark.parametrize("scalar, array", itertools.product(weaks, non_weaks))
-def test_compare_ufuncs(name, scalar, array):
-    if name in corners and (
-        array.dtype.name in corners[name]
-        or tnp.asarray(scalar).dtype.name in corners[name]
-    ):
-        return pytest.skip(f"{name}(..., dtype=array.dtype)")
+class TestCompareToNumpy(TestCase):
+    @parametrize(
+        "scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes)
+    )
+    def test_direct_compare(self, scalar, array, dtype):
+        # compare to NumPy w/ NEP 50.
+        try:
+            state = _np._get_promotion_state()
+            _np._set_promotion_state("weak")
 
-    try:
-        state = _np._get_promotion_state()
-        _np._set_promotion_state("weak")
+            if dtype is not None:
+                kwargs = {"dtype": dtype}
+            try:
+                result_numpy = _np.add(scalar, array.tensor.numpy(), **kwargs)
+            except Exception:
+                return
 
-        if name in ["matmul", "modf", "divmod", "ldexp"]:
-            return
-        ufunc = getattr(tnp, name)
-        ufunc_numpy = getattr(_np, name)
+            kwargs = {}
+            if dtype is not None:
+                kwargs = {"dtype": getattr(tnp, dtype.__name__)}
+            result = tnp.add(scalar, array, **kwargs).tensor.numpy()
+            assert result.dtype == result_numpy.dtype
+            assert result == result_numpy
+
+        finally:
+            _np._set_promotion_state(state)
+
+
+    @parametrize("name", tnp._ufuncs._binary)
+    @parametrize("scalar, array", itertools.product(weaks, non_weaks))
+    def test_compare_ufuncs(self, name, scalar, array):
+        if name in corners and (
+            array.dtype.name in corners[name]
+            or tnp.asarray(scalar).dtype.name in corners[name]
+        ):
+            return pytest.skip(f"{name}(..., dtype=array.dtype)")
 
         try:
-            result = ufunc(scalar, array)
-        except RuntimeError:
-            # RuntimeError: "bitwise_xor_cpu" not implemented for 'ComplexDouble' etc
-            result = None
+            state = _np._get_promotion_state()
+            _np._set_promotion_state("weak")
 
-        try:
-            result_numpy = ufunc_numpy(scalar, array.tensor.numpy())
-        except TypeError:
-            # TypeError: ufunc 'hypot' not supported for the input types
-            result_numpy = None
+            if name in ["matmul", "modf", "divmod", "ldexp"]:
+                return
+            ufunc = getattr(tnp, name)
+            ufunc_numpy = getattr(_np, name)
 
-        if result is not None and result_numpy is not None:
-            assert result.tensor.numpy().dtype == result_numpy.dtype
+            try:
+                result = ufunc(scalar, array)
+            except RuntimeError:
+                # RuntimeError: "bitwise_xor_cpu" not implemented for 'ComplexDouble' etc
+                result = None
 
-    finally:
-        _np._set_promotion_state(state)
+            try:
+                result_numpy = ufunc_numpy(scalar, array.tensor.numpy())
+            except TypeError:
+                # TypeError: ufunc 'hypot' not supported for the input types
+                result_numpy = None
 
+            if result is not None and result_numpy is not None:
+                assert result.tensor.numpy().dtype == result_numpy.dtype
+
+        finally:
+            _np._set_promotion_state(state)
+
+
+instantiate_parametrized_tests(TestNEP50Table)
+instantiate_parametrized_tests(TestCompareToNumpy)
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_nep50_examples.py
+++ b/test/torch_np/test_nep50_examples.py
@@ -3,6 +3,7 @@
 """Test examples for NEP 50."""
 
 import itertools
+from unittest import SkipTest, skipIf as skipif
 
 try:
     import numpy as _np
@@ -86,7 +87,8 @@ examples = {
 }
 
 
-@pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
+@skipif(not HAVE_NUMPY, reason="NumPy not found")
+@instantiate_parametrized_tests
 class TestNEP50Table(TestCase):
     @parametrize("example", examples)
     def test_nep50_exceptions(self, example):
@@ -150,7 +152,8 @@ corners = {
 }
 
 
-@pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
+@skipif(not HAVE_NUMPY, reason="NumPy not found")
+@instantiate_parametrized_tests
 class TestCompareToNumpy(TestCase):
     @parametrize("scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes))
     def test_direct_compare(self, scalar, array, dtype):
@@ -183,7 +186,7 @@ class TestCompareToNumpy(TestCase):
             array.dtype.name in corners[name]
             or tnp.asarray(scalar).dtype.name in corners[name]
         ):
-            return pytest.skip(f"{name}(..., dtype=array.dtype)")
+            raise SkipTest(f"{name}(..., dtype=array.dtype)")
 
         try:
             state = _np._get_promotion_state()
@@ -212,9 +215,6 @@ class TestCompareToNumpy(TestCase):
         finally:
             _np._set_promotion_state(state)
 
-
-instantiate_parametrized_tests(TestNEP50Table)
-instantiate_parametrized_tests(TestCompareToNumpy)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -13,6 +13,14 @@ import torch._dynamo.config as config
 import torch._numpy as tnp
 from torch._numpy.testing import assert_equal
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+    subtest,
+)
+
 
 @contextmanager
 def control_stream(use_numpy=False):
@@ -24,28 +32,43 @@ def control_stream(use_numpy=False):
         config.use_numpy_random_stream = oldstate
 
 
-@pytest.mark.parametrize("use_numpy", [True, False])
-@pytest.mark.parametrize(
-    "func",
-    [
-        tnp.random.normal,
-        tnp.random.rand,
-        partial(tnp.random.randint, 0, 5),
-        tnp.random.randn,
-        tnp.random.random,
-        tnp.random.random_sample,
-        tnp.random.sample,
-        tnp.random.uniform,
-    ],
-)
-class TestScalarReturn:
-    def test_scalar(self, func, use_numpy):
+
+class TestScalarReturn(TestCase):
+    @parametrize("use_numpy", [True, False])
+    @parametrize(
+        "func",
+        [
+            tnp.random.normal,
+            tnp.random.rand,
+            partial(tnp.random.randint, 0, 5),
+            tnp.random.randn,
+            subtest(tnp.random.random, name="random_random"),
+            subtest(tnp.random.random_sample, name="random_sample"),
+            tnp.random.sample,
+            tnp.random.uniform,
+        ],
+    )
+    def test_rndm_scalar(self, func, use_numpy):
         # default `size` means a python scalar return
         with control_stream(use_numpy):
             r = func()
         assert isinstance(r, (int, float))
 
-    def test_array(self, func, use_numpy):
+    @parametrize("use_numpy", [True, False])
+    @parametrize(
+        "func",
+        [
+            tnp.random.normal,
+            tnp.random.rand,
+            partial(tnp.random.randint, 0, 5),
+            tnp.random.randn,
+            subtest(tnp.random.random, name="random_random"),
+            subtest(tnp.random.random_sample, name="random_sample"),
+            tnp.random.sample,
+            tnp.random.uniform,
+        ],
+    )
+    def test_rndm_array(self, func, use_numpy):
         with control_stream(use_numpy):
             if func in (tnp.random.rand, tnp.random.randn):
                 r = func(10)
@@ -54,8 +77,8 @@ class TestScalarReturn:
         assert isinstance(r, tnp.ndarray)
 
 
-class TestShuffle:
-    @pytest.mark.parametrize("use_numpy", [True, False])
+class TestShuffle(TestCase):
+    @parametrize("use_numpy", [True, False])
     def test_1d(self, use_numpy):
         ax = tnp.asarray([1, 2, 3, 4, 5, 6])
         ox = ax.copy()
@@ -66,7 +89,7 @@ class TestShuffle:
         assert isinstance(ax, tnp.ndarray)
         assert not (ax == ox).all()
 
-    @pytest.mark.parametrize("use_numpy", [True, False])
+    @parametrize("use_numpy", [True, False])
     def test_2d(self, use_numpy):
         # np.shuffle only shuffles the first axis
         ax = tnp.asarray([[1, 2, 3], [4, 5, 6]])
@@ -78,7 +101,7 @@ class TestShuffle:
         assert isinstance(ax, tnp.ndarray)
         assert not (ax == ox).all()
 
-    @pytest.mark.parametrize("use_numpy", [True, False])
+    @parametrize("use_numpy", [True, False])
     def test_shuffle_list(self, use_numpy):
         # on eager, we refuse to shuffle lists
         # under dynamo, we always fall back to numpy
@@ -89,18 +112,19 @@ class TestShuffle:
             tnp.random.shuffle(x)
 
 
-@pytest.mark.parametrize("use_numpy", [True, False])
-def test_choice(use_numpy):
-    kwds = dict(size=3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
-    with control_stream(use_numpy):
-        tnp.random.seed(12345)
-        x = tnp.random.choice(5, **kwds)
-        tnp.random.seed(12345)
-        x_1 = tnp.random.choice(tnp.arange(5), **kwds)
-        assert_equal(x, x_1)
+class TestChoice(TestCase):
+    @parametrize("use_numpy", [True, False])
+    def test_choice(self, use_numpy):
+        kwds = dict(size=3, replace=False, p=[0.1, 0, 0.3, 0.6, 0])
+        with control_stream(use_numpy):
+            tnp.random.seed(12345)
+            x = tnp.random.choice(5, **kwds)
+            tnp.random.seed(12345)
+            x_1 = tnp.random.choice(tnp.arange(5), **kwds)
+            assert_equal(x, x_1)
 
 
-class TestNumpyGlobal:
+class TestNumpyGlobal(TestCase):
     def test_numpy_global(self):
         with control_stream(use_numpy=True):
             tnp.random.seed(12345)
@@ -119,7 +143,10 @@ class TestNumpyGlobal:
         assert not (x_1 == x).all()
 
 
-if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
+instantiate_parametrized_tests(TestScalarReturn)
+instantiate_parametrized_tests(TestShuffle)
+instantiate_parametrized_tests(TestChoice)
+instantiate_parametrized_tests(TestNumpyGlobal)
 
+if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -32,6 +32,7 @@ def control_stream(use_numpy=False):
         config.use_numpy_random_stream = oldstate
 
 
+@instantiate_parametrized_tests
 class TestScalarReturn(TestCase):
     @parametrize("use_numpy", [True, False])
     @parametrize(
@@ -76,6 +77,7 @@ class TestScalarReturn(TestCase):
         assert isinstance(r, tnp.ndarray)
 
 
+@instantiate_parametrized_tests
 class TestShuffle(TestCase):
     @parametrize("use_numpy", [True, False])
     def test_1d(self, use_numpy):
@@ -111,6 +113,7 @@ class TestShuffle(TestCase):
             tnp.random.shuffle(x)
 
 
+@instantiate_parametrized_tests
 class TestChoice(TestCase):
     @parametrize("use_numpy", [True, False])
     def test_choice(self, use_numpy):
@@ -141,11 +144,6 @@ class TestNumpyGlobal(TestCase):
 
         assert not (x_1 == x).all()
 
-
-instantiate_parametrized_tests(TestScalarReturn)
-instantiate_parametrized_tests(TestShuffle)
-instantiate_parametrized_tests(TestChoice)
-instantiate_parametrized_tests(TestNumpyGlobal)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -17,8 +17,8 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TestCase,
     subtest,
+    TestCase,
 )
 
 
@@ -30,7 +30,6 @@ def control_stream(use_numpy=False):
         yield
     finally:
         config.use_numpy_random_stream = oldstate
-
 
 
 class TestScalarReturn(TestCase):

--- a/test/torch_np/test_reductions.py
+++ b/test/torch_np/test_reductions.py
@@ -15,13 +15,11 @@ from torch._numpy.testing import (
     assert_equal,
 )
 
-
 from torch.testing._internal.common_utils import (
-instantiate_parametrized_tests,
+    instantiate_parametrized_tests,
     parametrize,
     run_tests,
     TestCase,
-    subtest,
 )
 
 
@@ -114,7 +112,7 @@ class TestMean(TestCase):
         # of float32.
         assert np.mean(np.ones(100000, dtype="float16")) == 1
 
-    @xfail #(reason="XXX: mean(..., where=...) not implemented")
+    @xfail  # (reason="XXX: mean(..., where=...) not implemented")
     def test_mean_where(self):
         a = np.arange(16).reshape((4, 4))
         wh_full = np.array(
@@ -180,7 +178,7 @@ class TestSum(TestCase):
         assert_allclose(res_float, 4.0, atol=1e-15)
         assert res_float.dtype == "float64"
 
-    @xfail   #(reason="sum: does not warn on overflow")
+    @xfail  # (reason="sum: does not warn on overflow")
     def test_sum_dtypes_warnings(self):
         for dt in (int, np.float16, np.float32, np.float64):
             for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127, 128, 1024, 1235):
@@ -247,7 +245,7 @@ class TestSum(TestCase):
         d += d
         assert_allclose(d, 2.0 + 2j, atol=1.5e-7)
 
-    @xfail  #(reason="initial=... need implementing")
+    @xfail  # (reason="initial=... need implementing")
     def test_sum_initial(self):
         # Integer, single axis
         assert_equal(np.sum([3], initial=2), 5)
@@ -261,7 +259,7 @@ class TestSum(TestCase):
             [12, 12, 12],
         )
 
-    @xfail  #(reason="where=... need implementing")
+    @xfail  # (reason="where=... need implementing")
     def test_sum_where(self):
         # More extensive tests done in test_reduction_with_where.
         assert_equal(np.sum([[1.0, 2.0], [3.0, 4.0]], where=[True, False]), 4.0)
@@ -271,14 +269,38 @@ class TestSum(TestCase):
         )
 
 
-parametrize_axis = parametrize('axis', [0, 1, 2, -1, -2, (0, 1), (1, 0), (0, 1, 2), (1, -1, 0)])
-parametrize_func = parametrize('func', [np.any, np.all, np.argmin, np.argmax, np.min, np.max, np.mean, np.sum, np.prod, np.std, np.var, np.count_nonzero])
-
-fails_axes_tuples = {np.any, np.all, np.argmin, np.argmax, 
+parametrize_axis = parametrize(
+    "axis", [0, 1, 2, -1, -2, (0, 1), (1, 0), (0, 1, 2), (1, -1, 0)]
+)
+parametrize_func = parametrize(
+    "func",
+    [
+        np.any,
+        np.all,
+        np.argmin,
+        np.argmax,
+        np.min,
+        np.max,
+        np.mean,
+        np.sum,
         np.prod,
+        np.std,
+        np.var,
+        np.count_nonzero,
+    ],
+)
+
+fails_axes_tuples = {
+    np.any,
+    np.all,
+    np.argmin,
+    np.argmax,
+    np.prod,
 }
 
-fails_out_arg = {np.count_nonzero,}
+fails_out_arg = {
+    np.count_nonzero,
+}
 
 
 @instantiate_parametrized_tests
@@ -315,9 +337,7 @@ class TestGenericReductions(TestCase):
     @parametrize_func
     def test_axis_empty_generic(self, func):
         a = np.array([[0, 0, 1], [1, 0, 1]])
-        assert_array_equal(
-            func(a, axis=()), func(np.expand_dims(a, axis=0), axis=0)
-        )
+        assert_array_equal(func(a, axis=()), func(np.expand_dims(a, axis=0), axis=0))
 
     @parametrize_func
     def test_axis_bad_tuple(self, func):
@@ -440,10 +460,9 @@ class TestGenericReductions(TestCase):
 
 @instantiate_parametrized_tests
 class TestGenericCumSumProd(TestCase):
-    """Run a set of generic tests to verify that cumsum/cumprod are sane.
-    """
+    """Run a set of generic tests to verify that cumsum/cumprod are sane."""
 
-    @parametrize('func', [np.cumsum, np.cumprod])
+    @parametrize("func", [np.cumsum, np.cumprod])
     def test_bad_axis(self, func):
         # Basic check of functionality
         m = np.array([[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]])
@@ -455,7 +474,7 @@ class TestGenericCumSumProd(TestCase):
 
         # TODO: add tests with np.int32(3) etc, when implemented
 
-    @parametrize('func', [np.cumsum, np.cumprod])
+    @parametrize("func", [np.cumsum, np.cumprod])
     def test_array_axis(self, func):
         a = np.array([[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]])
         assert_equal(func(a, axis=np.array(-1)), func(a, axis=-1))
@@ -463,18 +482,17 @@ class TestGenericCumSumProd(TestCase):
         with assert_raises(TypeError):
             func(a, axis=np.array([1, 2]))
 
-    @parametrize('func', [np.cumsum, np.cumprod])
+    @parametrize("func", [np.cumsum, np.cumprod])
     def test_axis_empty_generic(self, func):
         a = np.array([[0, 0, 1], [1, 0, 1]])
         assert_array_equal(func(a, axis=None), func(a.ravel(), axis=0))
 
-    @parametrize('func', [np.cumsum, np.cumprod])
+    @parametrize("func", [np.cumsum, np.cumprod])
     def test_axis_bad_tuple(self, func):
         # Basic check of functionality
         m = np.array([[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]])
         with assert_raises(TypeError):
             func(m, axis=(1, 1))
-
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_scalars_0D_arrays.py
+++ b/test/torch_np/test_scalars_0D_arrays.py
@@ -32,6 +32,7 @@ parametrize_value = parametrize(
 )
 
 
+@instantiate_parametrized_tests
 class TestArrayScalars(TestCase):
     @parametrize_value
     def test_array_scalar_basic(self, value):
@@ -78,6 +79,7 @@ class TestArrayScalars(TestCase):
         assert arr == 42
 
 
+@instantiate_parametrized_tests
 class TestIsScalar(TestCase):
     #
     # np.isscalar(...) checks that its argument is a numeric object with exactly one element.
@@ -120,9 +122,6 @@ class TestIsScalar(TestCase):
     def test_is_not_scalar(self, value):
         assert not np.isscalar(value)
 
-
-instantiate_parametrized_tests(TestArrayScalars)
-instantiate_parametrized_tests(TestIsScalar)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_scalars_0D_arrays.py
+++ b/test/torch_np/test_scalars_0D_arrays.py
@@ -13,23 +13,39 @@ import pytest
 import torch._numpy as np
 from torch._numpy.testing import assert_equal
 
-
-@pytest.mark.parametrize(
-    "value", [np.int64(42), np.array(42), np.asarray(42), np.asarray(np.int64(42))]
+from torch.testing._internal.common_utils import (
+instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+    subtest,
 )
-class TestArrayScalars:
+
+
+parametrize_value = parametrize(
+    "value", [subtest(np.int64(42), name='int64'),
+              subtest(np.array(42), name='array'),
+              subtest(np.asarray(42), name='asarray'),
+              subtest(np.asarray(np.int64(42)), name='asarray_int')]
+)
+
+class TestArrayScalars(TestCase):
+
+    @parametrize_value
     def test_array_scalar_basic(self, value):
         assert value.ndim == 0
         assert value.shape == ()
         assert value.size == 1
         assert value.dtype == np.dtype("int64")
 
+    @parametrize_value
     def test_conversion_to_int(self, value):
         py_scalar = int(value)
         assert py_scalar == 42
         assert isinstance(py_scalar, int)
         assert not isinstance(value, int)
 
+    @parametrize_value
     def test_decay_to_py_scalar(self, value):
         # NumPy distinguishes array scalars and 0D arrays. For instance
         # `scalar * list` is equivalent to `int(scalar) * list`, but
@@ -48,28 +64,27 @@ class TestArrayScalars:
         assert product.shape == (3,)
         assert_equal(product, [42, 42 * 2, 42 * 3])
 
+    def test_scalar_comparisons(self):
+        scalar = np.int64(42)
+        arr = np.array(42)
 
-def test_scalar_comparisons():
-    scalar = np.int64(42)
-    arr = np.array(42)
+        assert arr == scalar
+        assert arr >= scalar
+        assert arr <= scalar
 
-    assert arr == scalar
-    assert arr >= scalar
-    assert arr <= scalar
-
-    assert scalar == 42
-    assert arr == 42
+        assert scalar == 42
+        assert arr == 42
 
 
-class TestIsScalar:
+class TestIsScalar(TestCase):
     #
     # np.isscalar(...) checks that its argument is a numeric object with exactly one element.
     #
     # This differs from NumPy which also requires that shape == ().
     #
     scalars = [
-        42,
-        int(42.0),
+        subtest(42, 'literal'),
+        subtest(int(42.0), 'int'),
         np.float32(42),
         np.array(42),
         [42],
@@ -95,16 +110,17 @@ class TestIsScalar:
         np.float32([1, 2]),
     ]
 
-    @pytest.mark.parametrize("value", scalars)
+    @parametrize("value", scalars)
     def test_is_scalar(self, value):
         assert np.isscalar(value)
 
-    @pytest.mark.parametrize("value", not_scalars)
+    @parametrize("value", not_scalars)
     def test_is_not_scalar(self, value):
         assert not np.isscalar(value)
 
 
-if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
+instantiate_parametrized_tests(TestArrayScalars)
+instantiate_parametrized_tests(TestIsScalar)
 
+if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_scalars_0D_arrays.py
+++ b/test/torch_np/test_scalars_0D_arrays.py
@@ -8,29 +8,31 @@ Extensive tests of this sort of functionality is in numpy_tests/core/*scalar*
 
 Also test the isscalar function (which is deliberately a bit more lax).
 """
-import pytest
 
 import torch._numpy as np
 from torch._numpy.testing import assert_equal
 
 from torch.testing._internal.common_utils import (
-instantiate_parametrized_tests,
+    instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TestCase,
     subtest,
+    TestCase,
 )
 
 
 parametrize_value = parametrize(
-    "value", [subtest(np.int64(42), name='int64'),
-              subtest(np.array(42), name='array'),
-              subtest(np.asarray(42), name='asarray'),
-              subtest(np.asarray(np.int64(42)), name='asarray_int')]
+    "value",
+    [
+        subtest(np.int64(42), name="int64"),
+        subtest(np.array(42), name="array"),
+        subtest(np.asarray(42), name="asarray"),
+        subtest(np.asarray(np.int64(42)), name="asarray_int"),
+    ],
 )
 
-class TestArrayScalars(TestCase):
 
+class TestArrayScalars(TestCase):
     @parametrize_value
     def test_array_scalar_basic(self, value):
         assert value.ndim == 0
@@ -83,8 +85,8 @@ class TestIsScalar(TestCase):
     # This differs from NumPy which also requires that shape == ().
     #
     scalars = [
-        subtest(42, 'literal'),
-        subtest(int(42.0), 'int'),
+        subtest(42, "literal"),
+        subtest(int(42.0), "int"),
         np.float32(42),
         np.array(42),
         [42],

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -30,6 +30,7 @@ parametrize_casting = parametrize(
 )
 
 
+@instantiate_parametrized_tests
 class TestUnaryUfuncs(TestCase):
     def get_x(self, ufunc):
         return np.arange(5, dtype="float64")
@@ -149,6 +150,7 @@ parametrize_binary_ufuncs = parametrize(
 """
 
 
+@instantiate_parametrized_tests
 class TestBinaryUfuncs(TestCase):
     def get_xy(self, ufunc):
         return np.arange(5, dtype="float64"), np.arange(8, 13, dtype="float64")
@@ -205,6 +207,7 @@ class TestBinaryUfuncs(TestCase):
 dtypes_numeric = [np.int32, np.float32, np.float64, np.complex128]
 
 
+@instantiate_parametrized_tests
 class TestNdarrayDunderVsUfunc(TestCase):
     """Test ndarray dunders which delegate to ufuncs, vs ufuncs."""
 
@@ -394,12 +397,6 @@ class TestUfuncDtypeKwd(TestCase):
         r = np.add([1.0, 2.0], 1.0e-15, dtype=np.float64, out=out32)
         assert (r == [1, 2]).all()
         assert r.dtype == np.float32
-
-
-instantiate_parametrized_tests(TestUnaryUfuncs)
-instantiate_parametrized_tests(TestNdarrayDunderVsUfunc)
-
-instantiate_parametrized_tests(TestBinaryUfuncs)
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -11,13 +11,11 @@ by
 """
 import operator
 
-import pytest
+from unittest import skipIf as skip, SkipTest
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_equal
-
-from unittest import SkipTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -42,14 +40,14 @@ class TestUnaryUfuncs(TestCase):
         x = self.get_x(ufunc)[0]
         float(ufunc(x))
 
-    @pytest.mark.skip(reason="XXX: unary ufuncs ignore the dtype=... parameter")
+    @skip(True, reason="XXX: unary ufuncs ignore the dtype=... parameter")
     @parametrize_unary_ufuncs
     def test_x_and_dtype(self, ufunc):
         x = self.get_x(ufunc)
         res = ufunc(x, dtype="float")
         assert res.dtype == np.dtype("float")
 
-    @pytest.mark.skip(reason="XXX: unary ufuncs ignore the dtype=... parameter")
+    @skip(True, reason="XXX: unary ufuncs ignore the dtype=... parameter")
     @parametrize_casting
     @parametrize_unary_ufuncs
     @parametrize("dtype", ["float64", "complex128", "float32"])
@@ -245,7 +243,7 @@ class TestNdarrayDunderVsUfunc(TestCase):
         b = other_dtype(3)
 
         if ufunc in no_complex and issubclass(other_dtype, np.complexfloating):
-            pytest.skip(f"{ufunc} does not accept complex.")
+            raise SkipTest(f"{ufunc} does not accept complex.")
 
         # __op__
         result = op(a, b)
@@ -283,7 +281,7 @@ class TestNdarrayDunderVsUfunc(TestCase):
         b = np.array([5, 6, 7], dtype=other_dtype)
 
         if ufunc in no_complex and issubclass(other_dtype, np.complexfloating):
-            pytest.skip(f"{ufunc} does not accept complex.")
+            raise SkipTest(f"{ufunc} does not accept complex.")
 
         # __op__
         result = op(a, b)

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TestCase,
-    subtest,
 )
 
 

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -17,6 +17,7 @@ import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_equal
 
+from unittest import SkipTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -174,7 +175,7 @@ class TestBinaryUfuncs(TestCase):
         out = np.empty_like(x, dtype=out_dtype)
 
         if ufunc in no_complex and np.issubdtype(out_dtype, np.complexfloating):
-            pytest.skip(f"{ufunc} does not accept complex.")
+            raise SkipTest(f"{ufunc} does not accept complex.")
 
         can_cast_x = np.can_cast(x, out_dtype, casting=casting)
         can_cast_y = np.can_cast(y, out_dtype, casting=casting)

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -17,14 +17,22 @@ import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_equal
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+    subtest,
+)
 
-parametrize_unary_ufuncs = pytest.mark.parametrize("ufunc", [np.sin])
-parametrize_casting = pytest.mark.parametrize(
+
+parametrize_unary_ufuncs = parametrize("ufunc", [np.sin])
+parametrize_casting = parametrize(
     "casting", ["no", "equiv", "safe", "same_kind", "unsafe"]
 )
 
 
-class TestUnaryUfuncs:
+class TestUnaryUfuncs(TestCase):
     def get_x(self, ufunc):
         return np.arange(5, dtype="float64")
 
@@ -44,7 +52,7 @@ class TestUnaryUfuncs:
     @pytest.mark.skip(reason="XXX: unary ufuncs ignore the dtype=... parameter")
     @parametrize_casting
     @parametrize_unary_ufuncs
-    @pytest.mark.parametrize("dtype", ["float64", "complex128", "float32"])
+    @parametrize("dtype", ["float64", "complex128", "float32"])
     def test_x_and_dtype_casting(self, ufunc, casting, dtype):
         x = self.get_x(ufunc)
         if not np.can_cast(x, dtype, casting=casting):
@@ -55,7 +63,7 @@ class TestUnaryUfuncs:
 
     @parametrize_casting
     @parametrize_unary_ufuncs
-    @pytest.mark.parametrize("out_dtype", ["float64", "complex128", "float32"])
+    @parametrize("out_dtype", ["float64", "complex128", "float32"])
     def test_x_and_out_casting(self, ufunc, casting, out_dtype):
         x = self.get_x(ufunc)
         out = np.empty_like(x, dtype=out_dtype)
@@ -116,7 +124,7 @@ no_complex = [
     np.minimum,
 ]
 
-parametrize_binary_ufuncs = pytest.mark.parametrize(
+parametrize_binary_ufuncs = parametrize(
     "ufunc", ufuncs_with_dunders + numeric_binary_ufuncs + no_complex
 )
 
@@ -143,7 +151,7 @@ parametrize_binary_ufuncs = pytest.mark.parametrize(
 """
 
 
-class TestBinaryUfuncs:
+class TestBinaryUfuncs(TestCase):
     def get_xy(self, ufunc):
         return np.arange(5, dtype="float64"), np.arange(8, 13, dtype="float64")
 
@@ -161,7 +169,7 @@ class TestBinaryUfuncs:
 
     @parametrize_casting
     @parametrize_binary_ufuncs
-    @pytest.mark.parametrize("out_dtype", ["float64", "complex128", "float32"])
+    @parametrize("out_dtype", ["float64", "complex128", "float32"])
     def test_xy_and_out_casting(self, ufunc, casting, out_dtype):
         x, y = self.get_xy(ufunc)
         out = np.empty_like(x, dtype=out_dtype)
@@ -199,10 +207,10 @@ class TestBinaryUfuncs:
 dtypes_numeric = [np.int32, np.float32, np.float64, np.complex128]
 
 
-class TestNdarrayDunderVsUfunc:
+class TestNdarrayDunderVsUfunc(TestCase):
     """Test ndarray dunders which delegate to ufuncs, vs ufuncs."""
 
-    @pytest.mark.parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
+    @parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
     def test_basic(self, ufunc, op, iop):
         """basic op/rop/iop, no dtypes, no broadcasting"""
 
@@ -229,8 +237,8 @@ class TestNdarrayDunderVsUfunc:
         iop(a, a)
         assert_equal(a, op(a0, a0))
 
-    @pytest.mark.parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
-    @pytest.mark.parametrize("other_dtype", dtypes_numeric)
+    @parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
+    @parametrize("other_dtype", dtypes_numeric)
     def test_other_scalar(self, ufunc, op, iop, other_dtype):
         """Test op/iop/rop when the other argument is a scalar of a different dtype."""
         a = np.array([1, 2, 3])
@@ -267,8 +275,8 @@ class TestNdarrayDunderVsUfunc:
             with assert_raises((TypeError, RuntimeError)):  # XXX np.UFuncTypeError
                 iop(a, b)
 
-    @pytest.mark.parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
-    @pytest.mark.parametrize("other_dtype", dtypes_numeric)
+    @parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
+    @parametrize("other_dtype", dtypes_numeric)
     def test_other_array(self, ufunc, op, iop, other_dtype):
         """Test op/iop/rop when the other argument is an array of a different dtype."""
         a = np.array([1, 2, 3])
@@ -303,7 +311,7 @@ class TestNdarrayDunderVsUfunc:
             with assert_raises((TypeError, RuntimeError)):  # XXX np.UFuncTypeError
                 iop(a, b)
 
-    @pytest.mark.parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
+    @parametrize("ufunc, op, iop", ufunc_op_iop_numeric)
     def test_other_array_bcast(self, ufunc, op, iop):
         """Test op/rop/iop with broadcasting"""
         # __op__
@@ -345,7 +353,7 @@ class TestNdarrayDunderVsUfunc:
             assert result_op.dtype == result_ufunc.dtype
 
 
-class TestUfuncDtypeKwd:
+class TestUfuncDtypeKwd(TestCase):
     def test_binary_ufunc_dtype(self):
         # default computation uses float64:
         r64 = np.add(1, 1e-15)
@@ -390,7 +398,11 @@ class TestUfuncDtypeKwd:
         assert r.dtype == np.float32
 
 
-if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
+instantiate_parametrized_tests(TestUnaryUfuncs)
+instantiate_parametrized_tests(TestNdarrayDunderVsUfunc)
 
+instantiate_parametrized_tests(TestBinaryUfuncs)
+
+
+if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_unary_ufuncs.py
+++ b/test/torch_np/test_unary_ufuncs.py
@@ -8,178 +8,182 @@ import numpy as np
 from torch._numpy._ufuncs import *  # noqa: F403
 from torch._numpy.testing import assert_allclose
 
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+)
 
-def test_absolute():
-    assert_allclose(np.absolute(0.5), absolute(0.5), atol=1e-14, check_dtype=False)
 
+class TestUnaryUfuncs(TestCase):
+    def test_absolute(self):
+        assert_allclose(np.absolute(0.5), absolute(0.5), atol=1e-14, check_dtype=False)
 
-def test_arccos():
-    assert_allclose(np.arccos(0.5), arccos(0.5), atol=1e-14, check_dtype=False)
 
+    def test_arccos(self):
+        assert_allclose(np.arccos(0.5), arccos(0.5), atol=1e-14, check_dtype=False)
 
-def test_arccosh():
-    assert_allclose(np.arccosh(1.5), arccosh(1.5), atol=1e-14, check_dtype=False)
 
+    def test_arccosh(self):
+        assert_allclose(np.arccosh(1.5), arccosh(1.5), atol=1e-14, check_dtype=False)
 
-def test_arcsin():
-    assert_allclose(np.arcsin(0.5), arcsin(0.5), atol=1e-14, check_dtype=False)
 
+    def test_arcsin(self):
+        assert_allclose(np.arcsin(0.5), arcsin(0.5), atol=1e-14, check_dtype=False)
 
-def test_arcsinh():
-    assert_allclose(np.arcsinh(0.5), arcsinh(0.5), atol=1e-14, check_dtype=False)
 
+    def test_arcsinh(self):
+        assert_allclose(np.arcsinh(0.5), arcsinh(0.5), atol=1e-14, check_dtype=False)
 
-def test_arctan():
-    assert_allclose(np.arctan(0.5), arctan(0.5), atol=1e-14, check_dtype=False)
 
+    def test_arctan(self):
+        assert_allclose(np.arctan(0.5), arctan(0.5), atol=1e-14, check_dtype=False)
 
-def test_arctanh():
-    assert_allclose(np.arctanh(0.5), arctanh(0.5), atol=1e-14, check_dtype=False)
 
+    def test_arctanh(self):
+        assert_allclose(np.arctanh(0.5), arctanh(0.5), atol=1e-14, check_dtype=False)
 
-def test_cbrt():
-    assert_allclose(np.cbrt(0.5), cbrt(0.5), atol=1e-14, check_dtype=False)
 
+    def test_cbrt(self):
+        assert_allclose(np.cbrt(0.5), cbrt(0.5), atol=1e-14, check_dtype=False)
 
-def test_ceil():
-    assert_allclose(np.ceil(0.5), ceil(0.5), atol=1e-14, check_dtype=False)
 
+    def test_ceil(self):
+        assert_allclose(np.ceil(0.5), ceil(0.5), atol=1e-14, check_dtype=False)
 
-def test_conjugate():
-    assert_allclose(np.conjugate(0.5), conjugate(0.5), atol=1e-14, check_dtype=False)
 
+    def test_conjugate(self):
+        assert_allclose(np.conjugate(0.5), conjugate(0.5), atol=1e-14, check_dtype=False)
 
-def test_cos():
-    assert_allclose(np.cos(0.5), cos(0.5), atol=1e-14, check_dtype=False)
 
+    def test_cos(self):
+        assert_allclose(np.cos(0.5), cos(0.5), atol=1e-14, check_dtype=False)
 
-def test_cosh():
-    assert_allclose(np.cosh(0.5), cosh(0.5), atol=1e-14, check_dtype=False)
 
+    def test_cosh(self):
+        assert_allclose(np.cosh(0.5), cosh(0.5), atol=1e-14, check_dtype=False)
 
-def test_deg2rad():
-    assert_allclose(np.deg2rad(0.5), deg2rad(0.5), atol=1e-14, check_dtype=False)
 
+    def test_deg2rad(self):
+        assert_allclose(np.deg2rad(0.5), deg2rad(0.5), atol=1e-14, check_dtype=False)
 
-def test_degrees():
-    assert_allclose(np.degrees(0.5), degrees(0.5), atol=1e-14, check_dtype=False)
 
+    def test_degrees(self):
+        assert_allclose(np.degrees(0.5), degrees(0.5), atol=1e-14, check_dtype=False)
 
-def test_exp():
-    assert_allclose(np.exp(0.5), exp(0.5), atol=1e-14, check_dtype=False)
 
+    def test_exp(self):
+        assert_allclose(np.exp(0.5), exp(0.5), atol=1e-14, check_dtype=False)
 
-def test_exp2():
-    assert_allclose(np.exp2(0.5), exp2(0.5), atol=1e-14, check_dtype=False)
 
+    def test_exp2(self):
+        assert_allclose(np.exp2(0.5), exp2(0.5), atol=1e-14, check_dtype=False)
 
-def test_expm1():
-    assert_allclose(np.expm1(0.5), expm1(0.5), atol=1e-14, check_dtype=False)
 
+    def test_expm1(self):
+        assert_allclose(np.expm1(0.5), expm1(0.5), atol=1e-14, check_dtype=False)
 
-def test_fabs():
-    assert_allclose(np.fabs(0.5), fabs(0.5), atol=1e-14, check_dtype=False)
 
+    def test_fabs(self):
+        assert_allclose(np.fabs(0.5), fabs(0.5), atol=1e-14, check_dtype=False)
 
-def test_floor():
-    assert_allclose(np.floor(0.5), floor(0.5), atol=1e-14, check_dtype=False)
 
+    def test_floor(self):
+        assert_allclose(np.floor(0.5), floor(0.5), atol=1e-14, check_dtype=False)
 
-def test_isfinite():
-    assert_allclose(np.isfinite(0.5), isfinite(0.5), atol=1e-14, check_dtype=False)
 
+    def test_isfinite(self):
+        assert_allclose(np.isfinite(0.5), isfinite(0.5), atol=1e-14, check_dtype=False)
 
-def test_isinf():
-    assert_allclose(np.isinf(0.5), isinf(0.5), atol=1e-14, check_dtype=False)
 
+    def test_isinf(self):
+        assert_allclose(np.isinf(0.5), isinf(0.5), atol=1e-14, check_dtype=False)
 
-def test_isnan():
-    assert_allclose(np.isnan(0.5), isnan(0.5), atol=1e-14, check_dtype=False)
 
+    def test_isnan(self):
+        assert_allclose(np.isnan(0.5), isnan(0.5), atol=1e-14, check_dtype=False)
 
-def test_log():
-    assert_allclose(np.log(0.5), log(0.5), atol=1e-14, check_dtype=False)
 
+    def test_log(self):
+        assert_allclose(np.log(0.5), log(0.5), atol=1e-14, check_dtype=False)
 
-def test_log10():
-    assert_allclose(np.log10(0.5), log10(0.5), atol=1e-14, check_dtype=False)
 
+    def test_log10(self):
+        assert_allclose(np.log10(0.5), log10(0.5), atol=1e-14, check_dtype=False)
 
-def test_log1p():
-    assert_allclose(np.log1p(0.5), log1p(0.5), atol=1e-14, check_dtype=False)
 
+    def test_log1p(self):
+        assert_allclose(np.log1p(0.5), log1p(0.5), atol=1e-14, check_dtype=False)
 
-def test_log2():
-    assert_allclose(np.log2(0.5), log2(0.5), atol=1e-14, check_dtype=False)
 
+    def test_log2(self):
+        assert_allclose(np.log2(0.5), log2(0.5), atol=1e-14, check_dtype=False)
 
-def test_logical_not():
-    assert_allclose(
-        np.logical_not(0.5), logical_not(0.5), atol=1e-14, check_dtype=False
-    )
 
+    def test_logical_not(self):
+        assert_allclose(
+            np.logical_not(0.5), logical_not(0.5), atol=1e-14, check_dtype=False
+        )
 
-def test_negative():
-    assert_allclose(np.negative(0.5), negative(0.5), atol=1e-14, check_dtype=False)
 
+    def test_negative(self):
+        assert_allclose(np.negative(0.5), negative(0.5), atol=1e-14, check_dtype=False)
 
-def test_positive():
-    assert_allclose(np.positive(0.5), positive(0.5), atol=1e-14, check_dtype=False)
 
+    def test_positive(self):
+        assert_allclose(np.positive(0.5), positive(0.5), atol=1e-14, check_dtype=False)
 
-def test_rad2deg():
-    assert_allclose(np.rad2deg(0.5), rad2deg(0.5), atol=1e-14, check_dtype=False)
 
+    def test_rad2deg(self):
+        assert_allclose(np.rad2deg(0.5), rad2deg(0.5), atol=1e-14, check_dtype=False)
 
-def test_radians():
-    assert_allclose(np.radians(0.5), radians(0.5), atol=1e-14, check_dtype=False)
 
+    def test_radians(self):
+        assert_allclose(np.radians(0.5), radians(0.5), atol=1e-14, check_dtype=False)
 
-def test_reciprocal():
-    assert_allclose(np.reciprocal(0.5), reciprocal(0.5), atol=1e-14, check_dtype=False)
 
+    def test_reciprocal(self):
+        assert_allclose(np.reciprocal(0.5), reciprocal(0.5), atol=1e-14, check_dtype=False)
 
-def test_rint():
-    assert_allclose(np.rint(0.5), rint(0.5), atol=1e-14, check_dtype=False)
 
+    def test_rint(self):
+        assert_allclose(np.rint(0.5), rint(0.5), atol=1e-14, check_dtype=False)
 
-def test_sign():
-    assert_allclose(np.sign(0.5), sign(0.5), atol=1e-14, check_dtype=False)
 
+    def test_sign(self):
+        assert_allclose(np.sign(0.5), sign(0.5), atol=1e-14, check_dtype=False)
 
-def test_signbit():
-    assert_allclose(np.signbit(0.5), signbit(0.5), atol=1e-14, check_dtype=False)
 
+    def test_signbit(self):
+        assert_allclose(np.signbit(0.5), signbit(0.5), atol=1e-14, check_dtype=False)
 
-def test_sin():
-    assert_allclose(np.sin(0.5), sin(0.5), atol=1e-14, check_dtype=False)
 
+    def test_sin(self):
+        assert_allclose(np.sin(0.5), sin(0.5), atol=1e-14, check_dtype=False)
 
-def test_sinh():
-    assert_allclose(np.sinh(0.5), sinh(0.5), atol=1e-14, check_dtype=False)
 
+    def test_sinh(self):
+        assert_allclose(np.sinh(0.5), sinh(0.5), atol=1e-14, check_dtype=False)
 
-def test_sqrt():
-    assert_allclose(np.sqrt(0.5), sqrt(0.5), atol=1e-14, check_dtype=False)
 
+    def test_sqrt(self):
+        assert_allclose(np.sqrt(0.5), sqrt(0.5), atol=1e-14, check_dtype=False)
 
-def test_square():
-    assert_allclose(np.square(0.5), square(0.5), atol=1e-14, check_dtype=False)
 
+    def test_square(self):
+        assert_allclose(np.square(0.5), square(0.5), atol=1e-14, check_dtype=False)
 
-def test_tan():
-    assert_allclose(np.tan(0.5), tan(0.5), atol=1e-14, check_dtype=False)
 
+    def test_tan(self):
+        assert_allclose(np.tan(0.5), tan(0.5), atol=1e-14, check_dtype=False)
 
-def test_tanh():
-    assert_allclose(np.tanh(0.5), tanh(0.5), atol=1e-14, check_dtype=False)
 
+    def test_tanh(self):
+        assert_allclose(np.tanh(0.5), tanh(0.5), atol=1e-14, check_dtype=False)
 
-def test_trunc():
-    assert_allclose(np.trunc(0.5), trunc(0.5), atol=1e-14, check_dtype=False)
+
+    def test_trunc(self):
+        assert_allclose(np.trunc(0.5), trunc(0.5), atol=1e-14, check_dtype=False)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/test_unary_ufuncs.py
+++ b/test/torch_np/test_unary_ufuncs.py
@@ -8,178 +8,138 @@ import numpy as np
 from torch._numpy._ufuncs import *  # noqa: F403
 from torch._numpy.testing import assert_allclose
 
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TestCase,
-)
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestUnaryUfuncs(TestCase):
     def test_absolute(self):
         assert_allclose(np.absolute(0.5), absolute(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_arccos(self):
         assert_allclose(np.arccos(0.5), arccos(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_arccosh(self):
         assert_allclose(np.arccosh(1.5), arccosh(1.5), atol=1e-14, check_dtype=False)
 
-
     def test_arcsin(self):
         assert_allclose(np.arcsin(0.5), arcsin(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_arcsinh(self):
         assert_allclose(np.arcsinh(0.5), arcsinh(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_arctan(self):
         assert_allclose(np.arctan(0.5), arctan(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_arctanh(self):
         assert_allclose(np.arctanh(0.5), arctanh(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_cbrt(self):
         assert_allclose(np.cbrt(0.5), cbrt(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_ceil(self):
         assert_allclose(np.ceil(0.5), ceil(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_conjugate(self):
-        assert_allclose(np.conjugate(0.5), conjugate(0.5), atol=1e-14, check_dtype=False)
-
+        assert_allclose(
+            np.conjugate(0.5), conjugate(0.5), atol=1e-14, check_dtype=False
+        )
 
     def test_cos(self):
         assert_allclose(np.cos(0.5), cos(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_cosh(self):
         assert_allclose(np.cosh(0.5), cosh(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_deg2rad(self):
         assert_allclose(np.deg2rad(0.5), deg2rad(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_degrees(self):
         assert_allclose(np.degrees(0.5), degrees(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_exp(self):
         assert_allclose(np.exp(0.5), exp(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_exp2(self):
         assert_allclose(np.exp2(0.5), exp2(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_expm1(self):
         assert_allclose(np.expm1(0.5), expm1(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_fabs(self):
         assert_allclose(np.fabs(0.5), fabs(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_floor(self):
         assert_allclose(np.floor(0.5), floor(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_isfinite(self):
         assert_allclose(np.isfinite(0.5), isfinite(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_isinf(self):
         assert_allclose(np.isinf(0.5), isinf(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_isnan(self):
         assert_allclose(np.isnan(0.5), isnan(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_log(self):
         assert_allclose(np.log(0.5), log(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_log10(self):
         assert_allclose(np.log10(0.5), log10(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_log1p(self):
         assert_allclose(np.log1p(0.5), log1p(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_log2(self):
         assert_allclose(np.log2(0.5), log2(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_logical_not(self):
         assert_allclose(
             np.logical_not(0.5), logical_not(0.5), atol=1e-14, check_dtype=False
         )
 
-
     def test_negative(self):
         assert_allclose(np.negative(0.5), negative(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_positive(self):
         assert_allclose(np.positive(0.5), positive(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_rad2deg(self):
         assert_allclose(np.rad2deg(0.5), rad2deg(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_radians(self):
         assert_allclose(np.radians(0.5), radians(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_reciprocal(self):
-        assert_allclose(np.reciprocal(0.5), reciprocal(0.5), atol=1e-14, check_dtype=False)
-
+        assert_allclose(
+            np.reciprocal(0.5), reciprocal(0.5), atol=1e-14, check_dtype=False
+        )
 
     def test_rint(self):
         assert_allclose(np.rint(0.5), rint(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_sign(self):
         assert_allclose(np.sign(0.5), sign(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_signbit(self):
         assert_allclose(np.signbit(0.5), signbit(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_sin(self):
         assert_allclose(np.sin(0.5), sin(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_sinh(self):
         assert_allclose(np.sinh(0.5), sinh(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_sqrt(self):
         assert_allclose(np.sqrt(0.5), sqrt(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_square(self):
         assert_allclose(np.square(0.5), square(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_tan(self):
         assert_allclose(np.tan(0.5), tan(0.5), atol=1e-14, check_dtype=False)
 
-
     def test_tanh(self):
         assert_allclose(np.tanh(0.5), tanh(0.5), atol=1e-14, check_dtype=False)
-
 
     def test_trunc(self):
         assert_allclose(np.trunc(0.5), trunc(0.5), atol=1e-14, check_dtype=False)


### PR DESCRIPTION
1. Inherit from TestCase
2. Use pytorch parametrization
3. Use unittest.expectedFailure to mark xfails

All this to make pytest-less invocation work:

$ python test/torch_np/test_basic.py

Furthermor, tests can now be run under dynamo, and we see first errors:

```
$ PYTORCH_TEST_WITH_DYNAMO=1 python test/torch_np/test_basic.py -k test_toscalar_list_func
.E.
======================================================================
ERROR: test_toscalar_list_func_<function shape at 0x7f9b83a4fc10>_np_func_<function shape at 0x7f9a8dd38af0> (__main__.TestOneArrToScalar)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ev-br/repos/pytorch/torch/testing/_internal/common_utils.py", line 356, in instantiated_test
    test(self, **param_kwargs)
  File "test/torch_np/test_basic.py", line 232, in test_toscalar_list
    @parametrize("func, np_func", one_arg_scalar_funcs)
  File "/home/ev-br/repos/pytorch/torch/nn/modules/module.py", line 1519, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ev-br/repos/pytorch/torch/nn/modules/module.py", line 1528, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ev-br/repos/pytorch/torch/_dynamo/eval_frame.py", line 406, in _fn
    return fn(*args, **kwargs)
  File "/home/ev-br/repos/pytorch/torch/fx/graph_module.py", line 726, in call_wrapped
    return self._wrapped_call(self, *args, **kwargs)
  File "/home/ev-br/repos/pytorch/torch/fx/graph_module.py", line 305, in __call__
    raise e
  File "/home/ev-br/repos/pytorch/torch/fx/graph_module.py", line 292, in __call__
    return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
  File "/home/ev-br/repos/pytorch/torch/nn/modules/module.py", line 1519, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ev-br/repos/pytorch/torch/nn/modules/module.py", line 1528, in _call_impl
    return forward_call(*args, **kwargs)
  File "<eval_with_key>.2", line 5, in forward
    shape = torch._numpy._funcs_impl.shape([[1, 2, 3], [4, 5, 6]])
  File "/home/ev-br/repos/pytorch/torch/_numpy/_funcs_impl.py", line 655, in shape
    return tuple(a.shape)
AttributeError: 'list' object has no attribute 'shape'

----------------------------------------------------------------------
Ran 3 tests in 0.915s

FAILED (errors=1)
```


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng