### PR TITLE
[generate_opcheck_tests] tests should ignore meta/FakeTensors

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1737,6 +1737,19 @@ class MiniOpTest(CustomOpTestCaseBase):
         result = torch.ops.aten.mm.default(x, y)
         self.assertEqual(result, x @ y)
 
+    def test_mm_meta(self):
+        x = torch.randn(2, 3, requires_grad=True, device="meta")
+        y = torch.randn(3, 5, device="meta")
+        result = torch.ops.aten.mm.default(x, y)
+        self.assertEqual(result, x @ y)
+
+    def test_mm_fake(self):
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            x = torch.randn(2, 3, requires_grad=True, device="cpu")
+            y = torch.randn(3, 5, device="cpu")
+            result = torch.ops.aten.mm.default(x, y)
+            self.assertEqual(result, x @ y)
+
     def test_mm_errors(self):
         x = torch.randn(2, 3, requires_grad=True)
         y = torch.randn(4, 5)

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1741,14 +1741,14 @@ class MiniOpTest(CustomOpTestCaseBase):
         x = torch.randn(2, 3, requires_grad=True, device="meta")
         y = torch.randn(3, 5, device="meta")
         result = torch.ops.aten.mm.default(x, y)
-        self.assertEqual(result, x @ y)
+        self.assertEqual(result.shape, (x @ y).shape)
 
     def test_mm_fake(self):
         with torch._subclasses.fake_tensor.FakeTensorMode():
             x = torch.randn(2, 3, requires_grad=True, device="cpu")
             y = torch.randn(3, 5, device="cpu")
             result = torch.ops.aten.mm.default(x, y)
-            self.assertEqual(result, x @ y)
+            self.assertEqual(result.shape, (x @ y).shape)
 
     def test_mm_errors(self):
         x = torch.randn(2, 3, requires_grad=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109641
* #109640
* #109639
* #109638
* #109637

These tests generally don't work on meta tensors because they need to
compare the data of the Tensors. For example, SchemaCheckMode errors out
if any inputs are meta or Fake because it needs to check their storages
to see if any mutation occurred and those do not have storages.

Test Plan:
- new tests