### PR TITLE
[release-2.1] Make numpy dependency optional for torch.compile

### DIFF
--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -33,7 +33,7 @@ class ConstantVariable(VariableTracker):
             for disallowed_type, reason in _type_to_assert_reason.items():
                 assert not isinstance(value, disallowed_type), reason
 
-        if isinstance(value, np.number):
+        if np is not None and isinstance(value, np.number):
             self.value = value.item()
         else:
             self.value = value

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -9,7 +9,6 @@ import sys
 from copy import copy, deepcopy
 from typing import Dict, List
 
-import numpy
 import sympy
 
 import torch
@@ -2148,7 +2147,7 @@ class CppVecKernelChecker(CppVecKernel):
                     # VecKernel override dtype for constant
                     # Vectorization only support int32/fp32 now
                     # So if dtype = int64/fp64, we will cast it to int32/fp32 if possible
-                    i32_iinfo = numpy.iinfo(numpy.int32)
+                    i32_iinfo = torch.iinfo(torch.int32)
                     if (
                         dtype == torch.int64
                         and val <= i32_iinfo.max
@@ -2156,12 +2155,12 @@ class CppVecKernelChecker(CppVecKernel):
                     ):
                         opt_ctx.dtype = torch.int32
 
-                    f32_iinfo = numpy.finfo(numpy.float32)
+                    f32_iinfo = torch.finfo(torch.float32)
                     if dtype == torch.double:
                         if (
                             (val <= f32_iinfo.max and val >= f32_iinfo.min)
-                            or (val == numpy.inf)
-                            or (val == -numpy.inf)
+                            or (val == torch.inf)
+                            or (val == -torch.inf)
                         ):
                             opt_ctx.dtype = torch.float32
 
@@ -2206,7 +2205,7 @@ class CppVecKernelChecker(CppVecKernel):
 
                     vars_ranges = {k: ValueRanges(0, v - 1) for k, v in sizes.items()}
                     if not vars_ranges or len(vars_ranges) != len(free_symbols):
-                        i32_iinfo = numpy.iinfo(numpy.int32)
+                        i32_iinfo = torch.iinfo(torch.int32)
                         return (
                             expr.is_number
                             and expr <= i32_iinfo.max

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -3,8 +3,6 @@ import logging
 import operator
 from typing import Callable, List, Sequence, Tuple, Union
 
-import numpy
-
 import torch
 from torch._dynamo.utils import counters
 
@@ -454,8 +452,7 @@ class SplitCatSimplifier:
                 for user_input in user_inputs
                 if isinstance(user_input, tuple)
             }
-
-        cumulative_sizes = [0] + list(numpy.cumsum(split_sections))
+        cumulative_sizes = [0] + torch.cumsum(torch.tensor(split_sections), 0).tolist()
         split_ranges = sorted(
             [(cumulative_sizes[r[0]], cumulative_sizes[r[1] + 1]) for r in ranges]
         )
@@ -578,7 +575,7 @@ class SplitCatSimplifier:
                     for i in range(len(split_ranges))
                 ]
         # Now assign the right getitem to the right input
-        cumulative_sizes = [0] + list(numpy.cumsum(split_sections))
+        cumulative_sizes = [0] + torch.cumsum(torch.tensor(split_sections), 0).tolist()
         new_user_inputs_list = []
         for user_inputs in user_inputs_list:
             new_user_inputs = []


### PR DESCRIPTION
Cherrypick of https://github.com/pytorch/pytorch/commit/4ee179c9528c8c6aae17a01f2b0d7e8235219219  https://github.com/pytorch/pytorch/commit/a9bf1031d4b4822130a67055964625c586d624e8 and https://github.com/pytorch/pytorch/commit/fb58a72d968e34f6a917ce4bc47ed18cd661011b into release/2.1 branch

Test plan: `python3 -c "import torch;torch.compile(lambda x:print(x))('Hello World')"`

Fixes #109387 to the release branch



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov