### PR TITLE
[BE] Replace 8 with `CHAR_BIT`

### DIFF
--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -107,8 +107,7 @@ PyObject* THPDTypeInfo_compare(THPDTypeInfo* a, THPDTypeInfo* b, int op) {
 }
 
 static PyObject* THPDTypeInfo_bits(THPDTypeInfo* self, void*) {
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  uint64_t bits = elementSize(self->type) * 8;
+  uint64_t bits = elementSize(self->type) * CHAR_BIT;
   return THPUtils_packUInt64(bits);
 }
 


### PR DESCRIPTION
Defined in [limits.h](https://en.cppreference.com/w/c/types/limits) as number of bits per byte
