### PR TITLE
[FSDP][optim_state_dict] Add device to _shard_utils.py to explicitly use the device from fsdp_state

### DIFF
--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -44,6 +44,7 @@ class FSDPExtensions(ABC):
         world_size: int,
         num_devices_per_node: int,
         pg: dist.ProcessGroup,
+        device: Optional[torch.device] = None,
     ) -> torch.Tensor:
         """Shards a tensor to chunks and returns the local chunk."""
         ...

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -370,7 +370,9 @@ def _shard_orig_param_state(
     flat_param = fsdp_param_info.handle.flat_param
     param_idx = fsdp_param_info.param_indices[fqn]
     shard_param_info = flat_param._shard_param_infos[param_idx]  # type: ignore[attr-defined]
-    optim_state = _gather_state_dict(optim_state, fsdp_state.process_group)
+    optim_state = _gather_state_dict(
+        optim_state, pg=fsdp_state.process_group, device=fsdp_state.compute_device
+    )
     if not shard_param_info.in_shard:
         return {}
     # Flatten and shard the state.
@@ -583,7 +585,9 @@ def _flatten_optim_state(
     # without
     unflat_param_states = [
         _gather_state_dict(
-            unflat_osd_state[unflat_param_name], pg=fsdp_state.process_group
+            unflat_osd_state[unflat_param_name],
+            pg=fsdp_state.process_group,
+            device=fsdp_state.compute_device,
         )
         if unflat_param_name in unflat_osd_state
         else None

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -54,6 +54,7 @@ def enable_2d_with_fsdp() -> bool:
                 world_size: int,
                 num_devices_per_node: int,
                 pg: dist.ProcessGroup,
+                device: Optional[torch.device] = None,
             ) -> torch.Tensor:
                 return _chunk_tensor(tensor, rank, world_size, num_devices_per_node, pg)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109631

_get_pg_default_device does not always get the device we want. This PR let the user explicitly tell use the correct device.

Differential Revision: [D49425743](https://our.internmc.facebook.com/intern/diff/D49425743/)