### PR TITLE
Pytorchify numpy vendored tests in torch_np/lib/

### DIFF
--- a/test/torch_np/numpy_tests/lib/test_arraypad.py
+++ b/test/torch_np/numpy_tests/lib/test_arraypad.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
-from unittest import expectedFailure as xfail
+from unittest import expectedFailure as xfail, skipIf as skipif
 
 import torch._numpy as np
 from torch._numpy.testing import assert_allclose, assert_array_equal
@@ -545,7 +545,7 @@ class TestConstant(TestCase):
         )
         assert_allclose(test, expected)
 
-    @xfail  # (reason="int64 overflow")
+    @skipif(True, reason='passes on MacOS, fails otherwise')  # (reason="int64 overflow")
     def test_check_large_integers(self):
         int64_max = 2**63 - 1
         arr = np.full(5, int64_max, dtype=np.int64)

--- a/test/torch_np/numpy_tests/lib/test_arraypad.py
+++ b/test/torch_np/numpy_tests/lib/test_arraypad.py
@@ -1,13 +1,15 @@
 # Owner(s): ["module: dynamo"]
 
-import pytest
+from unittest import expectedFailure as xfail
 
 import torch._numpy as np
 from torch._numpy.testing import assert_allclose, assert_array_equal
 
+from torch.testing._internal.common_utils import run_tests, TestCase
 
-class TestConstant:
-    @pytest.mark.xfail(reason="tuple values")
+
+class TestConstant(TestCase):
+    @xfail  # (reason="tuple values")
     def test_check_constant(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), "constant", constant_values=(10, 20))
@@ -355,7 +357,7 @@ class TestConstant:
         )
         assert_allclose(test, expected)
 
-    @pytest.mark.xfail(reason="tuple values")
+    @xfail  # (reason="tuple values")
     def test_check_constant_float3(self):
         a = np.arange(100, dtype=float)
         a = np.pad(a, (25, 20), "constant", constant_values=(-1.1, -1.2))
@@ -526,7 +528,7 @@ class TestConstant:
         )
         assert_allclose(test, expected)
 
-    @pytest.mark.xfail(reason="tuple values")
+    @xfail  # (reason="tuple values")
     def test_check_constant_pad_2d(self):
         arr = np.arange(4).reshape(2, 2)
         test = np.lib.pad(
@@ -543,7 +545,7 @@ class TestConstant:
         )
         assert_allclose(test, expected)
 
-    @pytest.mark.xfail(reason="int64 overflow")
+    @xfail  # (reason="int64 overflow")
     def test_check_large_integers(self):
         int64_max = 2**63 - 1
         arr = np.full(5, int64_max, dtype=np.int64)
@@ -558,6 +560,4 @@ class TestConstant:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_arraypad.py
+++ b/test/torch_np/numpy_tests/lib/test_arraypad.py
@@ -545,7 +545,9 @@ class TestConstant(TestCase):
         )
         assert_allclose(test, expected)
 
-    @skipif(True, reason='passes on MacOS, fails otherwise')  # (reason="int64 overflow")
+    @skipif(
+        True, reason="passes on MacOS, fails otherwise"
+    )  # (reason="int64 overflow")
     def test_check_large_integers(self):
         int64_max = 2**63 - 1
         arr = np.full(5, int64_max, dtype=np.int64)

--- a/test/torch_np/numpy_tests/lib/test_arraysetops.py
+++ b/test/torch_np/numpy_tests/lib/test_arraysetops.py
@@ -3,11 +3,8 @@
 """Test functions for 1D array set operations.
 
 """
-# TODO: NotImplemented
-# from numpy.lib.arraysetops import (
-#    ediff1d, intersect1d, setxor1d, union1d, setdiff1d, in1d, isin
-#    )
-import pytest
+from unittest import expectedFailure as xfail
+
 import torch._numpy as np
 from pytest import raises as assert_raises
 
@@ -15,9 +12,16 @@ from torch._numpy import unique
 
 from torch._numpy.testing import assert_array_equal, assert_equal
 
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
-@pytest.mark.xfail(reason="TODO")
-class TestSetOps:
+
+@xfail  # (reason="TODO")
+class TestSetOps(TestCase):
     def test_intersect1d(self):
         # unique inputs
         a = np.array([5, 7, 1, 2])
@@ -131,7 +135,7 @@ class TestSetOps:
         assert_array_equal([7, 1], ediff1d(two_elem, to_begin=7))
         assert_array_equal([5, 6, 1], ediff1d(two_elem, to_begin=[5, 6]))
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "ary, prepend, append, expected",
         [
             # should fail because trying to cast
@@ -163,7 +167,7 @@ class TestSetOps:
         with assert_raises_regex(TypeError, msg):
             ediff1d(ary=ary, to_end=append, to_begin=prepend)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "ary,prepend,append,expected",
         [
             (
@@ -200,7 +204,7 @@ class TestSetOps:
         assert_equal(actual, expected)
         assert actual.dtype == expected.dtype
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_isin(self, kind):
         # the tests for in1d cover most of isin's behavior
         # if in1d is removed, would need to change those tests to test
@@ -262,7 +266,7 @@ class TestSetOps:
             assert_isin_equal(ar, empty_array)
             assert_isin_equal(empty_array, empty_array)
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d(self, kind):
         # we use two different sizes for the b array here to test the
         # two different paths in in1d().
@@ -361,7 +365,7 @@ class TestSetOps:
 
         assert_array_equal(c, ec)
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d_invert(self, kind):
         "Test in1d's invert parameter"
         # We use two different sizes for the b array here to test the
@@ -385,7 +389,7 @@ class TestSetOps:
                     np.invert(in1d(a, b, kind=kind)), in1d(a, b, invert=True, kind=kind)
                 )
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d_ravel(self, kind):
         # Test that in1d ravels its input arrays. This is not documented
         # behavior however. The test is to ensure consistentency.
@@ -415,7 +419,7 @@ class TestSetOps:
         c = in1d(a, b, assume_unique=True)
         assert_array_equal(c, ec)
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d_boolean(self, kind):
         """Test that in1d works for boolean input"""
         a = np.array([True, False])
@@ -424,7 +428,7 @@ class TestSetOps:
         assert_array_equal(expected, in1d(a, b, kind=kind))
         assert_array_equal(np.invert(expected), in1d(a, b, invert=True, kind=kind))
 
-    @pytest.mark.parametrize("kind", [None, "sort"])
+    @parametrize("kind", [None, "sort"])
     def test_in1d_timedelta(self, kind):
         """Test that in1d works for timedelta input"""
         rstate = np.random.RandomState(0)
@@ -442,14 +446,14 @@ class TestSetOps:
         with pytest.raises(ValueError):
             in1d(a, b, kind="table")
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "dtype1,dtype2",
         [
             (np.int8, np.int16),
             (np.int16, np.int8),
         ],
     )
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d_mixed_dtype(self, dtype1, dtype2, kind):
         """Test that in1d works as expected for mixed dtype input."""
         is_dtype2_signed = np.issubdtype(dtype2, np.signedinteger)
@@ -475,7 +479,7 @@ class TestSetOps:
         else:
             assert_array_equal(in1d(ar1, ar2, kind=kind), expected)
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    @parametrize("kind", [None, "sort", "table"])
     def test_in1d_mixed_boolean(self, kind):
         """Test that in1d works as expected for bool/int input."""
         for dtype in np.typecodes["AllInteger"]:
@@ -642,7 +646,8 @@ class TestSetOps:
         assert_array_equal(c1, c2)
 
 
-class TestUnique:
+@instantiate_parametrized_tests
+class TestUnique(TestCase):
     def test_unique_1d(self):
         def check_all(a, b, i1, i2, c, dt):
             base_msg = "check {0} failed for type {1}"
@@ -738,7 +743,7 @@ class TestUnique:
     #    assert_equal(a3_idx.dtype, np.intp)
     #    assert_equal(a3_inv.dtype, np.intp)
 
-    @pytest.mark.xfail(reason="unique with nans")
+    @xfail  # (reason="unique with nans")
     def test_unique_1d_2(self):
         # test for ticket 2111 - float
         a = [2.0, np.nan, 1.0, np.nan]
@@ -787,6 +792,8 @@ class TestUnique:
         assert_array_equal(unique(inp, axis=0), unique(inp_arr, axis=0), msg)
         assert_array_equal(unique(inp, axis=1), unique(inp_arr, axis=1), msg)
 
+    @xfail  # _run_axis_tests xfails with the message
+    #   torch has different unique ordering behaviour"
     def test_unique_axis(self):
         types = []
         types.extend(np.typecodes["AllInteger"])
@@ -805,13 +812,13 @@ class TestUnique:
         result = np.array([[-0.0, 0.0]])
         assert_array_equal(unique(data, axis=0), result, msg)
 
-    @pytest.mark.parametrize("axis", [0, -1])
+    @parametrize("axis", [0, -1])
     def test_unique_1d_with_axis(self, axis):
         x = np.array([4, 3, 2, 3, 2, 1, 2, 2])
         uniq = unique(x, axis=axis)
         assert_array_equal(uniq, [1, 2, 3, 4])
 
-    @pytest.mark.xfail(reason="unique / return_index")
+    @xfail  # (reason="unique / return_index")
     def test_unique_axis_zeros(self):
         # issue 15559
         single_zero = np.empty(shape=(2, 0), dtype=np.int8)
@@ -885,6 +892,9 @@ class TestUnique:
         result = np.array([[0, 0, 1], [0, 1, 0], [0, 0, 1], [0, 1, 0]])
         assert_array_equal(unique(data, axis=1), result.astype(dtype), msg)
 
+        # XXX: local import in an already xfailed test; restructure when not xfailed
+        import pytest
+
         pytest.xfail("torch has different unique ordering behaviour")
         # e.g.
         #
@@ -919,7 +929,7 @@ class TestUnique:
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
 
-    @pytest.mark.xfail(reason="unique / return_index / nans")
+    @xfail  # (reason="unique / return_index / nans")
     def test_unique_nanequals(self):
         # issue 20326
         a = np.array([1, 1, np.nan, np.nan, np.nan])
@@ -930,6 +940,4 @@ class TestUnique:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_arraysetops.py
+++ b/test/torch_np/numpy_tests/lib/test_arraysetops.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
 
 
 @xfail  # (reason="TODO")
+@instantiate_parametrized_tests
 class TestSetOps(TestCase):
     def test_intersect1d(self):
         # unique inputs
@@ -779,9 +780,6 @@ class TestUnique(TestCase):
         assert_equal(np.unique(all_nans, return_counts=True), (ua, ua_cnt))
 
     def test_unique_axis_errors(self):
-        assert_raises(TypeError, self._run_axis_tests, object)
-        assert_raises(TypeError, self._run_axis_tests, [("a", int), ("b", object)])
-
         assert_raises(np.AxisError, unique, np.arange(10), axis=2)
         assert_raises(np.AxisError, unique, np.arange(10), axis=-2)
 
@@ -892,10 +890,6 @@ class TestUnique(TestCase):
         result = np.array([[0, 0, 1], [0, 1, 0], [0, 0, 1], [0, 1, 0]])
         assert_array_equal(unique(data, axis=1), result.astype(dtype), msg)
 
-        # XXX: local import in an already xfailed test; restructure when not xfailed
-        import pytest
-
-        pytest.xfail("torch has different unique ordering behaviour")
         # e.g.
         #
         #     >>> x = np.array([[[1, 1], [0, 1]], [[1, 0], [0, 0]]])

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -1,10 +1,13 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import math
 import operator
 import sys
 import warnings
 from fractions import Fraction
+
+from unittest import expectedFailure as xfail, skipIf as skipif
 
 import hypothesis
 import hypothesis.strategies as st
@@ -25,6 +28,15 @@ from torch._numpy.testing import (
     assert_warns,
     suppress_warnings,  # HAS_REFCOUNT, IS_WASM
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
 
 HAS_REFCOUNT = True
 IS_WASM = False
@@ -74,7 +86,7 @@ def _make_complex(real, imag):
     return ret
 
 
-class TestRot90:
+class TestRot90(TestCase):
     def test_basic(self):
         assert_raises(ValueError, np.rot90, np.ones(4))
         assert_raises(
@@ -127,14 +139,14 @@ class TestRot90:
             )
 
 
-class TestFlip:
+class TestFlip(TestCase):
     def test_axes(self):
         assert_raises(np.AxisError, np.flip, np.ones(4), axis=1)
         assert_raises(np.AxisError, np.flip, np.ones((4, 4)), axis=2)
         assert_raises(np.AxisError, np.flip, np.ones((4, 4)), axis=-3)
         assert_raises(np.AxisError, np.flip, np.ones((4, 4)), axis=(0, 3))
 
-    @pytest.mark.skip(reason="no [::-1] indexing")
+    @skip(reason="no [::-1] indexing")
     def test_basic_lr(self):
         a = get_mat(4)
         b = a[:, ::-1]
@@ -143,7 +155,7 @@ class TestFlip:
         b = [[2, 1, 0], [5, 4, 3]]
         assert_equal(np.flip(a, 1), b)
 
-    @pytest.mark.skip(reason="no [::-1] indexing")
+    @skip(reason="no [::-1] indexing")
     def test_basic_ud(self):
         a = get_mat(4)
         b = a[::-1, :]
@@ -197,7 +209,7 @@ class TestFlip:
         assert_equal(np.flip(a, axis=(1, 2)), c)
 
 
-class TestAny:
+class TestAny(TestCase):
     def test_basic(self):
         y1 = [0, 0, 1, 0]
         y2 = [0, 0, 0, 0]
@@ -213,7 +225,7 @@ class TestAny:
         assert_array_equal(np.sometrue(y1, axis=1), [0, 1, 1])
 
 
-class TestAll:
+class TestAll(TestCase):
     def test_basic(self):
         y1 = [0, 1, 1, 0]
         y2 = [0, 0, 0, 0]
@@ -230,7 +242,7 @@ class TestAll:
         assert_array_equal(np.alltrue(y1, axis=1), [0, 0, 1])
 
 
-class TestCopy:
+class TestCopy(TestCase):
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
         a_copy = np.copy(a)
@@ -239,7 +251,7 @@ class TestCopy:
         assert_equal(a[0, 0], 1)
         assert_equal(a_copy[0, 0], 10)
 
-    @pytest.mark.xfail(reason="order='F' not implemented")
+    @xfail  # (reason="order='F' not implemented")
     def test_order(self):
         # It turns out that people rely on np.copy() preserving order by
         # default; changing this broke scikit-learn:
@@ -258,7 +270,8 @@ class TestCopy:
         assert_(a_fort_copy.flags.f_contiguous)
 
 
-class TestAverage:
+@instantiate_parametrized_tests
+class TestAverage(TestCase):
     def test_basic(self):
         y1 = np.array([1, 2, 3])
         assert_(np.average(y1, axis=0) == 2.0)
@@ -277,7 +290,7 @@ class TestAverage:
         assert_almost_equal(y5.mean(0), np.average(y5, 0))
         assert_almost_equal(y5.mean(1), np.average(y5, 1))
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "x, axis, expected_avg, weights, expected_wavg, expected_wsum",
         [
             ([1, 2, 3], None, [2.0], [3, 4, 1], [1.75], [8.0]),
@@ -393,15 +406,15 @@ class TestAverage:
             w = np.array([[1, 2], [3, 4]], dtype=wt)
             assert_equal(np.average(a, weights=w).dtype, np.dtype(rt))
 
-    @pytest.mark.skip(reason="support Fraction objects?")
+    @skip(reason="support Fraction objects?")
     def test_average_class_without_dtype(self):
         # see gh-21988
         a = np.array([Fraction(1, 5), Fraction(3, 5)])
         assert_equal(np.average(a), Fraction(2, 5))
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestSelect:
+@xfail  # (reason="TODO: implement")
+class TestSelect(TestCase):
     choices = [np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])]
     conditions = [
         np.array([False, False, False]),
@@ -464,8 +477,9 @@ class TestSelect:
         select(conditions, choices)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestInsert:
+@xfail  # (reason="TODO: implement")
+@instantiate_parametrized_tests
+class TestInsert(TestCase):
     def test_basic(self):
         a = [1, 2, 3]
         assert_equal(insert(a, 0, 1), [1, 1, 2, 3])
@@ -548,13 +562,13 @@ class TestInsert:
         with pytest.raises(IndexError):
             np.insert([0, 1, 2], np.array([], dtype=float), [])
 
-    @pytest.mark.parametrize("idx", [4, -4])
+    @parametrize("idx", [4, -4])
     def test_index_out_of_bounds(self, idx):
         with pytest.raises(IndexError, match="out of bounds"):
             np.insert([0, 1, 2], [idx], [3, 4])
 
 
-class TestAmax:
+class TestAmax(TestCase):
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amax(a), 10.0)
@@ -563,7 +577,7 @@ class TestAmax:
         assert_equal(np.amax(b, axis=1), [9.0, 10.0, 8.0])
 
 
-class TestAmin:
+class TestAmin(TestCase):
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.amin(a), -5.0)
@@ -572,7 +586,7 @@ class TestAmin:
         assert_equal(np.amin(b, axis=1), [3.0, 4.0, 2.0])
 
 
-class TestPtp:
+class TestPtp(TestCase):
     def test_basic(self):
         a = np.array([3, 4, 5, 10, -3, -5, 6.0])
         assert_equal(a.ptp(axis=0), 15.0)
@@ -584,7 +598,7 @@ class TestPtp:
         assert_equal(b.ptp(axis=(0, 1), keepdims=True), [[8.0]])
 
 
-class TestCumsum:
+class TestCumsum(TestCase):
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -611,7 +625,7 @@ class TestCumsum:
             assert_array_equal(np.cumsum(a2, axis=1), tgt)
 
 
-class TestProd:
+class TestProd(TestCase):
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -634,7 +648,7 @@ class TestProd:
                 assert_array_equal(a2.prod(axis=-1), np.array([24, 1890, 600], ctype))
 
 
-class TestCumprod:
+class TestCumprod(TestCase):
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]
@@ -669,7 +683,7 @@ class TestCumprod:
                 )
 
 
-class TestDiff:
+class TestDiff(TestCase):
     def test_basic(self):
         x = [1, 4, 6, 7, 12]
         out = np.array([3, 2, 1, 5])
@@ -781,8 +795,9 @@ class TestDiff:
         assert_raises(np.AxisError, diff, x, append=0, axis=3)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestDelete:
+@xfail  # (reason="TODO: implement")
+@instantiate_parametrized_tests
+class TestDelete(TestCase):
     def setup_method(self):
         self.a = np.arange(5)
         self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
@@ -879,7 +894,8 @@ class TestDelete:
         assert_array_equal(res, x[:, :0])
 
 
-class TestGradient:
+@instantiate_parametrized_tests
+class TestGradient(TestCase):
     def test_basic(self):
         v = [[1, 1], [3, 4]]
         x = np.array(v)
@@ -1056,7 +1072,7 @@ class TestGradient:
         assert_raises(ValueError, gradient, np.arange(1), edge_order=2)
         assert_raises(ValueError, gradient, np.arange(2), edge_order=2)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "f_dtype",
         [
             np.uint8,
@@ -1067,7 +1083,7 @@ class TestGradient:
         g = gradient(f)
         assert_array_equal(g, [-1] * len(f))
 
-    @pytest.mark.parametrize("f_dtype", [np.int8, np.int16, np.int32, np.int64])
+    @parametrize("f_dtype", [np.int8, np.int16, np.int32, np.int64])
     def test_f_signed_int_big_jump(self, f_dtype):
         maxint = np.iinfo(f_dtype).max
         x = np.array([1, 3])
@@ -1075,7 +1091,7 @@ class TestGradient:
         dfdx = gradient(f, x)
         assert_array_equal(dfdx, [(maxint + 1) // 2] * 2)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "x_dtype",
         [
             np.uint8,
@@ -1087,7 +1103,7 @@ class TestGradient:
         dfdx = gradient(f, x)
         assert_array_equal(dfdx, [-2] * len(x))
 
-    @pytest.mark.parametrize("x_dtype", [np.int8, np.int16, np.int32, np.int64])
+    @parametrize("x_dtype", [np.int8, np.int16, np.int32, np.int64])
     def test_x_signed_int_big_jump(self, x_dtype):
         minint = np.iinfo(x_dtype).min
         maxint = np.iinfo(x_dtype).max
@@ -1097,7 +1113,7 @@ class TestGradient:
         assert_array_equal(dfdx, [0.5, 0.5])
 
 
-class TestAngle:
+class TestAngle(TestCase):
     def test_basic(self):
         x = [
             1 + 3j,
@@ -1126,8 +1142,9 @@ class TestAngle:
         assert_array_almost_equal(z, zo, 11)
 
 
-@pytest.mark.xfail(reason="trim_zeros not implemented")
-class TestTrimZeros:
+@xfail  # (reason="trim_zeros not implemented")
+@instantiate_parametrized_tests
+class TestTrimZeros(TestCase):
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
     b = a.astype(float)
     c = a.astype(complex)
@@ -1170,7 +1187,7 @@ class TestTrimZeros:
         res = trim_zeros(arr)
         assert_array_equal(arr, res)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "arr",
         [
             np.array([0, 2**62, 0]),
@@ -1193,8 +1210,8 @@ class TestTrimZeros:
         assert isinstance(res, list)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestExtins:
+@xfail  # (reason="TODO: implement")
+class TestExtins(TestCase):
     def test_basic(self):
         a = np.array([1, 3, 2, 1, 2, 3, 3])
         b = extract(a > 1, a)
@@ -1246,8 +1263,8 @@ def _foo2(x, y=1.0, z=0.0):
     return y * math.floor(x) + z
 
 
-@pytest.mark.skip(reason="vectorize not implemented")
-class TestVectorize:
+@skip  # (reason="vectorize not implemented")
+class TestVectorize(TestCase):
     def test_simple(self):
         def addsubtract(a, b):
             if a > b:
@@ -1595,8 +1612,8 @@ class TestVectorize:
             f(x)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestDigitize:
+@xfail  # (reason="TODO: implement")
+class TestDigitize(TestCase):
     def test_forward(self):
         x = np.arange(-6, 5)
         bins = np.arange(-5, 5)
@@ -1672,8 +1689,8 @@ class TestDigitize:
         assert_equal(np.digitize(x, [x + 1, x - 1]), 1)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestUnwrap:
+@xfail  # (reason="TODO: implement")
+class TestUnwrap(TestCase):
     def test_simple(self):
         # check that unwrap removes jumps greater that 2*pi
         assert_array_equal(unwrap([1, 1 + 2 * np.pi]), [1, 1])
@@ -1699,9 +1716,10 @@ class TestUnwrap:
         assert sm_discont.dtype == wrap_uneven.dtype
 
 
-@pytest.mark.parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
-@pytest.mark.parametrize("M", [0, 1, 10])
+@instantiate_parametrized_tests
 class TestFilterwindows:
+    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize("M", [0, 1, 10])
     def test_hanning(self, dtype: str, M: int) -> None:
         scalar = M
 
@@ -1720,6 +1738,8 @@ class TestFilterwindows:
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.500, 4)
 
+    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize("M", [0, 1, 10])
     def test_hamming(self, dtype: str, M: int) -> None:
         scalar = M
 
@@ -1738,6 +1758,8 @@ class TestFilterwindows:
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.9400, 4)
 
+    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize("M", [0, 1, 10])
     def test_bartlett(self, dtype: str, M: int) -> None:
         scalar = M
 
@@ -1756,6 +1778,8 @@ class TestFilterwindows:
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.4444, 4)
 
+    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize("M", [0, 1, 10])
     def test_blackman(self, dtype: str, M: int) -> None:
         scalar = M
 
@@ -1774,6 +1798,8 @@ class TestFilterwindows:
         else:
             assert_almost_equal(np.sum(w, axis=0), 3.7800, 4)
 
+    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize("M", [0, 1, 10])
     def test_kaiser(self, dtype: str, M: int) -> None:
         scalar = M
 
@@ -1793,8 +1819,8 @@ class TestFilterwindows:
             assert_almost_equal(np.sum(w, axis=0), 10, 15)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestTrapz:
+@xfail  # (reason="TODO: implement")
+class TestTrapz(TestCase):
     def test_simple(self):
         x = np.arange(-10, 10, 0.1)
         r = trapz(np.exp(-0.5 * x**2) / np.sqrt(2 * np.pi), dx=0.1)
@@ -1839,7 +1865,7 @@ class TestTrapz:
         assert_almost_equal(r, qz)
 
 
-class TestSinc:
+class TestSinc(TestCase):
     def test_simple(self):
         assert_(sinc(0) == 1)
         w = sinc(np.linspace(-1, 1, 100))
@@ -1855,21 +1881,21 @@ class TestSinc:
         assert_array_equal(y1, y3)
 
 
-class TestUnique:
+class TestUnique(TestCase):
     def test_simple(self):
         x = np.array([4, 3, 2, 1, 1, 2, 3, 4, 0])
         assert_(np.all(unique(x) == [0, 1, 2, 3, 4]))
 
         assert_(unique(np.array([1, 1, 1, 1, 1])) == np.array([1]))
 
-    @pytest.mark.xfail(reason="unique not implemented for 'ComplexDouble'")
+    @xfail  # (reason="unique not implemented for 'ComplexDouble'")
     def test_simple_complex(self):
         x = np.array([5 + 6j, 1 + 1j, 1 + 10j, 10, 5 + 6j])
         assert_(np.all(unique(x) == [1 + 1j, 1 + 10j, 5 + 6j, 10]))
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestCheckFinite:
+@xfail  # (reason="TODO: implement")
+class TestCheckFinite(TestCase):
     def test_simple(self):
         a = [1, 2, 3]
         b = [1, 2, np.inf]
@@ -1885,7 +1911,8 @@ class TestCheckFinite:
         assert_(a.dtype == np.float64)
 
 
-class TestCorrCoef:
+@instantiate_parametrized_tests
+class TestCorrCoef(TestCase):
     A = np.array(
         [
             [0.15391142, 0.18045767, 0.14197213],
@@ -1932,7 +1959,7 @@ class TestCorrCoef:
         assert_almost_equal(tgt2, self.res2)
         assert_(np.all(np.abs(tgt2) <= 1.0))
 
-    @pytest.mark.skip(reason="deprecated in numpy, ignore")
+    @skip(reason="deprecated in numpy, ignore")
     def test_ddof(self):
         # ddof raises DeprecationWarning
         with suppress_warnings() as sup:
@@ -1945,7 +1972,7 @@ class TestCorrCoef:
             assert_almost_equal(corrcoef(self.A, ddof=3), self.res1)
             assert_almost_equal(corrcoef(self.A, self.B, ddof=3), self.res2)
 
-    @pytest.mark.skip(reason="deprecated in numpy, ignore")
+    @skip(reason="deprecated in numpy, ignore")
     def test_bias(self):
         # bias raises DeprecationWarning
         with suppress_warnings() as sup:
@@ -1986,14 +2013,15 @@ class TestCorrCoef:
         assert_array_almost_equal(c, np.array([[1.0, -1.0], [-1.0, 1.0]]))
         assert_(np.all(np.abs(c) <= 1.0))
 
-    @pytest.mark.parametrize("test_type", [np.half, np.single, np.double])
+    @parametrize("test_type", [np.half, np.single, np.double])
     def test_corrcoef_dtype(self, test_type):
         cast_A = self.A.astype(test_type)
         res = corrcoef(cast_A, dtype=test_type)
         assert test_type == res.dtype
 
 
-class TestCov:
+@instantiate_parametrized_tests
+class TestCov(TestCase):
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T
     res1 = np.array([[1.0, -1.0], [-1.0, 1.0]])
     x2 = np.array([0.0, 1.0, 2.0], ndmin=2)
@@ -2100,14 +2128,14 @@ class TestCov:
             self.res1,
         )
 
-    @pytest.mark.parametrize("test_type", [np.half, np.single, np.double])
+    @parametrize("test_type", [np.half, np.single, np.double])
     def test_cov_dtype(self, test_type):
         cast_x1 = self.x1.astype(test_type)
         res = cov(cast_x1, dtype=test_type)
         assert test_type == res.dtype
 
 
-class Test_I0:
+class Test_I0(TestCase):
     def test_simple(self):
         assert_almost_equal(i0(0.5), np.array(1.0634833707413234))
 
@@ -2154,7 +2182,7 @@ class Test_I0:
             res = i0(a)
 
 
-class TestKaiser:
+class TestKaiser(TestCase):
     def test_simple(self):
         assert_(np.isfinite(kaiser(1, 1.0)))
         assert_almost_equal(kaiser(0, 1.0), np.array([]))
@@ -2172,8 +2200,8 @@ class TestKaiser:
         kaiser(3, 4)
 
 
-@pytest.mark.skip(reason="msort is deprecated, do not bother")
-class TestMsort:
+@skip(reason="msort is deprecated, do not bother")
+class TestMsort(TestCase):
     def test_simple(self):
         A = np.array(
             [
@@ -2195,7 +2223,7 @@ class TestMsort:
             )
 
 
-class TestMeshgrid:
+class TestMeshgrid(TestCase):
     def test_simple(self):
         [X, Y] = meshgrid([1, 2, 3], [4, 5, 6, 7])
         assert_array_equal(X, np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]]))
@@ -2293,8 +2321,8 @@ class TestMeshgrid:
         assert_equal(c, [[[3, 4, 5], [3, 4, 5]]])
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestPiecewise:
+@xfail  # (reason="TODO: implement")
+class TestPiecewise(TestCase):
     def test_simple(self):
         # Condition is single bool list
         x = piecewise([0, 0], [True, False], [1])
@@ -2407,7 +2435,8 @@ class TestPiecewise:
         assert_array_equal(y, np.array([[-1.0, -1.0, -1.0], [3.0, 3.0, 1.0]]))
 
 
-class TestBincount:
+@instantiate_parametrized_tests
+class TestBincount(TestCase):
     def test_simple(self):
         y = np.bincount(np.arange(4))
         assert_array_equal(y, np.ones(4))
@@ -2484,7 +2513,7 @@ class TestBincount:
             lambda: np.bincount(x, minlength=-1),
         )
 
-    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    @skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test_dtype_reference_leaks(self):
         # gh-6805
         intp_refcount = sys.getrefcount(np.dtype(np.intp))
@@ -2500,7 +2529,7 @@ class TestBincount:
         assert_equal(sys.getrefcount(np.dtype(np.intp)), intp_refcount)
         assert_equal(sys.getrefcount(np.dtype(np.double)), double_refcount)
 
-    @pytest.mark.parametrize("vals", [[[2, 2]], 2])
+    @parametrize("vals", [[[2, 2]], 2])
     def test_error_not_1d(self, vals):
         # Test that values has to be 1-D (both as array and nested list)
         vals_arr = np.asarray(vals)
@@ -2510,8 +2539,8 @@ class TestBincount:
             np.bincount(vals)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestInterp:
+@xfail  # (reason="TODO: implement")
+class TestInterp(TestCase):
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])
         assert_raises(ValueError, interp, 0, [0], [1, 2])
@@ -2710,7 +2739,8 @@ class TestInterp:
         assert_almost_equal(np.interp(x, xp, fp, period=360), y)
 
 
-class TestPercentile:
+@instantiate_parametrized_tests
+class TestPercentile(TestCase):
     def test_basic(self):
         x = np.arange(8) * 0.5
         assert_equal(np.percentile(x, 0), 0.0)
@@ -2720,7 +2750,7 @@ class TestPercentile:
         assert_equal(np.percentile(x, 0), np.nan)
         assert_equal(np.percentile(x, 0, method="nearest"), np.nan)
 
-    @pytest.mark.skip(reason="support Fraction objects?")
+    @skip(reason="support Fraction objects?")
     def test_fraction(self):
         x = [Fraction(i, 2) for i in range(8)]
 
@@ -2747,7 +2777,7 @@ class TestPercentile:
         o = np.ones((1,))
         np.percentile(d, 5, None, o, False, "linear")
 
-    @pytest.mark.xfail(reason="TODO: implement")
+    @xfail  # (reason="TODO: implement")
     def test_complex(self):
         arr_c = np.array([0.5 + 3.0j, 2.1 + 0.5j, 1.6 + 2.3j], dtype="D")
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
@@ -2758,8 +2788,8 @@ class TestPercentile:
         x = np.array([[1, 1, 1], [1, 1, 1], [4, 4, 3], [1, 1, 1], [1, 1, 1]])
         assert_array_equal(np.percentile(x, 50, axis=0), [1, 1, 1])
 
-    @pytest.mark.xfail(reason="TODO: implement")
-    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
+    @xfail  # (reason="TODO: implement")
+    @parametrize("dtype", np.typecodes["Float"])
     def test_linear_nan_1D(self, dtype):
         # METHOD 1 of H&F
         arr = np.asarray([15.0, np.NAN, 35.0, 40.0, 50.0], dtype=dtype)
@@ -2775,10 +2805,10 @@ class TestPercentile:
         (np.float64, np.float64),
     ]
 
-    @pytest.mark.xfail(reason="TODO: implement percentile interpolations")
-    @pytest.mark.parametrize(["input_dtype", "expected_dtype"], H_F_TYPE_CODES)
-    @pytest.mark.parametrize(
-        ["method", "expected"],
+    @xfail  # (reason="TODO: implement percentile interpolations")
+    @parametrize("input_dtype, expected_dtype", H_F_TYPE_CODES)
+    @parametrize(
+        "method, expected",
         [
             ("inverted_cdf", 20),
             ("averaged_inverted_cdf", 27.5),
@@ -2808,12 +2838,12 @@ class TestPercentile:
 
     TYPE_CODES = np.typecodes["AllInteger"] + np.typecodes["Float"]
 
-    @pytest.mark.parametrize("dtype", TYPE_CODES)
+    @parametrize("dtype", TYPE_CODES)
     def test_lower_higher(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50, method="lower"), 4)
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50, method="higher"), 5)
 
-    @pytest.mark.parametrize("dtype", TYPE_CODES)
+    @parametrize("dtype", TYPE_CODES)
     def test_midpoint(self, dtype):
         assert_equal(
             np.percentile(np.arange(10, dtype=dtype), 51, method="midpoint"), 4.5
@@ -2828,7 +2858,7 @@ class TestPercentile:
             np.percentile(np.arange(11, dtype=dtype), 50, method="midpoint"), 5
         )
 
-    @pytest.mark.parametrize("dtype", TYPE_CODES)
+    @parametrize("dtype", TYPE_CODES)
     def test_nearest(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51, method="nearest"), 5)
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 49, method="nearest"), 4)
@@ -2919,9 +2949,7 @@ class TestPercentile:
         assert_almost_equal(c1, r1)
         assert_equal(c1.shape, r1.shape)
 
-    @pytest.mark.xfail(
-        reason="numpy: x.dtype is int, out is int; torch: result is float"
-    )
+    @xfail  # (reason="numpy: x.dtype is int, out is int; torch: result is float")
     def test_scalar_q_2(self):
         x = np.arange(12).reshape(3, 4)
         out = np.empty((), dtype=x.dtype)
@@ -3050,7 +3078,7 @@ class TestPercentile:
         b = np.percentile([2, 3, 4, 1], [50], overwrite_input=True)
         assert_equal(b, np.array([2.5]))
 
-    @pytest.mark.xfail(reason="pytorch percentile does not support tuple axes.")
+    @xfail  # (reason="pytorch percentile does not support tuple axes.")
     def test_extended_axis(self):
         o = np.random.normal(size=(71, 23))
         x = np.dstack([o] * 10)
@@ -3115,7 +3143,7 @@ class TestPercentile:
         d = np.ones((3, 5, 7, 11))
         assert_equal(np.percentile(d, 7, axis=None, keepdims=True).shape, (1, 1, 1, 1))
 
-    @pytest.mark.xfail(reason="pytorch percentile does not support tuple axes.")
+    @xfail  # (reason="pytorch percentile does not support tuple axes.")
     def test_keepdims_2(self):
         assert_equal(
             np.percentile(d, 7, axis=(0, 1), keepdims=True).shape, (1, 1, 7, 11)
@@ -3139,21 +3167,39 @@ class TestPercentile:
             np.percentile(d, [1, 7], axis=(0, 3), keepdims=True).shape, (2, 1, 5, 7, 1)
         )
 
-    @pytest.mark.parametrize("q", [7, [1, 7]])
-    @pytest.mark.parametrize(
-        argnames="axis",
-        argvalues=[
+    @parametrize(
+        "q",
+        [
+            7,
+            subtest(
+                [1, 7],
+                decorators=[
+                    xfail,
+                ],
+            ),
+        ],
+    )
+    @parametrize(
+        "axis",
+        [
             None,
             1,
-            (1,),
-            (0, 1),
-            (-3, -1),
+            subtest((1,)),
+            subtest(
+                (0, 1),
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                (-3, -1),
+                decorators=[
+                    xfail,
+                ],
+            ),
         ],
     )
     def test_keepdims_out(self, q, axis):
-        if isinstance(axis, tuple) or isinstance(q, list):
-            pytest.xfail("NotImplemented")
-
         d = np.ones((3, 5, 7, 11))
         if axis is None:
             shape_out = (1,) * d.ndim
@@ -3198,7 +3244,7 @@ class TestPercentile:
             assert_equal(np.percentile(d, 1, out=o), o)
             assert_equal(np.percentile(d, 1, method="nearest", out=o), o)
 
-    @pytest.mark.xfail(reason="np.percentile undocumented nan weirdness")
+    @xfail  # (reason="np.percentile undocumented nan weirdness")
     def test_nan_behavior(self):
         a = np.arange(24, dtype=float)
         a[2] = np.nan
@@ -3272,10 +3318,11 @@ class TestPercentile:
             np.percentile([1, 2, 3, 4.0], q)
 
 
-class TestQuantile:
+@instantiate_parametrized_tests
+class TestQuantile(TestCase):
     # most of this is already tested by TestPercentile
 
-    @pytest.mark.skip(reason="do not chase 1ulp")
+    @skip(reason="do not chase 1ulp")
     def test_max_ulp(self):
         x = [0.0, 0.2, 0.4]
         a = np.quantile(x, 0.45)
@@ -3290,7 +3337,7 @@ class TestQuantile:
         assert_equal(np.quantile(x, 1), 3.5)
         assert_equal(np.quantile(x, 0.5), 1.75)
 
-    @pytest.mark.xfail(reason="quantile w/integers or bools")
+    @xfail  # (reason="quantile w/integers or bools")
     def test_correct_quantile_value(self):
         a = np.array([True])
         tf_quant = np.quantile(True, False)
@@ -3301,7 +3348,7 @@ class TestQuantile:
         assert_array_equal(quant_res, a)
         assert_equal(quant_res.dtype, a.dtype)
 
-    @pytest.mark.skip(reason="support arrays of Fractions?")
+    @skip(reason="support arrays of Fractions?")
     def test_fraction(self):
         # fractional input, integral quantile
         x = [Fraction(i, 2) for i in range(8)]
@@ -3329,7 +3376,7 @@ class TestQuantile:
         x = np.arange(8)
         assert_equal(np.quantile(x, Fraction(1, 2)), Fraction(7, 2))
 
-    @pytest.mark.skip(reason="does not raise in numpy?")
+    @skip(reason="does not raise in numpy?")
     def test_complex(self):
         # See gh-22652
         arr_c = np.array([0.5 + 3.0j, 2.1 + 0.5j, 1.6 + 2.3j], dtype="D")
@@ -3349,24 +3396,64 @@ class TestQuantile:
         np.quantile(np.arange(100.0), p, method="midpoint")
         assert_array_equal(p, p0)
 
-    @pytest.mark.xfail(reason="TODO: make quantile preserve integers")
-    @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
+    @xfail  # (reason="TODO: make quantile preserve integers")
+    @parametrize("dtype", np.typecodes["AllInteger"])
     def test_quantile_preserve_int_type(self, dtype):
         res = np.quantile(np.array([1, 2], dtype=dtype), [0.5], method="nearest")
         assert res.dtype == dtype
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "method",
         [
-            "inverted_cdf",
-            "averaged_inverted_cdf",
-            "closest_observation",
-            "interpolated_inverted_cdf",
-            "hazen",
-            "weibull",
+            subtest(
+                "inverted_cdf",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "averaged_inverted_cdf",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "closest_observation",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "interpolated_inverted_cdf",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "hazen",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "weibull",
+                decorators=[
+                    xfail,
+                ],
+            ),
             "linear",
-            "median_unbiased",
-            "normal_unbiased",
+            subtest(
+                "median_unbiased",
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                "normal_unbiased",
+                decorators=[
+                    xfail,
+                ],
+            ),
             "nearest",
             "lower",
             "higher",
@@ -3374,9 +3461,6 @@ class TestQuantile:
         ],
     )
     def test_quantile_monotonic(self, method):
-        if method not in ("linear", "lower", "higher", "midpoint", "nearest"):
-            pytest.xfail("Not implemented")
-
         # GH 14685
         # test that the return value of quantile is monotonic if p0 is ordered
         # Also tests that the boundary values are not mishandled.
@@ -3392,7 +3476,7 @@ class TestQuantile:
         quantile = np.quantile([0.0, 1.0, 2.0, 3.0], p0, method=method)
         assert_equal(np.sort(quantile), quantile)
 
-    @pytest.mark.skip(reason="no hypothesis")
+    @skip(reason="no hypothesis")
     @hypothesis.given(
         arr=arrays(
             dtype=np.float64,
@@ -3415,7 +3499,8 @@ class TestQuantile:
         assert_equal(np.quantile(a, 0.5), np.nan)
 
 
-class TestMedian:
+@instantiate_parametrized_tests
+class TestMedian(TestCase):
     def test_basic(self):
         a0 = np.array(1)
         a1 = np.arange(2)
@@ -3434,7 +3519,7 @@ class TestMedian:
         a = np.array([0.0444502, 0.141249, 0.0463301])
         assert_equal(a[-1], np.median(a))
 
-    @pytest.mark.xfail(reason="median: scalar output vs 0-dim")
+    @xfail  # (reason="median: scalar output vs 0-dim")
     def test_basic_2(self):
         # check array scalar result
         a = np.array([0.0444502, 0.141249, 0.0463301])
@@ -3543,7 +3628,7 @@ class TestMedian:
         b[1, 2] = np.nan
         assert_equal(np.median(a, 1), b)
 
-    @pytest.mark.xfail(reason="median: does not support tuple axes")
+    @xfail  # (reason="median: does not support tuple axes")
     def test_nan_behavior_2(self):
         a = np.arange(24, dtype=float).reshape(2, 3, 4)
         a[1, 2, 3] = np.nan
@@ -3555,7 +3640,7 @@ class TestMedian:
         b[2] = np.nan
         assert_equal(np.median(a, (0, 2)), b)
 
-    @pytest.mark.xfail(reason="median: scalar vs 0-dim")
+    @xfail  # (reason="median: scalar vs 0-dim")
     def test_nan_behavior_3(self):
         a = np.arange(24, dtype=float).reshape(2, 3, 4)
         a[1, 2, 3] = np.nan
@@ -3564,8 +3649,8 @@ class TestMedian:
         # no axis
         assert_equal(np.median(a).ndim, 0)
 
-    @pytest.mark.xfail(reason="median: torch.quantile does not handle empty tensors")
-    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work correctly")
+    @xfail  # (reason="median: torch.quantile does not handle empty tensors")
+    @skipif(IS_WASM, reason="fp errors don't work correctly")
     def test_empty(self):
         # mean(empty array) emits two warnings: empty slice and divide by 0
         a = np.array([], dtype=float)
@@ -3595,7 +3680,7 @@ class TestMedian:
             assert_equal(np.median(a, axis=2), b)
             assert_(w[0].category is RuntimeWarning)
 
-    @pytest.mark.xfail(reason="median: tuple axes not implemented")
+    @xfail  # (reason="median: tuple axes not implemented")
     def test_extended_axis(self):
         o = np.random.normal(size=(71, 23))
         x = np.dstack([o] * 10)
@@ -3645,7 +3730,7 @@ class TestMedian:
         d = np.ones((3, 5, 7, 11))
         assert_equal(np.median(d, axis=None, keepdims=True).shape, (1, 1, 1, 1))
 
-    @pytest.mark.xfail(reason="median: tuple axis")
+    @xfail  # (reason="median: tuple axis")
     def test_keepdims_2(self):
         d = np.ones((3, 5, 7, 11))
         assert_equal(np.median(d, axis=(0, 1), keepdims=True).shape, (1, 1, 7, 11))
@@ -3654,20 +3739,27 @@ class TestMedian:
         assert_equal(np.median(d, axis=(0, 1, 2, 3), keepdims=True).shape, (1, 1, 1, 1))
         assert_equal(np.median(d, axis=(0, 1, 3), keepdims=True).shape, (1, 1, 7, 1))
 
-    @pytest.mark.parametrize(
-        argnames="axis",
-        argvalues=[
+    @parametrize(
+        "axis",
+        [
             None,
             1,
-            (1,),
-            (0, 1),
-            (-3, -1),
+            subtest((1,)),
+            subtest(
+                (0, 1),
+                decorators=[
+                    xfail,
+                ],
+            ),
+            subtest(
+                (-3, -1),
+                decorators=[
+                    xfail,
+                ],
+            ),
         ],
     )
     def test_keepdims_out(self, axis):
-        if isinstance(axis, tuple):
-            pytest.xfail("median: tuple axis")
-
         d = np.ones((3, 5, 7, 11))
         if axis is None:
             shape_out = (1,) * d.ndim
@@ -3682,9 +3774,9 @@ class TestMedian:
         assert_equal(result.shape, shape_out)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestSortComplex:
-    @pytest.mark.parametrize(
+@xfail  # (reason="TODO: implement")
+class TestSortComplex(TestCase):
+    @parametrize(
         "type_in, type_out",
         [
             ("l", "D"),
@@ -3713,6 +3805,4 @@ class TestSortComplex:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -1689,7 +1689,7 @@ class TestDigitize(TestCase):
         assert_equal(np.digitize(x, [x + 1, x - 1]), 1)
 
 
-@xfail  # (reason="TODO: implement")
+@skip  # (reason="TODO: implement; here unwrap if from numpy")
 class TestUnwrap(TestCase):
     def test_simple(self):
         # check that unwrap removes jumps greater that 2*pi

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -798,7 +798,7 @@ class TestDiff(TestCase):
 @xfail  # (reason="TODO: implement")
 @instantiate_parametrized_tests
 class TestDelete(TestCase):
-    def setup_method(self):
+    def setUp(self):
         self.a = np.arange(5)
         self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
 
@@ -1717,7 +1717,7 @@ class TestUnwrap(TestCase):
 
 
 @instantiate_parametrized_tests
-class TestFilterwindows:
+class TestFilterwindows(TestCase):
     @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_hanning(self, dtype: str, M: int) -> None:

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -867,7 +867,7 @@ class TestDelete(TestCase):
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
-    @pytest.mark.parametrize("indexer", [np.array([1]), [1]])
+    @parametrize("indexer", [np.array([1]), [1]])
     def test_single_item_array(self, indexer):
         a_del_int = delete(self.a, 1)
         a_del = delete(self.a, indexer)
@@ -1680,9 +1680,7 @@ class TestDigitize(TestCase):
         x = 2**54  # loses precision in a float
         assert_equal(np.digitize(x, [x - 1, x + 1]), 1)
 
-    @pytest.mark.xfail(
-        reason="gh-11022: np.core.multiarray._monoticity loses precision"
-    )
+    @xfail  # "gh-11022: np.core.multiarray._monoticity loses precision"
     def test_large_integers_decreasing(self):
         # gh-11022
         x = 2**54  # loses precision in a float
@@ -3775,6 +3773,7 @@ class TestMedian(TestCase):
 
 
 @xfail  # (reason="TODO: implement")
+@instantiate_parametrized_tests
 class TestSortComplex(TestCase):
     @parametrize(
         "type_in, type_out",

--- a/test/torch_np/numpy_tests/lib/test_histograms.py
+++ b/test/torch_np/numpy_tests/lib/test_histograms.py
@@ -31,12 +31,6 @@ skip = functools.partial(skipif, True)
 
 
 class TestHistogram(TestCase):
-    def setup_method(self):
-        pass
-
-    def teardown_method(self):
-        pass
-
     def test_simple(self):
         n = 100
         v = np.random.rand(n)

--- a/test/torch_np/numpy_tests/lib/test_histograms.py
+++ b/test/torch_np/numpy_tests/lib/test_histograms.py
@@ -3,7 +3,7 @@
 # from numpy.testing._private.utils import requires_memory
 import functools
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import expectedFailure as xfail, skipIf
 
 import pytest
 import torch._numpy as np
@@ -24,10 +24,11 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    slowTest as slow,
     TestCase,
 )
 
-skip = functools.partial(skipif, True)
+skip = functools.partial(skipIf, True)
 
 
 class TestHistogram(TestCase):
@@ -405,7 +406,7 @@ class TestHistogram(TestCase):
 
     # @requires_memory(free_bytes=1e10)
     @xfail  # (reason="pytorch does not support bins = [int, int, array]")
-    @pytest.mark.slow
+    @slow
     def test_big_arrays(self):
         sample = np.zeros([100000000, 3])
         xbins = 400

--- a/test/torch_np/numpy_tests/lib/test_histograms.py
+++ b/test/torch_np/numpy_tests/lib/test_histograms.py
@@ -1,6 +1,10 @@
 # Owner(s): ["module: dynamo"]
 
 # from numpy.testing._private.utils import requires_memory
+import functools
+
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 import torch._numpy as np
 from pytest import raises as assert_raises
@@ -16,9 +20,17 @@ from torch._numpy.testing import (
     assert_equal,
     # assert_array_max_ulp, #assert_raises_regex, suppress_warnings,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
 
 
-class TestHistogram:
+class TestHistogram(TestCase):
     def setup_method(self):
         pass
 
@@ -182,7 +194,7 @@ class TestHistogram:
         )
         assert_almost_equal(a, [0.2, 0.1, 0.1, 0.075])
 
-    @pytest.mark.xfail(reason="histogram complex weights")
+    @xfail  # (reason="histogram complex weights")
     def test_exotic_weights(self):
         # Test the use of weights that are not integer or floats, but e.g.
         # complex numbers or object types.
@@ -244,7 +256,7 @@ class TestHistogram:
         with assert_raises((RuntimeError, ValueError)):
             np.histogram(vals, range=[0.1, 0.01])
 
-    @pytest.mark.xfail(reason="edge cases")
+    @xfail  # (reason="edge cases")
     def test_bin_edge_cases(self):
         # Ensure that floating-point computations correctly place edge cases.
         arr = np.array([337, 404, 739, 806, 1007, 1811, 2012])
@@ -268,7 +280,7 @@ class TestHistogram:
         with assert_raises((RuntimeError, ValueError)):
             np.histogram(vals, bins=bins)
 
-    @pytest.mark.xfail(reason="no uint64")
+    @xfail  # (reason="no uint64")
     def test_unsigned_monotonicity_check(self):
         # Ensures ValueError is raised if bins not increasing monotonically
         # when bins contain unsigned values (see #9222)
@@ -294,7 +306,7 @@ class TestHistogram:
         np.histogram([np.array(0.5) for i in range(10)] + [0.500000000000001])
         np.histogram([np.array(0.5) for i in range(10)] + [0.5])
 
-    @pytest.mark.xfail(reason="bins='auto'")
+    @xfail  # (reason="bins='auto'")
     def test_some_nan_values(self):
         # gh-7503
         one_nan = np.array([0, 1, np.nan])
@@ -332,7 +344,7 @@ class TestHistogram:
         self.do_signed_overflow_bounds(np.short)
         self.do_signed_overflow_bounds(np.intc)
 
-    @pytest.mark.xfail(reason="int->float conversin loses precision")
+    @xfail  # (reason="int->float conversin loses precision")
     def test_signed_overflow_bounds_2(self):
         self.do_signed_overflow_bounds(np.int_)
         self.do_signed_overflow_bounds(np.longlong)
@@ -375,14 +387,14 @@ class TestHistogram:
         self.do_precision_lower_bound(float_small, float_large)
         self.do_precision_upper_bound(float_small, float_large)
 
-    @pytest.mark.xfail(reason="mixed dtypes")
+    @xfail  # (reason="mixed dtypes")
     def test_precision(self):
         # not looping results in a useful stack trace upon failure
         self.do_precision(np.half, np.single)
         self.do_precision(np.half, np.double)
         self.do_precision(np.single, np.double)
 
-    @pytest.mark.xfail(reason="histogram_bin_edges")
+    @xfail  # (reason="histogram_bin_edges")
     def test_histogram_bin_edges(self):
         hist, e = histogram([1, 2, 3, 4], [1, 2])
         edges = histogram_bin_edges([1, 2, 3, 4], [1, 2])
@@ -398,7 +410,7 @@ class TestHistogram:
         assert_array_equal(edges, e)
 
     # @requires_memory(free_bytes=1e10)
-    @pytest.mark.xfail(reason="pytorch does not support bins = [int, int, array]")
+    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
     @pytest.mark.slow
     def test_big_arrays(self):
         sample = np.zeros([100000000, 3])
@@ -409,8 +421,9 @@ class TestHistogram:
         assert_equal(type(hist), type((1, 2)))
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestHistogramOptimBinNums:
+@xfail  # (reason="TODO")
+@instantiate_parametrized_tests
+class TestHistogramOptimBinNums(TestCase):
     """
     Provide test coverage when using provided estimators for optimal number of
     bins
@@ -677,9 +690,7 @@ class TestHistogramOptimBinNums:
                 msg += f" with datasize of {testlen}"
                 assert_equal(len(a), numbins, err_msg=msg)
 
-    @pytest.mark.parametrize(
-        "bins", ["auto", "fd", "doane", "scott", "stone", "rice", "sturges"]
-    )
+    @parametrize("bins", ["auto", "fd", "doane", "scott", "stone", "rice", "sturges"])
     def test_signed_integer_data(self, bins):
         # Regression test for gh-14379.
         a = np.array([-2, 0, 127], dtype=np.int8)
@@ -698,7 +709,7 @@ class TestHistogramOptimBinNums:
             assert_raises(TypeError, histogram, [1, 2, 3], estimator, weights=[1, 2, 3])
 
 
-class TestHistogramdd:
+class TestHistogramdd(TestCase):
     def test_simple(self):
         x = np.array(
             [
@@ -834,13 +845,13 @@ class TestHistogramdd:
             (RuntimeError, ValueError), np.histogramdd, x, bins=[1, 1, 1, [1, 2, 3, -3]]
         )
 
-    @pytest.mark.xfail(reason="pytorch does not support bins = [int, int, array]")
+    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
     def test_bins_error_2(self):
         # mixing scalar (# of bins) and explicit bin arrays, ugh
         x = np.arange(8).reshape(2, 4)
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
 
-    @pytest.mark.xfail(reason="pytorch does not support bins = [int, int, array]")
+    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
     def test_inf_edges(self):
         # Test using +/-inf bin edges works. See #1788.
         x = np.arange(6).reshape(3, 2)
@@ -891,7 +902,7 @@ class TestHistogramdd:
             range=[[0.0, 1.0], [np.nan, 0.75], [0.25, 0.5]],
         )
 
-    @pytest.mark.xfail(reason="pytorch does not allow equal entries")
+    @xfail  # (reason="pytorch does not allow equal entries")
     def test_equal_edges(self):
         """Test that adjacent entries in an edge array can be equal"""
         x = np.array([0, 1, 2])
@@ -981,6 +992,4 @@ class TestHistogramdd:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_index_tricks.py
+++ b/test/torch_np/numpy_tests/lib/test_index_tricks.py
@@ -424,7 +424,7 @@ class TestIx_(TestCase):
 
 class TestC(TestCase):
     @xfail  # (reason="c_ not implemented")
-    def test_c_():
+    def test_c_(self):
         a = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]
         assert_equal(a, [[1, 2, 3, 0, 0, 4, 5, 6]])
 

--- a/test/torch_np/numpy_tests/lib/test_index_tricks.py
+++ b/test/torch_np/numpy_tests/lib/test_index_tricks.py
@@ -1,5 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
+
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
@@ -14,10 +18,13 @@ from torch._numpy.testing import (
     assert_array_equal,
     assert_equal,
 )
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+skip = functools.partial(skipif, True)
 
 
-@pytest.mark.xfail(reason="unravel_index not implemented")
-class TestRavelUnravelIndex:
+@xfail  # (reason="unravel_index not implemented")
+class TestRavelUnravelIndex(TestCase):
     def test_basic(self):
         assert_equal(np.unravel_index(2, (2, 2)), (1, 0))
 
@@ -189,8 +196,8 @@ class TestRavelUnravelIndex:
             np.unravel_index([1], (2, 1, 0))
 
 
-@pytest.mark.xfail(reason="mgrid not implemented")
-class TestGrid:
+@xfail  # (reason="mgrid not implemented")
+class TestGrid(TestCase):
     def test_basic(self):
         a = mgrid[-1:1:10j]
         b = mgrid[-1:1:0.1]
@@ -203,7 +210,7 @@ class TestGrid:
         assert_almost_equal(b[-1], b[0] + 19 * 0.1, 11)
         assert_almost_equal(a[1] - a[0], 2.0 / 9.0, 11)
 
-    @pytest.mark.xfail(reason="retstep not implemented")
+    @xfail  # (reason="retstep not implemented")
     def test_linspace_equivalence(self):
         y, st = np.linspace(2, 10, retstep=True)
         assert_almost_equal(st, 8 / 49.0)
@@ -230,7 +237,7 @@ class TestGrid:
         for f, b in zip(grid_full, grid_broadcast):
             assert_equal(f, b)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "start, stop, step, expected",
         [
             (None, 10, 10j, (200, 10)),
@@ -249,7 +256,7 @@ class TestGrid:
         assert_equal(grid.size, expected[0])
         assert_equal(grid_small.size, expected[1])
 
-    @pytest.mark.xfail(reason="mgrid not implementd")
+    @xfail  # (reason="mgrid not implementd")
     def test_accepts_npfloating(self):
         # regression test for #16466
         grid64 = mgrid[0.1:0.33:0.1,]
@@ -263,7 +270,7 @@ class TestGrid:
         assert_(grid32.dtype == np.float64)
         assert_array_almost_equal(grid64, grid32)
 
-    @pytest.mark.skip(reason="longdouble")
+    @skip(reason="longdouble")
     def test_accepts_longdouble(self):
         # regression tests for #16945
         grid64 = mgrid[0.1:0.33:0.1,]
@@ -282,7 +289,7 @@ class TestGrid:
         assert_(grid128.dtype == np.longdouble)
         assert_array_almost_equal(grid64, grid128)
 
-    @pytest.mark.skip(reason="longdouble")
+    @skip(reason="longdouble")
     def test_accepts_npcomplexfloating(self):
         # Related to #16466
         assert_array_almost_equal(
@@ -306,8 +313,8 @@ class TestGrid:
         assert_array_equal(grid64_a, grid64_b)
 
 
-@pytest.mark.xfail(reason="r_ not implemented")
-class TestConcatenator:
+@xfail  # (reason="r_ not implemented")
+class TestConcatenator(TestCase):
     def test_1d(self):
         assert_array_equal(r_[1, 2, 3, 4, 5, 6], np.array([1, 2, 3, 4, 5, 6]))
         b = np.ones(5)
@@ -349,8 +356,8 @@ class TestConcatenator:
         assert_equal(r_[np.array(0), [1, 2, 3]], [0, 1, 2, 3])
 
 
-@pytest.mark.xfail(reason="ndenumerate not implemented")
-class TestNdenumerate:
+@xfail  # (reason="ndenumerate not implemented")
+class TestNdenumerate(TestCase):
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
         assert_equal(
@@ -358,7 +365,7 @@ class TestNdenumerate:
         )
 
 
-class TestIndexExpression:
+class TestIndexExpression(TestCase):
     def test_regression_1(self):
         # ticket #1196
         a = np.arange(2)
@@ -372,8 +379,8 @@ class TestIndexExpression:
         assert_equal(a[:, :3, [1, 2]], a[s_[:, :3, [1, 2]]])
 
 
-@pytest.mark.xfail(reason="ix_ not implemented")
-class TestIx_:
+@xfail  # (reason="ix_ not implemented")
+class TestIx_(TestCase):
     def test_regression_1(self):
         # Test empty untyped inputs create outputs of indexing type, gh-5804
         (a,) = ix_(range(0))
@@ -415,13 +422,14 @@ class TestIx_:
         assert_equal(x.shape, (length_of_vector,))
 
 
-@pytest.mark.xfail(reason="c_ not implemented")
-def test_c_():
-    a = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]
-    assert_equal(a, [[1, 2, 3, 0, 0, 4, 5, 6]])
+class TestC(TestCase):
+    @xfail  # (reason="c_ not implemented")
+    def test_c_():
+        a = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]
+        assert_equal(a, [[1, 2, 3, 0, 0, 4, 5, 6]])
 
 
-class TestFillDiagonal:
+class TestFillDiagonal(TestCase):
     def test_basic(self):
         a = np.zeros((3, 3), dtype=int)
         fill_diagonal(a, 5)
@@ -503,25 +511,28 @@ class TestFillDiagonal:
             fill_diagonal(a, 2)
 
 
-def test_diag_indices():
-    di = diag_indices(4)
-    a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
-    a[di] = 100
-    assert_array_equal(
-        a,
-        np.array([[100, 2, 3, 4], [5, 100, 7, 8], [9, 10, 100, 12], [13, 14, 15, 100]]),
-    )
+class TestDiagIndices(TestCase):
+    def test_diag_indices(self):
+        di = diag_indices(4)
+        a = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
+        a[di] = 100
+        assert_array_equal(
+            a,
+            np.array(
+                [[100, 2, 3, 4], [5, 100, 7, 8], [9, 10, 100, 12], [13, 14, 15, 100]]
+            ),
+        )
 
-    # Now, we create indices to manipulate a 3-d array:
-    d3 = diag_indices(2, 3)
+        # Now, we create indices to manipulate a 3-d array:
+        d3 = diag_indices(2, 3)
 
-    # And use it to set the diagonal of a zeros array to 1:
-    a = np.zeros((2, 2, 2), dtype=int)
-    a[d3] = 1
-    assert_array_equal(a, np.array([[[1, 0], [0, 0]], [[0, 0], [0, 1]]]))
+        # And use it to set the diagonal of a zeros array to 1:
+        a = np.zeros((2, 2, 2), dtype=int)
+        a[d3] = 1
+        assert_array_equal(a, np.array([[[1, 0], [0, 0]], [[0, 0], [0, 1]]]))
 
 
-class TestDiagIndicesFrom:
+class TestDiagIndicesFrom(TestCase):
     def test_diag_indices_from(self):
         x = np.random.random((4, 4))
         r, c = diag_indices_from(x)
@@ -539,32 +550,31 @@ class TestDiagIndicesFrom:
             diag_indices_from(x)
 
 
-@pytest.mark.xfail(reason="ndindex not implemented")
-def test_ndindex():
-    x = list(ndindex(1, 2, 3))
-    expected = [ix for ix, e in ndenumerate(np.zeros((1, 2, 3)))]
-    assert_array_equal(x, expected)
+class TestNdIndex(TestCase):
+    @xfail  # (reason="ndindex not implemented")
+    def test_ndindex(self):
+        x = list(ndindex(1, 2, 3))
+        expected = [ix for ix, e in ndenumerate(np.zeros((1, 2, 3)))]
+        assert_array_equal(x, expected)
 
-    x = list(ndindex((1, 2, 3)))
-    assert_array_equal(x, expected)
+        x = list(ndindex((1, 2, 3)))
+        assert_array_equal(x, expected)
 
-    # Test use of scalars and tuples
-    x = list(ndindex((3,)))
-    assert_array_equal(x, list(ndindex(3)))
+        # Test use of scalars and tuples
+        x = list(ndindex((3,)))
+        assert_array_equal(x, list(ndindex(3)))
 
-    # Make sure size argument is optional
-    x = list(ndindex())
-    assert_equal(x, [()])
+        # Make sure size argument is optional
+        x = list(ndindex())
+        assert_equal(x, [()])
 
-    x = list(ndindex(()))
-    assert_equal(x, [()])
+        x = list(ndindex(()))
+        assert_equal(x, [()])
 
-    # Make sure 0-sized ndindex works correctly
-    x = list(ndindex(*[0]))
-    assert_equal(x, [])
+        # Make sure 0-sized ndindex works correctly
+        x = list(ndindex(*[0]))
+        assert_equal(x, [])
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_index_tricks.py
+++ b/test/torch_np/numpy_tests/lib/test_index_tricks.py
@@ -2,9 +2,7 @@
 
 import functools
 
-from unittest import expectedFailure as xfail, skipIf as skipif
-
-import pytest
+from unittest import expectedFailure as xfail, skipIf
 
 import torch._numpy as np
 
@@ -18,12 +16,18 @@ from torch._numpy.testing import (
     assert_array_equal,
     assert_equal,
 )
-from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
-skip = functools.partial(skipif, True)
+skip = functools.partial(skipIf, True)
 
 
 @xfail  # (reason="unravel_index not implemented")
+@instantiate_parametrized_tests
 class TestRavelUnravelIndex(TestCase):
     def test_basic(self):
         assert_equal(np.unravel_index(2, (2, 2)), (1, 0))
@@ -176,7 +180,7 @@ class TestRavelUnravelIndex(TestCase):
         assert_raises_regex(ValueError, "0d array", np.unravel_index, [0], ())
         assert_raises_regex(ValueError, "out of bounds", np.unravel_index, [1], ())
 
-    @pytest.mark.parametrize("mode", ["clip", "wrap", "raise"])
+    @parametrize("mode", ["clip", "wrap", "raise"])
     def test_empty_array_ravel(self, mode):
         res = np.ravel_multi_index(
             np.zeros((3, 0), dtype=np.intp), (2, 1, 0), mode=mode
@@ -197,6 +201,7 @@ class TestRavelUnravelIndex(TestCase):
 
 
 @xfail  # (reason="mgrid not implemented")
+@instantiate_parametrized_tests
 class TestGrid(TestCase):
     def test_basic(self):
         a = mgrid[-1:1:10j]

--- a/test/torch_np/numpy_tests/lib/test_shape_base_.py
+++ b/test/torch_np/numpy_tests/lib/test_shape_base_.py
@@ -3,6 +3,8 @@
 import functools
 import sys
 
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
@@ -26,6 +28,14 @@ from torch._numpy import (
 from torch._numpy.random import rand, randint
 
 from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
 
 
 IS_64BIT = sys.maxsize > 2**32
@@ -44,7 +54,7 @@ def _add_keepdims(func):
     return wrapped
 
 
-class TestTakeAlongAxis:
+class TestTakeAlongAxis(TestCase):
     def test_argequivalent(self):
         """Test it translates from arg<func> to <func>"""
         a = rand(3, 4, 5)
@@ -101,7 +111,7 @@ class TestTakeAlongAxis:
         assert_equal(actual.shape, (3, 2, 5))
 
 
-class TestPutAlongAxis:
+class TestPutAlongAxis(TestCase):
     def test_replace_max(self):
         a_base = np.array([[10, 30, 20], [60, 40, 50]])
 
@@ -118,9 +128,8 @@ class TestPutAlongAxis:
 
             assert_equal(i_min, i_max)
 
-    @pytest.mark.xfail(
-        reason="RuntimeError: Expected index [1, 2, 5] to be smaller than self [3, 4, 1] apart from dimension 1"
-    )
+    @xfail  # (
+    # reason="RuntimeError: Expected index [1, 2, 5] to be smaller than self [3, 4, 1] apart from dimension 1")
     def test_broadcast(self):
         """Test that non-indexing dimensions are broadcast in both directions"""
         a = np.ones((3, 4, 1))
@@ -129,8 +138,8 @@ class TestPutAlongAxis:
         assert_equal(take_along_axis(a, ai, axis=1), 20)
 
 
-@pytest.mark.xfail(reason="apply_along_axis not implemented")
-class TestApplyAlongAxis:
+@xfail  # (reason="apply_along_axis not implemented")
+class TestApplyAlongAxis(TestCase):
     def test_simple(self):
         a = np.ones((20, 10), "d")
         assert_array_equal(apply_along_axis(len, 0, a), len(a) * np.ones(a.shape[1]))
@@ -258,15 +267,15 @@ class TestApplyAlongAxis:
             assert_equal(type(actual[i]), type(expected[i]))
 
 
-@pytest.mark.xfail(reason="apply_over_axes not implemented")
-class TestApplyOverAxes:
+@xfail  # (reason="apply_over_axes not implemented")
+class TestApplyOverAxes(TestCase):
     def test_simple(self):
         a = np.arange(24).reshape(2, 3, 4)
         aoa_a = apply_over_axes(np.sum, a, [0, 2])
         assert_array_equal(aoa_a, np.array([[[60], [92], [124]]]))
 
 
-class TestExpandDims:
+class TestExpandDims(TestCase):
     def test_functionality(self):
         s = (2, 3, 4, 5)
         a = np.empty(s)
@@ -297,7 +306,7 @@ class TestExpandDims:
         assert_raises(ValueError, expand_dims, a, axis=(1, 1))
 
 
-class TestArraySplit:
+class TestArraySplit(TestCase):
     def test_integer_0_split(self):
         a = np.arange(10)
         assert_raises(ValueError, array_split, a, 0)
@@ -481,7 +490,7 @@ class TestArraySplit:
         compare_results(res, desired)
 
 
-class TestSplit:
+class TestSplit(TestCase):
     # The split function is essentially the same as array_split,
     # except that it test if splitting will result in an
     # equal split.  Only test for this case.
@@ -497,7 +506,7 @@ class TestSplit:
         assert_raises(ValueError, split, a, 3)
 
 
-class TestColumnStack:
+class TestColumnStack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, column_stack, 1)
 
@@ -523,7 +532,7 @@ class TestColumnStack:
         column_stack(np.arange(3) for _ in range(2))
 
 
-class TestDstack:
+class TestDstack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, dstack, 1)
 
@@ -573,7 +582,7 @@ class TestDstack:
 
 # array_split has more comprehensive test of splitting.
 # only do simple test on hsplit, vsplit, and dsplit
-class TestHsplit:
+class TestHsplit(TestCase):
     """Only testing for integer splits."""
 
     def test_non_iterable(self):
@@ -600,7 +609,7 @@ class TestHsplit:
         compare_results(res, desired)
 
 
-class TestVsplit:
+class TestVsplit(TestCase):
     """Only testing for integer splits."""
 
     def test_non_iterable(self):
@@ -625,7 +634,7 @@ class TestVsplit:
         compare_results(res, desired)
 
 
-class TestDsplit:
+class TestDsplit(TestCase):
     # Only testing for integer splits.
     def test_non_iterable(self):
         assert_raises(ValueError, dsplit, 1, 1)
@@ -656,7 +665,7 @@ class TestDsplit:
         compare_results(res, desired)
 
 
-class TestSqueeze:
+class TestSqueeze(TestCase):
     def test_basic(self):
         a = rand(20, 10, 10, 1, 1)
         b = rand(20, 1, 10, 1, 20)
@@ -696,7 +705,7 @@ class TestSqueeze:
         assert type(a.squeeze()) is np.ndarray
         assert type(b.squeeze()) is np.ndarray
 
-    @pytest.mark.skip(reason="XXX: order='F' not implemented")
+    @skip(reason="XXX: order='F' not implemented")
     def test_squeeze_contiguous(self):
         # Similar to GitHub issue #387
         a = np.zeros((1, 2)).squeeze()
@@ -705,13 +714,14 @@ class TestSqueeze:
         assert_(a.flags.f_contiguous)
         assert_(b.flags.f_contiguous)
 
-    @pytest.mark.xfail(reason="XXX: noop in torch, while numpy raises")
+    @xfail  # (reason="XXX: noop in torch, while numpy raises")
     def test_squeeze_axis_handling(self):
         with assert_raises(ValueError):
             np.squeeze(np.array([[1], [2], [3]]), axis=0)
 
 
-class TestKron:
+@instantiate_parametrized_tests
+class TestKron(TestCase):
     def test_basic(self):
         # Using 0-dimensional ndarray
         a = np.array(1)
@@ -741,7 +751,7 @@ class TestKron:
         k = np.array([[[1, 2], [3, 4]], [[2, 4], [6, 8]]])
         assert_array_equal(np.kron(a, b), k)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "shape_a,shape_b",
         [
             ((1, 1), (1, 1)),
@@ -763,7 +773,7 @@ class TestKron:
         assert np.array_equal(k.shape, expected_shape), "Unexpected shape from kron"
 
 
-class TestTile:
+class TestTile(TestCase):
     def test_basic(self):
         a = np.array([0, 1, 2])
         b = [[1, 2], [3, 4]]
@@ -802,8 +812,8 @@ class TestTile:
                 assert_equal(large, klarge)
 
 
-@pytest.mark.xfail(reason="TODO: implement")
-class TestMayShareMemory:
+@xfail  # (reason="TODO: implement")
+class TestMayShareMemory(TestCase):
     def test_basic(self):
         d = np.ones((50, 60))
         d2 = np.ones((30, 60, 6))
@@ -829,6 +839,4 @@ def compare_results(res, desired):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/lib/test_shape_base_.py
+++ b/test/torch_np/numpy_tests/lib/test_shape_base_.py
@@ -5,8 +5,6 @@ import sys
 
 from unittest import expectedFailure as xfail, skipIf as skipif
 
-import pytest
-
 import torch._numpy as np
 
 from pytest import raises as assert_raises
@@ -452,7 +450,7 @@ class TestArraySplit(TestCase):
         assert_(a.dtype.type is res[-1].dtype.type)
         # perhaps should check higher dimensions
 
-    @pytest.mark.skipif(not IS_64BIT, reason="Needs 64bit platform")
+    @skipif(not IS_64BIT, reason="Needs 64bit platform")
     def test_integer_split_2D_rows_greater_max_int32(self):
         a = np.broadcast_to([0], (1 << 32, 2))
         res = array_split(a, 4)

--- a/test/torch_np/numpy_tests/lib/test_type_check.py
+++ b/test/torch_np/numpy_tests/lib/test_type_check.py
@@ -1,6 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
-import pytest
+
+import functools
+
+from unittest import expectedFailure as xfail, skipIf as skipif
 
 import torch._numpy as np
 from pytest import raises as assert_raises
@@ -17,18 +20,8 @@ from torch._numpy import (
     real_if_close,
 )
 from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+from torch.testing._internal.common_utils import run_tests, TestCase
 
-
-from unittest import expectedFailure as xfail, skipIf as skipif
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
-    run_tests,
-    TestCase,
-    subtest
-)
-
-import functools
 skip = functools.partial(skipif, True)
 
 
@@ -36,7 +29,7 @@ def assert_all(x):
     assert_(np.all(x), x)
 
 
-@xfail  #(reason="common_type not implemented")
+@xfail  # (reason="common_type not implemented")
 class TestCommonType(TestCase):
     def test_basic(self):
         ai32 = np.array([[1, 2], [3, 4]], dtype=np.int32)
@@ -53,7 +46,7 @@ class TestCommonType(TestCase):
         assert_(common_type(acd) == np.cdouble)
 
 
-@xfail  #(reason="not implemented")
+@xfail  # (reason="not implemented")
 class TestMintypecode(TestCase):
     def test_default_1(self):
         for itype in "1bcsuwil":
@@ -103,7 +96,7 @@ class TestMintypecode(TestCase):
         assert_equal(mintypecode("idD"), "D")
 
 
-@xfail  #(reason="TODO: decide on if [1] is a scalar or not")
+@xfail  # (reason="TODO: decide on if [1] is a scalar or not")
 class TestIsscalar(TestCase):
     def test_basic(self):
         assert_(np.isscalar(3))
@@ -433,7 +426,7 @@ class TestRealIfClose(TestCase):
         assert_all(isrealobj(b))
 
 
-@xfail  #(reason="not implemented")
+@xfail  # (reason="not implemented")
 class TestArrayConversion(TestCase):
     def test_asfarray(self):
         a = asfarray(np.array([1, 2, 3]))

--- a/test/torch_np/numpy_tests/lib/test_type_check.py
+++ b/test/torch_np/numpy_tests/lib/test_type_check.py
@@ -19,12 +19,25 @@ from torch._numpy import (
 from torch._numpy.testing import assert_, assert_array_equal, assert_equal
 
 
+from unittest import expectedFailure as xfail, skipIf as skipif
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+    subtest
+)
+
+import functools
+skip = functools.partial(skipif, True)
+
+
 def assert_all(x):
     assert_(np.all(x), x)
 
 
-@pytest.mark.xfail(reason="common_type not implemented")
-class TestCommonType:
+@xfail  #(reason="common_type not implemented")
+class TestCommonType(TestCase):
     def test_basic(self):
         ai32 = np.array([[1, 2], [3, 4]], dtype=np.int32)
         af16 = np.array([[1, 2], [3, 4]], dtype=np.float16)
@@ -40,8 +53,8 @@ class TestCommonType:
         assert_(common_type(acd) == np.cdouble)
 
 
-@pytest.mark.xfail(reason="not implemented")
-class TestMintypecode:
+@xfail  #(reason="not implemented")
+class TestMintypecode(TestCase):
     def test_default_1(self):
         for itype in "1bcsuwil":
             assert_equal(mintypecode(itype), "d")
@@ -90,8 +103,8 @@ class TestMintypecode:
         assert_equal(mintypecode("idD"), "D")
 
 
-@pytest.mark.xfail(reason="TODO: decide on if [1] is a scalar or not")
-class TestIsscalar:
+@xfail  #(reason="TODO: decide on if [1] is a scalar or not")
+class TestIsscalar(TestCase):
     def test_basic(self):
         assert_(np.isscalar(3))
         assert_(not np.isscalar([3]))
@@ -100,7 +113,7 @@ class TestIsscalar:
         assert_(np.isscalar(4.0))
 
 
-class TestReal:
+class TestReal(TestCase):
     def test_real(self):
         y = np.random.rand(
             10,
@@ -136,7 +149,7 @@ class TestReal:
         # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
 
-class TestImag:
+class TestImag(TestCase):
     def test_real(self):
         y = np.random.rand(
             10,
@@ -172,7 +185,7 @@ class TestImag:
         # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
 
-class TestIscomplex:
+class TestIscomplex(TestCase):
     def test_fail(self):
         z = np.array([-1, 0, 1])
         res = iscomplex(z)
@@ -184,7 +197,7 @@ class TestIscomplex:
         assert_array_equal(res, [1, 0, 0])
 
 
-class TestIsreal:
+class TestIsreal(TestCase):
     def test_pass(self):
         z = np.array([-1, 0, 1j])
         res = isreal(z)
@@ -201,7 +214,7 @@ class TestIsreal:
         assert res.all()
 
 
-class TestIscomplexobj:
+class TestIscomplexobj(TestCase):
     def test_basic(self):
         z = np.array([-1, 0, 1])
         assert_(not iscomplexobj(z))
@@ -217,7 +230,7 @@ class TestIscomplexobj:
         assert_(not iscomplexobj([3, 1, True]))
 
 
-class TestIsrealobj:
+class TestIsrealobj(TestCase):
     def test_basic(self):
         z = np.array([-1, 0, 1])
         assert_(isrealobj(z))
@@ -225,7 +238,7 @@ class TestIsrealobj:
         assert_(not isrealobj(z))
 
 
-class TestIsnan:
+class TestIsnan(TestCase):
     def test_goodvalues(self):
         z = np.array((-1.0, 0.0, 1.0))
         res = np.isnan(z) == 0
@@ -250,7 +263,7 @@ class TestIsnan:
         assert_all(np.isnan(np.array(0 + 0j) / 0.0) == 1)
 
 
-class TestIsfinite:
+class TestIsfinite(TestCase):
     # Fixme, wrong place, isfinite now ufunc
 
     def test_goodvalues(self):
@@ -277,7 +290,7 @@ class TestIsfinite:
         assert_all(np.isfinite(np.array(1 + 1j) / 0.0) == 0)
 
 
-class TestIsinf:
+class TestIsinf(TestCase):
     # Fixme, wrong place, isinf now ufunc
 
     def test_goodvalues(self):
@@ -309,7 +322,7 @@ class TestIsinf:
         assert_all(np.isinf(np.array((0.0,)) / 0.0) == 0)
 
 
-class TestIsposinf:
+class TestIsposinf(TestCase):
     def test_generic(self):
         vals = isposinf(np.array((-1.0, 0, 1)) / 0.0)
         assert_(vals[0] == 0)
@@ -317,7 +330,7 @@ class TestIsposinf:
         assert_(vals[2] == 1)
 
 
-class TestIsneginf:
+class TestIsneginf(TestCase):
     def test_generic(self):
         vals = isneginf(np.array((-1.0, 0, 1)) / 0.0)
         assert_(vals[0] == 1)
@@ -325,8 +338,8 @@ class TestIsneginf:
         assert_(vals[2] == 0)
 
 
-# @pytest.mark.xfail(reason="not implemented")
-class TestNanToNum:
+# @xfail  #(reason="not implemented")
+class TestNanToNum(TestCase):
     def test_generic(self):
         vals = nan_to_num(np.array((-1.0, 0, 1)) / 0.0)
         assert_all(vals[0] < -1e10) and assert_all(np.isfinite(vals[0]))
@@ -348,7 +361,7 @@ class TestNanToNum:
         assert_array_equal(vals, np.array([1], int))
         assert isinstance(vals, np.ndarray)
 
-    @pytest.mark.skip(reason="we return OD arrays not scalars")
+    @skip(reason="we return OD arrays not scalars")
     def test_integer(self):
         vals = nan_to_num(1)
         assert_all(vals == 1)
@@ -357,7 +370,7 @@ class TestNanToNum:
         assert_all(vals == 1)
         assert isinstance(vals, np.int_)
 
-    @pytest.mark.skip(reason="we return OD arrays not scalars")
+    @skip(reason="we return OD arrays not scalars")
     def test_float(self):
         vals = nan_to_num(1.0)
         assert_all(vals == 1.0)
@@ -366,7 +379,7 @@ class TestNanToNum:
         assert_all(vals == 1.1)
         assert_equal(type(vals), np.float_)
 
-    @pytest.mark.skip(reason="we return OD arrays not scalars")
+    @skip(reason="we return OD arrays not scalars")
     def test_complex_good(self):
         vals = nan_to_num(1 + 1j)
         assert_all(vals == 1 + 1j)
@@ -375,7 +388,7 @@ class TestNanToNum:
         assert_all(vals == 1 + 1j)
         assert_equal(type(vals), np.complex_)
 
-    @pytest.mark.skip(reason="we return OD arrays not scalars")
+    @skip(reason="we return OD arrays not scalars")
     def test_complex_bad(self):
         v = 1 + 1j
         v += np.array(0 + 1.0j) / 0.0
@@ -384,7 +397,7 @@ class TestNanToNum:
         assert_all(np.isfinite(vals))
         assert_equal(type(vals), np.complex_)
 
-    @pytest.mark.skip(reason="we return OD arrays not scalars")
+    @skip(reason="we return OD arrays not scalars")
     def test_complex_bad2(self):
         v = 1 + 1j
         v += np.array(-1 + 1.0j) / 0.0
@@ -408,7 +421,7 @@ class TestNanToNum:
         assert isinstance(vals, np.ndarray)
 
 
-class TestRealIfClose:
+class TestRealIfClose(TestCase):
     def test_basic(self):
         a = np.random.rand(10)
         b = real_if_close(a + 1e-15j)
@@ -420,8 +433,8 @@ class TestRealIfClose:
         assert_all(isrealobj(b))
 
 
-@pytest.mark.xfail(reason="not implemented")
-class TestArrayConversion:
+@xfail  #(reason="not implemented")
+class TestArrayConversion(TestCase):
     def test_asfarray(self):
         a = asfarray(np.array([1, 2, 3]))
         assert_equal(a.__class__, np.ndarray)
@@ -433,6 +446,4 @@ class TestArrayConversion:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()


### PR DESCRIPTION
1. Inherit from TestCase
2. Use pytorch parametrization
3. Use unittest.expectedFailure to mark xfails, also unittest skips

All this to make pytest-less invocation work:

$ python test/torch_np/test_basic.py

cross-ref https://github.com/pytorch/pytorch/pull/109593, https://github.com/pytorch/pytorch/pull/109775


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng