### PR TITLE
[inductor] Enable mypy checking for codegen/triton_foreach

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -200,7 +200,6 @@ exclude_patterns = [
     'torch/_inductor/scheduler.py',
     'torch/_inductor/sizevars.py',
     'torch/_inductor/pattern_matcher.py',
-    'torch/_inductor/codegen/triton_foreach.py',
     'torch/_inductor/codegen/cpp.py',
     'torch/_inductor/fx_passes/split_cat.py',
     'torch/_inductor/fx_passes/joint_graph.py',

--- a/torch/_inductor/codegen/triton_foreach.py
+++ b/torch/_inductor/codegen/triton_foreach.py
@@ -1,9 +1,12 @@
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Dict, List, Tuple
+
+from sympy import Integer
 
 from .. import metrics
+from ..scheduler import SchedulerNode
 from ..utils import ceildiv, Placeholder
 from ..virtualized import V
 from .common import IndentedBuffer, Kernel
@@ -13,8 +16,12 @@ from .triton_utils import config_of, signature_to_meta
 
 @dataclass
 class PartitionState:
-    partitions: List[Tuple]
-    cur_partition: List[Tuple]
+    partitions: List[
+        List[Tuple[List[SchedulerNode], Tuple[Integer, ...], Integer, Integer]]
+    ]
+    cur_partition: List[
+        Tuple[List[SchedulerNode], Tuple[Integer, ...], Integer, Integer]
+    ]
     cur_count: int
 
     def finalize(self):
@@ -43,7 +50,9 @@ class ForeachKernel(Kernel):
         assert len(subkernel_nodes) >= 1
 
         partition_state_1d = PartitionState([], [], 0)
-        yelem_to_partition_state_2d = defaultdict(lambda: PartitionState([], [], 0))
+        yelem_to_partition_state_2d: Dict[Integer, PartitionState] = defaultdict(
+            lambda: PartitionState([], [], 0)
+        )
 
         for node in subkernel_nodes:
             fused_nodes = node.get_nodes()
@@ -144,10 +153,11 @@ class ForeachKernel(Kernel):
 
     def jit_line(self):
         can_use_32bit = all(k.index_dtype == "tl.int32" for k in self.sub_kernels)
+        size_dtype = "tl.int32" if can_use_32bit else "tl.int64"
         index_dtype = "tl.int32" if can_use_32bit else "tl.int64"
         _, _, signature = self.args.python_argdefs()
         triton_meta = {
-            "signature": signature_to_meta(signature, size_dtype=can_use_32bit),
+            "signature": signature_to_meta(signature, size_dtype=size_dtype),
             "device": V.graph.scheduler.current_device.index,
             "device_type": V.graph.scheduler.current_device.type,
             "constants": {},

--- a/torch/_inductor/codegen/triton_foreach.py
+++ b/torch/_inductor/codegen/triton_foreach.py
@@ -154,7 +154,6 @@ class ForeachKernel(Kernel):
     def jit_line(self):
         can_use_32bit = all(k.index_dtype == "tl.int32" for k in self.sub_kernels)
         size_dtype = "tl.int32" if can_use_32bit else "tl.int64"
-        index_dtype = "tl.int32" if can_use_32bit else "tl.int64"
         _, _, signature = self.args.python_argdefs()
         triton_meta = {
             "signature": signature_to_meta(signature, size_dtype=size_dtype),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109643
* #109146

Summary: Add enough typehints to enable mypy checking for codegen/triton_foreach. Also fixed a bug in a dtype param.

Test Plan:
* `python test/inductor/test_foreach.py`
* `lintrunner`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov