### PR TITLE
[BE][foreach] name tests correctly. noncontiguous inputs != fastpath

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -138,7 +138,7 @@ class TestForeach(TestCase):
         "noncontiguous,inplace",
         [(False, False), (False, True), (True, False), (True, True)],
         name_fn=lambda x, y: '{}_{}'.format(
-            'fastpath' if x else 'slowpath', 'inplace' if y else 'outplace'
+            'fastpath' if not x else 'slowpath', 'inplace' if y else 'outplace'
         )
     )
     def test_parity(self, device, dtype, op, noncontiguous, inplace):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109771

