### PR TITLE
Added a UserWarning when using torch.{std,var,std_mean,std_var} with dof<=0

### DIFF
--- a/aten/src/ATen/native/Correlation.cpp
+++ b/aten/src/ATen/native/Correlation.cpp
@@ -114,7 +114,7 @@ Tensor cov(
   }
 
   if (at::is_scalar_tensor_true(norm_factor.le(0))) {
-    TORCH_WARN("cov(): degrees of freedom is <= 0");
+    TORCH_WARN("cov(): degrees of freedom is <= 0. Correction should be strictly less than the number of observations.");
     norm_factor.zero_();
   }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1662,6 +1662,17 @@ static double std_var_all_cpu(const Tensor& self, double correction, bool take_s
   return result;
 }
 
+namespace {
+  static inline void warn_invalid_degrees_of_freedom(const char* fname, const TensorIterator iter, double correction) {
+    int64_t reducing_over_num_elements = iter.num_output_elements() == 0 ? 0 : iter.numel() / iter.num_output_elements();
+    if (reducing_over_num_elements - correction <= 0) {
+      std::ostringstream ss;
+      ss << fname << "(): degrees of freedom is <= 0";
+      TORCH_WARN(ss.str());
+    }
+  }
+} // namespace
+
 static Tensor& std_var_out(
     const char* fname, Tensor& result, const Tensor& self,
     at::OptionalIntArrayRef dim, const c10::optional<Scalar>& correction_opt,
@@ -1714,6 +1725,7 @@ static Tensor& std_var_out(
   TORCH_CHECK(at::canCast(self.scalar_type(), result.scalar_type()),
               "result type ", self.scalar_type(), " can't be cast to the "
               "desired output type ", result.scalar_type());
+  warn_invalid_degrees_of_freedom(fname, iter, correction);
 
   if (iter.numel() == 0) {
     // Trivial reduction
@@ -1793,6 +1805,7 @@ static std::tuple<Tensor&, Tensor&> std_var_mean_out(
   ScalarType dtype = get_dtype_from_result(result1, {});
   auto iter =
       make_reduction(fname, result1, result2, self, dim, keepdim, dtype);
+  warn_invalid_degrees_of_freedom(fname, iter, correction);
 
   if (iter.numel() == 0) {
     // Trivial reduction

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1663,12 +1663,10 @@ static double std_var_all_cpu(const Tensor& self, double correction, bool take_s
 }
 
 namespace {
-  static inline void warn_invalid_degrees_of_freedom(const char* fname, const TensorIterator iter, double correction) {
+  inline void warn_invalid_degrees_of_freedom(const char* fname, const TensorIterator& iter, double correction) {
     int64_t reducing_over_num_elements = iter.num_output_elements() == 0 ? 0 : iter.numel() / iter.num_output_elements();
     if (reducing_over_num_elements - correction <= 0) {
-      std::ostringstream ss;
-      ss << fname << "(): degrees of freedom is <= 0";
-      TORCH_WARN(ss.str());
+      TORCH_WARN(fname, "(): degrees of freedom is <= 0. Correction should be strictly less than the reduction factor (input numel divided by output numel).");
     }
   }
 } // namespace

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2827,15 +2827,14 @@ class TestReductions(TestCase):
 
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_warn_invalid_degrees_of_freedom(self, device, dtype):
-        correction = 20
-        _size = (10, correction)
-        tensor = make_tensor(_size, dtype=dtype, device=device)
-
-        def _assert_warning(func, tensor, correction):
+        def _assert_warning(_func, _tensor, _correction):
             with warnings.catch_warnings(record=True) as w:
-                func(tensor, dim=-1, correction=correction)
+                _func(_tensor, dim=-1, correction=_correction)
             self.assertIn('degrees of freedom is <= 0', str(w[0].message))
 
+        correction = 20
+        size = (10, correction)
+        tensor = make_tensor(size, dtype=dtype, device=device)
         for f in [torch.std, torch.var, torch.var_mean, torch.std_mean]:
             _assert_warning(f, tensor, correction)
 

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2825,6 +2825,20 @@ class TestReductions(TestCase):
             self.assertEqual(var1, var2)
             self.assertEqual(mean1, mean2)
 
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_warn_invalid_degrees_of_freedom(self, device, dtype):
+        correction = 20
+        _size = (10, correction)
+        tensor = make_tensor(_size, dtype=dtype, device=device)
+
+        def _assert_warning(func, tensor, correction):
+            with warnings.catch_warnings(record=True) as w:
+                func(tensor, dim=-1, correction=correction)
+            self.assertIn('degrees of freedom is <= 0', str(w[0].message))
+
+        for f in [torch.std, torch.var, torch.var_mean, torch.std_mean]:
+            _assert_warning(f, tensor, correction)
+
     def test_amin_amax_some_dims(self, device):
         sizes = (4, 6, 7, 5, 3)
         dims = len(sizes)


### PR DESCRIPTION
Fixes #109696.

This PR adds a `UserWarning` when calling 
- `torch.var`
- `torch.var_mean`
- `torch.std`
- `torch.std_mean`

with an effective `dof<=0`. Until now, only `torch.cov` warned about this. The code also handles edge cases, such as `torch.empty`
```
>>> import torch; torch.std_mean(torch.empty(0), correction=0)
<stdin>:1: UserWarning: std_mean(): degrees of freedom is <= 0 (Triggered internally at /app/aten/src/ATen/native/ReduceOps.cpp:1671.)
(tensor(nan), tensor(nan))
```

multi-dim reductions

```
>>> import torch; torch.std_mean(torch.empty(10, 30, 20, 50), correction=600, dim=(1, 2))
<stdin>:1: UserWarning: std_mean(): degrees of freedom is <= 0 (Triggered internally at /app/aten/src/ATen/native/ReduceOps.cpp:1671.)
[... snip ...]
```

and a negative `correction`.

```
>>> import torch; torch.std_mean(torch.randn(0), correction=-5)
(tensor(nan), tensor(nan))
```
