### PR TITLE
[pytorch] make IterableDataset of Iterable type

### DIFF
--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -116,6 +116,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
     _snapshot_state: _SnapshotState = _SnapshotState.NotStarted
     _fast_forward_iterator: Optional[Iterator] = None
 
+    def __iter__(self) -> Iterator[T_co]:
+        return self
+
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
             if attribute_name in _iter_deprecated_functional_names:

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -4,7 +4,6 @@ import math
 from typing import (
     Generic,
     Iterable,
-    Iterator,
     List,
     Optional,
     Sequence,
@@ -72,7 +71,7 @@ class Dataset(Generic[T_co]):
     # in pytorch/torch/utils/data/sampler.py
 
 
-class IterableDataset(Dataset[T_co]):
+class IterableDataset(Dataset[T_co], Iterable[T_co]):
     r"""An iterable Dataset.
 
     All datasets that represent an iterable of data samples should subclass it.
@@ -180,8 +179,6 @@ class IterableDataset(Dataset[T_co]):
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=12, worker_init_fn=worker_init_fn)))
         [3, 4, 5, 6]
     """
-    def __iter__(self) -> Iterator[T_co]:
-        raise NotImplementedError("Subclasses of IterableDataset should implement __iter__.")
 
     def __add__(self, other: Dataset[T_co]):
         return ChainDataset([self, other])


### PR DESCRIPTION
Summary: Makes `IterableDataset` of `Iterable` type.

Test Plan: tests next diff in the stack are all green

Differential Revision: D49420146


