### PR TITLE
Handle unbacked symints in buffer reuse calculation

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -24,6 +24,7 @@ from ..utils import (
     LineContext,
     sympy_dot,
     sympy_product,
+    sympy_str,
 )
 from ..virtualized import V
 from .common import CodeGen, DeferredLine, IndentedBuffer, PythonPrinter
@@ -35,13 +36,24 @@ pexpr = PythonPrinter().doprint
 def buffer_reuse_key(node: ir.Buffer):
     size = node.get_size()
     stride = node.get_stride()
+    # Detect gaps in tensor storage caused by strides
+    # The point is that the last element size hint says how big
+    # the extent of the tensor is, even if pieces inside it aren't
+    # actually used (because striding skips over it).
+    # Suppose you have a 2x2 tensor with stride 4x1, versus 1x4.
+    # In both cases, the extent of the tensor is (41 + 11 == 5),
+    # so you can represent both variants in the same amount of memory,
+    # so you can reuse the buffer in this case.
     last_element = sympy_dot([s - 1 for s in size], stride)
+    if any(V.graph.sizevars.shape_env.is_unbacked_symint(s) for s in last_element.free_symbols):
+        size_hint_of_last_element = sympy_str(last_element)
+    else:
+        size_hint_of_last_element = V.graph.sizevars.size_hint(last_element)
     return (
         node.get_device(),
         node.get_dtype(),
         V.graph.sizevars.simplify(sympy_product(size)),
-        # Detect gaps in tensor storage caused by strides
-        V.graph.sizevars.size_hint(last_element),
+        size_hint_of_last_element,
     )
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -22,7 +22,6 @@ from ..utils import (
     cache_on_self,
     get_benchmark_name,
     LineContext,
-    sympy_dot,
     sympy_product,
     sympy_str,
 )

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2715,6 +2715,9 @@ class ShapeEnv:
 
         return SymInt(SymNode(symbol, self, int, None, fx_node=fx_node))
 
+    def is_unbacked_symint(self, symbol: sympy.Symbol) -> bool:
+        return str(symbol).startswith("i")
+
     @record_shapeenv_event()
     def create_unbacked_symbool(self):
         symbol: sympy.Symbol = sympy.Symbol(f"i{next(self.unbacked_symint_counter)}", integer=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #109609
* __->__ #109603

This is rewritten from https://github.com/pytorch/pytorch/pull/106655 to land faster, with peterbell10's comments.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov