### PR TITLE
add path for DPC++ SYCL device code in Float8_e4m3fn

### DIFF
--- a/c10/util/Float8_e4m3fn.h
+++ b/c10/util/Float8_e4m3fn.h
@@ -98,6 +98,10 @@ inline C10_HOST_DEVICE float fp8e4m3fn_to_fp32_value(uint8_t input) {
    */
 #if defined(__CUDA_ARCH__)
   uint32_t renorm_shift = __clz(nonsign);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  // Note: zero is not a supported input into `__builtin_clz`
+  uint32_t renorm_shift =
+      nonsign != 0 ? __builtin_clz(nonsign) : sizeof(uint32_t) * CHAR_BIT;
 #elif defined(_MSC_VER)
   unsigned long nonsign_bsr;
   _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign);


### PR DESCRIPTION
Building IPEX-XPU with PyTorch fails with `error: builtin is not supported on this target _BitScanReverse` on Windows. 

The root cause of the error is due to `_BitScanReverse` compiler intrinsic function not being supported in SYCL target device code with DPC++ compiler, while being supported in host code with MSVC compiler. Thanks to @gujinghui, @xuhancn for the help in identifying the root cause and debugging.

A minimal reproducible script:
```cpp
#include <CL/sycl.hpp>
#include <chrono>
#include <iostream>

#ifdef _MSC_VER
#include <intrin.h>
#endif

void test(
  sycl::queue& q) {

  uint8_t input = 123;
  const uint32_t w = (uint32_t)input << 24;
  const uint32_t nonsign = w & UINT32_C(0x7FFFFFFF);
  unsigned long nonsign_bsr;
  _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign); // host code, no error

  sycl::range<2> global_range{1, 1};
  sycl::range<2> local_range{1, 1};

  auto e = q.submit([&](auto& h) {
    sycl::stream out(100000, 256, h);
    h.parallel_for(sycl::nd_range<2>{global_range, local_range},
      [=](sycl::nd_item<2> item) {
        
        #if defined(_MSC_VER)
          uint8_t input = 123;
          const uint32_t w = (uint32_t)input << 24;
          unsigned long nonsign_bsr;
          _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign); // device code, error: builtin is not supported on this target
        #else
          __builtin_clz(nonsign);
        #endif
        

      // Fix to add a check for SYCL device code:
      /*
      #if defined(__SYCL_DEVICE_ONLY__)
          out << "DPC++ SYCL" << sycl::endl;
          __builtin_clz(nonsign);
      #elif defined(_MSC_VER)
          out << "MSVC" << sycl::endl;
          uint8_t input = 123;
          const uint32_t w = (uint32_t)input << 24;
          unsigned long nonsign_bsr;
          _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign);
      #endif
      */

      });
    });
  q.wait();
}

int main() {
  #if defined(__SYCL_DEVICE_ONLY__)
    std::cout << "DPC++ SYCL" << std::endl;
  #elif defined(_MSC_VER)
    std::cout << "MSVC" << std::endl;
  #endif

  sycl::queue q(sycl::default_selector_v);
  test(q);

  return 0;
}
```



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10