### PR TITLE
Ensure fill_ works when value is a view of self

### DIFF
--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -57,9 +57,8 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
   // Check if value is a view of self and if it is we clone
   // it to avoid overwriting self prematurely
-  const at::TensorBase self_base = self.is_view() ? self._base() : self;
-  const at::TensorBase value_base = value.is_view() ? value._base() : value;
-  if(self_base.is_same(value_base)){
+  if(self.is_alias_of(value))
+  {
     self.copy_(value.clone());
   } else{
     self.copy_(value);

--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -55,7 +55,13 @@ Tensor& fill_quantized_(Tensor& self, const Scalar& value) {
 
 Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
-  self.copy_(value);
+  // Check if value is a view of self and if it is we clone
+  // it to avoid overwriting self prematurely
+  if(self._base().is_same(value._base())){
+    self.copy_(value.clone());
+  } else{
+    self.copy_(value);
+  }
   return self;
 }
 

--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -57,8 +57,7 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
   // Check if value is a view of self and if it is we clone
   // it to avoid overwriting self prematurely
-  if(self.is_alias_of(value))
-  {
+  if(self.is_alias_of(value)) {
     self.copy_(value.clone());
   } else{
     self.copy_(value);

--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -57,7 +57,9 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
   // Check if value is a view of self and if it is we clone
   // it to avoid overwriting self prematurely
-  if(self._base().is_same(value._base())){
+  const at::TensorBase self_base = self.is_view() ? self._base() : self;
+  const at::TensorBase value_base = value.is_view() ? value._base() : value;
+  if(self_base.is_same(value_base)){
     self.copy_(value.clone());
   } else{
     self.copy_(value);

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -602,8 +602,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                     # Fill one row with duplicate index so we can test with a fully
                     # padded row
                     duplicate_row = random.randint(0, indices_dim0 - 1)
-                    fill_value = indices[duplicate_row][0].clone()
-                    indices[duplicate_row] = fill_value
+                    indices[duplicate_row] = indices[duplicate_row][0]
 
             for padding_idx in list(set(indices.flatten(0, -1).tolist())):
                 weights = torch.randn(num_words, num_features, dtype=dtype, device=device, requires_grad=True)


### PR DESCRIPTION
# Summary
Introduced a BC breaking change in #109533 when self is a view of the value. By using the copy_() op inside fill_ we were hitting `assert_no_partial_overlap` in tensor iterator. 

Ideal we would be able to avoid this check if value.numel() ==1 . But rather than monkeying around with tensor iterator I just clone the input instead.