### PR TITLE
[inductor] Use _unsafe_view decompostion

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -67,7 +67,6 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 # the Inductor decomp table.
 decomps_to_exclude = [
     aten._unsafe_index,
-    aten._unsafe_view,
     aten._scaled_dot_product_flash_attention.default,  # See comments in torch/_decomp/decompositions.py
     aten.clamp_max,
     aten.clamp_min,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -821,7 +821,6 @@ def repeat(x, repeats):
     )
 
 
-@register_lowering(aten._unsafe_view, type_promotion_kind=None)
 @register_lowering(aten.view, type_promotion_kind=None)
 @register_lowering(aten.reshape, type_promotion_kind=None)
 def view(x, sizes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109669
* #109668
* #109667

As per the old comment, decomposing is better than lowering because patterns for
`view` would apply to `_unsafe_view` as well.

https://github.com/salilsdesai/pytorch/blob/fc47ba2794564592a243b8b3484b5cfee1e72fda/torch/_inductor/decomposition.py#L89

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov