### PR TITLE
Native c10d_functional ops

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -519,6 +519,7 @@ libtorch_core_sources = sorted(
 libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/Backend.cpp",
     "torch/csrc/distributed/c10d/FileStore.cpp",
+    "torch/csrc/distributed/c10d/Functional.cpp",
     "torch/csrc/distributed/c10d/GlooDeviceFactory.cpp",
     "torch/csrc/distributed/c10d/Ops.cpp",
     "torch/csrc/distributed/c10d/ParamCommsUtils.cpp",

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1,0 +1,197 @@
+# Owner(s): ["module: c10d"]
+from typing import List
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests
+
+
+if not dist.is_available():
+    print("distributed package not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+
+@requires_nccl()
+class C10DFunctionalNativeTest(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @property
+    def ranks(self) -> List[int]:
+        return list(range(self.world_size))
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process_group(self) -> None:
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        dist.group.WORLD._set_group_name("default")
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_reduce(self) -> None:
+        self._init_process_group()
+
+        input = torch.full((10, 10), float(self.rank), device=self.device)
+        output = torch.ops._c10d_functional.all_reduce(
+            input,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        output = torch.ops._c10d_functional.wait_tensor(output)
+        assert id(output) != id(input)
+        expect = sum(self.ranks) / self.world_size
+        assert output.eq(expect).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_reduce_(self) -> None:
+        self._init_process_group()
+
+        input = torch.full((10, 10), float(self.rank), device=self.device)
+        output = torch.ops._c10d_functional.all_reduce_(
+            input,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        output = torch.ops._c10d_functional.wait_tensor(output)
+        assert id(output) == id(input)
+        expect = sum(self.ranks) / self.world_size
+        assert output.eq(expect).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_reduce_coalesced(self) -> None:
+        self._init_process_group()
+
+        inputs = [
+            torch.full((i, i), float(self.rank * i), device=self.device)
+            for i in range(10)
+        ]
+        outputs = torch.ops._c10d_functional.all_reduce_coalesced(
+            inputs,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        for i, (output, input) in enumerate(zip(outputs, inputs)):
+            output = torch.ops._c10d_functional.wait_tensor(output)
+            assert id(output) != id(input)
+            assert output.eq(sum(self.ranks) / self.world_size * i).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_reduce_coalesced_(self) -> None:
+        self._init_process_group()
+
+        inputs = [
+            torch.full((i, i), float(self.rank * i), device=self.device)
+            for i in range(10)
+        ]
+        outputs = torch.ops._c10d_functional.all_reduce_coalesced_(
+            inputs,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        for i, (output, input) in enumerate(zip(outputs, inputs)):
+            output = torch.ops._c10d_functional.wait_tensor(output)
+            assert id(output) == id(input)
+            assert output.eq(sum(self.ranks) / self.world_size * i).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_gather_into_tensor(self) -> None:
+        self._init_process_group()
+
+        input = torch.full((10, 10), float(self.rank), device=self.device)
+        output = torch.ops._c10d_functional.all_gather_into_tensor(
+            input,
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        output = torch.ops._c10d_functional.wait_tensor(output)
+        expect = torch.cat(
+            [
+                torch.full((10, 10), float(rank), device=self.device)
+                for rank in self.ranks
+            ]
+        )
+        assert torch.allclose(output, expect)
+        assert output.eq(expect).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_gather_into_tensor_coalesced(self) -> None:
+        self._init_process_group()
+
+        inputs = [
+            torch.full((10, 10), float(self.rank * i), device=self.device)
+            for i in range(10)
+        ]
+        outputs = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+            inputs,
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        for i, output in enumerate(outputs):
+            output = torch.ops._c10d_functional.wait_tensor(output)
+            expect = torch.cat(
+                [
+                    torch.full((10, 10), float(rank) * i, device=self.device)
+                    for rank in self.ranks
+                ]
+            )
+            assert output.eq(expect).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_tensor(self) -> None:
+        self._init_process_group()
+
+        input = torch.tensor(self.ranks, device=self.device)
+        output = torch.ops._c10d_functional.reduce_scatter_tensor(
+            input,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        output = torch.ops._c10d_functional.wait_tensor(output)
+        assert output.eq(self.rank).all()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_tensor_coalesced(self) -> None:
+        inputs = [torch.tensor(self.ranks, device=self.device) * i for i in range(10)]
+        output = torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+            inputs,
+            "avg",
+            "default",
+            self.ranks,
+            self.world_size,
+        )
+        for i, output in enumerate(outputs):
+            output = torch.ops._c10d_functional.wait_tensor(output)
+            assert output.eq(rank * i).all()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -1,0 +1,280 @@
+#include <string>
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <c10/core/DispatchKey.h>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+
+// _c10d_functional ops and relevant runtime APIs.
+//
+// _c10d_functional is a native port of c10d_functional which currently resides
+// in python. _c10d_functional will replace c10d_functional once functionality
+// parity is verified.
+//
+// Motivations for porting c10d_functional ops to c++:
+// - Support collective ops for aot inductor and native interpreters
+// - Support multi-threaded native runtimes
+// - Unify collective codegens between inductor python and aot inductor
+//
+// Changes compared to c10d_functional:
+// - The namespace now contains in-place variants for collective calls inductor
+// decides to de-functionalize (should we put them in a different namespace?).
+// - Process group resolution now only relies on tag. Ranks are useful for the
+// compiler to determine whether two collectives using different process groups
+// are fuse-able. However, they are not required for process group resolution.
+// - Process group resolution now doesn't upsert a process group.
+
+static thread_local std::unordered_map<void*, c10::intrusive_ptr<c10d::Work>>
+    pendingWork;
+
+namespace {
+
+const std::unordered_map<std::string, c10d::ReduceOp> strToReduceOp = {
+    {"sum", c10d::ReduceOp(c10d::ReduceOp::RedOpType::SUM)},
+    {"avg", c10d::ReduceOp(c10d::ReduceOp::RedOpType::AVG)},
+    {"product", c10d::ReduceOp(c10d::ReduceOp::RedOpType::PRODUCT)},
+    {"min", c10d::ReduceOp(c10d::ReduceOp::RedOpType::MIN)},
+    {"max", c10d::ReduceOp(c10d::ReduceOp::RedOpType::MAX)},
+    {"band", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BAND)},
+    {"bor", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BOR)},
+    {"bxor", c10d::ReduceOp(c10d::ReduceOp::RedOpType::BXOR)},
+    // {"premul_sum", c10d::ReduceOp(c10d::ReduceOp::RedOpType::PREMUL_SUM)},
+    {"unused", c10d::ReduceOp(c10d::ReduceOp::RedOpType::UNUSED)}};
+
+at::Tensor all_reduce_(
+    at::Tensor input,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  c10d::AllreduceOptions opts;
+  auto reduceOpIt = strToReduceOp.find(reduceOp);
+  if (reduceOpIt == strToReduceOp.end()) {
+    LOG(FATAL) << "Unrecognized reduceOp: " << reduceOp;
+  }
+  opts.reduceOp = reduceOpIt->second;
+
+  std::vector<at::Tensor> inputs{input};
+  auto pg = c10d::ProcessGroup::resolveFromName(tag);
+  if (groupSize != pg->getSize()) {
+    LOG(FATAL) << "Mismatch between group size argument and world size"
+                  "of process group ("
+               << tag << ")";
+  }
+  auto work = pg->allreduce(inputs, opts);
+  pendingWork[input.data_ptr()] = work;
+  return input;
+}
+
+at::Tensor all_reduce(
+    const at::Tensor& input,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  auto output = input.clone();
+  return all_reduce_(output, reduceOp, tag, ranks, groupSize);
+}
+
+std::vector<at::Tensor> all_reduce_coalesced_(
+    std::vector<at::Tensor> inputs,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  c10d::AllreduceCoalescedOptions opts;
+  auto reduceOpIt = strToReduceOp.find(reduceOp);
+  if (reduceOpIt == strToReduceOp.end()) {
+    LOG(FATAL) << "Unrecognized reduceOp: " << reduceOp;
+  }
+  opts.reduceOp = reduceOpIt->second;
+
+  auto pg = c10d::ProcessGroup::resolveFromName(tag);
+  if (groupSize != pg->getSize()) {
+    LOG(FATAL) << "Mismatch between group size argument and world size"
+                  "of process group ("
+               << tag << ")";
+  }
+  auto work = pg->allreduce_coalesced(inputs, opts);
+  for (const auto& tensor : inputs) {
+    // c10d::Work::wait is idempotent
+    pendingWork[tensor.data_ptr()] = work;
+  }
+  return inputs;
+}
+
+std::vector<at::Tensor> all_reduce_coalesced(
+    const std::vector<at::Tensor>& inputs,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  std::vector<at::Tensor> outputs;
+  for (const auto& tensor : inputs) {
+    outputs.push_back(tensor.clone());
+  }
+  return all_reduce_coalesced_(outputs, reduceOp, tag, ranks, groupSize);
+}
+
+at::Tensor allocateAllGatherOutput(const at::Tensor& input, int64_t groupSize) {
+  auto outputSize = input.sizes().vec();
+  outputSize[0] *= groupSize;
+  return at::empty(
+      outputSize,
+      at::TensorOptions().dtype(input.dtype()).device(input.device()));
+}
+
+std::vector<at::Tensor> all_gather_into_tensor_coalesced(
+    const std::vector<at::Tensor>& inputs,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  std::vector<at::Tensor> outputs;
+  for (const auto& tensor : inputs) {
+    outputs.push_back(allocateAllGatherOutput(tensor, groupSize));
+  }
+  // TODO: assert groupSize
+  auto pg = c10d::ProcessGroup::resolveFromName(tag);
+  if (groupSize != pg->getSize()) {
+    LOG(FATAL) << "Mismatch between group size argument and world size"
+                  "of process group ("
+               << tag << ")";
+  }
+  auto work = pg->allgather_into_tensor_coalesced(
+      outputs, const_cast<std::vector<at::Tensor>&>(inputs));
+  for (const auto& tensor : outputs) {
+    pendingWork[tensor.data_ptr()] = work;
+  }
+  return outputs;
+}
+
+at::Tensor all_gather_into_tensor(
+    const at::Tensor& input,
+    const std::string& tag,
+    const std::vector<int64_t> ranks,
+    const int64_t groupSize) {
+  std::vector<at::Tensor> inputs{input};
+  return all_gather_into_tensor_coalesced(inputs, tag, ranks, groupSize)[0];
+}
+
+at::Tensor allocateReduceScatterOutput(
+    const at::Tensor& input,
+    int64_t groupSize) {
+  auto outputSize = input.sizes().vec();
+  outputSize[0] /= groupSize;
+  return at::empty(
+      outputSize,
+      at::TensorOptions().dtype(input.dtype()).device(input.device()));
+}
+
+std::vector<at::Tensor> reduce_scatter_tensor_coalesced(
+    const std::vector<at::Tensor>& inputs,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t>& ranks,
+    const int64_t groupSize) {
+  c10d::ReduceScatterOptions opts;
+  auto reduceOpIt = strToReduceOp.find(reduceOp);
+  if (reduceOpIt == strToReduceOp.end()) {
+    LOG(FATAL) << "Unrecognized reduceOp: " << reduceOp;
+  }
+  opts.reduceOp = reduceOpIt->second;
+
+  std::vector<at::Tensor> outputs;
+  for (const auto& tensor : inputs) {
+    outputs.push_back(allocateReduceScatterOutput(tensor, groupSize));
+  }
+  auto pg = c10d::ProcessGroup::resolveFromName(tag);
+  if (groupSize != pg->getSize()) {
+    LOG(FATAL) << "Mismatch between group size argument and world size"
+                  "of process group ("
+               << tag << ")";
+  }
+  auto work = pg->reduce_scatter_tensor_coalesced(
+      outputs, const_cast<std::vector<at::Tensor>&>(inputs), opts);
+  for (const auto& tensor : outputs) {
+    // c10d::Work::wait is idempotent
+    pendingWork[tensor.data_ptr()] = work;
+  }
+  return outputs;
+}
+
+at::Tensor reduce_scatter_tensor(
+    at::Tensor input,
+    const std::string& reduceOp,
+    const std::string& tag,
+    const std::vector<int64_t>& ranks,
+    const int64_t groupSize) {
+  std::vector<at::Tensor> inputs{input};
+  return reduce_scatter_tensor_coalesced(
+      inputs, reduceOp, tag, ranks, groupSize)[0];
+}
+
+at::Tensor wait_tensor(const at::Tensor& tensor) {
+  auto it = pendingWork.find(tensor.data_ptr());
+  if (it == pendingWork.end()) {
+    LOG(FATAL)
+        << "No pending collective is associated with the input tensor. "
+           "This typically means that the input tensor is not a collective output, "
+           "or the tensor has already been waited on.";
+  }
+  it->second->wait();
+  pendingWork.erase(it);
+  return tensor;
+}
+
+} // namespace
+
+TORCH_LIBRARY(_c10d_functional, m) {
+  // TODO(yifu): is it neccessary to keep the same argument names used in
+  // c10d_functional? It would be nice to modify it to be more consistent.
+  m.def(
+      "all_reduce(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce));
+
+  m.def(
+      "all_reduce_(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce_));
+
+  m.def(
+      "all_reduce_coalesced(Tensor[] self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce_coalesced));
+
+  m.def(
+      "all_reduce_coalesced_(Tensor[] self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::all_reduce_coalesced_));
+
+  m.def(
+      "all_gather_into_tensor(Tensor shard, str tag, int[] ranks, int group_size) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::all_gather_into_tensor));
+
+  m.def(
+      "all_gather_into_tensor_coalesced(Tensor[] input, str tag, int[] ranks, int group_size) -> Tensor[]",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::all_gather_into_tensor_coalesced));
+
+  m.def(
+      "reduce_scatter_tensor(Tensor input, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::reduce_scatter_tensor));
+
+  m.def(
+      "reduce_scatter_tensor_coalesced(Tensor[] inputs, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::reduce_scatter_tensor_coalesced));
+
+  m.def(
+      "wait_tensor(Tensor self) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, ::wait_tensor));
+}

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -7,18 +7,18 @@
 
 // _c10d_functional ops and relevant runtime APIs.
 //
-// _c10d_functional is a native port of c10d_functional which currently resides
-// in python. _c10d_functional will replace c10d_functional once functionality
-// parity is verified.
+// _c10d_functional is a native port of the existing c10d_functional from
+// Python. _c10d_functional will supercede c10d_functional upon confirmation of
+// feature parity.
 //
-// Motivations for porting c10d_functional ops to c++:
-// - Support collective ops for aot inductor and native interpreters
-// - Support multi-threaded native runtimes
-// - Unify collective codegens between inductor python and aot inductor
+// Reasons for transitioning c10d_functional ops to C++:
+// - Enable collective ops for AOT Inductor and native interpreters.
+// - Enable collective ops for multi-threaded native runtimes.
+// - Unify collective codegens between Python Inductor and AOT Inductor.
 //
-// Changes compared to c10d_functional:
-// - The namespace now contains in-place variants for collective calls inductor
-// decides to de-functionalize (should we put them in a different namespace?).
+// Difference from the Python c10d_functional:
+// - The namespace now included in-place variation of collectives calls, which
+// will be used by Inductor wrapper for de-functionalized collective calls.
 // - Process group resolution now only relies on tag. Ranks are useful for the
 // compiler to determine whether two collectives using different process groups
 // are fuse-able. However, they are not required for process group resolution.

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -239,7 +239,7 @@ TORCH_LIBRARY(_c10d_functional, m) {
           c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce));
 
   m.def(
-      "all_reduce_(Tensor self(a!), str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
+      "all_reduce_(Tensor(a!) self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce_));
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -680,6 +680,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
   const std::string& getGroupName() const;
   void setGroupName(const std::string& name);
+  static c10::intrusive_ptr<c10d::ProcessGroup> resolveFromName(
+      const std::string& name);
 
  protected:
   // Implementations of this interface need to call this to setup

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1766,6 +1766,13 @@ Arguments:
               "group_name",
               &::c10d::ProcessGroup::getGroupName,
               "(Gets this process group name. It's cluster unique)");
+  module.def(
+      "_resolve_process_group_from_name",
+      [](const std::string& name) -> c10::intrusive_ptr<::c10d::ProcessGroup> {
+        return ::c10d::ProcessGroup::resolveFromName(name);
+      },
+      py::arg("process_groups"),
+      py::call_guard<py::gil_scoped_release>());
 
   py::enum_<::c10d::ProcessGroup::BackendType>(processGroup, "BackendType")
       .value("UNDEFINED", ::c10d::ProcessGroup::BackendType::UNDEFINED)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109738

_c10d_functional is a native port of the existing c10d_functional from
Python. _c10d_functional will supercede c10d_functional upon confirmation of
feature parity.

Reasons for transitioning c10d_functional ops to C++:
- Enable collective ops for AOT Inductor and native interpreters.
- Enable collective ops for multi-threaded native runtimes.
- Unify collective codegens between Python Inductor and AOT Inductor.

Difference from the Python c10d_functional:
- The namespace now included in-place variation of collectives calls, which
will be used by Inductor wrapper for de-functionalized collective calls.
- Process group resolution now only relies on tag. Ranks are useful for the
compiler to determine whether two collectives using different process groups
are fuse-able. However, they are not required for process group resolution.
- Process group resolution now doesn't upsert a process group.

Differential Revision: [D49479258](https://our.internmc.facebook.com/intern/diff/D49479258)