### PR TITLE
do not pick bs for sd

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -209,6 +209,7 @@ DONT_CHANGE_BATCH_SIZE = {
     "pytorch_struct",
     "pyhpc_turbulent_kinetic_energy",
     "vision_maskrcnn",  # https://github.com/pytorch/benchmark/pull/1656
+    "stable_diffusion", 
 }
 
 


### PR DESCRIPTION
Fixes https://ossci-raw-job-status.s3.amazonaws.com/log/17031370158

```
2023-09-22T12:36:28.5104516Z Traceback (most recent call last):
2023-09-22T12:36:28.5105013Z   File "/var/lib/jenkins/workspace/benchmarks/dynamo/common.py", line 3428, in run
2023-09-22T12:36:28.5107076Z     ) = runner.load_model(
2023-09-22T12:36:28.5107891Z   File "/var/lib/jenkins/workspace/benchmarks/dynamo/torchbench.py", line 393, in load_model
2023-09-22T12:36:28.5108637Z     benchmark = benchmark_cls(
2023-09-22T12:36:28.5109418Z   File "/var/lib/jenkins/workspace/torchbench/torchbenchmark/util/model.py", line 25, in __call__
2023-09-22T12:36:28.5110075Z     obj = type.__call__(cls, *args, **kwargs)
2023-09-22T12:36:28.5110834Z   File "/var/lib/jenkins/workspace/torchbench/torchbenchmark/models/stable_diffusion/__init__.py", line 25, in __init__
2023-09-22T12:36:28.5111657Z     super().__init__(test=test, device=device,
2023-09-22T12:36:28.5112419Z   File "/var/lib/jenkins/workspace/torchbench/torchbenchmark/util/model.py", line 117, in __init__
2023-09-22T12:36:28.5112838Z     self.determine_batch_size(batch_size)
2023-09-22T12:36:28.5113259Z   File "/var/lib/jenkins/workspace/torchbench/torchbenchmark/util/model.py", line 183, in determine_batch_size
2023-09-22T12:36:28.5113982Z     raise NotImplementedError("Model doesn't support customizing batch size.")
2023-09-22T12:36:28.5114522Z NotImplementedError: Model doesn't support customizing batch size.
2023-09-22T12:36:28.5114765Z 
2023-09-22T12:36:28.5114909Z WARNING:root:stable_diffusion failed to load
```

There's also another open issue around why inference but training is OOMing it seems related to memory efficient attention


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng