### PR TITLE
[inductor] Add a RAIITensorToHandleAllocator class for input/output tensor conversion

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -67,10 +67,9 @@ TEST(AotInductorTest, BasicTest) {
   const auto stream_id = cuda_stream.stream();
   AOTInductorStreamHandle stream_handle =
       reinterpret_cast<AOTInductorStreamHandle>(stream_id);
-  std::vector<AtenTensorHandle> input_handles =
-      torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
-  std::vector<AtenTensorHandle> output_handles =
-      torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(outputs);
+  auto input_handles = torch::aot_inductor::RAIITensorToHandleAllocator(inputs);
+  auto output_handles =
+      torch::aot_inductor::RAIITensorToHandleAllocator(outputs);
 
   std::vector<const int64_t*> output_sizes(outputs.size());
   std::vector<int64_t> output_ndims(outputs.size());
@@ -79,9 +78,9 @@ TEST(AotInductorTest, BasicTest) {
 
   AOTI_RUNTIME_ERROR_CODE_CHECK(AOTInductorModelContainerRun(
       container_handle,
-      input_handles.data(),
+      input_handles.release(),
       inputs.size(),
-      output_handles.data(),
+      output_handles.release(),
       outputs.size(),
       stream_handle,
       proxy_executor_handle,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1193,10 +1193,8 @@ aot_inductor_launcher = """
         AOTInductorStreamHandle stream_handle =
             reinterpret_cast<AOTInductorStreamHandle>(stream_id);
 
-        std::vector<AtenTensorHandle> input_handles =
-            torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(input_tensors);
-        std::vector<AtenTensorHandle> output_handles =
-            torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(output_tensors);
+        auto input_handles = torch::aot_inductor::RAIITensorToHandleAllocator(input_tensors);
+        auto output_handles = torch::aot_inductor::RAIITensorToHandleAllocator(output_tensors);
 
         std::vector<const int64_t*> output_sizes(output_tensors.size());
         std::vector<int64_t> output_ndims(output_tensors.size());
@@ -1204,9 +1202,9 @@ aot_inductor_launcher = """
 
         AOTI_RUNTIME_ERROR_CODE_CHECK(AOTInductorModelContainerRun(
             container_handle,
-            input_handles.data(),
+            input_handles.release(),
             input_tensors.size(),
-            output_handles.data(),
+            output_handles.release(),
             output_tensors.size(),
             stream_handle,
             proxy_executor_handle,

--- a/torch/csrc/inductor/aot_runtime/model.h
+++ b/torch/csrc/inductor/aot_runtime/model.h
@@ -91,7 +91,8 @@ class RAIIAtenTensorHandle {
 
 using ConstantMap = std::unordered_map<std::string, RAIIAtenTensorHandle>;
 
-// Steal the ownership from raw AtenTensorHandle to RAIIAtenTensorHandle
+// Steal the passed-in array and steal the its elements from raw
+// AtenTensorHandle to RAIIAtenTensorHandle
 std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_unique_handles(
     AtenTensorHandle* handles,
     size_t size) {
@@ -101,6 +102,7 @@ std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_unique_handles(
     result.push_back(std::move(RAIIAtenTensorHandle(handles[i])));
     handles[i] = nullptr;
   }
+  delete[] handles;
   return result;
 }
 

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.h
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.h
@@ -16,17 +16,45 @@ TORCH_API at::Tensor* tensor_handle_to_tensor_pointer(AtenTensorHandle handle);
 // No ownership transfer, just pointer type conversion
 TORCH_API AtenTensorHandle tensor_pointer_to_tensor_handle(at::Tensor* tensor);
 
-// unsafe_alloc_new_handles_from_tensors is used for allocating new aten
-// tensor objects and return them as a vector of AtenTensorHandle (raw
-// pointers), and those pointers will be stolen by model.so.
-TORCH_API std::vector<AtenTensorHandle> unsafe_alloc_new_handles_from_tensors(
-    std::vector<at::Tensor>& tensors);
-
 // alloc_tensors_by_stealing_from_handles is used for creating a vector of aten
 // tensors by stealing from a vector of handles
 // WARNING: only used in the non ABI compatible mode
 TORCH_API std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
     std::vector<AtenTensorHandle>& handles);
+
+class TORCH_API RAIITensorToHandleAllocator {
+ public:
+  RAIITensorToHandleAllocator() = delete;
+  RAIITensorToHandleAllocator(const RAIITensorToHandleAllocator& other) =
+      delete;
+  RAIITensorToHandleAllocator(RAIITensorToHandleAllocator&& other) = delete;
+  RAIITensorToHandleAllocator& operator=(
+      const RAIITensorToHandleAllocator& other) = delete;
+  RAIITensorToHandleAllocator& operator=(RAIITensorToHandleAllocator&& other) =
+      delete;
+
+  // Allocate new tensor objects and allocate an array to store pointers
+  // (AtenTensorHandle) to those objects
+  RAIITensorToHandleAllocator(std::vector<at::Tensor>& tensors);
+
+  ~RAIITensorToHandleAllocator() {
+    if (handles_) {
+      delete[] handles_;
+    }
+  }
+
+  // Release the handle array and the caller is REQUIRED to steal both the
+  // ownership of the allocated array and the allocated tensor objects stored as
+  // pointers in that array
+  AtenTensorHandle* release() {
+    AtenTensorHandle* result = handles_;
+    handles_ = nullptr;
+    return result;
+  }
+
+ private:
+  AtenTensorHandle* handles_;
+};
 
 } // namespace aot_inductor
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109673
* #109606
* #109450
* #109498
* #109436

Summary: RAIITensorToHandleAllocator is used to allocate arrays of AtenTensorHandle for inputs and outputs. This makes sure when model.so steals input and output tensors, it steals the the tensor array as well. This provides a more unified behavior for ownship transferring.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov