### PR TITLE
[Release/2.1] [Docs] Fix typo in `torch.unflatten`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4554,7 +4554,7 @@ Examples::
     torch.Size([3, 2, 2, 1])
     >>> torch.unflatten(torch.randn(3, 4, 1), 1, (-1, 2)).shape
     torch.Size([3, 2, 2, 1])
-    >>> torch.unflatten(torch.randn(5, 12, 3), -1, (2, 2, 3, 1, 1)).shape
+    >>> torch.unflatten(torch.randn(5, 12, 3), -2, (2, 2, 3, 1, 1)).shape
     torch.Size([5, 2, 2, 3, 1, 1, 3])
 """.format(
         **common_args


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/109559

Cherry-pick of  https://github.com/pytorch/pytorch/pull/109588 into release/2.1 branch
Approved by: https://github.com/lezcano

(cherry picked from commit 2f53bca0fc84d1829cc571d76c58ea411f4fc288)