### PR TITLE
MAINT: pytorchify torch._numpy tests: core/ and fft/

### DIFF
--- a/test/torch_np/check_tests_conform.py
+++ b/test/torch_np/check_tests_conform.py
@@ -1,0 +1,72 @@
+import pathlib
+import sys
+import textwrap
+
+
+def check(path):
+    """Check a test file for common issues with pytest->pytorch conversion."""
+    print(path.name)
+    print("=" * len(path.name), "\n")
+
+    src = path.read_text().split("\n")
+    for num, line in enumerate(src):
+        if is_comment(line):
+            continue
+
+        # module level test functions
+        if line.startswith("def test"):
+            report_violation(line, num, header="Module-level test function")
+
+        # test classes must inherit from TestCase
+        if line.startswith("class Test") and "TestCase" not in line:
+            report_violation(
+                line, num, header="Test class does not inherit from TestCase"
+            )
+
+        # last vestiges of pytest-specific stuff
+        if "pytest.mark" in line:
+            report_violation(line, num, header="pytest.mark.something")
+
+        for part in ["pytest.xfail", "pytest.skip", "pytest.param"]:
+            if part in line:
+                report_violation(line, num, header=f"stray {part}")
+
+        if textwrap.dedent(line).startswith("@parametrize"):
+            # backtrack to check
+            #  report_violation(line, num, header="parametrize")
+            nn = num
+            for nn in range(num, -1, -1):
+                ln = src[nn]
+                if "class Test" in ln:
+                    break
+            else:
+                report_violation(line, num, "off-class parametrize")
+            if not src[nn - 1].startswith("@instantiate_parametrized_tests"):
+                # breakpoint()
+                report_violation(
+                    line, num, f"missing instantiation of parametrized tests in {ln}?"
+                )
+
+
+def is_comment(line):
+    return textwrap.dedent(line).startswith("#")
+
+
+def report_violation(line, lineno, header):
+    print(f">>>> line {lineno} : {header}\n {line}\n")
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) != 2:
+        raise ValueError("Usage : python check_tests_conform path/to/file/or/dir")
+
+    path = pathlib.Path(argv[1])
+
+    if path.is_dir():
+        # run for all files in the directory (no subdirs)
+        for this_path in path.glob("test*.py"):
+            #   breakpoint()
+            check(this_path)
+    else:
+        check(path)

--- a/test/torch_np/check_tests_conform.py
+++ b/test/torch_np/check_tests_conform.py
@@ -33,12 +33,13 @@ def check(path):
 
         if textwrap.dedent(line).startswith("@parametrize"):
             # backtrack to check
-            #  report_violation(line, num, header="parametrize")
             nn = num
             for nn in range(num, -1, -1):
                 ln = src[nn]
                 if "class Test" in ln:
-                    break
+                    # hack: large indent => likely an inner class
+                    if len(ln) - len(ln.lstrip()) < 8:
+                        break
             else:
                 report_violation(line, num, "off-class parametrize")
             if not src[nn - 1].startswith("@instantiate_parametrized_tests"):

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import operator
 
 import pickle
@@ -8,11 +9,22 @@ import types
 from itertools import permutations
 from typing import Any
 
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_, assert_equal
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
 
 
 def assert_dtype_equal(a, b):
@@ -27,8 +39,9 @@ def assert_dtype_not_equal(a, b):
     assert_(hash(a) != hash(b), "two different types hash to the same value !")
 
 
-class TestBuiltin:
-    @pytest.mark.parametrize("t", [int, float, complex, np.int32])
+@instantiate_parametrized_tests
+class TestBuiltin(TestCase):
+    @parametrize("t", [int, float, complex, np.int32])
     def test_run(self, t):
         """Only test hash runs at all."""
         dt = np.dtype(t)
@@ -81,9 +94,7 @@ class TestBuiltin:
         assert not np.dtype(np.int32) == 7, "dtype richcompare failed for =="
         assert np.dtype(np.int32) != 7, "dtype richcompare failed for !="
 
-    @pytest.mark.parametrize(
-        "operation", [operator.le, operator.lt, operator.ge, operator.gt]
-    )
+    @parametrize("operation", [operator.le, operator.lt, operator.ge, operator.gt])
     def test_richcompare_invalid_dtype_comparison(self, operation):
         # Make sure TypeError is raised for comparison operators
         # for invalid dtypes. Here 7 is an invalid dtype.
@@ -91,7 +102,7 @@ class TestBuiltin:
         with pytest.raises(TypeError):
             operation(np.dtype(np.int32), 7)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "dtype",
         [
             "Bool",
@@ -125,8 +136,8 @@ class TestBuiltin:
             np.dtype(dtype)
 
 
-@pytest.mark.skip(reason="dtype attributes not yet implemented")
-class TestDtypeAttributeDeletion:
+@skip(reason="dtype attributes not yet implemented")
+class TestDtypeAttributeDeletion(TestCase):
     def test_dtype_non_writable_attributes_deletion(self):
         dt = np.dtype(np.double)
         attr = [
@@ -154,7 +165,8 @@ class TestDtypeAttributeDeletion:
             assert_raises(AttributeError, delattr, dt, s)
 
 
-class TestPickling:
+@instantiate_parametrized_tests
+class TestPickling(TestCase):
     def check_pickling(self, dtype):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             buf = pickle.dumps(dtype, proto)
@@ -176,12 +188,17 @@ class TestPickling:
             assert_equal(x, y)
             assert_equal(x[0], y[0])
 
-    @pytest.mark.parametrize("t", [int, float, complex, np.int32, bool])
+    @parametrize("t", [int, float, complex, np.int32, bool])
     def test_builtin(self, t):
         self.check_pickling(np.dtype(t))
 
-    @pytest.mark.parametrize(
-        "DType", [type(np.dtype(t)) for t in np.typecodes["All"]] + [np.dtype]
+    @parametrize(
+        "DType",
+        [
+            subtest(type(np.dtype(t)), name=f"{np.dtype(t).name}")
+            for t in np.typecodes["All"]
+        ]
+        + [np.dtype],
     )
     def test_pickle_types(self, DType):
         # Check that DTypes (the classes/types) roundtrip when pickling
@@ -190,14 +207,14 @@ class TestPickling:
             assert roundtrip_DType is DType
 
 
-@pytest.mark.skip(reason="XXX: value-based promotions, we don't have.")
-class TestPromotion:
+@skip(reason="XXX: value-based promotions, we don't have.")
+class TestPromotion(TestCase):
     """Test cases related to more complex DType promotions.  Further promotion
     tests are defined in `test_numeric.py`
     """
 
-    @pytest.mark.parametrize(
-        ["other", "expected", "expected_weak"],
+    @parametrize(
+        "other, expected, expected_weak",
         [
             (2**16 - 1, np.complex64, None),
             (2**32 - 1, np.complex128, np.complex64),
@@ -222,8 +239,8 @@ class TestPromotion:
         res = np.minimum(other, np.ones(3, dtype=min_complex)).dtype
         assert res == expected
 
-    @pytest.mark.parametrize(
-        ["other", "expected"],
+    @parametrize(
+        "other, expected",
         [
             (np.bool_, np.complex128),
             (np.int64, np.complex128),
@@ -244,7 +261,7 @@ class TestPromotion:
         res = np.minimum(np.ones(3, dtype=other), complex_scalar).dtype
         assert res == expected
 
-    @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2 * 100])
+    @parametrize("val", [2, 2**32, 2**63, 2**64, 2 * 100])
     def test_python_integer_promotion(self, val):
         # If we only path scalars (mainly python ones!), the result must take
         # into account that the integer may be considered int32, int64, uint64,
@@ -254,8 +271,8 @@ class TestPromotion:
         # For completeness sake, also check with a NumPy scalar as second arg:
         assert np.result_type(val, np.int8(0)) == expected_dtype
 
-    @pytest.mark.parametrize(
-        ["dtypes", "expected"],
+    @parametrize(
+        "dtypes, expected",
         [
             # These promotions are not associative/commutative:
             ([np.int16, np.float16], np.float32),
@@ -280,19 +297,25 @@ class TestPromotion:
             assert np.result_type(*perm) == expected
 
 
-def test_dtypes_are_true():
-    # test for gh-6294
-    assert bool(np.dtype("f8"))
-    assert bool(np.dtype("i8"))
+class TestMisc(TestCase):
+    def test_dtypes_are_true(self):
+        # test for gh-6294
+        assert bool(np.dtype("f8"))
+        assert bool(np.dtype("i8"))
+
+    @xfail  # (reason="No keyword arg for dtype ctor.")
+    def test_keyword_argument(self):
+        # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
+        assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
+
+    @skipif(sys.version_info >= (3, 9), reason="Requires python 3.9")
+    def test_class_getitem_38(self) -> None:
+        match = "Type subscription requires python >= 3.9"
+        with pytest.raises(TypeError):  # , match=match):
+            np.dtype[Any]
 
 
-@pytest.mark.xfail(reason="No keyword arg for dtype ctor.")
-def test_keyword_argument():
-    # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
-    assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
-
-
-class TestFromDTypeAttribute:
+class TestFromDTypeAttribute(TestCase):
     def test_simple(self):
         class dt:
             dtype = np.dtype("f8")
@@ -300,7 +323,7 @@ class TestFromDTypeAttribute:
         assert np.dtype(dt) == np.float64
         assert np.dtype(dt()) == np.float64
 
-    @pytest.mark.skip(
+    @skip(
         reason="We simply require the .name attribute, so this "
         "fails with an AttributeError."
     )
@@ -318,22 +341,22 @@ class TestFromDTypeAttribute:
             np.dtype(dt_instance)
 
 
-@pytest.mark.skip(reason="Parameteric dtypes, our stuff is simpler.")
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
-class TestClassGetItem:
+@skip(reason="Parameteric dtypes, our stuff is simpler.")
+@skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+class TestClassGetItem(TestCase):
     def test_dtype(self) -> None:
         alias = np.dtype[Any]
         assert isinstance(alias, types.GenericAlias)
         assert alias.__origin__ is np.dtype
 
-    @pytest.mark.parametrize("code", np.typecodes["All"])
+    @parametrize("code", np.typecodes["All"])
     def test_dtype_subclass(self, code: str) -> None:
         cls = type(np.dtype(code))
         alias = cls[Any]
         assert isinstance(alias, types.GenericAlias)
         assert alias.__origin__ is cls
 
-    @pytest.mark.parametrize("arg_len", range(4))
+    @parametrize("arg_len", range(4))
     def test_subscript_tuple(self, arg_len: int) -> None:
         arg_tup = (Any,) * arg_len
         if arg_len == 1:
@@ -346,14 +369,5 @@ class TestClassGetItem:
         assert np.dtype[Any]
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Requires python 3.9")
-def test_class_getitem_38() -> None:
-    match = "Type subscription requires python >= 3.9"
-    with pytest.raises(TypeError):  # , match=match):
-        np.dtype[Any]
-
-
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_einsum.py
+++ b/test/torch_np/numpy_tests/core/test_einsum.py
@@ -1,8 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import itertools
 
-import pytest
+from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 import torch._numpy as np
 from pytest import raises as assert_raises
@@ -14,6 +15,15 @@ from torch._numpy.testing import (
     assert_equal,
     suppress_warnings,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+
 
 # Setup for optimize einsum
 chars = "abcdefghij"
@@ -21,7 +31,8 @@ sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3])
 global_size_dict = dict(zip(chars, sizes))
 
 
-class TestEinsum:
+@instantiate_parametrized_tests
+class TestEinsum(TestCase):
     def test_einsum_errors(self):
         for do_opt in [True, False]:
             # Need enough arguments
@@ -184,7 +195,7 @@ class TestEinsum:
                 order="d",
             )
 
-    @pytest.mark.xfail(reason="a view into smth else")
+    @xfail  # (reason="a view into smth else")
     def test_einsum_views(self):
         # pass-through
         for do_opt in [True, False]:
@@ -734,15 +745,15 @@ class TestEinsum:
             np.einsum("ij,i->", x, y, optimize=optimize), [2.0]
         )  # contig_stride0_outstride0_two
 
-    @pytest.mark.xfail(reason="int overflow differs in numpy and pytorch")
+    @xfail  # (reason="int overflow differs in numpy and pytorch")
     def test_einsum_sums_int8(self):
         self.check_einsum_sums("i1")
 
-    @pytest.mark.xfail(reason="int overflow differs in numpy and pytorch")
+    @xfail  # (reason="int overflow differs in numpy and pytorch")
     def test_einsum_sums_uint8(self):
         self.check_einsum_sums("u1")
 
-    @pytest.mark.xfail(reason="int overflow differs in numpy and pytorch")
+    @xfail  # (reason="int overflow differs in numpy and pytorch")
     def test_einsum_sums_int16(self):
         self.check_einsum_sums("i2")
 
@@ -753,7 +764,7 @@ class TestEinsum:
     def test_einsum_sums_int64(self):
         self.check_einsum_sums("i8")
 
-    @pytest.mark.xfail(reason="np.float16(4641) == 4640.0")
+    @xfail  # (reason="np.float16(4641) == 4640.0")
     def test_einsum_sums_float16(self):
         self.check_einsum_sums("f2")
 
@@ -937,7 +948,7 @@ class TestEinsum:
         y = tensor.trace(axis1=0, axis2=2).trace()
         assert_allclose(x, y)
 
-    @pytest.mark.xfail(reason="no base")
+    @xfail  # (reason="no base")
     def test_einsum_all_contig_non_contig_output(self):
         # Issue gh-5907, tests that the all contiguous special case
         # actually checks the contiguity of the output
@@ -961,9 +972,7 @@ class TestEinsum:
         np.einsum("ij,jk->ik", x, x, out=out)
         assert_array_equal(out.base, correct_base)
 
-    @pytest.mark.parametrize(
-        "dtype", np.typecodes["AllFloat"] + np.typecodes["AllInteger"]
-    )
+    @parametrize("dtype", np.typecodes["AllFloat"] + np.typecodes["AllInteger"])
     def test_different_paths(self, dtype):
         # Test originally added to cover broken float16 path: gh-20305
         # Likely most are covered elsewhere, at least partially.
@@ -1003,7 +1012,9 @@ class TestEinsum:
         # contig + contig + contig -> scalar
 
         if dtype in ["e", "B", "b"]:
-            pytest.xfail(reason="overflow differs in pytorch and numpy")
+            # FIXME
+            # pytest.xfail(reason="overflow differs in pytorch and numpy")
+            raise SkipTest("overflow differs in pytorch and numpy")
 
         arr = np.array([0.5, 0.5, 0.25, 4.5, 3.0], dtype=dtype)
         res = np.einsum("i,i,i->", arr, arr, arr)
@@ -1148,7 +1159,7 @@ class TestEinsum:
         g = np.arange(64).reshape(2, 4, 8)
         self.optimize_compare("obk,ijk->ioj", operands=[g, g])
 
-    @pytest.mark.xfail(reason="order='F' not supported")
+    @xfail  # (reason="order='F' not supported")
     def test_output_order(self):
         # Ensure output order is respected for optimize cases, the below
         # conraction should yield a reshaped tensor view
@@ -1186,8 +1197,8 @@ class TestEinsum:
             assert_(tmp.flags.c_contiguous)
 
 
-@pytest.mark.skip(reason="no pytorch analog")
-class TestEinsumPath:
+@skip(reason="no pytorch analog")
+class TestEinsumPath(TestCase):
     def build_operands(self, string, size_dict=global_size_dict):
         # Builds views based off initial operands
         operands = [string]
@@ -1348,19 +1359,18 @@ class TestEinsumPath:
             np.einsum("{}...a{}->{}...a{}".format(*sp), arr)
 
 
-def test_overlap():
-    a = np.arange(9, dtype=int).reshape(3, 3)
-    b = np.arange(9, dtype=int).reshape(3, 3)
-    d = np.dot(a, b)
-    # sanity check
-    c = np.einsum("ij,jk->ik", a, b)
-    assert_equal(c, d)
-    # gh-10080, out overlaps one of the operands
-    c = np.einsum("ij,jk->ik", a, b, out=b)
-    assert_equal(c, d)
+class TestMisc(TestCase):
+    def test_overlap(self):
+        a = np.arange(9, dtype=int).reshape(3, 3)
+        b = np.arange(9, dtype=int).reshape(3, 3)
+        d = np.dot(a, b)
+        # sanity check
+        c = np.einsum("ij,jk->ik", a, b)
+        assert_equal(c, d)
+        # gh-10080, out overlaps one of the operands
+        c = np.einsum("ij,jk->ik", a, b, out=b)
+        assert_equal(c, d)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_einsum.py
+++ b/test/torch_np/numpy_tests/core/test_einsum.py
@@ -1012,8 +1012,7 @@ class TestEinsum(TestCase):
         # contig + contig + contig -> scalar
 
         if dtype in ["e", "B", "b"]:
-            # FIXME
-            # pytest.xfail(reason="overflow differs in pytorch and numpy")
+            # FIXME make xfail
             raise SkipTest("overflow differs in pytorch and numpy")
 
         arr = np.array([0.5, 0.5, 0.25, 4.5, 3.0], dtype=dtype)

--- a/test/torch_np/numpy_tests/core/test_getlimits.py
+++ b/test/torch_np/numpy_tests/core/test_getlimits.py
@@ -3,53 +3,57 @@
 """ Test functions for limits module.
 
 """
+import functools
 import warnings
 
-import pytest
+# from numpy.core.getlimits import _discovered_machar, _float_ma
+
+from unittest import expectedFailure as xfail, skipIf as skipif
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy import double, finfo, half, iinfo, single
 from torch._numpy.testing import assert_, assert_equal
+from torch.testing._internal.common_utils import run_tests, TestCase
 
-# from numpy.core.getlimits import _discovered_machar, _float_ma
+skip = functools.partial(skipif, True)
 
 ##################################################
 
 
-@pytest.mark.skip(reason="torch.finfo is not a singleton. Why demanding it is?")
-class TestPythonFloat:
+@skip(reason="torch.finfo is not a singleton. Why demanding it is?")
+class TestPythonFloat(TestCase):
     def test_singleton(self):
         ftype = finfo(float)
         ftype2 = finfo(float)
         assert_equal(id(ftype), id(ftype2))
 
 
-@pytest.mark.skip(reason="torch.finfo is not a singleton. Why demanding it is?")
-class TestHalf:
+@skip(reason="torch.finfo is not a singleton. Why demanding it is?")
+class TestHalf(TestCase):
     def test_singleton(self):
         ftype = finfo(half)
         ftype2 = finfo(half)
         assert_equal(id(ftype), id(ftype2))
 
 
-@pytest.mark.skip(reason="torch.finfo is not a singleton. Why demanding it is?")
-class TestSingle:
+@skip(reason="torch.finfo is not a singleton. Why demanding it is?")
+class TestSingle(TestCase):
     def test_singleton(self):
         ftype = finfo(single)
         ftype2 = finfo(single)
         assert_equal(id(ftype), id(ftype2))
 
 
-@pytest.mark.skip(reason="torch.finfo is not a singleton. Why demanding it is?")
-class TestDouble:
+@skip(reason="torch.finfo is not a singleton. Why demanding it is?")
+class TestDouble(TestCase):
     def test_singleton(self):
         ftype = finfo(double)
         ftype2 = finfo(double)
         assert_equal(id(ftype), id(ftype2))
 
 
-class TestFinfo:
+class TestFinfo(TestCase):
     def test_basic(self):
         dts = list(
             zip(
@@ -71,7 +75,7 @@ class TestFinfo:
         with assert_raises((TypeError, ValueError)):
             finfo("i4")
 
-    @pytest.mark.xfail(reason="These attributes are not implemented yet.")
+    @xfail  # (reason="These attributes are not implemented yet.")
     def test_basic_missing(self):
         dt = np.float32
         for attr in [
@@ -89,7 +93,7 @@ class TestFinfo:
             getattr(finfo(dt), attr)
 
 
-class TestIinfo:
+class TestIinfo(TestCase):
     def test_basic(self):
         dts = list(
             zip(
@@ -116,7 +120,7 @@ class TestIinfo:
             assert_equal(iinfo(T).max, max_calculated)
 
 
-class TestRepr:
+class TestRepr(TestCase):
     def test_iinfo_repr(self):
         expected = "iinfo(min=-32768, max=32767, dtype=int16)"
         assert_equal(repr(np.iinfo(np.int16)), expected)
@@ -127,13 +131,6 @@ class TestRepr:
         assert "dtype=float32" in repr_f32
 
 
-@pytest.mark.skip(reason="Instantiate {i,f}info from dtypes.")
-def test_instances():
-    iinfo(10)
-    finfo(3.0)
-
-
-@pytest.mark.skip(reason="MachAr no implemented (does it need to be)?")
 def assert_ma_equal(discovered, ma_like):
     # Check MachAr-like objects same as calculated MachAr instances
     for key, value in discovered.__dict__.items():
@@ -143,59 +140,61 @@ def assert_ma_equal(discovered, ma_like):
             assert_equal(value.dtype, getattr(ma_like, key).dtype)
 
 
-@pytest.mark.skip(reason="MachAr no implemented (does it need to)?")
-def test_known_types():
-    # Test we are correctly compiling parameters for known types
-    for ftype, ma_like in (
-        (np.float16, _float_ma[16]),
-        (np.float32, _float_ma[32]),
-        (np.float64, _float_ma[64]),
-    ):
-        assert_ma_equal(_discovered_machar(ftype), ma_like)
-    # Suppress warning for broken discovery of double double on PPC
-    ld_ma = _discovered_machar(np.longdouble)
-    bytes = np.dtype(np.longdouble).itemsize
-    if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
-        # 80-bit extended precision
-        assert_ma_equal(ld_ma, _float_ma[80])
-    elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
-        # IEE 754 128-bit
-        assert_ma_equal(ld_ma, _float_ma[128])
+class TestMisc(TestCase):
+    @skip(reason="Instantiate {i,f}info from dtypes.")
+    def test_instances(self):
+        iinfo(10)
+        finfo(3.0)
 
-
-@pytest.mark.skip(reason="MachAr no implemented (does it need to be)?")
-def test_subnormal_warning():
-    """Test that the subnormal is zero warning is not being raised."""
-    ld_ma = _discovered_machar(np.longdouble)
-    bytes = np.dtype(np.longdouble).itemsize
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    @skip(reason="MachAr no implemented (does it need to)?")
+    def test_known_types(self):
+        # Test we are correctly compiling parameters for known types
+        for ftype, ma_like in (
+            (np.float16, _float_ma[16]),
+            (np.float32, _float_ma[32]),
+            (np.float64, _float_ma[64]),
+        ):
+            assert_ma_equal(_discovered_machar(ftype), ma_like)
+        # Suppress warning for broken discovery of double double on PPC
+        ld_ma = _discovered_machar(np.longdouble)
+        bytes = np.dtype(np.longdouble).itemsize
         if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
             # 80-bit extended precision
-            ld_ma.smallest_subnormal
-            assert len(w) == 0
+            assert_ma_equal(ld_ma, _float_ma[80])
         elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
             # IEE 754 128-bit
-            ld_ma.smallest_subnormal
-            assert len(w) == 0
-        else:
-            # Double double
-            ld_ma.smallest_subnormal
-            # This test may fail on some platforms
-            assert len(w) == 0
+            assert_ma_equal(ld_ma, _float_ma[128])
 
+    @skip(reason="MachAr no implemented (does it need to be)?")
+    def test_subnormal_warning(self):
+        """Test that the subnormal is zero warning is not being raised."""
+        ld_ma = _discovered_machar(np.longdouble)
+        bytes = np.dtype(np.longdouble).itemsize
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
+                # 80-bit extended precision
+                ld_ma.smallest_subnormal
+                assert len(w) == 0
+            elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
+                # IEE 754 128-bit
+                ld_ma.smallest_subnormal
+                assert len(w) == 0
+            else:
+                # Double double
+                ld_ma.smallest_subnormal
+                # This test may fail on some platforms
+                assert len(w) == 0
 
-@pytest.mark.xfail(reason="None of nmant, minexp, maxexp is implemented.")
-def test_plausible_finfo():
-    # Assert that finfo returns reasonable results for all types
-    for ftype in np.sctypes["float"] + np.sctypes["complex"]:
-        info = np.finfo(ftype)
-        assert_(info.nmant > 1)
-        assert_(info.minexp < -1)
-        assert_(info.maxexp > 1)
+    @xfail  # (reason="None of nmant, minexp, maxexp is implemented.")
+    def test_plausible_finfo(self):
+        # Assert that finfo returns reasonable results for all types
+        for ftype in np.sctypes["float"] + np.sctypes["complex"]:
+            info = np.finfo(ftype)
+            assert_(info.nmant > 1)
+            assert_(info.minexp < -1)
+            assert_(info.maxexp > 1)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_getlimits.py
+++ b/test/torch_np/numpy_tests/core/test_getlimits.py
@@ -8,7 +8,7 @@ import warnings
 
 # from numpy.core.getlimits import _discovered_machar, _float_ma
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import expectedFailure as xfail, skipIf
 
 import torch._numpy as np
 from pytest import raises as assert_raises
@@ -16,7 +16,7 @@ from torch._numpy import double, finfo, half, iinfo, single
 from torch._numpy.testing import assert_, assert_equal
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-skip = functools.partial(skipif, True)
+skip = functools.partial(skipIf, True)
 
 ##################################################
 

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -1,11 +1,14 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import operator
 import re
 import sys
 import warnings
 
 from itertools import product
+
+from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 import pytest
 
@@ -18,9 +21,18 @@ from torch._numpy.testing import (
     assert_warns,
     HAS_REFCOUNT,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
 
 
-class TestIndexing:
+@instantiate_parametrized_tests
+class TestIndexing(TestCase):
     def test_index_no_floats(self):
         a = np.array([[[5]]])
 
@@ -91,7 +103,7 @@ class TestIndexing:
         # should still get the DeprecationWarning if step = 0.
         assert_raises(TypeError, lambda: a[::0.0])
 
-    @pytest.mark.skip(reason="torch allows slicing with non-0d array components")
+    @skip(reason="torch allows slicing with non-0d array components")
     def test_index_no_array_to_index(self):
         # No non-scalar arrays.
         a = np.array([[[1]]])
@@ -116,7 +128,7 @@ class TestIndexing:
         assert_equal(a[()], a)
         assert_(a[()].tensor._base is a.tensor)
         a = np.array(0)
-        pytest.skip(
+        raise SkipTest(
             "torch doesn't have scalar types with distinct instancing behaviours"
         )
         assert_(isinstance(a[()], np.int_))
@@ -292,7 +304,7 @@ class TestIndexing:
 
         assert_equal(a, b)
 
-    @pytest.mark.skip(reason="torch does not limit dims to 32")
+    @skip(reason="torch does not limit dims to 32")
     def test_too_many_fancy_indices_special_case(self):
         # Just documents behaviour, this is a small limitation.
         a = np.ones((1,) * 32)  # 32 is NPY_MAXDIMS
@@ -388,7 +400,7 @@ class TestIndexing:
         # Unlike the non nd-index:
         assert_(arr[index,].shape != (1,))
 
-    @pytest.mark.xfail(reason="XXX: low-prio behaviour to support")
+    @xfail  # (reason="XXX: low-prio behaviour to support")
     def test_broken_sequence_not_nd_index(self):
         # See https://github.com/numpy/numpy/issues/5063
         # If we have an object which claims to be a sequence, but fails
@@ -438,16 +450,17 @@ class TestIndexing:
         arr[slices] = 10
         assert_array_equal(arr, 10.0)
 
-    @pytest.mark.parametrize("index", [True, False, np.array([0])])
-    @pytest.mark.parametrize("num", [32, 40])
-    @pytest.mark.parametrize("original_ndim", [1, 32])
+    @parametrize("index", [True, False, np.array([0])])
+    @parametrize("num", [32, 40])
+    @parametrize("original_ndim", [1, 32])
     def test_too_many_advanced_indices(self, index, num, original_ndim):
         # These are limitations based on the number of arguments we can process.
         # For `num=32` (and all boolean cases), the result is actually define;
         # but the use of NpyIter (NPY_MAXARGS) limits it for technical reasons.
         if not (isinstance(index, np.ndarray) and original_ndim < num):
             # unskipped cases fail because of assigning too many indices
-            pytest.skip("torch does not limit dims to 32")
+            raise SkipTest("torch does not limit dims to 32")
+
         arr = np.ones((1,) * original_ndim)
         with pytest.raises(IndexError):
             arr[(index,) * num]
@@ -458,7 +471,7 @@ class TestIndexing:
         a = np.arange(25).reshape((5, 5))
         assert_equal(a[[0, 1]], np.array([a[0], a[1]]))
         assert_equal(a[[0, 1], [0, 1]], np.array([0, 6]))
-        pytest.skip(
+        raise SkipTest(
             "torch happily consumes non-tuple sequences with multi-axis "
             "indices (i.e. slices) as an index, whereas NumPy invalidates "
             "them, assumedly to keep things simple. This invalidation "
@@ -467,7 +480,8 @@ class TestIndexing:
         assert_raises(IndexError, a.__getitem__, [slice(None)])
 
 
-class TestBroadcastedAssignments:
+@instantiate_parametrized_tests
+class TestBroadcastedAssignments(TestCase):
     def assign(self, a, ind, val):
         a[ind] = val
         return a
@@ -513,7 +527,7 @@ class TestBroadcastedAssignments:
             (ValueError, RuntimeError), assign, a, s_[[0], :], np.zeros((2, 1))
         )
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "index", [(..., [1, 2], slice(None)), ([0, 1], ..., 0), (..., [1, 2], [1, 2])]
     )
     def test_broadcast_error_reports_correct_shape(self, index):
@@ -543,10 +557,10 @@ class TestBroadcastedAssignments:
         assert_((a[::-1] == v).all())
 
 
-class TestFancyIndexingCast:
-    @pytest.mark.xfail(
-        reason="XXX: low-prio to support assigning complex values on floating arrays"
-    )
+class TestFancyIndexingCast(TestCase):
+    @xfail  # (
+    #    reason="XXX: low-prio to support assigning complex values on floating arrays"
+    # )
     def test_boolean_index_cast_assign(self):
         # Setup the boolean index and float arrays.
         shape = (8, 63)
@@ -571,8 +585,8 @@ class TestFancyIndexingCast:
         assert_equal(zero_array[0, 1], 0)
 
 
-@pytest.mark.xfail(reason="XXX: requires broadcast() and broadcast_to()")
-class TestMultiIndexingAutomated:
+@xfail  # (reason="XXX: requires broadcast() and broadcast_to()")
+class TestMultiIndexingAutomated(TestCase):
     """
     These tests use code to mimic the C-Code indexing for selection.
 
@@ -917,7 +931,7 @@ class TestMultiIndexingAutomated:
 
     def _compare_index_result(self, arr, index, mimic_get, no_copy):
         """Compare mimicked result to indexing result."""
-        pytest.skip("torch does not support subclassing")
+        raise SkipTest("torch does not support subclassing")
         arr = arr.copy()
         indexed_arr = arr[index]
         assert_array_equal(indexed_arr, mimic_get)
@@ -1001,7 +1015,7 @@ class TestMultiIndexingAutomated:
             self._check_single_index(a, index)
 
 
-class TestFloatNonIntegerArgument:
+class TestFloatNonIntegerArgument(TestCase):
     """
     These test that ``TypeError`` is raised when you try to use
     non-integers as arguments to for indexing and slicing e.g. ``a[0.0:5]``
@@ -1040,7 +1054,7 @@ class TestFloatNonIntegerArgument:
         assert_raises(TypeError, np.take, a, [0], 1.0)
         assert_raises((TypeError, RuntimeError), np.take, a, [0], np.float64(1.0))
 
-    @pytest.mark.skip(
+    @skip(
         reason=("torch doesn't have scalar types with distinct element-wise behaviours")
     )
     def test_non_integer_sequence_multiplication(self):
@@ -1060,7 +1074,7 @@ class TestFloatNonIntegerArgument:
         assert_raises(TypeError, np.min, d, (0.2, 1.2))
 
 
-class TestBooleanIndexing:
+class TestBooleanIndexing(TestCase):
     # Using a boolean as integer argument/indexing is an error.
     def test_bool_as_int_argument_errors(self):
         a = np.array([[[1]]])
@@ -1072,7 +1086,7 @@ class TestBooleanIndexing:
 
         assert_raises(TypeError, np.take, args=(a, [0], False))
 
-        pytest.skip("torch consumes boolean tensors as ints, no bother raising here")
+        raise SkipTest("torch consumes boolean tensors as ints, no bother raising here")
         assert_raises(TypeError, np.reshape, a, (np.bool_(True), -1))
         assert_raises(TypeError, operator.index, np.array(True))
 
@@ -1110,7 +1124,7 @@ class TestBooleanIndexing:
             a[idx]
 
 
-class TestArrayToIndexDeprecation:
+class TestArrayToIndexDeprecation(TestCase):
     """Creating an index from array not 0-D is an error."""
 
     def test_array_to_index_error(self):
@@ -1119,17 +1133,17 @@ class TestArrayToIndexDeprecation:
 
         assert_raises((TypeError, RuntimeError), np.take, a, [0], a)
 
-        pytest.skip(
+        raise SkipTest(
             "Multi-dimensional tensors are indexable just as long as they only "
             "contain a single element, no bother raising here"
         )
         assert_raises(TypeError, operator.index, np.array([1]))
 
-        pytest.skip("torch consumes tensors as ints, no bother raising here")
+        raise SkipTest("torch consumes tensors as ints, no bother raising here")
         assert_raises(TypeError, np.reshape, a, (a, -1))
 
 
-class TestNonIntegerArrayLike:
+class TestNonIntegerArrayLike(TestCase):
     """Tests that array_likes only valid if can safely cast to integer.
 
     For instance, lists give IndexError when they cannot be safely cast to
@@ -1137,7 +1151,7 @@ class TestNonIntegerArrayLike:
 
     """
 
-    @pytest.mark.skip(
+    @skip(
         reason=(
             "torch consumes floats by way of falling back on its deprecated "
             "__index__ behaviour, no bother raising here"
@@ -1154,15 +1168,15 @@ class TestNonIntegerArrayLike:
         a.__getitem__([])
 
 
-class TestMultipleEllipsisError:
+class TestMultipleEllipsisError(TestCase):
     """An index can only have a single ellipsis."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "torch currently consumes multiple ellipsis, no bother raising "
-            "here. See https://github.com/pytorch/pytorch/issues/59787#issue-917252204"
-        )
-    )
+    @xfail  # (
+    #    reason=(
+    #        "torch currently consumes multiple ellipsis, no bother raising "
+    #        "here. See https://github.com/pytorch/pytorch/issues/59787#issue-917252204"
+    #    )
+    # )
     def test_basic(self):
         a = np.arange(10)
         assert_raises(IndexError, lambda: a[..., ...])
@@ -1171,6 +1185,4 @@ class TestMultipleEllipsisError:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -1157,7 +1157,6 @@ class TestNonIntegerArrayLike(TestCase):
             "__index__ behaviour, no bother raising here"
         )
     )
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_basic(self):
         a = np.arange(10)
 

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -608,7 +608,7 @@ class TestMultiIndexingAutomated(TestCase):
 
     """
 
-    def setup_method(self):
+    def setupUp(self):
         self.a = np.arange(np.prod([3, 1, 5, 6])).reshape(3, 1, 5, 6)
         self.b = np.empty((3, 0, 5, 6))
         self.complex_indices = [

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -4251,7 +4251,7 @@ class TestIO(TestCase):
 @xfail  # (reason="TODO")
 @instantiate_parametrized_tests
 class TestFromBuffer(TestCase):
-    @parametrize("byteorder", ["<", ">"])
+    @parametrize("byteorder", [subtest("<", name="less"), subtest(">", name="greater")])
     @parametrize("dtype", [float, int, complex])
     def test_basic(self, byteorder, dtype):
         dt = np.dtype(dtype).newbyteorder(byteorder)

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -18,6 +18,8 @@ import weakref
 from contextlib import contextmanager
 from decimal import Decimal
 
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
@@ -36,6 +38,16 @@ from torch._numpy.testing import (
     # runstring, temppath,
     suppress_warnings,  # break_cycles,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 IS_PYPY = False
 IS_PYSTON = False
@@ -118,9 +130,9 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
     return data
 
 
-@pytest.mark.xfail(reason="TODO: flags")
-class TestFlags:
-    def setup_method(self):
+@xfail  # (reason="TODO: flags")
+class TestFlag(TestCase):
+    def setUp(self):
         self.a = np.arange(10)
 
     def test_writeable(self):
@@ -216,8 +228,8 @@ class TestFlags:
             # only warn once
             assert_(len(w) == 1)
 
-    @pytest.mark.parametrize(
-        ["flag", "flag_value", "writeable"],
+    @parametrize(
+        "flag, flag_value, writeable",
         [
             ("writeable", True, True),
             # Delete _warn_on_write after deprecation and simplify
@@ -263,8 +275,8 @@ class TestFlags:
         assert_(a.flags.aligned)
 
 
-@pytest.mark.xfail(reason="TODO: hash")
-class TestHash:
+@xfail  # (reason="TODO: hash")
+class TestHash(TestCase):
     # see #3793
     def test_int(self):
         for st, ut, s in [
@@ -301,9 +313,9 @@ class TestHash:
                 )
 
 
-@pytest.mark.xfail(reason="TODO: hash")
-class TestAttributes:
-    def setup_method(self):
+@xfail  # (reason="TODO: hash")
+class TestAttributes(TestCase):
+    def setUp(self):
         self.one = np.arange(10)
         self.two = np.arange(20).reshape(4, 5)
         self.three = np.arange(60, dtype=np.float64).reshape(2, 5, 6)
@@ -434,7 +446,8 @@ class TestAttributes:
             a.fill(0)
 
 
-class TestArrayConstruction:
+@instantiate_parametrized_tests
+class TestArrayConstruction(TestCase):
     def test_array(self):
         d = np.ones(6)
         r = np.array([d, d])
@@ -468,7 +481,7 @@ class TestArrayConstruction:
         r = np.array([[True, False], [True, False], [False, True]])
         assert_equal(r, tgt.T)
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_array_object(self):
         d = np.ones((6,))
         r = np.array([[d, d + 1], d + 2], dtype=object)
@@ -488,7 +501,7 @@ class TestArrayConstruction:
         d[1] = 3
         assert_array_equal(e, [1, 3, 3])
 
-    @pytest.mark.xfail(reason="order='F'")
+    @xfail  # (reason="order='F'")
     def test_array_copy_false_2(self):
         d = np.array([1, 2, 3])
         e = np.array(d, copy=False, order="F")
@@ -505,7 +518,7 @@ class TestArrayConstruction:
         assert_array_equal(e, [[1, 2, -7], [1, 2, 3]])
         assert_array_equal(d, [[1, 3, 3], [1, 2, 3]])
 
-    @pytest.mark.xfail(reason="order='F'")
+    @xfail  # (reason="order='F'")
     def test_array_copy_true_2(self):
         d = np.array([[1, 2, 3], [1, 2, 3]])
         e = np.array(d, copy=True, order="F")
@@ -524,9 +537,15 @@ class TestArrayConstruction:
         assert_(np.ascontiguousarray(d).flags.c_contiguous)
         # assert_(np.asfortranarray(d).flags.f_contiguous)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "func",
-        [np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray],
+        [
+            subtest(np.array, name="array"),
+            subtest(np.asarray, name="asarray"),
+            subtest(np.asanyarray, name="asanyarray"),
+            subtest(np.ascontiguousarray, name="ascontiguousarray"),
+            subtest(np.asfortranarray, name="asfortranarray"),
+        ],
     )
     def test_bad_arguments_error(self, func):
         with pytest.raises(TypeError):
@@ -536,10 +555,16 @@ class TestArrayConstruction:
         with pytest.raises(TypeError):
             func(1, 2, 3, 4, 5, 6, 7, 8)  # too many arguments
 
-    @pytest.mark.skip(reason="np.array w/keyword argument")
-    @pytest.mark.parametrize(
+    @skip(reason="np.array w/keyword argument")
+    @parametrize(
         "func",
-        [np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray],
+        [
+            subtest(np.array, name="array"),
+            subtest(np.asarray, name="asarray"),
+            subtest(np.asanyarray, name="asanyarray"),
+            subtest(np.ascontiguousarray, name="ascontiguousarray"),
+            subtest(np.asfortranarray, name="asfortranarray"),
+        ],
     )
     def test_array_as_keyword(self, func):
         # This should likely be made positional only, but do not change
@@ -550,7 +575,7 @@ class TestArrayConstruction:
             func(a=3)
 
 
-class TestAssignment:
+class TestAssignment(TestCase):
     def test_assignment_broadcasting(self):
         a = np.arange(6).reshape(2, 3)
 
@@ -592,7 +617,7 @@ class TestAssignment:
         assert_raises((RuntimeError, TypeError), assign, C())
         # assert_raises((TypeError, ValueError), assign, [1])  # numpy raises, we do not
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_unicode_assignment(self):
         # gh-5049
         from numpy.core.numeric import set_string_function
@@ -615,7 +640,7 @@ class TestAssignment:
         # this would crash for the same reason
         np.array([np.array("\xe5\xe4\xf6")])
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_stringlike_empty_list(self):
         # gh-8902
         u = np.array(["done"])
@@ -634,7 +659,7 @@ class TestAssignment:
         assert_raises(ValueError, operator.setitem, u, 0, bad_sequence())
         assert_raises(ValueError, operator.setitem, b, 0, bad_sequence())
 
-    @pytest.mark.skip(reason="longdouble")
+    @skip(reason="longdouble")
     def test_longdouble_assignment(self):
         # only relevant if longdouble is larger than float
         # we're looking for loss of precision
@@ -667,7 +692,7 @@ class TestAssignment:
             arr = np.array([np.array(tinya)])
             assert_equal(arr[0], tinya)
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_cast_to_string(self):
         # cast to str should do "str(scalar)", not "str(scalar.item())"
         # Example: In python2, str(float) is truncated, so we want to avoid
@@ -677,7 +702,7 @@ class TestAssignment:
         assert_equal(a[0], b"1.1234567890123457")
 
 
-class TestDtypedescr:
+class TestDtypedescr(TestCase):
     def test_construction(self):
         d1 = np.dtype("i4")
         assert_equal(d1, np.dtype(np.int32))
@@ -685,9 +710,9 @@ class TestDtypedescr:
         assert_equal(d2, np.dtype(np.float64))
 
 
-@pytest.mark.xfail(reason="TODO: zero-rank?")
-class TestZeroRank:
-    def setup_method(self):
+@skip  # (reason="TODO: zero-rank?")   # FIXME: revert skip into xfail
+class TestZeroRank(TestCase):
+    def setUp(self):
         self.d = np.array(0), np.array("x", object)
 
     def test_ellipsis_subscript(self):
@@ -790,8 +815,8 @@ class TestZeroRank:
         assert_equal(xi.flags.f_contiguous, True)
 
 
-class TestScalarIndexing:
-    def setup_method(self):
+class TestScalarIndexing(TestCase):
+    def setUp(self):
         self.d = np.array([0, 1])[0]
 
     def test_ellipsis_subscript(self):
@@ -839,7 +864,7 @@ class TestScalarIndexing:
         # this assersion fails because 50 > NPY_MAXDIMS = 32
         # assert_raises(IndexError, subscript, a, (np.newaxis,)*50)
 
-    @pytest.mark.xfail(reason="pytorch disallows overlapping assignments")
+    @xfail  # (reason="pytorch disallows overlapping assignments")
     def test_overlapping_assignment(self):
         # With positive strides
         a = np.arange(4)
@@ -889,8 +914,8 @@ class TestScalarIndexing:
         assert_equal(a, [0, 1, 0, 1, 2])
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestCreation:
+@xfail  # (reason="TODO")
+class TestCreation(TestCase):
     """
     Test the np.array constructor
     """
@@ -930,7 +955,7 @@ class TestCreation:
         with pytest.raises(TypeError):
             np.array([b"1234", b"12345"], dtype="O").astype("V")
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "idx", [pytest.param(Ellipsis, id="arr"), pytest.param((), id="scalar")]
     )
     def test_structured_void_promotion(self, idx):
@@ -990,7 +1015,7 @@ class TestCreation:
             d = np.zeros(2, dtype="(2,4)i4, (2,4)i4")
             assert_equal(np.count_nonzero(d), 0)
 
-    @pytest.mark.slow
+    @slow
     def test_zeros_big(self):
         # test big array as they might be allocated different by the system
         types = np.typecodes["AllInteger"] + np.typecodes["AllFloat"]
@@ -1230,8 +1255,8 @@ class TestCreation:
         a = np.array([1, Decimal(1)])
         a = np.array([[1], [Decimal(1)]])
 
-    @pytest.mark.parametrize("dtype", [object, "O,O", "O,(3)O", "(2,3)O"])
-    @pytest.mark.parametrize(
+    @parametrize("dtype", [object, "O,O", "O,(3)O", "(2,3)O"])
+    @parametrize(
         "function",
         [
             np.ndarray,
@@ -1250,8 +1275,8 @@ class TestCreation:
         assert arr.tobytes() == expected
 
 
-class TestBool:
-    @pytest.mark.xfail(reason="bools not interned")
+class TestBool(TestCase):
+    @xfail  # (reason="bools not interned")
     def test_test_interning(self):
         a0 = np.bool_(0)
         b0 = np.bool_(False)
@@ -1268,7 +1293,7 @@ class TestBool:
         assert_equal(d[::2].sum(), d[::2].size)
         # assert_equal(d[::-2].sum(), d[::-2].size)
 
-    @pytest.mark.xfail(reason="frombuffer")
+    @xfail  # (reason="frombuffer")
     def test_sum_2(self):
         d = np.frombuffer(b"\xff\xff" * 100, dtype=bool)
         assert_equal(d.sum(), d.size)
@@ -1295,7 +1320,7 @@ class TestBool:
         # covers most cases of the 16 byte unrolled code
         self.check_count_nonzero(12, 17)
 
-    @pytest.mark.slow
+    @slow
     def test_count_nonzero_all(self):
         # check all combinations in a length 17 array
         # covers all cases of the 16 byte unrolled code
@@ -1331,23 +1356,24 @@ class TestBool:
                 assert_(isinstance(v.astype(bool), np.ndarray))
                 assert_(v[()].astype(bool) is np.True_)
 
-    @pytest.mark.skip(reason="np.void")
+    @skip(reason="np.void")
     def test_cast_from_void(self):
         self._test_cast_from_flexible(np.void)
 
-    @pytest.mark.xfail(reason="See gh-9847")
+    @xfail  # (reason="See gh-9847")
     def test_cast_from_unicode(self):
         self._test_cast_from_flexible(np.unicode_)
 
-    @pytest.mark.xfail(reason="See gh-9847")
+    @xfail  # (reason="See gh-9847")
     def test_cast_from_bytes(self):
         self._test_cast_from_flexible(np.bytes_)
 
 
-class TestMethods:
+@instantiate_parametrized_tests
+class TestMethods(TestCase):
     sort_kinds = ["quicksort", "heapsort", "stable"]
 
-    @pytest.mark.xfail(reason="all(..., where=...)")
+    @xfail  # (reason="all(..., where=...)")
     def test_all_where(self):
         a = np.array([[True, False, True], [False, False, False], [True, True, True]])
         wh_full = np.array(
@@ -1367,7 +1393,7 @@ class TestMethods:
         assert_equal(a.all(where=False), True)
         assert_equal(np.all(a, where=False), True)
 
-    @pytest.mark.xfail(reason="any(..., where=...)")
+    @xfail  # (reason="any(..., where=...)")
     def test_any_where(self):
         a = np.array([[True, False, True], [False, False, False], [True, True, True]])
         wh_full = np.array(
@@ -1388,7 +1414,7 @@ class TestMethods:
         assert_equal(a.any(where=False), False)
         assert_equal(np.any(a, where=False), False)
 
-    @pytest.mark.xfail(reason="TODO: compress")
+    @xfail  # (reason="TODO: compress")
     def test_compress(self):
         tgt = [[5, 6, 7, 8, 9]]
         arr = np.arange(10).reshape(2, 5)
@@ -1429,7 +1455,7 @@ class TestMethods:
         assert out is ret
         assert_equal(out[()], 20)
 
-    @pytest.mark.xfail(reason="choose(..., mode=...) not implemented")
+    @xfail  # (reason="choose(..., mode=...) not implemented")
     def test_choose_2(self):
         # gh-6272 check overlap on out
         x = np.arange(5)
@@ -1480,7 +1506,7 @@ class TestMethods:
         A = m_rect.repeat(2, axis=1)
         assert_equal(A, [[1, 1, 2, 2, 3, 3], [4, 4, 5, 5, 6, 6]])
 
-    @pytest.mark.xfail(reason="reshape(..., order='F')")
+    @xfail  # (reason="reshape(..., order='F')")
     def test_reshape(self):
         arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
 
@@ -1539,7 +1565,7 @@ class TestMethods:
         b = np.sort(a)
         assert_equal(b, np.flip(a), msg)
 
-    @pytest.mark.xfail(reason="sort complex")
+    @xfail  # (reason="sort complex")
     def test_sort_complex_nans(self):
         # check complex
         msg = "Test complex sort order with nans"
@@ -1555,7 +1581,7 @@ class TestMethods:
     # algorithm because quick and merge sort fall over to insertion
     # sort for small arrays.
 
-    @pytest.mark.parametrize("dtype", [np.uint8, np.float16, np.float32, np.float64])
+    @parametrize("dtype", [np.uint8, np.float16, np.float32, np.float64])
     def test_sort_unsigned(self, dtype):
         a = np.arange(101, dtype=dtype)
         b = np.flip(a)
@@ -1568,7 +1594,7 @@ class TestMethods:
             c.sort(kind=kind)
             assert_equal(c, a, msg)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "dtype",
         [np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64],
     )
@@ -1584,9 +1610,9 @@ class TestMethods:
             c.sort(kind=kind)
             assert_equal(c, a, msg)
 
-    @pytest.mark.xfail(reason="sort complex")
-    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-    @pytest.mark.parametrize("part", ["real", "imag"])
+    @xfail  # (reason="sort complex")
+    @parametrize("dtype", [np.float32, np.float64])
+    @parametrize("part", ["real", "imag"])
     def test_sort_complex(self, part, dtype):
         # test complex sorts. These use the same code as the scalars
         # but the compare function differs.
@@ -1635,7 +1661,7 @@ class TestMethods:
         msg = "test empty array sort with axis=None"
         assert_equal(np.sort(a, axis=None), a.ravel(), msg)
 
-    @pytest.mark.skip(reason="waaay tooo sloooow")
+    @skip(reason="waaay tooo sloooow")
     def test_sort_degraded(self):
         # test degraded dataset would take minutes to run with normal qsort
         d = np.arange(1000000)
@@ -1651,7 +1677,7 @@ class TestMethods:
         assert_equal(np.sort(d), do)
         assert_equal(d[np.argsort(d)], do)
 
-    @pytest.mark.xfail(reason="order='F'")
+    @xfail  # (reason="order='F'")
     def test_copy(self):
         def assert_fortran(arr):
             assert_(arr.flags.fortran)
@@ -1677,8 +1703,8 @@ class TestMethods:
         assert_fortran(a.copy("F"))
         assert_c(a.copy("A"))
 
-    @pytest.mark.skip(reason="no .ctypes attribute")
-    @pytest.mark.parametrize("dtype", [np.int32])
+    @skip(reason="no .ctypes attribute")
+    @parametrize("dtype", [np.int32])
     def test__deepcopy__(self, dtype):
         # Force the entry of NULLs into array
         a = np.empty(4, dtype=dtype)
@@ -1706,7 +1732,7 @@ class TestMethods:
                 assert_equal(a.copy().argsort(kind=kind), a, msg)
                 assert_equal(b.copy().argsort(kind=kind), b, msg)
 
-    @pytest.mark.skip(reason="argsort complex")
+    @skip(reason="argsort complex")
     def test_argsort_complex(self):
         a = np.arange(101, dtype=np.float32)
         b = np.flip(a)
@@ -1733,7 +1759,7 @@ class TestMethods:
                 msg = f"byte-swapped complex argsort, dtype={dt}"
                 assert_equal(arr.argsort(), np.arange(len(arr), dtype=np.intp), msg)
 
-    @pytest.mark.xfail(reason="argsort axis TODO")
+    @xfail  # (reason="argsort axis TODO")
     def test_argsort_axis(self):
         # check axis handling. This should be the same for all type
         # specific argsorts, so we only check it for one type and one kind
@@ -1770,8 +1796,8 @@ class TestMethods:
         a = np.array(["aaaaaaaaa" for i in range(100)], dtype=np.unicode_)
         assert_equal(a.argsort(kind="m"), r)
 
-    @pytest.mark.xfail(reason="TODO: searchsorted with nans differs in pytorch")
-    @pytest.mark.parametrize(
+    @xfail  # (reason="TODO: searchsorted with nans differs in pytorch")
+    @parametrize(
         "a",
         [
             np.array([0, 1, np.nan], dtype=np.float16),
@@ -1795,9 +1821,9 @@ class TestMethods:
         y = np.searchsorted(x, x[-1])
         assert_equal(y, 2)
 
-    @pytest.mark.xfail(
-        reason="'searchsorted_out_cpu' not implemented for 'ComplexDouble'"
-    )
+    @xfail  # (
+    #    reason="'searchsorted_out_cpu' not implemented for 'ComplexDouble'"
+    # )
     def test_searchsorted_complex(self):
         # test for complex arrays containing nans.
         # The search sorted routines use the compare functions for the
@@ -1842,9 +1868,9 @@ class TestMethods:
         b = a.searchsorted([0, 1, 2], "right")
         assert_equal(b, [0, 2, 2])
 
-    @pytest.mark.xfail(
-        reason="RuntimeError: self.storage_offset() must be divisible by 8"
-    )
+    @xfail  # (
+    #    reason="RuntimeError: self.storage_offset() must be divisible by 8"
+    # )
     def test_searchsorted_unaligned_array(self):
         # Test searching unaligned array
         a = np.arange(10)
@@ -1885,7 +1911,7 @@ class TestMethods:
             b = a.searchsorted(a, "right")
             assert_equal(b, out + 1)
 
-    @pytest.mark.xfail(reason="ndarray ctor")
+    @xfail  # (reason="ndarray ctor")
     def test_searchsorted_type_specific_2(self):
         # Test all type specific binary search functions
         types = "".join((np.typecodes["AllInteger"], np.typecodes["AllFloat"], "?"))
@@ -1921,7 +1947,7 @@ class TestMethods:
         # assert_raises(ValueError, np.searchsorted, a, 0, sorter=[-1, 0, 1, 2, 3])
         # assert_raises(ValueError, np.searchsorted, a, 0, sorter=[4, 0, -1, 2, 3])
 
-    @pytest.mark.xfail(reason="self.storage_offset() must be divisible by 8")
+    @xfail  # (reason="self.storage_offset() must be divisible by 8")
     def test_searchsorted_with_sorter(self):
         a = np.random.rand(300)
         s = a.argsort()
@@ -1996,23 +2022,23 @@ class TestMethods:
         b = a.searchsorted(a, "right", s)
         assert_equal(b, out + 1)
 
-    @pytest.mark.xfail(reason="TODO argpartition")
-    @pytest.mark.parametrize("dtype", np.typecodes["All"])
+    @xfail  # (reason="TODO argpartition")
+    @parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):
         # Test out of range values in kth raise an error, gh-5469
         d = np.arange(10).astype(dtype=dtype)
         assert_raises(ValueError, d.argpartition, 10)
         assert_raises(ValueError, d.argpartition, -11)
 
-    @pytest.mark.xfail(reason="TODO partition")
-    @pytest.mark.parametrize("dtype", np.typecodes["All"])
+    @xfail  # (reason="TODO partition")
+    @parametrize("dtype", np.typecodes["All"])
     def test_partition_out_of_range(self, dtype):
         # Test out of range values in kth raise an error, gh-5469
         d = np.arange(10).astype(dtype=dtype)
         assert_raises(ValueError, d.partition, 10)
         assert_raises(ValueError, d.partition, -11)
 
-    @pytest.mark.xfail(reason="TODO argpartition")
+    @xfail  # (reason="TODO argpartition")
     def test_argpartition_integer(self):
         # Test non-integer values in kth raise an error/
         d = np.arange(10)
@@ -2022,7 +2048,7 @@ class TestMethods:
         d_obj = np.arange(10, dtype=object)
         assert_raises(TypeError, d_obj.argpartition, 9.0)
 
-    @pytest.mark.xfail(reason="TODO partition")
+    @xfail  # (reason="TODO partition")
     def test_partition_integer(self):
         # Test out of range values in kth raise an error, gh-5469
         d = np.arange(10)
@@ -2032,8 +2058,8 @@ class TestMethods:
         d_obj = np.arange(10, dtype=object)
         assert_raises(TypeError, d_obj.partition, 9.0)
 
-    @pytest.mark.xfail(reason="TODO partition")
-    @pytest.mark.parametrize("kth_dtype", np.typecodes["AllInteger"])
+    @xfail  # (reason="TODO partition")
+    @parametrize("kth_dtype", np.typecodes["AllInteger"])
     def test_partition_empty_array(self, kth_dtype):
         # check axis handling for multidimensional empty arrays
         kth = np.array(0, dtype=kth_dtype)[()]
@@ -2045,8 +2071,8 @@ class TestMethods:
         msg = "test empty array partition with axis=None"
         assert_equal(np.partition(a, kth, axis=None), a.ravel(), msg)
 
-    @pytest.mark.xfail(reason="TODO argpartition")
-    @pytest.mark.parametrize("kth_dtype", np.typecodes["AllInteger"])
+    @xfail  # (reason="TODO argpartition")
+    @parametrize("kth_dtype", np.typecodes["AllInteger"])
     def test_argpartition_empty_array(self, kth_dtype):
         # check axis handling for multidimensional empty arrays
         kth = np.array(0, dtype=kth_dtype)[()]
@@ -2064,7 +2090,7 @@ class TestMethods:
             msg,
         )
 
-    @pytest.mark.xfail(reason="TODO partition")
+    @xfail  # (reason="TODO partition")
     def test_partition(self):
         d = np.arange(10)
         assert_raises(TypeError, np.partition, d, 2, kind=1)
@@ -2325,7 +2351,7 @@ class TestMethods:
             )
             prev = k + 1
 
-    @pytest.mark.xfail(reason="TODO partition")
+    @xfail  # (reason="TODO partition")
     def test_partition_iterative(self):
         d = np.arange(17)
         kth = (0, 1, 2, 429, 231)
@@ -2392,7 +2418,7 @@ class TestMethods:
         for i in range(d0.shape[1]):
             self.assert_partitioned(p[:, i], kth)
 
-    @pytest.mark.xfail(reason="TODO partition")
+    @xfail  # (reason="TODO partition")
     def test_partition_fuzz(self):
         # a few rounds of random data testing
         for j in range(10, 30):
@@ -2409,8 +2435,8 @@ class TestMethods:
                     err_msg=f"data: {d!r}\n kth: {kth!r}",
                 )
 
-    @pytest.mark.xfail(reason="TODO partition")
-    @pytest.mark.parametrize("kth_dtype", np.typecodes["AllInteger"])
+    @xfail  # (reason="TODO partition")
+    @parametrize("kth_dtype", np.typecodes["AllInteger"])
     def test_argpartition_gh5524(self, kth_dtype):
         #  A test for functionality of argpartition on lists.
         kth = np.array(1, dtype=kth_dtype)[()]
@@ -2418,7 +2444,7 @@ class TestMethods:
         p = np.argpartition(d, kth)
         self.assert_partitioned(np.array(d)[p], [1])
 
-    @pytest.mark.xfail(reason="TODO order='F'")
+    @xfail  # (reason="TODO order='F'")
     def test_flatten(self):
         x0 = np.array([[1, 2, 3], [4, 5, 6]], np.int32)
         x1 = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], np.int32)
@@ -2433,7 +2459,7 @@ class TestMethods:
         assert_equal(x1.flatten("F"), y1f)
         assert_equal(x1.flatten("F"), x1.T.flatten())
 
-    @pytest.mark.parametrize("func", (np.dot, np.matmul))
+    @parametrize("func", (np.dot, np.matmul))
     def test_arr_mult(self, func):
         a = np.array([[1, 0], [0, 1]])
         b = np.array([[0, 1], [1, 0]])
@@ -2494,8 +2520,8 @@ class TestMethods:
                 func(edf[::2, :].copy(), edf[: edf.shape[0] // 2, :].T.copy()),
             )
 
-    @pytest.mark.skip(reason="dot/matmul with negative strides")
-    @pytest.mark.parametrize("func", (np.dot, np.matmul))
+    @skip(reason="dot/matmul with negative strides")
+    @parametrize("func", (np.dot, np.matmul))
     def test_arr_mult_2(self, func):
         # syrk - different shape, stride, and view validations
         for et in [np.float32, np.float64, np.complex64, np.complex128]:
@@ -2509,8 +2535,8 @@ class TestMethods:
             assert_equal(func(edf, edf[::-1, :].T), func(edf, edf[::-1, :].T.copy()))
             assert_equal(func(edf, edf[:, ::-1].T), func(edf, edf[:, ::-1].T.copy()))
 
-    @pytest.mark.parametrize("func", (np.dot, np.matmul))
-    @pytest.mark.parametrize("dtype", "ifdFD")
+    @parametrize("func", (np.dot, np.matmul))
+    @parametrize("dtype", "ifdFD")
     def test_no_dgemv(self, func, dtype):
         # check vector arg for contiguous before gemv
         # gh-12156
@@ -2524,9 +2550,9 @@ class TestMethods:
         ret2 = func(b.T.copy(), a.T)
         assert_equal(ret1, ret2)
 
-    @pytest.mark.skip(reason="__array_interface__")
-    @pytest.mark.parametrize("func", (np.dot, np.matmul))
-    @pytest.mark.parametrize("dtype", "ifdFD")
+    @skip(reason="__array_interface__")
+    @parametrize("func", (np.dot, np.matmul))
+    @parametrize("dtype", "ifdFD")
     def test_no_dgemv_2(self, func, dtype):
         # check for unaligned data
         dt = np.dtype(dtype)
@@ -2561,7 +2587,7 @@ class TestMethods:
         a.dot(b=b, out=c)
         assert_equal(c, np.dot(a, b))
 
-    @pytest.mark.xfail(reason="_aligned_zeros")
+    @xfail  # (reason="_aligned_zeros")
     def test_dot_out_mem_overlap(self):
         np.random.seed(1)
 
@@ -2583,7 +2609,7 @@ class TestMethods:
             assert_raises(ValueError, np.dot, a, b, out=b[::2])
             assert_raises(ValueError, np.dot, a, b, out=b.T)
 
-    @pytest.mark.xfail(reason="TODO: overlapping memor in matmul")
+    @xfail  # (reason="TODO: overlapping memor in matmul")
     def test_matmul_out(self):
         # overlapping memory
         a = np.arange(18).reshape(2, 3, 3)
@@ -2619,7 +2645,7 @@ class TestMethods:
         # Order of axis argument doesn't matter:
         assert_equal(b.diagonal(0, 2, 1), [[0, 3], [4, 7]])
 
-    @pytest.mark.xfail(reason="no readonly views")
+    @xfail  # (reason="no readonly views")
     def test_diagonal_view_notwriteable(self):
         a = np.eye(3).diagonal()
         assert_(not a.flags.writeable)
@@ -2710,7 +2736,7 @@ class TestMethods:
         bad_array = [1, 2, 3]
         assert_raises(TypeError, np.put, bad_array, [0, 2], 5)
 
-    @pytest.mark.xfail(reason="TODO: implement order='F'")
+    @xfail  # (reason="TODO: implement order='F'")
     def test_ravel(self):
         a = np.array([[0, 1], [2, 3]])
         assert_equal(a.ravel(), [0, 1, 2, 3])
@@ -2919,13 +2945,13 @@ class TestMethods:
         assert_raises(ValueError, complex, c)
 
 
-class TestCequenceMethods:
+class TestCequenceMethods(TestCase):
     def test_array_contains(self):
         assert_(4.0 in np.arange(16.0).reshape(4, 4))
         assert_(20.0 not in np.arange(16.0).reshape(4, 4))
 
 
-class TestBinop:
+class TestBinop(TestCase):
     def test_inplace(self):
         # test refcount 1 inplace conversion
         assert_array_almost_equal(np.array([0.5]) * np.array([1.0, 2.0]), [0.5, 1.0])
@@ -2956,15 +2982,15 @@ class TestBinop:
         assert_equal(b, 3)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestSubscripting:
+@xfail  # (reason="TODO")
+class TestSubscripting(TestCase):
     def test_test_zero_rank(self):
         x = np.array([1, 2, 3])
         assert_(isinstance(x[0], np.int_))
         assert_(type(x[0, ...]) is np.ndarray)
 
 
-class TestFancyIndexing:
+class TestFancyIndexing(TestCase):
     def test_list(self):
         x = np.ones((1, 1))
         x[:, [0]] = 2.0
@@ -3018,7 +3044,8 @@ class TestFancyIndexing:
         assert_array_equal(x, np.array([[1, 10, 3, 4], [5, 6, 7, 8]]))
 
 
-class TestArgmaxArgminCommon:
+@instantiate_parametrized_tests
+class TestArgmaxArgminCommon(TestCase):
     sizes = [
         (),
         (3,),
@@ -3036,16 +3063,21 @@ class TestArgmaxArgminCommon:
         (256,),
     ]
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "size, axis",
-        itertools.chain(
-            *[
-                [(size, axis) for axis in list(range(-len(size), len(size))) + [None]]
-                for size in sizes
-            ]
+        list(
+            itertools.chain(
+                *[
+                    [
+                        (size, axis)
+                        for axis in list(range(-len(size), len(size))) + [None]
+                    ]
+                    for size in sizes
+                ]
+            )
         ),
     )
-    @pytest.mark.parametrize("method", [np.argmax, np.argmin])
+    @parametrize("method", [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
         arr = np.random.normal(size=size)
         if size is None or size == ():
@@ -3114,8 +3146,8 @@ class TestArgmaxArgminCommon:
             with pytest.raises(ValueError):
                 method(arr.T, axis=axis, out=wrong_outarray, keepdims=True)
 
-    @pytest.mark.xfail(reason="TODO: implement choose")
-    @pytest.mark.parametrize("method", ["max", "min"])
+    @xfail  # (reason="TODO: implement choose")
+    @parametrize("method", ["max", "min"])
     def test_all(self, method):
         a = np.random.normal(0, 1, (4, 5, 6, 7, 8))
         arg_method = getattr(a, "arg" + method)
@@ -3127,7 +3159,7 @@ class TestArgmaxArgminCommon:
             axes.remove(i)
             assert_(np.all(a_maxmin == aarg_maxmin.choose(*a.transpose(i, *axes))))
 
-    @pytest.mark.parametrize("method", ["argmax", "argmin"])
+    @parametrize("method", ["argmax", "argmin"])
     def test_output_shape(self, method):
         # see also gh-616
         a = np.ones((10, 5))
@@ -3147,8 +3179,8 @@ class TestArgmaxArgminCommon:
         arg_method(-1, out=out)
         assert_equal(out, arg_method(-1))
 
-    @pytest.mark.parametrize("ndim", [0, 1])
-    @pytest.mark.parametrize("method", ["argmax", "argmin"])
+    @parametrize("ndim", [0, 1])
+    @parametrize("method", ["argmax", "argmin"])
     def test_ret_is_out(self, ndim, method):
         a = np.ones((4,) + (256,) * ndim)
         arg_method = getattr(a, method)
@@ -3156,7 +3188,7 @@ class TestArgmaxArgminCommon:
         ret = arg_method(axis=0, out=out)
         assert ret is out
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "arr_method, np_method", [("argmax", np.argmax), ("argmin", np.argmin)]
     )
     def test_np_vs_ndarray(self, arr_method, np_method):
@@ -3178,7 +3210,8 @@ class TestArgmaxArgminCommon:
         assert_equal(out1, out2)
 
 
-class TestArgmax:
+@instantiate_parametrized_tests
+class TestArgmax(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 0),
         ([3, 3, 3, 3, 2, 2, 2, 2], 0),
@@ -3242,7 +3275,7 @@ class TestArgmax:
         ([True, False, True, False, False], 0),
     ]
 
-    @pytest.mark.parametrize("data", nan_arr)
+    @parametrize("data", nan_arr)
     def test_combinations(self, data):
         arr, pos = data
         with suppress_warnings() as sup:
@@ -3286,7 +3319,8 @@ class TestArgmax:
         assert_equal(np.argmax(a), 129)
 
 
-class TestArgmin:
+@instantiate_parametrized_tests
+class TestArgmin(TestCase):
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 8),
         ([3, 3, 3, 3, 2, 2, 2, 2], 4),
@@ -3350,7 +3384,7 @@ class TestArgmin:
         ([False, True, False, True, True], 0),
     ]
 
-    @pytest.mark.parametrize("data", nan_arr)
+    @parametrize("data", nan_arr)
     def test_combinations(self, data):
         arr, pos = data
         with suppress_warnings() as sup:
@@ -3394,12 +3428,12 @@ class TestArgmin:
         assert_equal(np.argmin(a), 129)
 
 
-class TestMinMax:
+class TestMinMax(TestCase):
+    @xfail
     def test_scalar(self):
         assert_raises(np.AxisError, np.amax, 1, 1)
         assert_raises(np.AxisError, np.amin, 1, 1)
 
-        pytest.xfail(reason="min/max/argmin/argmax on 0D arrays & axis")
         assert_equal(np.amax(1, axis=0), 1)
         assert_equal(np.amin(1, axis=0), 1)
         assert_equal(np.amax(1, axis=None), 1)
@@ -3410,14 +3444,14 @@ class TestMinMax:
         assert_equal(np.amax([[1, 2, 3]], axis=1), 3)
 
 
-class TestNewaxis:
+class TestNewaxis(TestCase):
     def test_basic(self):
         sk = np.array([0, -0.1, 0.1])
         res = 250 * sk[:, np.newaxis]
         assert_almost_equal(res.ravel(), 250 * sk)
 
 
-class TestClip:
+class TestClip(TestCase):
     def _check_range(self, x, cmin, cmax):
         assert_(np.all(x >= cmin))
         assert_(np.all(x <= cmax))
@@ -3463,7 +3497,7 @@ class TestClip:
                 self._check_range(x, expected_min, expected_max)
         return x
 
-    @pytest.mark.skip(reason="endianness")
+    @skip(reason="endianness")
     def test_basic(self):
         for inplace in [False, True]:
             self._clip_type("float", 1024, -12.8, 100.2, inplace=inplace)
@@ -3491,8 +3525,8 @@ class TestClip:
         assert_array_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestCompress:
+@xfail  # (reason="TODO")
+class TestCompress(TestCase):
     def test_axis(self):
         tgt = [[5, 6, 7, 8, 9]]
         arr = np.arange(10).reshape(2, 5)
@@ -3515,8 +3549,8 @@ class TestCompress:
         assert_equal(out, 1)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestPutmask:
+@xfail  # (reason="TODO")
+class TestPutmask(TestCase):
     def tst_basic(self, x, T, mask, val):
         np.putmask(x, mask, val)
         assert_equal(x[mask], np.array(val, T))
@@ -3542,7 +3576,7 @@ class TestPutmask:
     def test_mask_size(self):
         assert_raises(ValueError, np.putmask, np.array([1, 2, 3]), [True], 5)
 
-    @pytest.mark.parametrize("dtype", (">i4", "<i4"))
+    @parametrize("dtype", (">i4", "<i4"))
     def test_byteorder(self, dtype):
         x = np.array([1, 2, 3], dtype)
         np.putmask(x, [True, False, True], -1)
@@ -3597,7 +3631,8 @@ class TestPutmask:
             np.putmask(a=x, values=[-1, -2], mask=[0, 1])
 
 
-class TestTake:
+@instantiate_parametrized_tests
+class TestTake(TestCase):
     def tst_basic(self, x):
         ind = list(range(x.shape[0]))
         assert_array_equal(np.take(x, ind, axis=0), x)
@@ -3616,14 +3651,14 @@ class TestTake:
         assert_raises(IndexError, np.take, x, [-3], axis=0)
         assert_array_equal(np.take(x, [-1], axis=0)[0], x[1])
 
-    @pytest.mark.xfail(reason="XXX: take(..., mode='clip')")
+    @xfail  # (reason="XXX: take(..., mode='clip')")
     def test_clip(self):
         x = np.random.random(24) * 100
         x = np.reshape(x, (2, 3, 4))
         assert_array_equal(np.take(x, [-1], axis=0, mode="clip")[0], x[0])
         assert_array_equal(np.take(x, [2], axis=0, mode="clip")[0], x[1])
 
-    @pytest.mark.xfail(reason="XXX: take(..., mode='wrap')")
+    @xfail  # (reason="XXX: take(..., mode='wrap')")
     def test_wrap(self):
         x = np.random.random(24) * 100
         x = np.reshape(x, (2, 3, 4))
@@ -3631,14 +3666,14 @@ class TestTake:
         assert_array_equal(np.take(x, [2], axis=0, mode="wrap")[0], x[0])
         assert_array_equal(np.take(x, [3], axis=0, mode="wrap")[0], x[1])
 
-    @pytest.mark.xfail(reason="XXX: take(mode='wrap')")
+    @xfail  # (reason="XXX: take(mode='wrap')")
     def test_out_overlap(self):
         # gh-6272 check overlap on out
         x = np.arange(5)
         y = np.take(x, [1, 2, 3], out=x[2:5], mode="wrap")
         assert_equal(y, np.array([1, 2, 3]))
 
-    @pytest.mark.parametrize("shape", [(1, 2), (1,), ()])
+    @parametrize("shape", [(1, 2), (1,), ()])
     def test_ret_is_out(self, shape):
         # 0d arrays should not be an exception to this rule
         x = np.arange(5)
@@ -3648,9 +3683,9 @@ class TestTake:
         assert ret is out
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestLexsort:
-    @pytest.mark.parametrize(
+@xfail  # (reason="TODO")
+class TestLexsort(TestCase):
+    @parametrize(
         "dtype",
         [
             np.uint8,
@@ -3713,8 +3748,8 @@ class TestLexsort:
         assert_raises(np.AxisError, np.lexsort, x, axis=2)
 
 
-@pytest.mark.skip(reason="dont worry about IO")
-class TestIO:
+@skip(reason="dont worry about IO")
+class TestIO(TestCase):
     """Test tofile, fromfile, tobytes, and fromstring"""
 
     @pytest.fixture()
@@ -4061,7 +4096,7 @@ class TestIO:
             dtype="<f4",
         )
 
-    @pytest.mark.slow  # takes > 1 minute on mechanical hard drive
+    @slow  # takes > 1 minute on mechanical hard drive
     def test_big_binary(self):
         """Test workarounds for 32-bit limit for MSVC fwrite, fseek, and ftell
 
@@ -4207,17 +4242,17 @@ class TestIO:
         assert_array_equal(res, expected)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestFromBuffer:
-    @pytest.mark.parametrize("byteorder", ["<", ">"])
-    @pytest.mark.parametrize("dtype", [float, int, complex])
+@xfail  # (reason="TODO")
+class TestFromBuffer(TestCase):
+    @parametrize("byteorder", ["<", ">"])
+    @parametrize("dtype", [float, int, complex])
     def test_basic(self, byteorder, dtype):
         dt = np.dtype(dtype).newbyteorder(byteorder)
         x = (np.random.random((4, 7)) * 5).astype(dt)
         buf = x.tobytes()
         assert_array_equal(np.frombuffer(buf, dtype=dt), x.flat)
 
-    @pytest.mark.parametrize("obj", [np.arange(10), b"12345678"])
+    @parametrize("obj", [np.arange(10), b"12345678"])
     def test_array_base(self, obj):
         # Objects (including NumPy arrays), which do not use the
         # `release_buffer` slot should be directly used as a base object.
@@ -4248,9 +4283,9 @@ class TestFromBuffer:
             mm.close()
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestFlat:
-    def setup_method(self):
+@skip  # (reason="TODO")   # FIXME: skip -> xfail (a0.shape = (4, 5) raises)
+class TestFlat(TestCase):
+    def setUp(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)
         a0.shape = (4, 5)
@@ -4321,7 +4356,7 @@ class TestFlat:
         assert it.index == it.base.size
 
 
-class TestResize:
+class TestResize(TestCase):
     @_no_tracing
     def test_basic(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -4334,7 +4369,7 @@ class TestResize:
         )
         assert_array_equal(x[9:].ravel(), 0)
 
-    @pytest.mark.skip(reason="how to find if someone is refencing an array")
+    @skip(reason="how to find if someone is refencing an array")
     def test_check_reference(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         y = x
@@ -4402,7 +4437,7 @@ class TestResize:
         x_view.resize((0, 10))
         x_view.resize((0, 100))
 
-    @pytest.mark.skip(reason="ignore weakrefs for ndarray.resize")
+    @skip(reason="ignore weakrefs for ndarray.resize")
     def test_check_weakref(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         xref = weakref.ref(x)
@@ -4422,10 +4457,11 @@ def _std(a, **args):
     return a.std(**args)
 
 
-class TestStats:
+@instantiate_parametrized_tests
+class TestStats(TestCase):
     funcs = [_mean, _var, _std]
 
-    def setup_method(self):
+    def setUp(self):
         np.random.seed(3)
         self.rmat = np.random.random((4, 5))
         self.cmat = self.rmat + 1j * self.rmat
@@ -4586,7 +4622,7 @@ class TestStats:
         with assert_raises(np.AxisError):
             np.arange(10).mean(axis=2)
 
-    @pytest.mark.xfail(reason="implement mean(..., where=...)")
+    @xfail  # (reason="implement mean(..., where=...)")
     def test_mean_where(self):
         a = np.arange(16).reshape((4, 4))
         wh_full = np.array(
@@ -4632,8 +4668,8 @@ class TestStats:
                 res = _var(mat, axis=axis)
                 assert_almost_equal(res, tgt)
 
-    @pytest.mark.parametrize(
-        ("complex_dtype", "ndec"),
+    @parametrize(
+        "complex_dtype, ndec",
         (
             ("complex64", 6),
             ("complex128", 7),
@@ -4660,7 +4696,7 @@ class TestStats:
             res = _var(mat, axis=axis)
             assert_almost_equal(res, tgt)
 
-    @pytest.mark.skip(reason="endianness")
+    @skip(reason="endianness")
     def test_var_complex_byteorder(self):
         # Test that var fast-path does not cause failures for complex arrays
         # with non-native byteorder
@@ -4674,7 +4710,7 @@ class TestStats:
         with assert_raises(np.AxisError):
             np.arange(10).var(axis=2)
 
-    @pytest.mark.xfail(reason="implement var(..., where=...)")
+    @xfail  # (reason="implement var(..., where=...)")
     def test_var_where(self):
         a = np.arange(25).reshape((5, 5))
         wh_full = np.array(
@@ -4719,7 +4755,7 @@ class TestStats:
                 res = _std(mat, axis=axis)
                 assert_almost_equal(res, tgt)
 
-    @pytest.mark.xfail(reason="implement std(..., where=...)")
+    @xfail  # (reason="implement std(..., where=...)")
     def test_std_where(self):
         a = np.arange(25).reshape((5, 5))[::-1]
         whf = np.array(
@@ -4762,7 +4798,7 @@ class TestStats:
             assert_equal(np.std(a, where=False), np.nan)
 
 
-class TestVdot:
+class TestVdot(TestCase):
     def test_basic(self):
         dt_numeric = np.typecodes["AllFloat"] + np.typecodes["AllInteger"]
         dt_complex = np.typecodes["Complex"]
@@ -4789,7 +4825,7 @@ class TestVdot:
         assert_(np.isscalar(res))
         assert_equal(np.vdot(b, b), True)
 
-    @pytest.mark.xfail(reason="implement order='F'")
+    @xfail  # (reason="implement order='F'")
     def test_vdot_array_order(self):
         a = np.array([[1, 2], [3, 4]], order="C")
         b = np.array([[1, 2], [3, 4]], order="F")
@@ -4815,7 +4851,7 @@ class TestVdot:
             assert_equal(np.vdot(a, b.copy()), np.vdot(a.flatten(), b.flatten()))
             assert_equal(np.vdot(a.copy(), b), np.vdot(a.flatten(), b.flatten()))
 
-    @pytest.mark.xfail(reason="implement order='F'")
+    @xfail  # (reason="implement order='F'")
     def test_vdot_uncontiguous_2(self):
         # test order='F' separately
         for size in [2, 1000]:
@@ -4832,8 +4868,8 @@ class TestVdot:
             assert_equal(np.vdot(a, b.copy("F")), np.vdot(a.flatten(), b.flatten()))
 
 
-class TestDot:
-    def setup_method(self):
+class TestDot(TestCase):
+    def setUp(self):
         np.random.seed(128)
 
         # Numpy and pytorch random streams differ, so inline the
@@ -4961,7 +4997,7 @@ class TestDot:
             assert_(res.shape == tgt.shape)
             assert_almost_equal(res, tgt, decimal=self.N)
 
-    @pytest.mark.skip(reason="numpy internals")
+    @skip(reason="numpy internals")
     def test_dot_2args(self):
         from numpy.core.multiarray import dot
 
@@ -4972,7 +5008,7 @@ class TestDot:
         d = dot(a, b)
         assert_allclose(c, d)
 
-    @pytest.mark.skip(reason="numpy internals")
+    @skip(reason="numpy internals")
     def test_dot_3args(self):
         from numpy.core.multiarray import dot
 
@@ -4995,7 +5031,7 @@ class TestDot:
         assert_(r is dot(f, v, r))
         assert_array_equal(r2, r)
 
-    @pytest.mark.skip(reason="numpy internals")
+    @skip(reason="numpy internals")
     def test_dot_3args_errors(self):
         from numpy.core.multiarray import dot
 
@@ -5026,7 +5062,7 @@ class TestDot:
         r = np.empty((1024, 32), dtype=int)
         assert_raises(ValueError, dot, f, v, r)
 
-    @pytest.mark.xfail(reason="TODO order='F'")
+    @xfail  # (reason="TODO order='F'")
     def test_dot_array_order(self):
         a = np.array([[1, 2], [3, 4]], order="C")
         b = np.array([[1, 2], [3, 4]], order="F")
@@ -5037,7 +5073,7 @@ class TestDot:
         assert_equal(np.dot(b, a), res)
         assert_equal(np.dot(b, b), res)
 
-    @pytest.mark.skip(reason="TODO: nbytes, view, __array_interface__")
+    @skip(reason="TODO: nbytes, view, __array_interface__")
     def test_accelerate_framework_sgemv_fix(self):
         def aligned_array(shape, align, dtype, order="C"):
             d = dtype(0)
@@ -5101,8 +5137,8 @@ class TestDot:
             # Strides in A cols and X
             assert_dot_close(A_f_12, X_f_2, desired)
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+    @slow
+    @parametrize("dtype", [np.float64, np.complex128])
     @requires_memory(free_bytes=18e9)  # complex case needs 18GiB+
     def test_huge_vectordot(self, dtype):
         # Large vector multiplications are chunked with 32bit BLAS
@@ -5173,7 +5209,7 @@ class MatmulCommon:
                 res = self.matmul(*arg)
                 assert_(res.dtype == dt)
 
-    @pytest.mark.xfail(reason="no scalars")
+    @xfail  # (reason="no scalars")
     def test_result_types_2(self):
         # in numpy, vector vector returns scalars
         # we return a 0D array instead
@@ -5340,8 +5376,9 @@ class MatmulCommon:
         assert_equal(res, tgt12_21)
 
 
-class TestMatmul(MatmulCommon):
-    def setup_method(self):
+@instantiate_parametrized_tests
+class TestMatmul(MatmulCommon, TestCase):
+    def setUp(self):
         self.matmul = np.matmul
 
     def test_out_arg(self):
@@ -5419,50 +5456,50 @@ class TestMatmul(MatmulCommon):
     vr = np.arange(6.0)
     m0 = np.zeros((3, 0))
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "args",
         (
             # matrix-matrix
-            (m1, m2),
-            (m2.T, m1.T),
-            (m2.T.copy(), m1.T),
-            (m2.T, m1.T.copy()),
+            subtest((m1, m2), name="mm1"),
+            subtest((m2.T, m1.T), name="mm2"),
+            subtest((m2.T.copy(), m1.T), name="mm3"),
+            subtest((m2.T, m1.T.copy()), name="mm4"),
             # matrix-matrix-transpose, contiguous and non
-            (m1, m1.T),
-            (m1.T, m1),
-            (m1, m3.T),
-            (m3, m1.T),
-            (m3, m3.T),
-            (m3.T, m3),
+            subtest((m1, m1.T), name="mmT1"),
+            subtest((m1.T, m1), name="mmT2"),
+            subtest((m1, m3.T), name="mmT3"),
+            subtest((m3, m1.T), name="mmT4"),
+            subtest((m3, m3.T), name="mmT5"),
+            subtest((m3.T, m3), name="mmT6"),
             # matrix-matrix non-contiguous
-            (m3, m2),
-            (m2.T, m3.T),
-            (m2.T.copy(), m3.T),
+            subtest((m3, m2), name="mmN1"),
+            subtest((m2.T, m3.T), name="mmN2"),
+            subtest((m2.T.copy(), m3.T), name="mmN3"),
             # vector-matrix, matrix-vector, contiguous
-            (m1, vr[:3]),
-            (vc[:5], m1),
-            (m1.T, vc[:5]),
-            (vr[:3], m1.T),
+            subtest((m1, vr[:3]), name="vm1"),
+            subtest((vc[:5], m1), name="vm2"),
+            subtest((m1.T, vc[:5]), name="vm3"),
+            subtest((vr[:3], m1.T), name="vm4"),
             # vector-matrix, matrix-vector, vector non-contiguous
-            (m1, vr[::2]),
-            (vc[::2], m1),
-            (m1.T, vc[::2]),
-            (vr[::2], m1.T),
+            subtest((m1, vr[::2]), name="mvN1"),
+            subtest((vc[::2], m1), name="mvN2"),
+            subtest((m1.T, vc[::2]), name="mvN3"),
+            subtest((vr[::2], m1.T), name="mvN4"),
             # vector-matrix, matrix-vector, matrix non-contiguous
-            (m3, vr[:3]),
-            (vc[:5], m3),
-            (m3.T, vc[:5]),
-            (vr[:3], m3.T),
+            subtest((m3, vr[:3]), name="mvN5"),
+            subtest((vc[:5], m3), name="mvN6"),
+            subtest((m3.T, vc[:5]), name="mvN7"),
+            subtest((vr[:3], m3.T), name="mvN8"),
             # vector-matrix, matrix-vector, both non-contiguous
-            (m3, vr[::2]),
-            (vc[::2], m3),
-            (m3.T, vc[::2]),
-            (vr[::2], m3.T),
+            subtest((m3, vr[::2]), name="mvN9"),
+            subtest((vc[::2], m3), name="mvn10"),
+            subtest((m3.T, vc[::2]), name="mv11"),
+            subtest((vr[::2], m3.T), name="mv12"),
             # size == 0
-            (m0, m0.T),
-            (m0.T, m0),
-            (m1, m0),
-            (m0.T, m1.T),
+            subtest((m0, m0.T), name="s0_1"),
+            subtest((m0.T, m0), name="s0_2"),
+            subtest((m1, m0), name="s0_3"),
+            subtest((m0.T, m1.T), name="s0_4"),
         ),
     )
     def test_dot_equivalent(self, args):
@@ -5473,7 +5510,7 @@ class TestMatmul(MatmulCommon):
         r3 = np.matmul(args[0].copy(), args[1].copy())
         assert_equal(r1, r3)
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_matmul_exception_multiply(self):
         # test that matmul fails if `__mul__` is missing
         class add_not_multiply:
@@ -5484,7 +5521,7 @@ class TestMatmul(MatmulCommon):
         with assert_raises(TypeError):
             b = np.matmul(a, a)
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_matmul_exception_add(self):
         # test that matmul fails if `__add__` is missing
         class multiply_not_add:
@@ -5517,12 +5554,12 @@ class TestMatmul(MatmulCommon):
         assert not np.any(c)
 
 
-class TestMatmulOperator(MatmulCommon):
+class TestMatmulOperator(MatmulCommon, TestCase):
     import operator
 
     matmul = operator.matmul
 
-    @pytest.mark.skip(reason="no __array_priority__")
+    @skip(reason="no __array_priority__")
     def test_array_priority_override(self):
         class A:
             __array_priority__ = 1000
@@ -5541,35 +5578,33 @@ class TestMatmulOperator(MatmulCommon):
     def test_matmul_raises(self):
         assert_raises((RuntimeError, TypeError), self.matmul, np.int8(5), np.int8(5))
 
+    @xfail  # (reason="torch supports inplace matmul, and so do we")
+    def test_matmul_inplace(self):
+        # It would be nice to support in-place matmul eventually, but for now
+        # we don't have a working implementation, so better just to error out
+        # and nudge people to writing "a = a @ b".
+        a = np.eye(3)
+        b = np.eye(3)
+        assert_raises(TypeError, a.__imatmul__, b)
+        import operator
 
-@pytest.mark.xfail(reason="torch supports inplace matmul, and so do we")
-def test_matmul_inplace():
-    # It would be nice to support in-place matmul eventually, but for now
-    # we don't have a working implementation, so better just to error out
-    # and nudge people to writing "a = a @ b".
-    a = np.eye(3)
-    b = np.eye(3)
-    assert_raises(TypeError, a.__imatmul__, b)
-    import operator
+        assert_raises(TypeError, operator.imatmul, a, b)
+        assert_raises(TypeError, exec, "a @= b", globals(), locals())
 
-    assert_raises(TypeError, operator.imatmul, a, b)
-    assert_raises(TypeError, exec, "a @= b", globals(), locals())
-
-
-@pytest.mark.xfail(reason="matmul_axes")
-def test_matmul_axes():
-    a = np.arange(3 * 4 * 5).reshape(3, 4, 5)
-    c = np.matmul(a, a, axes=[(-2, -1), (-1, -2), (1, 2)])
-    assert c.shape == (3, 4, 4)
-    d = np.matmul(a, a, axes=[(-2, -1), (-1, -2), (0, 1)])
-    assert d.shape == (4, 4, 3)
-    e = np.swapaxes(d, 0, 2)
-    assert_array_equal(e, c)
-    f = np.matmul(a, np.arange(3), axes=[(1, 0), (0), (0)])
-    assert f.shape == (4, 5)
+    @xfail  # (reason="matmul_axes")
+    def test_matmul_axes(self):
+        a = np.arange(3 * 4 * 5).reshape(3, 4, 5)
+        c = np.matmul(a, a, axes=[(-2, -1), (-1, -2), (1, 2)])
+        assert c.shape == (3, 4, 4)
+        d = np.matmul(a, a, axes=[(-2, -1), (-1, -2), (0, 1)])
+        assert d.shape == (4, 4, 3)
+        e = np.swapaxes(d, 0, 2)
+        assert_array_equal(e, c)
+        f = np.matmul(a, np.arange(3), axes=[(1, 0), (0), (0)])
+        assert f.shape == (4, 5)
 
 
-class TestInner:
+class TestInner(TestCase):
     def test_inner_scalar_and_vector(self):
         for dt in np.typecodes["AllInteger"] + np.typecodes["AllFloat"] + "?":
             sca = np.array(3, dtype=dt)[()]
@@ -5606,7 +5641,7 @@ class TestInner:
             assert_equal(np.inner(A, A), desired)
             assert_equal(np.inner(A, A.copy()), desired)
 
-    @pytest.mark.skip(reason="[::-1] not supported")
+    @skip(reason="[::-1] not supported")
     def test_inner_product_reversed_view(self):
         for dt in np.typecodes["AllInteger"] + np.typecodes["AllFloat"] + "?":
             # check an inner product involving an aliased and reversed view
@@ -5637,8 +5672,9 @@ class TestInner:
             assert_equal(np.inner(b, a).transpose(2, 3, 0, 1), desired)
 
 
-class TestChoose:
-    def setup_method(self):
+@instantiate_parametrized_tests
+class TestChoose(TestCase):
+    def setUp(self):
         self.x = 2 * np.ones((3,), dtype=int)
         self.y = 3 * np.ones((3,), dtype=int)
         self.x2 = 2 * np.ones((2, 3), dtype=int)
@@ -5657,7 +5693,7 @@ class TestChoose:
         A = np.choose(self.ind, (self.x, self.y2))
         assert_equal(A, [[2, 2, 3], [2, 2, 3]])
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "ops",
         [
             (1000, np.array([1], dtype=np.uint8)),
@@ -5698,8 +5734,8 @@ class TestChoose:
         assert_equal(A, expected)
 
 
-class TestRepeat:
-    def setup_method(self):
+class TestRepeat(TestCase):
+    def setUp(self):
         self.m = np.array([1, 2, 3, 4, 5, 6])
         self.m_rect = self.m.reshape((2, 3))
 
@@ -5730,8 +5766,8 @@ class TestRepeat:
 NEIGH_MODE = {"zero": 0, "one": 1, "constant": 2, "circular": 3, "mirror": 4}
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestWarnings:
+@xfail  # (reason="TODO")
+class TestWarnings(TestCase):
     def test_complex_warning(self):
         x = np.array([1, 2])
         y = np.array([1 - 2j, 1 + 2j])
@@ -5742,7 +5778,7 @@ class TestWarnings:
             assert_equal(x, [1, 2])
 
 
-class TestMinScalarType:
+class TestMinScalarType(TestCase):
     def test_usigned_shortshort(self):
         dt = np.min_scalar_type(2**8 - 1)
         wanted = np.dtype("uint8")
@@ -5765,8 +5801,8 @@ class TestMinScalarType:
 from numpy.core._internal import _dtype_from_pep3118
 
 
-@pytest.mark.skip(reason="dont worry about buffer protocol")
-class TestPEP3118Dtype:
+@skip(reason="dont worry about buffer protocol")
+class TestPEP3118Dtype(TestCase):
     def _check(self, spec, wanted):
         dt = np.dtype(wanted)
         actual = _dtype_from_pep3118(spec)
@@ -5879,8 +5915,8 @@ class TestPEP3118Dtype:
         self._check("i:f0:", [("f0", "i")])
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestArrayCreationCopyArgument:
+@xfail  # (reason="TODO")
+class TestArrayCreationCopyArgument(TestCase):
     class RaiseOnBool:
         def __bool__(self):
             raise ValueError
@@ -6007,9 +6043,9 @@ class TestArrayCreationCopyArgument:
         with pytest.raises(ValueError):
             np.array(arr, copy=np._CopyMode.NEVER)
 
-    @pytest.mark.parametrize("arr", [np.ones(()), np.arange(81).reshape((9, 9))])
-    @pytest.mark.parametrize("order1", ["C", "F", None])
-    @pytest.mark.parametrize("order2", ["C", "F", "A", "K"])
+    @parametrize("arr", [np.ones(()), np.arange(81).reshape((9, 9))])
+    @parametrize("order1", ["C", "F", None])
+    @parametrize("order2", ["C", "F", "A", "K"])
     def test_order_mismatch(self, arr, order1, order2):
         # The order is the main (python side) reason that can cause
         # a never-copy to fail.
@@ -6084,7 +6120,7 @@ class TestArrayCreationCopyArgument:
         )
 
 
-class TestArrayAttributeDeletion:
+class TestArrayAttributeDeletion(TestCase):
     def test_multiarray_writable_attributes_deletion(self):
         # ticket #2046, should not seqfault, raise AttributeError
         a = np.ones(2)
@@ -6138,8 +6174,8 @@ class TestArrayAttributeDeletion:
             assert_raises(AttributeError, delattr, a, s)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestArrayInterface:
+@xfail  # (reason="TODO")
+class TestArrayInterface(TestCase):
     class Foo:
         def __init__(self, value):
             self.value = value
@@ -6154,7 +6190,7 @@ class TestArrayInterface:
 
     f = Foo(0.5)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "val, iface, expected",
         [
             (f, {}, 0.5),
@@ -6187,19 +6223,20 @@ class TestArrayInterface:
             assert_equal(pre_cnt, post_cnt)
 
 
-@pytest.mark.xfail(reason="TODO")
-def test_flat_element_deletion():
-    it = np.ones(3).flat
-    try:
-        del it[1]
-        del it[1:2]
-    except TypeError:
-        pass
-    except Exception:
-        raise AssertionError
+class TestDelMisc(TestCase):
+    @xfail  # (reason="TODO")
+    def test_flat_element_deletion(self):
+        it = np.ones(3).flat
+        try:
+            del it[1]
+            del it[1:2]
+        except TypeError:
+            pass
+        except Exception:
+            raise AssertionError
 
 
-class TestConversion:
+class TestConversion(TestCase):
     def test_array_scalar_relational_operation(self):
         # All integer
         for dt1 in np.typecodes["AllInteger"]:
@@ -6257,7 +6294,7 @@ class TestConversion:
                     f"type {dt1} and {dt2} failed",
                 )
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_to_bool_scalar(self):
         assert_equal(bool(np.array([False])), False)
         assert_equal(bool(np.array([True])), True)
@@ -6290,7 +6327,7 @@ class TestConversion:
             assert_equal(int_func(np.array([[42]])), 42)
             assert_raises((ValueError, TypeError), int_func, np.array([1, 2]))
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_to_int_scalar_2(self):
         int_funcs = (int, lambda x: x.__int__())
         for int_func in int_funcs:
@@ -6320,7 +6357,7 @@ class TestConversion:
             assert_raises(NotImplementedError, int_func, np.array([NotConvertible()]))
 
 
-class TestWhere:
+class TestWhere(TestCase):
     def test_basic(self):
         dts = [bool, np.int16, np.int32, np.int64, np.double, np.complex128]
         for dt in dts:
@@ -6352,7 +6389,7 @@ class TestWhere:
         b = np.array([], dtype=np.float64).reshape(0, 3)
         assert_array_equal(np.where(m, 0, b), np.array([]).reshape(0, 3))
 
-    @pytest.mark.skip(reason="object arrays")
+    @skip(reason="object arrays")
     def test_exotic_2(self):
         # object cast
         d = np.array(
@@ -6487,7 +6524,7 @@ class TestWhere:
         c[tmpmask] = 0
         assert_equal(np.where(c, b, a), r)
 
-    @pytest.mark.skip(reason="endianness")
+    @skip(reason="endianness")
     def test_foreign(self):
         c = np.array(
             [
@@ -6558,8 +6595,8 @@ class TestWhere:
 
 if not IS_PYPY:
     # sys.getsizeof() is not valid on PyPy
-    @pytest.mark.xfail(reason="TODO")
-    class TestSizeOf:
+    @xfail  # (reason="TODO")
+    class TestSizeOf(TestCase):
         def test_empty_array(self):
             pytest.xpass()
             x = np.array([])
@@ -6608,7 +6645,7 @@ if not IS_PYPY:
             assert_raises(TypeError, d.__sizeof__, "a")
 
 
-class TestHashing:
+class TestHashing(TestCase):
     def test_arrays_not_hashable(self):
         x = np.ones(3)
         assert_raises(TypeError, hash, x)
@@ -6618,8 +6655,8 @@ class TestHashing:
         assert_(not isinstance(x, collections.abc.Hashable))
 
 
-class TestFormat:
-    @pytest.mark.xfail(reason="TODO")
+class TestFormat(TestCase):
+    @xfail  # (reason="TODO")
     def test_0d(self):
         a = np.array(np.pi)
         assert_equal(f"{a:0.3g}", "3.14")
@@ -6638,7 +6675,7 @@ class TestFormat:
 from numpy.testing import IS_PYPY
 
 
-class TestWritebackIfCopy:
+class TestWritebackIfCopy(TestCase):
     # all these tests use the WRITEBACKIFCOPY mechanism
     def test_argmax_with_out(self):
         mat = np.eye(5)
@@ -6652,7 +6689,7 @@ class TestWritebackIfCopy:
         res = np.argmin(mat, 0, out=out)
         assert_equal(res, range(5))
 
-    @pytest.mark.xfail(reason="XXX: place()")
+    @xfail  # (reason="XXX: place()")
     def test_insert_noncontiguous(self):
         a = np.arange(6).reshape(2, 3).T  # force non-c-contiguous
         # uses arr_insert
@@ -6667,7 +6704,7 @@ class TestWritebackIfCopy:
         np.put(a, [0, 2], [44, 55])
         assert_equal(a, np.array([[44, 3], [55, 4], [2, 5]]))
 
-    @pytest.mark.xfail(reason="XXX: putmask()")
+    @xfail  # (reason="XXX: putmask()")
     def test_putmask_noncontiguous(self):
         a = np.arange(6).reshape(2, 3).T  # force non-c-contiguous
         # uses arr_putmask
@@ -6687,7 +6724,7 @@ class TestWritebackIfCopy:
         np.choose(a, choices, out=out, mode="raise")
         assert_equal(out, np.array([[10, -10, 10], [-10, 10, -10], [10, -10, 10]]))
 
-    @pytest.mark.xfail(reason="XXX: ndarray.flat")
+    @xfail  # (reason="XXX: ndarray.flat")
     def test_flatiter__array__(self):
         a = np.arange(9).reshape(3, 3)
         b = a.T.flat
@@ -6702,7 +6739,8 @@ class TestWritebackIfCopy:
         assert_equal(b, np.array([[15, 18, 21], [42, 54, 66], [69, 90, 111]]))
 
 
-class TestArange:
+@instantiate_parametrized_tests
+class TestArange(TestCase):
     def test_infinite(self):
         assert_raises(
             (RuntimeError, ValueError), np.arange, 0, np.inf  # "unsupported range",
@@ -6730,7 +6768,7 @@ class TestArange:
         assert_raises(TypeError, np.arange, step=3)
         assert_raises(TypeError, np.arange, dtype="int64")
 
-    @pytest.mark.xfail(reason="weird arange signature (optionals before required args)")
+    @xfail  # (reason="weird arange signature (optionals before required args)")
     def test_require_range_2(self):
         assert_raises(TypeError, np.arange, start=4)
 
@@ -6744,7 +6782,7 @@ class TestArange:
         assert len(keyword_start_stop) == 6
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
-    @pytest.mark.skip(reason="arange for booleans: numpy maybe deprecates?")
+    @skip(reason="arange for booleans: numpy maybe deprecates?")
     def test_arange_booleans(self):
         # Arange makes some sense for booleans and works up to length 2.
         # But it is weird since `arange(2, 4, dtype=bool)` works.
@@ -6765,7 +6803,7 @@ class TestArange:
         with pytest.raises(TypeError):
             np.arange(3, dtype="bool")
 
-    @pytest.mark.parametrize("which", [0, 1, 2])
+    @parametrize("which", [0, 1, 2])
     def test_error_paths_and_promotion(self, which):
         args = [0, 1, 2]  # start, stop, and step
         args[which] = np.float64(2.0)  # should ensure float64 output
@@ -6779,18 +6817,19 @@ class TestArange:
             np.arange(*args)
 
 
-@pytest.mark.xfail(reason="comparison: builtin.bools or...?")
-def test_richcompare_scalar_boolean_singleton_return():
-    # These are currently guaranteed to be the boolean singletons, but maybe
-    # returning NumPy booleans would also be OK:
-    assert (np.array(0) == "a") is False
-    assert (np.array(0) != "a") is True
-    assert (np.int16(0) == "a") is False
-    assert (np.int16(0) != "a") is True
+class TestRichcompareScalar(TestCase):
+    @xfail  # (reason="comparison: builtin.bools or...?")
+    def test_richcompare_scalar_boolean_singleton_return(self):
+        # These are currently guaranteed to be the boolean singletons, but maybe
+        # returning NumPy booleans would also be OK:
+        assert (np.array(0) == "a") is False
+        assert (np.array(0) != "a") is True
+        assert (np.int16(0) == "a") is False
+        assert (np.int16(0) != "a") is True
 
 
-@pytest.mark.xfail(reason="implement views/dtypes")
-class TestViewDtype:
+@xfail  # (reason="implement views/dtypes")
+class TestViewDtype(TestCase):
     """
     Verify that making a view of a non-contiguous array works as expected.
     """
@@ -6856,47 +6895,46 @@ class TestViewDtype:
         assert_array_equal(x.view("<i2"), expected)
 
 
-# Test various array sizes that hit different code paths in quicksort-avx512
-@pytest.mark.parametrize(
-    "N", [8, 16, 24, 32, 48, 64, 96, 128, 151, 191, 256, 383, 512, 1023, 2047]
-)
-def test_sort_float(N):
-    # Regular data with nan sprinkled
-    np.random.seed(42)
-    arr = -0.5 + np.random.sample(N).astype("f")
-    arr[np.random.choice(arr.shape[0], 3)] = np.nan
-    assert_equal(np.sort(arr, kind="quick"), np.sort(arr, kind="heap"))
+@instantiate_parametrized_tests
+class TestSortFloatMisc(TestCase):
+    # Test various array sizes that hit different code paths in quicksort-avx512
+    @parametrize(
+        "N", [8, 16, 24, 32, 48, 64, 96, 128, 151, 191, 256, 383, 512, 1023, 2047]
+    )
+    def test_sort_float(self, N):
+        # Regular data with nan sprinkled
+        np.random.seed(42)
+        arr = -0.5 + np.random.sample(N).astype("f")
+        arr[np.random.choice(arr.shape[0], 3)] = np.nan
+        assert_equal(np.sort(arr, kind="quick"), np.sort(arr, kind="heap"))
 
-    # (2) with +INF
-    infarr = np.inf * np.ones(N, dtype="f")
-    infarr[np.random.choice(infarr.shape[0], 5)] = -1.0
-    assert_equal(np.sort(infarr, kind="quick"), np.sort(infarr, kind="heap"))
+        # (2) with +INF
+        infarr = np.inf * np.ones(N, dtype="f")
+        infarr[np.random.choice(infarr.shape[0], 5)] = -1.0
+        assert_equal(np.sort(infarr, kind="quick"), np.sort(infarr, kind="heap"))
 
-    # (3) with -INF
-    neginfarr = -np.inf * np.ones(N, dtype="f")
-    neginfarr[np.random.choice(neginfarr.shape[0], 5)] = 1.0
-    assert_equal(np.sort(neginfarr, kind="quick"), np.sort(neginfarr, kind="heap"))
+        # (3) with -INF
+        neginfarr = -np.inf * np.ones(N, dtype="f")
+        neginfarr[np.random.choice(neginfarr.shape[0], 5)] = 1.0
+        assert_equal(np.sort(neginfarr, kind="quick"), np.sort(neginfarr, kind="heap"))
 
-    # (4) with +/-INF
-    infarr = np.inf * np.ones(N, dtype="f")
-    infarr[np.random.choice(infarr.shape[0], (int)(N / 2))] = -np.inf
-    assert_equal(np.sort(infarr, kind="quick"), np.sort(infarr, kind="heap"))
+        # (4) with +/-INF
+        infarr = np.inf * np.ones(N, dtype="f")
+        infarr[np.random.choice(infarr.shape[0], (int)(N / 2))] = -np.inf
+        assert_equal(np.sort(infarr, kind="quick"), np.sort(infarr, kind="heap"))
 
-
-def test_sort_int():
-    # Random data with NPY_MAX_INT32 and NPY_MIN_INT32 sprinkled
-    # rng = np.random.default_rng(42)
-    np.random.seed(1234)
-    N = 2047
-    minv = np.iinfo(np.int32).min
-    maxv = np.iinfo(np.int32).max
-    arr = np.random.randint(low=minv, high=maxv, size=N).astype("int32")
-    arr[np.random.choice(arr.shape[0], 10)] = minv
-    arr[np.random.choice(arr.shape[0], 10)] = maxv
-    assert_equal(np.sort(arr, kind="quick"), np.sort(arr, kind="heap"))
+    def test_sort_int(self):
+        # Random data with NPY_MAX_INT32 and NPY_MIN_INT32 sprinkled
+        # rng = np.random.default_rng(42)
+        np.random.seed(1234)
+        N = 2047
+        minv = np.iinfo(np.int32).min
+        maxv = np.iinfo(np.int32).max
+        arr = np.random.randint(low=minv, high=maxv, size=N).astype("int32")
+        arr[np.random.choice(arr.shape[0], 10)] = minv
+        arr[np.random.choice(arr.shape[0], 10)] = maxv
+        assert_equal(np.sort(arr, kind="quick"), np.sort(arr, kind="heap"))
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -915,7 +915,7 @@ class TestScalarIndexing(TestCase):
         assert_equal(a, [0, 1, 0, 1, 2])
 
 
-@xfail  # (reason="TODO")
+@skip(reason="object, void, structured dtypes")
 @instantiate_parametrized_tests
 class TestCreation(TestCase):
     """

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -4268,7 +4268,7 @@ class TestFromBuffer(TestCase):
         # See also gh-21612
         if isinstance(obj, str):
             # @parametrize breaks with bytes objects
-            obj = bytes(obj, enconding=latin-1)
+            obj = bytes(obj, enconding="latin-1")
         new = np.frombuffer(obj)
         assert new.base is obj
 

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -4251,7 +4251,9 @@ class TestIO(TestCase):
 @xfail  # (reason="TODO")
 @instantiate_parametrized_tests
 class TestFromBuffer(TestCase):
-    @parametrize("byteorder", [subtest("<", name="less"), subtest(">", name="greater")])
+    @parametrize(
+        "byteorder", [subtest("little", name="little"), subtest("big", name="big")]
+    )
     @parametrize("dtype", [float, int, complex])
     def test_basic(self, byteorder, dtype):
         dt = np.dtype(dtype).newbyteorder(byteorder)
@@ -4259,11 +4261,14 @@ class TestFromBuffer(TestCase):
         buf = x.tobytes()
         assert_array_equal(np.frombuffer(buf, dtype=dt), x.flat)
 
-    @parametrize("obj", [np.arange(10), b"12345678"])
+    @parametrize("obj", [np.arange(10), "12345678"])
     def test_array_base(self, obj):
         # Objects (including NumPy arrays), which do not use the
         # `release_buffer` slot should be directly used as a base object.
         # See also gh-21612
+        if isinstance(obj, str):
+            # @parametrize breaks with bytes objects
+            obj = bytes(obj, enconding=latin-1)
         new = np.frombuffer(obj)
         assert new.base is obj
 

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import itertools
 import math
 import platform
@@ -23,12 +24,23 @@ from torch._numpy.testing import (
 IS_WASM = False
 HAS_REFCOUNT = True
 
+from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
+
 from hypothesis import given, strategies as st
 from hypothesis.extra import numpy as hynp
 from pytest import raises as assert_raises
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 
-class TestResize:
+class TestResize(TestCase):
     def test_copies(self):
         A = np.array([[1, 2], [3, 4]])
         Ar1 = np.array([[1, 2, 3, 4], [1, 2, 3, 4]])
@@ -77,7 +89,7 @@ class TestResize:
             np.resize(A, new_shape=new_shape)
 
 
-class TestNonarrayArgs:
+class TestNonarrayArgs(TestCase):
     # check that non-array arguments to functions wrap them in arrays
     def test_choose(self):
         choices = [[0, 1, 2], [3, 4, 5], [5, 6, 7]]
@@ -93,7 +105,7 @@ class TestNonarrayArgs:
         tgt = [2, 5, 2, 3, 7, 2, 2]
         assert_equal(out, tgt)
 
-    @pytest.mark.xfail(reason="TODO implement compress(...)")
+    @xfail  # (reason="TODO implement compress(...)")
     def test_compress(self):
         arr = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
         tgt = [[5, 6, 7, 8, 9]]
@@ -163,13 +175,13 @@ class TestNonarrayArgs:
         s = np.float64(1.0)
         assert_equal(s.round(), 1.0)
 
-    @pytest.mark.xfail(reason="scalar instances")
+    @xfail  # (reason="scalar instances")
     def test_round_2(self):
         s = np.float64(1.0)
         assert_(isinstance(s.round(), np.float64))
 
-    @pytest.mark.xfail(reason="scalar instances")
-    @pytest.mark.parametrize(
+    @xfail  # (reason="scalar instances")
+    @parametrize(
         "dtype",
         [
             np.int8,
@@ -191,8 +203,8 @@ class TestNonarrayArgs:
         assert_equal(round(s, None), 1)
         assert_equal(round(s, ndigits=None), 1)
 
-    @pytest.mark.xfail(reason="scalar instances")
-    @pytest.mark.parametrize(
+    @xfail  # (reason="scalar instances")
+    @parametrize(
         "val, ndigits",
         [
             pytest.param(
@@ -205,7 +217,7 @@ class TestNonarrayArgs:
     def test_dunder_round_edgecases(self, val, ndigits):
         assert_equal(round(val, ndigits), round(np.int32(val), ndigits))
 
-    @pytest.mark.xfail(reason="scalar instances")
+    @xfail  # (reason="scalar instances")
     def test_dunder_round_accuracy(self):
         f = np.float64(5.1 * 10**73)
         assert_(isinstance(round(f, -73), np.float64))
@@ -219,8 +231,8 @@ class TestNonarrayArgs:
         assert_(isinstance(round(i, ndigits=-2), np.int64))
         assert_array_max_ulp(round(i, ndigits=-2), 500)
 
-    # @pytest.mark.xfail(raises=AssertionError, reason="gh-15896")
-    @pytest.mark.xfail
+    # @xfail  #(raises=AssertionError, reason="gh-15896")
+    @xfail
     def test_round_py_consistency(self):
         f = 5.1 * 10**73
         assert_equal(round(np.float64(f), -73), round(f, -73))
@@ -303,8 +315,8 @@ class TestNonarrayArgs:
     #      assert_(w[0].category is RuntimeWarning)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestIsscalar:
+@xfail  # (reason="TODO")
+class TestIsscalar(TestCase):
     def test_isscalar(self):
         assert_(np.isscalar(3.1))
         assert_(np.isscalar(np.int16(12345)))
@@ -322,7 +334,7 @@ class TestIsscalar:
         assert_(np.isscalar(Number()))
 
 
-class TestBoolScalar:
+class TestBoolScalar(TestCase):
     def test_logical(self):
         f = np.False_
         t = np.True_
@@ -355,8 +367,8 @@ class TestBoolScalar:
         assert_((f ^ f) is f)
 
 
-class TestBoolArray:
-    def setup_method(self):
+class TestBoolArray(TestCase):
+    def setUp(self):
         # offset for simd tests
         self.t = np.array([True] * 41, dtype=bool)[1::]
         self.f = np.array([False] * 41, dtype=bool)[1::]
@@ -442,8 +454,8 @@ class TestBoolArray:
         assert_array_equal(self.im ^ False, self.im)
 
 
-class TestBoolCmp:
-    def setup_method(self):
+class TestBoolCmp(TestCase):
+    def setUp(self):
         self.f = np.ones(256, dtype=np.float32)
         self.ef = np.ones(self.f.size, dtype=bool)
         self.d = np.ones(128, dtype=np.float64)
@@ -542,8 +554,8 @@ class TestBoolCmp:
             assert_array_equal(np.signbit(self.signd[i:]), self.ed[i:])
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestSeterr:
+@xfail  # (reason="TODO")
+class TestSeterr(TestCase):
     def test_default(self):
         err = np.geterr()
         assert_equal(
@@ -562,8 +574,8 @@ class TestSeterr:
         np.seterr(**old)
         assert_(np.geterr() == old)
 
-    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
-    @pytest.mark.skipif(platform.machine() == "armv5tel", reason="See gh-413.")
+    @skipif(IS_WASM, reason="no wasm fp exception support")
+    @skipif(platform.machine() == "armv5tel", reason="See gh-413.")
     def test_divide_err(self):
         with assert_raises(FloatingPointError):
             np.array([1.0]) / np.array([0.0])
@@ -571,7 +583,7 @@ class TestSeterr:
         np.seterr(divide="ignore")
         np.array([1.0]) / np.array([0.0])
 
-    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
+    @skipif(IS_WASM, reason="no wasm fp exception support")
     def test_errobj(self):
         olderrobj = np.geterrobj()
         self.called = 0
@@ -600,8 +612,8 @@ class TestSeterr:
             del self.called
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestFloatExceptions:
+@xfail  # (reason="TODO")
+class TestFloatExceptions(TestCase):
     def assert_raises_fpe(self, fpeerr, flop, x, y):
         ftype = type(x)
         try:
@@ -626,8 +638,8 @@ class TestFloatExceptions:
         self.assert_raises_fpe(fpeerr, flop, sc1[()], sc2[()])
 
     # Test for all real and complex float types
-    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
-    @pytest.mark.parametrize("typecode", np.typecodes["AllFloat"])
+    @skipif(IS_WASM, reason="no wasm fp exception support")
+    @parametrize("typecode", np.typecodes["AllFloat"])
     def test_floating_exceptions(self, typecode):
         # Test basic arithmetic function errors
         ftype = np.obj2sctype(typecode)
@@ -675,7 +687,7 @@ class TestFloatExceptions:
         )
         self.assert_raises_fpe(invalid, lambda a, b: a * b, ftype(0), ftype(np.inf))
 
-    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
+    @skipif(IS_WASM, reason="no wasm fp exception support")
     def test_warnings(self):
         # test warning code path
         with warnings.catch_warnings(record=True) as w:
@@ -694,7 +706,7 @@ class TestFloatExceptions:
             assert_("underflow" in str(w[-1].message))
 
 
-class TestTypes:
+class TestTypes(TestCase):
     def check_promotion_cases(self, promote_func):
         # tests that the scalars get coerced correctly.
         b = np.bool_(0)
@@ -805,7 +817,7 @@ class TestTypes:
         # assert_equal(b, [0.0, 1.5])
         # assert_equal(b.dtype, np.dtype('f4'))
 
-    @pytest.mark.xfail(reason="'Scalars do not upcast arrays' rule")
+    @xfail  # (reason="'Scalars do not upcast arrays' rule")
     def test_coercion_2(self):
         def res_type(a, b):
             return np.add(a, b).dtype
@@ -815,11 +827,11 @@ class TestTypes:
     def test_result_type(self):
         self.check_promotion_cases(np.result_type)
 
-    @pytest.mark.skip(reason="array(None) not supported")
+    @skip(reason="array(None) not supported")
     def test_tesult_type_2(self):
         assert_(np.result_type(None) == np.dtype(None))
 
-    @pytest.mark.skip(reason="no endianness in dtypes")
+    @skip(reason="no endianness in dtypes")
     def test_promote_types_endian(self):
         # promote_types should always return native-endian types
         assert_equal(np.promote_types("<i8", "<i8"), np.dtype("i8"))
@@ -835,7 +847,7 @@ class TestTypes:
 
         assert_(np.can_cast("i8", "i8", "no"))
 
-    @pytest.mark.skip(reason="no endianness in dtypes")
+    @skip(reason="no endianness in dtypes")
     def test_can_cast_2(self):
         assert_(not np.can_cast("<i8", ">i8", "no"))
 
@@ -856,7 +868,7 @@ class TestTypes:
         # Also test keyword arguments
         assert_(np.can_cast(from_=np.int32, to=np.int64))
 
-    @pytest.mark.xfail(reason="value-based casting?")
+    @xfail  # (reason="value-based casting?")
     def test_can_cast_values(self):
         # gh-5917
         for dt in np.sctypes["int"] + np.sctypes["uint"]:
@@ -877,8 +889,8 @@ class NIterError(Exception):
     pass
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestFromiter:
+@xfail  # (reason="TODO")
+class TestFromiter(TestCase):
     def makegen(self):
         return (x**2 for x in range(24))
 
@@ -913,8 +925,8 @@ class TestFromiter:
                 raise NIterError("error at index %s" % eindex)
             yield e
 
-    @pytest.mark.parametrize("dtype", [int])
-    @pytest.mark.parametrize(["count", "error_index"], [(10, 5), (10, 9)])
+    @parametrize("dtype", [int])
+    @parametrize("count, error_index", [(10, 5), (10, 9)])
     def test_2592(self, count, error_index, dtype):
         # Test iteration exceptions are correctly raised. The data/generator
         # has `count` elements but errors at `error_index`
@@ -949,7 +961,8 @@ class TestFromiter:
             np.fromiter(iterable, dtype=np.dtype((int, 2)))
 
 
-class TestNonzeroAndCountNonzero:
+@instantiate_parametrized_tests
+class TestNonzeroAndCountNonzero(TestCase):
     def test_count_nonzero_list(self):
         lst = [[0, 1, 2, 3], [1, 0, 0, 6]]
         assert np.count_nonzero(lst) == 5
@@ -1035,7 +1048,7 @@ class TestNonzeroAndCountNonzero:
         assert_raises(np.AxisError, np.count_nonzero, m, axis=3)
         assert_raises(TypeError, np.count_nonzero, m, axis=np.array([[1], [2]]))
 
-    @pytest.mark.parametrize("typecode", np.typecodes["All"])
+    @parametrize("typecode", np.typecodes["All"])
     def test_count_nonzero_axis_all_dtypes(self, typecode):
         # More thorough test that the axis argument is respected
         # for all dtypes and responds correctly when presented with
@@ -1074,7 +1087,7 @@ class TestNonzeroAndCountNonzero:
         assert isinstance(np.count_nonzero(a, axis=1, keepdims=True), np.ndarray)
 
 
-class TestIndex:
+class TestIndex(TestCase):
     def test_boolean(self):
         a = rand(3, 5, 8)
         V = rand(5, 8)
@@ -1093,8 +1106,8 @@ class TestIndex:
         assert_equal(c.dtype, np.dtype("int32"))
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestBinaryRepr:
+@xfail  # (reason="TODO")
+class TestBinaryRepr(TestCase):
     def test_zero(self):
         assert_equal(np.binary_repr(0), "0")
 
@@ -1131,8 +1144,8 @@ class TestBinaryRepr:
         assert_equal(np.binary_repr(np.int64(-(2**62)), width=64), "11" + "0" * 62)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestBaseRepr:
+@xfail  # (reason="TODO")
+class TestBaseRepr(TestCase):
     def test_base3(self):
         assert_equal(np.base_repr(3**5, 3), "100000")
 
@@ -1154,7 +1167,7 @@ class TestBaseRepr:
             np.base_repr(1, 37)
 
 
-class TestArrayComparisons:
+class TestArrayComparisons(TestCase):
     def test_array_equal(self):
         res = np.array_equal(np.array([1, 2]), np.array([1, 2]))
         assert_(res)
@@ -1237,8 +1250,9 @@ class TestArrayComparisons:
         assert_(type(res) is bool)
 
 
-class TestClip:
-    def setup_method(self):
+@instantiate_parametrized_tests
+class TestClip(TestCase):
+    def setUp(self):
         self.nr = 5
         self.nc = 3
 
@@ -1291,7 +1305,7 @@ class TestClip:
 
     # Now the real test cases
 
-    @pytest.mark.parametrize("dtype", "?bhilBfd")
+    @parametrize("dtype", "?bhilBfd")
     def test_ones_pathological(self, dtype):
         # for preservation of behavior described in
         # gh-12519; amin > amax behavior may still change
@@ -1301,10 +1315,11 @@ class TestClip:
         actual = np.clip(arr, 1, 0)
         assert_equal(actual, expected)
 
-    @pytest.mark.parametrize("dtype", "eFD")
+    @parametrize("dtype", "eFD")
     def test_ones_pathological_2(self, dtype):
         if dtype in "FD":
-            pytest.xfail("torch.clamp not implemented for complex types")
+            # FIXME: make xfail
+            raise SkipTest("torch.clamp not implemented for complex types")
         # for preservation of behavior described in
         # gh-12519; amin > amax behavior may still change
         # in the future
@@ -1341,7 +1356,7 @@ class TestClip:
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="byteorder not supported in torch")
+    @xfail  # (reason="byteorder not supported in torch")
     def test_simple_nonnative(self):
         # Test non native double input with scalar min/max.
         # Test native double input with non native double scalar min/max.
@@ -1361,7 +1376,7 @@ class TestClip:
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="clamp not supported for complex")
+    @xfail  # (reason="clamp not supported for complex")
     def test_simple_complex(self):
         # Test native complex input with native double scalar min/max.
         # Test native input with complex double scalar min/max.
@@ -1380,7 +1395,7 @@ class TestClip:
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="clamp not supported for complex")
+    @xfail  # (reason="clamp not supported for complex")
     def test_clip_complex(self):
         # Address Issue gh-5354 for clipping complex arrays
         # Test native complex input without explicit min/max
@@ -1414,8 +1429,8 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="casting not supported")
-    @pytest.mark.parametrize("casting", [None, "unsafe"])
+    @xfail  # (reason="casting not supported")
+    @parametrize("casting", [None, "unsafe"])
     def test_simple_int32_inout(self, casting):
         # Test native int32 input with double min/max and int32 out.
         a = self._generate_int32_data(self.nr, self.nc)
@@ -1440,7 +1455,7 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="FIXME arrays not equal")
+    @xfail  # (reason="FIXME arrays not equal")
     def test_simple_int64_inout(self):
         # Test native int32 input with double array min/max and int32 out.
         a = self._generate_int32_data(self.nr, self.nc)
@@ -1451,7 +1466,7 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="FIXME arrays not equal")
+    @xfail  # (reason="FIXME arrays not equal")
     def test_simple_int32_out(self):
         # Test native double input with scalar min/max and int out.
         a = self._generate_data(self.nr, self.nc)
@@ -1541,7 +1556,7 @@ class TestClip:
         act = self.clip(a, m * np.zeros(a.shape), M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="newbyteorder not supported")
+    @xfail  # (reason="newbyteorder not supported")
     def test_type_cast_06(self):
         # Test native with NON native scalar min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1552,7 +1567,7 @@ class TestClip:
         ac = self.fastclip(a, m_s, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="newbyteorder not supported")
+    @xfail  # (reason="newbyteorder not supported")
     def test_type_cast_07(self):
         # Test NON native with native array min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1564,7 +1579,7 @@ class TestClip:
         ac = self.fastclip(a_s, m, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="newbyteorder not supported")
+    @xfail  # (reason="newbyteorder not supported")
     def test_type_cast_08(self):
         # Test NON native with native scalar min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1576,7 +1591,7 @@ class TestClip:
         act = a_s.clip(m, M)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="newbyteorder not supported")
+    @xfail  # (reason="newbyteorder not supported")
     def test_type_cast_09(self):
         # Test native with NON native array min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1598,7 +1613,7 @@ class TestClip:
         ac = self.fastclip(a, m, M, out=b)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="newbyteorder not supported")
+    @xfail  # (reason="newbyteorder not supported")
     def test_type_cast_11(self):
         # Test non native with native scalar, min/max, out non native
         a = self._generate_non_native_data(self.nr, self.nc)
@@ -1632,7 +1647,7 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="FIXME arrays not equal")
+    @xfail  # (reason="FIXME arrays not equal")
     def test_clip_with_out_simple2(self):
         # Test native int32 input with double min/max and int32 out
         a = self._generate_int32_data(self.nr, self.nc)
@@ -1654,7 +1669,7 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="FIXME arrays not equal")
+    @xfail  # (reason="FIXME arrays not equal")
     def test_clip_with_out_array_int32(self):
         # Test native int32 input with double array min/max and int32 out
         a = self._generate_int32_data(self.nr, self.nc)
@@ -1665,7 +1680,7 @@ class TestClip:
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @pytest.mark.xfail(reason="FIXME arrays not equal")
+    @xfail  # (reason="FIXME arrays not equal")
     def test_clip_with_out_array_outint32(self):
         # Test native double input with scalar min/max and int out
         a = self._generate_data(self.nr, self.nc)
@@ -1723,7 +1738,7 @@ class TestClip:
         assert_array_equal(a2, ac)
         assert_(a2 is a)
 
-    @pytest.mark.skip(reason="Edge case; Wait until deprecation graduates")
+    @skip(reason="Edge case; Wait until deprecation graduates")
     def test_clip_nan(self):
         d = np.arange(7.0)
         with assert_warns(DeprecationWarning):
@@ -1737,7 +1752,7 @@ class TestClip:
         with assert_warns(DeprecationWarning):
             assert_equal(d.clip(min=np.nan, max=10), d)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "amin, amax",
         [
             # two scalars
@@ -1755,7 +1770,7 @@ class TestClip:
         actual = np.clip(a, amin, amax)
         assert_equal(actual, expected)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "arr, amin, amax",
         [
             # problematic scalar nan case from hypothesis
@@ -1774,7 +1789,7 @@ class TestClip:
         actual = np.clip(arr, amin, amax)
         assert_equal(actual, expected)
 
-    @pytest.mark.xfail(reason="np.maximum(..., dtype=) needs implementing")
+    @xfail  # (reason="np.maximum(..., dtype=) needs implementing")
     @given(
         data=st.data(),
         arr=hynp.arrays(
@@ -1830,15 +1845,9 @@ class TestClip:
         assert_array_equal(result, expected)
 
 
-class TestAllclose:
+class TestAllclose(TestCase):
     rtol = 1e-5
     atol = 1e-8
-
-    #  def setup_method(self):
-    #      self.olderr = np.seterr(invalid='ignore')
-
-    #  def teardown_method(self):
-    #      np.seterr(**self.olderr)
 
     def tst_allclose(self, x, y):
         assert_(np.allclose(x, y), f"{x} and {y} not close")
@@ -1909,7 +1918,7 @@ class TestAllclose:
         assert_(np.allclose(x, x, equal_nan=True))
 
 
-class TestIsclose:
+class TestIsclose(TestCase):
     rtol = 1e-5
     atol = 1e-8
 
@@ -2019,8 +2028,8 @@ class TestIsclose:
         assert_(np.isclose(0, np.inf).item() is False)
 
 
-class TestStdVar:
-    def setup_method(self):
+class TestStdVar(TestCase):
+    def setUp(self):
         self.A = np.array([1, -1, 1, -1])
         self.real_var = 1
 
@@ -2062,7 +2071,7 @@ class TestStdVar:
         assert_array_equal(r, out)
 
 
-class TestStdVarComplex:
+class TestStdVarComplex(TestCase):
     def test_basic(self):
         A = np.array([1, 1.0j, -1, -1.0j])
         real_var = 1
@@ -2074,10 +2083,10 @@ class TestStdVarComplex:
         assert_equal(np.std(1j), 0)
 
 
-class TestCreationFuncs:
+class TestCreationFuncs(TestCase):
     # Test ones, zeros, empty and full.
 
-    def setup_method(self):
+    def setUp(self):
         dtypes = {np.dtype(tp) for tp in itertools.chain(*np.sctypes.values())}
         self.dtypes = dtypes
         self.orders = {
@@ -2116,7 +2125,7 @@ class TestCreationFuncs:
         self.check_function(np.full, 0)
         self.check_function(np.full, 1)
 
-    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    @skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test_for_reference_leak(self):
         # Make sure we have an object for reference
         dim = 1
@@ -2131,11 +2140,12 @@ class TestCreationFuncs:
         assert_(sys.getrefcount(dim) == beg)
 
 
-@pytest.mark.xfail(reason="implement order etc")
-class TestLikeFuncs:
+@skip(reason="implement order etc")  # FIXME: make xfail
+@instantiate_parametrized_tests
+class TestLikeFuncs(TestCase):
     """Test ones_like, zeros_like, empty_like and full_like"""
 
-    def setup_method(self):
+    def setUp(self):
         self.data = [
             # Array scalars
             (np.array(3.0), None),
@@ -2289,10 +2299,8 @@ class TestLikeFuncs:
         # Inf to integer casts cause invalid-value errors: ignore them.
         self.check_like_function(np.full_like, np.inf, True)
 
-    @pytest.mark.parametrize(
-        "likefunc", [np.empty_like, np.full_like, np.zeros_like, np.ones_like]
-    )
-    @pytest.mark.parametrize("dtype", [str, bytes])
+    @parametrize("likefunc", [np.empty_like, np.full_like, np.zeros_like, np.ones_like])
+    @parametrize("dtype", [str, bytes])
     def test_dtype_str_bytes(self, likefunc, dtype):
         # Regression test for gh-19860
         a = np.arange(16).reshape(2, 8)
@@ -2306,7 +2314,7 @@ class TestLikeFuncs:
             assert result.strides == (4, 1)
 
 
-class TestCorrelate:
+class TestCorrelate(TestCase):
     def _setup(self, dt):
         self.x = np.array([1, 2, 3, 4, 5], dtype=dt)
         self.xs = np.arange(1, 20)[::3]
@@ -2356,7 +2364,7 @@ class TestCorrelate:
         with pytest.raises((ValueError, RuntimeError)):
             np.correlate(np.ones(1000), np.array([]), mode="full")
 
-    @pytest.mark.skip(reason="do not implement deprecated behavior")
+    @skip(reason="do not implement deprecated behavior")
     def test_mode(self):
         d = np.ones(100)
         k = np.ones(3)
@@ -2373,7 +2381,7 @@ class TestCorrelate:
             np.correlate(d, k, mode=None)
 
 
-class TestConvolve:
+class TestConvolve(TestCase):
     def test_object(self):
         d = [1.0] * 100
         k = [1.0] * 3
@@ -2386,7 +2394,7 @@ class TestConvolve:
         assert_array_equal(d, np.ones(100))
         assert_array_equal(k, np.ones(3))
 
-    @pytest.mark.skip(reason="do not implement deprecated behavior")
+    @skip(reason="do not implement deprecated behavior")
     def test_mode(self):
         d = np.ones(100)
         k = np.ones(3)
@@ -2413,13 +2421,14 @@ class TestConvolve:
         assert_allclose(conv, [2.5], atol=1e-15)
 
 
-class TestDtypePositional:
+class TestDtypePositional(TestCase):
     def test_dtype_positional(self):
         np.empty((2,), bool)
 
 
-class TestArgwhere:
-    @pytest.mark.parametrize("nd", [0, 1, 2])
+@instantiate_parametrized_tests
+class TestArgwhere(TestCase):
+    @parametrize("nd", [0, 1, 2])
     def test_nd(self, nd):
         # get an nd array with multiple elements in every dimension
         x = np.empty((2,) * nd, dtype=bool)
@@ -2450,8 +2459,8 @@ class TestArgwhere:
         assert_equal(np.argwhere([4, 0, 2, 1, 3]), [[0], [2], [3], [4]])
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestStringFunction:
+@xfail  # (reason="TODO")
+class TestStringFunction(TestCase):
     def test_set_string_function(self):
         a = np.array([1])
         np.set_string_function(lambda x: "FOO", repr=True)
@@ -2465,7 +2474,7 @@ class TestStringFunction:
         assert_equal(str(a), "[1]")
 
 
-class TestRoll:
+class TestRoll(TestCase):
     def test_roll1d(self):
         x = np.arange(10)
         xr = np.roll(x, 2)
@@ -2523,7 +2532,7 @@ class TestRoll:
         assert_equal(np.roll(x, 1), np.array([]))
 
 
-class TestRollaxis:
+class TestRollaxis(TestCase):
     # expected shape indexed by (axis, start) for array of
     # shape (1, 2, 3, 4)
     tgtshape = {
@@ -2556,7 +2565,7 @@ class TestRollaxis:
         assert_raises(np.AxisError, np.rollaxis, a, 4, 0)
         assert_raises(np.AxisError, np.rollaxis, a, 0, 5)
 
-    @pytest.mark.xfail(reason="needs fancy indexing")
+    @xfail  # (reason="needs fancy indexing")
     def test_results(self):
         a = np.arange(1 * 2 * 3 * 4).reshape(1, 2, 3, 4).copy()
         aind = np.indices(a.shape)
@@ -2595,7 +2604,7 @@ class TestRollaxis:
             assert_(not res.flags["OWNDATA"])
 
 
-class TestMoveaxis:
+class TestMoveaxis(TestCase):
     def test_move_to_end(self):
         x = np.random.randn(5, 6, 7)
         for source, expected in [
@@ -2680,7 +2689,7 @@ class TestMoveaxis:
         assert_(isinstance(result, np.ndarray))
 
 
-class TestCross:
+class TestCross(TestCase):
     def test_2x2(self):
         u = [1, 2]
         v = [3, 4]
@@ -2766,18 +2775,20 @@ class TestCross:
         assert_equal(np.cross(u, v), -z)
 
 
-def test_outer_out_param():
-    arr1 = np.ones((5,))
-    arr2 = np.ones((2,))
-    arr3 = np.linspace(-2, 2, 5)
-    out1 = np.empty(shape=(5, 5))
-    out2 = np.empty(shape=(2, 5))
-    res1 = np.outer(arr1, arr3, out1)
-    assert_equal(res1, out1)
-    assert_equal(np.outer(arr2, arr3, out2), out2)
+class TestOuterMisc(TestCase):
+    def test_outer_out_param(self):
+        arr1 = np.ones((5,))
+        arr2 = np.ones((2,))
+        arr3 = np.linspace(-2, 2, 5)
+        out1 = np.empty(shape=(5, 5))
+        out2 = np.empty(shape=(2, 5))
+        res1 = np.outer(arr1, arr3, out1)
+        assert_equal(res1, out1)
+        assert_equal(np.outer(arr2, arr3, out2), out2)
 
 
-class TestIndices:
+@instantiate_parametrized_tests
+class TestIndices(TestCase):
     def test_simple(self):
         [x, y] = np.indices((4, 3))
         assert_array_equal(x, np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]]))
@@ -2801,8 +2812,8 @@ class TestIndices:
         assert_array_equal(x, np.array([[0], [1], [2], [3]]))
         assert_array_equal(y, np.array([[0, 1, 2]]))
 
-    @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
-    @pytest.mark.parametrize("dims", [(), (0,), (4, 3)])
+    @parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
+    @parametrize("dims", [(), (0,), (4, 3)])
     def test_return_type(self, dtype, dims):
         inds = np.indices(dims, dtype=dtype)
         assert_(inds.dtype == dtype)
@@ -2811,8 +2822,8 @@ class TestIndices:
             assert_(arr.dtype == dtype)
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestRequire:
+@xfail  # (reason="TODO")
+class TestRequire(TestCase):
     flag_names = [
         "C",
         "C_CONTIGUOUS",
@@ -2878,8 +2889,8 @@ class TestRequire:
         assert_raises(ValueError, np.require, a, None, ["C", "F"])
 
 
-@pytest.mark.xfail(reason="TODO")
-class TestBroadcast:
+@xfail  # (reason="TODO")
+class TestBroadcast(TestCase):
     def test_broadcast_in_args(self):
         # gh-5881
         arrs = [
@@ -2944,7 +2955,7 @@ class TestBroadcast:
             np.broadcast([[1, 2, 3]], [[4], [5]], [6, 7])
 
 
-class TestTensordot:
+class TestTensordot(TestCase):
     def test_zero_dimension(self):
         # Test resolution to issue #5663
         a = np.zeros((3, 0))
@@ -2969,6 +2980,4 @@ class TestTensordot:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TestCase,
+    TEST_WITH_TORCHDYNAMO
 )
 
 skip = functools.partial(skipif, True)
@@ -2125,6 +2126,7 @@ class TestCreationFuncs(TestCase):
         self.check_function(np.full, 0)
         self.check_function(np.full, 1)
 
+    @skipif(TEST_WITH_TORCHDYNAMO, reason='fails with dynamo')
     @skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test_for_reference_leak(self):
         # Make sure we have an object for reference

--- a/test/torch_np/numpy_tests/core/test_numerictypes.py
+++ b/test/torch_np/numpy_tests/core/test_numerictypes.py
@@ -17,7 +17,6 @@ from torch.testing._internal.common_utils import (
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 @xfail  # (

--- a/test/torch_np/numpy_tests/core/test_numerictypes.py
+++ b/test/torch_np/numpy_tests/core/test_numerictypes.py
@@ -1,20 +1,30 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import itertools
 import sys
 
-import pytest
+from unittest import expectedFailure as xfail, skipIf as skipif
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_
-
-
-@pytest.mark.xfail(
-    reason="We do not disctinguish between scalar and array types."
-    " Thus, scalars can upcast arrays."
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
 )
-class TestCommonType:
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
+
+
+@xfail  # (
+#    reason="We do not disctinguish between scalar and array types."
+#    " Thus, scalars can upcast arrays."
+# )
+class TestCommonType(TestCase):
     def test_scalar_loses1(self):
         res = np.find_common_type(["f4", "f4", "i2"], ["f8"])
         assert_(res == "f4")
@@ -36,7 +46,7 @@ class TestCommonType:
         assert_(res == "f8")
 
 
-class TestIsSubDType:
+class TestIsSubDType(TestCase):
     # scalar types can be promoted into dtypes
     wrappers = [np.dtype, lambda x: x]
 
@@ -92,21 +102,21 @@ class TestIsSubDType:
         assert np.issubdtype(np.float32, "f")
 
 
-@pytest.mark.xfail(
-    reason="We do not have (or need) np.core.numerictypes."
-    " Our type aliases are in _dtypes.py."
-)
-class TestBitName:
+@xfail  # (
+#    reason="We do not have (or need) np.core.numerictypes."
+#    " Our type aliases are in _dtypes.py."
+# )
+class TestBitName(TestCase):
     def test_abstract(self):
         assert_raises(ValueError, np.core.numerictypes.bitname, np.floating)
 
 
-@pytest.mark.skip(reason="Docstrings for scalar types, not yet.")
-@pytest.mark.skipif(
+@skip(reason="Docstrings for scalar types, not yet.")
+@skipif(
     sys.flags.optimize > 1,
     reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1",
 )
-class TestDocStrings:
+class TestDocStrings(TestCase):
     def test_platform_dependent_aliases(self):
         if np.int64 is np.int_:
             assert_("int64" in np.int_.__doc__)
@@ -114,7 +124,8 @@ class TestDocStrings:
             assert_("int64" in np.longlong.__doc__)
 
 
-class TestScalarTypeNames:
+@instantiate_parametrized_tests
+class TestScalarTypeNames(TestCase):
     # gh-9799
 
     numeric_types = [
@@ -138,18 +149,16 @@ class TestScalarTypeNames:
         names = [t.__name__ for t in self.numeric_types]
         assert len(set(names)) == len(names)
 
-    @pytest.mark.parametrize("t", numeric_types)
+    @parametrize("t", numeric_types)
     def test_names_reflect_attributes(self, t):
         """Test that names correspond to where the type is under ``np.``"""
         assert getattr(np, t.__name__) is t
 
-    @pytest.mark.parametrize("t", numeric_types)
+    @parametrize("t", numeric_types)
     def test_names_are_undersood_by_dtype(self, t):
         """Test the dtype constructor maps names back to the type"""
         assert np.dtype(t.__name__).type is t
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_scalar_ctors.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_ctors.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_utils import (
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 class TestFromString(TestCase):

--- a/test/torch_np/numpy_tests/core/test_scalar_ctors.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_ctors.py
@@ -3,14 +3,28 @@
 """
 Test the scalar constructors, which also do type-coercion
 """
+import functools
+
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
 from torch._numpy.testing import assert_almost_equal, assert_equal
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 
-class TestFromString:
-    @pytest.mark.xfail(reason="XXX: floats from strings")
+class TestFromString(TestCase):
+    @xfail  # (reason="XXX: floats from strings")
     def test_floating(self):
         # Ticket #640, floats from string
         fsingle = np.single("1.234")
@@ -18,7 +32,7 @@ class TestFromString:
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
 
-    @pytest.mark.xfail(reason="XXX: floats from strings")
+    @xfail  # (reason="XXX: floats from strings")
     def test_floating_overflow(self):
         """Strings containing an unrepresentable float overflow"""
         fhalf = np.half("1e10000")
@@ -40,7 +54,7 @@ class TestFromString:
             np.bool_(False, garbage=True)
 
 
-class TestFromInt:
+class TestFromInt(TestCase):
     def test_intp(self):
         # Ticket #99
         assert_equal(1024, np.intp(1024))
@@ -50,13 +64,20 @@ class TestFromInt:
         assert_equal(np.uint8(-2), np.uint8(254))
 
 
-int_types = [np.byte, np.short, np.intc, np.int_, np.longlong]
+int_types = [
+    subtest(np.byte, name="np_byte"),
+    subtest(np.short, name="np_short"),
+    subtest(np.intc, name="np_intc"),
+    subtest(np.int_, name="np_int_"),
+    subtest(np.longlong, name="np_longlong"),
+]
 uint_types = [np.ubyte]
 float_types = [np.half, np.single, np.double]
 cfloat_types = [np.csingle, np.cdouble]
 
 
-class TestArrayFromScalar:
+@instantiate_parametrized_tests
+class TestArrayFromScalar(TestCase):
     """gh-15467"""
 
     def _do_test(self, t1, t2):
@@ -74,23 +95,21 @@ class TestArrayFromScalar:
         else:
             assert arr1.dtype.type is t2
 
-    @pytest.mark.parametrize("t1", int_types + uint_types)
-    @pytest.mark.parametrize("t2", int_types + uint_types + [None])
+    @parametrize("t1", int_types + uint_types)
+    @parametrize("t2", int_types + uint_types + [None])
     def test_integers(self, t1, t2):
         return self._do_test(t1, t2)
 
-    @pytest.mark.parametrize("t1", float_types)
-    @pytest.mark.parametrize("t2", float_types + [None])
+    @parametrize("t1", float_types)
+    @parametrize("t2", float_types + [None])
     def test_reals(self, t1, t2):
         return self._do_test(t1, t2)
 
-    @pytest.mark.parametrize("t1", cfloat_types)
-    @pytest.mark.parametrize("t2", cfloat_types + [None])
+    @parametrize("t1", cfloat_types)
+    @parametrize("t2", cfloat_types + [None])
     def test_complex(self, t1, t2):
         return self._do_test(t1, t2)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -9,7 +9,7 @@ import sys
 import types
 from typing import Any, Type
 
-from unittest import skipIf as skipif
+from unittest import skipIf as skipif, SkipTest
 
 import pytest
 
@@ -24,7 +24,6 @@ from torch.testing._internal.common_utils import (
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 @skip(reason="XXX: scalar.as_integer_ratio not implemented")
@@ -125,7 +124,7 @@ class TestAsIntegerRatio(TestCase):
                 df = np.longdouble(d)
             except (OverflowError, RuntimeWarning):
                 # the values may not fit in any float type
-                pytest.skip("longdouble too small on this platform")
+                raise SkipTest("longdouble too small on this platform")
 
             assert_equal(nf / df, f, f"{n}/{d}")
 

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -4,23 +4,36 @@
 Test the scalar constructors, which also do type-coercion
 """
 import fractions
+import functools
 import sys
 import types
 from typing import Any, Type
+
+from unittest import skipIf as skipif
 
 import pytest
 
 import torch._numpy as np
 from pytest import raises as assert_raises
 from torch._numpy.testing import assert_equal
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 
-@pytest.mark.skip(reason="XXX: scalar.as_integer_ratio not implemented")
-class TestAsIntegerRatio:
+@skip(reason="XXX: scalar.as_integer_ratio not implemented")
+@instantiate_parametrized_tests
+class TestAsIntegerRatio(TestCase):
     # derived in part from the cpython test "test_floatasratio"
 
-    @pytest.mark.parametrize("ftype", [np.half, np.single, np.double])
-    @pytest.mark.parametrize(
+    @parametrize("ftype", [np.half, np.single, np.double])
+    @parametrize(
         "f, ratio",
         [
             (0.875, (7, 8)),
@@ -32,7 +45,7 @@ class TestAsIntegerRatio:
     def test_small(self, ftype, f, ratio):
         assert_equal(ftype(f).as_integer_ratio(), ratio)
 
-    @pytest.mark.parametrize("ftype", [np.half, np.single, np.double])
+    @parametrize("ftype", [np.half, np.single, np.double])
     def test_simple_fractions(self, ftype):
         R = fractions.Fraction
         assert_equal(R(0, 1), R(*ftype(0.0).as_integer_ratio()))
@@ -40,7 +53,7 @@ class TestAsIntegerRatio:
         assert_equal(R(1, 2), R(*ftype(0.5).as_integer_ratio()))
         assert_equal(R(-2100, 1), R(*ftype(-2100.0).as_integer_ratio()))
 
-    @pytest.mark.parametrize("ftype", [np.half, np.single, np.double])
+    @parametrize("ftype", [np.half, np.single, np.double])
     def test_errors(self, ftype):
         assert_raises(OverflowError, ftype("inf").as_integer_ratio)
         assert_raises(OverflowError, ftype("-inf").as_integer_ratio)
@@ -61,7 +74,7 @@ class TestAsIntegerRatio:
         )
         # longdouble is platform dependent
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "ftype, frac_vals, exp_vals",
         [
             # dtype test cases generated using hypothesis
@@ -117,21 +130,22 @@ class TestAsIntegerRatio:
             assert_equal(nf / df, f, f"{n}/{d}")
 
 
-class TestIsInteger:
-    @pytest.mark.parametrize("str_value", ["inf", "nan"])
-    @pytest.mark.parametrize("code", np.typecodes["Float"])
-    def test_special(self, code: str, str_value: str) -> None:
+@instantiate_parametrized_tests
+class TestIsInteger(TestCase):
+    @parametrize("str_value", ["inf", "nan"])
+    @parametrize("code", np.typecodes["Float"])
+    def test_special(self, code, str_value):
         cls = np.dtype(code).type
         value = cls(str_value)
         assert not value.is_integer()
 
-    @pytest.mark.parametrize("code", np.typecodes["Float"] + np.typecodes["AllInteger"])
+    @parametrize("code", np.typecodes["Float"] + np.typecodes["AllInteger"])
     def test_true(self, code: str) -> None:
         float_array = np.arange(-5, 5).astype(code)
         for value in float_array:
             assert value.is_integer()
 
-    @pytest.mark.parametrize("code", np.typecodes["Float"])
+    @parametrize("code", np.typecodes["Float"])
     def test_false(self, code: str) -> None:
         float_array = np.arange(-5, 5).astype(code)
         float_array *= 1.1
@@ -141,10 +155,11 @@ class TestIsInteger:
             assert not value.is_integer()
 
 
-@pytest.mark.skip(reason="XXX: implementation details of the type system differ")
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
-class TestClassGetItem:
-    @pytest.mark.parametrize(
+@skip(reason="XXX: implementation details of the type system differ")
+@skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+@instantiate_parametrized_tests
+class TestClassGetItem(TestCase):
+    @parametrize(
         "cls",
         [
             np.number,
@@ -165,7 +180,7 @@ class TestClassGetItem:
         assert isinstance(alias, types.GenericAlias)
         assert alias.__origin__ is np.complexfloating
 
-    @pytest.mark.parametrize("arg_len", range(4))
+    @parametrize("arg_len", range(4))
     def test_abc_complexfloating_subscript_tuple(self, arg_len: int) -> None:
         arg_tup = (Any,) * arg_len
         if arg_len in (1, 2):
@@ -175,18 +190,18 @@ class TestClassGetItem:
             with pytest.raises(TypeError, match=match):
                 np.complexfloating[arg_tup]
 
-    @pytest.mark.parametrize("cls", [np.generic])
+    @parametrize("cls", [np.generic])
     def test_abc_non_numeric(self, cls: Type[np.generic]) -> None:
         with pytest.raises(TypeError):
             cls[Any]
 
-    @pytest.mark.parametrize("code", np.typecodes["All"])
+    @parametrize("code", np.typecodes["All"])
     def test_concrete(self, code: str) -> None:
         cls = np.dtype(code).type
         with pytest.raises(TypeError):
             cls[Any]
 
-    @pytest.mark.parametrize("arg_len", range(4))
+    @parametrize("arg_len", range(4))
     def test_subscript_tuple(self, arg_len: int) -> None:
         arg_tup = (Any,) * arg_len
         if arg_len == 1:
@@ -199,19 +214,22 @@ class TestClassGetItem:
         assert np.number[Any]
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
-@pytest.mark.parametrize("cls", [np.number, np.complexfloating, np.int64])
-def test_class_getitem_38(cls: Type[np.number]) -> None:
-    match = "Type subscription requires python >= 3.9"
-    with pytest.raises(TypeError):  # , match=match):
-        cls[Any]
+@instantiate_parametrized_tests
+class TestClassGetitemMisc(TestCase):
+    @skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
+    @parametrize("cls", [np.number, np.complexfloating, np.int64])
+    def test_class_getitem_38(self, cls: Type[np.number]) -> None:
+        match = "Type subscription requires python >= 3.9"
+        with pytest.raises(TypeError):  # , match=match):
+            cls[Any]
 
 
-@pytest.mark.skip(reason="scalartype(...).bit_count() not implemented")
-class TestBitCount:
+@skip(reason="scalartype(...).bit_count() not implemented")
+@instantiate_parametrized_tests
+class TestBitCount(TestCase):
     # derived in part from the cpython test "test_bit_count"
 
-    @pytest.mark.parametrize("itype", np.sctypes["int"] + np.sctypes["uint"])
+    @parametrize("itype", np.sctypes["int"] + np.sctypes["uint"])
     def test_small(self, itype):
         for a in range(max(np.iinfo(itype).min, 0), 128):
             msg = f"Smoke test for {itype}({a}).bit_count()"
@@ -227,6 +245,4 @@ class TestBitCount:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_scalarinherit.py
+++ b/test/torch_np/numpy_tests/core/test_scalarinherit.py
@@ -3,10 +3,18 @@
 """ Test printing of scalar types.
 
 """
+import functools
+
+from unittest import skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
 from torch._numpy.testing import assert_
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 class A:
@@ -42,8 +50,8 @@ class B1(np.float64, HasNew):
     pass
 
 
-@pytest.mark.skip(reason="scalar repr: numpy plans to make it more explicit")
-class TestInherit:
+@skip(reason="scalar repr: numpy plans to make it more explicit")
+class TestInherit(TestCase):
     def test_init(self):
         x = B(1.0)
         assert_(str(x) == "1.0")
@@ -69,6 +77,4 @@ class TestInherit:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_scalarinherit.py
+++ b/test/torch_np/numpy_tests/core/test_scalarinherit.py
@@ -14,7 +14,6 @@ from torch._numpy.testing import assert_
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 class A:

--- a/test/torch_np/numpy_tests/core/test_scalarmath.py
+++ b/test/torch_np/numpy_tests/core/test_scalarmath.py
@@ -30,12 +30,12 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    slowTest as slow,
     subtest,
     TestCase,
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 IS_PYPY = False
 
@@ -118,43 +118,6 @@ class TestTypes(TestCase):
         # a leak would show up in valgrind as still-reachable of ~2.6MB
         for i in range(200000):
             np.add(1, 1)
-
-
-'''
-@pytest.mark.slow
-@settings(max_examples=10000, deadline=2000)
-@given(sampled_from(reasonable_operators_for_scalars),
-       hynp.arrays(dtype=hynp.scalar_dtypes(), shape=()),
-       hynp.arrays(dtype=hynp.scalar_dtypes(), shape=()))
-def test_array_scalar_ufunc_equivalence(op, arr1, arr2):
-    """
-    This is a thorough test attempting to cover important promotion paths
-    and ensuring that arrays and scalars stay as aligned as possible.
-    However, if it creates troubles, it should maybe just be removed.
-    """
-    scalar1 = arr1[()]
-    scalar2 = arr2[()]
-    assert isinstance(scalar1, np.generic)
-    assert isinstance(scalar2, np.generic)
-
-    if arr1.dtype.kind == "c" or arr2.dtype.kind == "c":
-        comp_ops = {operator.ge, operator.gt, operator.le, operator.lt}
-        if op in comp_ops and (np.isnan(scalar1) or np.isnan(scalar2)):
-            pytest.xfail("complex comp ufuncs use sort-order, scalars do not.")
-
-    # ignore fpe's since they may just mismatch for integers anyway.
-    with warnings.catch_warnings(), np.errstate(all="ignore"):
-        # Comparisons DeprecationWarnings replacing errors (2022-03):
-        warnings.simplefilter("error", DeprecationWarning)
-        try:
-            res = op(arr1, arr2)
-        except Exception as e:
-            with pytest.raises(type(e)):
-                op(scalar1, scalar2)
-        else:
-            scalar_res = op(scalar1, scalar2)
-            assert_array_equal(scalar_res, res)
-'''
 
 
 class TestBaseMath(TestCase):
@@ -821,41 +784,6 @@ def recursionlimit(n):
         yield
     finally:
         sys.setrecursionlimit(o)
-
-
-"""
-@given(sampled_from(objecty_things),
-       sampled_from(reasonable_operators_for_scalars),
-       sampled_from(types))
-def test_operator_object_left(o, op, type_):
-    try:
-        with recursionlimit(200):
-            op(o, type_(1))
-    except TypeError:
-        pass
-
-
-
-@given(sampled_from(objecty_things),
-       sampled_from(reasonable_operators_for_scalars),
-       sampled_from(types))
-def test_operator_object_right(o, op, type_):
-    try:
-        with recursionlimit(200):
-            op(type_(1), o)
-    except TypeError:
-        pass
-
-
-@given(sampled_from(reasonable_operators_for_scalars),
-       sampled_from(types),
-       sampled_from(types))
-def test_operator_scalars(op, type1, type2):
-    try:
-        op(type1(1), type2(1))
-    except TypeError:
-        pass
-"""
 
 
 @instantiate_parametrized_tests

--- a/test/torch_np/numpy_tests/core/test_scalarmath.py
+++ b/test/torch_np/numpy_tests/core/test_scalarmath.py
@@ -1,10 +1,13 @@
 # Owner(s): ["module: dynamo"]
 
 import contextlib
+import functools
 import itertools
 import operator
 import sys
 import warnings
+
+from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 # from numpy._utils import _pep440
 import pytest
@@ -23,6 +26,16 @@ from torch._numpy.testing import (
     #    assert_array_equal, suppress_warnings, _gen_alignment_data,
     #    assert_warns,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
 
 IS_PYPY = False
 
@@ -65,7 +78,7 @@ reasonable_operators_for_scalars = [
 # This compares scalarmath against ufuncs.
 
 
-class TestTypes:
+class TestTypes(TestCase):
     def test_types(self):
         for atype in types:
             a = atype(1)
@@ -144,7 +157,7 @@ def test_array_scalar_ufunc_equivalence(op, arr1, arr2):
 '''
 
 
-class TestBaseMath:
+class TestBaseMath(TestCase):
     def test_blocked(self):
         # test alignments offsets for simd instructions
         # alignments for vz + 2 * (vs - 1) + 1
@@ -179,7 +192,7 @@ class TestBaseMath:
                 np.add(2, inp2, out=out)
                 assert_almost_equal(out, exp1 + 2, err_msg=msg)
 
-    @pytest.mark.xfail(reason="pytorch does not have .view")
+    @xfail  # (reason="pytorch does not have .view")
     def test_lower_align(self):
         # check data that is not aligned to element size
         # i.e doubles are aligned to 4 bytes on i386
@@ -193,7 +206,7 @@ class TestBaseMath:
         np.add(d, np.ones_like(d))
 
 
-class TestPower:
+class TestPower(TestCase):
     def test_small_types(self):
         for t in [np.int8, np.int16, np.float16]:
             a = t(3)
@@ -210,7 +223,7 @@ class TestPower:
             else:
                 assert_almost_equal(b, 6765201, err_msg=msg)
 
-    @pytest.mark.xfail(reason="Value-based casting: (2)**(-2) -> 0 in pytorch.")
+    @xfail  # (reason="Value-based casting: (2)**(-2) -> 0 in pytorch.")
     def test_integers_to_negative_integer_power(self):
         # Note that the combination of uint64 with a signed integer
         # has common type np.float64. The other combinations should all
@@ -293,7 +306,8 @@ def _signs(dt):
         return (+1, -1)
 
 
-class TestModulus:
+@instantiate_parametrized_tests
+class TestModulus(TestCase):
     def test_modulus_basic(self):
         dt = np.typecodes["AllInteger"] + np.typecodes["Float"]
         for op in [floordiv_and_mod, divmod]:
@@ -310,7 +324,7 @@ class TestModulus:
                     else:
                         assert_(b > rem >= 0, msg)
 
-    @pytest.mark.slow
+    @slow
     def test_float_modulus_exact(self):
         # test that float results are exact for small integers. This also
         # holds for the same integers scaled by powers of two.
@@ -356,12 +370,11 @@ class TestModulus:
                     else:
                         assert_(b > rem >= 0, msg)
 
-    @pytest.mark.parametrize("dt", np.typecodes["Float"])
+    @parametrize("dt", np.typecodes["Float"])
     def test_float_modulus_corner_cases(self, dt):
         if dt == "e":
-            pytest.xfail(
-                reason="RuntimeError: 'nextafter_cpu' not implemented for 'Half'"
-            )
+            # FIXME: make xfail
+            raise SkipTest("RuntimeError: 'nextafter_cpu' not implemented for 'Half'")
 
         b = np.array(1.0, dtype=dt)
         a = np.nextafter(np.array(0.0, dtype=dt), -b)
@@ -396,8 +409,8 @@ class TestModulus:
                 assert_(np.isinf(div)) and assert_(np.isnan(mod))
 
 
-class TestComplexDivision:
-    @pytest.mark.skip(reason="With pytorch, 1/(0+0j) is nan + nan*j, not inf + nan*j")
+class TestComplexDivision(TestCase):
+    @skip(reason="With pytorch, 1/(0+0j) is nan + nan*j, not inf + nan*j")
     def test_zero_division(self):
         for t in [np.complex64, np.complex128]:
             a = t(0.0)
@@ -466,7 +479,7 @@ class TestComplexDivision:
                 assert_equal(result.imag, ex[1])
 
 
-class TestConversion:
+class TestConversion(TestCase):
     def test_int_from_long(self):
         # NB: this test assumes that the default fp type is float64
         l = [1e6, 1e12, 1e18, -1e6, -1e12, -1e18]
@@ -475,7 +488,7 @@ class TestConversion:
             a = np.array(l, dtype=T)
             assert_equal([int(_m) for _m in a], li)
 
-    @pytest.mark.xfail(reason="pytorch does not emit this warning.")
+    @xfail  # (reason="pytorch does not emit this warning.")
     def test_iinfo_long_values_1(self):
         for code in "bBh":
             with pytest.warns(DeprecationWarning):
@@ -578,8 +591,8 @@ class TestConversion:
 #            assert_equal( val, val2 )
 
 
-@pytest.mark.xfail(reason="can delegate repr to pytorch")
-class TestRepr:
+@xfail  # (reason="can delegate repr to pytorch")
+class TestRepr(TestCase):
     def _test_type_repr(self, t):
         finfo = np.finfo(t)
         last_fraction_bit_idx = finfo.nexp + finfo.nmant
@@ -612,8 +625,8 @@ class TestRepr:
             self._test_type_repr(t)
 
 
-@pytest.mark.skip(reason="Array scalars do not decay to python scalars.")
-class TestMultiply:
+@skip(reason="Array scalars do not decay to python scalars.")
+class TestMultiply(TestCase):
     def test_seq_repeat(self):
         # Test that basic sequences get repeated when multiplied with
         # numpy integers. And errors are raised when multiplied with others.
@@ -664,7 +677,7 @@ class TestMultiply:
             assert_array_equal(np.int_(3) * arr_like, np.full(3, 3))
 
 
-class TestNegative:
+class TestNegative(TestCase):
     def test_exceptions(self):
         a = np.ones((), dtype=np.bool_)[()]
         # XXX: TypeError from numpy, RuntimeError from torch
@@ -684,7 +697,7 @@ class TestNegative:
                 assert_equal(operator.neg(a) + a, 0)
 
 
-class TestSubtract:
+class TestSubtract(TestCase):
     def test_exceptions(self):
         a = np.ones((), dtype=np.bool_)[()]
         with assert_raises((TypeError, RuntimeError)):  # XXX: TypeError from numpy
@@ -699,7 +712,8 @@ class TestSubtract:
             assert_equal(operator.sub(a, a), 0)
 
 
-class TestAbs:
+@instantiate_parametrized_tests
+class TestAbs(TestCase):
     def _test_abs_func(self, absfunc, test_dtype):
         x = test_dtype(-1.5)
         assert_equal(absfunc(x), 1.5)
@@ -722,18 +736,19 @@ class TestAbs:
         x = test_dtype(np.finfo(test_dtype).min)
         assert_equal(absfunc(x), -x.real)
 
-    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
+    @parametrize("dtype", floating_types + complex_floating_types)
     def test_builtin_abs(self, dtype):
         self._test_abs_func(abs, dtype)
 
-    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
+    @parametrize("dtype", floating_types + complex_floating_types)
     def test_numpy_abs(self, dtype):
         self._test_abs_func(np.abs, dtype)
 
 
-class TestBitShifts:
-    @pytest.mark.parametrize("type_code", np.typecodes["AllInteger"])
-    @pytest.mark.parametrize("op", [operator.rshift, operator.lshift], ids=[">>", "<<"])
+@instantiate_parametrized_tests
+class TestBitShifts(TestCase):
+    @parametrize("type_code", np.typecodes["AllInteger"])
+    @parametrize("op", [operator.rshift, operator.lshift])
     def test_shift_all_bits(self, type_code, op):
         """Shifts where the shift amount is the width of the type or wider"""
         # gh-2449
@@ -750,7 +765,10 @@ class TestBitShifts:
                     assert_equal(res_scl, -1)
                 else:
                     if type_code in ("i", "l") and shift == np.iinfo(type_code).bits:
-                        pytest.xfail("https://github.com/pytorch/pytorch/issues/70904")
+                        # FIXME: make xfail
+                        raise SkipTest(
+                            "https://github.com/pytorch/pytorch/issues/70904"
+                        )
                     assert_equal(res_scl, 0)
 
                 # Result on scalars should be the same as on arrays
@@ -760,15 +778,16 @@ class TestBitShifts:
                 assert_equal(res_arr, res_scl)
 
 
-@pytest.mark.skip(reason="Will rely on pytest for hashing")
-class TestHash:
-    @pytest.mark.parametrize("type_code", np.typecodes["AllInteger"])
+@skip(reason="Will rely on pytest for hashing")
+@instantiate_parametrized_tests
+class TestHash(TestCase):
+    @parametrize("type_code", np.typecodes["AllInteger"])
     def test_integer_hashes(self, type_code):
         scalar = np.dtype(type_code).type
         for i in range(128):
             assert hash(i) == hash(scalar(i))
 
-    @pytest.mark.parametrize("type_code", np.typecodes["AllFloat"])
+    @parametrize("type_code", np.typecodes["AllFloat"])
     def test_float_and_complex_hashes(self, type_code):
         scalar = np.dtype(type_code).type
         for val in [np.pi, np.inf, 3, 6.0]:
@@ -785,7 +804,7 @@ class TestHash:
             # If Python distinguishes different NaNs we do so too (gh-18833)
             assert hash(scalar(np.nan)) != hash(scalar(np.nan))
 
-    @pytest.mark.parametrize("type_code", np.typecodes["Complex"])
+    @parametrize("type_code", np.typecodes["Complex"])
     def test_complex_hashes(self, type_code):
         # Test some complex valued hashes specifically:
         scalar = np.dtype(type_code).type
@@ -839,79 +858,75 @@ def test_operator_scalars(op, type1, type2):
 """
 
 
-@pytest.mark.xfail(reason="pytorch does not warn on overflow")
-@pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
-@pytest.mark.parametrize(
-    "operation",
-    [
-        lambda min, max: max + max,
-        lambda min, max: min - max,
-        lambda min, max: max * max,
-    ],
-    ids=["+", "-", "*"],
-)
-def test_scalar_integer_operation_overflow(dtype, operation):
-    st = np.dtype(dtype).type
-    min = st(np.iinfo(dtype).min)
-    max = st(np.iinfo(dtype).max)
+@instantiate_parametrized_tests
+class TestScalarOpsMisc(TestCase):
+    @xfail  # (reason="pytorch does not warn on overflow")
+    @parametrize("dtype", np.typecodes["AllInteger"])
+    @parametrize(
+        "operation",
+        [
+            lambda min, max: max + max,
+            lambda min, max: min - max,
+            lambda min, max: max * max,
+        ],
+    )
+    def test_scalar_integer_operation_overflow(self, dtype, operation):
+        st = np.dtype(dtype).type
+        min = st(np.iinfo(dtype).min)
+        max = st(np.iinfo(dtype).max)
 
-    with pytest.warns(RuntimeWarning, match="overflow encountered"):
-        operation(min, max)
+        with pytest.warns(RuntimeWarning, match="overflow encountered"):
+            operation(min, max)
 
+    @skip(reason="integer overflow UB: crashes pytorch under ASAN")
+    @parametrize("dtype", np.typecodes["Integer"])
+    @parametrize(
+        "operation",
+        [
+            lambda min, neg_1: -min,
+            lambda min, neg_1: abs(min),
+            lambda min, neg_1: min * neg_1,
+            subtest(
+                lambda min, neg_1: min // neg_1,
+                decorators=[skip(reason="broken on some platforms")],
+            ),
+        ],
+    )
+    def test_scalar_signed_integer_overflow(self, dtype, operation):
+        # The minimum signed integer can "overflow" for some additional operations
+        st = np.dtype(dtype).type
+        min = st(np.iinfo(dtype).min)
+        neg_1 = st(-1)
 
-@pytest.mark.skip(reason="integer overflow UB: crashes pytorch under ASAN")
-@pytest.mark.parametrize("dtype", np.typecodes["Integer"])
-@pytest.mark.parametrize(
-    "operation",
-    [
-        lambda min, neg_1: -min,
-        lambda min, neg_1: abs(min),
-        lambda min, neg_1: min * neg_1,
-        pytest.param(
-            lambda min, neg_1: min // neg_1,
-            marks=pytest.mark.skip(reason="broken on some platforms"),
-        ),
-    ],
-    ids=["neg", "abs", "*", "//"],
-)
-def test_scalar_signed_integer_overflow(dtype, operation):
-    # The minimum signed integer can "overflow" for some additional operations
-    st = np.dtype(dtype).type
-    min = st(np.iinfo(dtype).min)
-    neg_1 = st(-1)
+        with pytest.warns(RuntimeWarning, match="overflow encountered"):
+            operation(min, neg_1)
 
-    with pytest.warns(RuntimeWarning, match="overflow encountered"):
-        operation(min, neg_1)
+    @xfail  # (reason="pytorch does not warn on overflow")
+    @parametrize("dtype", np.typecodes["UnsignedInteger"])
+    def test_scalar_unsigned_integer_overflow(self, dtype):
+        val = np.dtype(dtype).type(8)
+        with pytest.warns(RuntimeWarning, match="overflow encountered"):
+            -val
 
+        zero = np.dtype(dtype).type(0)
+        -zero  # does not warn
 
-@pytest.mark.xfail(reason="pytorch does not warn on overflow")
-@pytest.mark.parametrize("dtype", np.typecodes["UnsignedInteger"])
-def test_scalar_unsigned_integer_overflow(dtype):
-    val = np.dtype(dtype).type(8)
-    with pytest.warns(RuntimeWarning, match="overflow encountered"):
-        -val
+    @xfail  # (reason="pytorch raises RuntimeError on division by zero")
+    @parametrize("dtype", np.typecodes["AllInteger"])
+    @parametrize(
+        "operation",
+        [
+            lambda val, zero: val // zero,
+            lambda val, zero: val % zero,
+        ],
+    )
+    def test_scalar_integer_operation_divbyzero(self, dtype, operation):
+        st = np.dtype(dtype).type
+        val = st(100)
+        zero = st(0)
 
-    zero = np.dtype(dtype).type(0)
-    -zero  # does not warn
-
-
-@pytest.mark.xfail(reason="pytorch raises RuntimeError on division by zero")
-@pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
-@pytest.mark.parametrize(
-    "operation",
-    [
-        lambda val, zero: val // zero,
-        lambda val, zero: val % zero,
-    ],
-    ids=["//", "%"],
-)
-def test_scalar_integer_operation_divbyzero(dtype, operation):
-    st = np.dtype(dtype).type
-    val = st(100)
-    zero = st(0)
-
-    with pytest.warns(RuntimeWarning, match="divide by zero"):
-        operation(val, zero)
+        with pytest.warns(RuntimeWarning, match="divide by zero"):
+            operation(val, zero)
 
 
 ops_with_names = [
@@ -932,87 +947,88 @@ ops_with_names = [
 ]
 
 
-@pytest.mark.skip(reason="We do not support subclassing scalars.")
-@pytest.mark.parametrize(["__op__", "__rop__", "op", "cmp"], ops_with_names)
-@pytest.mark.parametrize("sctype", [np.float32, np.float64])
-def test_subclass_deferral(sctype, __op__, __rop__, op, cmp):
-    """
-    This test covers scalar subclass deferral.  Note that this is exceedingly
-    complicated, especially since it tends to fall back to the array paths and
-    these additionally add the "array priority" mechanism.
+@instantiate_parametrized_tests
+class TestScalarSubclassingMisc(TestCase):
+    @skip(reason="We do not support subclassing scalars.")
+    @parametrize("__op__, __rop__, op, cmp", ops_with_names)
+    @parametrize("sctype", [np.float32, np.float64])
+    def test_subclass_deferral(self, sctype, __op__, __rop__, op, cmp):
+        """
+        This test covers scalar subclass deferral.  Note that this is exceedingly
+        complicated, especially since it tends to fall back to the array paths and
+        these additionally add the "array priority" mechanism.
 
-    The behaviour was modified subtly in 1.22 (to make it closer to how Python
-    scalars work).  Due to its complexity and the fact that subclassing NumPy
-    scalars is probably a bad idea to begin with.  There is probably room
-    for adjustments here.
-    """
+        The behaviour was modified subtly in 1.22 (to make it closer to how Python
+        scalars work).  Due to its complexity and the fact that subclassing NumPy
+        scalars is probably a bad idea to begin with.  There is probably room
+        for adjustments here.
+        """
 
-    class myf_simple1(sctype):
-        pass
+        class myf_simple1(sctype):
+            pass
 
-    class myf_simple2(sctype):
-        pass
+        class myf_simple2(sctype):
+            pass
 
-    def op_func(self, other):
-        return __op__
+        def op_func(self, other):
+            return __op__
 
-    def rop_func(self, other):
-        return __rop__
+        def rop_func(self, other):
+            return __rop__
 
-    myf_op = type("myf_op", (sctype,), {__op__: op_func, __rop__: rop_func})
+        myf_op = type("myf_op", (sctype,), {__op__: op_func, __rop__: rop_func})
 
-    # inheritance has to override, or this is correctly lost:
-    res = op(myf_simple1(1), myf_simple2(2))
-    assert type(res) == sctype or type(res) == np.bool_
-    assert op(myf_simple1(1), myf_simple2(2)) == op(1, 2)  # inherited
+        # inheritance has to override, or this is correctly lost:
+        res = op(myf_simple1(1), myf_simple2(2))
+        assert type(res) == sctype or type(res) == np.bool_
+        assert op(myf_simple1(1), myf_simple2(2)) == op(1, 2)  # inherited
 
-    # Two independent subclasses do not really define an order.  This could
-    # be attempted, but we do not since Python's `int` does neither:
-    assert op(myf_op(1), myf_simple1(2)) == __op__
-    assert op(myf_simple1(1), myf_op(2)) == op(1, 2)  # inherited
+        # Two independent subclasses do not really define an order.  This could
+        # be attempted, but we do not since Python's `int` does neither:
+        assert op(myf_op(1), myf_simple1(2)) == __op__
+        assert op(myf_simple1(1), myf_op(2)) == op(1, 2)  # inherited
 
+    @skip(reason="We do not support subclassing scalars.")
+    @parametrize("__op__, __rop__, op, cmp", ops_with_names)
+    @parametrize("subtype", [float, int, complex, np.float16])
+    # @np._no_nep50_warning()
+    def test_pyscalar_subclasses(self, subtype, __op__, __rop__, op, cmp):
+        def op_func(self, other):
+            return __op__
 
-@pytest.mark.skip(reason="We do not support subclassing scalars.")
-@pytest.mark.parametrize(["__op__", "__rop__", "op", "cmp"], ops_with_names)
-@pytest.mark.parametrize("subtype", [float, int, complex, np.float16])
-# @np._no_nep50_warning()
-def test_pyscalar_subclasses(subtype, __op__, __rop__, op, cmp):
-    def op_func(self, other):
-        return __op__
+        def rop_func(self, other):
+            return __rop__
 
-    def rop_func(self, other):
-        return __rop__
+        # Check that deferring is indicated using `__array_ufunc__`:
+        myt = type(
+            "myt",
+            (subtype,),
+            {__op__: op_func, __rop__: rop_func, "__array_ufunc__": None},
+        )
 
-    # Check that deferring is indicated using `__array_ufunc__`:
-    myt = type(
-        "myt", (subtype,), {__op__: op_func, __rop__: rop_func, "__array_ufunc__": None}
-    )
+        # Just like normally, we should never presume we can modify the float.
+        assert op(myt(1), np.float64(2)) == __op__
+        assert op(np.float64(1), myt(2)) == __rop__
 
-    # Just like normally, we should never presume we can modify the float.
-    assert op(myt(1), np.float64(2)) == __op__
-    assert op(np.float64(1), myt(2)) == __rop__
+        if op in {operator.mod, operator.floordiv} and subtype == complex:
+            return  # module is not support for complex.  Do not test.
 
-    if op in {operator.mod, operator.floordiv} and subtype == complex:
-        return  # module is not support for complex.  Do not test.
+        if __rop__ == __op__:
+            return
 
-    if __rop__ == __op__:
-        return
+        # When no deferring is indicated, subclasses are handled normally.
+        myt = type("myt", (subtype,), {__rop__: rop_func})
 
-    # When no deferring is indicated, subclasses are handled normally.
-    myt = type("myt", (subtype,), {__rop__: rop_func})
-
-    # Check for float32, as a float subclass float64 may behave differently
-    res = op(myt(1), np.float16(2))
-    expected = op(subtype(1), np.float16(2))
-    assert res == expected
-    assert type(res) == type(expected)
-    res = op(np.float32(2), myt(1))
-    expected = op(np.float32(2), subtype(1))
-    assert res == expected
-    assert type(res) == type(expected)
+        # Check for float32, as a float subclass float64 may behave differently
+        res = op(myt(1), np.float16(2))
+        expected = op(subtype(1), np.float16(2))
+        assert res == expected
+        assert type(res) == type(expected)
+        res = op(np.float32(2), myt(1))
+        expected = op(np.float32(2), subtype(1))
+        assert res == expected
+        assert type(res) == type(expected)
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_shape_base.py
+++ b/test/torch_np/numpy_tests/core/test_shape_base.py
@@ -1,5 +1,9 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
+
+from unittest import expectedFailure as xfail, skipIf as skipif
+
 import pytest
 
 import torch._numpy as np
@@ -17,11 +21,21 @@ from torch._numpy import (
     vstack,
 )
 from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
+
 
 IS_PYPY = False
 
 
-class TestAtleast1d:
+class TestAtleast1d(TestCase):
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -60,7 +74,7 @@ class TestAtleast1d:
         assert atleast_1d([[2, 3], [4, 5]]).shape == (2, 2)
 
 
-class TestAtleast2d:
+class TestAtleast2d(TestCase):
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -98,7 +112,7 @@ class TestAtleast2d:
         assert atleast_2d([[[3, 1], [4, 5]], [[3, 5], [1, 2]]]).shape == (2, 2, 2)
 
 
-class TestAtleast3d:
+class TestAtleast3d(TestCase):
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -130,7 +144,7 @@ class TestAtleast3d:
         assert_array_equal(res, desired)
 
 
-class TestHstack:
+class TestHstack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, hstack, 1)
 
@@ -179,7 +193,7 @@ class TestHstack:
             hstack((a, b), casting="safe", dtype=np.int64)
 
 
-class TestVstack:
+class TestVstack(TestCase):
     def test_non_iterable(self):
         assert_raises(TypeError, vstack, 1)
 
@@ -214,7 +228,7 @@ class TestVstack:
         desired = array([[1, 2], [1, 2]])
         assert_array_equal(res, desired)
 
-    @pytest.mark.xfail(reason="vstack w/generators")
+    @xfail  # (reason="vstack w/generators")
     def test_generator(self):
         with pytest.raises(TypeError, match="arrays to stack must be"):
             vstack(np.arange(3) for _ in range(2))
@@ -233,7 +247,8 @@ class TestVstack:
             vstack((a, b), casting="safe", dtype=np.int64)
 
 
-class TestConcatenate:
+@instantiate_parametrized_tests
+class TestConcatenate(TestCase):
     def test_out_and_dtype_simple(self):
         # numpy raises TypeError on both out=... and dtype=...
         a, b, out = np.ones(3), np.ones(4), np.ones(3 + 4)
@@ -318,7 +333,7 @@ class TestConcatenate:
         assert out is rout
         assert np.all(r == rout)
 
-    @pytest.mark.xfail(reason="concatenate(x, axis=None) relies on x being a sequence")
+    @xfail  # (reason="concatenate(x, axis=None) relies on x being a sequence")
     def test_large_concatenate_axis_None(self):
         # When no axis is given, concatenate uses flattened versions.
         # This also had a bug with many arrays (see gh-5979).
@@ -374,10 +389,8 @@ class TestConcatenate:
         assert_(out is rout)
         assert_equal(res, rout)
 
-    @pytest.mark.skipif(reason="concat, arrays, sequence")
-    @pytest.mark.skipif(
-        IS_PYPY, reason="PYPY handles sq_concat, nb_add differently than cpython"
-    )
+    @skip(reason="concat, arrays, sequence")
+    @skipif(IS_PYPY, reason="PYPY handles sq_concat, nb_add differently than cpython")
     def test_operator_concat(self):
         import operator
 
@@ -400,11 +413,11 @@ class TestConcatenate:
         assert_raises(ValueError, concatenate, (a, b), out=np.empty((1, 4)))
         concatenate((a, b), out=np.empty(4))
 
-    @pytest.mark.parametrize("axis", [None, 0])
-    @pytest.mark.parametrize(
+    @parametrize("axis", [None, 0])
+    @parametrize(
         "out_dtype", ["c8", "f4", "f8", "i8"]
     )  # torch does not have ">f8", "S4"
-    @pytest.mark.parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])
+    @parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])
     def test_out_and_dtype(self, axis, out_dtype, casting):
         # Compare usage of `out=out` with `dtype=out.dtype`
         out = np.empty(4, dtype=out_dtype)
@@ -428,114 +441,114 @@ class TestConcatenate:
             concatenate(to_concat, out=out, dtype=out_dtype, axis=axis)
 
 
-def test_stack():
-    # non-iterable input
-    assert_raises(TypeError, stack, 1)
+@instantiate_parametrized_tests
+class TestStackMisc(TestCase):
+    def test_stack(self):
+        # non-iterable input
+        assert_raises(TypeError, stack, 1)
 
-    # 0d input
-    for input_ in [
-        (1, 2, 3),
-        [np.int32(1), np.int32(2), np.int32(3)],
-        [np.array(1), np.array(2), np.array(3)],
-    ]:
-        assert_array_equal(stack(input_), [1, 2, 3])
-    # 1d input examples
-    a = np.array([1, 2, 3])
-    b = np.array([4, 5, 6])
-    r1 = array([[1, 2, 3], [4, 5, 6]])
-    assert_array_equal(np.stack((a, b)), r1)
-    assert_array_equal(np.stack((a, b), axis=1), r1.T)
-    # all input types
-    assert_array_equal(np.stack([a, b]), r1)
-    assert_array_equal(np.stack(array([a, b])), r1)
-    # all shapes for 1d input
-    arrays = [np.random.randn(3) for _ in range(10)]
-    axes = [0, 1, -1, -2]
-    expected_shapes = [(10, 3), (3, 10), (3, 10), (10, 3)]
-    for axis, expected_shape in zip(axes, expected_shapes):
-        assert_equal(np.stack(arrays, axis).shape, expected_shape)
+        # 0d input
+        for input_ in [
+            (1, 2, 3),
+            [np.int32(1), np.int32(2), np.int32(3)],
+            [np.array(1), np.array(2), np.array(3)],
+        ]:
+            assert_array_equal(stack(input_), [1, 2, 3])
+        # 1d input examples
+        a = np.array([1, 2, 3])
+        b = np.array([4, 5, 6])
+        r1 = array([[1, 2, 3], [4, 5, 6]])
+        assert_array_equal(np.stack((a, b)), r1)
+        assert_array_equal(np.stack((a, b), axis=1), r1.T)
+        # all input types
+        assert_array_equal(np.stack([a, b]), r1)
+        assert_array_equal(np.stack(array([a, b])), r1)
+        # all shapes for 1d input
+        arrays = [np.random.randn(3) for _ in range(10)]
+        axes = [0, 1, -1, -2]
+        expected_shapes = [(10, 3), (3, 10), (3, 10), (10, 3)]
+        for axis, expected_shape in zip(axes, expected_shapes):
+            assert_equal(np.stack(arrays, axis).shape, expected_shape)
 
-    assert_raises(AxisError, stack, arrays, axis=2)
-    assert_raises(AxisError, stack, arrays, axis=-3)
+        assert_raises(AxisError, stack, arrays, axis=2)
+        assert_raises(AxisError, stack, arrays, axis=-3)
 
-    # all shapes for 2d input
-    arrays = [np.random.randn(3, 4) for _ in range(10)]
-    axes = [0, 1, 2, -1, -2, -3]
-    expected_shapes = [
-        (10, 3, 4),
-        (3, 10, 4),
-        (3, 4, 10),
-        (3, 4, 10),
-        (3, 10, 4),
-        (10, 3, 4),
-    ]
-    for axis, expected_shape in zip(axes, expected_shapes):
-        assert_equal(np.stack(arrays, axis).shape, expected_shape)
+        # all shapes for 2d input
+        arrays = [np.random.randn(3, 4) for _ in range(10)]
+        axes = [0, 1, 2, -1, -2, -3]
+        expected_shapes = [
+            (10, 3, 4),
+            (3, 10, 4),
+            (3, 4, 10),
+            (3, 4, 10),
+            (3, 10, 4),
+            (10, 3, 4),
+        ]
+        for axis, expected_shape in zip(axes, expected_shapes):
+            assert_equal(np.stack(arrays, axis).shape, expected_shape)
 
-    # empty arrays
-    assert stack([[], [], []]).shape == (3, 0)
-    assert stack([[], [], []], axis=1).shape == (0, 3)
+        # empty arrays
+        assert stack([[], [], []]).shape == (3, 0)
+        assert stack([[], [], []], axis=1).shape == (0, 3)
 
-    # out
-    out = np.zeros_like(r1)
-    np.stack((a, b), out=out)
-    assert_array_equal(out, r1)
+        # out
+        out = np.zeros_like(r1)
+        np.stack((a, b), out=out)
+        assert_array_equal(out, r1)
 
-    # edge cases
-    assert_raises(ValueError, stack, [])
-    assert_raises(ValueError, stack, [])
-    assert_raises((RuntimeError, ValueError), stack, [1, np.arange(3)])
-    assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1])
-    assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1], axis=1)
-    assert_raises(
-        (RuntimeError, ValueError), stack, [np.zeros((3, 3)), np.zeros(3)], axis=1
-    )
-    assert_raises((RuntimeError, ValueError), stack, [np.arange(2), np.arange(3)])
+        # edge cases
+        assert_raises(ValueError, stack, [])
+        assert_raises(ValueError, stack, [])
+        assert_raises((RuntimeError, ValueError), stack, [1, np.arange(3)])
+        assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1])
+        assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1], axis=1)
+        assert_raises(
+            (RuntimeError, ValueError), stack, [np.zeros((3, 3)), np.zeros(3)], axis=1
+        )
+        assert_raises((RuntimeError, ValueError), stack, [np.arange(2), np.arange(3)])
 
-    # generator is deprecated: numpy 1.24 emits a warning but we don't
-    # with assert_warns(FutureWarning):
-    result = stack(x for x in range(3))
+        # generator is deprecated: numpy 1.24 emits a warning but we don't
+        # with assert_warns(FutureWarning):
+        result = stack(x for x in range(3))
 
-    assert_array_equal(result, np.array([0, 1, 2]))
+        assert_array_equal(result, np.array([0, 1, 2]))
 
-    # casting and dtype test
-    a = np.array([1, 2, 3])
-    b = np.array([2.5, 3.5, 4.5])
-    res = np.stack((a, b), axis=1, casting="unsafe", dtype=np.int64)
-    expected_res = np.array([[1, 2], [2, 3], [3, 4]])
-    assert_array_equal(res, expected_res)
+        # casting and dtype test
+        a = np.array([1, 2, 3])
+        b = np.array([2.5, 3.5, 4.5])
+        res = np.stack((a, b), axis=1, casting="unsafe", dtype=np.int64)
+        expected_res = np.array([[1, 2], [2, 3], [3, 4]])
+        assert_array_equal(res, expected_res)
 
-    # casting and dtype with TypeError
-    with assert_raises(TypeError):
-        stack((a, b), dtype=np.int64, axis=1, casting="safe")
-
-
-@pytest.mark.parametrize("axis", [0])
-@pytest.mark.parametrize(
-    "out_dtype", ["c8", "f4", "f8", "i8"]
-)  # torch does not have ">f8",
-@pytest.mark.parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])
-def test_stack_out_and_dtype(axis, out_dtype, casting):
-    to_concat = (array([1, 2]), array([3, 4]))
-    res = array([[1, 2], [3, 4]])
-    out = np.zeros_like(res)
-
-    if not np.can_cast(to_concat[0], out_dtype, casting=casting):
+        # casting and dtype with TypeError
         with assert_raises(TypeError):
-            stack(to_concat, dtype=out_dtype, axis=axis, casting=casting)
-    else:
-        res_out = stack(to_concat, out=out, axis=axis, casting=casting)
-        res_dtype = stack(to_concat, dtype=out_dtype, axis=axis, casting=casting)
-        assert res_out is out
-        assert_array_equal(out, res_dtype)
-        assert res_dtype.dtype == out_dtype
+            stack((a, b), dtype=np.int64, axis=1, casting="safe")
 
-    with assert_raises(TypeError):
-        stack(to_concat, out=out, dtype=out_dtype, axis=axis)
+    @parametrize("axis", [0])
+    @parametrize("out_dtype", ["c8", "f4", "f8", "i8"])  # torch does not have ">f8",
+    @parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])
+    def test_stack_out_and_dtype(self, axis, out_dtype, casting):
+        to_concat = (array([1, 2]), array([3, 4]))
+        res = array([[1, 2], [3, 4]])
+        out = np.zeros_like(res)
+
+        if not np.can_cast(to_concat[0], out_dtype, casting=casting):
+            with assert_raises(TypeError):
+                stack(to_concat, dtype=out_dtype, axis=axis, casting=casting)
+        else:
+            res_out = stack(to_concat, out=out, axis=axis, casting=casting)
+            res_dtype = stack(to_concat, dtype=out_dtype, axis=axis, casting=casting)
+            assert res_out is out
+            assert_array_equal(out, res_dtype)
+            assert res_dtype.dtype == out_dtype
+
+        with assert_raises(TypeError):
+            stack(to_concat, out=out, dtype=out_dtype, axis=axis)
 
 
-@pytest.mark.xfail(reason="TODO: implement block(...)")
-class TestBlock:
+@xfail  # (reason="TODO: implement block(...)")
+@instantiate_parametrized_tests
+class TestBlock(TestCase):
     @pytest.fixture(params=["block", "force_concatenate", "force_slicing"])
     def block(self, request):
         # blocking small arrays and large arrays go through different paths.
@@ -823,6 +836,4 @@ class TestBlock:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/core/test_shape_base.py
+++ b/test/torch_np/numpy_tests/core/test_shape_base.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_utils import (
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 IS_PYPY = False

--- a/test/torch_np/numpy_tests/fft/test_helper.py
+++ b/test/torch_np/numpy_tests/fft/test_helper.py
@@ -8,9 +8,10 @@ Copied from fftpack.helper by Pearu Peterson, October 2005
 import torch._numpy as np
 from torch._numpy import fft, pi
 from torch._numpy.testing import assert_array_almost_equal
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-class TestFFTShift:
+class TestFFTShift(TestCase):
     def test_definition(self):
         x = [0, 1, 2, 3, 4, -4, -3, -2, -1]
         y = [-4, -3, -2, -1, 0, 1, 2, 3, 4]
@@ -124,7 +125,7 @@ class TestFFTShift:
                     )
 
 
-class TestFFTFreq:
+class TestFFTFreq(TestCase):
     def test_definition(self):
         x = [0, 1, 2, 3, 4, -4, -3, -2, -1]
         assert_array_almost_equal(9 * fft.fftfreq(9), x)
@@ -134,7 +135,7 @@ class TestFFTFreq:
         assert_array_almost_equal(10 * pi * fft.fftfreq(10, pi), x)
 
 
-class TestRFFTFreq:
+class TestRFFTFreq(TestCase):
     def test_definition(self):
         x = [0, 1, 2, 3, 4]
         assert_array_almost_equal(9 * fft.rfftfreq(9), x)
@@ -144,7 +145,7 @@ class TestRFFTFreq:
         assert_array_almost_equal(10 * pi * fft.rfftfreq(10, pi), x)
 
 
-class TestIRFFTN:
+class TestIRFFTN(TestCase):
     def test_not_last_axis_success(self):
         ar, ai = np.random.random((2, 16, 8, 32))
         a = ar + 1j * ai
@@ -156,6 +157,4 @@ class TestIRFFTN:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/fft/test_pocketfft.py
+++ b/test/torch_np/numpy_tests/fft/test_pocketfft.py
@@ -1,14 +1,27 @@
 # Owner(s): ["module: dynamo"]
 
+import functools
 import queue
 import threading
+from unittest import skipIf as skipif, SkipTest
 
 import pytest
 import torch._numpy as np
 from pytest import raises as assert_raises
 
 from torch._numpy.random import random
+
 from torch._numpy.testing import assert_allclose, assert_array_equal  # , IS_WASM
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+skip = functools.partial(skipif, True)
+slow = skip  # FIXME: slow tests never ran (= broken)
+
 
 IS_WASM = False
 
@@ -20,13 +33,14 @@ def fft1(x):
     return np.sum(x * np.exp(phase), axis=1)
 
 
-class TestFFTShift:
+class TestFFTShift(TestCase):
     def test_fft_n(self):
         assert_raises((ValueError, RuntimeError), np.fft.fft, [1, 2, 3], 0)
 
 
-class TestFFT1D:
-    def setup_method(self):
+@instantiate_parametrized_tests
+class TestFFT1D(TestCase):
+    def setUp(self):
         np.random.seed(123456)
 
     def test_identity(self):
@@ -45,7 +59,7 @@ class TestFFT1D:
         assert_allclose(fft1(x) / np.sqrt(30), np.fft.fft(x, norm="ortho"), atol=5e-6)
         assert_allclose(fft1(x) / 30.0, np.fft.fft(x, norm="forward"), atol=5e-6)
 
-    @pytest.mark.parametrize("norm", (None, "backward", "ortho", "forward"))
+    @parametrize("norm", (None, "backward", "ortho", "forward"))
     def test_ifft(self, norm):
         x = random(30) + 1j * random(30)
         assert_allclose(x, np.fft.ifft(np.fft.fft(x, norm=norm), norm=norm), atol=1e-6)
@@ -247,9 +261,7 @@ class TestFFT1D:
             atol=1e-6,
         )
 
-    @pytest.mark.parametrize(
-        "op", [np.fft.fftn, np.fft.ifftn, np.fft.rfftn, np.fft.irfftn]
-    )
+    @parametrize("op", [np.fft.fftn, np.fft.ifftn, np.fft.rfftn, np.fft.irfftn])
     def test_axes(self, op):
         x = random((30, 20, 10))
         axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
@@ -277,7 +289,7 @@ class TestFFT1D:
                     tmp = back(tmp, n=n, norm=norm)
                     assert_allclose(x_norm, np.linalg.norm(tmp), atol=1e-6)
 
-    @pytest.mark.parametrize("dtype", [np.half, np.single, np.double])
+    @parametrize("dtype", [np.half, np.single, np.double])
     def test_dtypes(self, dtype):
         # make sure that all input precisions are accepted and internally
         # converted to 64bit
@@ -285,50 +297,49 @@ class TestFFT1D:
         assert_allclose(np.fft.ifft(np.fft.fft(x)), x, atol=1e-6)
         assert_allclose(np.fft.irfft(np.fft.rfft(x)), x, atol=1e-6)
 
+    @parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+    @parametrize("order", ["F", "non-contiguous"])
+    @parametrize(
+        "fft",
+        [np.fft.fft, np.fft.fft2, np.fft.fftn, np.fft.ifft, np.fft.ifft2, np.fft.ifftn],
+    )
+    def test_fft_with_order(self, dtype, order, fft):
+        # Check that FFT/IFFT produces identical results for C, Fortran and
+        # non contiguous arrays
+        #   rng = np.random.RandomState(42)
+        rng = np.random
+        X = rng.rand(8, 7, 13).astype(dtype)  # , copy=False)
+        # See discussion in pull/14178
+        _tol = float(8.0 * np.sqrt(np.log2(X.size)) * np.finfo(X.dtype).eps)
+        if order == "F":
+            raise SkipTest("Fortran order arrays")
+            Y = np.asfortranarray(X)
+        else:
+            # Make a non contiguous array
+            Z = np.empty((16, 7, 13), dtype=X.dtype)
+            Z[::2] = X
+            Y = Z[::2]
+            X = Y.copy()
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
-@pytest.mark.parametrize("order", ["F", "non-contiguous"])
-@pytest.mark.parametrize(
-    "fft",
-    [np.fft.fft, np.fft.fft2, np.fft.fftn, np.fft.ifft, np.fft.ifft2, np.fft.ifftn],
-)
-def test_fft_with_order(dtype, order, fft):
-    # Check that FFT/IFFT produces identical results for C, Fortran and
-    # non contiguous arrays
-    #   rng = np.random.RandomState(42)
-    rng = np.random
-    X = rng.rand(8, 7, 13).astype(dtype)  # , copy=False)
-    # See discussion in pull/14178
-    _tol = float(8.0 * np.sqrt(np.log2(X.size)) * np.finfo(X.dtype).eps)
-    if order == "F":
-        pytest.skip("Fortran order arrays")
-        Y = np.asfortranarray(X)
-    else:
-        # Make a non contiguous array
-        Z = np.empty((16, 7, 13), dtype=X.dtype)
-        Z[::2] = X
-        Y = Z[::2]
-        X = Y.copy()
-
-    if fft.__name__.endswith("fft"):
-        for axis in range(3):
-            X_res = fft(X, axis=axis)
-            Y_res = fft(Y, axis=axis)
-            assert_allclose(X_res, Y_res, atol=_tol, rtol=_tol)
-    elif fft.__name__.endswith(("fft2", "fftn")):
-        axes = [(0, 1), (1, 2), (0, 2)]
-        if fft.__name__.endswith("fftn"):
-            axes.extend([(0,), (1,), (2,), None])
-        for ax in axes:
-            X_res = fft(X, axes=ax)
-            Y_res = fft(Y, axes=ax)
-            assert_allclose(X_res, Y_res, atol=_tol, rtol=_tol)
-    else:
-        raise ValueError()
+        if fft.__name__.endswith("fft"):
+            for axis in range(3):
+                X_res = fft(X, axis=axis)
+                Y_res = fft(Y, axis=axis)
+                assert_allclose(X_res, Y_res, atol=_tol, rtol=_tol)
+        elif fft.__name__.endswith(("fft2", "fftn")):
+            axes = [(0, 1), (1, 2), (0, 2)]
+            if fft.__name__.endswith("fftn"):
+                axes.extend([(0,), (1,), (2,), None])
+            for ax in axes:
+                X_res = fft(X, axes=ax)
+                Y_res = fft(Y, axes=ax)
+                assert_allclose(X_res, Y_res, atol=_tol, rtol=_tol)
+        else:
+            raise ValueError()
 
 
-@pytest.mark.skipif(IS_WASM, reason="Cannot start thread")
-class TestFFTThreadSafe:
+@skipif(IS_WASM, reason="Cannot start thread")
+class TestFFTThreadSafe(TestCase):
     threads = 16
     input_shape = (800, 200)
 
@@ -372,6 +383,4 @@ class TestFFTThreadSafe:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/torch_np/numpy_tests/fft/test_pocketfft.py
+++ b/test/torch_np/numpy_tests/fft/test_pocketfft.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_utils import (
 )
 
 skip = functools.partial(skipif, True)
-slow = skip  # FIXME: slow tests never ran (= broken)
 
 
 IS_WASM = False


### PR DESCRIPTION

1. Inherit from TestCase
2. Use pytorch parametrization
3. Use unittest.expectedFailure to mark xfails, also unittest skips

All this to make pytest-less invocation work:

$ python test/torch_np/test_basic.py

cross-ref #109593, #109718, #109775

cc @mruberry @rgommers @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng