### PR TITLE
[FSDP][state_dict][dtensor][bugfix] Fix dtensor not picked up in load

### DIFF
--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -125,11 +125,15 @@ def _ext_chunk_dtensor(
 
 
 def _ext_pre_load_state_dict_transform(
-    tensor: torch.Tensor,
+    tensor: torch.Tensor, param_name: Optional[str] = None
 ) -> Tuple[torch.Tensor, List[Shard]]:
     if _extensions is not None:
         return _extensions.pre_load_state_dict_transform(tensor)
 
-    assert type(tensor) is ShardedTensor
+    assert (
+        type(tensor) is ShardedTensor
+    ), "{} expected to be ShardedTensor, but got {}".format(
+        param_name if param_name is not None else "", type(tensor)
+    )
     shards = tensor.local_shards()
     return (tensor, shards)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -39,6 +39,7 @@ from torch.distributed.fsdp._runtime_utils import (
 )
 from torch.distributed.fsdp.api import (
     FullStateDictConfig,
+    ShardedStateDictConfig,
     ShardingStrategy,
     StateDictType,
 )
@@ -811,6 +812,13 @@ def _pre_load_state_dict_hook(
         context = contextlib.nullcontext()
 
     _lazy_init(fsdp_state, module)
+    # Workaround for https://github.com/pytorch/pytorch/issues/109648 - setting use_dtensor
+    # based on device_mesh. This issue similarly may need to be resolved for optim
+    # state_dict and a unittest should be added.
+    if getattr(module, "device_mesh", None) and isinstance(
+        module._state_dict_config, ShardedStateDictConfig
+    ):
+        module._state_dict_config._use_dtensor = True
     if fsdp_state._is_root:
         SimpleProfiler.reset()
 
@@ -824,6 +832,7 @@ def _pre_load_state_dict_hook(
         if fsdp_state._device_handle.is_available():
             fsdp_state._device_handle.synchronize()
         # Dispatch into state_dict specific implementation of pre-hook.
+        print(f"RV: cfg {fsdp_state._state_dict_config}")
         _pre_load_state_dict_hook_fn[fsdp_state._state_dict_type](
             module, fsdp_state, state_dict, prefix
         )

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -832,7 +832,6 @@ def _pre_load_state_dict_hook(
         if fsdp_state._device_handle.is_available():
             fsdp_state._device_handle.synchronize()
         # Dispatch into state_dict specific implementation of pre-hook.
-        print(f"RV: cfg {fsdp_state._state_dict_config}")
         _pre_load_state_dict_hook_fn[fsdp_state._state_dict_type](
             module, fsdp_state, state_dict, prefix
         )

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -617,7 +617,7 @@ def _sharded_pre_load_state_dict_hook(
 
         if not fsdp_state._state_dict_config._use_dtensor:
             # All-gather the param (ShardedTensor)
-            param, shards = _ext_pre_load_state_dict_transform(param)
+            param, shards = _ext_pre_load_state_dict_transform(param, fqn_from_global_root)
 
             assert len(shards) < 2, (
                 "Expects 0 or 1 shard per rank "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109651

Fixes https://github.com/pytorch/pytorch/issues/109648. When loading
with DTensor + device_mesh, it is not picked up that dtensor should be used.
Probably unittests don't catch this as we mostly test save + load in the same
function, and the save path sets this.

Also added a param_name to `_ext_pre_load_state_dict_transform` for better debug.

Should follow up with a fix for optimizer side + unittest.

Differential Revision: [D49435019](https://our.internmc.facebook.com/intern/diff/D49435019/)