### PR TITLE
Trace frames with `numpy.ndarray`.

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -28,7 +28,6 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch.onnx.operators
-from test.distributions.test_distributions import TEST_NUMPY
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph, bytecode_analysis, bytecode_transformation
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
@@ -7075,11 +7074,7 @@ def ___make_guard_fn():
         self.assertEqual(list(eager), list(compiled))
         self.assertEqual(counter.frame_count, 1)
 
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    @torch._dynamo.config(trace_numpy=True)
     def test_trace_ndarray_frame(self):
-        import numpy as np
-
         def fn(x):
             x = x**2
             print("graph break.")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -28,6 +28,7 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch.onnx.operators
+from test.distributions.test_distributions import TEST_NUMPY
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph, bytecode_analysis, bytecode_transformation
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
@@ -7074,6 +7075,8 @@ def ___make_guard_fn():
         self.assertEqual(list(eager), list(compiled))
         self.assertEqual(counter.frame_count, 1)
 
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @torch._dynamo.config(trace_numpy=True)
     def test_trace_ndarray_frame(self):
         import numpy as np
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7074,6 +7074,22 @@ def ___make_guard_fn():
         self.assertEqual(list(eager), list(compiled))
         self.assertEqual(counter.frame_count, 1)
 
+    def test_trace_ndarray_frame(self):
+        import numpy as np
+
+        def fn(x):
+            x = x ** 2
+            print("graph break.")
+            return 2 * x
+
+        counter = CompileCounter()
+        compiled_fn = torch._dynamo.optimize(counter)(fn)
+
+        x = np.arange(8)
+        self.assertEqual(fn(x), compiled_fn(x))
+        self.assertEqual(counter.frame_count, 2)
+
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7078,7 +7078,7 @@ def ___make_guard_fn():
         import numpy as np
 
         def fn(x):
-            x = x ** 2
+            x = x**2
             print("graph break.")
             return 2 * x
 
@@ -7088,7 +7088,6 @@ def ___make_guard_fn():
         x = np.arange(8)
         self.assertEqual(fn(x), compiled_fn(x))
         self.assertEqual(counter.frame_count, 2)
-
 
 
 class TestTracer(JitTestCase):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import itertools
 import logging
+import numpy
 import os
 import random
 import types
@@ -177,7 +178,7 @@ def has_tensor_in_frame(frame):
             return seen_ids[obj_id]
         seen_ids[obj_id] = False
 
-        if isinstance(obj, (torch.Tensor, torch.nn.Module)) or (
+        if isinstance(obj, (torch.Tensor, torch.nn.Module, numpy.ndarray)) or (
             istype(obj, type) and issubclass(obj, torch.nn.Module)
         ):
             seen_ids[obj_id] = True

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2,13 +2,17 @@ import collections
 import functools
 import itertools
 import logging
-import numpy
 import os
 import random
 import types
 import typing
 import weakref
 from typing import Any, Callable, Dict, List, Optional, Set
+
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    np = None  # type: ignore[assignment]
 
 import torch
 import torch._logging
@@ -178,9 +182,12 @@ def has_tensor_in_frame(frame):
             return seen_ids[obj_id]
         seen_ids[obj_id] = False
 
-        if isinstance(obj, (torch.Tensor, torch.nn.Module, numpy.ndarray)) or (
+        if isinstance(obj, (torch.Tensor, torch.nn.Module)) or (
             istype(obj, type) and issubclass(obj, torch.nn.Module)
         ):
+            seen_ids[obj_id] = True
+            return seen_ids[obj_id]
+        elif config.trace_numpy and np and isinstance(obj, np.ndarray):
             seen_ids[obj_id] = True
             return seen_ids[obj_id]
         elif istype(obj, (list, tuple)):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109715

Fix: #109604

This PR enables tracing of frames that contain NumPy arrays (without PyTorch modules or
tensors).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng