### PR TITLE
Add `endpoint` argument in `linspace` to match numpy behavior

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -713,10 +713,11 @@ Tensor linspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(start.dim() == 0 && end.dim() == 0, "linspace only supports 0-dimensional start and end tensors, "
     "but got start with ", start.dim(), " dimension(s) and end with ", end.dim()," dimension(s).");
-  return at::linspace(start.item(), end.item(), steps, dtype, layout, device, pin_memory);
+  return at::linspace(start.item(), end.item(), steps, dtype, layout, device, pin_memory, endpoint);
 }
 
 Tensor linspace(
@@ -726,10 +727,11 @@ Tensor linspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(start.dim() == 0, "linspace only supports 0-dimensional start and end tensors, "
     "but got start with ", start.dim(), " dimension(s).");
-  return at::linspace(start.item(), end, steps, dtype, layout, device, pin_memory);
+  return at::linspace(start.item(), end, steps, dtype, layout, device, pin_memory, endpoint);
 }
 
 Tensor linspace(
@@ -739,10 +741,11 @@ Tensor linspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(end.dim() == 0, "linspace only supports 0-dimensional start and end tensors, "
     "but got end with ", end.dim()," dimension(s).");
-  return at::linspace(start, end.item(), steps, dtype, layout, device, pin_memory);
+  return at::linspace(start, end.item(), steps, dtype, layout, device, pin_memory, endpoint);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ logspace ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -773,10 +776,11 @@ Tensor logspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(start.dim() == 0 && end.dim() == 0, "logspace only supports 0-dimensional start and end tensors, "
     "but got start with ", start.dim(), " dimension(s) and end with ", end.dim()," dimension(s).");
-  return at::logspace(start.item(), end.item(), steps, base, dtype, layout, device, pin_memory);
+  return at::logspace(start.item(), end.item(), steps, base, dtype, layout, device, pin_memory, endpoint);
 }
 
 Tensor logspace(
@@ -787,10 +791,11 @@ Tensor logspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(start.dim() == 0, "logspace only supports 0-dimensional start and end tensors, "
     "but got start with ", start.dim(), " dimension(s).");
-  return at::logspace(start.item(), end, steps, base, dtype, layout, device, pin_memory);
+  return at::logspace(start.item(), end, steps, base, dtype, layout, device, pin_memory, endpoint);
 }
 
 Tensor logspace(
@@ -801,10 +806,11 @@ Tensor logspace(
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+    c10::optional<bool> pin_memory,
+    c10::optional<bool> endpoint) {
   TORCH_CHECK(end.dim() == 0, "logspace only supports 0-dimensional start and end tensors, "
     "but got end with ", end.dim()," dimension(s).");
-  return at::logspace(start, end.item(), steps, base, dtype, layout, device, pin_memory);
+  return at::logspace(start, end.item(), steps, base, dtype, layout, device, pin_memory, endpoint);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ones ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3290,21 +3290,21 @@
 - func: ldexp.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   tags: pointwise
 
-- func: linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   dispatch:
     CompositeExplicitAutograd: linspace
 
-- func: linspace.Tensor_Tensor(Tensor start, Tensor end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace.Tensor_Tensor(Tensor start, Tensor end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: linspace
 
-- func: linspace.Tensor_Scalar(Tensor start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace.Tensor_Scalar(Tensor start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: linspace
 
-- func: linspace.Scalar_Tensor(Scalar start, Tensor end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace.Scalar_Tensor(Scalar start, Tensor end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: linspace
@@ -3506,21 +3506,21 @@
     CompositeExplicitAutograd: xlogy_out
   tags: pointwise
 
-- func: logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   dispatch:
     CompositeExplicitAutograd: logspace
 
-- func: logspace.Tensor_Tensor(Tensor start, Tensor end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace.Tensor_Tensor(Tensor start, Tensor end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: logspace
 
-- func: logspace.Tensor_Scalar(Tensor start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace.Tensor_Scalar(Tensor start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: logspace
 
-- func: logspace.Scalar_Tensor(Scalar start, Tensor end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace.Scalar_Tensor(Scalar start, Tensor end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool? endpoint=None) -> Tensor
   category_override: factory
   dispatch:
     CompositeExplicitAutograd: logspace

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4914,6 +4914,7 @@ def linspace(
     layout: torch.layout = torch.strided,
     pin_memory: bool = False,
     requires_grad: bool = False,
+    endpoint: bool = True,
 ) -> TensorLikeType:
     if isinstance(start, TensorLikeType):
         torch._check(
@@ -4982,11 +4983,12 @@ def linspace(
 
     # We implement torch.lerp without performing rg / (steps - 1) explicitly
     # With this we get out[0] == start, out[-1] == end
-    step = (end - start) / (steps - 1)
+    div = steps - 1 if endpoint else steps
+    step = (end - start) / div
     out = torch.where(
-        rg < steps / 2,
+        rg < steps // 2,
         start + step * cast_rg(rg),  # type: ignore[arg-type,operator]
-        end - step * cast_rg((steps - 1) - rg),  # type: ignore[arg-type,operator]
+        end - step * cast_rg(div - rg),  # type: ignore[arg-type,operator]
     )
     return _maybe_convert_to_dtype(out, dtype)  # type: ignore[return-value]
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5006,6 +5006,7 @@ def logspace(
     layout: torch.layout = torch.strided,
     pin_memory: bool = False,
     requires_grad: bool = False,
+    endpoint: bool = True,
 ) -> TensorLikeType:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -5050,6 +5051,7 @@ def logspace(
         device=device,
         pin_memory=pin_memory,
         requires_grad=requires_grad,
+        endpoint=endpoint,
     )
     return _maybe_convert_to_dtype(torch.pow(base, ret), dtype)  # type: ignore[arg-type,return-value]
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5937,10 +5937,10 @@ Example::
 add_docstr(
     torch.linspace,
     r"""
-linspace(start, end, steps, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
+linspace(start, end, steps, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False, endpoint=True) -> Tensor
 
 Creates a one-dimensional tensor of size :attr:`steps` whose values are evenly
-spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
+spaced from :attr:`start` to :attr:`end`, inclusive of :attr:`end` if `endpoint` is ``True``. That is, the values are:
 
 .. math::
     (\text{start},
@@ -5948,6 +5948,14 @@ spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
     \ldots,
     \text{start} + (\text{steps} - 2) * \frac{\text{end} - \text{start}}{\text{steps} - 1},
     \text{end})
+
+The values are exclusive of :attr:`end` if `endpoint` is ``False``:
+
+.. math::
+    (\text{start},
+    \text{start} + \frac{\text{end} - \text{start}}{\text{steps}},
+    \ldots,
+    \text{start} + (\text{steps} - 1) * \frac{\text{end} - \text{start}}{\text{steps}})
 """
     + """
 


### PR DESCRIPTION
Fixes #70919

Basically I copied the line from `numpy`
https://github.com/numpy/numpy/blob/d35cd07ea997f033b2d89d349734c61f5de54b0d/numpy/core/function_base.py#L125

There is also a slight change in @lezcano 's implementation using `torch.where` to improve performance by 10% when the `steps` is an odd number.

I updated the docs as well and I am not sure if this is needed. @mruberry