### PR TITLE
Histogram Fixes for QAT

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -1203,11 +1203,11 @@ class HistogramObserver(UniformQuantizationObserverBase):
                     self.bins,
                 )
 
-            self.histogram.detach_().resize_(combined_histogram.shape)
+            self.histogram = self.histogram.detach().resize_(combined_histogram.shape)
             self.histogram.copy_(combined_histogram)
-            self.min_val.detach_().resize_(combined_min.shape)
+            self.min_val = self.min_val.detach().resize_(combined_min.shape)
             self.min_val.copy_(combined_min)
-            self.max_val.detach_().resize_(combined_max.shape)
+            self.max_val = self.max_val.detach().resize_(combined_max.shape)
             self.max_val.copy_(combined_max)
         return x_orig
 


### PR DESCRIPTION
Summary: Histogram observer needs to avoid in-place detach , followed by re-shape tensors for per-channel quant

Test Plan:
Before:
```
File "/tmp/jetter.vxtgekjr/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/tmp/jetter.vxtgekjr/torch/ao/quantization/observer.py", line 1195, in forward
    self.min_val.detach_().resize_(combined_min.shape)
RuntimeError: Can't detach views in-place. Use detach() instead. If you are using DistributedDataParallel (DDP) for training, and gradient_as_bucket_view is set as True, gradients are views of DDP buckets, and hence detach_() cannot be called on these gradients. To fix this error, please refer to the Optimizer.zero_grad() function in torch/optim/optimizer.py as the solution.
```
After:
no issue.

Differential Revision: D49466364


