### PR TITLE
[dynamo][`__torch_function__` 3/n] TensorWithTFOverrideVariable inheritance from TensorVariable

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1131,6 +1131,30 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 3)
 
+    def test_getset_descriptor(self):
+        def fn(g, x):
+            return g.__get__(x)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fullgraph=True, backend="eager")(fn)
+        g = torch.Tensor.shape
+
+        res = opt_fn(g, torch.ones(2, 2))
+        exp_res = fn(g, torch.ones(2, 2))
+        self.assertEqual(res, exp_res)
+
+    def test_get_attr_function(self):
+        def fn(g, x):
+            return g(x)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        g = torch.Tensor.shape.__get__
+
+        res = opt_fn(g, torch.ones(2, 2))
+        exp_res = fn(g, torch.ones(2, 2))
+        self.assertEqual(res, exp_res)
+
     def test_user_getattribute(self):
         class MyObject:
             def __init__(self):

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -25,9 +25,9 @@ from .variables.tensor import (
     NumpyNdarrayVariable,
     SymNodeVariable,
     TensorVariable,
-    TensorWithTFOverrideVariable,
     UnspecializedPythonVariable,
 )
+from .variables.torch_function import TensorWithTFOverrideVariable
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -105,8 +105,7 @@ class PyCodegen:
         ):
             output.append(self.create_load_const(value.as_python_constant()))
         elif isinstance(value, TensorWithTFOverrideVariable):
-            tensor_variable = value.tensor_variable
-            graph_outputs_key = self.add_graph_output(tensor_variable)
+            graph_outputs_key = self.add_graph_output(value)
             output.append(
                 self.create_load_global(value.global_class_name(), True, add=True)
             )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -101,6 +101,8 @@ from .variables.tensor import (
     UnspecializedPythonVariable,
 )
 
+from .variables.torch_function import TensorWithTFOverrideVariable
+
 log = logging.getLogger(__name__)
 graph_tabular_log = torch._logging.getArtifactLogger(__name__, "graph")
 graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
@@ -854,7 +856,14 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         if (
             stack_values
             and all(
-                not isinstance(v, (UnspecializedPythonVariable, NumpyNdarrayVariable))
+                not isinstance(
+                    v,
+                    (
+                        UnspecializedPythonVariable,
+                        NumpyNdarrayVariable,
+                        TensorWithTFOverrideVariable,
+                    ),
+                )
                 for v in stack_values
             )
             and all(isinstance(x, TensorVariable) for x in stack_values)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -114,7 +114,9 @@ from .misc import (
     AutogradFunctionContextVariable,
     AutogradFunctionVariable,
     ComptimeVariable,
+    GetAttrFunctionVariable,
     GetAttrVariable,
+    GetSetDescriptorVariable,
     InspectSignatureVariable,
     LambdaVariable,
     NumpyVariable,
@@ -670,6 +672,17 @@ class VariableBuilder:
             # TODO: this doing it manually is bad
             return self.tx.output.side_effects.track_object_existing(
                 self.source, value, result
+            )
+        elif isinstance(value, types.GetSetDescriptorType):
+            return GetSetDescriptorVariable(
+                value, guards=self.make_guards(GuardBuilder.ID_MATCH)
+            )
+        elif isinstance(value, types.MethodWrapperType) and value.__name__ == "__get__":
+            return GetAttrFunctionVariable(
+                value,
+                value.__self__.__name__,
+                source=self.source,
+                guards=self.make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         elif isinstance(value, torch.optim.Optimizer):
             return OptimizerVariable(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1004,14 +1004,14 @@ class VariableBuilder:
             # To simplify things for now, the __dict__ tracking bits haven't
             # been implemented yet, but they can be added into this design at
             # a later point in time.
-            ignore_subclass = True
+            subclass_type = type(value)
         else:
             assert type(value) in (
                 torch.Tensor,
                 torch.nn.Parameter,
                 torch._subclasses.fake_tensor.FakeTensor,
             ) or is_traceable_wrapper_subclass(value), type(value)
-            ignore_subclass = False
+            subclass_type = None
 
         # NB: this just says we accessed a tensor from the same source again
         # (e.g., a tensor lives in a global foo, and we LOAD_GLOBAL it twice).
@@ -1051,6 +1051,9 @@ class VariableBuilder:
         tensor_proxy = self.tx.output.root_tracer.create_graph_input(
             re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(value), source=source
         )
+        options = {}
+        if type(value) in config.traceable_tensor_subclasses:
+            options["torch_function_fn"] = value.__torch_function__
         tensor_variable = wrap_fx_proxy(
             tx=self.tx,
             proxy=tensor_proxy,
@@ -1064,8 +1067,9 @@ class VariableBuilder:
                 )
             ),
             should_specialize=self.tensor_should_specialize(),
-            ignore_subclass=ignore_subclass,
+            subclass_type=subclass_type,
             source=source,
+            **options,
         )
         self.tx.output.input_source_to_var[source] = tensor_variable
         assert "tensor_dict" not in tensor_proxy.node.meta
@@ -1073,6 +1077,7 @@ class VariableBuilder:
 
         # TODO: I think the result is guaranteed to be fake with
         # ignore_subclass changes
+        # Note: this information is conveyed via subclass_type now
         fake_tensor_value = None
         example_value = tensor_variable.proxy.node.meta["example_value"]
         if is_fake(example_value):
@@ -1081,18 +1086,6 @@ class VariableBuilder:
         grapharg = GraphArg(source, value, False, fake_tensor_value)
         tensor_proxy.node.meta["grapharg"] = grapharg
         self.tx.output.add_symbol_bindings(grapharg)
-
-        if type(value) in config.traceable_tensor_subclasses:
-            # NB: This is slightly misnamed, a tensor subclass might not have
-            # any explicit __torch_function__ implementation and is relying
-            # on the default inherited from torch.Tensor
-            return TensorWithTFOverrideVariable.create(
-                self.tx,
-                tensor_variable,
-                value.__torch_function__.__func__,
-                type(value),
-            )
-
         return tensor_variable
 
     def wrap_numpy_ndarray(self, value):
@@ -1284,12 +1277,15 @@ def _dataclasses_fields_lambda(obj):
     return TupleVariable(items).add_options(obj)
 
 
-def wrap_fx_proxy(tx, proxy, example_value=None, **options):
+def wrap_fx_proxy(tx, proxy, example_value=None, subclass_type=None, **options):
     return wrap_fx_proxy_cls(
-        target_cls=TensorVariable,
+        target_cls=TensorVariable
+        if not subclass_type
+        else TensorWithTFOverrideVariable,
         tx=tx,
         proxy=proxy,
         example_value=example_value,
+        subclass_type=subclass_type,
         **options,
     )
 
@@ -1335,7 +1331,7 @@ def wrap_fx_proxy(tx, proxy, example_value=None, **options):
 # SOMETHING INTO THE GRAPH.  This is sort of obvious, because you can't call
 # this function without a proxy.
 def wrap_fx_proxy_cls(
-    target_cls, tx, proxy, example_value=None, ignore_subclass=False, **options
+    target_cls, tx, proxy, example_value=None, subclass_type=None, **options
 ):
     import torch._export.constraints
     from ..symbolic_convert import InstructionTranslatorBase
@@ -1395,8 +1391,9 @@ def wrap_fx_proxy_cls(
             # accurate TensorVariable that is able to track subclass-ness;
             # otherwise this is wrong!
             kwargs = {
-                "ignore_subclass": ignore_subclass,
-                "is_tensor": target_cls is TensorVariable,
+                "ignore_subclass": subclass_type is not None,
+                "is_tensor": target_cls
+                in (TensorVariable, TensorWithTFOverrideVariable),
             }
             assert "source" in options and options["source"] is not None
             kwargs["source"] = options["source"]
@@ -1424,8 +1421,9 @@ def wrap_fx_proxy_cls(
             and example_value.fake_mode is tx.fake_mode
         ):
             # NB: This will be wrong for ignore_subclass; fix it up later!
+            tensor_type = subclass_type if subclass_type else torch.Tensor
             specialized_props["class_type"] = (
-                torch.nn.Parameter if is_parameter else torch.Tensor
+                torch.nn.Parameter if is_parameter else tensor_type
             )
 
         specialized_props["specialized_value"] = specialized_value

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -132,10 +132,10 @@ from .tensor import (
     SymNodeVariable,
     TensorSubclassVariable,
     TensorVariable,
-    TensorWithTFOverrideVariable,
     UnspecializedPythonVariable,
 )
 from .torch import tensor_dunder_fns, torch_special_class_types, TorchVariable
+from .torch_function import TensorWithTFOverrideVariable
 from .user_defined import (
     KeyedJaggedTensorVariable,
     UserDefinedClassVariable,
@@ -1089,7 +1089,6 @@ class VariableBuilder:
             return TensorWithTFOverrideVariable.create(
                 self.tx,
                 tensor_variable,
-                source,
                 value.__torch_function__.__func__,
                 type(value),
             )

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -666,6 +666,14 @@ class GetSetDescriptorVariable(VariableTracker):
             return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
                 self.desc.__get__
             )
+        else:
+            return super().var_getattr(tx, name)
+
+    def is_python_constant(self):
+        return True
+
+    def as_python_constant(self):
+        return self.desc
 
 
 class PythonModuleVariable(VariableTracker):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -635,6 +635,39 @@ class GetAttrVariable(VariableTracker):
         return super().call_method(tx, name, args, kwargs)
 
 
+class GetAttrFunctionVariable(VariableTracker):
+    def __init__(self, get_fn, name, **kwargs):
+        super().__init__(**kwargs)
+        self.get_fn = get_fn
+        self.name = name
+
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        assert len(args) == 1 and len(kwargs) == 0
+        return args[0].var_getattr(tx, self.name)
+
+    def is_python_constant(self):
+        return True
+
+    def as_python_constant(self):
+        return self.get_fn
+
+
+class GetSetDescriptorVariable(VariableTracker):
+    def __init__(self, desc, **kwargs):
+        super().__init__(**kwargs)
+        self.desc = desc
+
+    def var_getattr(self, tx, name):
+        if name == "__get__":
+            from .builder import VariableBuilder
+
+            return VariableBuilder(tx, AttrSource(self.source, "__get__"))(
+                self.desc.__get__
+            )
+
+
 class PythonModuleVariable(VariableTracker):
     def __init__(self, value: types.ModuleType, **kwargs):
         super().__init__(**kwargs)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -916,11 +916,11 @@ class TensorSubclassVariable(VariableTracker):
         if len(args) == 1 and isinstance(args[0], TensorVariable):
             from .torch_function import TensorWithTFOverrideVariable
 
-            return TensorWithTFOverrideVariable.create(
+            return TensorWithTFOverrideVariable.from_tensor_var(
                 tx,
                 args[0],
-                self.value.__torch_function__.__func__,
                 self.value,
+                self.value.__torch_function__.__func__,
             )
 
         return super().call_function(tx, args, kwargs)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -756,148 +756,6 @@ class SymNodeVariable(VariableTracker):
         )
 
 
-class TensorWithTFOverrideVariable(VariableTracker):
-    """
-    Represents a tensor subclass instance with a __torch_function__ override.
-    """
-
-    @staticmethod
-    def create(
-        tx,
-        tensor_variable,
-        orig_tensor_variable_source,
-        torch_function_fn,
-        subclass_type,
-        **kwargs,
-    ):
-        var = TensorWithTFOverrideVariable(
-            tensor_variable,
-            orig_tensor_variable_source,
-            torch_function_fn,
-            subclass_type,
-            **kwargs,
-        )
-        # stash the subclass type to rewrap an output tensor if needed
-        tx.output.install_global(var.global_class_name(), subclass_type)
-        return var
-
-    def __init__(
-        self,
-        tensor_variable,
-        orig_tensor_variable_source,
-        subclass_torch_function__func,
-        subclass_type,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.tensor_variable = tensor_variable
-        self.orig_tensor_variable_source = orig_tensor_variable_source
-        self.subclass_torch_function__func = subclass_torch_function__func
-        self.subclass_type = subclass_type
-
-    def call_method(
-        self,
-        tx,
-        name,
-        args: "List[VariableTracker]",
-        kwargs: "Dict[str, VariableTracker]",
-    ) -> "VariableTracker":
-        # This code block implements inlining the __torch_function__ override
-        # of `call_method`.
-        from . import GetAttrVariable
-
-        options = VariableTracker.propagate(self, args, kwargs.values())
-        # insert unwrapped version of self as the first argument
-        # TODO: This is wrong!  When you call the internal __torch_function__,
-        # you still get the wrapped version of self, and if you call functions
-        # inside __torch_function__, they should come back here.  If we unwrap
-        # the tensor immediately, that will not happen.
-        # See https://github.com/pytorch/torchdynamo/issues/1951
-        args = list(args)
-        args.insert(0, self.tensor_variable)
-        func_var = GetAttrVariable(self.tensor_variable, name)
-
-        unwrapped = TensorWithTFOverrideVariable.inline_torch_function_unwrapped(
-            tx,
-            func_var,
-            self.orig_tensor_variable_source,
-            self.subclass_torch_function__func,
-            self.subclass_type,
-            options,
-            args,
-            kwargs,
-        )
-
-        # TODO(future PR): implement rewrapping conditional on method presence
-        # in `torch.overrides.get_default_nowrap_function()`. It's unclear how
-        # to do this easily in the current codebase since the resolution of
-        # `GetAttrVariable` depends on the type of the underlying object.
-
-        return TensorWithTFOverrideVariable(
-            unwrapped,
-            self.orig_tensor_variable_source,
-            self.subclass_torch_function__func,
-            self.subclass_type,
-        )
-
-    def global_class_name(self):
-        return f"__subclass_{self.subclass_type.__name__}"
-
-    @staticmethod
-    def inline_torch_function_unwrapped(
-        tx,
-        original_func_var,
-        tensor_with_tf_override_source,
-        tf_func,
-        subclass_type,
-        options,
-        args,
-        kwargs,
-    ):
-        """
-        This function inlines the `__torch_function__` override for `original_func_var`.
-        For example, if the user code is
-
-           x1 = torch.sigmoid(x0)
-
-        And `x0` has an override, then:
-        * `original_func_var` will be a `VariableTracker` object wrapping `torch.sigmoid`
-        * `tensor_with_tf_override_source` will be the `Source` object from
-          the original tensor override instance in the beginning of the program
-        * `tf_func` will be the custom `__torch_function__` function
-        * `subclass_type` will be `type(x0)`
-
-        The caller is expected to properly massage args and kwargs before
-        passing them into this function.
-
-        The caller is responsible for wrapping the return value, if needed.
-        """
-        from . import UserDefinedClassVariable
-        from .builder import TupleVariable, VariableBuilder
-
-        source = AttrSource(
-            AttrSource(tensor_with_tf_override_source, "__torch_function__"),
-            "__func__",
-        )
-        tf_func_var = VariableBuilder(tx, source)(tf_func)
-        type_var = UserDefinedClassVariable(subclass_type, **options)
-
-        # signature:
-        # def __torch_function__(cls, func, types, args=(), kwargs=None):
-        tf_args = (
-            type_var,  # cls
-            original_func_var,  # func
-            (type_var,),  # types
-            TupleVariable(args),  # args
-            kwargs,  # kwargs
-        )
-
-        # Disable __torch_function__ here to prevent the clone of the
-        # example tensor from going into the override.
-        with torch._C.DisableTorchFunctionSubclass():
-            return tx.inline_user_function_return(tf_func_var, tf_args, {})
-
-
 class NumpyNdarrayVariable(TensorVariable):
     """
     Represents an np.ndarray, but backed by torch Tensor via torch._numpy.ndarray.
@@ -1056,10 +914,11 @@ class TensorSubclassVariable(VariableTracker):
         self, tx, args: List[VariableTracker], kwargs: Dict[str, VariableTracker]
     ) -> VariableTracker:
         if len(args) == 1 and isinstance(args[0], TensorVariable):
+            from .torch_function import TensorWithTFOverrideVariable
+
             return TensorWithTFOverrideVariable.create(
                 tx,
                 args[0],
-                args[0].source,
                 self.value.__torch_function__.__func__,
                 self.value,
             )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -400,11 +400,11 @@ class TorchVariable(VariableTracker):
             # `torch.Tensor.__torch_function__`.
             if self.value in torch.overrides.get_default_nowrap_functions():
                 return unwrapped
-            return TensorWithTFOverrideVariable.create(
+            return TensorWithTFOverrideVariable.from_tensor_var(
                 tx,
                 unwrapped,
+                args[0].class_type,
                 args[0].torch_function_fn,
-                args[0].subclass_type,
             )
         elif self.value in [
             torch.amp.autocast_mode.autocast,

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -5,7 +5,6 @@ from ..source import AttrSource
 from .base import VariableTracker
 from .constant import ConstantVariable
 from .lists import TupleVariable
-from .user_defined import UserDefinedClassVariable
 
 # [Note: __torch_function__] This feature is partially supported with many rough edges (contact mlazos with issues):
 # At a high level, a torch function tensor subclass is represented as a TensorWithTFOverrideVariable, which dispatches

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -1,0 +1,195 @@
+from torch.overrides import _get_overloaded_args, get_default_nowrap_functions
+from torch.utils._pytree import tree_flatten
+from ..exc import unimplemented
+from ..source import AttrSource
+from .base import VariableTracker
+from .constant import ConstantVariable
+from .lists import TupleVariable
+from .user_defined import UserDefinedClassVariable
+
+# [Note: __torch_function__] This feature is partially supported with many rough edges (contact mlazos with issues):
+# At a high level, a torch function tensor subclass is represented as a TensorWithTFOverrideVariable, which dispatches
+# __torch_function__ on attribute accesses, method calls, and torch API calls.
+# The following is not supported:
+# - triggering __torch_function__ on tensor subclass non-tensor custom attributes
+# - graph breaking on mutating guardable tensor properties within a __torch_function__ context, this can cause
+# excessive recompiles in certain degenerate cases
+# - Matching the exact eager behavior of *ignoring* __torch_function__ objects in non-tensor argument positions of Torch API calls
+
+# The following is supported:
+# - static method impls of __torch_function__ on custom objects; this will trigger on torch API calls with the object as
+# any argument
+# - triggering __torch_function__ on torch API calls with tensor subclass arguments
+# - __torch_function__ calls on base tensor attribute access and method calls for tensor subclass instances
+# - matches the dispatch ordering behavior of eager __torch_function__ with subclass/object argumnents in any argument position
+
+# See https://docs.google.com/document/d/1WBxBSvW3NXhRp9ncmtokJloMLCtF4AYNhJaffvHe8Kw/edit#heading=h.vacn73lozd9w
+# for more information on the design.
+
+# To enable subclass behavior, add your tensor subclass type to traceable_tensor_subclasses in dynamo/config.py
+
+
+banned_attrs = [fn.__name__ for fn in get_default_nowrap_functions()]
+
+
+def is_torch_function_user_object(obj):
+    return hasattr(obj, "__torch_function__") and hasattr(
+        type(obj), "__torch_function__"
+    )
+
+
+def call_torch_function(
+    tx, torch_function_type, torch_function_var, fn, types, args, kwargs
+):
+    # signature:
+    # def __torch_function__(cls, func, types, args=(), kwargs=None):
+    tf_args = (torch_function_type, fn, types, TupleVariable(list(args)))
+    return tx.inline_user_function_return(torch_function_var, tf_args, kwargs)
+
+
+def build_torch_function_var(tx, fn_value, source):
+    from .builder import SourcelessBuilder, VariableBuilder
+
+    if source:
+        source = AttrSource(
+            AttrSource(source, "__torch_function__"),
+            "__func__",
+        )
+        return VariableBuilder(tx, source)(fn_value)
+    else:
+        return SourcelessBuilder()(tx, fn_value)
+
+
+class TensorWithTFOverrideVariable(VariableTracker):
+    """
+    Represents a tensor subclass instance with a __torch_function__ override.
+    """
+
+    @staticmethod
+    def create(
+        tx,
+        tensor_variable,
+        torch_function_fn,
+        subclass_type,
+        **kwargs,
+    ):
+        var = TensorWithTFOverrideVariable(
+            tensor_variable,
+            torch_function_fn,
+            subclass_type,
+            **kwargs,
+        )
+        # stash the subclass type to rewrap an output tensor if needed
+        if var.global_class_name() not in tx.output.global_scope:
+            tx.output.install_global(var.global_class_name(), subclass_type)
+
+        return var
+
+    def __init__(
+        self,
+        tensor_variable,
+        torch_function_fn,
+        subclass_type,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.tensor_variable = tensor_variable
+        self.torch_function_fn = torch_function_fn
+        self.subclass_type = subclass_type
+
+    def as_proxy(self):
+        return self.tensor_variable.as_proxy()
+
+    def python_type(self):
+        return self.subclass_type
+
+    def torch_function_var(self, tx):
+        from .builder import VariableBuilder
+
+        source = AttrSource(
+            AttrSource(self.source, "__torch_function__"),
+            "__func__",
+        )
+        return VariableBuilder(tx, source)(self.torch_function_fn)
+
+    def subclass_type_var(self):
+        return UserDefinedClassVariable(self.subclass_type)
+
+    def global_class_name(self):
+        return f"__subclass_{self.subclass_type.__name__}"
+
+    def call_torch_function(self, tx, fn, types, args, kwargs):
+        return call_torch_function(
+            tx,
+            self.subclass_type_var(),
+            build_torch_function_var(tx, self.torch_function_fn, self.source),
+            fn,
+            types,
+            args,
+            kwargs,
+        )
+
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        # This code block implements inlining the __torch_function__ override
+        # of `call_method`.
+        if tx.output.torch_function_enabled:
+            import torch
+            from .builder import SourcelessBuilder
+
+            options = VariableTracker.propagate(self, args, kwargs.values())
+            args = [self] + list(args)
+            # [Note: __torch_function__] Currently we only support methods that are defined on tensor
+            # we will graph break in other cases this will need a bigger overhaul of extracting methods/comparing them for equality
+            func_var = SourcelessBuilder()(tx, getattr(torch.Tensor, name))
+            all_args = args + tree_flatten(kwargs)[0]
+            types = TupleVariable(
+                [
+                    a.subclass_type_var()
+                    for a in all_args
+                    if isinstance(a, TensorWithTFOverrideVariable)
+                ]
+            )
+
+            return self.call_torch_function(tx, func_var, types, args, kwargs)
+        else:
+            return self.tensor_variable.call_method(tx, name, args, kwargs)
+
+
+def can_dispatch_torch_function(tx, args, kwargs):
+    if tx.output.torch_function_enabled:
+        all_args = tree_flatten(args)[0] + tree_flatten(kwargs)[0]
+        return any(isinstance(arg, TensorWithTFOverrideVariable) for arg in all_args)
+    else:
+        return False
+
+
+def dispatch_torch_function(tx, fn, args, kwargs):
+    """Gathers all args that are TensorWithTFOverrideVariable and dispatches based on the ordering in _get_overloaded_args"""
+
+    all_args = args + tree_flatten(kwargs)[0]
+    overloaded_args = _get_overloaded_args(
+        [arg for arg in all_args if isinstance(arg, TensorWithTFOverrideVariable)],
+        lambda x: x.subclass_type,
+    )
+
+    for arg in overloaded_args:
+        res = arg.call_torch_function(
+            tx,
+            fn,
+            TupleVariable(list({arg.subclass_type_var() for arg in overloaded_args})),
+            args,
+            kwargs,
+        )
+
+        if not (isinstance(res, ConstantVariable) and res.value is NotImplemented):
+            return res
+
+    unimplemented(
+        f"All __torch_function__ overrides for call {fn} with args {args} and kwargs {kwargs} returned NotImplemented"
+    )

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -5,6 +5,7 @@ from ..source import AttrSource
 from .base import VariableTracker
 from .constant import ConstantVariable
 from .lists import TupleVariable
+from .user_defined import UserDefinedClassVariable
 
 # [Note: __torch_function__] This feature is partially supported with many rough edges (contact mlazos with issues):
 # At a high level, a torch function tensor subclass is represented as a TensorWithTFOverrideVariable, which dispatches


### PR DESCRIPTION
* Refactors tensor wrapping to output TensorWithTFOverrideVariable for subclass instances
* Implements TensorWithTFOverrideVariable as a subclass of TensorVariable

depends on #109556 #109542 

towards tracing for https://github.com/pytorch/pytorch/issues/93723


cc @hameerabbasi @rgommers @peterbell10 @ezyang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng