### PR TITLE
[pytorch][jit] allow passing in obj loader in unpickle api

### DIFF
--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -149,5 +149,9 @@ TORCH_API Module parse_and_initialize_jit_module(
     ExtraFilesMap& extra_files,
     c10::optional<at::Device> device);
 
+TORCH_API c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
+    const at::StrongTypePtr& type,
+    IValue input);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -120,15 +120,31 @@ IValue unpickle(
     std::function<size_t(char*, size_t)> reader,
     TypeResolver type_resolver,
     c10::ArrayRef<at::Tensor> tensor_table,
-    c10::TypePtr (*type_parser)(const std::string&)) {
+    c10::TypePtr (*type_parser)(const std::string&),
+    ObjLoader obj_loader) {
   Unpickler unpickler(
-      std::move(reader), std::move(type_resolver), tensor_table, type_parser);
+      std::move(reader),
+      std::move(type_resolver),
+      tensor_table,
+      std::move(obj_loader),
+      type_parser);
   return unpickler.parse_ivalue();
 }
 
 IValue unpickle(
     const char* data,
     size_t size,
+    TypeResolver type_resolver,
+    c10::ArrayRef<at::Tensor> tensor_table,
+    c10::TypePtr (*type_parser)(const std::string&)) {
+  return unpickle(
+      data, size, nullptr, std::move(type_resolver), tensor_table, type_parser);
+}
+
+IValue unpickle(
+    const char* data,
+    size_t size,
+    ObjLoader obj_loader,
     TypeResolver type_resolver,
     c10::ArrayRef<at::Tensor> tensor_table,
     c10::TypePtr (*type_parser)(const std::string&)) {
@@ -147,7 +163,8 @@ IValue unpickle(
       },
       std::move(type_resolver),
       tensor_table,
-      type_parser);
+      type_parser,
+      std::move(obj_loader));
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/serialization/pickle.h
+++ b/torch/csrc/jit/serialization/pickle.h
@@ -71,6 +71,21 @@ TORCH_API IValue unpickle(
     TypeResolver type_resolver,
     c10::ArrayRef<at::Tensor> tensor_table,
     c10::TypePtr (*type_parser)(const std::string&) =
+        Unpickler::defaultTypeParser,
+    ObjLoader obj_loader = nullptr);
+
+/// Decode a chunk of memory containing pickled data into its `torch::IValue`s.
+///
+/// If any `torch::IValue`s in the pickled data are `Object`s, then a
+/// `class_resolver` function must be provided.
+///
+/// See `torch::pickle` for details.
+TORCH_API IValue unpickle(
+    const char* data,
+    size_t size,
+    TypeResolver type_resolver = nullptr,
+    c10::ArrayRef<at::Tensor> tensor_table = {},
+    c10::TypePtr (*type_parser)(const std::string&) =
         Unpickler::defaultTypeParser);
 
 /// Decode a chunk of memory containing pickled data into its `torch::IValue`s.
@@ -82,6 +97,7 @@ TORCH_API IValue unpickle(
 TORCH_API IValue unpickle(
     const char* data,
     size_t size,
+    ObjLoader obj_loader,
     TypeResolver type_resolver = nullptr,
     c10::ArrayRef<at::Tensor> tensor_table = {},
     c10::TypePtr (*type_parser)(const std::string&) =

--- a/torch/csrc/jit/serialization/unpickler.h
+++ b/torch/csrc/jit/serialization/unpickler.h
@@ -46,6 +46,20 @@ class TORCH_API Unpickler {
         type_parser_(type_parser),
         version_(caffe2::serialize::kProducedFileFormatVersion) {}
 
+  Unpickler(
+      std::function<size_t(char*, size_t)> reader,
+      TypeResolver type_resolver,
+      c10::ArrayRef<at::Tensor> tensor_table,
+      ObjLoader obj_loader,
+      TypeParserT type_parser = defaultTypeParser)
+      : reader_(std::move(reader)),
+        tensor_table_(tensor_table),
+        type_resolver_(std::move(type_resolver)),
+        obj_loader_(std::move(obj_loader)),
+        use_storage_device_(false),
+        type_parser_(type_parser),
+        version_(caffe2::serialize::kProducedFileFormatVersion) {}
+
   // tensors inside the pickle contain meta-data, the raw tensor
   // dead is retrieved by calling `read_record`.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)


### PR DESCRIPTION
Summary: We are trying to use wired message to pass python objects like KJT. In order to make JIT be able to unpickle it, we need to provide a type resolver as well as an obj loader. This diff modify the interface to let we be able to do that.

Test Plan:
Rely on current CI to make sure existing usage doesn't break.

In the next diff, test e2e

Differential Revision: D49438569

