### PR TITLE
[aot inductor] Make unit tests work on CPU

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -779,7 +779,7 @@ def get_include_and_linking_paths(
         os.environ["CUDA_HOME"] = os.path.dirname(build_paths.cuda())
     from torch.utils import cpp_extension
 
-    if aot_mode and config.is_fbcode():
+    if aot_mode:
         # Hack.  The AOT inductor libs reference CUDA, so let's just include it for now.
         cuda = True
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1186,7 +1186,7 @@ aot_inductor_launcher = """
             std::vector<at::Tensor>& output_tensors) {
         AOTInductorModelContainerHandle container_handle;
         AOT_INDUCTOR_ERROR_CHECK(
-            AOTInductorModelContainerCreate(&container_handle, 1 /*num_models*/))
+            AOTInductorModelContainerCreate(&container_handle, 1 /*num_models*/, false /*is_cpu*/))
         const auto& cuda_stream = c10::cuda::getCurrentCUDAStream();
         const auto stream_id = cuda_stream.stream();
         AOTInductorStreamHandle stream_handle =


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109625

Summary: AOT inductor is only sort-of supported on CPU right now, but it works
with a few hacks (the .so needs to be compiled and run with CUDA present,
because we haven't excised the CUDA deps; also there's an `is_cpu` flag that
needs to be plumbed into the call, or else all the weights are erroneously
allocated on GPU).

But, with those hacks in place, it currently works, so it's worth having the
current state of it continue working (and at some point we'll remove the
hacks).

Test Plan:
```
python test_aot_inductor -k test_simple_cpu
```

Reviewers: binbao

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov

Differential Revision: [D49427400](https://our.internmc.facebook.com/intern/diff/D49427400)