### PR TITLE
[ONNX] Remove the depreacated function in symbolic_helper

### DIFF
--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -5,6 +5,7 @@ import pytorch_test_common
 import torch
 from pytorch_test_common import skipIfNoCuda
 from torch.onnx import verification
+from torch.onnx._globals import GLOBALS
 from torch.testing._internal import common_utils
 
 
@@ -18,7 +19,7 @@ def _jit_graph_to_onnx_model(graph, operator_export_type, opset_version):
     PyTorch tensor inputs.
     """
 
-    torch.onnx.symbolic_helper._set_opset_version(opset_version)
+    GLOBALS.export_onnx_opset_version = opset_version
     graph = torch.onnx.utils._optimize_graph(
         graph, operator_export_type, params_dict={}
     )

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -7,7 +7,8 @@ import onnx
 import pytorch_test_common
 import torch
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion
-from torch.onnx import _constants, symbolic_helper, utils
+from torch.onnx import _constants, utils
+from torch.onnx._globals import GLOBALS
 from torch.onnx._internal import jit_utils
 from torch.testing._internal import common_utils
 
@@ -41,8 +42,7 @@ def g_op(graph: torch.Graph, op_name: str, *args, **kwargs):
 class TestONNXShapeInference(pytorch_test_common.ExportTestCase):
     def setUp(self):
         self.opset_version = _constants.ONNX_TORCHSCRIPT_EXPORTER_MAX_OPSET
-        symbolic_helper._set_onnx_shape_inference(True)
-        symbolic_helper._set_opset_version(self.opset_version)
+        GLOBALS.export_onnx_opset_version = self.opset_version
 
     def run_test(self, g, n, type_assertion_funcs):
         if not isinstance(type_assertion_funcs, list):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -23,7 +23,7 @@ import torch._C._onnx as _C_onnx
 from torch import _C
 
 # Monkey-patch graph manipulation methods on Graph, used for the ONNX symbolics
-from torch.onnx import _constants, _deprecation, _type_utils, errors
+from torch.onnx import _constants, _type_utils, errors
 from torch.onnx._globals import GLOBALS
 from torch.onnx._internal import _beartype, jit_utils
 from torch.types import Number
@@ -1710,36 +1710,6 @@ def args_have_same_dtype(args):
         _type_utils.JitScalarType.from_value(elem) == base_dtype for elem in args
     )
     return has_same_dtype
-
-
-# TODO(justinchuby): Delete these setters, users should set the vars directly.
-@_deprecation.deprecated(
-    "1.13",
-    "2.0",
-    "remove its usage and avoid setting internal variables directly",
-)
-def _set_opset_version(opset_version: int):
-    GLOBALS.export_onnx_opset_version = opset_version
-
-
-@_deprecation.deprecated(
-    "1.13",
-    "2.0",
-    "remove its usage and avoid setting internal variables directly",
-)
-def _set_operator_export_type(operator_export_type):
-    GLOBALS.operator_export_type = operator_export_type
-
-
-# This function is for debug use only.
-# onnx_shape_inference = True by default.
-@_deprecation.deprecated(
-    "1.13",
-    "2.0",
-    "remove its usage and avoid setting internal variables directly",
-)
-def _set_onnx_shape_inference(onnx_shape_inference: bool):
-    GLOBALS.onnx_shape_inference = onnx_shape_inference
 
 
 # Deprecated. Internally use _type_utils.ScalarType


### PR DESCRIPTION
These three functions in symbolic_helper are depreacated and should be removed after pytorch 2.0.

The clean up job will be separated into several patches to ensure the safety. See: https://github.com/pytorch/pytorch/pull/107208
