### PR TITLE
Revert D49346965: Multisect successfully blamed "D49346965: [ONNX] Remove deprecated functions (#107208)" for test or build failures

### DIFF
--- a/test/onnx/test_export_modes.py
+++ b/test/onnx/test_export_modes.py
@@ -32,7 +32,7 @@ class TestExportModes(pytorch_test_common.ExportTestCase):
         torch_model = TestExportModes.MyModel()
         fake_input = Variable(torch.randn(1, 1, 224, 224), requires_grad=True)
         f = io.BytesIO()
-        torch.onnx.utils._export(
+        torch.onnx._export(
             torch_model,
             (fake_input),
             f,
@@ -44,7 +44,7 @@ class TestExportModes(pytorch_test_common.ExportTestCase):
         torch_model = TestExportModes.MyModel()
         fake_input = Variable(torch.randn(1, 1, 224, 224), requires_grad=True)
         f = io.BytesIO()
-        torch.onnx.utils._export(
+        torch.onnx._export(
             torch_model,
             (fake_input),
             f,
@@ -56,7 +56,7 @@ class TestExportModes(pytorch_test_common.ExportTestCase):
         torch_model = TestExportModes.MyModel()
         fake_input = Variable(torch.randn(1, 1, 224, 224), requires_grad=True)
         f = io.BytesIO()
-        torch.onnx.utils._export(
+        torch.onnx._export(
             torch_model,
             (fake_input),
             f,
@@ -68,7 +68,7 @@ class TestExportModes(pytorch_test_common.ExportTestCase):
         torch_model = TestExportModes.MyModel()
         fake_input = Variable(torch.randn(1, 1, 224, 224), requires_grad=True)
         d = tempfile.mkdtemp()
-        torch.onnx.utils._export(
+        torch.onnx._export(
             torch_model,
             (fake_input),
             d,

--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -4,9 +4,7 @@ import pytorch_test_common
 
 import torch
 from pytorch_test_common import skipIfNoCuda
-
 from torch.onnx import verification
-from torch.onnx._globals import GLOBALS
 from torch.testing._internal import common_utils
 
 
@@ -19,7 +17,8 @@ def _jit_graph_to_onnx_model(graph, operator_export_type, opset_version):
     It also does not interact with actual PyTorch modules nor
     PyTorch tensor inputs.
     """
-    GLOBALS.export_onnx_opset_version = opset_version
+
+    torch.onnx.symbolic_helper._set_opset_version(opset_version)
     graph = torch.onnx.utils._optimize_graph(
         graph, operator_export_type, params_dict={}
     )

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -7,7 +7,7 @@ import onnx
 import pytorch_test_common
 import torch
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion
-from torch.onnx import _constants, utils
+from torch.onnx import _constants, symbolic_helper, utils
 from torch.onnx._internal import jit_utils
 from torch.testing._internal import common_utils
 
@@ -41,6 +41,8 @@ def g_op(graph: torch.Graph, op_name: str, *args, **kwargs):
 class TestONNXShapeInference(pytorch_test_common.ExportTestCase):
     def setUp(self):
         self.opset_version = _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
+        symbolic_helper._set_onnx_shape_inference(True)
+        symbolic_helper._set_opset_version(self.opset_version)
 
     def run_test(self, g, n, type_assertion_funcs):
         if not isinstance(type_assertion_funcs, list):

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -377,7 +377,7 @@ def verify(
 
     with torch.onnx.select_model_mode_for_export(model, training):
         proto_bytes = io.BytesIO()
-        torch_out = torch.onnx.utils._export(
+        torch_out = torch.onnx._export(
             model,
             args,
             proto_bytes,
@@ -397,7 +397,7 @@ def verify(
 
         def run(args, remained_onnx_input_idx):
             alt_proto_bytes = io.BytesIO()
-            torch_out = torch.onnx.utils._export(
+            torch_out = torch.onnx._export(
                 model,
                 args,
                 alt_proto_bytes,

--- a/test/onnx_caffe2/export_onnx_tests_generator.py
+++ b/test/onnx_caffe2/export_onnx_tests_generator.py
@@ -101,7 +101,7 @@ def convert_tests(testcases, sets=1):
         try:
             input = gen_input(t)
             f = io.BytesIO()
-            torch.onnx.utils._export(
+            torch.onnx._export(
                 module,
                 input,
                 f,

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
@@ -97,7 +97,7 @@ def skipIfNoEmbed(func):
 
 def do_export(model, inputs, *args, **kwargs):
     f = io.BytesIO()
-    out = torch.onnx.utils._export(model, inputs, f, *args, **kwargs)
+    out = torch.onnx._export(model, inputs, f, *args, **kwargs)
     if isinstance(model, torch.jit.ScriptModule):
         # Special case for common case of passing a single Tensor
         if isinstance(inputs, torch.Tensor):
@@ -320,7 +320,7 @@ class TestCaffe2Backend_opset9(pytorch_test_common.ExportTestCase):
         # Note that the export call explicitly sets the names of not just the input,
         # but also the parameters. This test checks that the model can be loaded and
         # executed in Caffe2 backend correctly.
-        torch.onnx.utils._export(
+        torch.onnx._export(
             model,
             input,
             f,
@@ -353,7 +353,7 @@ class TestCaffe2Backend_opset9(pytorch_test_common.ExportTestCase):
         # But note that the target first parameter name is the same as the second parameter name.
         # This test checks that given this edge condition, the model can be loaded and executed
         # in Caffe2 backend correctly.
-        torch.onnx.utils._export(
+        torch.onnx._export(
             model,
             input,
             f,
@@ -1613,7 +1613,7 @@ class TestCaffe2Backend_opset9(pytorch_test_common.ExportTestCase):
         f = io.BytesIO()
         from torch.onnx import ExportTypes
 
-        torch.onnx.utils._export(
+        torch.onnx._export(
             MyModel(),
             (torch.rand(3, 4),),
             f,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -8,6 +8,7 @@ from torch._C._onnx import (
 )
 
 from . import (  # usort:skip. Keep the order instead of sorting lexicographically
+    _deprecation,
     errors,
     symbolic_caffe2,
     symbolic_helper,
@@ -127,6 +128,13 @@ _OrtBackend.__module__ = "torch.onnx"
 
 producer_name = "pytorch"
 producer_version = _C_onnx.PRODUCER_VERSION
+
+
+@_deprecation.deprecated(
+    since="1.12.0", removed_in="2.0", instructions="use `torch.onnx.export` instead"
+)
+def _export(*args, **kwargs):
+    return utils._export(*args, **kwargs)
 
 
 # TODO(justinchuby): Deprecate these logging functions in favor of the new diagnostic module.

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5846,7 +5846,9 @@ def index(g: jit_utils.GraphContext, self, index):
             if rank is None:
                 return symbolic_helper._unimplemented(
                     "aten::index",
-                    "operator of advanced indexing on tensor of unknown rank.",
+                    "operator of advanced indexing on tensor of unknown rank. "
+                    "Try turning on shape inference during export: "
+                    "torch.onnx._export(..., onnx_shape_inference=True).",
                     self,
                 )
             # TODO: If indexing is supported natively in ONNX in future opsets,


### PR DESCRIPTION
Summary:
This diff is reverting D49346965
D49346965: [ONNX] Remove deprecated functions (#107208) by generatedunixname499836121 has been identified to be causing the following test or build failures:

Tests affected:
- [mobile-vision/mobile_cv/mobile_cv/arch/tests:fb_test_jit_backend - test_jit_hta (mobile_cv.arch.tests.fb.test_jit_backend.TestJitBackend)](https://www.internalfb.com/intern/test/844425028079287/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3068610
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: amirshim

Differential Revision: D49351830


