### PR TITLE
Fix tensor unpickling

### DIFF
--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -738,6 +738,27 @@ class TestSaveLoad(JitTestCase):
         loaded_output = loaded_ts(inp)
         self.assertEqual(ts_output, loaded_output)
 
+    def test_load_malformed_tensor_size(self):
+        """
+        Check that tensors have valid sizes/strides during model loading.
+        """
+
+        # Load default valid model.
+        test_file = os.path.realpath(sys.modules[self.__class__.__module__].__file__)
+        path = os.path.join(os.path.dirname(test_file), "../quantization/serialized")
+        def_model = os.path.join(path, "TestSerialization.test_conv2d_nobias_graph.scripted.pt")
+        loaded_model = io.BytesIO()
+        torch.jit.save(torch.jit.load(def_model), loaded_model)
+
+        # Modify raw bytes to change tensor metadata.
+        b = loaded_model.getvalue()
+        b_ = b[:718] + b'\x0c' + b[719:]
+        malformed_model = io.BytesIO(b_)
+
+        # Try to load model from binary data again.
+        with self.assertRaises(Exception) as context:
+            torch.jit.load(malformed_model)
+        self.assertTrue('Unpickle tensor: mismatching storage and size/stride' in str(context.exception))
 
 def script_module_to_buffer(script_module):
     module_buffer = io.BytesIO(

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -987,7 +987,7 @@ void Unpickler::rebuildTensor(bool quantized) {
         result.nbytes(),
         ", but unpickled sizes and strides requires ",
         expected_size,
-        "bytes");
+        " bytes");
 
     // Handle if math_bits were pickled.
     // See `args` of _reduce_ex_internal


### PR DESCRIPTION
Fixes #109791

Validates that tensor have sizes and strides that are in bounds of its storage.

PyTorch method `set_sizes_and_strides` used during tensor unpickling from raw binary data, but there are no checks for consistency of tensor metadata.
