### PR TITLE
Don't record function call if `ShapeEnv` is not found.

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -275,9 +275,6 @@ translation_validation_timeout = int(
 translation_validation_no_bisect = (
     os.environ.get("TORCHDYNAMO_TRANSLATION_NO_BISECT", "0") == "1"
 )
-# Disables ShapeEnv event recording.
-# See: [Note: Recording ShapeEnv Events]
-dont_record_shape_env_events = False
 # Checks whether replaying ShapeEnv events on a freshly constructed one yields
 # the a ShapeEnv with the same state. This should be used only in testing.
 check_shape_env_recorded_events = False

--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -185,7 +185,6 @@ def _extract_shape_env_and_assert_equal(args, kwargs):
         if isinstance(val, SymTypes):
             shape_env = assert_equal(shape_env, val.node.shape_env)
 
-    assert shape_env is not None, "ShapeEnv not found"
     return shape_env
 
 
@@ -230,6 +229,11 @@ def record_shapeenv_event(*, save_tracked_fakes: bool = False) -> Callable:
             # Assumption: the collection of args and kwargs may not reference
             # different ShapeEnv instances.
             self = _extract_shape_env_and_assert_equal(args, kwargs)
+
+            # If we are calling this function without any ShapeEnv instance
+            # alive in its arguments, we don't record and call the original.
+            if self is None:
+                return fn(*args, **kwargs)
 
             # Otherwise, start recording and call the function.
             with self.recording():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #109945
* #109944
* __->__ #109904

Fix: #109844

- Redirecting execution to original function if `ShapeEnv` instance is not found in its arguments
- Removed `dont_record_shape_env_events`, as it wasn't being used anywhere

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng