### PR TITLE
[ONNX] Support `quantized::linear_relu`

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -13027,7 +13027,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self):
                 super().__init__()
                 self.quant = torch.ao.quantization.QuantStub()
-                self.conv = torch.nn.Conv2d(2, 4, 3, stride=2)
+                self.conv = torch.nn.Conv2d(4, 2, 3, stride=2)
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
@@ -13058,7 +13058,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self):
                 super().__init__()
                 self.quant = torch.ao.quantization.QuantStub()
-                self.conv = torch.nn.Conv2d(2, 4, 3, stride=2)
+                self.conv = torch.nn.Conv2d(4, 2, 3, stride=2)
                 self.relu = torch.nn.ReLU()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -13091,7 +13091,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self):
                 super().__init__()
                 self.quant = torch.ao.quantization.QuantStub()
-                self.conv = torch.nn.Conv2d(2, 4, 3, stride=2)
+                self.conv = torch.nn.Conv2d(4, 2, 3, stride=2)
                 self.relu = torch.nn.ReLU()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -13125,7 +13125,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self):
                 super().__init__()
                 self.quant = torch.ao.quantization.QuantStub()
-                self.linear = torch.nn.Linear(2, 4)
+                self.linear = torch.nn.Linear(4, 2)
                 self.relu = torch.nn.ReLU()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -13144,7 +13144,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         model.linear.weight = torch.nn.Parameter(
             _construct_tensor_for_quantization_test((2, 4), max_val=2)
         )
-        model.linear.bias = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+        model.linear.bias = torch.nn.Parameter(torch.tensor([0.0, 1.0]))
         model = torch.ao.quantization.convert(model)
 
         # Set fixed input to avoid flaky test.

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -13144,7 +13144,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         model.linear.weight = torch.nn.Parameter(
             _construct_tensor_for_quantization_test((2, 4), max_val=2)
         )
-        model.linear.bias = torch.nn.Parameter(torch.arange(4))
+        model.linear.bias = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
         model = torch.ao.quantization.convert(model)
 
         # Set fixed input to avoid flaky test.

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -13148,7 +13148,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         model = torch.ao.quantization.convert(model)
 
         # Set fixed input to avoid flaky test.
-        input = _construct_tensor_for_quantization_test((3, 2), offset=-384, max_val=12)
+        input = _construct_tensor_for_quantization_test((3, 4), offset=-384, max_val=12)
         self.run_test(model, input)
 
     @skipIfUnsupportedMinOpsetVersion(10)

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -679,6 +679,10 @@ void UnpackQuantizedWeights(
   graph(%input, %packed_weight, %w_scale, %w_zero_point):
         %r = quantized::linear(%input, %packed_weight, %w_scale, %w_zero_point)
         return (%r) )";
+  std::string qlinear_relu = R"(
+  graph(%input, %packed_weight, %w_scale, %w_zero_point):
+        %r = quantized::linear_relu(%input, %packed_weight, %w_scale, %w_zero_point)
+        return (%r) )";
   std::string qconv1d = R"(
   graph(%input, %packed_params, %scale, %zero_point):
         %r = quantized::conv1d(%input, %packed_params, %scale, %zero_point)
@@ -719,6 +723,13 @@ void UnpackQuantizedWeights(
       graph,
       paramsDict,
       qlinear,
+      "quantized::linear_unpack",
+      QuantizedParamsType::LINEAR,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qlinear_relu,
       "quantized::linear_unpack",
       QuantizedParamsType::LINEAR,
       caffe2);

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -888,6 +888,24 @@ def quantized_linear(
     return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
 
 
+@_onnx_symbolic("quantized::linear_relu")
+@_beartype.beartype
+def quantized_linear_relu(
+    g: jit_utils.GraphContext, q_input, q_weight, bias, op_scale, op_zero_point
+):
+    input, input_scale, _, _ = symbolic_helper.dequantize_helper(g, q_input)
+    weight, weight_scale, _, axis = symbolic_helper.dequantize_helper(g, q_weight)
+    q_bias = symbolic_helper.requantize_bias_helper(
+        g, bias, input_scale, weight_scale, axis
+    )
+    bias, _, _, _ = symbolic_helper.dequantize_helper(g, q_bias)
+
+    output = opset9.linear(g, input, weight, bias)
+    output = opset9.relu(g, output)
+
+    return symbolic_helper.quantize_helper(g, output, op_scale, op_zero_point)
+
+
 @_onnx_symbolic("quantized::conv1d_relu")
 @_beartype.beartype
 def quantized_conv1d_relu(


### PR DESCRIPTION
- Adds support for quantized::linear_relu
  - Adds weight unpacking pattern matcher
  - Adds to export for opset 10 and 13.
- Adds QAT test modeled after conv2d+relu fusion test


