### PR TITLE
Back out "[decomp] Fix baddbmm decomposition (#109714)"

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4145,9 +4145,9 @@ def register_inplace(aten_op, outplace_op):
     return inplace_op
 
 
-@register_decomposition([aten.baddbmm])
 @out_wrapper()
 @pw_cast_for_opmath
+@register_decomposition([aten.baddbmm])
 def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     if not self.is_floating_point() and not self.is_complex():
         beta = int(beta)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9904,6 +9904,18 @@ op_db: List[OpInfo] = [
                DecorateInfo(
                    toleranceOverride({torch.complex64: tol(atol=1e-05, rtol=1.2e-03)}),
                    'TestMathBits', 'test_conj_view', device_type='cuda'),
+               DecorateInfo(
+                   unittest.skip("Skipped - baddbmm decomp does not have enough precision for 16-bit float"),
+                   'TestDecomp',
+                   'test_comprehensive',
+                   dtypes=(torch.bfloat16, torch.float16),
+               ),
+               DecorateInfo(
+                   unittest.skip("Skipped - baddbmm decomp does not have enough precision for 16-bit float"),
+                   'TestDecomp',
+                   'test_quick',
+                   dtypes=(torch.bfloat16, torch.float16),
+               ),
            ],
            sample_inputs_func=sample_inputs_baddbmm,
            skips=(


### PR DESCRIPTION
Summary:
Original commit changeset: 95c462a380c9

Original Phabricator Diff: D49484954

this diff cause test failure for deterministic ne test see:https://www.internalfb.com/sandcastle/job/18014399565419856/

Test Plan:
buck2 test 'fbcode//mode/opt' fbcode//aps_models/ads/icvr/tests:icvr_fm_e2e_deterministic_ne_test -- --exact 'aps_models/ads/icvr/tests:icvr_fm_e2e_deterministic_ne_test - aps_models.ads.icvr.tests.icvr_fm_e2e_deterministic_ne_test.ICVR_FM_E2EDeterministicNeTest: test_e2e_deterministic_icvr_fm_pt2_fsdp_multi_gpus'

https://www.internalfb.com/intern/testinfra/testrun/16888498605839953

Differential Revision: D49527271

