### PR TITLE
Don't -Werror on cast-function-type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,7 +932,6 @@ if(NOT MSVC)
   append_cxx_flag_if_supported("-fno-math-errno" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-fno-trapping-math" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Werror=format" CMAKE_CXX_FLAGS)
-  append_cxx_flag_if_supported("-Werror=cast-function-type" CMAKE_CXX_FLAGS)
 else()
   # skip unwanted includes from windows.h
   add_compile_definitions(WIN32_LEAN_AND_MEAN)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109796

I recently built PyTorch with clang and we are apparently
not warnings clean on this.  Since we don't have any contbuild
that catches this situation, just get rid of it.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>