### PR TITLE
Disabled UserWarnings for some public functions in torch.overrides

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -13,8 +13,10 @@ from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_
 from torch.overrides import (
     handle_torch_function,
     has_torch_function,
+    get_ignored_functions,
     get_overridable_functions,
     get_testing_overrides,
+    resolve_name,
     is_tensor_method_or_property,
     TorchFunctionMode,
     _get_current_function_mode,
@@ -1136,6 +1138,14 @@ class TestTorchFunctionWarning(TestCase):
             with self.assertWarnsRegex(UserWarning, "as a plain method is deprecated"):
                 # Function that handles torch_function in C++
                 torch.abs(a)
+
+class TestDisabledUserWarnings(TestCase):
+    def test_no_implicit_user_warning_for_deprecated_functions(self):
+        self.assertNotWarn(get_ignored_functions)
+        self.assertNotWarn(get_testing_overrides)
+        self.assertNotWarn(get_overridable_functions)
+        self.assertNotWarn(lambda: resolve_name(torch.Tensor.add))
+        self.assertNotWarn(lambda: is_tensor_method_or_property(torch.Tensor.add))
 
 @unittest.skipIf(TEST_WITH_CROSSREF, "not run with crossref")
 class TestTorchFunctionMode(TestCase):

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -27,6 +27,7 @@ import functools
 import types
 import warnings
 from typing import Dict, Set, List, Any, Callable, Iterable, Type, Tuple
+from functools import wraps
 import contextlib
 
 import torch
@@ -49,7 +50,38 @@ __all__ = [
     "enable_reentrant_dispatch",
 ]
 
+
+def disable_user_warnings(
+        func: Callable, regex: str = '.*is deprecated, please use.*', module: str = 'torch') -> Callable:
+    """
+    Decorator that temporarily disables ``UserWarning``s for the given ``module`` if the warning message matches the
+    given ``regex`` pattern.
+
+    Arguments
+    ---------
+    func : function
+        Function to disable the warnings for.
+    regex : str
+        A regex pattern compilable by ``re.compile``. This is used to match the ``UserWarning`` message.
+    module : str
+        The python module to which the filtering should be restricted.
+
+    Returns
+    -------
+    function
+        The wrapped function.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning, message=regex, module=module)
+            return func(*args, **kwargs)
+    return wrapper
+
+
 @functools.lru_cache(None)
+@disable_user_warnings
 def get_ignored_functions() -> Set[Callable]:
     """
     Return public functions that cannot be overridden by ``__torch_function__``.
@@ -354,6 +386,7 @@ def get_default_nowrap_functions() -> Set[Callable]:
 
 
 @functools.lru_cache(None)
+@disable_user_warnings
 def get_testing_overrides() -> Dict[Callable, Callable]:
     """Return a dict containing dummy overrides for all overridable functions
 
@@ -1714,6 +1747,7 @@ def _get_overridable_functions() -> Tuple[Dict[Any, List[Callable]], Dict[Callab
             overridable_funcs[namespace].append(func)
     return overridable_funcs, index
 
+@disable_user_warnings
 def get_overridable_functions() -> Dict[Any, List[Callable]]:
     """List functions that are overridable via __torch_function__
 
@@ -1725,6 +1759,7 @@ def get_overridable_functions() -> Dict[Any, List[Callable]]:
     """
     return _get_overridable_functions()[0]
 
+@disable_user_warnings
 def resolve_name(f):
     """Get a human readable string name for a function passed to
     __torch_function__
@@ -1751,6 +1786,7 @@ def _get_tensor_methods() -> Set[Callable]:
     methods = set(overridable_funcs[torch.Tensor])
     return methods
 
+@disable_user_warnings
 def is_tensor_method_or_property(func: Callable) -> bool:
     """
     Returns True if the function passed in is a handler for a

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -51,7 +51,7 @@ __all__ = [
 ]
 
 
-def disable_user_warnings(
+def _disable_user_warnings(
         func: Callable, regex: str = '.*is deprecated, please use.*', module: str = 'torch') -> Callable:
     """
     Decorator that temporarily disables ``UserWarning``s for the given ``module`` if the warning message matches the
@@ -81,7 +81,7 @@ def disable_user_warnings(
 
 
 @functools.lru_cache(None)
-@disable_user_warnings
+@_disable_user_warnings
 def get_ignored_functions() -> Set[Callable]:
     """
     Return public functions that cannot be overridden by ``__torch_function__``.
@@ -386,7 +386,7 @@ def get_default_nowrap_functions() -> Set[Callable]:
 
 
 @functools.lru_cache(None)
-@disable_user_warnings
+@_disable_user_warnings
 def get_testing_overrides() -> Dict[Callable, Callable]:
     """Return a dict containing dummy overrides for all overridable functions
 
@@ -1747,7 +1747,7 @@ def _get_overridable_functions() -> Tuple[Dict[Any, List[Callable]], Dict[Callab
             overridable_funcs[namespace].append(func)
     return overridable_funcs, index
 
-@disable_user_warnings
+@_disable_user_warnings
 def get_overridable_functions() -> Dict[Any, List[Callable]]:
     """List functions that are overridable via __torch_function__
 
@@ -1759,7 +1759,7 @@ def get_overridable_functions() -> Dict[Any, List[Callable]]:
     """
     return _get_overridable_functions()[0]
 
-@disable_user_warnings
+@_disable_user_warnings
 def resolve_name(f):
     """Get a human readable string name for a function passed to
     __torch_function__
@@ -1786,7 +1786,7 @@ def _get_tensor_methods() -> Set[Callable]:
     methods = set(overridable_funcs[torch.Tensor])
     return methods
 
-@disable_user_warnings
+@_disable_user_warnings
 def is_tensor_method_or_property(func: Callable) -> bool:
     """
     Returns True if the function passed in is a handler for a


### PR DESCRIPTION
Fixes #109842.

This disables the implicit `UserWarning`s that were raised for deprecated `torch` attributes. The filtering was designed to be as specific as possible, in order to not filter any other warnings that may be raised.
