### PR TITLE
[ONNX] Relax getting module attributes in ONNX export

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1094,6 +1094,43 @@ class TestUtilityFuns(_BaseTestCase):
             self.assertIn(ln_node.attribute[0], expected_ln_attrs)
             self.assertIn(ln_node.attribute[1], expected_ln_attrs)
 
+    # This test cases checks the issue where an object does not have an attribute.
+    # When enabling `export_modules_as_functions = True`, the exporter could return an
+    # AttributeError. With this test case, we check that the export passes successfully
+    # without any AttributeError exceptions. 
+    # See https://github.com/pytorch/pytorch/pull/109759 for an example. The exception that
+    # this test tries to avoid is `AttributeError: 'Embedding' object has no attribute 'freeze'`.
+    @skipIfUnsupportedMinOpsetVersion(15)
+    def test_local_function_subset_of_predefined_attributes(self):
+        class M(torch.nn.Module):
+            num_layers: int
+
+            def __init__(self, num_layers):
+                super().__init__()
+                self.embed_layer = torch.nn.Embedding.from_pretrained(torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]]))
+                self.num_layers = num_layers
+                self.lns = torch.nn.ModuleList(
+                    [torch.nn.LayerNorm(3, eps=1e-4) for _ in range(num_layers)]
+                )
+
+            def forward(self, x):
+                e = self.embed_layer(torch.LongTensor([1]))
+                for ln in self.lns:
+                    x = ln(x)
+                return x, e
+
+        x = torch.randn(2, 3)
+        f = io.BytesIO()
+        model = M(3)
+        torch.onnx.export(
+            model,
+            (x,),
+            f,
+            export_modules_as_functions=True,
+            opset_version=self.opset_version,
+            verbose=True,  # Allows the test case to print `Skipping module attribute 'freeze'`
+        )
+
     def test_node_scope(self):
         class N(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1097,7 +1097,7 @@ class TestUtilityFuns(_BaseTestCase):
     # This test cases checks the issue where an object does not have an attribute.
     # When enabling `export_modules_as_functions = True`, the exporter could return an
     # AttributeError. With this test case, we check that the export passes successfully
-    # without any AttributeError exceptions. 
+    # without any AttributeError exceptions.
     # See https://github.com/pytorch/pytorch/pull/109759 for an example. The exception that
     # this test tries to avoid is `AttributeError: 'Embedding' object has no attribute 'freeze'`.
     @skipIfUnsupportedMinOpsetVersion(15)
@@ -1107,7 +1107,9 @@ class TestUtilityFuns(_BaseTestCase):
 
             def __init__(self, num_layers):
                 super().__init__()
-                self.embed_layer = torch.nn.Embedding.from_pretrained(torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]]))
+                self.embed_layer = torch.nn.Embedding.from_pretrained(
+                    torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
+                )
                 self.num_layers = num_layers
                 self.lns = torch.nn.ModuleList(
                     [torch.nn.LayerNorm(3, eps=1e-4) for _ in range(num_layers)]

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1471,6 +1471,16 @@ def _get_module_attributes(module):
     annotations = typing.get_type_hints(type(module))
     base_m_annotations = typing.get_type_hints(torch.nn.Module)
     [annotations.pop(k, None) for k in base_m_annotations]
+    # Check whether module attributes can be accessed. Some classes
+    # define attributes but don't provide access to them in their
+    # constructor.
+    # 
+    # For example, torch.nn.Embedding has the `freeze` variable and its
+    # type specified in the class but the attribute is not created in the
+    # constructor. In other words, there is no `self.freeze = <True | False>`
+    # in the constructor.
+    #
+    # Reference: https://github.com/pytorch/pytorch/blob/92de1d322223fb5584e384971b32c46b93bc2f4b/torch/nn/modules/sparse.py#L120
     attrs = {}
     for k in annotations:
         try:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1474,7 +1474,7 @@ def _get_module_attributes(module):
     # Check whether module attributes can be accessed. Some classes
     # define attributes but don't provide access to them in their
     # constructor.
-    # 
+    #
     # For example, torch.nn.Embedding has the `freeze` variable and its
     # type specified in the class but the attribute is not created in the
     # constructor. In other words, there is no `self.freeze = <True | False>`

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1474,9 +1474,9 @@ def _get_module_attributes(module):
     attrs = {}
     for k in annotations:
         try:
-            v = getattr(module, k)
-            attrs[k] = v
-        except:
+            attrs[k] = getattr(module, k)
+        except AttributeError:
+            torch.onnx.log(f"Skipping module attribute '{k}'")
             continue
     return attrs
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1471,7 +1471,14 @@ def _get_module_attributes(module):
     annotations = typing.get_type_hints(type(module))
     base_m_annotations = typing.get_type_hints(torch.nn.Module)
     [annotations.pop(k, None) for k in base_m_annotations]
-    return {k: getattr(module, k) for k in annotations}
+    attrs = {}
+    for k in annotations:
+        try:
+            v = getattr(module, k)
+            attrs[k] = v
+        except:
+            continue
+    return attrs
 
 
 @_beartype.beartype


### PR DESCRIPTION
### Description

This PR fixes a bug with getting module attributes during `torch.onnx.export` when `export_modules_as_functions` is used. With this fix, we can compare the LLaMA-2 models produced by the TorchScript exporter and the [Dynamo exporter](https://github.com/pytorch/pytorch/issues/104903).

### Context
When exporting LLaMA-2 from Hugging Face with `export_modules_as_functions`, the `Embedding` object does not have the `freeze` attribute.
```
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/transformers/models/llama/modeling_llama.py", line 662, in forward
    inputs_embeds = self.embed_tokens(input_ids)
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1519, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1558, in _call_impl
    args_result = hook(self, args)
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/onnx/utils.py", line 1394, in _track_module_attributes_forward_pre_hook
    setattr(module, attr_name, _get_module_attributes(module))
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/onnx/utils.py", line 1474, in _get_module_attributes
    return {k: getattr(module, k) for k in annotations}
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/onnx/utils.py", line 1474, in <dictcomp>
    return {k: getattr(module, k) for k in annotations}
  File "/home/kvaishnavi/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1696, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'Embedding' object has no attribute 'freeze'
```
To get around this issue, we can skip adding the keys in the dictionary when the object does not have the attribute.