### PR TITLE
Re-enable more Windows tests

### DIFF
--- a/.ci/pytorch/win-test-helpers/test_custom_script_ops.bat
+++ b/.ci/pytorch/win-test-helpers/test_custom_script_ops.bat
@@ -26,9 +26,6 @@ popd
 python test_custom_ops.py -v
 if ERRORLEVEL 1 exit /b 1
 
-python test_custom_classes.py -v
-if ERRORLEVEL 1 exit /b 1
-
 python model.py --export-script-module="build/model.pt"
 if ERRORLEVEL 1 exit /b 1
 

--- a/.ci/pytorch/win-test-helpers/test_custom_script_ops.bat
+++ b/.ci/pytorch/win-test-helpers/test_custom_script_ops.bat
@@ -26,10 +26,8 @@ popd
 python test_custom_ops.py -v
 if ERRORLEVEL 1 exit /b 1
 
-:: TODO: fix and re-enable this test
-:: See https://github.com/pytorch/pytorch/issues/25155
-:: python test_custom_classes.py -v
-:: if ERRORLEVEL 1 exit /b 1
+python test_custom_classes.py -v
+if ERRORLEVEL 1 exit /b 1
 
 python model.py --export-script-module="build/model.pt"
 if ERRORLEVEL 1 exit /b 1

--- a/.ci/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.ci/pytorch/win-test-helpers/test_libtorch.bat
@@ -30,8 +30,6 @@ set CPP_TESTS_DIR=%TMP_DIR_WIN%\build\torch\test
 :: Skip verify_api_visibility as it a compile level test
 if "%~1" == "verify_api_visibility" goto :eof
 
-if "%~1" == "module_test" goto :eof
-
 echo Running "%~2"
 if "%~1" == "c10_intrusive_ptr_benchmark" (
   :: NB: This is not a gtest executable file, thus couldn't be handled by pytest-cpp

--- a/.ci/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.ci/pytorch/win-test-helpers/test_libtorch.bat
@@ -1,7 +1,3 @@
-:: Skip LibTorch tests when building a GPU binary and testing on a CPU machine
-:: because LibTorch tests are not well designed for this use case.
-::if "%USE_CUDA%" == "0" IF NOT "%CUDA_VERSION%" == "cpu" exit /b 0
-
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 if errorlevel 1 exit /b 1
 
@@ -35,8 +31,6 @@ set CPP_TESTS_DIR=%TMP_DIR_WIN%\build\torch\test
 if "%~1" == "verify_api_visibility" goto :eof
 
 if "%~1" == "module_test" goto :eof
-:: See https://github.com/pytorch/pytorch/issues/25312
-if "%~1" == "converter_nomigraph_test" goto :eof
 
 echo Running "%~2"
 if "%~1" == "c10_intrusive_ptr_benchmark" (


### PR DESCRIPTION
Follows the work of #108930.


The commented test_custom_classes.py was removed since the file doesn't exist.