### PR TITLE
[inductor] Refactor some libtorch c shim interfaces

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1019,7 +1019,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     var_name = f"var_{next(self.arg_var_id)}"
                     self.writeline(f"void *{var_name}{self.ending}")
                     self.writeline(
-                        f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr(&{var_name}, {arg}));"
+                        f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr({arg}, &{var_name}));"
                     )
                     dtype = V.graph.get_dtype(arg)
                     cpp_dtype = DTYPE_TO_CPP[dtype]
@@ -1215,7 +1215,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         if config.aot_inductor.abi_compatible:
             code.writeline(f"int64_t* {name}_size;")
             code.writeline(
-                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_sizes(&{name}_size, {name}));"
+                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_sizes({name}, &{name}_size));"
             )
         else:
             super().codegen_input_size_var_decl(code, name)
@@ -1224,7 +1224,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         if config.aot_inductor.abi_compatible:
             code.writeline(f"int64_t* {name}_stride;")
             code.writeline(
-                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(&{name}_stride, {name}));"
+                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides({name}, &{name}_stride));"
             )
         else:
             super().codegen_input_stride_var_decl(code, name)
@@ -1587,13 +1587,13 @@ class CppWrapperCodeGen(WrapperCodeGen):
         if config.aot_inductor.abi_compatible:
             device_type, device_id = device.split(",")
             args = [
-                f"&{name}_handle",
                 str(len(buffer.get_size())),
                 self.codegen_int_array_var(size, self.wrapper_call),
                 self.codegen_int_array_var(stride, self.wrapper_call),
                 dtype,
                 device_type,
                 device_id,
+                f"&{name}_handle",
             ]
             self.wrapper_call.writeline(f"AtenTensorHandle {name}_handle;")
             self.wrapper_call.writeline(
@@ -1619,12 +1619,12 @@ class CppWrapperCodeGen(WrapperCodeGen):
             if writer is None:
                 writer = self
             args = [
-                f"&{tmp_name}",
                 f"{name}",
                 dim,
                 self.codegen_int_array_var(size, writer),
                 self.codegen_int_array_var(stride, writer),
                 offset,
+                f"&{tmp_name}",
             ]
             writer.writeline(f"AtenTensorHandle {tmp_name};")
             writer.writeline(
@@ -2025,7 +2025,7 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 if config.aot_inductor.abi_compatible:
                     self.writeline(f"CUdeviceptr {var_name};")
                     self.writeline(
-                        f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr(reinterpret_cast<void**>(&{var_name}), {arg}));"
+                        f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_data_ptr({arg}, reinterpret_cast<void**>(&{var_name})));"
                     )
                 else:
                     self.writeline(

--- a/torch/csrc/inductor/aot_runtime/model.h
+++ b/torch/csrc/inductor/aot_runtime/model.h
@@ -429,7 +429,7 @@ class AOTICudaStreamGuard {
   AOTICudaStreamGuard(cudaStream_t stream, int32_t device_index) {
     CUDAStreamGuardHandle ptr;
     AOTI_TORCH_ERROR_CODE_CHECK(
-        aoti_torch_create_cuda_stream_guard(&ptr, stream, device_index));
+        aoti_torch_create_cuda_stream_guard(stream, device_index, &ptr));
     guard_ =
         std::unique_ptr<void, std::function<void(void*)>>(ptr, [](void* ptr) {
           AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_delete_cuda_stream_guard(

--- a/torch/csrc/inductor/aot_runtime/model_container.h
+++ b/torch/csrc/inductor/aot_runtime/model_container.h
@@ -139,7 +139,6 @@ class AOTInductorModelContainer {
 
       AtenTensorHandle tensor_handle;
       AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_create_tensor_from_blob(
-          &tensor_handle,
           internal_ptr,
           ndim,
           size,
@@ -147,8 +146,8 @@ class AOTInductorModelContainer {
           offset,
           dtype,
           device_type,
-          0 // device index, should read it from cudaStream_t?
-          ));
+          0, // device index, should read it from cudaStream_t?
+          &tensor_handle));
       constants_->emplace(
           std::move(name), std::move(RAIIAtenTensorHandle(tensor_handle)));
     }

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -99,44 +99,48 @@ aoti_torch_delete_tensor_object(AtenTensorHandle tensor);
 
 // Get a pointer to the underlying storage data
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_data_ptr(
-    void** ret, // returns borrowed reference
-    AtenTensorHandle tensor);
+    AtenTensorHandle tensor,
+    void** ret_data_ptr // returns borrowed reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_sizes(
-    int64_t** ret, // returns borrowed reference
-    AtenTensorHandle tensor);
+    AtenTensorHandle tensor,
+    int64_t** ret_size // returns borrowed reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_strides(
-    int64_t** ret, // returns borrowed reference
-    AtenTensorHandle tensor);
+    AtenTensorHandle tensor,
+    int64_t** ret_strides // returns borrowed reference
+);
 
 // This function will create a new tensor object and its pointer is returned
 // through *out. The caller is responsible for wrapping the tensor pointer
 // with RAIIAtenTensorHandle which will call aoti_torch_delete_tensor_object
 // when going out of scope.
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch__reinterpret_tensor(
-    AtenTensorHandle* ret, // returns new reference
     AtenTensorHandle self,
     int64_t ndim,
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
-    int64_t storage_offset);
+    int64_t storage_offset,
+    AtenTensorHandle* ret_new_tensor // returns new reference
+);
 
 // This function will create a new tensor object and its pointer is returned
 // through *out. The caller is responsible for wrapping the tensor pointer
 // with RAIIAtenTensorHandle which will call aoti_torch_delete_tensor_object
 // when going out of scope.
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_empty_strided(
-    AtenTensorHandle* ret, // returns new reference
     int64_t ndim,
     const int64_t* sizes_ptr,
     const int64_t* strides_ptr,
     int32_t dtype,
     int32_t device_type,
-    int32_t device_index);
+    int32_t device_index,
+    AtenTensorHandle* ret_new_tensor // returns new reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
-    AtenTensorHandle* ret, // returns new reference
     void* data,
     int64_t ndim,
     const int64_t* sizes_ptr,
@@ -144,7 +148,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     int64_t storage_offset,
     int32_t dtype,
     int32_t device_type,
-    int32_t device_index);
+    int32_t device_index,
+    AtenTensorHandle* ret // returns new reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_tensor_copy_(AtenTensorHandle src, AtenTensorHandle dst);
@@ -173,9 +179,10 @@ struct CUDAStreamGuardOpaque;
 using CUDAStreamGuardHandle = CUDAStreamGuardOpaque*;
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_cuda_stream_guard(
-    CUDAStreamGuardHandle* ret_guard, // returns new reference
     void* stream,
-    int32_t device_index);
+    int32_t device_index,
+    CUDAStreamGuardHandle* ret_guard // returns new reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_delete_cuda_stream_guard(CUDAStreamGuardHandle guard);

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -6,9 +6,9 @@
 #include <c10/cuda/CUDAStream.h>
 
 AOTITorchError aoti_torch_create_cuda_stream_guard(
-    CUDAStreamGuardHandle* ret_guard,
     void* stream,
-    int32_t device_index) {
+    int32_t device_index,
+    CUDAStreamGuardHandle* ret_guard) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::cuda::CUDAStreamGuard* guard =
         new at::cuda::CUDAStreamGuard(at::cuda::getStreamFromExternal(


### PR DESCRIPTION
Summary: Change the returned values to be in the back of the parameters, because 1) it is more consistent with AOTInductor runtime API convention; 2) because the out-variant ops have the out tensor at the beginning of parameters, this makes the return values more distinguished from those

Test Plan:
```
buck test mode/opt caffe2/torch/fb/model_transform/experimental/benchmark/test/aotinductor:test_aot_inductor_benchmark
```

Differential Revision: D49522928




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov