### PR TITLE
[BE]s/DEFINE_ENUM/DEFINE_ST_ENUM_VAL_/

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -93,9 +93,9 @@ namespace c10 {
   _(at::Float8_e4m3fn, Float8_e4m3fn)
 
 enum class ScalarType : int8_t {
-#define DEFINE_ENUM(_1, n) n,
-  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_ENUM)
-#undef DEFINE_ENUM
+#define DEFINE_ST_ENUM_VAL_(_1, n) n,
+  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_ST_ENUM_VAL_)
+#undef DEFINE_ENUM_ST_ENUM_VAL_
       Undefined,
   NumOptions
 };


### PR DESCRIPTION
To avoid potential collisions with other libraries that can define such enum globally (which is a bad practice, but happens sometimes)
